### PR TITLE
Reuse batch admission leases on produce hot path

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3834,6 +3834,25 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             topic, partition, keyIsNull, keyLength, valueIsNull, valueLength,
             headers, headerCount, recordSize);
 
+        if (_unackedBudgetEnabled
+            && headers is null
+            && headerCount == 0
+            && TryAppendFromSpansUsingExistingAdmission(
+                topic,
+                partition,
+                timestamp,
+                keyData,
+                keyIsNull,
+                valueData,
+                valueIsNull,
+                completionSource,
+                callback: null,
+                recordSize,
+                partitionCount))
+        {
+            return true;
+        }
+
         if (!TryAdmitAndReserve(topic, partition, recordSize, out var admissionReservation))
             return false;
 
@@ -4283,6 +4302,25 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             throw;
         }
 
+        if (_unackedBudgetEnabled
+            && headers is null
+            && headerCount == 0
+            && TryAppendFromSpansUsingExistingAdmission(
+                topic,
+                partition,
+                timestamp,
+                keyData,
+                keyIsNull,
+                valueData,
+                valueIsNull,
+                completionSource: null,
+                callback,
+                recordSize,
+                partitionCount))
+        {
+            return new ValueTask<bool>(true);
+        }
+
         // Hot path: non-blocking gate check + CAS reservation — no async state machine
         // allocated. An over-budget broker applies the same backpressure as a full buffer.
         if (TryAdmitAndReserve(topic, partition, recordSize, out var admissionReservation))
@@ -4403,6 +4441,109 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         return AppendFromSpansAfterReservationCore(topic, partition, timestamp, keyData, keyIsNull,
             valueData, valueIsNull, headers, headerCount, completionSource: null, callback,
             recordSize, partitionCount, returnHeadersOnFailure: true, admissionReservation);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryAppendFromSpansUsingExistingAdmission(
+        string topic,
+        int partition,
+        long timestamp,
+        ReadOnlySpan<byte> keyData,
+        bool keyIsNull,
+        ReadOnlySpan<byte> valueData,
+        bool valueIsNull,
+        PooledValueTaskSource<RecordMetadata>? completionSource,
+        Action<RecordMetadata, Exception?>? callback,
+        int recordSize,
+        int partitionCount)
+    {
+        var pd = GetOrCreateDeque(topic, partition);
+        if (Volatile.Read(ref pd.SlowPathAppendCount) != 0)
+            return false;
+
+        PartitionBatch? batchToComplete = null;
+        var actualBytesAdded = 0;
+        var memoryReserved = false;
+        var appendCommitted = false;
+
+        // The admission owner normally spans a lease decision and a later append. When the
+        // current batch already owns enough credit, keep both checks and the append under the
+        // partition lock so the common path needs neither the admission CAS nor a second lock.
+        try
+        {
+            {
+                using var guard = new SpinLockGuard(ref pd.Lock);
+
+                if (Volatile.Read(ref _disposed) != 0
+                    || pd.RotationInProgress
+                    || pd.AppendInProgress
+                    || Volatile.Read(ref pd.AdmissionInProgress) != 0
+                    || pd.CurrentBatch is not { } currentBatch)
+                {
+                    return false;
+                }
+
+                var budget = GetCachedAdmissionBudget(pd, topic, partition);
+                if (NeedsAdmissionLease(currentBatch, budget, recordSize)
+                    || !TryReserveMemory(recordSize))
+                {
+                    return false;
+                }
+
+                memoryReserved = true;
+                var result = currentBatch.TryAppendFromSpans(
+                    timestamp,
+                    keyData,
+                    keyIsNull,
+                    valueData,
+                    valueIsNull,
+                    headers: null,
+                    headerCount: 0,
+                    completionSource,
+                    callback,
+                    estimatedSize: recordSize);
+
+                if (result.Success)
+                {
+                    appendCommitted = true;
+                    actualBytesAdded = result.ActualSizeAdded;
+                    ProducerDebugCounters.RecordMessageAppended(hasCompletionSource: completionSource is not null);
+
+                    if (result.FirstCompletionSourceInBatch)
+                        TrackPendingAwaitedProduceBatch();
+
+                    if (ShouldSealAppendedBatch(pd, currentBatch, completionSource))
+                        batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
+                }
+            }
+        }
+        catch
+        {
+            if (memoryReserved && !appendCommitted)
+                ReleaseMemory(recordSize);
+            throw;
+        }
+
+        if (!appendCommitted)
+        {
+            if (memoryReserved)
+                ReleaseMemory(recordSize);
+            return false;
+        }
+
+        NotifyRecordAppended(topic, partition, actualBytesAdded, partitionCount);
+        if (batchToComplete is not null)
+        {
+            var readyBatch = CompleteDetachedBatchAndEnqueue(pd, batchToComplete);
+            if (readyBatch is not null)
+                StartPreSerialization(readyBatch);
+        }
+        else if (completionSource is not null)
+        {
+            QueueLingerPartition(pd, new TopicPartition(topic, partition), signalLingerLoop: false);
+        }
+
+        return true;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
@@ -210,6 +210,130 @@ public sealed class BrokerUnackedAdmissionTests
     }
 
     [Test]
