### PR TITLE
Retain completion arrays for fire-only batches

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -7451,7 +7451,7 @@ internal sealed class PartitionBatch
     private int _recordCount;
 
     // Zero-allocation array management: use pooled arrays instead of List<T>
-    private PooledValueTaskSource<RecordMetadata>[] _completionSources;
+    private PooledValueTaskSource<RecordMetadata>[]? _completionSources;
     private int _completionSourceCount;
     // Dense prefixes need no index array; only delivery records after the first gap are tracked.
     private int _completionSourceDenseCount;
@@ -7521,7 +7521,7 @@ internal sealed class PartitionBatch
         CreateAppendBuffer(options, rentFullArenaFromPool: false);
         _recordCount = 0;
 
-        // Rent arrays from pool - eliminates List allocations
+        // Rent arrays from pool - eliminates List allocations.
         _completionSources = ProducerContainerPools.CompletionSources.Rent(_initialRecordCapacity);
         _completionSourceCount = 0;
     }
@@ -7603,7 +7603,7 @@ internal sealed class PartitionBatch
 
     /// <summary>
     /// Prepares the batch for returning to the pool.
-    /// Allocates new arrays (the old ones were transferred to ReadyBatch).
+    /// Recreates transferred append storage while retaining fire-only completion storage.
     /// IMPORTANT: This must only be called after Complete() which transfers arrays to ReadyBatch.
     /// </summary>
     internal void PrepareForPooling(ProducerOptions options, BatchArrayReuseQueue? arrayReuseQueue = null)
@@ -7619,18 +7619,18 @@ internal sealed class PartitionBatch
 
         CreateAppendBuffer(options);
 
-        // The completion sources array was transferred to ReadyBatch by Complete() and is now null.
-        // Try to reclaim one from the reuse queue first (returned by ReadyBatch.Cleanup()),
-        // avoiding an ArrayPool Rent operation per batch cycle.
-        if (_arrayReuseQueue is not null && _arrayReuseQueue.TryDequeue(out var reusable))
+        // Awaited batches transfer completion storage to ReadyBatch. Fire-only batches
+        // retain their array across pool rotations and skip this cross-thread handoff.
+        if (_completionSources is null)
         {
-            _completionSources = reusable;
-        }
-        else
-        {
-            // Fallback: rent a fresh array from the dedicated pool (not ArrayPool<T>.Shared)
-            // to prevent TLS accumulation from cross-thread rent/return patterns
-            _completionSources = ProducerContainerPools.CompletionSources.Rent(_initialRecordCapacity);
+            if (_arrayReuseQueue is not null && _arrayReuseQueue.TryDequeue(out var reusable))
+            {
+                _completionSources = reusable;
+            }
+            else
+            {
+                _completionSources = ProducerContainerPools.CompletionSources.Rent(_initialRecordCapacity);
+            }
         }
 
         // Reset counters and state for reuse.
@@ -8002,7 +8002,7 @@ internal sealed class PartitionBatch
             return new RecordAppendResult(false);
         }
 
