### PR TITLE
Park deferred producer linger batches

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1442,6 +1442,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         public int LingerQueued;
 
         /// <summary>
+        /// 1 when an expired partial batch is parked behind a muted or in-flight predecessor.
+        /// The predecessor's exit reactivates linger instead of polling the partition.
+        /// </summary>
+        public int LingerDeferred;
+
+        /// <summary>
         /// True while a thread has detached CurrentBatch and is completing it outside Lock.
         /// Appenders wait for the ready batch to be enqueued before creating or rotating another batch.
         /// </summary>
@@ -2296,6 +2302,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (HasQueuedBatches(tp))
             _readyPartitions.Enqueue(tp);
 
+        if (_partitionDeques.TryGetValue(tp, out var pd))
+            ReactivateDeferredLinger(tp, pd);
+
         SignalWakeup(); // Wake sender loop so it can drain the newly-unmuted partition
     }
     internal bool IsMuted(TopicPartition tp) => _mutedPartitions.ContainsKey(tp);
@@ -2604,6 +2613,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// Computes how long the linger loop may sleep before the earliest unsealed batch can
     /// reach its linger deadline. Based on the oldest-batch hint (a lower bound on the oldest
     /// unsealed batch's creation time), so the result can only wake the loop early, never late.
+    /// When every expired batch is deferred, waits until the next orphan check or an explicit
+    /// predecessor-exit signal instead of polling an already-expired deadline.
     /// Clamped to [1, <paramref name="maxWaitMs"/>]: the 1 ms floor prevents a busy spin when
     /// a deadline has already passed (e.g. a muted partition defers its seal past linger).
     /// </summary>
@@ -2616,6 +2627,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             : _options.LingerMs;
 
         var oldestTicks = Volatile.Read(ref _oldestBatchCreatedTicks);
+        if (oldestTicks == long.MaxValue && HasUnsealedBatches())
+            return Math.Max(1, maxWaitMs);
+
         var elapsedMs = oldestTicks == long.MaxValue
             ? 0.0
             : Stopwatch.GetElapsedTime(oldestTicks).TotalMilliseconds;