+    public async Task CompletionSpanAppend_ReusesCurrentBatchAdmissionLease()
+    {
+        const int batchSize = 1_024;
+        var options = CreateOptions(capOverride: batchSize, batchSize: batchSize);
+        var accumulator = new RecordAccumulator(options, resolveLeaderId: static (_, _) => LeaderNodeId);
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
+        var metadataManager = AccumulatorTestHelpers.CreateMetadataManager("test-topic", 1, LeaderNodeId);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+            var first = pool.Rent();
+            var second = pool.Rent();
+            var firstTask = first.Task;
+            var secondTask = second.Task;
+
+            await Assert.That(accumulator.TryAppendFromSpansWithCompletion(
+                "test-topic", 0, 1,
+                ReadOnlySpan<byte>.Empty, keyIsNull: true,
+                "first"u8, valueIsNull: false,
+                headers: null, headerCount: 0, first)).IsTrue();
+            var artificialCharge = budget.BudgetBytes - budget.UnackedBytes;
+            budget.Charge(artificialCharge);
+            await Assert.That(budget.IsOverBudget()).IsTrue();
+
+            var blockEvents = budget.AdmissionBlockEvents;
+            await Assert.That(accumulator.TryAppendFromSpansWithCompletion(
+                "test-topic", 0, 2,
+                ReadOnlySpan<byte>.Empty, keyIsNull: true,
+                "second"u8, valueIsNull: false,
+                headers: null, headerCount: 0, second)).IsTrue();
+            await Assert.That(budget.AdmissionBlockEvents).IsEqualTo(blockEvents);
+
+            await SealAllAsync(accumulator);
+            var batch = DrainSealedBatches(accumulator, metadataManager).Single();
+            await Assert.That(batch.RecordCount).IsEqualTo(2);
+            var bufferedBytes = accumulator.BufferedBytes;
+            var batchDataSize = batch.DataSize;
+            await Assert.That(bufferedBytes).IsGreaterThan(0);
+
+            ExitAndReturn(accumulator, batch);
+            accumulator.ReleaseMemory(batchDataSize);
+            budget.Release(artificialCharge);
+            _ = await firstTask;
+            _ = await secondTask;
+
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(bufferedBytes - batchDataSize);
+            await Assert.That(budget.UnackedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await metadataManager.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task CallbackSpanAppend_ReusesLeaseThenQueuesAfterSeal()
+    {
+        const int batchSize = 1_024;
+        var options = CreateOptions(capOverride: batchSize, batchSize: batchSize);
+        var accumulator = new RecordAccumulator(options, resolveLeaderId: static (_, _) => LeaderNodeId);
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
+        var metadataManager = AccumulatorTestHelpers.CreateMetadataManager("test-topic", 1, LeaderNodeId);
+        var callbackCount = 0;
+        Action<RecordMetadata, Exception?> callback = (_, error) =>
+        {
+            if (error is null)
+                Interlocked.Increment(ref callbackCount);
+        };
+
+        try
+        {
+            var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+            var first = accumulator.AppendFromSpansAsync(
+                "test-topic", 0, 1,
+                ReadOnlySpan<byte>.Empty, keyIsNull: true,
+                "first"u8, valueIsNull: false,
+                headers: null, headerCount: 0, callback, CancellationToken.None);
+            await Assert.That(first.IsCompletedSuccessfully).IsTrue();
+            await Assert.That(await first).IsTrue();
+            var artificialCharge = budget.BudgetBytes - budget.UnackedBytes;
+            budget.Charge(artificialCharge);
+            await Assert.That(budget.IsOverBudget()).IsTrue();
+
+            var blockEvents = budget.AdmissionBlockEvents;
+            var second = accumulator.AppendFromSpansAsync(
+                "test-topic", 0, 2,
+                ReadOnlySpan<byte>.Empty, keyIsNull: true,
+                "second"u8, valueIsNull: false,
+                headers: null, headerCount: 0, callback, CancellationToken.None);
+            await Assert.That(second.IsCompletedSuccessfully).IsTrue();
+            await Assert.That(await second).IsTrue();
+            await Assert.That(budget.AdmissionBlockEvents).IsEqualTo(blockEvents);
+
+            await SealAllAsync(accumulator);
+            var batch = DrainSealedBatches(accumulator, metadataManager).Single();
+            var queued = accumulator.AppendFromSpansAsync(
+                "test-topic", 0, 3,
+                ReadOnlySpan<byte>.Empty, keyIsNull: true,
+                "queued"u8, valueIsNull: false,
+                headers: null, headerCount: 0, callback, CancellationToken.None);
+            await Assert.That(queued.IsCompleted).IsFalse();
+            await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(1);
+
+            var batchDataSize = batch.DataSize;
+            ExitAndReturn(accumulator, batch);
+            accumulator.ReleaseMemory(batchDataSize);
+
+            await Assert.That(await queued).IsTrue();
+            budget.Release(artificialCharge);
+            await Assert.That(callbackCount).IsEqualTo(2);
+            await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
     [Timeout(30_000)]
     public async Task AsyncAppend_Unblocks_WhenChargedBatchExits(CancellationToken cancellationToken)
     {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AdmissionLeaseAppendBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AdmissionLeaseAppendBenchmarks.cs
@@ -7,8 +7,9 @@ using Dekaf.Producer;
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
 /// <summary>
-/// Measures both headerless span entry points with broker admission enabled. A background
-/// drainer acknowledges sealed batches so the benchmark remains on the synchronous lease path.
+/// Measures both headerless span entry points while one open batch repeatedly consumes and
+/// replenishes broker admission leases. Iteration setup keeps sealing and delivery outside
+/// the measured append path.
 /// </summary>
 [MemoryDiagnoser]
 [OperationsPerSecond]
@@ -16,8 +17,8 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 public class AdmissionLeaseAppendBenchmarks
 {
     private const int BatchSize = 1_048_576;
-    private const int OperationsPerInvocation = 100;
-    private const int CompletionSourceCount = 4_096;
+    private const int OperationsPerInvocation = 900;
+    private const int CompletionSourceCount = 1_024;
 
     private RecordAccumulator _accumulator = null!;
     private IDisposable _bulkScope = null!;
@@ -25,12 +26,20 @@ public class AdmissionLeaseAppendBenchmarks
     private int _completionSourceIndex;
     private byte[] _keyBytes = null!;
     private byte[] _valueBytes = null!;
-    private CancellationTokenSource _drainerCts = null!;
-    private Thread _drainerThread = null!;
-
     [GlobalSetup]
     public void Setup()
     {
+        _completionSources = new PooledValueTaskSource<RecordMetadata>[CompletionSourceCount];
+        for (var i = 0; i < _completionSources.Length; i++)
+            _completionSources[i] = new PooledValueTaskSource<RecordMetadata>();
+        _keyBytes = Encoding.UTF8.GetBytes("benchmark-key-0");
+        _valueBytes = new byte[1_000];
+    }
+
+    [IterationSetup]
+    public void SetupIteration()
+    {
+        _completionSourceIndex = 0;
         _accumulator = new RecordAccumulator(
             new ProducerOptions
             {
@@ -43,35 +52,19 @@ public class AdmissionLeaseAppendBenchmarks
             },
             resolveLeaderId: static (_, _) => 0);
         _bulkScope = _accumulator.EnterBulkProduceScope();
-        _completionSources = new PooledValueTaskSource<RecordMetadata>[CompletionSourceCount];
-        for (var i = 0; i < _completionSources.Length; i++)
-            _completionSources[i] = new PooledValueTaskSource<RecordMetadata>();
-        _keyBytes = Encoding.UTF8.GetBytes("benchmark-key-0");
-        _valueBytes = new byte[1_000];
-
-        _drainerCts = new CancellationTokenSource();
-        _drainerThread = new Thread(() => DrainLoop(_drainerCts.Token))
-        {
-            IsBackground = true,
-            Name = "admission-lease-benchmark-drainer",
-            Priority = ThreadPriority.Highest,
-        };
-        _drainerThread.Start();
-
-        for (var i = 0; i < 40; i++)
-            AppendFromSpans();
-        for (var i = 0; i < 40; i++)
-            AppendFromSpansWithCompletion();
+        var seeded = _accumulator.AppendFromSpansAsync(
+            "bench-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            _keyBytes, false, _valueBytes, false,
+            null, 0, null, CancellationToken.None);
+        if (!seeded.IsCompletedSuccessfully || !seeded.Result)
+            throw new InvalidOperationException("Admission lease seed append failed.");
     }
 
-    [GlobalCleanup]
-    public async Task Cleanup()
+    [IterationCleanup]
+    public void CleanupIteration()
     {
-        _drainerCts.Cancel();
-        _drainerThread.Join();
-        _drainerCts.Dispose();
         _bulkScope.Dispose();
-        await _accumulator.DisposeAsync().ConfigureAwait(false);
+        _accumulator.DisposeAsync().GetAwaiter().GetResult();
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvocation)]
@@ -106,26 +99,6 @@ public class AdmissionLeaseAppendBenchmarks
                 Thread.SpinWait(32);
 
             completion.ObserveForFireAndForget();
-        }
-    }
-
-    private void DrainLoop(CancellationToken cancellationToken)
-    {
-        var spinner = new SpinWait();
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            if (!_accumulator.TryDrainBatch(out var batch))
-            {
-                spinner.SpinOnce();
-                continue;
-            }
-
-            var dataSize = batch.DataSize;
-            _accumulator.OnBatchExitsPipeline(batch);
-            batch.CompleteSend(0, DateTimeOffset.UtcNow);
-            _accumulator.ReleaseMemory(dataSize);
-            _accumulator.ReturnReadyBatch(batch);
-            spinner.Reset();
         }
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AdmissionLeaseAppendBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AdmissionLeaseAppendBenchmarks.cs
@@ -19,6 +19,7 @@ public class AdmissionLeaseAppendBenchmarks
     private const int OperationsPerInvocation = 100;
 
     private RecordAccumulator _accumulator = null!;
+    private IDisposable _bulkScope = null!;
     private ValueTaskSourcePool<RecordMetadata> _completionPool = null!;
     private byte[] _keyBytes = null!;
     private byte[] _valueBytes = null!;
@@ -34,11 +35,12 @@ public class AdmissionLeaseAppendBenchmarks
                 BootstrapServers = ["localhost:9092"],
                 BatchSize = BatchSize,
                 BufferMemory = 256L * 1024 * 1024,
-                LingerMs = 0,
+                LingerMs = 1_000,
                 DeliveryLatencyTargetMs = 10,
                 UnackedByteBudgetCapOverride = 1L << 30,
             },
             resolveLeaderId: static (_, _) => 0);
+        _bulkScope = _accumulator.EnterBulkProduceScope();
         _completionPool = new ValueTaskSourcePool<RecordMetadata>();
         _keyBytes = Encoding.UTF8.GetBytes("benchmark-key-0");
         _valueBytes = new byte[1_000];
@@ -70,6 +72,7 @@ public class AdmissionLeaseAppendBenchmarks
         _drainerCts.Cancel();
         _drainerThread.Join();
         _drainerCts.Dispose();
+        _bulkScope.Dispose();
         await _accumulator.DisposeAsync().ConfigureAwait(false);
         await _completionPool.DisposeAsync().ConfigureAwait(false);
     }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AdmissionLeaseAppendBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AdmissionLeaseAppendBenchmarks.cs
