### PR TITLE
perf(producer): reuse response ownership claim

### DIFF
--- a/src/Dekaf/Networking/IKafkaConnection.cs
+++ b/src/Dekaf/Networking/IKafkaConnection.cs
@@ -158,22 +158,27 @@ internal interface IPipelinedResponseSource<TResponse> : IValueTaskSource<TRespo
 
 internal interface IPipelinedResponseExternalOwnership
 {
-    bool TryRetainExternalOwner(short token);
-    bool TryReleaseExternalOwner(short token);
+    bool TryRetainExternalOwner(int generation);
+    bool TryReleaseExternalOwner(int generation);
 }
 
 internal readonly struct PipelinedResponse<TResponse>
 {
     private readonly Task<TResponse>? _task;
     private readonly IPipelinedResponseSource<TResponse>? _source;
+    private readonly int _ownershipGeneration;
     private readonly short _token;
 
     public PipelinedResponse(Task<TResponse> task) => _task = task;
 
-    public PipelinedResponse(IPipelinedResponseSource<TResponse> source, short token)
+    public PipelinedResponse(
+        IPipelinedResponseSource<TResponse> source,
+        short token,
+        int ownershipGeneration = 0)
     {
         _source = source;
         _token = token;
+        _ownershipGeneration = ownershipGeneration;
     }
 
     public bool IsCompleted => _task?.IsCompleted
@@ -216,9 +221,9 @@ internal readonly struct PipelinedResponse<TResponse>
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryRetainExternalOwner() =>
-        (_source as IPipelinedResponseExternalOwnership)?.TryRetainExternalOwner(_token) == true;
+        (_source as IPipelinedResponseExternalOwnership)?.TryRetainExternalOwner(_ownershipGeneration) == true;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryReleaseExternalOwner() =>
-        (_source as IPipelinedResponseExternalOwnership)?.TryReleaseExternalOwner(_token) == true;
+        (_source as IPipelinedResponseExternalOwnership)?.TryReleaseExternalOwner(_ownershipGeneration) == true;
 }

--- a/src/Dekaf/Networking/IKafkaConnection.cs
+++ b/src/Dekaf/Networking/IKafkaConnection.cs
@@ -162,6 +162,13 @@ internal interface IPipelinedResponseExternalOwnership
     bool TryReleaseExternalOwner(int generation);
 }
 
+internal enum ExternalOwnershipClaimResult : byte
+{
+    Unsupported,
+    Retained,
+    Rejected
+}
+
 internal readonly struct PipelinedResponse<TResponse>
 {
     private readonly Task<TResponse>? _task;
@@ -220,8 +227,15 @@ internal readonly struct PipelinedResponse<TResponse>
     public void Abandon() => _source?.Abandon(_token);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool TryRetainExternalOwner() =>
-        (_source as IPipelinedResponseExternalOwnership)?.TryRetainExternalOwner(_ownershipGeneration) == true;
+    public ExternalOwnershipClaimResult TryRetainExternalOwner()
+    {
+        if (_source is not IPipelinedResponseExternalOwnership externalOwnership)
+            return ExternalOwnershipClaimResult.Unsupported;
+
+        return externalOwnership.TryRetainExternalOwner(_ownershipGeneration)
+            ? ExternalOwnershipClaimResult.Retained
+            : ExternalOwnershipClaimResult.Rejected;
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryReleaseExternalOwner() =>

--- a/src/Dekaf/Networking/IKafkaConnection.cs
+++ b/src/Dekaf/Networking/IKafkaConnection.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks.Sources;
 using Dekaf.Protocol;
 
@@ -155,6 +156,12 @@ internal interface IPipelinedResponseSource<TResponse> : IValueTaskSource<TRespo
     void Abandon(short token);
 }
 
+internal interface IPipelinedResponseExternalOwnership
+{
+    bool TryRetainExternalOwner(short token);
+    bool TryReleaseExternalOwner(short token);
+}
+
 internal readonly struct PipelinedResponse<TResponse>
 {
     private readonly Task<TResponse>? _task;
@@ -206,4 +213,12 @@ internal readonly struct PipelinedResponse<TResponse>
     }
 
     public void Abandon() => _source?.Abandon(_token);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryRetainExternalOwner() =>
+        (_source as IPipelinedResponseExternalOwnership)?.TryRetainExternalOwner(_token) == true;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryReleaseExternalOwner() =>
+        (_source as IPipelinedResponseExternalOwnership)?.TryReleaseExternalOwner(_token) == true;
 }

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1102,6 +1102,8 @@ public sealed partial class KafkaConnection :
         private const int ExternalOwnerRetained = 4;
         private const int ExternalOwnerReady = 8;
         private const int ReturnReady = CompletionReady | ConsumerReady;
+        private const int ReturnReadinessMask = 0xff;
+        private const int ReturnTokenShift = 8;
 
         private static readonly Reservoir.ObjectPool<
             PooledPipelinedResponse<TRequest, TResponse>,
@@ -1110,7 +1112,7 @@ public sealed partial class KafkaConnection :
 
         // The pending request already enters this completion from an asynchronous callback.
         // Resume the internal response consumer inline to avoid a second ThreadPool hop;
-        // _returnReadiness prevents pooling until this completion frame exits. Producer
+        // _returnState prevents pooling until this completion frame exits. Producer
         // delivery sources still dispatch application continuations asynchronously.
         private ManualResetValueTaskSourceCore<TResponse> _core;
         private readonly Action _pendingContinuation;
@@ -1126,7 +1128,9 @@ public sealed partial class KafkaConnection :
         private bool _canceled;
         private long _telemetryStartTimestamp;
         private int _consumerState;
