### PR TITLE
ci(security): add dependency review gate

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,46 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    # GitHub's dependency-review API requires the repository dependency graph.
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          fail-on-scopes: runtime, development, unknown
+          # Permit only licenses compatible with MIT distribution; additions require review.
+          allow-licenses: >-
+            0BSD,
+            Apache-2.0,
+            BSD-2-Clause,
+            BSD-3-Clause,
+            BSL-1.0,
+            CC0-1.0,
+            ISC,
+            MIT,
+            MIT-0,
+            MPL-2.0,
+            MS-PL,
+            Unlicense,
+            Zlib


### PR DESCRIPTION
## Summary
- keep Renovate as the repository's sole dependency update service; no Dependabot configuration is added
- add a read-only dependency-review gate for every pull request
- reject newly introduced high/critical vulnerabilities in all scopes
- enforce a conservative SPDX license allowlist
- pin actions by immutable SHA and expose no secrets to fork or Renovate PRs
- enable the repository dependency graph required by GitHub's dependency-review API

## Test plan
- [x] actionlint v1.7.12 .github/workflows/dependency-review.yml
- [x] verify dependency-review-action v5.0.0 inputs and commit SHA from the official action repository
- [x] verify repository Dependabot alerts/dependency graph endpoint is enabled
- [x] dotnet build Dekaf.sln --configuration Release -p:TreatWarningsAsErrors=true (0 warnings, 0 errors)
- [x] verify final diff contains no .github/dependabot.yml

TDD is not applicable to declarative GitHub configuration; syntax, action metadata, repository prerequisite, and unchanged solution build were validated directly.

Closes #2651


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency checks for pull requests targeting the main branch.
  * Configured checks to flag high-severity vulnerabilities and disallowed licenses.
  * Added safeguards to cancel outdated checks and limit execution time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->