@@ -17,10 +17,12 @@ public class AdmissionLeaseAppendBenchmarks
 {
     private const int BatchSize = 1_048_576;
     private const int OperationsPerInvocation = 100;
+    private const int CompletionSourceCount = 4_096;
 
     private RecordAccumulator _accumulator = null!;
     private IDisposable _bulkScope = null!;
-    private ValueTaskSourcePool<RecordMetadata> _completionPool = null!;
+    private PooledValueTaskSource<RecordMetadata>[] _completionSources = null!;
+    private int _completionSourceIndex;
     private byte[] _keyBytes = null!;
     private byte[] _valueBytes = null!;
     private CancellationTokenSource _drainerCts = null!;
@@ -41,15 +43,11 @@ public class AdmissionLeaseAppendBenchmarks
             },
             resolveLeaderId: static (_, _) => 0);
         _bulkScope = _accumulator.EnterBulkProduceScope();
-        _completionPool = new ValueTaskSourcePool<RecordMetadata>();
+        _completionSources = new PooledValueTaskSource<RecordMetadata>[CompletionSourceCount];
+        for (var i = 0; i < _completionSources.Length; i++)
+            _completionSources[i] = new PooledValueTaskSource<RecordMetadata>();
         _keyBytes = Encoding.UTF8.GetBytes("benchmark-key-0");
         _valueBytes = new byte[1_000];