-        // Defensive check: if the array is null, batch is in inconsistent state (being pooled)
+        // A completed awaited batch transfers this array before returning to the pool.
         if (_completionSources is null)
         {
             reservedAppend = default;
@@ -8182,9 +8182,10 @@ internal sealed class PartitionBatch
         _encodedRecordsLength += reservedAppend.EncodedRecordSize;
         _maxTimestamp = recordIndex == 0 ? reservedAppend.Timestamp : Math.Max(_maxTimestamp, reservedAppend.Timestamp);
 
-        _completionSources[recordIndex] = completionSource!;
         if (completionSource is not null)
         {
+            Debug.Assert(_completionSources is not null);
+            _completionSources![recordIndex] = completionSource;
             TrackDeliveryIndex(
                 recordIndex,
                 _completionSourceCount,
@@ -8477,12 +8478,14 @@ internal sealed class PartitionBatch
             // This eliminates per-batch class allocations at high throughput
             readyBatch = _readyBatchPool?.Rent() ?? new ReadyBatch();
 
-            // Initialize with batch data - ownership of arrays transfers to ReadyBatch
+            // Initialize with batch data. Fire-only batches retain their unused completion
+            // array locally; awaited batches transfer ownership to ReadyBatch.
             // PooledValueTaskSource auto-returns to its pool when GetResult() is called
+            var transfersCompletionSources = _completionSourceCount > 0;
             readyBatch.Initialize(
                 _topicPartition,
                 batch,
-                _completionSources,
+                transfersCompletionSources ? _completionSources : null,
                 _completionSourceCount,
                 _recordCount,
                 _estimatedSize,
@@ -8525,8 +8528,9 @@ internal sealed class PartitionBatch
             batch = null;
             readyBatch = null;
 
-            // Null out references - ownership transferred to ReadyBatch
-            _completionSources = null!;
+            // Null out references whose ownership transferred to ReadyBatch.
+            if (transfersCompletionSources)
+                _completionSources = null;
             _completionSourceIndexes = null;
             _arena = null;
             _incrementalBuffer = null;
@@ -8652,7 +8656,7 @@ internal sealed class PartitionBatch
             IncrementalBatchBuffer.ReturnToPool(_incrementalBuffer);
 
         // Null out references to prevent accidental reuse
-        _completionSources = null!;
+        _completionSources = null;
         _completionSourceIndexes = null;
         _arena = null;
         _incrementalBuffer = null;
@@ -8745,10 +8749,10 @@ internal sealed class ReadyBatchPool(int maxPoolSize = BatchArena.DefaultPoolSiz
 }
 
 /// <summary>
-/// Reuse queue for the completion sources array that PartitionBatch rents from ArrayPool.
+/// Reuse queue for completion source arrays rented by PartitionBatch.
 /// When ReadyBatch finishes cleanup, it pushes the array here instead of returning it to
 /// ArrayPool. PartitionBatch.PrepareForPooling() dequeues from here first, falling back
-/// to ArrayPool on miss. This eliminates an ArrayPool Rent/Return pair per batch cycle.
+/// to ArrayPool on miss. Fire-only batches retain their array and skip the handoff.
 /// </summary>
 internal sealed class BatchArrayReuseQueue
 {

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -8896,7 +8896,34 @@ internal sealed class ReadyBatch
     private int[]? _callbackIndexes;
 
     internal PooledValueTaskSource<RecordMetadata>? GetCompletionSource(int recordIndex)
-        => _completionSourcesArray?[recordIndex];
+    {
+        if (_completionSourcesArray is null || recordIndex < 0)
+            return null;
+
+        if (recordIndex < _completionSourceDenseCount)
+            return _completionSourcesArray[recordIndex];
+
+        var indexes = _completionSourceIndexes;
+        if (indexes is null)
+            return null;
+
+        var low = 0;
+        var high = _completionSourcesCount - _completionSourceDenseCount - 1;
+        while (low <= high)
+        {
+            var middle = low + ((high - low) >> 1);
+            var indexedRecord = indexes[middle];
+            if (indexedRecord == recordIndex)
+                return _completionSourcesArray[recordIndex];
+
+            if (indexedRecord < recordIndex)
+                low = middle + 1;
+            else
+                high = middle - 1;
+        }
+
+        return null;
+    }
 
     internal Action<RecordMetadata, Exception?>? GetCallback(int recordIndex)
         => _callbacks?[recordIndex];

--- a/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Reflection;
 using Dekaf.Compression;
 using Dekaf.Metadata;
 using Dekaf.Producer;
@@ -9,6 +10,56 @@ namespace Dekaf.Tests.Unit.Producer;
 
 public sealed class Kip126BatchSplittingTests
 {
+    [Test]
+    public async Task FireOnlyBatch_DoesNotTransferCompletionSourceStorage()
+    {
+        var options = new ProducerOptions { BootstrapServers = ["localhost:9092"], BatchSize = 4096 };
+        var batch = new PartitionBatch(new TopicPartition("fire-only", 0), options);
+        var partitionStorage = typeof(PartitionBatch).GetField(
+            "_completionSources",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var readyStorage = typeof(ReadyBatch).GetField(
+            "_completionSourcesArray",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        var storage = partitionStorage.GetValue(batch);
+        await Assert.That(storage).IsNotNull();
+        Append(batch, 0, completionSource: null, callback: null);
+        await Assert.That(partitionStorage.GetValue(batch)).IsSameReferenceAs(storage);
+
+        var ready = batch.Complete()!;
+        await Assert.That(readyStorage.GetValue(ready)).IsNull();
+        await Assert.That(partitionStorage.GetValue(batch)).IsSameReferenceAs(storage);
+        ready.CompleteSend(0, DateTimeOffset.UnixEpoch);
+    }
+
+    [Test]
+    public async Task FirstLateCompletion_PreservesOriginalRecordIndex()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 64 * 1024,
+            InitialBatchRecordCapacity = 16
+        };
+        var batch = new PartitionBatch(new TopicPartition("late-completion", 0), options);
+        var sourcePool = new ValueTaskSourcePool<RecordMetadata>();
+
+        for (var i = 0; i < 100; i++)
+            Append(batch, i, completionSource: null, callback: null);
+
+        var source = sourcePool.Rent();
+        var task = source.Task;
+        Append(batch, 100, source, callback: null);
+
+        var ready = batch.Complete()!;
+        ready.TrySetMemoryReleased();
+        ready.CompleteSend(500, DateTimeOffset.UnixEpoch);
+
+        await Assert.That((await task).Offset).IsEqualTo(600);
+        await sourcePool.DisposeAsync();
+    }
+
     [Test]
     public async Task CompressedBatch_ZeroBufferMemory_UsesMinimumSizeLimit()
     {

--- a/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
@@ -30,7 +30,60 @@ public sealed class Kip126BatchSplittingTests
         var ready = batch.Complete()!;
         await Assert.That(readyStorage.GetValue(ready)).IsNull();
         await Assert.That(partitionStorage.GetValue(batch)).IsSameReferenceAs(storage);
+
+        batch.PrepareForPooling(options);
+        batch.Reset(new TopicPartition("fire-only-reused", 1), partitionCount: 2);
+        await Assert.That(partitionStorage.GetValue(batch)).IsSameReferenceAs(storage);
+
         ready.CompleteSend(0, DateTimeOffset.UnixEpoch);
+        batch.Complete();
+    }
+
+    [Test]
+    public async Task MixedBatch_SplitLookupIgnoresStaleFireOnlySlot()
+    {
+        var options = new ProducerOptions { BootstrapServers = ["localhost:9092"], BatchSize = 4096 };
+        var batch = new PartitionBatch(new TopicPartition("mixed-stale", 0), options);
+        var sourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var stale = sourcePool.Rent();
+        var awaited = sourcePool.Rent();
+        var staleTask = stale.Task;
+        var awaitedTask = awaited.Task;
+        var completionStorage = typeof(PartitionBatch).GetField(
+            "_completionSources",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var storage = (PooledValueTaskSource<RecordMetadata>[])completionStorage.GetValue(batch)!;
+
+        // Simulate retained, uncleared storage from an earlier awaited batch.
+        storage[0] = stale;
+        Append(batch, 0, completionSource: null, callback: null);
+        Append(batch, 1, awaited, callback: null);
+
+        var ready = batch.Complete()!;
+        await Assert.That(ready.GetCompletionSource(0)).IsNull();
+        await Assert.That(ready.GetCompletionSource(1)).IsSameReferenceAs(awaited);
+
+        ready.TrySetMemoryReleased();
+        await using var accumulator = new RecordAccumulator(options, new CompressionCodecRegistry());
+        var children = accumulator.SplitForSenderRetry(
+            ready,
+            ready.Generation,
+            static () => { })!;
+        await Assert.That(children.Sum(static child => child.CompletionSourcesCount)).IsEqualTo(1);
+
+        var baseOffset = 100L;
+        foreach (var child in children)
+        {
+            CompleteAndReturn(accumulator, child, baseOffset);
+            baseOffset += child.RecordCount;
+        }
+
+        await Assert.That((await awaitedTask).Offset).IsEqualTo(101);
+        await Assert.That(staleTask.IsCompleted).IsFalse();
+        await Assert.That(stale.TrySetException(new InvalidOperationException("Test cleanup."))).IsTrue();
+        await Assert.That(async () => await staleTask)
+            .ThrowsExactly<InvalidOperationException>();
+        await sourcePool.DisposeAsync();
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- stop writing `null` into the record-aligned completion array for every fire-and-forget append
- keep the completion array attached to `PartitionBatch` across fire-only pool rotations
- transfer completion storage to `ReadyBatch` only when the batch contains awaited produces
- preserve sparse completion offsets and awaited-batch ownership semantics

## Performance

Baseline: `456167f68d555d24e8ce2a7ae3a204e554f7ea29`
Candidate: `49abcef8`
Runtime: .NET 10.0.11, Windows 11, i7-12700K

`BatchMemoryAllocationBenchmarks` (`MemoryDiagnoser`, 1 launch, 3 warmups, 5 iterations):

| Message | Storage | Baseline | Candidate | Delta | Allocated |
|---:|---|---:|---:|---:|---:|
| 100 B | Full | 31.07 ns | 29.53 ns | -5.0% | 0 B -> 0 B |
| 100 B | Incremental | 37.05 ns | 35.88 ns | -3.2% | 0 B -> 0 B |
| 1000 B | Full | 82.13 ns | 73.94 ns | -10.0% | 0 B -> 0 B |
| 1000 B | Incremental | 135.59 ns | 134.83 ns | -0.6% | 0 B -> 0 B |

Protected awaited comparator, repository-original `DenseDeliveryIndexTrackingBenchmarks`:

| Benchmark | Baseline | Candidate | Delta | Allocated |
|---|---:|---:|---:|---:|
| Dense awaited append | 21.54 ns | 20.50 ns | -4.8% | 0 B -> 0 B |

A first lazy-rent design was rejected before commit: it regressed dense awaited append by 3.6%. The retained-array design removes fire-only transfer/churn without adding an awaited per-message branch.

## Validation

- `dotnet build tests/Dekaf.Tests.Unit --configuration Release --no-restore`
- `Dekaf.Tests.Unit.exe --treenode-filter '/*/*/Kip126BatchSplittingTests/*'` (12/12 passed)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of fire-and-forget and awaited message batches.
  * Preserved original record indexes when processing late completions.
  * Enhanced batch resource cleanup and reuse for more reliable processing.

* **Tests**
  * Added coverage for completion handling and record-index preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->