-        private int _returnReadiness;
+        // Packs ManualResetValueTaskSourceCore.Version with readiness bits. External release
+        // validates token and claims ownership in one CAS, preventing pool-reset ABA races.
+        private int _returnState;
 
         private PooledPipelinedResponse()
         {
@@ -1176,7 +1180,7 @@ public sealed partial class KafkaConnection :
             _cancellationToken = cancellationToken;
             _canceled = false;
             _consumerState = ConsumerActive;
-            _returnReadiness = 0;
+            _returnState = PackReturnState(_core.Version, readiness: 0);
             connection.LogWaitingForResponse(correlationId);
 
             if (callerOwnsTimeout && cancellationToken.CanBeCanceled)
@@ -1316,23 +1320,21 @@ public sealed partial class KafkaConnection :
 
         public bool TryRetainExternalOwner(short token)
         {
-            if (token != _core.Version)
-                return false;
-
-            var readiness = Volatile.Read(ref _returnReadiness);
-            while ((readiness & (ConsumerReady | ExternalOwnerRetained)) == 0)
+            var state = Volatile.Read(ref _returnState);
+            while (GetReturnToken(state) == token)
             {
-                var observed = Interlocked.CompareExchange(
-                    ref _returnReadiness,
-                    readiness | ExternalOwnerRetained,
-                    readiness);
-                if (observed == readiness)
-                    return true;
-
-                if (token != _core.Version)
+                var readiness = GetReturnReadiness(state);
+                if ((readiness & (ConsumerReady | ExternalOwnerRetained)) != 0)
                     return false;
 
-                readiness = observed;
+                var observed = Interlocked.CompareExchange(
+                    ref _returnState,
+                    state | ExternalOwnerRetained,
+                    state);
+                if (observed == state)
+                    return true;
+
+                state = observed;
             }
 
             return false;
@@ -1340,18 +1342,28 @@ public sealed partial class KafkaConnection :
 
         public bool TryReleaseExternalOwner(short token)
         {
-            if (token != _core.Version
-                || (Volatile.Read(ref _returnReadiness) & ExternalOwnerRetained) == 0)
+            var state = Volatile.Read(ref _returnState);
+            while (GetReturnToken(state) == token)
             {
-                return false;
+                var readiness = GetReturnReadiness(state);
+                if ((readiness & ExternalOwnerRetained) == 0
+                    || (readiness & ExternalOwnerReady) != 0)
+                {
+                    return false;
+                }
+
+                var updated = state | ExternalOwnerReady;
+                var observed = Interlocked.CompareExchange(ref _returnState, updated, state);
+                if (observed == state)
+                {
+                    ReturnIfReady(state, updated);
+                    return true;
+                }
+
+                state = observed;
             }
 
-            var previous = Interlocked.Or(ref _returnReadiness, ExternalOwnerReady);
-            if ((previous & ExternalOwnerReady) != 0)
-                return false;
-
-            ReturnIfReady(previous, previous | ExternalOwnerReady);
-            return true;
+            return false;
         }
 
         private void ReturnIfAbandoned()
@@ -1379,12 +1391,14 @@ public sealed partial class KafkaConnection :
 
         private void SignalReturnReady(int readiness)
         {
-            var previous = Interlocked.Or(ref _returnReadiness, readiness);
+            var previous = Interlocked.Or(ref _returnState, readiness);
             ReturnIfReady(previous, previous | readiness);
         }
 
-        private void ReturnIfReady(int previous, int readiness)
+        private void ReturnIfReady(int previousState, int state)
         {
+            var previous = GetReturnReadiness(previousState);
+            var readiness = GetReturnReadiness(state);
             var required = ReturnReady;
             if ((readiness & ExternalOwnerRetained) != 0)
                 required |= ExternalOwnerReady;
@@ -1392,6 +1406,15 @@ public sealed partial class KafkaConnection :
             if ((previous & required) != required && (readiness & required) == required)
                 ReturnToPool();
         }
+
+        private static int PackReturnState(short token, int readiness) =>
+            (ushort)token << ReturnTokenShift | readiness;
+
+        private static short GetReturnToken(int state) =>
+            (short)(state >> ReturnTokenShift);
+
+        private static int GetReturnReadiness(int state) =>
+            state & ReturnReadinessMask;
 
         private void ReturnToPool()
         {
@@ -1412,8 +1435,8 @@ public sealed partial class KafkaConnection :
             _callerOwnsTimeout = false;
             _canceled = false;
             _telemetryStartTimestamp = 0;
-            _returnReadiness = 0;
             _core.Reset();
+            _returnState = PackReturnState(_core.Version, readiness: 0);
         }
 
         private readonly struct PoolPolicy

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1088,7 +1088,8 @@ public sealed partial class KafkaConnection :
     internal static Action? PendingRequestDrainStartedTestHook;
 
     private sealed class PooledPipelinedResponse<TRequest, TResponse> :
-        IPipelinedResponseSource<TResponse>
+        IPipelinedResponseSource<TResponse>,
+        IPipelinedResponseExternalOwnership
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
@@ -1098,6 +1099,8 @@ public sealed partial class KafkaConnection :
         private const int ConsumerReturned = 2;
         private const int CompletionReady = 1;
         private const int ConsumerReady = 2;
+        private const int ExternalOwnerRetained = 4;
+        private const int ExternalOwnerReady = 8;
         private const int ReturnReady = CompletionReady | ConsumerReady;
 
         private static readonly Reservoir.ObjectPool<
@@ -1311,6 +1314,46 @@ public sealed partial class KafkaConnection :
             ReturnIfAbandoned();
         }
 
+        public bool TryRetainExternalOwner(short token)
+        {
+            if (token != _core.Version)
+                return false;
+
+            var readiness = Volatile.Read(ref _returnReadiness);
+            while ((readiness & (ConsumerReady | ExternalOwnerRetained)) == 0)
+            {
+                var observed = Interlocked.CompareExchange(
+                    ref _returnReadiness,
+                    readiness | ExternalOwnerRetained,
+                    readiness);
+                if (observed == readiness)
+                    return true;
+
+                if (token != _core.Version)
+                    return false;
+
+                readiness = observed;
+            }
+
+            return false;
+        }
+
+        public bool TryReleaseExternalOwner(short token)
+        {
+            if (token != _core.Version
+                || (Volatile.Read(ref _returnReadiness) & ExternalOwnerRetained) == 0)
+            {
+                return false;
+            }
+
+            var previous = Interlocked.Or(ref _returnReadiness, ExternalOwnerReady);
+            if ((previous & ExternalOwnerReady) != 0)
+                return false;
+
+            ReturnIfReady(previous, previous | ExternalOwnerReady);
+            return true;
+        }
+
         private void ReturnIfAbandoned()
         {
             if (_core.GetStatus(_core.Version) == ValueTaskSourceStatus.Pending
@@ -1337,7 +1380,16 @@ public sealed partial class KafkaConnection :
         private void SignalReturnReady(int readiness)
         {
             var previous = Interlocked.Or(ref _returnReadiness, readiness);
-            if (previous != ReturnReady && (previous | readiness) == ReturnReady)
+            ReturnIfReady(previous, previous | readiness);
+        }
+
+        private void ReturnIfReady(int previous, int readiness)
+        {
+            var required = ReturnReady;
+            if ((readiness & ExternalOwnerRetained) != 0)
+                required |= ExternalOwnerReady;
+
+            if ((previous & required) != required && (readiness & required) == required)
                 ReturnToPool();
         }
 

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1103,7 +1103,8 @@ public sealed partial class KafkaConnection :
         private const int ExternalOwnerReady = 8;
         private const int ReturnReady = CompletionReady | ConsumerReady;
         private const int ReturnReadinessMask = 0xff;
-        private const int ReturnTokenShift = 8;
+        private const int ReturnGenerationShift = 8;
+        private const int MaxOwnershipGeneration = 0x00ff_ffff;
 
         private static readonly Reservoir.ObjectPool<
             PooledPipelinedResponse<TRequest, TResponse>,
@@ -1128,8 +1129,10 @@ public sealed partial class KafkaConnection :
         private bool _canceled;
         private long _telemetryStartTimestamp;
         private int _consumerState;
-        // Packs ManualResetValueTaskSourceCore.Version with readiness bits. External release
-        // validates token and claims ownership in one CAS, preventing pool-reset ABA races.
+        private int _ownershipGeneration;
+        // Packs a non-wrapping per-source generation with readiness bits. External release
+        // validates generation and claims ownership in one CAS, preventing pool-reset ABA races.
+        // The source is retired before its 24-bit generation can wrap.
         private int _returnState;
 
         private PooledPipelinedResponse()
@@ -1159,7 +1162,10 @@ public sealed partial class KafkaConnection :
                 callerOwnsTimeout,
                 telemetryStartTimestamp,
                 cancellationToken);
-            return new PipelinedResponse<TResponse>(operation, operation._core.Version);
+            return new PipelinedResponse<TResponse>(
+                operation,
+                operation._core.Version,
+                operation._ownershipGeneration);
         }
 
         private void Initialize(
@@ -1180,7 +1186,7 @@ public sealed partial class KafkaConnection :
             _cancellationToken = cancellationToken;
             _canceled = false;
             _consumerState = ConsumerActive;
-            _returnState = PackReturnState(_core.Version, readiness: 0);
+            _returnState = PackReturnState(_ownershipGeneration, readiness: 0);
             connection.LogWaitingForResponse(correlationId);
 
             if (callerOwnsTimeout && cancellationToken.CanBeCanceled)
@@ -1318,10 +1324,10 @@ public sealed partial class KafkaConnection :
             ReturnIfAbandoned();
         }
 
-        public bool TryRetainExternalOwner(short token)
+        public bool TryRetainExternalOwner(int generation)
         {
             var state = Volatile.Read(ref _returnState);
-            while (GetReturnToken(state) == token)
+            while (GetReturnGeneration(state) == generation)
             {
                 var readiness = GetReturnReadiness(state);
                 if ((readiness & (ConsumerReady | ExternalOwnerRetained)) != 0)
@@ -1340,10 +1346,10 @@ public sealed partial class KafkaConnection :
             return false;
         }
 
-        public bool TryReleaseExternalOwner(short token)
+        public bool TryReleaseExternalOwner(int generation)
         {
             var state = Volatile.Read(ref _returnState);
-            while (GetReturnToken(state) == token)
+            while (GetReturnGeneration(state) == generation)
             {
                 var readiness = GetReturnReadiness(state);
                 if ((readiness & ExternalOwnerRetained) == 0
@@ -1407,11 +1413,11 @@ public sealed partial class KafkaConnection :
                 ReturnToPool();
         }
 
-        private static int PackReturnState(short token, int readiness) =>
-            (ushort)token << ReturnTokenShift | readiness;
+        private static int PackReturnState(int generation, int readiness) =>
+            unchecked(generation << ReturnGenerationShift) | readiness;
 
-        private static short GetReturnToken(int state) =>
-            (short)(state >> ReturnTokenShift);
+        private static int GetReturnGeneration(int state) =>
+            (int)((uint)state >> ReturnGenerationShift);
 
         private static int GetReturnReadiness(int state) =>
             state & ReturnReadinessMask;
@@ -1424,7 +1430,7 @@ public sealed partial class KafkaConnection :
             Interlocked.Increment(ref s_poolCount);
         }
 
-        private void ResetForPooling()
+        private bool TryResetForPooling()
         {
             _connection = null;
             _pending = null;
@@ -1435,8 +1441,14 @@ public sealed partial class KafkaConnection :
             _callerOwnsTimeout = false;
             _canceled = false;
             _telemetryStartTimestamp = 0;
+
+            if (_ownershipGeneration == MaxOwnershipGeneration)
+                return false;
+
             _core.Reset();
-            _returnState = PackReturnState(_core.Version, readiness: 0);
+            _ownershipGeneration++;
+            _returnState = PackReturnState(_ownershipGeneration, readiness: 0);
+            return true;
         }
 
         private readonly struct PoolPolicy
@@ -1452,10 +1464,7 @@ public sealed partial class KafkaConnection :
             }
 
             public bool TryReset(PooledPipelinedResponse<TRequest, TResponse> operation)
-            {
-                operation.ResetForPooling();
-                return true;
-            }
+                => operation.TryResetForPooling();
 
             public void Destroy(PooledPipelinedResponse<TRequest, TResponse> operation)
                 => Interlocked.Decrement(ref s_poolCount);

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
@@ -264,7 +265,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             long dataBytes,
             long requestStartTime,
             BrokerUnackedByteBudget.DeliverySnapshot deliverySnapshotAtSend)
-            => new(
+        {
+            var ownershipClaim = responseTask.TryRetainExternalOwner();
+            if (ownershipClaim == ExternalOwnershipClaimResult.Rejected)
+                ThrowExternalOwnershipClaimRejected();
+
+            return new PendingResponse(
                 responseTask,
                 batches,
                 batchGenerations,
@@ -275,7 +281,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 dataBytes,
                 requestStartTime,
                 deliverySnapshotAtSend,
-                responseTask.TryRetainExternalOwner() ? null : new ArrayReturnGuard());
+                ownershipClaim == ExternalOwnershipClaimResult.Retained
+                    ? null
+                    : new ArrayReturnGuard());
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowExternalOwnershipClaimRejected() =>
+            throw new InvalidOperationException(
+                "Pooled pipelined response rejected its external ownership claim.");
 
         /// <summary>
         /// True for the default-valued tombstone left in a pending list by

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -175,30 +175,107 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// Wraps a pipelined response with the batch-generation snapshot the send captured
     /// at send start (before its first await) — the generations detect batch object
     /// recycling between send and response processing. Ownership of the rented
-    /// <paramref name="BatchGenerations"/>, <paramref name="TopicIds"/>, and
-    /// <paramref name="Batches"/> arrays transfers
+    /// <see cref="PendingResponse.BatchGenerations"/>, <see cref="PendingResponse.TopicIds"/>, and
+    /// <see cref="PendingResponse.Batches"/> arrays transfers
     /// to this PendingResponse; they are returned by <see cref="TryReturnArrays"/>.
     /// </summary>
-    internal readonly record struct PendingResponse(
-        PipelinedResponse<ProduceResponse> ResponseTask,
-        ReadyBatch[] Batches,
-        int[] BatchGenerations,
-        Guid[]? TopicIds,
-        short ApiVersion,
-        int Count,
-        long EncodedBytes,
-        long DataBytes,
-        long RequestStartTime,
-        BrokerUnackedByteBudget.DeliverySnapshot DeliverySnapshotAtSend)
+    internal readonly struct PendingResponse
     {
+        public PipelinedResponse<ProduceResponse> ResponseTask { get; }
+        public ReadyBatch[] Batches { get; }
+        public int[] BatchGenerations { get; }
+        public Guid[]? TopicIds { get; }
+        public short ApiVersion { get; }
+        public int Count { get; }
+        public long EncodedBytes { get; }
+        public long DataBytes { get; }
+        public long RequestStartTime { get; }
+        public BrokerUnackedByteBudget.DeliverySnapshot DeliverySnapshotAtSend { get; }
+
         /// <summary>
-        /// One-time-return claim for the rented arrays. Lives in a reference type because
-        /// PendingResponse is a struct copied by value (lists, locals, sweeps) — every copy
-        /// must observe the same claim, or two copies could each return the arrays and
-        /// poison <see cref="ArrayPool{T}.Shared"/> with a double-returned array (#2187:
-        /// a poisoned pool hands the same array to two renters, cross-contaminating requests).
+        /// Task-backed fallbacks keep a reference-typed claim because PendingResponse is
+        /// copied by value. The normal producer path keeps the claim on its already-pooled,
+        /// versioned response source, which cannot return to its pool until arrays release.
+        /// Both forms prevent two copies from returning the same arrays (#2187).
         /// </summary>
-        private ArrayReturnGuard ReturnGuard { get; } = new();
+        private ArrayReturnGuard? ReturnGuard { get; }
+
+        public PendingResponse(
+            PipelinedResponse<ProduceResponse> responseTask,
+            ReadyBatch[] batches,
+            int[] batchGenerations,
+            Guid[]? topicIds,
+            short apiVersion,
+            int count,
+            long encodedBytes,
+            long dataBytes,
+            long requestStartTime,
+            BrokerUnackedByteBudget.DeliverySnapshot deliverySnapshotAtSend)
+            : this(
+                responseTask,
+                batches,
+                batchGenerations,
+                topicIds,
+                apiVersion,
+                count,
+                encodedBytes,
+                dataBytes,
+                requestStartTime,
+                deliverySnapshotAtSend,
+                new ArrayReturnGuard())
+        {
+        }
+
+        private PendingResponse(
+            PipelinedResponse<ProduceResponse> responseTask,
+            ReadyBatch[] batches,
+            int[] batchGenerations,
+            Guid[]? topicIds,
+            short apiVersion,
+            int count,
+            long encodedBytes,
+            long dataBytes,
+            long requestStartTime,
+            BrokerUnackedByteBudget.DeliverySnapshot deliverySnapshotAtSend,
+            ArrayReturnGuard? returnGuard)
+        {
+            ResponseTask = responseTask;
+            Batches = batches;
+            BatchGenerations = batchGenerations;
+            TopicIds = topicIds;
+            ApiVersion = apiVersion;
+            Count = count;
+            EncodedBytes = encodedBytes;
+            DataBytes = dataBytes;
+            RequestStartTime = requestStartTime;
+            DeliverySnapshotAtSend = deliverySnapshotAtSend;
+            ReturnGuard = returnGuard;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static PendingResponse Create(
+            PipelinedResponse<ProduceResponse> responseTask,
+            ReadyBatch[] batches,
+            int[] batchGenerations,
+            Guid[]? topicIds,
+            short apiVersion,
+            int count,
+            long encodedBytes,
+            long dataBytes,
+            long requestStartTime,
+            BrokerUnackedByteBudget.DeliverySnapshot deliverySnapshotAtSend)
+            => new(
+                responseTask,
+                batches,
+                batchGenerations,
+                topicIds,
+                apiVersion,
+                count,
+                encodedBytes,
+                dataBytes,
+                requestStartTime,
+                deliverySnapshotAtSend,
+                responseTask.TryRetainExternalOwner() ? null : new ArrayReturnGuard());
 
         /// <summary>
         /// True for the default-valued tombstone left in a pending list by
@@ -223,7 +300,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         /// </summary>
         public bool TryReturnArrays()
         {
-            if (!ReturnGuard.TryClaim())
+            if (!TryClaimArrayOwnership())
                 return false;
 
             ArrayPool<int>.Shared.Return(BatchGenerations);
@@ -232,6 +309,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             ArrayPool<ReadyBatch>.Shared.Return(Batches, clearArray: true);
             return true;
         }
+
+        internal bool TryAbandonArrayOwnership() => TryClaimArrayOwnership();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool TryClaimArrayOwnership() => ReturnGuard?.TryClaim()
+            ?? ResponseTask.TryReleaseExternalOwner();
     }
 
     internal readonly record struct ProduceResponseKey(string Topic, Guid TopicId, int Partition)
@@ -3946,7 +4029,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                 Debug.Assert(count > 0,
                     "PendingResponse must never be constructed empty — Count == 0 is the claimed-tombstone sentinel (IsClaimed).");
-                var pendingResponse = new PendingResponse(
+                var pendingResponse = PendingResponse.Create(
                     responseTask,
                     batches,
                     generations,
@@ -3957,7 +4040,17 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     dataBytes,
                     requestStartTime,
                     deliverySnapshotAtSend);
-                _pendingResponsesByConnection[connectionIndex].Add(pendingResponse);
+                try
+                {
+                    _pendingResponsesByConnection[connectionIndex].Add(pendingResponse);
+                }
+                catch
+                {
+                    // The outer failure path still owns and returns the arrays. Release only
+                    // the ownership claim acquired by PendingResponse.Create().
+                    pendingResponse.TryAbandonArrayOwnership();
+                    throw;
+                }
                 pendingResponseAdded = true; // Array ownership transferred to PendingResponse
                 Interlocked.Increment(ref _totalPendingResponseCount);
                 Interlocked.Add(ref _totalPendingResponseBytes, encodedBytes);

--- a/tests/Dekaf.Tests.Integration/ProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerTests.cs
@@ -1,6 +1,8 @@
 using Dekaf.Admin;
 using Dekaf.Consumer;
+using Dekaf.Networking;
 using Dekaf.Producer;
+using Dekaf.Protocol.Messages;
 using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Integration;
@@ -149,6 +151,50 @@ public class ProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
         // Assert
         await Assert.That(metadata.Topic).IsEqualTo(topic);
         await Assert.That(metadata.Offset).IsGreaterThanOrEqualTo(0);
+    }
+
+    [Test, NotInParallel]
+    [Timeout(60_000)]
+    public async Task Producer_AcknowledgedResponses_ReleasePooledOwnership(
+        CancellationToken cancellationToken)
+    {
+        var baseline = KafkaConnection.GetPipelinedResponsePoolCount<
+            ProduceRequest,
+            ProduceResponse>();
+        var expectedAfterReturn = Math.Max(1, baseline);
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-producer-response-ownership")
+            .WithIdempotence(false)
+            .WithAcks(Acks.Leader)
+            .WithLinger(TimeSpan.FromMilliseconds(5))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken);
+
+        for (var wave = 0; wave < 2; wave++)
+        {
+            var produces = new Task<RecordMetadata>[32];
+            for (var i = 0; i < produces.Length; i++)
+            {
+                produces[i] = producer.ProduceAsync(
+                    topic,
+                    $"key-{wave}-{i}",
+                    $"value-{wave}-{i}",
+                    cancellationToken).AsTask();
+            }
+
+            var results = await Task.WhenAll(produces)
+                .WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+            await Assert.That(results.All(static result => result.Offset >= 0)).IsTrue();
+            await WaitForConditionAsync(
+                () => KafkaConnection.GetPipelinedResponsePoolCount<ProduceRequest, ProduceResponse>()
+                    >= expectedAfterReturn,
+                TimeSpan.FromSeconds(10),
+                pollIntervalMs: 10,
+                description: "acknowledged response ownership source to return to pool");
+        }
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -689,11 +689,29 @@ public sealed class KafkaConnectionTests
                 ApiVersionsRequest,
                 ApiVersionsResponse>()).IsEqualTo(expectedWhileRetained);
 
-            await Assert.That(response.TryReleaseExternalOwner()).IsTrue();
+            using var releaseGate = new ManualResetEventSlim();
+            var firstRelease = Task.Run(() =>
+            {
+                releaseGate.Wait(cancellationToken);
+                return response.TryReleaseExternalOwner();
+            }, cancellationToken);
+            var secondRelease = Task.Run(() =>
+            {
+                releaseGate.Wait(cancellationToken);
+                return response.TryReleaseExternalOwner();
+            }, cancellationToken);
+            releaseGate.Set();
+            var releaseResults = await Task.WhenAll(firstRelease, secondRelease);
+
+            await Assert.That(releaseResults.Count(static released => released)).IsEqualTo(1);
             await Assert.That(response.TryReleaseExternalOwner()).IsFalse();
-            await Assert.That(KafkaConnection.GetPipelinedResponsePoolCount<
-                ApiVersionsRequest,
-                ApiVersionsResponse>()).IsEqualTo(expectedAfterReturn);
+            while (KafkaConnection.GetPipelinedResponsePoolCount<
+                       ApiVersionsRequest,
+                       ApiVersionsResponse>() < expectedAfterReturn)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Reflection;
+using System.Threading.Tasks.Sources;
 using Dekaf.Compression;
 using Dekaf.Errors;
 using Dekaf.Networking;
@@ -719,6 +720,35 @@ public sealed class KafkaConnectionTests
         {
             listener.Stop();
         }
+    }
+
+    [Test]
+    public async Task PipelinedResponse_MaxOwnershipGeneration_RetiresWithoutReset()
+    {
+        const BindingFlags instanceFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+        const BindingFlags staticFlags = BindingFlags.Static | BindingFlags.NonPublic;
+        var responseType = typeof(KafkaConnection)
+            .GetNestedType("PooledPipelinedResponse`2", BindingFlags.NonPublic)!
+            .MakeGenericType(typeof(ApiVersionsRequest), typeof(ApiVersionsResponse));
+        var response = Activator.CreateInstance(responseType, nonPublic: true)!;
+        var generationField = responseType.GetField("_ownershipGeneration", instanceFlags)!;
+        var maxGeneration = (int)responseType
+            .GetField("MaxOwnershipGeneration", staticFlags)!
+            .GetRawConstantValue()!;
+        generationField.SetValue(response, maxGeneration);
+
+        var coreField = responseType.GetField("_core", instanceFlags)!;
+        var versionBefore = ((ManualResetValueTaskSourceCore<ApiVersionsResponse>)coreField
+            .GetValue(response)!).Version;
+        var reset = (bool)responseType
+            .GetMethod("TryResetForPooling", instanceFlags)!
+            .Invoke(response, null)!;
+        var versionAfter = ((ManualResetValueTaskSourceCore<ApiVersionsResponse>)coreField
+            .GetValue(response)!).Version;
+
+        await Assert.That(reset).IsFalse();
+        await Assert.That(generationField.GetValue(response)).IsEqualTo(maxGeneration);
+        await Assert.That(versionAfter).IsEqualTo(versionBefore);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -645,6 +645,63 @@ public sealed class KafkaConnectionTests
     }
 
     [Test]
+    [NotInParallel]
+    [Timeout(10_000)]
+    public async Task PipelinedResponse_ExternalOwner_DelaysPoolReturn(
+        CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            var baseline = KafkaConnection.GetPipelinedResponsePoolCount<
+                ApiVersionsRequest,
+                ApiVersionsResponse>();
+            var expectedWhileRetained = Math.Max(0, baseline - 1);
+            var expectedAfterReturn = Math.Max(1, baseline);
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
+            await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
+            await connection.ConnectAsync(cancellationToken);
+            using var serverClient = await acceptTask.ConfigureAwait(false);
+
+            var response = await ((IKafkaPipelinedWriteCompletionConnection)connection)
+                .SendPipelinedAfterWriteAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                    new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
+                    apiVersion: 3,
+                    cancellationToken);
+            await Assert.That(response.TryRetainExternalOwner()).IsTrue();
+            await Assert.That(response.TryRetainExternalOwner()).IsFalse();
+
+            var requestFrame = await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
+            var correlationId = BinaryPrimitives.ReadInt32BigEndian(requestFrame.AsSpan(4, 4));
+            await serverClient.GetStream().WriteAsync(
+                BuildApiVersionsV3ResponseFrame(correlationId),
+                cancellationToken);
+
+            while (!response.IsCompleted)
+                await Task.Yield();
+            var parsed = response.GetResult();
+
+            await Assert.That(parsed.ErrorCode).IsEqualTo(ErrorCode.None);
+            await Assert.That(KafkaConnection.GetPipelinedResponsePoolCount<
+                ApiVersionsRequest,
+                ApiVersionsResponse>()).IsEqualTo(expectedWhileRetained);
+
+            await Assert.That(response.TryReleaseExternalOwner()).IsTrue();
+            await Assert.That(response.TryReleaseExternalOwner()).IsFalse();
+            await Assert.That(KafkaConnection.GetPipelinedResponsePoolCount<
+                ApiVersionsRequest,
+                ApiVersionsResponse>()).IsEqualTo(expectedAfterReturn);
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Test]
     [Timeout(10_000)]
     public async Task SendAsync_ResponseCancellation_PreservesCallerCancellationToken(CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -671,8 +671,10 @@ public sealed class KafkaConnectionTests
                     new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
                     apiVersion: 3,
                     cancellationToken);