-
-        var pooledSources = new PooledValueTaskSource<RecordMetadata>[_completionPool.MaxPoolSize];
-        for (var i = 0; i < pooledSources.Length; i++)
-            pooledSources[i] = _completionPool.Rent();
-        for (var i = 0; i < pooledSources.Length; i++)
-            _completionPool.Return(pooledSources[i]);
 
         _drainerCts = new CancellationTokenSource();
         _drainerThread = new Thread(() => DrainLoop(_drainerCts.Token))
@@ -74,7 +72,6 @@ public class AdmissionLeaseAppendBenchmarks
         _drainerCts.Dispose();
         _bulkScope.Dispose();
         await _accumulator.DisposeAsync().ConfigureAwait(false);
-        await _completionPool.DisposeAsync().ConfigureAwait(false);
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvocation)]
@@ -100,7 +97,7 @@ public class AdmissionLeaseAppendBenchmarks
         var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         for (var i = 0; i < OperationsPerInvocation; i++)
         {
-            var completion = _completionPool.Rent();
+            var completion = _completionSources[_completionSourceIndex++ & (CompletionSourceCount - 1)];
             completion.SetRunContinuationsAsynchronously(false);
             while (!_accumulator.TryAppendFromSpansWithCompletion(
                        "bench-topic", 0, timestamp,

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AdmissionLeaseAppendBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AdmissionLeaseAppendBenchmarks.cs
@@ -1,0 +1,126 @@
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures both headerless span entry points with broker admission enabled. A background
+/// drainer acknowledges sealed batches so the benchmark remains on the synchronous lease path.
+/// </summary>
+[MemoryDiagnoser]
+[OperationsPerSecond]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class AdmissionLeaseAppendBenchmarks
+{
+    private const int BatchSize = 1_048_576;
+    private const int OperationsPerInvocation = 100;
+
+    private RecordAccumulator _accumulator = null!;
+    private ValueTaskSourcePool<RecordMetadata> _completionPool = null!;
+    private byte[] _keyBytes = null!;
+    private byte[] _valueBytes = null!;
+    private CancellationTokenSource _drainerCts = null!;
+    private Task _drainerTask = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _accumulator = new RecordAccumulator(
+            new ProducerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                BatchSize = BatchSize,
+                BufferMemory = 256L * 1024 * 1024,
+                LingerMs = 0,
+                DeliveryLatencyTargetMs = 10,
+                UnackedByteBudgetCapOverride = 1L << 30,
+            },
+            resolveLeaderId: static (_, _) => 0);
+        _completionPool = new ValueTaskSourcePool<RecordMetadata>();
+        _keyBytes = Encoding.UTF8.GetBytes("benchmark-key-0");
+        _valueBytes = new byte[1_000];
+
+        var pooledSources = new PooledValueTaskSource<RecordMetadata>[_completionPool.MaxPoolSize];
+        for (var i = 0; i < pooledSources.Length; i++)
+            pooledSources[i] = _completionPool.Rent();
+        for (var i = 0; i < pooledSources.Length; i++)
+            _completionPool.Return(pooledSources[i]);
+
+        _drainerCts = new CancellationTokenSource();
+        _drainerTask = Task.Run(() => DrainLoop(_drainerCts.Token));
+
+        for (var i = 0; i < 40; i++)
+            AppendFromSpans();
+        for (var i = 0; i < 40; i++)
+            AppendFromSpansWithCompletion();
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        _drainerCts.Cancel();
+        try { await _drainerTask.ConfigureAwait(false); } catch (OperationCanceledException) { }
+        _drainerCts.Dispose();
+        await _accumulator.DisposeAsync().ConfigureAwait(false);
+        await _completionPool.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvocation)]
+    public void AppendFromSpans()
+    {
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        for (var i = 0; i < OperationsPerInvocation; i++)
+        {
+            var result = _accumulator.AppendFromSpansAsync(
+                "bench-topic", 0, timestamp,
+                _keyBytes, false, _valueBytes, false,
+                null, 0, null, CancellationToken.None);
+            if (!result.IsCompletedSuccessfully || !result.Result)
+                throw new InvalidOperationException("Span append left the synchronous admission path.");
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvocation)]
+    public void AppendFromSpansWithCompletion()
+    {
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        for (var i = 0; i < OperationsPerInvocation; i++)
+        {
+            var completion = _completionPool.Rent();
+            completion.SetRunContinuationsAsynchronously(false);
+            if (!_accumulator.TryAppendFromSpansWithCompletion(
+                "bench-topic", 0, timestamp,
+                _keyBytes, false, _valueBytes, false,
+                null, 0, completion))
+            {
+                _completionPool.Return(completion);
+                throw new InvalidOperationException("Completion append left the synchronous admission path.");
+            }
+
+            completion.ObserveForFireAndForget();
+        }
+    }
+
+    private void DrainLoop(CancellationToken cancellationToken)
+    {
+        var spinner = new SpinWait();
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            if (!_accumulator.TryDrainBatch(out var batch))
+            {
+                spinner.SpinOnce();
+                continue;
+            }
+
+            var dataSize = batch.DataSize;
+            _accumulator.OnBatchExitsPipeline(batch);
+            batch.CompleteSend(0, DateTimeOffset.UtcNow);
+            _accumulator.ReleaseMemory(dataSize);
+            _accumulator.ReturnReadyBatch(batch);
+            spinner.Reset();
+        }
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AdmissionLeaseAppendBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AdmissionLeaseAppendBenchmarks.cs
@@ -23,7 +23,7 @@ public class AdmissionLeaseAppendBenchmarks
     private byte[] _keyBytes = null!;
     private byte[] _valueBytes = null!;
     private CancellationTokenSource _drainerCts = null!;
-    private Task _drainerTask = null!;
+    private Thread _drainerThread = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -50,7 +50,13 @@ public class AdmissionLeaseAppendBenchmarks
             _completionPool.Return(pooledSources[i]);
 
         _drainerCts = new CancellationTokenSource();
-        _drainerTask = Task.Run(() => DrainLoop(_drainerCts.Token));
+        _drainerThread = new Thread(() => DrainLoop(_drainerCts.Token))
+        {
+            IsBackground = true,
+            Name = "admission-lease-benchmark-drainer",
+            Priority = ThreadPriority.Highest,
+        };
+        _drainerThread.Start();
 
         for (var i = 0; i < 40; i++)
             AppendFromSpans();
@@ -62,7 +68,7 @@ public class AdmissionLeaseAppendBenchmarks
     public async Task Cleanup()
     {
         _drainerCts.Cancel();
-        try { await _drainerTask.ConfigureAwait(false); } catch (OperationCanceledException) { }
+        _drainerThread.Join();
         _drainerCts.Dispose();
         await _accumulator.DisposeAsync().ConfigureAwait(false);
         await _completionPool.DisposeAsync().ConfigureAwait(false);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AdmissionLeaseAppendBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AdmissionLeaseAppendBenchmarks.cs
@@ -87,8 +87,10 @@ public class AdmissionLeaseAppendBenchmarks
                 "bench-topic", 0, timestamp,
                 _keyBytes, false, _valueBytes, false,
                 null, 0, null, CancellationToken.None);
-            if (!result.IsCompletedSuccessfully || !result.Result)
-                throw new InvalidOperationException("Span append left the synchronous admission path.");
+            while (!result.IsCompleted)
+                Thread.SpinWait(32);
+            if (!result.Result)
+                throw new InvalidOperationException("Span append failed.");
         }
     }
 
