### PR TITLE
Fix producer fire hot-path benchmark completion

### DIFF
--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
@@ -93,8 +93,17 @@ public class ProducerFireHotPathBenchmarks
         {
             var result = _producer.FireAsync(Topic, Keys[i], _value);
             if (!result.IsCompletedSuccessfully)
-                result.GetAwaiter().GetResult();
+                WaitForCompletion(result);
         }
+    }
+
+    private static void WaitForCompletion(ValueTask pending)
+    {
+        var spinner = new SpinWait();
+        while (!pending.IsCompleted)
+            spinner.SpinOnce();
+
+        pending.GetAwaiter().GetResult();
     }
 
     private void DrainLoop(CancellationToken cancellationToken)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Reflection;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
@@ -20,12 +19,13 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 public class ProducerFireHotPathBenchmarks
 {
     private const string Topic = "producer-fire-hot-path";
+    private const long FixtureCapacityBytes = 1L << 30;
     private static readonly string[] Keys = BenchmarkData.CreateKeys(10_000);
 
     private KafkaProducer<string, string> _producer = null!;
     private RecordAccumulator _accumulator = null!;
     private CancellationTokenSource _drainerCts = null!;
-    private Task _drainerTask = null!;
+    private Thread _drainerThread = null!;
     private string _value = null!;
 
     [Params(1000)]
@@ -45,7 +45,7 @@ public class ProducerFireHotPathBenchmarks
             {
                 BootstrapServers = ["localhost:9092"],
                 ClientId = "producer-fire-hot-path",
-                BufferMemory = 256UL * 1024 * 1024,
+                BufferMemory = (ulong)FixtureCapacityBytes,
                 BatchSize = 1_048_576,
                 LingerMs = 1_000,
                 RequestTimeoutMs = 500,
@@ -54,7 +54,7 @@ public class ProducerFireHotPathBenchmarks
                 EnableIdempotence = false,
                 DeliveryLatencyTargetMs = DeliveryLatencyTargetMs,
                 // Keep admission non-blocking so this measures front-end CPU, not drainer scheduling.
-                UnackedByteBudgetCapOverride = 1L << 30,
+                UnackedByteBudgetCapOverride = FixtureCapacityBytes,
             },
             Serializers.String,
             Serializers.String);
@@ -64,9 +64,23 @@ public class ProducerFireHotPathBenchmarks
         SetInstanceField(_producer, "_initialized", true);
 
         _accumulator = _producer.RecordAccumulator;
+        if (_accumulator.GetBrokerUnackedBudget(brokerId: 0) is { } budget)
+        {
+            // Measure admission bookkeeping, not an intentionally-tight adaptive window.
+            // The stopped sender cannot provide real acknowledgement pacing, so keep the
+            // explicit benchmark cap published while the drainer releases each charge.
+            SetInstanceField(budget, "_budgetBytes", FixtureCapacityBytes);
+        }
+
         _value = new string('x', MessageSize);
         _drainerCts = new CancellationTokenSource();
-        _drainerTask = Task.Run(() => DrainLoop(_drainerCts.Token));
+        _drainerThread = new Thread(() => DrainLoop(_drainerCts.Token))
+        {
+            IsBackground = true,
+            Name = "producer-fire-hot-path-drainer",
+            Priority = ThreadPriority.Highest,
+        };
+        _drainerThread.Start();
 
         FireBatch();
     }
@@ -74,14 +88,9 @@ public class ProducerFireHotPathBenchmarks
     [GlobalCleanup]
     public async Task Cleanup()
     {
-        await _drainerCts.CancelAsync().ConfigureAwait(false);
-        try
-        {
-            await _drainerTask.ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-        }
+        _drainerCts.Cancel();
+        _drainerThread.Join();
+        _drainerCts.Dispose();
 
         await _producer.DisposeAsync().ConfigureAwait(false);
     }
