### PR TITLE
Remove duplicate ThreadPool hop from linger timeouts

### DIFF
--- a/src/Dekaf/Internal/AsyncAutoResetSignal.cs
+++ b/src/Dekaf/Internal/AsyncAutoResetSignal.cs
@@ -15,9 +15,18 @@ namespace Dekaf.Internal;
 /// <see cref="WaitAsync"/> must only be called by a single consumer
 /// (not thread-safe for multiple concurrent waiters).
 /// </summary>
-internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>, IDisposable
+internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>,
+#if NET
+    IThreadPoolWorkItem,
+#endif
+    IDisposable
 {
+    private const int QueuedSignal = 1;
+    private const int QueuedShutdown = 2;
+
     private ManualResetValueTaskSourceCore<bool> _core;
+    private readonly bool _inlineTimeoutContinuations;
+    private int _queuedCompletion;
 
     /// <summary>
     /// 0 = idle (no waiter), 1 = waiting (waiter registered), 2 = signaled-before-wait.
@@ -54,9 +63,10 @@ internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>, IDisposable
     private int _shutdownRequested; // 0 = running, 1 = shutdown requested — terminal once set
     private CancellationToken _shutdownToken;
 
-    public AsyncAutoResetSignal()
+    public AsyncAutoResetSignal(bool inlineTimeoutContinuations = false)
     {
-        _core.RunContinuationsAsynchronously = true;
+        _inlineTimeoutContinuations = inlineTimeoutContinuations;
+        _core.RunContinuationsAsynchronously = !inlineTimeoutContinuations;
         _timeoutCallback = static state =>
         {
             var self = (AsyncAutoResetSignal)state!;
@@ -102,7 +112,7 @@ internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>, IDisposable
                 // Shutdown requested — complete the waiter if one is pending.
                 if (Interlocked.CompareExchange(ref self._state, Idle, Waiting) == Waiting)
                 {
-                    self._core.SetException(new OperationCanceledException(self._shutdownToken));
+                    self.CompleteShutdown();
                 }
             },
             this);
@@ -126,7 +136,7 @@ internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>, IDisposable
         // having already transitioned Waiting → Idle and called SetResult/SetException.
         // Double-completion of ManualResetValueTaskSourceCore is undefined behavior.
         if (Interlocked.CompareExchange(ref _state, Idle, Waiting) == Waiting)
-            _core.SetResult(true);
+            CompleteSignal();
     }
 
     /// <summary>
@@ -220,6 +230,53 @@ internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>, IDisposable
 
     void IValueTaskSource<bool>.OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
         => _core.OnCompleted(continuation, state, token, flags);
