### PR TITLE
Pool request serialization writers

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1610,7 +1610,7 @@ public sealed partial class KafkaConnection :
     {
         // Serialize directly into a rented array at offset 4 (reserving space for the size
         // prefix). The only copy is rented array -> PipeWriter under the write lock.
-        using var writer = new RentedBufferWriter(
+        using var writer = RentedBufferWriter.Rent(
             GetPreSerializeInitialCapacity<TResponse>(request),
             MessageSizePrefixLength);
 
@@ -1757,7 +1757,7 @@ public sealed partial class KafkaConnection :
         if (!batch.CanWriteSegmented(partition.Compression))
             return false;
 
-        using var metadataWriter = new RentedBufferWriter(
+        using var metadataWriter = RentedBufferWriter.Rent(
             DefaultPreSerializeInitialCapacity,
             MessageSizePrefixLength);
         var writer = new KafkaProtocolWriter(metadataWriter);

--- a/src/Dekaf/Networking/RentedBufferWriter.cs
+++ b/src/Dekaf/Networking/RentedBufferWriter.cs
@@ -17,17 +17,31 @@ namespace Dekaf.Networking;
 /// the retained working set grows linearly with the number of unique threads visited —
 /// proportional to broker count and test duration. A dedicated <c>ConfigurableArrayPool</c>
 /// uses a single lock-based pool with bounded bucket depth, eliminating TLS accumulation.
+/// The writer object is pooled separately so request serialization does not allocate a wrapper.
 /// </summary>
 internal sealed class RentedBufferWriter : IBufferWriter<byte>, IDisposable
 {
-    private byte[] _buffer;
+    private const int MaxPoolSize = 256;
+    private static readonly Reservoir.ObjectPool<RentedBufferWriter, PoolPolicy> Pool = new(MaxPoolSize);
+
+    private byte[] _buffer = null!;
     private int _written;
     private bool _detached;
+    private bool _active;
 
-    public RentedBufferWriter(int initialCapacity, int offset)
+    private RentedBufferWriter()
     {
-        _written = offset;
-        _buffer = DekafPools.SerializationBuffers.Rent(initialCapacity + offset);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static RentedBufferWriter Rent(int initialCapacity, int offset)
+    {
+        var writer = Pool.Rent();
+        writer._written = offset;
+        writer._buffer = DekafPools.SerializationBuffers.Rent(initialCapacity + offset);
+        writer._detached = false;
+        writer._active = true;
+        return writer;
     }
 
     internal int WrittenCount => _written;
@@ -47,13 +61,16 @@ internal sealed class RentedBufferWriter : IBufferWriter<byte>, IDisposable
     /// </summary>
     public void Dispose()
     {
+        if (!_active)
+            return;
+
+        _active = false;
+        var buffer = _buffer;
+        _buffer = null!;
         if (!_detached)
-        {
-            var buf = _buffer;
-            _buffer = null!;
-            _detached = true;
-            DekafPools.SerializationBuffers.Return(buf, clearArray: false);
-        }
+            DekafPools.SerializationBuffers.Return(buffer, clearArray: false);
+
+        Pool.Return(this);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -103,5 +120,17 @@ internal sealed class RentedBufferWriter : IBufferWriter<byte>, IDisposable
         _buffer.AsSpan(0, _written).CopyTo(newBuffer);
         DekafPools.SerializationBuffers.Return(_buffer, clearArray: false);
         _buffer = newBuffer;
+    }
+
+    private readonly struct PoolPolicy : Reservoir.IPooledObjectPolicy<RentedBufferWriter>
+    {
+        public RentedBufferWriter Create() => new();
+
+        public bool TryReset(RentedBufferWriter writer)
+        {
+            writer._written = 0;
+            writer._detached = false;
+            return true;
+        }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Networking/RentedBufferWriterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/RentedBufferWriterTests.cs
@@ -1,4 +1,3 @@
-using System.Buffers;
 using Dekaf.Networking;
 
 namespace Dekaf.Tests.Unit.Networking;
@@ -9,7 +8,7 @@ public class RentedBufferWriterTests
     public async Task Write_And_DetachBuffer_ReturnsCorrectLengthAndPreservesPrefix()
     {
         const int offset = 4;
-        using var writer = new RentedBufferWriter(initialCapacity: 64, offset: offset);
+        using var writer = RentedBufferWriter.Rent(initialCapacity: 64, offset: offset);
 
         // Write some data after the reserved prefix
         var span = writer.GetSpan(3);
@@ -33,7 +32,7 @@ public class RentedBufferWriterTests
         }
         finally
         {
-            ArrayPool<byte>.Shared.Return(array);
+            DekafPools.SerializationBuffers.Return(array);
         }
     }
 
@@ -42,7 +41,7 @@ public class RentedBufferWriterTests
     {
         const int offset = 4;
         // Use a tiny initial capacity to force growth
-        using var writer = new RentedBufferWriter(initialCapacity: 8, offset: offset);
+        using var writer = RentedBufferWriter.Rent(initialCapacity: 8, offset: offset);
 
         // Write the prefix area manually via GetSpan at construction time isn't possible,
         // so write a known pattern into the data area, force a grow, then verify.
@@ -74,7 +73,7 @@ public class RentedBufferWriterTests
         }
         finally
         {
-            ArrayPool<byte>.Shared.Return(array);
+            DekafPools.SerializationBuffers.Return(array);
         }
     }
 
@@ -82,7 +81,7 @@ public class RentedBufferWriterTests
     public async Task Dispose_WithoutDetach_ReturnsBufferToPool()
     {
         // Verifying pool return isn't directly observable, but we verify no exception is thrown.
-        var writer = new RentedBufferWriter(initialCapacity: 64, offset: 0);
+        var writer = RentedBufferWriter.Rent(initialCapacity: 64, offset: 0);
         var span = writer.GetSpan(4);
         span[0] = 0xFF;
         writer.Advance(4);
@@ -93,9 +92,28 @@ public class RentedBufferWriterTests
     }
 
     [Test]
-    public async Task Dispose_AfterDetach_IsNoOp()
+    public async Task Rent_AfterDispose_ReinitializesWriter()
     {
-        var writer = new RentedBufferWriter(initialCapacity: 64, offset: 0);
+        var writer = RentedBufferWriter.Rent(initialCapacity: 64, offset: 0);
+        writer.Advance(1);
+        writer.Dispose();
+
+        using var reused = RentedBufferWriter.Rent(initialCapacity: 64, offset: 4);
+        var (array, length) = reused.DetachBuffer();
+        try
+        {
+            await Assert.That(length).IsEqualTo(4);
+        }
+        finally
+        {
+            DekafPools.SerializationBuffers.Return(array);
+        }
+    }
+
+    [Test]
+    public async Task Dispose_AfterDetach_DoesNotReturnDetachedBuffer()
+    {
+        var writer = RentedBufferWriter.Rent(initialCapacity: 64, offset: 0);
         var span = writer.GetSpan(1);
         span[0] = 0x42;
         writer.Advance(1);
@@ -112,14 +130,14 @@ public class RentedBufferWriterTests
         }
         finally
         {
-            ArrayPool<byte>.Shared.Return(array);
+            DekafPools.SerializationBuffers.Return(array);
         }
     }
 
     [Test]
     public async Task Advance_WithNegativeCount_ThrowsArgumentOutOfRangeException()
     {
-        using var writer = new RentedBufferWriter(initialCapacity: 64, offset: 0);
+        using var writer = RentedBufferWriter.Rent(initialCapacity: 64, offset: 0);
 
         var action = () => writer.Advance(-1);
 
@@ -130,7 +148,7 @@ public class RentedBufferWriterTests
     [Test]
     public async Task Advance_ExceedingCapacity_ThrowsArgumentOutOfRangeException()
     {
-        using var writer = new RentedBufferWriter(initialCapacity: 16, offset: 0);
+        using var writer = RentedBufferWriter.Rent(initialCapacity: 16, offset: 0);
 
         // ArrayPool may return a larger buffer than requested, so get actual capacity
         // by requesting 0 span and checking how much we can advance.


### PR DESCRIPTION
## Summary

- pool the `RentedBufferWriter` wrapper used by request pre-serialization
- keep detached byte-buffer ownership unchanged: callers still return buffers to `DekafPools.SerializationBuffers`
- reset writer state on pool return and preserve dispose-without-detach cleanup
- correct writer tests to return detached arrays to their owning dedicated pool

## Performance

Baseline: `456167f68d555d24e8ce2a7ae3a204e554f7ea29`
Candidate: `f696412a`
Runtime: .NET 10.0.11, Windows 11, i7-12700K

`PipelinedResponseAllocationBenchmarks` (`MemoryDiagnoser`, real loopback TCP, two exact runs per SHA):

| Producer path | Baseline | Candidate | Result |
|---|---:|---:|---:|
| Allocated/request | 696 B, 696 B | 664 B, 664 B | **-32 B (-4.6%)** |
| Mean | 32.03 µs, 31.07 µs | 31.97 µs, 30.63 µs | non-regressive |

The public Task-adapter control is scheduling-sensitive: baseline allocation varied `834–878 B`; candidate was `845–847 B`, inside baseline variance. No metric was averaged into a pass. The producer comparator was deterministic in all four measurements.

This is a per-Kafka-request allocation removal, amortized across the records in a produce batch; it does not introduce per-message work.

## Validation

- `dotnet build tests/Dekaf.Tests.Unit --configuration Release --no-restore`
- `RentedBufferWriterTests` (7/7 passed)
- `KafkaConnectionTests/PipelinedResponse*` (5/5 passed)
- `git diff --check`