@@ -93,17 +102,12 @@ public class ProducerFireHotPathBenchmarks
         {
             var result = _producer.FireAsync(Topic, Keys[i], _value);
             if (!result.IsCompletedSuccessfully)
-                WaitForCompletion(result);
+            {
+                throw new InvalidOperationException(
+                    $"Producer front-end became asynchronous; benchmark fixture failed to keep its drainer ahead. " +
+                    $"BufferedBytes={_accumulator.BufferedBytes}, PendingAppends={_accumulator.PendingAppendCountForTest}.");
+            }
         }
-    }
-
-    private static void WaitForCompletion(ValueTask pending)
-    {
-        var spinner = new SpinWait();
-        while (!pending.IsCompleted)
-            spinner.SpinOnce();
-
-        pending.GetAwaiter().GetResult();
     }
 
     private void DrainLoop(CancellationToken cancellationToken)
@@ -113,19 +117,6 @@ public class ProducerFireHotPathBenchmarks
         {
             if (_accumulator.TryDrainBatch(out var batch))
             {
-                if (batch.UnackedBudget is { } budget)
-                {
-                    var acknowledgedAt = Stopwatch.GetTimestamp();
-                    var sentAt = acknowledgedAt - Stopwatch.Frequency / 1_000;
-                    var snapshot = budget.SnapshotDelivery(
-                        sentAt,
-                        appLimited: false,
-                        batch.StopwatchCreatedTicks,
-                        batch.AdmissionGeneration);
-                    budget.OnAcked(batch.DataSize, snapshot, acknowledgedAt);
-                    budget.CompleteAckedPass(acknowledgedAt);
-                }
-
                 _accumulator.OnBatchExitsPipeline(batch);
                 _accumulator.ReleaseMemory(batch.DataSize);
                 _accumulator.ReturnReadyBatch(batch);


### PR DESCRIPTION
## What changed

- Keep the `FireAsync` benchmark measured region strictly synchronous.
- Use a dedicated high-priority drainer thread and 1 GiB fixture headroom.
- Hold the benchmark-only published admission window at the explicit cap because the stopped sender cannot supply real acknowledgement pacing.
- Fail immediately if the producer front end becomes asynchronous instead of measuring drainer scheduling.

## Root cause

The original benchmark called `GetResult()` on an incomplete pooled `ValueTask`, so three of four parameter combinations failed with `InvalidOperationException`.

The first fix waited inside the benchmark invocation. Review correctly identified that this mixed OS scheduling and drainer contention into the producer front-end measurement. The final fixture keeps completion synchronous and treats failure to do so as an invalid benchmark setup.

## Benchmark evidence

BenchmarkDotNet, Release, `[MemoryDiagnoser]`:

| Version | Target ms | Partitions | Mean | Allocated |
|---|---:|---:|---:|---:|
| Baseline `ef66d00f` | 0 | 12 | 206.4 ns | 0 B |
| Baseline `ef66d00f` | other 3 cases | — | failed | — |
| Spin-wait interim `7ff3ca25` | 0 | 1 | 209.9 ns | 0 B |
| Spin-wait interim `7ff3ca25` | 0 | 12 | 209.0 ns | 0 B |
| Spin-wait interim `7ff3ca25` | 10 | 1 | 1,865.7 ns | 0 B |
| Spin-wait interim `7ff3ca25` | 10 | 12 | 2,695.1 ns | 0 B |
| Final `ec2ed364` | 0 | 1 | 207.1 ns | 0 B |
| Final `ec2ed364` | 0 | 12 | 219.2 ns | 0 B |
| Final `ec2ed364` | 10 | 1 | 226.8 ns | 0 B |
| Final `ec2ed364` | 10 | 12 | 228.1 ns | 0 B |

The 10 ms cases dropping from 1.87–2.70 µs to 227–228 ns demonstrates that the measured wait was fixture scheduling contamination, not producer front-end work. All final cases remain zero-allocation.

## Validation

- `dotnet build tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj --configuration Release`
- `dotnet run --project tools/Dekaf.Benchmarks --configuration Release --no-build -- --filter "*ProducerFireHotPathBenchmarks*" --artifacts ".artifacts/review-fix-final"`
- Final code simplification review completed; no behavior-expanding cleanup applied.
