### PR TITLE
Adapt producer wave-coalescing tail

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1613,7 +1613,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     var started = Stopwatch.GetTimestamp();
                     var hardDeadline = started + waveCoalesceMaxTicks;
                     var quietDeadline = Math.Min(started + waveCoalesceQuietTicks, hardDeadline);
-                    var previousArrival = started;
+                    var previousArrival = 0L;
                     var maximumArrivalGap = 0L;
                     var additionalBatchCount = 0;
                     _onWaveCoalesceStarted?.Invoke();
@@ -1639,9 +1639,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             if (coalescedCount > countBefore)
                             {
                                 var now = Stopwatch.GetTimestamp();
-                                maximumArrivalGap = Math.Max(maximumArrivalGap, now - previousArrival);
-                                previousArrival = now;
-                                additionalBatchCount++;
+                                RecordWaveArrival(
+                                    now,
+                                    ref previousArrival,
+                                    ref maximumArrivalGap,
+                                    ref additionalBatchCount);
                                 var tailTicks = SelectWaveCoalesceTailTicks(
                                     waveCoalesceQuietTicks,
                                     maximumArrivalGap,
@@ -2522,6 +2524,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             quietMicroseconds,
             WaveCoalesceMaxMicroseconds);
         return ((int)quietMicroseconds, (int)maximumMicroseconds);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void RecordWaveArrival(
+        long now,
+        ref long previousArrival,
+        ref long maximumArrivalGap,
+        ref int additionalBatchCount)
+    {
+        if (additionalBatchCount > 0)
+            maximumArrivalGap = Math.Max(maximumArrivalGap, now - previousArrival);
+
+        previousArrival = now;
+        additionalBatchCount++;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -121,6 +121,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private const int WaveCoalesceQuietMicroseconds = 1000;
     private const int WaveCoalesceMaxMicroseconds = 2000;
     private const int WaveCoalesceLingerDivisor = 5;
+    private const int WaveCoalesceTailDivisor = 2;
+    private const int WaveCoalesceGapMultiplier = 2;
     private const int ZeroLingerWaveCoalesceQuietMicroseconds = 75;
     private const int ZeroLingerWaveCoalesceMaxMicroseconds = 500;
 
@@ -1611,6 +1613,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     var started = Stopwatch.GetTimestamp();
                     var hardDeadline = started + waveCoalesceMaxTicks;
                     var quietDeadline = Math.Min(started + waveCoalesceQuietTicks, hardDeadline);
+                    var previousArrival = started;
+                    var maximumArrivalGap = 0L;
+                    var additionalBatchCount = 0;
                     _onWaveCoalesceStarted?.Invoke();
                     // Probe once before consulting the deadline. A queued sibling must not be
                     // split into a later request solely because this thread was preempted here.
@@ -1634,7 +1639,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             if (coalescedCount > countBefore)
                             {
                                 var now = Stopwatch.GetTimestamp();
-                                quietDeadline = Math.Min(now + waveCoalesceQuietTicks, hardDeadline);
+                                maximumArrivalGap = Math.Max(maximumArrivalGap, now - previousArrival);
+                                previousArrival = now;
+                                additionalBatchCount++;
+                                var tailTicks = SelectWaveCoalesceTailTicks(
+                                    waveCoalesceQuietTicks,
+                                    maximumArrivalGap,
+                                    additionalBatchCount);
+                                quietDeadline = Math.Min(now + tailTicks, hardDeadline);
                             }
                         }
                         else if (evt.Type == SendLoopEventType.TransactionEnrollmentReady)
@@ -2510,6 +2522,23 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             quietMicroseconds,
             WaveCoalesceMaxMicroseconds);
         return ((int)quietMicroseconds, (int)maximumMicroseconds);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static long SelectWaveCoalesceTailTicks(
+        long configuredQuietTicks,
+        long maximumArrivalGapTicks,
+        int additionalBatchCount)
+    {
+        // Preserve the full discovery window until two siblings establish a wave cadence.
+        // Thereafter, stop paying the full quiet interval after the final sibling while
+        // retaining enough slack for a sibling delayed by up to twice the widest observed gap.
+        if (additionalBatchCount < 2)
+            return configuredQuietTicks;
+
+        var minimumTailTicks = Math.Max(1, configuredQuietTicks / WaveCoalesceTailDivisor);
+        var arrivalTailTicks = maximumArrivalGapTicks * WaveCoalesceGapMultiplier;
+        return Math.Min(configuredQuietTicks, Math.Max(minimumTailTicks, arrivalTailTicks));
     }
 
     private static long MicrosecondsToStopwatchTicks(long microseconds) =>