@@ -3261,6 +3275,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void TrackCurrentBatchForLinger(PartitionDeque pd, TopicPartition topicPartition, PartitionBatch batch)
     {
+        Volatile.Write(ref pd.LingerDeferred, 0);
         var observedSweepVersion = Volatile.Read(ref _lingerSweepVersion);
         var shortensDeadline = TrackOldestBatchCreated(batch.CreatedAtStopwatchTimestamp);
         QueueLingerPartition(
@@ -3322,6 +3337,27 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private static void MarkLingerPartitionDequeued(PartitionDeque pd)
     {
         Volatile.Write(ref pd.LingerQueued, 0);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ClearLingerPartitionTracking(PartitionDeque pd)
+    {
+        MarkLingerPartitionDequeued(pd);
+        Volatile.Write(ref pd.LingerDeferred, 0);
+    }
+
+    private void ReactivateDeferredLinger(TopicPartition topicPartition, PartitionDeque pd)
+    {
+        if (Volatile.Read(ref pd.LingerDeferred) == 0
+            || Volatile.Read(ref pd.QueueBytes) > 0
+            || _mutedPartitions.ContainsKey(topicPartition)
+            || Interlocked.CompareExchange(ref pd.LingerDeferred, 0, 1) != 1)
+        {
+            return;
+        }
+
+        QueueLingerPartition(pd, topicPartition, signalLingerLoop: false);
+        _lingerWakeupSignal.Signal();
     }
 
     /// <summary>
@@ -3552,7 +3588,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             else
                             {
                                 pd.CurrentBatch = null;
-                                MarkLingerPartitionDequeued(pd);
+                                ClearLingerPartitionTracking(pd);
                                 Interlocked.Decrement(ref _unsealedBatchCount);
                                 ClearRotationInProgressUnderLock(pd);
                                 ownsRotation = false;
@@ -4001,7 +4037,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             else
                             {
                                 pd.CurrentBatch = null;
-                                MarkLingerPartitionDequeued(pd);
+                                ClearLingerPartitionTracking(pd);
                                 Interlocked.Decrement(ref _unsealedBatchCount);
                                 ClearRotationInProgressUnderLock(pd);
                                 ownsRotation = false;
@@ -4525,7 +4561,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private PartitionBatch DetachCurrentBatchForSealUnderLock(PartitionDeque pd, PartitionBatch currentBatch)
     {
         pd.CurrentBatch = null;
-        MarkLingerPartitionDequeued(pd);
+        ClearLingerPartitionTracking(pd);
         pd.RotationInProgress = true;
         Interlocked.Decrement(ref _unsealedBatchCount);
         return currentBatch;
@@ -4651,7 +4687,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void RemovePartitionQueueBytes(PartitionDeque pd, int bytes)
+    private static bool RemovePartitionQueueBytes(PartitionDeque pd, int bytes)
     {
         var current = Volatile.Read(ref pd.QueueBytes);
         while (true)
@@ -4659,7 +4695,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             var updated = Math.Max(0, current - bytes);
             var observed = Interlocked.CompareExchange(ref pd.QueueBytes, updated, current);
             if (observed == current)
-                return;
+                return updated == 0;
 
             current = observed;
         }
@@ -5395,7 +5431,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             {
                 Interlocked.Decrement(ref _unsealedBatchCount);
                 pd.CurrentBatch = null;
-                MarkLingerPartitionDequeued(pd);
+                ClearLingerPartitionTracking(pd);
                 ClearAdmissionFlushRequestUnderLock(pd);
             }
         }
@@ -5429,6 +5465,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (Volatile.Read(ref _pendingAwaitedProduceCount) == 0)
         {
             var oldestTicks = Volatile.Read(ref _oldestBatchCreatedTicks);
+            if (oldestTicks == long.MaxValue && _lingerPartitions.IsEmpty)
+                return default;
+
             if (oldestTicks != long.MaxValue)
             {
                 var millisSinceOldest = (long)Stopwatch.GetElapsedTime(oldestTicks).TotalMilliseconds;
@@ -5591,6 +5630,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         ReadyBatch? sealedBatch = null;
         PartitionBatch? batchToComplete = null;
+        var lingerDeferred = false;
         var spinner = new SpinWait();
 
         while (true)
@@ -5608,6 +5648,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 }
                 else if (pd.CurrentBatch is null)
                 {
+                    Volatile.Write(ref pd.LingerDeferred, 0);
                     ClearAdmissionFlushRequestUnderLock(pd);
                     break;
                 }
@@ -5615,23 +5656,33 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 // Keep its partial arena open so zero-linger appends coalesce instead of
                 // allocating one BatchSize arena per record while they wait. Size-full batches
                 // still seal in the append path, and FlushAsync must always seal.
-                else if (sealAll
-                    || IsAdmissionFlushRequiredUnderLock(pd)
-                    || (!ShouldDeferPartialBatchSeal(pd, pd.CurrentBatch)
-                        && pd.CurrentBatch.ShouldFlush(now, _options.LingerMs)))
-                {
-                    ProducerDebugCounters.RecordBatchFlushedFromDictionary();
-                    batchToComplete = DetachCurrentBatchForSealUnderLock(pd, pd.CurrentBatch);
-                    break;
-                }
                 else
                 {
-                    var batchCreatedTicks = pd.CurrentBatch.CreatedAtStopwatchTimestamp;
-                    if (batchCreatedTicks < newOldestTicks)
-                        newOldestTicks = batchCreatedTicks;
+                    var currentBatch = pd.CurrentBatch;
+                    var shouldDefer = !sealAll && ShouldDeferPartialBatchSeal(pd, currentBatch);
+                    var forceSeal = sealAll || IsAdmissionFlushRequiredUnderLock(pd);
+                    var shouldFlush = forceSeal || currentBatch.ShouldFlush(now, _options.LingerMs);
 
-                    if (!sealAll)
-                        QueueLingerPartition(pd, topicPartition, signalLingerLoop: false);
+                    if (forceSeal || (shouldFlush && !shouldDefer))
+                    {
+                        ProducerDebugCounters.RecordBatchFlushedFromDictionary();
+                        batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
+                    }
+                    else if (shouldFlush)
+                    {
+                        Volatile.Write(ref pd.LingerDeferred, 1);
+                        lingerDeferred = true;
+                    }
+                    else
+                    {
+                        Volatile.Write(ref pd.LingerDeferred, 0);
+                        var batchCreatedTicks = currentBatch.CreatedAtStopwatchTimestamp;
+                        if (batchCreatedTicks < newOldestTicks)
+                            newOldestTicks = batchCreatedTicks;
+
+                        if (!sealAll)
+                            QueueLingerPartition(pd, topicPartition, signalLingerLoop: false);
+                    }
                     break;
                 }
             }
@@ -5651,6 +5702,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             cancellationToken.ThrowIfCancellationRequested();
             spinner.SpinOnce();
         }
+
+        if (lingerDeferred)
+            ReactivateDeferredLinger(topicPartition, pd);
 
         if (batchToComplete is null)
             return false;
@@ -5761,8 +5815,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             SignalBufferSpaceAvailable();
         }
 
-        if (_partitionDeques.TryGetValue(batch.TopicPartition, out var pd))
-            RemovePartitionQueueBytes(pd, batch.DataSize);
+        if (_partitionDeques.TryGetValue(batch.TopicPartition, out var pd)
+            && RemovePartitionQueueBytes(pd, batch.DataSize))
+        {
+            ReactivateDeferredLinger(batch.TopicPartition, pd);
+        }
 
         if (_options.EnableDeliveryDiagnostics)
             batch.AppendDiag('X');
@@ -6765,7 +6822,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         if (pd.CurrentBatch is { } currentBatch)
                         {
                             pd.CurrentBatch = null;
-                            MarkLingerPartitionDequeued(pd);
+                            ClearLingerPartitionTracking(pd);
                             ClearAdmissionFlushRequestUnderLock(pd);
                             Interlocked.Decrement(ref _unsealedBatchCount);
 
@@ -7188,7 +7245,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             if (pd.CurrentBatch is { } current)
                             {
                                 pd.CurrentBatch = null;
-                                MarkLingerPartitionDequeued(pd);
+                                ClearLingerPartitionTracking(pd);
                                 ClearAdmissionFlushRequestUnderLock(pd);
                                 Interlocked.Decrement(ref _unsealedBatchCount);
 

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -919,11 +919,16 @@ public class RecordAccumulatorReadyTests
 
             await Assert.That(appended).IsTrue();
             await Assert.That(accumulator.TryGetBatch("test-topic", 0, out _)).IsTrue();
+            await Assert.That(await accumulator.WaitForLingerWakeupAsync(5_000)).IsTrue();
 
             await accumulator.ExpireLingerAsync(CancellationToken.None);
             await Assert.That(accumulator.TryGetBatch("test-topic", 0, out _)).IsTrue();
+            await Assert.That(GetPrivateField<ConcurrentQueue<TopicPartition>>(accumulator, "_lingerPartitions").IsEmpty).IsTrue();
+            await Assert.That(accumulator.GetMillisUntilEarliestLingerDeadline(5_000)).IsEqualTo(5_000);
 
+            var lingerWakeup = accumulator.WaitForLingerWakeupAsync(5_000).AsTask();
             accumulator.UnmutePartition(topicPartition);
+            await Assert.That(await lingerWakeup).IsTrue();
             await accumulator.ExpireLingerAsync(CancellationToken.None);
             await Assert.That(accumulator.TryGetBatch("test-topic", 0, out _)).IsFalse();
 
@@ -1033,8 +1038,19 @@ public class RecordAccumulatorReadyTests
         await Assert.That(accumulator.TryGetBatch("test-topic", 0, out _)).IsTrue()
             .Because("an in-flight predecessor should keep the next partial batch open");
 
+        await accumulator.ExpireLingerAsync(CancellationToken.None);
+        await Assert.That(GetPrivateField<ConcurrentQueue<TopicPartition>>(accumulator, "_lingerPartitions").IsEmpty).IsTrue();
+        await Assert.That(accumulator.GetMillisUntilEarliestLingerDeadline(5_000)).IsEqualTo(5_000);
+
+        while (await accumulator.WaitForLingerWakeupAsync(1))
+        {
+        }
+
+        var lingerWakeup = accumulator.WaitForLingerWakeupAsync(5_000).AsTask();
+
         firstBatch!.CompleteSend(baseOffset: 0, timestamp: DateTimeOffset.UtcNow);
         accumulator.OnBatchExitsPipeline(firstBatch);
+        await Assert.That(await lingerWakeup).IsTrue();
         accumulator.ReturnReadyBatch(firstBatch);
 
         await accumulator.ExpireLingerAsync(CancellationToken.None);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/DeferredLingerSweepBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/DeferredLingerSweepBenchmarks.cs
@@ -1,0 +1,68 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Producer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures a linger wake after an expired partial batch has been deferred behind an
+/// earlier in-flight batch. The steady state models small batches under sustained load.
+/// </summary>
+[MemoryDiagnoser]
+public class DeferredLingerSweepBenchmarks
+{
+    private RecordAccumulator _accumulator = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _accumulator = new RecordAccumulator(new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 100_000,
+            LingerMs = 0,
+            EnableIdempotence = false,
+            MaxInFlightRequestsPerConnection = 2
+        });
+
+        Append("first"u8);
+        if (!_accumulator.TryDrainBatch(out _))
+            throw new InvalidOperationException("Expected the first batch to enter the pipeline.");
+
+        Append("second"u8);
+        ExpireLinger();
+    }
+
+    [Benchmark]
+    public void ExpiredBatchBlockedByPipelineBatch() => ExpireLinger();
+
+    [GlobalCleanup]
+    public async Task Cleanup() => await _accumulator.DisposeAsync();
+
+    private void Append(ReadOnlySpan<byte> value)
+    {
+        var append = _accumulator.AppendFromSpansAsync(
+            "benchmark-topic",
+            partition: 0,
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            value,
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 1);
+
+        if (!append.IsCompletedSuccessfully || !append.Result)
+            throw new InvalidOperationException("Expected synchronous append completion.");
+    }
+
+    private void ExpireLinger()
+    {
+        var expire = _accumulator.ExpireLingerAsync(CancellationToken.None);
+        if (!expire.IsCompletedSuccessfully)
+            expire.GetAwaiter().GetResult();
+    }
+}


### PR DESCRIPTION
## Summary

- park expired partial batches while a partition is muted or has an earlier pipeline batch
- reactivate linger from final unmute or the pipeline queue-byte transition to zero
- close the exit-vs-defer race without polling or per-message allocation
- add a focused `[MemoryDiagnoser]` benchmark and event-driven regression tests

## Profile finding

A 16 KiB real-Kafka producer profile showed repeated `SealBatchesAsync` work: blocked partial batches retained an expired oldest-deadline hint, so the linger loop woke every 1 ms, reacquired the flush/linger semaphore, locked the partition, and requeued the same batch.

Baseline product SHA: `ef66d00fe2dd0f2bab50eef3b2196fcdb844045c`

## BenchmarkDotNet

Same machine/runtime (.NET 10.0.11, i7-12700K):

| Benchmark | Before | After | Delta | Allocated |
|---|---:|---:|---:|---:|
| ExpiredBatchBlockedByPipelineBatch | 137.009 ns | 1.593 ns | -98.8% | 0 B -> 0 B |
| AppendHotPath, 100 B | 70.44 ns | 69.43 ns | -1.4% | 0 B -> 0 B |
| AppendHotPath, 1,000 B | 155.47 ns | 152.58 ns | -1.9% | 0 B -> 0 B |

All six AccumulatorAppend variants remained 0 B/op.

## Real Kafka check

Identical local shape: 10 s/variant, 1,000 B messages, 16 KiB batches, 6 partitions, 1 connection/broker.

| Run | Non-idempotent msg/s | B/msg | Idempotent msg/s | B/msg | Gen2 |
|---|---:|---:|---:|---:|---:|
| Before | 68,494 | 7.0 | 71,779 | 4.9 | 0 / 0 |
| After 1 | 69,913 | 5.8 | 68,767 | 3.2 | 0 / 0 |
| After 2 | 67,677 | 7.1 | 72,087 | 3.7 | 0 / 0 |

The short Kafka runs bracket the baseline in opposite directions, indicating runner/broker noise rather than a consistent throughput trade. The isolated causal benchmark removes the repeated sweep cost by 98.8%, while append throughput and zero-allocation behavior remain protected.

## Verification

- `dotnet build --configuration Release`: 0 warnings, 0 errors
- unit tests: 6,696 passed
- producer integration tests: 64 passed
- simplify review completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved handling of delayed partial batches when earlier batches are still processing or partitions are temporarily paused.
  * Reduced unnecessary polling while waiting for batches to become eligible for delivery.
  * Improved flushing behavior for app-limited and bulk produce operations.

* **Reliability**
  * Improved linger expiration, wakeups, and batch cleanup across retries, failures, rotation, and disposal.
  * Added coverage for deferred batch processing and related timing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->