### PR TITLE
ci(security): add CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # GitVersion.MsBuild fails on shallow clones.
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup .NET
@@ -44,7 +46,11 @@ jobs:
           queries: security-and-quality
 
       - name: Restore
-        run: dotnet restore Dekaf.sln
+        run: |
+          dotnet restore Dekaf.sln
+          dotnet restore tools/Dekaf.Profiling/Dekaf.Profiling.csproj
+          dotnet restore samples/PackageSmoke/Dekaf.PackageSmoke.NetStandard20/Dekaf.PackageSmoke.NetStandard20.csproj
+          dotnet restore samples/PackageSmoke/Dekaf.PackageSmoke.Runner/Dekaf.PackageSmoke.Runner.csproj
 
       - name: Build all projects and target frameworks
         run: >-
@@ -52,6 +58,13 @@ jobs:
           --configuration Release
           --no-restore
           -p:TreatWarningsAsErrors=true
+
+      - name: Build projects outside the solution
+        run: |
+          dotnet build tools/Dekaf.Profiling/Dekaf.Profiling.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true
+          dotnet build samples/PackageSmoke/Dekaf.PackageSmoke.NetStandard20/Dekaf.PackageSmoke.NetStandard20.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true
+          dotnet build samples/PackageSmoke/Dekaf.PackageSmoke.Runner/Dekaf.PackageSmoke.Runner.csproj --configuration Release --framework net8.0 --no-restore -p:TreatWarningsAsErrors=true
+          dotnet build samples/PackageSmoke/Dekaf.PackageSmoke.Runner/Dekaf.PackageSmoke.Runner.csproj --configuration Release --framework net10.0 --no-restore -p:TreatWarningsAsErrors=true
 
       - name: Analyze
         uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,59 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+
+jobs:
+  analyze:
+    name: Analyze (csharp)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: csharp
+          build-mode: manual
+          queries: security-and-quality
+
+      - name: Restore
+        run: dotnet restore Dekaf.sln
+
+      - name: Build all projects and target frameworks
+        run: >-
+          dotnet build Dekaf.sln
+          --configuration Release
+          --no-restore
+          -p:TreatWarningsAsErrors=true
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: /language:csharp


### PR DESCRIPTION
## Summary
- add advanced CodeQL scanning for C# on pull requests, main, weekly schedule, and manual dispatch
- trace an explicit full-solution build so unsafe code, generators, and every configured target framework are analyzed
- use the security-and-quality suite, immutable action SHAs, disabled checkout credentials, and minimal token permissions
- keep the stable required-check candidate named Analyze (csharp); add it to the active Main ruleset after its first successful run

## Test plan
- [x] actionlint v1.7.12 .github/workflows/codeql.yml
- [x] dotnet restore Dekaf.sln
- [x] dotnet build Dekaf.sln --configuration Release --no-restore -p:TreatWarningsAsErrors=true (0 warnings, 0 errors)
- [x] verified CodeQL default setup is currently not-configured, avoiding advanced/default setup conflict

Closes #2650


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated CodeQL security analysis for C# code changes.
  * Security checks now run on updates to the main branch, pull requests, weekly schedules, and manual requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->