@@ -100,14 +102,11 @@ public class AdmissionLeaseAppendBenchmarks
         {
             var completion = _completionPool.Rent();
             completion.SetRunContinuationsAsynchronously(false);
-            if (!_accumulator.TryAppendFromSpansWithCompletion(
-                "bench-topic", 0, timestamp,
-                _keyBytes, false, _valueBytes, false,
-                null, 0, completion))
-            {
-                _completionPool.Return(completion);
-                throw new InvalidOperationException("Completion append left the synchronous admission path.");
-            }
+            while (!_accumulator.TryAppendFromSpansWithCompletion(
+                       "bench-topic", 0, timestamp,
+                       _keyBytes, false, _valueBytes, false,
+                       null, 0, completion))
+                Thread.SpinWait(32);
 
             completion.ObserveForFireAndForget();
         }


### PR DESCRIPTION
## What changed

- append headerless span records directly when the current batch already owns enough broker admission credit
- perform lease validation, memory reservation, encoding, and commit under one partition lock
- keep lease refill, backpressure, rotation, headers, and pending-append paths unchanged
- release memory safely if encoding fails before commit

## Why

With `DeliveryLatencyTargetMs > 0`, every record previously acquired `AdmissionInProgress`, entered the partition lock to check batch-local credit, released it, and entered the same lock again to append. A 64 KiB lease already amortizes the broker-wide reservation; records consuming existing credit do not need the separate admission handoff.