--- a/tests/Dekaf.Tests.Integration/ProducerOrderingTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerOrderingTests.cs
@@ -497,6 +497,51 @@ public sealed class ProducerOrderingTests(KafkaTestContainer kafka) : KafkaInteg
     }
 
     [Test]
+    [Timeout(120_000)]
+    public async Task AdaptiveWaveCoalescing_CrossPartitionBurst_DeliversThroughRealBroker(
+        CancellationToken cancellationToken)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 4);
+        const int messageCount = 128;
+        var value = new string('x', 1_000);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-adaptive-wave-coalescing")
+            .WithAcks(Acks.All)
+            .WithBatchSize(1_200)
+            .WithLinger(TimeSpan.FromMilliseconds(5))
+            .WithDeliveryDiagnostics()
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken);
+
+        await producer.WarmUpAllPartitionsAsync(topic, 4);
+        var diagnostics = (IProducerDiagnostics)producer;
+        diagnostics.ResetProduceRequestDiagnostics();
+
+        var deliveries = new Task<RecordMetadata>[messageCount];
+        for (var i = 0; i < deliveries.Length; i++)
+        {
+            deliveries[i] = producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = $"key-{i}",
+                Value = value,
+                Partition = i % 4
+            }, cancellationToken).AsTask();
+        }
+
+        var metadata = await Task.WhenAll(deliveries).WaitAsync(cancellationToken);
+        await producer.FlushAsync(cancellationToken);
+        var snapshot = diagnostics.GetDeliveryDiagnosticsSnapshot();
+
+        await Assert.That(metadata.All(static result => result.Offset >= 0)).IsTrue();
+        await Assert.That(snapshot.CoalesceWidthHistogram.Any(
+                static bucket => bucket.MinimumWidth >= 2 && bucket.RequestCount > 0))
+            .IsTrue();
+    }
+
+    [Test]
     public async Task MultiDrainCycles_OrderingPreservedAcrossDrains()
     {
         // Regression test: produces in waves to force multiple drain cycles, each with

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -521,6 +521,33 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
     }
 
     [Test]
+    public async Task SelectWaveCoalesceTailTicks_ExcludesInitialDiscoveryDelay()
+    {
+        const long configuredQuietTicks = 1_000;
+        var previousArrival = 0L;
+        var maximumSiblingGap = 0L;
+        var additionalBatchCount = 0;
+
+        BrokerSender.RecordWaveArrival(
+            now: 800,
+            ref previousArrival,
+            ref maximumSiblingGap,
+            ref additionalBatchCount);
+        BrokerSender.RecordWaveArrival(
+            now: 801,
+            ref previousArrival,
+            ref maximumSiblingGap,
+            ref additionalBatchCount);
+        var tailTicks = BrokerSender.SelectWaveCoalesceTailTicks(
+            configuredQuietTicks,
+            maximumSiblingGap,
+            additionalBatchCount);
+
+        await Assert.That(maximumSiblingGap).IsEqualTo(1);
+        await Assert.That(tailTicks).IsEqualTo(500);
+    }
+
+    [Test]
     [Timeout(120_000)]
     public async Task SendLoop_WaveCoalesce_RearmsAfterIdleWaitAtDefaultLinger(
         CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -505,6 +505,22 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
     }
 
     [Test]
+    public async Task SelectWaveCoalesceTailTicks_AdaptsOnlyAfterWaveCadenceIsEstablished()
+    {
+        await Assert.That(BrokerSender.SelectWaveCoalesceTailTicks(
+                configuredQuietTicks: 1_000,
+                maximumArrivalGapTicks: 100,
+                additionalBatchCount: 1))
+            .IsEqualTo(1_000);
+        await Assert.That(BrokerSender.SelectWaveCoalesceTailTicks(1_000, 100, 2))
+            .IsEqualTo(500);
+        await Assert.That(BrokerSender.SelectWaveCoalesceTailTicks(1_000, 300, 2))
+            .IsEqualTo(600);
+        await Assert.That(BrokerSender.SelectWaveCoalesceTailTicks(1_000, 800, 3))
+            .IsEqualTo(1_000);
+    }
+
+    [Test]
     [Timeout(120_000)]
     public async Task SendLoop_WaveCoalesce_RearmsAfterIdleWaitAtDefaultLinger(
         CancellationToken cancellationToken)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/WaveCoalesceProbeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/WaveCoalesceProbeBenchmarks.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Threading.Channels;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
