### PR TITLE
Reuse produce-path monotonic clock read

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1110,7 +1110,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // FAST PATH: Check thread-local cached topic metadata first.
         // Avoids MetadataManager dictionary lookup for consecutive messages to the same topic.
         TopicInfo? topicInfo;
-        if (!TryGetCachedTopicInfo(topic, out topicInfo))
+        if (!TryGetCachedTopicInfo(topic, out topicInfo, out var currentTicks))
         {
             // Cache miss - try MetadataManager
             if (!_metadataManager.TryGetCachedTopicMetadata(topic, out topicInfo) || topicInfo is null)
@@ -1119,7 +1119,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             }
 
             // Update thread-local cache for next call
-            UpdateCachedTopicInfo(topic, topicInfo);
+            UpdateCachedTopicInfo(topic, topicInfo, currentTicks);
         }
 
         if (topicInfo!.PartitionCount == 0)
@@ -1131,7 +1131,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         completion = RentCompletion(runContinuationsAsynchronously);
         try
         {
-            TryProduceSyncCore(topic, key, value, headers, partition, timestamp, topicInfo, completion, cancellationToken);
+            TryProduceSyncCore(topic, key, value, headers, partition, timestamp, topicInfo, completion, currentTicks, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -1214,16 +1214,16 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             return FireWithAsyncSerializationAsync(message, activity, deliveryHandler: null);
 
         // Fast path: try thread-local cached topic metadata first
-        var inThreadLocalCache = TryGetCachedTopicInfo(message.Topic, out var topicInfo);
+        var inThreadLocalCache = TryGetCachedTopicInfo(message.Topic, out var topicInfo, out var currentTicks);
         if (inThreadLocalCache ||
             (_metadataManager.TryGetCachedTopicMetadata(message.Topic, out topicInfo) && topicInfo is not null && topicInfo.PartitionCount > 0))
         {
             if (!inThreadLocalCache)
-                UpdateCachedTopicInfo(message.Topic, topicInfo!);
+                UpdateCachedTopicInfo(message.Topic, topicInfo!, currentTicks);
 
             try
             {
-                var appendResult = SerializeAndAppendFromSpansAsync(message.Topic, message.Key, message.Value, message.Headers, message.Partition, message.Timestamp, topicInfo!, null);
+                var appendResult = SerializeAndAppendFromSpansAsync(message.Topic, message.Key, message.Value, message.Headers, message.Partition, message.Timestamp, topicInfo!, null, currentTicks);
 
                 if (appendResult.IsCompleted)
                 {
@@ -1281,16 +1281,16 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         // Fast path: no ProducerMessage allocation, no interceptors, no activity tracing
-        var inThreadLocalCache = TryGetCachedTopicInfo(topic, out var topicInfo);
+        var inThreadLocalCache = TryGetCachedTopicInfo(topic, out var topicInfo, out var currentTicks);
         if (inThreadLocalCache ||
             (_metadataManager.TryGetCachedTopicMetadata(topic, out topicInfo) && topicInfo is not null && topicInfo.PartitionCount > 0))
         {
             if (!inThreadLocalCache)
-                UpdateCachedTopicInfo(topic, topicInfo!);
+                UpdateCachedTopicInfo(topic, topicInfo!, currentTicks);
 
             try
             {
-                var appendResult = SerializeAndAppendFromSpansAsync(topic, key, value, null, null, null, topicInfo!, null);
+                var appendResult = SerializeAndAppendFromSpansAsync(topic, key, value, null, null, null, topicInfo!, null, currentTicks);
 
                 if (appendResult.IsCompleted)
                 {
@@ -1319,9 +1319,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     /// Returns true if valid cached metadata exists, false if cache miss or expired.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool TryGetCachedTopicInfo(string topic, out TopicInfo? topicInfo)
+    private bool TryGetCachedTopicInfo(string topic, out TopicInfo? topicInfo, out long currentTicks)
     {
         topicInfo = null;
+        currentTicks = Dekaf.MonotonicClock.GetMilliseconds();
 
         // Early exit if disposed - prevents using stale cache from disposed producer
         if (Volatile.Read(ref _disposed) != 0)
@@ -1330,7 +1331,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // Check if cache is for this metadata manager, topic, and still valid
         // Use signed comparison to handle TickCount64 wraparound (every ~292 million years)
         var cache = GetOrCreateCache();
-        var currentTicks = Dekaf.MonotonicClock.GetMilliseconds();
         if (cache.CachedMetadataManager == _metadataManager &&
             cache.CachedTopicName == topic &&
             cache.CachedTopicInfo is not null &&
@@ -1350,6 +1350,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void UpdateCachedTopicInfo(string topic, TopicInfo topicInfo)
+        => UpdateCachedTopicInfo(topic, topicInfo, Dekaf.MonotonicClock.GetMilliseconds());
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void UpdateCachedTopicInfo(string topic, TopicInfo topicInfo, long currentTicks)
     {
         var cache = GetOrCreateCache();
         cache.CachedMetadataManager = _metadataManager;
@@ -1357,7 +1361,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         cache.CachedTopicInfo = topicInfo;
         // Cache valid for ~1 second (1000 ticks) - enough for high-throughput bursts
         // while still detecting stale metadata reasonably quickly
-        cache.CachedTopicValidUntilTicks = Dekaf.MonotonicClock.GetMilliseconds() + 1000;
+        cache.CachedTopicValidUntilTicks = currentTicks + 1000;
     }
 
     /// <summary>
@@ -1381,6 +1385,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             message.Timestamp,
             topicInfo,
             completion,
+            Dekaf.MonotonicClock.GetMilliseconds(),
             cancellationToken);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1409,6 +1414,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         DateTimeOffset? timestamp,
         TopicInfo topicInfo,
         PooledValueTaskSource<RecordMetadata> completion,
+        long currentTicks,
         CancellationToken cancellationToken)
     {
         Header[]? pooledHeaderArray = null;
@@ -1476,7 +1482,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 partition, keySpan, keyIsNull, topicInfo.PartitionCount);
 
             // Get timestamp - use fast cached timestamp when no override provided
-            var timestampMs = timestamp?.ToUnixTimeMilliseconds() ?? GetFastTimestampMs();
+            var timestampMs = timestamp?.ToUnixTimeMilliseconds() ?? GetFastTimestampMs(currentTicks);
 
             // Convert headers
             var headerCount = 0;
@@ -1678,16 +1684,16 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             return FireWithAsyncSerializationAsync(message, activity: null, deliveryHandler);
 
         // Fast path: try thread-local cached topic metadata first
-        var inThreadLocalCache = TryGetCachedTopicInfo(message.Topic, out var topicInfo);
+        var inThreadLocalCache = TryGetCachedTopicInfo(message.Topic, out var topicInfo, out var currentTicks);
         if (inThreadLocalCache ||
             (_metadataManager.TryGetCachedTopicMetadata(message.Topic, out topicInfo) && topicInfo is not null && topicInfo.PartitionCount > 0))
         {
             if (!inThreadLocalCache)
-                UpdateCachedTopicInfo(message.Topic, topicInfo!);
+                UpdateCachedTopicInfo(message.Topic, topicInfo!, currentTicks);
 
             try
             {
-                var appendResult = SerializeAndAppendFromSpansAsync(message.Topic, message.Key, message.Value, message.Headers, message.Partition, message.Timestamp, topicInfo!, deliveryHandler);
+                var appendResult = SerializeAndAppendFromSpansAsync(message.Topic, message.Key, message.Value, message.Headers, message.Partition, message.Timestamp, topicInfo!, deliveryHandler, currentTicks);
 
                 if (appendResult.IsCompleted)
                 {
@@ -1722,7 +1728,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // manager's cache; async fetch only on a true miss. The thread-local hit matters for
         // the async-serialization path (issue #2309), which routes every message through here.
         TopicInfo? topicInfo;
-        if (!TryGetCachedTopicInfo(message.Topic, out topicInfo) &&
+        if (!TryGetCachedTopicInfo(message.Topic, out topicInfo, out _) &&
             !_metadataManager.TryGetCachedTopicMetadata(message.Topic, out topicInfo))
         {
             // Slow path: cache miss, need async refresh with MaxBlockMs timeout
@@ -4529,7 +4535,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private ValueTask<bool> SerializeAndAppendFromSpansAsync(
         string topic, TKey? key, TValue value, Headers? headers, int? partition, DateTimeOffset? timestamp,
         TopicInfo topicInfo,
-        Action<RecordMetadata, Exception?>? callback)
+        Action<RecordMetadata, Exception?>? callback,
+        long currentTicks = long.MinValue)
     {
         var cache = GetOrCreateCache();
         var keyIsNull = key is null;
@@ -4566,7 +4573,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var batchCompletionPartitionCount = GetUniformStickyPartitionCount(
             partition, keySpan, keyIsNull, topicInfo.PartitionCount);
 
-        var timestampMs = timestamp?.ToUnixTimeMilliseconds() ?? GetFastTimestampMs();
+        var timestampMs = timestamp?.ToUnixTimeMilliseconds() ?? GetFastTimestampMs(currentTicks);
 
         Header[]? pooledHeaderArray = null;
         var headerCount = 0;
@@ -5001,7 +5008,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             // Metadata: thread-local cache, then manager cache, then bounded fetch
             // (mirrors FireAsyncSlow).
             TopicInfo? topicInfo;
-            if (!TryGetCachedTopicInfo(message.Topic, out topicInfo) &&
+            if (!TryGetCachedTopicInfo(message.Topic, out topicInfo, out _) &&
                 !_metadataManager.TryGetCachedTopicMetadata(message.Topic, out topicInfo))
             {
                 using var timeoutCts = new CancellationTokenSource(_options.MaxBlockMs);
@@ -5157,14 +5164,15 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     /// This is ~10x faster than DateTimeOffset.UtcNow for high-throughput scenarios.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static long GetFastTimestampMs()
+    private static long GetFastTimestampMs(long currentTicks = long.MinValue)
     {
         var cache = GetOrCreateCache();
 
         // Use a cheap monotonic counter to determine if we need to refresh.
         // TickCount64 increments every ~15.6ms on Windows, ~1ms on Linux, but checking
         // the difference is still much cheaper than calling DateTimeOffset.UtcNow.
-        var currentTicks = Dekaf.MonotonicClock.GetMilliseconds();
+        if (currentTicks == long.MinValue)
+            currentTicks = Dekaf.MonotonicClock.GetMilliseconds();
 
         // Refresh if more than ~1ms has passed (or on first call when CachedTimestampTicks is 0)
         if (currentTicks - cache.CachedTimestampTicks > 1 || cache.CachedTimestampTicks == 0)

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1728,7 +1728,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // manager's cache; async fetch only on a true miss. The thread-local hit matters for
         // the async-serialization path (issue #2309), which routes every message through here.
         TopicInfo? topicInfo;
-        if (!TryGetCachedTopicInfo(message.Topic, out topicInfo, out _) &&
+        if (!TryGetCachedTopicInfo(message.Topic, out topicInfo, out var currentTicks) &&
             !_metadataManager.TryGetCachedTopicMetadata(message.Topic, out topicInfo))
         {
             // Slow path: cache miss, need async refresh with MaxBlockMs timeout
@@ -1739,6 +1739,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 topicInfo = await _metadataManager.GetTopicMetadataAsync(message.Topic, timeoutCts.Token)
                     .ConfigureAwait(false);
+                currentTicks = Dekaf.MonotonicClock.GetMilliseconds();
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
@@ -1759,7 +1760,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             throw NoUsablePartitionsException(message.Topic, topicInfo);
         }
 
-        UpdateCachedTopicInfo(message.Topic, topicInfo);
+        UpdateCachedTopicInfo(message.Topic, topicInfo, currentTicks);
 
         // Serialize key and value to pooled memory (returned to pool when batch completes).
         // Async serializers (issue #2309) are awaited per component; a mixed configuration uses
@@ -1798,8 +1799,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 message.Partition, key.Span, keyIsNull, topicInfo.PartitionCount);
 
             // Get timestamp
-            var timestamp = message.Timestamp ?? DateTimeOffset.UtcNow;
-            var timestampMs = timestamp.ToUnixTimeMilliseconds();
+            var timestampMs = message.Timestamp?.ToUnixTimeMilliseconds()
+                ?? GetFastTimestampMs(currentTicks);
 
             // Convert headers with minimal allocations
             var headerCount = 0;
@@ -5008,7 +5009,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             // Metadata: thread-local cache, then manager cache, then bounded fetch
             // (mirrors FireAsyncSlow).
             TopicInfo? topicInfo;
-            if (!TryGetCachedTopicInfo(message.Topic, out topicInfo, out _) &&
+            if (!TryGetCachedTopicInfo(message.Topic, out topicInfo, out var currentTicks) &&
                 !_metadataManager.TryGetCachedTopicMetadata(message.Topic, out topicInfo))
             {
                 using var timeoutCts = new CancellationTokenSource(_options.MaxBlockMs);
@@ -5016,6 +5017,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 {
                     topicInfo = await _metadataManager.GetTopicMetadataAsync(message.Topic, timeoutCts.Token)
                         .ConfigureAwait(false);
+                    currentTicks = Dekaf.MonotonicClock.GetMilliseconds();
                 }
                 catch (OperationCanceledException)
                 {
@@ -5037,7 +5039,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 throw metadataException;
             }
 
-            UpdateCachedTopicInfo(message.Topic, topicInfo);
+            UpdateCachedTopicInfo(message.Topic, topicInfo, currentTicks);
 
             var keyIsNull = message.Key is null;
             var valueIsNull = message.Value is null;
@@ -5066,7 +5068,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 var appendResult = await AppendSerializedToAccumulatorAsync(
                     message.Topic, key, keyIsNull, value, valueIsNull,
                     message.Headers, message.Partition, message.Timestamp,
-                    topicInfo, deliveryHandler).ConfigureAwait(false);
+                    topicInfo, deliveryHandler, currentTicks).ConfigureAwait(false);
 
                 if (!appendResult)
                     throw new ObjectDisposedException(nameof(KafkaProducer<TKey, TValue>));
@@ -5122,14 +5124,15 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         int? explicitPartition,
         DateTimeOffset? timestamp,
         TopicInfo topicInfo,
-        Action<RecordMetadata, Exception?>? callback)
+        Action<RecordMetadata, Exception?>? callback,
+        long currentTicks)
     {
         var keySpan = key.Span;
         var partition = explicitPartition
             ?? _partitioner.Partition(topic, keySpan, keyIsNull, topicInfo.PartitionCount);
         var batchCompletionPartitionCount = GetUniformStickyPartitionCount(
             explicitPartition, keySpan, keyIsNull, topicInfo.PartitionCount);
-        var timestampMs = timestamp?.ToUnixTimeMilliseconds() ?? GetFastTimestampMs();
+        var timestampMs = timestamp?.ToUnixTimeMilliseconds() ?? GetFastTimestampMs(currentTicks);
 
         Header[]? pooledHeaderArray = null;
         var headerCount = 0;

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1771,26 +1771,46 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var valueIsNull = message.Value is null;
         var key = PooledMemory.Null;
         var value = PooledMemory.Null;
+        var serializationSuspended = false;
         Header[]? pooledHeaderArray = null;
         try
         {
             if (!keyIsNull)
             {
-                key = _asyncKeySerializer is not null
-                    ? await SerializeToPooledAsync(
+                if (_asyncKeySerializer is not null)
+                {
+                    var pendingKey = SerializeToPooledAsync(
                         _asyncKeySerializer, message.Key!, message.Topic,
-                        SerializationComponent.Key, message.Headers, cancellationToken).ConfigureAwait(false)
-                    : SerializeKeyToPooled(message.Key!, message.Topic, message.Headers);
+                        SerializationComponent.Key, message.Headers, cancellationToken);
+                    serializationSuspended |= !pendingKey.IsCompletedSuccessfully;
+                    key = await pendingKey.ConfigureAwait(false);
+                }
+                else
+                {
+                    key = SerializeKeyToPooled(message.Key!, message.Topic, message.Headers);
+                }
             }
 
             if (!valueIsNull)
             {
-                value = _asyncValueSerializer is not null
-                    ? await SerializeToPooledAsync(
+                if (_asyncValueSerializer is not null)
+                {
+                    var pendingValue = SerializeToPooledAsync(
                         _asyncValueSerializer, message.Value!, message.Topic,
-                        SerializationComponent.Value, message.Headers, cancellationToken).ConfigureAwait(false)
-                    : SerializeValueToPooled(message.Value!, message.Topic, message.Headers);
+                        SerializationComponent.Value, message.Headers, cancellationToken);
+                    serializationSuspended |= !pendingValue.IsCompletedSuccessfully;
+                    value = await pendingValue.ConfigureAwait(false);
+                }
+                else
+                {
+                    value = SerializeValueToPooled(message.Value!, message.Topic, message.Headers);
+                }
             }
+
+            // An async serializer may wait arbitrarily long. Preserve the sampled fast path
+            // only when every serializer completed synchronously; otherwise refresh CreateTime.
+            if (message.Timestamp is null && serializationSuspended)
+                currentTicks = Dekaf.MonotonicClock.GetMilliseconds();
 
             // Determine partition
             var partition = message.Partition
@@ -5045,25 +5065,45 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             var valueIsNull = message.Value is null;
             var key = PooledMemory.Null;
             var value = PooledMemory.Null;
+            var serializationSuspended = false;
             try
             {
                 if (!keyIsNull)
                 {
-                    key = _asyncKeySerializer is not null
-                        ? await SerializeToPooledAsync(
+                    if (_asyncKeySerializer is not null)
+                    {
+                        var pendingKey = SerializeToPooledAsync(
                             _asyncKeySerializer, message.Key!, message.Topic,
-                            SerializationComponent.Key, message.Headers, CancellationToken.None).ConfigureAwait(false)
-                        : SerializeKeyToPooled(message.Key!, message.Topic, message.Headers);
+                            SerializationComponent.Key, message.Headers, CancellationToken.None);
+                        serializationSuspended |= !pendingKey.IsCompletedSuccessfully;
+                        key = await pendingKey.ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        key = SerializeKeyToPooled(message.Key!, message.Topic, message.Headers);
+                    }
                 }
 
                 if (!valueIsNull)
                 {
-                    value = _asyncValueSerializer is not null
-                        ? await SerializeToPooledAsync(
+                    if (_asyncValueSerializer is not null)
+                    {
+                        var pendingValue = SerializeToPooledAsync(
                             _asyncValueSerializer, message.Value!, message.Topic,
-                            SerializationComponent.Value, message.Headers, CancellationToken.None).ConfigureAwait(false)
-                        : SerializeValueToPooled(message.Value!, message.Topic, message.Headers);
+                            SerializationComponent.Value, message.Headers, CancellationToken.None);
+                        serializationSuspended |= !pendingValue.IsCompletedSuccessfully;
+                        value = await pendingValue.ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        value = SerializeValueToPooled(message.Value!, message.Topic, message.Headers);
+                    }
                 }
+
+                // Match ProduceInternalAsync: suspended user serialization must not stamp the
+                // record with the pre-serialization cache time.
+                if (message.Timestamp is null && serializationSuspended)
+                    currentTicks = Dekaf.MonotonicClock.GetMilliseconds();
 
                 var appendResult = await AppendSerializedToAccumulatorAsync(
                     message.Topic, key, keyIsNull, value, valueIsNull,


### PR DESCRIPTION
## What changed

- return the metadata-cache monotonic timestamp to synchronous produce callers
- reuse that timestamp for timestamp-cache refresh and metadata-cache expiry
- preserve the original private fast-path overload used by reentrancy tests

## Why

The synchronous produce path read `MonotonicClock.GetMilliseconds()` once for metadata-cache validity and again for the record timestamp. The second read was redundant for the same operation.

## Benchmark

`ProducerFireHotPathBenchmarks`, 1000-byte messages, 5 warmups, 10 measured iterations, exact baseline `b1a7d67e`:

| Delivery target | Partitions | Before | After | Delta | Allocated |
|---:|---:|---:|---:|---:|---:|
| 0 ms | 1 | 208.1 ns | 202.1 ns | -2.9% | 0 B |
| 0 ms | 12 | 215.9 ns | 212.7 ns | -1.5% | 1 B* |
| 10 ms | 1 | 221.3 ns | 220.3 ns | -0.4% | 0 B |
| 10 ms | 12 | 228.4 ns | 227.7 ns | -0.3% | 0 B |

`*` The benchmark's documented stochastic drainer-behind path produced one amortized byte in that shape; the other three candidate shapes and all four baseline shapes remained at 0 B.

## Validation

- `dotnet build tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj -c Release`
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release`
- 6,719 unit tests passed
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved producer efficiency by reducing repeated timestamp lookups during message publishing.
  * Streamlined synchronous, asynchronous, callback-based, metadata, and serialized publishing paths.
  * Maintained existing producer APIs and message publishing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->