+
+    private void CompleteSignal()
+    {
+        if (!_inlineTimeoutContinuations)
+        {
+            _core.SetResult(true);
+            return;
+        }
+
+        Volatile.Write(ref _queuedCompletion, QueuedSignal);
+        QueueCompletion();
+    }
+
+    private void CompleteShutdown()
+    {
+        if (!_inlineTimeoutContinuations)
+        {
+            _core.SetException(new OperationCanceledException(_shutdownToken));
+            return;
+        }
+
+        Volatile.Write(ref _queuedCompletion, QueuedShutdown);
+        QueueCompletion();
+    }
+
+#if NET
+    void IThreadPoolWorkItem.Execute()
+#else
+    private void ExecuteQueuedCompletion()
+#endif
+    {
+        var completion = Volatile.Read(ref _queuedCompletion);
+        if (completion == QueuedSignal)
+            _core.SetResult(true);
+        else
+            _core.SetException(new OperationCanceledException(_shutdownToken));
+    }
+
+    private void QueueCompletion()
+    {
+#if NET
+        ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
+#else
+        ThreadPool.UnsafeQueueUserWorkItem(static state =>
+            ((AsyncAutoResetSignal)state!).ExecuteQueuedCompletion(), this);
+#endif
+    }
 
     public void Dispose()
     {

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1128,7 +1128,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// <summary>
     /// Arms the periodic linger cadence when the first unsealed batch becomes active.
     /// </summary>
+#if NET
+    private readonly AsyncAutoResetSignal _lingerWakeupSignal = new(inlineTimeoutContinuations: true);
+#else
     private readonly AsyncAutoResetSignal _lingerWakeupSignal = new();
+#endif
 
     // Per-partition-affine append workers: each worker owns a channel and processes
     // appends for a subset of partitions (partition % workerCount). This reduces

--- a/tests/Dekaf.Tests.Unit/Internal/AsyncAutoResetSignalTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/AsyncAutoResetSignalTests.cs
@@ -5,6 +5,36 @@ namespace Dekaf.Tests.Unit.Internal;
 public class AsyncAutoResetSignalTests
 {
     [Test]
+    public async Task InlineTimeoutContinuations_RearmAcrossTimeoutsAndSignals()
+    {
+        using var signal = new AsyncAutoResetSignal(inlineTimeoutContinuations: true);
+
+        for (var i = 0; i < 100; i++)
+            await Assert.That(await signal.WaitAsync(1)).IsFalse();
+
+        for (var i = 0; i < 100; i++)
+        {
+            var wait = signal.WaitAsync(1_000);
+            signal.Signal();
+            await Assert.That(await wait).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task InlineTimeoutContinuations_ShutdownCompletesWaiter()
+    {
+        using var signal = new AsyncAutoResetSignal(inlineTimeoutContinuations: true);
+        using var cancellation = new CancellationTokenSource();
+        signal.RegisterShutdownToken(cancellation.Token);
+
+        var wait = signal.WaitAsync(Timeout.Infinite).AsTask();
+        cancellation.Cancel();
+
+        await Assert.That(async () => await wait.WaitAsync(TimeSpan.FromSeconds(1)))
+            .Throws<OperationCanceledException>();
+    }
+
+    [Test]
     public async Task WaitAsync_AfterIdleShutdown_ThrowsCancellation()
     {
         using var signal = new AsyncAutoResetSignal();

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AsyncAutoResetSignalTimeoutBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AsyncAutoResetSignalTimeoutBenchmarks.cs
@@ -1,0 +1,19 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Internal;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[ThreadingDiagnoser]
+[SimpleJob(RunStrategy.Monitoring, launchCount: 1, warmupCount: 3, iterationCount: 10, invocationCount: 100)]
+public class AsyncAutoResetSignalTimeoutBenchmarks
+{
+    private readonly AsyncAutoResetSignal _signal = new(inlineTimeoutContinuations: true);
+
+    [Benchmark]
+    public ValueTask<bool> TimeoutWait() => _signal.WaitAsync(1);
+
+    [GlobalCleanup]
+    public void Cleanup() => _signal.Dispose();
+}


### PR DESCRIPTION
## What changed

- let timer-expired linger waits resume on the timer ThreadPool work item
- keep producer-thread signals and shutdown completion asynchronous through a reusable `IThreadPoolWorkItem`
- enable the mode only for the .NET linger signal; `netstandard2.0` behavior is unchanged
- add repeated timeout/signal/shutdown tests and a focused `ThreadingDiagnoser` benchmark

## Why

The reusable timer already enters the ThreadPool once. `ManualResetValueTaskSourceCore.RunContinuationsAsynchronously=true` then queued the linger continuation as a second work item. CPU profiles showed this TimerQueue-to-ThreadPool handoff dominating active producer CPU.

Signals cannot resume inline because that would run linger work on the producer caller. The reusable work-item path preserves asynchronous signal semantics without a per-signal work-item allocation.

## Focused benchmark

`AsyncAutoResetSignalTimeoutBenchmarks`, 100 invocations per iteration, 3 warmups, 10 measured iterations, exact baseline `b1a7d67e`:

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Completed ThreadPool work items / timeout | 2.000 | 1.000 | -50% |
| Allocated / timeout | 32 B | 0 B | -100% |
| Timeout wall time | 15.53 ms | 15.49 ms | -0.2% |

## Producer stress benchmark

Local baseline → candidate → baseline; 1 broker, 6 partitions, 1000-byte messages, 1 MiB batches, 1 minute each:

| Metric | Baseline A | Candidate | Baseline B |
|---|---:|---:|---:|
| Messages/sec | 228,236 | 231,294 | 224,933 |
| Median messages/sec | 231,535 | 234,181 | 227,800 |
| CPU µs/message | 1.04 | 0.94 | 0.92 |
| Standing cores | 0.24 | 0.22 | 0.21 |
| p50 | 40.75 ms | 40.45 ms | 41.05 ms |
| p99 | 253.95 ms | 241.25 ms | 266.15 ms |
| Max | 530.63 ms | 328.17 ms | 393.66 ms |
| Allocated/message | 2 B | 2 B | 2 B |
| Errors | 0 | 0 | 0 |

The one-minute lanes are exploratory rather than formal stability gates. They show no protected-metric regression; the focused benchmark proves the work-item and allocation reduction directly.

## Validation

- multi-target unit build: `net10.0` and `netstandard2.0`
- 4 `AsyncAutoResetSignalTests` passed
- 9 `LingerDeadlineWaitTests` passed
- all 6,721 unit tests passed
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved asynchronous timeout and signaling behavior on supported platforms.
  * Reduced unnecessary scheduling overhead for timeout continuations.

* **Bug Fixes**
  * Improved reliability when rearming timed-out waits and completing active waits during shutdown.

* **Tests**
  * Added coverage for repeated timeouts, signal completion, and shutdown cancellation.
  * Added benchmarks for asynchronous timeout performance and resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->