@@ -32,4 +33,22 @@ public class WaveCoalesceProbeBenchmarks
 
         return _channel.Writer.TryWrite(item);
     }
+}
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class WaveCoalesceTailBenchmarks
+{
+    private long _configuredQuietTicks = 1_000;
+    private long _maximumArrivalGapTicks = 100;
+    private int _additionalBatchCount = 2;
+
+    [Benchmark(Baseline = true)]
+    public long FixedTail() => _configuredQuietTicks;
+
+    [Benchmark]
+    public long AdaptiveTail() => BrokerSender.SelectWaveCoalesceTailTicks(
+        _configuredQuietTicks,
+        _maximumArrivalGapTicks,
+        _additionalBatchCount);
 }


### PR DESCRIPTION
## Summary
- keep the full wave discovery window until two distinct sibling batches establish an arrival cadence
- shorten only the trailing quiet wait, bounded between 50% and 100% of the configured quiet interval
- size that tail from twice the widest observed sibling gap, preserving slower waves
- add focused policy coverage and a MemoryDiagnoser benchmark

## Before / after evidence

Parent SHA: `b1a7d67e`
Candidate SHA: `eab996bb`

Local exact-configuration baseline -> candidate -> baseline, 1 minute each, Dekaf producer, 1 broker, 1 connection, 6 partitions, 1000-byte messages, 16 KiB batches, 5 ms linger, no compression:

| Metric | Baseline A | Candidate | Baseline B | Candidate vs A | Candidate vs B |
|---|---:|---:|---:|---:|---:|
| Throughput | 69,506 msg/s | 69,737 msg/s | 68,212 msg/s | +0.3% | +2.2% |
| Median throughput | 70,725 msg/s | 70,910 msg/s | 69,405 msg/s | +0.3% | +2.2% |
| CPU/message | 12.21 us | 11.08 us | 11.77 us | -9.3% | -5.9% |
| CPU/request | 883.86 us | 789.15 us | 847.02 us | -10.7% | -6.8% |
| p50 | 2.45 ms | 2.35 ms | 2.55 ms | -4.1% | -7.8% |
| p95 | 5.55 ms | 5.55 ms | 5.65 ms | 0.0% | -1.8% |
| p99 | 8.05 ms | 9.75 ms | 9.55 ms | +21.1% | +2.1% |
| max | 103.81 ms | 105.72 ms | 105.27 ms | +1.8% | +0.4% |
| allocation | 2 B/msg | 2 B/msg | 2 B/msg | unchanged | unchanged |
| errors | 0 | 0 | 0 | unchanged | unchanged |

The one-minute p99 samples are noisy: the two unchanged baselines differ by 18.6%. Candidate is 2.1% above the closing baseline, while p50/p95 improve or hold and max remains within 0.4% of that baseline. Candidate recorded three >100 ms broker/backlog outliers versus seven in closing baseline. This local run is exploratory evidence, not the repository's formal paid regression-gate verdict.

MemoryDiagnoser (5 warmups, 10 iterations): adaptive tail selection is 0.130 ns per arriving batch and 0 B allocated. The fixed-return baseline is below BenchmarkDotNet's measurement floor; it is retained only to represent the prior policy.

## Validation
- `dotnet build --configuration Release` - clean, 0 warnings
- `BrokerSenderSendLoopTests` - 75 passed
- full net10.0 unit suite - 6,720 passed
- `/simplify` final review completed; no allocation, virtual dispatch, async state machine, or O(n) work added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Wave coalescing now adapts its quiet-period tail based on batch arrival timing and volume.
  * Initial discovery delays remain unchanged until sufficient arrival history is established.

* **Tests**
  * Added coverage for adaptive tail timing, discovery-delay handling, and cross-partition burst delivery.

* **Benchmarks**
  * Added comparisons between fixed and adaptive wave-coalescing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->