## Benchmark

`ProducerFireHotPathBenchmarks`, 1000-byte messages, 5 warmups, 10 measured iterations, exact baseline `b1a7d67e`:

| Delivery target | Partitions | Before | After | Delta | Allocated |
|---:|---:|---:|---:|---:|---:|
| 0 ms | 1 | 205.5 ns | 201.9 ns | -1.8% | 0 B |
| 0 ms | 12 | 207.1 ns | 209.7 ns | +1.3% | 0 B |
| 10 ms | 1 | 220.6 ns | 188.7 ns | -14.5% | 0 B |
| 10 ms | 12 | 229.9 ns | 205.9 ns | -10.4% | 0 B |

The final 12-partition candidate was bimodal. Two earlier exact candidate runs measured 197.5 ns and 196.4 ns; both independently confirm the enabled-path improvement. A baseline-candidate-baseline sequence and exact candidate repeat kept disabled-mode controls inside local variance.

## Validation

- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release`
- 20 `BrokerUnackedAdmissionTests` passed
- all 6,719 unit tests passed
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved efficiency for span-based record appends when existing batches have sufficient broker credit and memory.
  * Reduced unnecessary admission reservations while preserving existing fallback behavior.
  * Maintained delivery tracking, batch completion, linger notifications, and memory cleanup during append operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->