-            await Assert.That(response.TryRetainExternalOwner()).IsTrue();
-            await Assert.That(response.TryRetainExternalOwner()).IsFalse();
+            await Assert.That(response.TryRetainExternalOwner())
+                .IsEqualTo(ExternalOwnershipClaimResult.Retained);
+            await Assert.That(response.TryRetainExternalOwner())
+                .IsEqualTo(ExternalOwnershipClaimResult.Rejected);
 
             var requestFrame = await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
             var correlationId = BinaryPrimitives.ReadInt32BigEndian(requestFrame.AsSpan(4, 4));

--- a/tests/Dekaf.Tests.Unit/Producer/PendingResponseArrayOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PendingResponseArrayOwnershipTests.cs
@@ -55,8 +55,8 @@ public sealed class PendingResponseArrayOwnershipTests : ScriptedProduceResponse
         // Standalone struct, never attached to a live sender. The claim lives in the
         // reference-typed guard, so it is shared across every by-value copy — the second
         // call must no-op even from a different copy.
-        var pending = new BrokerSender.PendingResponse(
-            default,
+        var pending = BrokerSender.PendingResponse.Create(
+            new PipelinedResponse<ProduceResponse>(Task.FromResult(new ProduceResponse())),
             ArrayPool<ReadyBatch>.Shared.Rent(1),
             ArrayPool<int>.Shared.Rent(1),
             topicIds: null,
@@ -80,14 +80,40 @@ public sealed class PendingResponseArrayOwnershipTests : ScriptedProduceResponse
     {
         var source = new GenerationOwnershipSource();
         var stale = new PipelinedResponse<ProduceResponse>(source, token: 0, ownershipGeneration: 0);
-        await Assert.That(stale.TryRetainExternalOwner()).IsTrue();
+        await Assert.That(stale.TryRetainExternalOwner())
+            .IsEqualTo(ExternalOwnershipClaimResult.Retained);
 
         source.Reset(generation: 1);
         var current = new PipelinedResponse<ProduceResponse>(source, token: 0, ownershipGeneration: 1);
-        await Assert.That(current.TryRetainExternalOwner()).IsTrue();
+        await Assert.That(current.TryRetainExternalOwner())
+            .IsEqualTo(ExternalOwnershipClaimResult.Retained);
 
         await Assert.That(stale.TryReleaseExternalOwner()).IsFalse();
         await Assert.That(current.TryReleaseExternalOwner()).IsTrue();
+    }
+
+    [Test]
+    public async Task PendingResponse_Create_RejectsFailedPooledOwnershipClaim()
+    {
+        var source = new GenerationOwnershipSource();
+        source.Reset(generation: 1);
+        var stale = new PipelinedResponse<ProduceResponse>(
+            source,
+            token: 0,
+            ownershipGeneration: 0);
+
+        await Assert.That(() => BrokerSender.PendingResponse.Create(
+                stale,
+                [],
+                [],
+                topicIds: null,
+                apiVersion: 12,
+                count: 1,
+                encodedBytes: 0,
+                dataBytes: 0,
+                requestStartTime: 0,
+                default))
+            .Throws<InvalidOperationException>();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/PendingResponseArrayOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PendingResponseArrayOwnershipTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Threading.Tasks.Sources;
 using Dekaf.Networking;
 using Dekaf.Producer;
 using Dekaf.Protocol;
@@ -75,6 +76,21 @@ public sealed class PendingResponseArrayOwnershipTests : ScriptedProduceResponse
     }
 
     [Test]
+    public async Task PipelinedResponse_StaleGenerationCannotReleaseReusedSource()
+    {
+        var source = new GenerationOwnershipSource();
+        var stale = new PipelinedResponse<ProduceResponse>(source, token: 0, ownershipGeneration: 0);
+        await Assert.That(stale.TryRetainExternalOwner()).IsTrue();
+
+        source.Reset(generation: 1);
+        var current = new PipelinedResponse<ProduceResponse>(source, token: 0, ownershipGeneration: 1);
+        await Assert.That(current.TryRetainExternalOwner()).IsTrue();
+
+        await Assert.That(stale.TryReleaseExternalOwner()).IsFalse();
+        await Assert.That(current.TryReleaseExternalOwner()).IsTrue();
+    }
+
+    [Test]
     [Timeout(120_000)]
     public async Task BufferMemory_AckedWaves_AlwaysReleaseReservations(
         CancellationToken cancellationToken)
@@ -143,6 +159,44 @@ public sealed class PendingResponseArrayOwnershipTests : ScriptedProduceResponse
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    private sealed class GenerationOwnershipSource :
+        IPipelinedResponseSource<ProduceResponse>,
+        IPipelinedResponseExternalOwnership
+    {
+        private const int Retained = 1;
+        private const int Released = 2;
+        private int _generation;
+        private int _readiness;
+
+        public void Reset(int generation)
+        {
+            _generation = generation;
+            _readiness = 0;
+        }
+
+        public bool TryRetainExternalOwner(int generation) =>
+            generation == Volatile.Read(ref _generation)
+            && Interlocked.CompareExchange(ref _readiness, Retained, 0) == 0;
+
+        public bool TryReleaseExternalOwner(int generation) =>
+            generation == Volatile.Read(ref _generation)
+            && Interlocked.CompareExchange(ref _readiness, Released, Retained) == Retained;
+
+        public ProduceResponse GetResult(short token) => throw new NotSupportedException();
+
+        public ValueTaskSourceStatus GetStatus(short token) => ValueTaskSourceStatus.Pending;
+
+        public void OnCompleted(
+            Action<object?> continuation,
+            object? state,
+            short token,
+            ValueTaskSourceOnCompletedFlags flags) => throw new NotSupportedException();
+
+        public void Abandon(short token)
+        {
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/PendingResponseArrayOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PendingResponseArrayOwnershipTests.cs
@@ -58,12 +58,12 @@ public sealed class PendingResponseArrayOwnershipTests : ScriptedProduceResponse
             default,
             ArrayPool<ReadyBatch>.Shared.Rent(1),
             ArrayPool<int>.Shared.Rent(1),
-            TopicIds: null,
-            ApiVersion: 12,
-            Count: 0,
-            EncodedBytes: 0,
-            DataBytes: 0,
-            RequestStartTime: 0,
+            topicIds: null,
+            apiVersion: 12,
+            count: 0,
+            encodedBytes: 0,
+            dataBytes: 0,
+            requestStartTime: 0,
             default);
         var copy = pending;
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PendingResponseOwnershipBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PendingResponseOwnershipBenchmarks.cs
@@ -17,6 +17,7 @@ public class PendingResponseOwnershipBenchmarks
     private static readonly ReadyBatch[] EmptyBatches = [];
     private static readonly int[] EmptyGenerations = [];
     private readonly ExternalOwnershipSource _source = new();
+
     [Benchmark(Baseline = true)]
     public bool GuardPerRequest()
     {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PendingResponseOwnershipBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PendingResponseOwnershipBenchmarks.cs
@@ -61,15 +61,15 @@ public class PendingResponseOwnershipBenchmarks
 
         public void Reset() => _readiness = 0;
 
-        public bool TryRetainExternalOwner(short token)
+        public bool TryRetainExternalOwner(int generation)
         {
             var readiness = Volatile.Read(ref _readiness);
-            return token == 0
+            return generation == 0
                 && Interlocked.CompareExchange(ref _readiness, readiness | 4, readiness) == readiness;
         }
 
-        public bool TryReleaseExternalOwner(short token) =>
-            token == 0 && (Interlocked.Or(ref _readiness, 8) & 8) == 0;
+        public bool TryReleaseExternalOwner(int generation) =>
+            generation == 0 && (Interlocked.Or(ref _readiness, 8) & 8) == 0;
 
         public ProduceResponse GetResult(short token) => throw new NotSupportedException();
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PendingResponseOwnershipBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PendingResponseOwnershipBenchmarks.cs
@@ -1,0 +1,87 @@
+using System.Threading.Tasks.Sources;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures the one-time array-return claim attached to each acknowledged produce request.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class PendingResponseOwnershipBenchmarks
+{
+    private static readonly ReadyBatch[] EmptyBatches = [];
+    private static readonly int[] EmptyGenerations = [];
+    private readonly ExternalOwnershipSource _source = new();
+    [Benchmark(Baseline = true)]
+    public bool GuardPerRequest()
+    {
+        var pending = new BrokerSender.PendingResponse(
+            default,
+            EmptyBatches,
+            EmptyGenerations,
+            topicIds: null,
+            apiVersion: 12,
+            count: 1,
+            encodedBytes: 0,
+            dataBytes: 0,
+            requestStartTime: 0,
+            default);
+        return pending.TryAbandonArrayOwnership();
+    }
+
+    [Benchmark]
+    public bool PooledResponseClaim()
+    {
+        _source.Reset();
+        var pending = BrokerSender.PendingResponse.Create(
+            new PipelinedResponse<ProduceResponse>(_source, token: 0),
+            EmptyBatches,
+            EmptyGenerations,
+            topicIds: null,
+            apiVersion: 12,
+            count: 1,
+            encodedBytes: 0,
+            dataBytes: 0,
+            requestStartTime: 0,
+            default);
+        return pending.TryAbandonArrayOwnership();
+    }
+
+    private sealed class ExternalOwnershipSource :
+        IPipelinedResponseSource<ProduceResponse>,
+        IPipelinedResponseExternalOwnership
+    {
+        private int _readiness;
+
+        public void Reset() => _readiness = 0;
+
+        public bool TryRetainExternalOwner(short token)
+        {
+            var readiness = Volatile.Read(ref _readiness);
+            return token == 0
+                && Interlocked.CompareExchange(ref _readiness, readiness | 4, readiness) == readiness;
+        }
+
+        public bool TryReleaseExternalOwner(short token) =>
+            token == 0 && (Interlocked.Or(ref _readiness, 8) & 8) == 0;
+
+        public ProduceResponse GetResult(short token) => throw new NotSupportedException();
+
+        public ValueTaskSourceStatus GetStatus(short token) => ValueTaskSourceStatus.Pending;
+
+        public void OnCompleted(
+            Action<object?> continuation,
+            object? state,
+            short token,
+            ValueTaskSourceOnCompletedFlags flags) => throw new NotSupportedException();
+
+        public void Abandon(short token)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move acknowledged produce-request array ownership onto the existing pooled, versioned response source
- retain the reference guard only for task-backed/test response sources
- delay response-source pool return until completion, consumption, and external array release all finish
- add lifecycle/concurrency coverage and a permanent MemoryDiagnoser benchmark

## Before / after
Exact product baseline: `456167f68d555d24e8ce2a7ae3a204e554f7ea29`
Candidate: `2ac621d9a4e8f9dcc66e55ef0272c0522f7975ce`
Machine: i7-12700K, .NET 10.0.11, Windows 11

### Ownership microbenchmark
`PendingResponseOwnershipBenchmarks` (10 measured iterations):

| path | mean | allocated |
|---|---:|---:|
| guard per request (before) | 5.106 ns | 24 B |
| pooled response claim (after) | 13.615 ns | 0 B |

The 8.509 ns bookkeeping increase is once per produce request/batch, not once per message. The fire-and-forget bracket below validates the broader producer path but does not execute the ownership claim; the acknowledged-produce A-B-A bracket supplies the causal end-to-end evidence.

### Post-review ABA hardening
Review fix: `d41bcf0cd355008fe08b5df56098b78c78027154` → `a8ba9d9bfb93125ccb862e4ab572ee2dfac9fdc1`

| metric | before | after | delta |
|---|---:|---:|---:|
| pooled response claim | 13.544 ns | 13.636 ns | +0.68% |
| allocated | 0 B | 0 B | 0 B |

The timing confidence intervals overlap; no material regression. The fix separates the `short` ValueTask token from a non-wrapping ownership generation and retires each source before generation reuse.

### Real Kafka producer bracket
`producer-fire-forget 10 1000 100 1`, identical machine/configuration; baseline → candidate → baseline:

| run | throughput | allocated | GC |
|---|---:|---:|---:|
| baseline A | 102,234 msg/s | 11.00 MB | 0/0/0 |
| candidate | 103,432 msg/s | 9.90 MB | 0/0/0 |
| baseline B | 103,197 msg/s | 11.13 MB | 0/0/0 |

Candidate throughput is +1.17% vs baseline A and +0.23% vs baseline B. Allocated bytes fall 10.0% and 11.1%, respectively. No GC or stability regression observed.

## Acknowledged-produce A-B-A
Exact product baseline: `456167f68d555d24e8ce2a7ae3a204e554f7ea29`
Candidate: `a8ba9d9bfb93125ccb862e4ab572ee2dfac9fdc1`
Machine: i7-12700K, .NET 10.0.11, Windows 11, Docker Desktop Kafka 4.3.1
Configuration: `producer-acks-all`, Dekaf only, 3 minutes, 1000 B messages, 6 partitions, 5 ms linger, 1 MiB batch, 1 broker, 1 connection; baseline → candidate → baseline.

| run | delivered msg/s | median msg/s | CPU μs/msg | alloc B/msg | p50 | p95 | p99 | max |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| baseline A | 197,887 | 202,751 | 0.952 | 2.197 | 45.65 ms | 221.65 ms | 337.15 ms | 1,070.43 ms |
| candidate | 218,251 | 221,144 | 0.968 | 2.154 | 40.85 ms | 161.25 ms | 235.35 ms | 436.46 ms |
| baseline B | 200,438 | 205,240 | 0.984 | 2.195 | 41.55 ms | 195.75 ms | 297.15 ms | 691.55 ms |

| run | delivered | errors | GC 0/1/2 | drift | slope/min | steady-state/peak |
|---|---:|---:|---:|---:|---:|---:|
| baseline A | 100% | 0 | 3/1/1 | +6.49% | +3.85% | 84.54% |
| candidate | 100% | 0 | 3/1/1 | +1.41% | +1.85% | 86.40% |
| baseline B | 100% | 0 | 3/1/1 | +6.57% | +2.36% | 84.03% |

Candidate throughput is +10.29% vs baseline A and +8.89% vs baseline B. CPU/message sits inside the baseline bracket (+1.67% / -1.62%), allocation/message improves 1.94% / 1.86%, every latency percentile and max improve, and stability clears the 85% steady-state/peak threshold that both controls narrowly miss. No protected metric regresses.
## Verification
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release` (0 warnings/errors; net8.0 + net10.0)
- `KafkaConnectionTests/PipelinedResponse*`: 6/6
- `PendingResponseArrayOwnershipTests`: 5/5
- `BrokerSenderSendLoopTests`: 74/74
- `PendingResponseOwnershipBenchmarks`: 24 B → 0 B
- real Kafka baseline → candidate → baseline profile above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when managing pooled responses during asynchronous operations.
  - Prevented responses from returning to the pool while still held by an external operation.
  - Added safeguards against duplicate or stale ownership claims and releases.
  - Ensured pending response resources are correctly cleaned up when sending fails.

- **Tests**
  - Added coverage for response ownership, pooling, and generation safety.
  - Added benchmarks to measure ownership-management overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



## Self-review ownership-claim hardening
Commit: `d5d05695a69cc9e88c16bb956227bdb878238303`

`PendingResponse.Create` now distinguishes an unsupported external-ownership source from a pooled source that rejected its generation claim. Unsupported task/test sources keep the fallback guard; rejected pooled claims fail the invariant instead of allowing the response source to recycle while the pending response still references it.

| ownership microbenchmark | before | after | delta | allocated |
|---|---:|---:|---:|---:|
| pooled response claim | 13.732 ns | 13.666 ns | -0.48% | 0 B → 0 B |

99.9% confidence intervals overlap (`13.589–13.875 ns` before; `13.500–13.833 ns` after). No material timing regression; zero-allocation gate preserved.

Validation: dual-target unit build and benchmark build clean; `PendingResponseArrayOwnershipTests` 6/6; `KafkaConnectionTests/PipelinedResponse_*` 6/6; `BrokerSenderSendLoopTests` 74/74; concurrent external-owner lifecycle 20/20 repeated runs.

## Review-requested ownership coverage
Commit: `7db545cac608dd4ddf9f39c2711ec21f94cf05c5`

- deterministic `MaxOwnershipGeneration` retirement coverage: 1/1
- Testcontainers.Kafka acknowledged-response retain/release/reset/reuse coverage: 1/1
- dual-target unit build: 0 warnings/errors
- dual-target integration build: 0 warnings/errors

This commit changes tests only; the `d5d05695` MemoryDiagnoser result remains the final product-code benchmark: 13.732 ns → 13.666 ns (-0.48%), 0 B → 0 B.
