### PR TITLE
feat(consumer): add allocation-free batch offset storage

### DIFF
--- a/src/Dekaf.Testing/Dekaf.Testing.csproj
+++ b/src/Dekaf.Testing/Dekaf.Testing.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Dekaf.Tests.Unit" />
+  </ItemGroup>
+
 </Project>

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -33,7 +33,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private readonly HashSet<TopicPartition> _assignment = [];
     private readonly HashSet<TopicPartition> _paused = [];
     private readonly Dictionary<TopicPartition, long> _positions = [];
-    private readonly Dictionary<TopicPartition, long> _storedOffsets = [];
+    private readonly Dictionary<TopicPartition, TopicPartitionOffset> _storedOffsets = [];
     // In-doubt record under OffsetStoreTiming.AfterProcessing: delivered but not yet proven
     // processed. Staged for commit only when the next consume call or an explicit commit
     // proves it; an unwind (or close) leaves it unstaged so it is redelivered.
@@ -510,7 +510,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         TopicPartitionOffsetValidator.Validate(offset, nameof(offset));
 
         lock (_gate)
-            _storedOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
+            StoreOffsetUnderLock(offset);
     }
 
     public void StoreOffsets<TOffsets>(TOffsets offsets)
@@ -527,10 +527,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         lock (_gate)
         {
             for (var index = 0; index < count; index++)
-            {
-                var offset = offsets[index];
-                _storedOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
-            }
+                StoreOffsetUnderLock(offsets[index]);
         }
     }
 
@@ -544,10 +541,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         lock (_gate)
         {
             for (var index = 0; index < offsets.Length; index++)
-            {
-                ref readonly var offset = ref offsets[index];
-                _storedOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
-            }
+                StoreOffsetUnderLock(offsets[index]);
         }
     }
 
@@ -626,7 +620,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             DiscardInDoubtRecordUnderLock(partition);
             _positions[partition] = offset.Offset;
             if (_options.EnableAutoOffsetStore)
-                _storedOffsets[partition] = offset.Offset;
+                StoreOffsetUnderLock(partition, offset.Offset);
         }
     }
 
@@ -643,7 +637,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 DiscardInDoubtRecordUnderLock(partition);
                 _positions[partition] = position;
                 if (_options.EnableAutoOffsetStore)
-                    _storedOffsets[partition] = position;
+                    StoreOffsetUnderLock(partition, position);
             }
         }
     }
@@ -661,7 +655,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 DiscardInDoubtRecordUnderLock(partition);
                 _positions[partition] = position;
                 if (_options.EnableAutoOffsetStore)
-                    _storedOffsets[partition] = position;
+                    StoreOffsetUnderLock(partition, position);
             }
         }
     }
@@ -890,7 +884,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             if (_options.OffsetStoreTiming == OffsetStoreTiming.OnDelivery)
             {
                 if (_options.EnableAutoOffsetStore)
-                    _storedOffsets[partition] = record.Offset + 1;
+                    StoreOffsetUnderLock(partition, record.Offset + 1);
                 if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
                     CommitStoredOffsets();
             }
@@ -914,7 +908,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             return;
 
         if (_options.EnableAutoOffsetStore)
-            _storedOffsets[_inDoubtPartition] = _inDoubtNextOffset;
+            StoreOffsetUnderLock(_inDoubtPartition, _inDoubtNextOffset);
 
         _inDoubtNextOffset = -1;
 
@@ -1097,7 +1091,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private void CommitStoredOffsets()
         => CommitOffsetsFrom(_storedOffsets);
 
-    private void CommitOffsetsFrom(Dictionary<TopicPartition, long> positions)
+    private void CommitOffsetsFrom(Dictionary<TopicPartition, TopicPartitionOffset> positions)
     {
         if (_groupId is null)
             return;
@@ -1105,15 +1099,24 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         var assignment = GetCurrentAssignmentUnderLock();
         var offsets = positions
             .Where(item => assignment.Contains(item.Key))
-            .Select(item => new TopicPartitionOffset(
-                item.Key.Topic,
-                item.Key.Partition,
-                item.Value))
+            .Select(static item => item.Value)
             .ToArray();
 
         if (offsets.Length > 0)
             _cluster.CommitOffsets(_groupId, offsets);
     }
+
+    private void StoreOffsetUnderLock(TopicPartitionOffset offset)
+    {
+        var partition = new TopicPartition(offset.Topic, offset.Partition);
+        _storedOffsets[partition] = offset;
+    }
+
+    private void StoreOffsetUnderLock(TopicPartition partition, long offset)
+        => _storedOffsets[partition] = new TopicPartitionOffset(
+            partition.Topic,
+            partition.Partition,
+            offset);
 
     private IReadOnlySet<TopicPartition> GetCurrentAssignmentUnderLock()
     {

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -15,6 +15,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     IConsumerPositions,
     IConsumerPartitions,
     IConsumerOffsets,
+    IConsumerBatchOffsetStore,
     IConsumerCommitConfiguration
 {
     private readonly object _gate = new();
@@ -512,15 +513,11 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             _storedOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
     }
 
-    public void StoreOffsets(TopicPartitionOffset[] offsets)
+    public void StoreOffsets<TOffsets>(TOffsets offsets)
+        where TOffsets : IReadOnlyList<TopicPartitionOffset>
     {
-        ArgumentNullException.ThrowIfNull(offsets);
-        StoreOffsets(offsets.AsSpan());
-    }
-
-    public void StoreOffsets(IReadOnlyList<TopicPartitionOffset> offsets)
-    {
-        ArgumentNullException.ThrowIfNull(offsets);
+        if (offsets is null)
+            throw new ArgumentNullException(nameof(offsets));
         ThrowIfDisposed();
 
         var count = offsets.Count;

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -506,9 +506,52 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     public void StoreOffset(TopicPartitionOffset offset)
     {
         ThrowIfDisposed();
+        TopicPartitionOffsetValidator.Validate(offset, nameof(offset));
 
         lock (_gate)
             _storedOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
+    }
+
+    public void StoreOffsets(TopicPartitionOffset[] offsets)
+    {
+        ArgumentNullException.ThrowIfNull(offsets);
+        StoreOffsets(offsets.AsSpan());
+    }
+
+    public void StoreOffsets(IReadOnlyList<TopicPartitionOffset> offsets)
+    {
+        ArgumentNullException.ThrowIfNull(offsets);
+        ThrowIfDisposed();
+
+        var count = offsets.Count;
+        for (var index = 0; index < count; index++)
+            TopicPartitionOffsetValidator.Validate(offsets[index], nameof(offsets));
+
+        lock (_gate)
+        {
+            for (var index = 0; index < count; index++)
+            {
+                var offset = offsets[index];
+                _storedOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
+            }
+        }
+    }
+
+    public void StoreOffsets(ReadOnlySpan<TopicPartitionOffset> offsets)
+    {
+        ThrowIfDisposed();
+
+        for (var index = 0; index < offsets.Length; index++)
+            TopicPartitionOffsetValidator.Validate(offsets[index], nameof(offsets));
+
+        lock (_gate)
+        {
+            for (var index = 0; index < offsets.Length; index++)
+            {
+                ref readonly var offset = ref offsets[index];
+                _storedOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
+            }
+        }
     }
 
     public ValueTask CloseAsync(CancellationToken cancellationToken = default) =>

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -13,7 +13,7 @@ public sealed class InMemoryKafkaCluster
 {
     private readonly object _gate = new();
     private readonly Dictionary<string, TopicState> _topics = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, Dictionary<TopicPartition, long>> _consumerGroupOffsets = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dictionary<TopicPartition, TopicPartitionOffset>> _consumerGroupOffsets = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<string, HashSet<TopicPartition>>> _consumerGroupMembers = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, ShareLeaseState>>> _shareLeases = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, int>>> _shareDeliveryCounts = new(StringComparer.Ordinal);
@@ -403,6 +403,19 @@ public sealed class InMemoryKafkaCluster
         {
             return _consumerGroupOffsets.TryGetValue(groupId, out var offsets) &&
                    offsets.TryGetValue(topicPartition, out var offset)
+                ? offset.Offset
+                : null;
+        }
+    }
+
+    internal TopicPartitionOffset? GetCommittedOffsetInfo(
+        string groupId,
+        TopicPartition topicPartition)
+    {
+        lock (_gate)
+        {
+            return _consumerGroupOffsets.TryGetValue(groupId, out var offsets) &&
+                   offsets.TryGetValue(topicPartition, out var offset)
                 ? offset
                 : null;
         }
@@ -419,7 +432,7 @@ public sealed class InMemoryKafkaCluster
         lock (_gate)
         {
             return _consumerGroupOffsets.TryGetValue(groupId, out var offsets)
-                ? new Dictionary<TopicPartition, long>(offsets)
+                ? offsets.ToDictionary(static item => item.Key, static item => item.Value.Offset)
                 : new Dictionary<TopicPartition, long>();
         }
     }
@@ -608,7 +621,7 @@ public sealed class InMemoryKafkaCluster
         }
 
         foreach (var offset in offsets)
-            groupOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
+            groupOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset;
     }
 
     private Dictionary<long, ShareLeaseState>? GetShareLeasePartition(

--- a/src/Dekaf/Consumer/ConsumerOffsetStoreExtensions.cs
+++ b/src/Dekaf/Consumer/ConsumerOffsetStoreExtensions.cs
@@ -1,0 +1,91 @@
+namespace Dekaf.Consumer;
+
+/// <summary>
+/// Allocation-free batch offset storage for Kafka consumers.
+/// </summary>
+/// <remarks>
+/// Every overload validates the full input before staging its first offset. Duplicate
+/// topic-partitions use the last entry. A non-negative leader epoch stores or replaces the staged
+/// epoch; a negative epoch clears it. Publication is ordered but is not globally atomic relative
+/// to concurrent commit snapshots. These methods perform no broker I/O.
+/// </remarks>
+public static class ConsumerOffsetStoreExtensions
+{
+    /// <summary>Stores next offsets from an array for the automatic commit loop.</summary>
+    public static void StoreOffsets<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        TopicPartitionOffset[] offsets)
+    {
+        ArgumentNullException.ThrowIfNull(offsets);
+        StoreOffsets(consumer, offsets.AsSpan());
+    }
+
+    /// <summary>Stores next offsets from a span for the automatic commit loop.</summary>
+    public static void StoreOffsets<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        ReadOnlySpan<TopicPartitionOffset> offsets)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+
+        if (consumer is KafkaConsumer<TKey, TValue> kafkaConsumer)
+        {
+            kafkaConsumer.StoreOffsets(offsets);
+            return;
+        }
+
+        if (consumer is IConsumerBatchOffsetStore batchStore)
+        {
+            batchStore.StoreOffsets(offsets);
+            return;
+        }
+
+        Validate(offsets);
+        for (var index = 0; index < offsets.Length; index++)
+            consumer.StoreOffset(offsets[index]);
+    }
+
+    /// <summary>Stores next offsets from an indexed collection without boxing value-type collections.</summary>
+    /// <typeparam name="TKey">Key type.</typeparam>
+    /// <typeparam name="TValue">Value type.</typeparam>
+    /// <typeparam name="TOffsets">The indexed collection type.</typeparam>
+    public static void StoreOffsets<TKey, TValue, TOffsets>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        TOffsets offsets)
+        where TOffsets : IReadOnlyList<TopicPartitionOffset>
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        if (offsets is null)
+            throw new ArgumentNullException(nameof(offsets));
+
+        if (consumer is KafkaConsumer<TKey, TValue> kafkaConsumer)
+        {
+            kafkaConsumer.StoreOffsets(offsets);
+            return;
+        }
+
+        if (consumer is IConsumerBatchOffsetStore batchStore)
+        {
+            batchStore.StoreOffsets(offsets);
+            return;
+        }
+
+        Validate(offsets);
+        var count = offsets.Count;
+        for (var index = 0; index < count; index++)
+            consumer.StoreOffset(offsets[index]);
+    }
+
+    private static void Validate(ReadOnlySpan<TopicPartitionOffset> offsets)
+    {
+        for (var index = 0; index < offsets.Length; index++)
+            TopicPartitionOffsetValidator.Validate(offsets[index], nameof(offsets));
+    }
+
+    private static void Validate<TOffsets>(TOffsets offsets)
+        where TOffsets : IReadOnlyList<TopicPartitionOffset>
+    {
+        var count = offsets.Count;
+        for (var index = 0; index < count; index++)
+            TopicPartitionOffsetValidator.Validate(offsets[index], nameof(offsets));
+    }
+}

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -175,39 +175,6 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     void StoreOffset(TopicPartitionOffset offset);
 
     /// <summary>
-    /// Stores next offsets from an array for the automatic commit loop without allocating.
-    /// </summary>
-    /// <remarks>
-    /// Input is validated before any offset is changed. Duplicate topic-partitions use the last
-    /// entry. A non-negative leader epoch stores or replaces the staged epoch; a negative epoch
-    /// clears it. Publication is ordered but is not globally atomic relative to concurrent commit
-    /// snapshots. This method only stages offsets locally; it performs no broker I/O.
-    /// </remarks>
-    void StoreOffsets(TopicPartitionOffset[] offsets);
-
-    /// <summary>
-    /// Stores next offsets from a list for the automatic commit loop without copying the collection.
-    /// </summary>
-    /// <remarks>
-    /// Input is validated before any offset is changed. Duplicate topic-partitions use the last
-    /// entry. A non-negative leader epoch stores or replaces the staged epoch; a negative epoch
-    /// clears it. Publication is ordered but is not globally atomic relative to concurrent commit
-    /// snapshots. This method only stages offsets locally; it performs no broker I/O.
-    /// </remarks>
-    void StoreOffsets(IReadOnlyList<TopicPartitionOffset> offsets);
-
-    /// <summary>
-    /// Stores next offsets from a span for the automatic commit loop without allocating.
-    /// </summary>
-    /// <remarks>
-    /// Input is validated before any offset is changed. Duplicate topic-partitions use the last
-    /// entry. A non-negative leader epoch stores or replaces the staged epoch; a negative epoch
-    /// clears it. Publication is ordered but is not globally atomic relative to concurrent commit
-    /// snapshots. This method only stages offsets locally; it performs no broker I/O.
-    /// </remarks>
-    void StoreOffsets(ReadOnlySpan<TopicPartitionOffset> offsets);
-
-    /// <summary>
     /// Gracefully closes the consumer: stops background tasks (heartbeat, auto-commit, prefetch),
     /// notifies <see cref="IPartitionStopListener"/> when configured, commits pending offsets,
     /// leaves the consumer group, and releases resources.
@@ -245,6 +212,31 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// The operation exceeds <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>.
     /// </exception>
     ValueTask CloseAsync(ConsumerCloseOptions options, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Optional capability for allocation-free batch offset storage.
+/// </summary>
+/// <remarks>
+/// Dekaf's built-in consumers implement this interface. The separate capability keeps existing
+/// <see cref="IKafkaConsumer{TKey,TValue}"/> implementations binary compatible while
+/// <see cref="ConsumerOffsetStoreExtensions"/> provides the batch API on every consumer.
+/// Input is validated before any offset is changed. Duplicate topic-partitions use the last entry.
+/// A non-negative leader epoch stores or replaces the staged epoch; a negative epoch clears it.
+/// Publication is ordered but is not globally atomic relative to concurrent commit snapshots.
+/// Storage is local and synchronous; broker persistence remains controlled by automatic commit or
+/// <see cref="IKafkaConsumer{TKey,TValue}.CommitAsync(CancellationToken)"/>.
+/// </remarks>
+public interface IConsumerBatchOffsetStore
+{
+    /// <summary>Stores next offsets from a span for the automatic commit loop.</summary>
+    void StoreOffsets(ReadOnlySpan<TopicPartitionOffset> offsets);
+
+    /// <summary>Stores next offsets from an indexed collection without boxing value-type collections.</summary>
+    /// <typeparam name="TOffsets">The indexed collection type.</typeparam>
+    /// <param name="offsets">The next offsets to stage.</param>
+    void StoreOffsets<TOffsets>(TOffsets offsets)
+        where TOffsets : IReadOnlyList<TopicPartitionOffset>;
 }
 
 /// <summary>

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -166,9 +166,46 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     void StoreOffset(ConsumeResult<TKey, TValue> result);
 
     /// <summary>
-    /// Stores an offset for the automatic commit loop.
+    /// Stores a next offset for the automatic commit loop.
     /// </summary>
+    /// <remarks>
+    /// This method only stages the offset locally. Broker persistence is controlled by automatic
+    /// commit or <see cref="CommitAsync(CancellationToken)"/>.
+    /// </remarks>
     void StoreOffset(TopicPartitionOffset offset);
+
+    /// <summary>
+    /// Stores next offsets from an array for the automatic commit loop without allocating.
+    /// </summary>
+    /// <remarks>
+    /// Input is validated before any offset is changed. Duplicate topic-partitions use the last
+    /// entry. A non-negative leader epoch stores or replaces the staged epoch; a negative epoch
+    /// clears it. Publication is ordered but is not globally atomic relative to concurrent commit
+    /// snapshots. This method only stages offsets locally; it performs no broker I/O.
+    /// </remarks>
+    void StoreOffsets(TopicPartitionOffset[] offsets);
+
+    /// <summary>
+    /// Stores next offsets from a list for the automatic commit loop without copying the collection.
+    /// </summary>
+    /// <remarks>
+    /// Input is validated before any offset is changed. Duplicate topic-partitions use the last
+    /// entry. A non-negative leader epoch stores or replaces the staged epoch; a negative epoch
+    /// clears it. Publication is ordered but is not globally atomic relative to concurrent commit
+    /// snapshots. This method only stages offsets locally; it performs no broker I/O.
+    /// </remarks>
+    void StoreOffsets(IReadOnlyList<TopicPartitionOffset> offsets);
+
+    /// <summary>
+    /// Stores next offsets from a span for the automatic commit loop without allocating.
+    /// </summary>
+    /// <remarks>
+    /// Input is validated before any offset is changed. Duplicate topic-partitions use the last
+    /// entry. A non-negative leader epoch stores or replaces the staged epoch; a negative epoch
+    /// clears it. Publication is ordered but is not globally atomic relative to concurrent commit
+    /// snapshots. This method only stages offsets locally; it performs no broker I/O.
+    /// </remarks>
+    void StoreOffsets(ReadOnlySpan<TopicPartitionOffset> offsets);
 
     /// <summary>
     /// Gracefully closes the consumer: stops background tasks (heartbeat, auto-commit, prefetch),

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -5,9 +5,6 @@ using System.Diagnostics.Metrics;
 using Dekaf.Errors;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
-#if !NETSTANDARD2_0
-using System.Runtime.InteropServices;
-#endif
 using Dekaf.Compression;
 using Dekaf.Internal;
 using Dekaf.Metadata;
@@ -871,6 +868,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     IConsumerRebalanceEventSource,
     IConsumerLoggerFactorySource,
     IConsumerCommitConfiguration,
+    IConsumerBatchOffsetStore,
     DeadLetter.IRawRecordAccessor,
     IBudgetedInstance
 {
@@ -5112,29 +5110,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         StoreOffsetCore(new TopicPartition(offset.Topic, offset.Partition), offset.Offset, offset.LeaderEpoch);
     }
 
-    public void StoreOffsets(TopicPartitionOffset[] offsets)
+    public void StoreOffsets<TOffsets>(TOffsets offsets)
+        where TOffsets : IReadOnlyList<TopicPartitionOffset>
     {
-        ArgumentNullException.ThrowIfNull(offsets);
-        StoreOffsets(offsets.AsSpan());
-    }
-
-    public void StoreOffsets(IReadOnlyList<TopicPartitionOffset> offsets)
-    {
-        ArgumentNullException.ThrowIfNull(offsets);
-
-        if (offsets is TopicPartitionOffset[] array)
-        {
-            StoreOffsets(array.AsSpan());
-            return;
-        }
-
-#if !NETSTANDARD2_0
-        if (offsets is List<TopicPartitionOffset> list)
-        {
-            StoreOffsets(CollectionsMarshal.AsSpan(list));
-            return;
-        }
-#endif
+        if (offsets is null)
+            throw new ArgumentNullException(nameof(offsets));
 
         var count = offsets.Count;
         for (var index = 0; index < count; index++)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -5,6 +5,9 @@ using System.Diagnostics.Metrics;
 using Dekaf.Errors;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+#if !NETSTANDARD2_0
+using System.Runtime.InteropServices;
+#endif
 using Dekaf.Compression;
 using Dekaf.Internal;
 using Dekaf.Metadata;
@@ -5097,16 +5100,63 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (result.IsPartitionEof)
             return;
 
-        StoreOffset(new TopicPartitionOffset(
-            result.Topic,
-            result.Partition,
+        StoreOffsetCore(
+            new TopicPartition(result.Topic, result.Partition),
             checked(result.Offset + 1),
-            result.LeaderEpoch ?? -1));
+            result.LeaderEpoch ?? -1);
     }
 
     public void StoreOffset(TopicPartitionOffset offset)
     {
+        TopicPartitionOffsetValidator.Validate(offset, nameof(offset));
         StoreOffsetCore(new TopicPartition(offset.Topic, offset.Partition), offset.Offset, offset.LeaderEpoch);
+    }
+
+    public void StoreOffsets(TopicPartitionOffset[] offsets)
+    {
+        ArgumentNullException.ThrowIfNull(offsets);
+        StoreOffsets(offsets.AsSpan());
+    }
+
+    public void StoreOffsets(IReadOnlyList<TopicPartitionOffset> offsets)
+    {
+        ArgumentNullException.ThrowIfNull(offsets);
+
+        if (offsets is TopicPartitionOffset[] array)
+        {
+            StoreOffsets(array.AsSpan());
+            return;
+        }
+
+#if !NETSTANDARD2_0
+        if (offsets is List<TopicPartitionOffset> list)
+        {
+            StoreOffsets(CollectionsMarshal.AsSpan(list));
+            return;
+        }
+#endif
+
+        var count = offsets.Count;
+        for (var index = 0; index < count; index++)
+            TopicPartitionOffsetValidator.Validate(offsets[index], nameof(offsets));
+
+        for (var index = 0; index < count; index++)
+        {
+            var offset = offsets[index];
+            StoreOffsetCore(new TopicPartition(offset.Topic, offset.Partition), offset.Offset, offset.LeaderEpoch);
+        }
+    }
+
+    public void StoreOffsets(ReadOnlySpan<TopicPartitionOffset> offsets)
+    {
+        for (var index = 0; index < offsets.Length; index++)
+            TopicPartitionOffsetValidator.Validate(offsets[index], nameof(offsets));
+
+        for (var index = 0; index < offsets.Length; index++)
+        {
+            ref readonly var offset = ref offsets[index];
+            StoreOffsetCore(new TopicPartition(offset.Topic, offset.Partition), offset.Offset, offset.LeaderEpoch);
+        }
     }
 
     public async ValueTask<long?> GetCommittedOffsetAsync(TopicPartition partition, CancellationToken cancellationToken = default)

--- a/src/Dekaf/Consumer/TopicPartitionOffsetValidator.cs
+++ b/src/Dekaf/Consumer/TopicPartitionOffsetValidator.cs
@@ -1,0 +1,19 @@
+using System.Runtime.CompilerServices;
+
+namespace Dekaf.Consumer;
+
+internal static class TopicPartitionOffsetValidator
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void Validate(in TopicPartitionOffset offset, string paramName)
+    {
+        if (string.IsNullOrEmpty(offset.Topic))
+            throw new ArgumentException("Topic must be specified.", paramName);
+
+        if (offset.Partition < 0)
+            throw new ArgumentOutOfRangeException(paramName, offset.Partition, "Partition must be non-negative.");
+
+        if (offset.Offset < 0)
+            throw new ArgumentOutOfRangeException(paramName, offset.Offset, "Offset must be non-negative.");
+    }
+}

--- a/tests/Dekaf.Tests.Integration/StoreOffsetTests.cs
+++ b/tests/Dekaf.Tests.Integration/StoreOffsetTests.cs
@@ -1,3 +1,4 @@
+using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 
@@ -522,5 +523,78 @@ public class OffsetCommitModeTests(KafkaTestContainer kafka) : KafkaIntegrationT
         }
 
         await Assert.That(committedOffset).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task StoreOffsets_MultiplePartitions_StagesLocallyThenCommitsBatch()
+    {
+        const int partitionCount = 3;
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: partitionCount).ConfigureAwait(false);
+        var groupId = $"batch-store-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("batch-store-producer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        for (var partition = 0; partition < partitionCount; partition++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = partition,
+                Key = $"key-{partition}",
+                Value = $"value-{partition}"
+            }, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("batch-store-consumer")
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithAutoOffsetStore(false)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+        consumer.Subscribe(topic);
+
+        var consumed = new List<ConsumeResult<string, string>>(partitionCount);
+        using var consumeCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        while (consumed.Count < partitionCount)
+        {
+            var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), consumeCts.Token)
+                .ConfigureAwait(false);
+            await Assert.That(result).IsNotNull();
+            consumed.Add(result!.Value);
+        }
+
+        TopicPartitionOffset[] offsets = consumed
+            .Select(static result => new TopicPartitionOffset(
+                result.Topic,
+                result.Partition,
+                checked(result.Offset + 1),
+                result.LeaderEpoch ?? -1))
+            .ToArray();
+        consumer.StoreOffsets(offsets);
+
+        await using var admin = new AdminClientBuilder()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("batch-store-admin")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .Build();
+        var beforeCommit = await admin.ListConsumerGroupOffsetsAsync(groupId).ConfigureAwait(false);
+        await Assert.That(beforeCommit).IsEmpty();
+
+        await consumer.CommitAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var committed = await admin.ListConsumerGroupOffsetsAsync(groupId).ConfigureAwait(false);
+        await Assert.That(committed).Count().IsEqualTo(partitionCount);
+        foreach (var offset in offsets)
+        {
+            await Assert.That(committed[new TopicPartition(offset.Topic, offset.Partition)])
+                .IsEqualTo(offset.Offset);
+        }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
@@ -178,6 +178,239 @@ public sealed class ConsumerDirtyCommitTests
     }
 
     [Test]
+    public async Task StoreOffsets_EmptyBatch_DoesNotStageOffsets()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(requests, ErrorCode.None);
+
+        consumer.StoreOffsets(ReadOnlySpan<TopicPartitionOffset>.Empty);
+
+        await CommitStoredOffsetsAsync(consumer);
+
+        await Assert.That(requests).IsEmpty();
+    }
+
+    [Test]
+    public async Task StoreOffsets_Array_StagesOneAndManyPartitions()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(requests, ErrorCode.None);
+        TopicPartitionOffset[] singleOffset =
+        [
+            new("topic-a", 0, 10, leaderEpoch: 3)
+        ];
+        TopicPartitionOffset[] offsets =
+        [
+            new("topic-a", 1, 20, leaderEpoch: 4),
+            new("topic-b", 0, 30)
+        ];
+
+        consumer.StoreOffsets(singleOffset);
+        await CommitStoredOffsetsAsync(consumer);
+        consumer.StoreOffsets(offsets);
+        await CommitStoredOffsetsAsync(consumer);
+
+        await Assert.That(requests).Count().IsEqualTo(2);
+        await Assert.That(GetCommittedOffsets(requests[0])).IsEquivalentTo(singleOffset);
+        await Assert.That(GetCommittedOffsets(requests[1])).IsEquivalentTo(offsets);
+    }
+
+    [Test]
+    public async Task StoreOffsets_DuplicatePartition_LastEntryWinsAndNegativeEpochClearsPriorEpoch()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(requests, ErrorCode.None);
+        consumer.StoreOffset(new TopicPartitionOffset("topic-a", 0, 5, leaderEpoch: 2));
+        consumer.StoreOffsets(
+        [
+            new TopicPartitionOffset("topic-a", 0, 9, leaderEpoch: 7)
+        ]);
+
+        await CommitStoredOffsetsAsync(consumer);
+
+        await Assert.That(GetCommittedOffsets(requests[0])).IsEquivalentTo(
+        [
+            new TopicPartitionOffset("topic-a", 0, 9, leaderEpoch: 7)
+        ]);
+
+        TopicPartitionOffset[] offsets =
+        [
+            new TopicPartitionOffset("topic-a", 0, 10, leaderEpoch: 8),
+            new TopicPartitionOffset("topic-a", 0, 11)
+        ];
+
+        consumer.StoreOffsets(offsets);
+
+        await CommitStoredOffsetsAsync(consumer);
+
+        await Assert.That(GetCommittedOffsets(requests[1])).IsEquivalentTo(
+        [
+            new TopicPartitionOffset("topic-a", 0, 11)
+        ]);
+    }
+
+    [Test]
+    public async Task StoreOffsets_InvalidEntry_StagesNothing()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(requests, ErrorCode.None);
+        TopicPartitionOffset[] offsets =
+        [
+            new("topic-a", 0, 10),
+            new("", 1, 20),
+            new("topic-a", 2, 30)
+        ];
+
+        await Assert.That(() => consumer.StoreOffsets(offsets))
+            .Throws<ArgumentException>();
+
+        await CommitStoredOffsetsAsync(consumer);
+
+        await Assert.That(requests).IsEmpty();
+    }
+
+    [Test]
+    public async Task StoreOffsets_NullCollection_ThrowsWithoutStaging()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(requests, ErrorCode.None);
+
+        await Assert.That(() => consumer.StoreOffsets((TopicPartitionOffset[])null!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => consumer.StoreOffsets((IReadOnlyList<TopicPartitionOffset>)null!))
+            .Throws<ArgumentNullException>();
+
+        await CommitStoredOffsetsAsync(consumer);
+
+        await Assert.That(requests).IsEmpty();
+    }
+
+    [Test]
+    [Arguments(null, 0, 0, typeof(ArgumentException))]
+    [Arguments("", 0, 0, typeof(ArgumentException))]
+    [Arguments("topic-a", -1, 0, typeof(ArgumentOutOfRangeException))]
+    [Arguments("topic-a", 0, -1, typeof(ArgumentOutOfRangeException))]
+    public async Task StoreOffset_InvalidValue_ThrowsWithoutStaging(
+        string? topic,
+        int partition,
+        long offset,
+        Type exceptionType)
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(requests, ErrorCode.None);
+
+        var exception = Assert.Throws(
+            exceptionType,
+            () => consumer.StoreOffset(new TopicPartitionOffset(topic!, partition, offset)));
+
+        await Assert.That(exception).IsNotNull();
+        await CommitStoredOffsetsAsync(consumer);
+        await Assert.That(requests).IsEmpty();
+    }
+
+    [Test]
+    public async Task StoreOffsets_ArrayListAndSpan_StageIdenticalOffsets()
+    {
+        TopicPartitionOffset[] offsets =
+        [
+            new("topic-a", 0, 10, leaderEpoch: 3),
+            new("topic-a", 1, 20, leaderEpoch: 4)
+        ];
+        var requests = new List<OffsetCommitRequest>();
+
+        await using (var arrayConsumer = CreateConsumer(requests, ErrorCode.None))
+        {
+            arrayConsumer.StoreOffsets(offsets);
+            await CommitStoredOffsetsAsync(arrayConsumer);
+        }
+
+        await using (var listConsumer = CreateConsumer(requests, ErrorCode.None))
+        {
+            IReadOnlyList<TopicPartitionOffset> list = offsets.ToList();
+            listConsumer.StoreOffsets(list);
+            await CommitStoredOffsetsAsync(listConsumer);
+        }
+
+        await using (var spanConsumer = CreateConsumer(requests, ErrorCode.None))
+        {
+            ReadOnlySpan<TopicPartitionOffset> span = offsets;
+            spanConsumer.StoreOffsets(span);
+            await CommitStoredOffsetsAsync(spanConsumer);
+        }
+
+        await Assert.That(requests).Count().IsEqualTo(3);
+        foreach (var request in requests)
+            await Assert.That(GetCommittedOffsets(request)).IsEquivalentTo(offsets);
+    }
+
+    [Test]
+    public async Task StoreOffsets_ConcurrentCalls_DoNotCorruptStoredState()
+    {
+        const int partitionCount = 64;
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(requests, ErrorCode.None);
+
+        Parallel.For(0, partitionCount, partition =>
+        {
+            TopicPartitionOffset[] offsets = [new("topic-a", partition, partition + 1)];
+            consumer.StoreOffsets(offsets);
+        });
+
+        await CommitStoredOffsetsAsync(consumer);
+
+        var committed = GetCommittedOffsets(requests.Single());
+        await Assert.That(committed).Count().IsEqualTo(partitionCount);
+        for (var partition = 0; partition < partitionCount; partition++)
+        {
+            await Assert.That(committed).Contains(
+                new TopicPartitionOffset("topic-a", partition, partition + 1));
+        }
+    }
+
+    [Test]
+    public async Task StoreOffsets_ParameterlessCommit_CommitsStagedBatch()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(
+            requests,
+            ErrorCode.None,
+            OffsetCommitMode.Manual,
+            enableAutoOffsetStore: false);
+        TopicPartitionOffset[] offsets =
+        [
+            new("topic-a", 0, 10),
+            new("topic-a", 1, 20)
+        ];
+
+        consumer.StoreOffsets(offsets);
+        await consumer.CommitAsync(CancellationToken.None);
+
+        await Assert.That(GetCommittedOffsets(requests.Single())).IsEquivalentTo(offsets);
+    }
+
+    [Test]
+    public async Task StoreOffsets_AutoCommitCycle_CommitsStagedBatch()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(
+            requests,
+            ErrorCode.None,
+            OffsetCommitMode.Auto,
+            enableAutoOffsetStore: false);
+        TopicPartitionOffset[] offsets =
+        [
+            new("topic-a", 0, 10),
+            new("topic-a", 1, 20)
+        ];
+        SetCoordinatorState(consumer, CoordinatorState.Stable);
+
+        consumer.StoreOffsets(offsets);
+        await RunAutoCommitCycleAsync(consumer);
+
+        await Assert.That(GetCommittedOffsets(requests.Single())).IsEquivalentTo(offsets);
+    }
+
+    [Test]
     public async Task CloseAsync_UnknownCoordinator_RediscoversAndCommitsPendingOffset()
     {
         var requests = new List<OffsetCommitRequest>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
@@ -344,6 +344,24 @@ public sealed class ConsumerDirtyCommitTests
     }
 
     [Test]
+    public async Task StoreOffsets_StructBackedList_StagesOffsetsWithoutInterfaceConversion()
+    {
+        TopicPartitionOffset[] expected =
+        [
+            new("topic-a", 0, 10, leaderEpoch: 3),
+            new("topic-a", 1, 20, leaderEpoch: 4)
+        ];
+        var offsets = new StructOffsetList(expected);
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(requests, ErrorCode.None);
+
+        consumer.StoreOffsets(offsets);
+        await CommitStoredOffsetsAsync(consumer);
+
+        await Assert.That(GetCommittedOffsets(requests.Single())).IsEquivalentTo(expected);
+    }
+
+    [Test]
     public async Task StoreOffsets_ConcurrentCalls_DoNotCorruptStoredState()
     {
         const int partitionCount = 64;
@@ -1058,5 +1076,17 @@ public sealed class ConsumerDirtyCommitTests
             .ThenBy(static offset => offset.Partition)
             .ThenBy(static offset => offset.Offset)
             .ToArray();
+    }
+
+    private readonly struct StructOffsetList(TopicPartitionOffset[] offsets) : IReadOnlyList<TopicPartitionOffset>
+    {
+        public int Count => offsets.Length;
+
+        public TopicPartitionOffset this[int index] => offsets[index];
+
+        public IEnumerator<TopicPartitionOffset> GetEnumerator() =>
+            ((IEnumerable<TopicPartitionOffset>)offsets).GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => offsets.GetEnumerator();
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetCommitModeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetCommitModeTests.cs
@@ -74,7 +74,7 @@ public class OffsetCommitModeTests
     }
 
     [Test]
-    public async Task IKafkaConsumer_OffsetCommitAndStoreMethods_Exist()
+    public async Task ConsumerOffsetStoreApi_PreservesInterfaceAndExposesBatchExtensions()
     {
         // Verify the interface has the CommitAsync methods defined
         var interfaceType = typeof(IKafkaConsumer<string, string>);
@@ -92,23 +92,14 @@ public class OffsetCommitModeTests
         var storeSpecificOffset = interfaceType.GetMethod(
             nameof(IKafkaConsumer<string, string>.StoreOffset),
             [typeof(TopicPartitionOffset)]);
-        var storeOffsetArray = interfaceType.GetMethod(
-            nameof(IKafkaConsumer<string, string>.StoreOffsets),
-            [typeof(TopicPartitionOffset[])]);
-        var storeOffsetList = interfaceType.GetMethod(
-            nameof(IKafkaConsumer<string, string>.StoreOffsets),
-            [typeof(IReadOnlyList<TopicPartitionOffset>)]);
-        var storeOffsetSpan = interfaceType.GetMethod(
-            nameof(IKafkaConsumer<string, string>.StoreOffsets),
-            [typeof(ReadOnlySpan<TopicPartitionOffset>)]);
 
         await Assert.That(commitAsyncNoArgs).IsNotNull();
         await Assert.That(commitAsyncWithOffsets).IsNotNull();
         await Assert.That(storeOffset).IsNotNull();
         await Assert.That(storeSpecificOffset).IsNotNull();
-        await Assert.That(storeOffsetArray).IsNotNull();
-        await Assert.That(storeOffsetList).IsNotNull();
-        await Assert.That(storeOffsetSpan).IsNotNull();
+        await Assert.That(interfaceType.GetMethods().Any(static method => method.Name == "StoreOffsets")).IsFalse();
+        await Assert.That(typeof(ConsumerOffsetStoreExtensions).GetMethods()
+            .Count(static method => method.Name == "StoreOffsets")).IsEqualTo(3);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetCommitModeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetCommitModeTests.cs
@@ -74,7 +74,7 @@ public class OffsetCommitModeTests
     }
 
     [Test]
-    public async Task IKafkaConsumer_CommitAsync_MethodExists()
+    public async Task IKafkaConsumer_OffsetCommitAndStoreMethods_Exist()
     {
         // Verify the interface has the CommitAsync methods defined
         var interfaceType = typeof(IKafkaConsumer<string, string>);
@@ -92,11 +92,23 @@ public class OffsetCommitModeTests
         var storeSpecificOffset = interfaceType.GetMethod(
             nameof(IKafkaConsumer<string, string>.StoreOffset),
             [typeof(TopicPartitionOffset)]);
+        var storeOffsetArray = interfaceType.GetMethod(
+            nameof(IKafkaConsumer<string, string>.StoreOffsets),
+            [typeof(TopicPartitionOffset[])]);
+        var storeOffsetList = interfaceType.GetMethod(
+            nameof(IKafkaConsumer<string, string>.StoreOffsets),
+            [typeof(IReadOnlyList<TopicPartitionOffset>)]);
+        var storeOffsetSpan = interfaceType.GetMethod(
+            nameof(IKafkaConsumer<string, string>.StoreOffsets),
+            [typeof(ReadOnlySpan<TopicPartitionOffset>)]);
 
         await Assert.That(commitAsyncNoArgs).IsNotNull();
         await Assert.That(commitAsyncWithOffsets).IsNotNull();
         await Assert.That(storeOffset).IsNotNull();
         await Assert.That(storeSpecificOffset).IsNotNull();
+        await Assert.That(storeOffsetArray).IsNotNull();
+        await Assert.That(storeOffsetList).IsNotNull();
+        await Assert.That(storeOffsetSpan).IsNotNull();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -12,6 +12,37 @@ namespace Dekaf.Tests.Unit.Consumer;
 public sealed class PartitionedConsumerRuntimeTests
 {
     [Test]
+    public async Task StoreOffsets_LegacyConsumerFallback_AcceptsStructBackedList()
+    {
+        var implementation = new TestConsumer();
+        IKafkaConsumer<string, string> consumer = implementation;
+        TopicPartitionOffset[] expected =
+        [
+            new("topic-a", 0, 10),
+            new("topic-a", 1, 20)
+        ];
+
+        consumer.StoreOffsets(new StructOffsetList(expected));
+
+        await Assert.That(implementation.StoredOffsets).IsEquivalentTo(expected);
+    }
+
+    [Test]
+    public async Task StoreOffsets_LegacyConsumerFallback_ValidatesBeforeMutation()
+    {
+        var implementation = new TestConsumer();
+        IKafkaConsumer<string, string> consumer = implementation;
+        var offsets = new StructOffsetList(
+        [
+            new TopicPartitionOffset("topic-a", 0, 10),
+            new TopicPartitionOffset("", 1, 20)
+        ]);
+
+        await Assert.That(() => consumer.StoreOffsets(offsets)).Throws<ArgumentException>();
+        await Assert.That(implementation.StoredOffsets).IsEmpty();
+    }
+
+    [Test]
     public async Task RunPartitionedAsync_RoutesAssignedPartitionsInOrderAndConcurrently()
     {
         var firstPartition = new TopicPartition("topic-a", 0);
@@ -1222,6 +1253,8 @@ public sealed class PartitionedConsumerRuntimeTests
 
         public List<TopicPartitionOffset[]> CommitCalls { get; } = [];
 
+        public List<TopicPartitionOffset> StoredOffsets { get; } = [];
+
         public int ConsumeOneCalls => Volatile.Read(ref _consumeOneCalls);
 
         public int ConsumeBatchCalls => Volatile.Read(ref _consumeBatchCalls);
@@ -1393,18 +1426,8 @@ public sealed class PartitionedConsumerRuntimeTests
 
         public void StoreOffset(TopicPartitionOffset offset)
         {
-        }
-
-        public void StoreOffsets(TopicPartitionOffset[] offsets)
-        {
-        }
-
-        public void StoreOffsets(IReadOnlyList<TopicPartitionOffset> offsets)
-        {
-        }
-
-        public void StoreOffsets(ReadOnlySpan<TopicPartitionOffset> offsets)
-        {
+            lock (_gate)
+                StoredOffsets.Add(offset);
         }
 
         public ValueTask CloseAsync(CancellationToken cancellationToken = default)
@@ -1699,6 +1722,18 @@ public sealed class PartitionedConsumerRuntimeTests
                     consumer.RemoveRebalanceListener(listener);
             }
         }
+    }
+
+    private readonly struct StructOffsetList(TopicPartitionOffset[] offsets) : IReadOnlyList<TopicPartitionOffset>
+    {
+        public int Count => offsets.Length;
+
+        public TopicPartitionOffset this[int index] => offsets[index];
+
+        public IEnumerator<TopicPartitionOffset> GetEnumerator() =>
+            ((IEnumerable<TopicPartitionOffset>)offsets).GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => offsets.GetEnumerator();
     }
 
     private sealed class CapturingLoggerFactory : ILoggerFactory

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -1395,6 +1395,18 @@ public sealed class PartitionedConsumerRuntimeTests
         {
         }
 
+        public void StoreOffsets(TopicPartitionOffset[] offsets)
+        {
+        }
+
+        public void StoreOffsets(IReadOnlyList<TopicPartitionOffset> offsets)
+        {
+        }
+
+        public void StoreOffsets(ReadOnlySpan<TopicPartitionOffset> offsets)
+        {
+        }
+
         public ValueTask CloseAsync(CancellationToken cancellationToken = default)
             => ValueTask.CompletedTask;
 

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -224,6 +224,47 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task Consumer_BatchOffsetStore_MatchesOrderedValidationAndCommitSemantics()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "workers",
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                EnableAutoOffsetStore = false
+            });
+        var admin = new InMemoryAdminClient(cluster);
+        consumer.Assign(
+            new TopicPartition("jobs", 0),
+            new TopicPartition("tasks", 0));
+        TopicPartitionOffset[] invalidOffsets =
+        [
+            new("jobs", 0, 1),
+            new("jobs", -1, 2)
+        ];
+
+        await Assert.That(() => consumer.StoreOffsets(invalidOffsets))
+            .Throws<ArgumentOutOfRangeException>();
+        await consumer.CommitAsync();
+        await Assert.That(await admin.ListConsumerGroupOffsetsAsync("workers")).IsEmpty();
+
+        TopicPartitionOffset[] offsets =
+        [
+            new("jobs", 0, 1),
+            new("tasks", 0, 2),
+            new("jobs", 0, 3)
+        ];
+        consumer.StoreOffsets(offsets);
+        await consumer.CommitAsync();
+
+        var committed = await admin.ListConsumerGroupOffsetsAsync("workers");
+        await Assert.That(committed[new TopicPartition("jobs", 0)]).IsEqualTo(3);
+        await Assert.That(committed[new TopicPartition("tasks", 0)]).IsEqualTo(2);
+    }
+
+    [Test]
     [Arguments("Seek")]
     [Arguments("SeekToBeginning")]
     [Arguments("SeekToEnd")]

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -252,9 +252,9 @@ public sealed class InMemoryKafkaClusterTests
 
         var offsets = new StructOffsetList(
         [
-            new("jobs", 0, 1),
-            new("tasks", 0, 2),
-            new("jobs", 0, 3)
+            new("jobs", 0, 1, leaderEpoch: 1),
+            new("tasks", 0, 2, leaderEpoch: 2),
+            new("jobs", 0, 3, leaderEpoch: 3)
         ]);
         consumer.StoreOffsets(offsets);
         await consumer.CommitAsync();
@@ -262,6 +262,27 @@ public sealed class InMemoryKafkaClusterTests
         var committed = await admin.ListConsumerGroupOffsetsAsync("workers");
         await Assert.That(committed[new TopicPartition("jobs", 0)]).IsEqualTo(3);
         await Assert.That(committed[new TopicPartition("tasks", 0)]).IsEqualTo(2);
+        await Assert.That(cluster.GetCommittedOffsetInfo("workers", new TopicPartition("jobs", 0))!.Value.LeaderEpoch)
+            .IsEqualTo(3);
+        await Assert.That(cluster.GetCommittedOffsetInfo("workers", new TopicPartition("tasks", 0))!.Value.LeaderEpoch)
+            .IsEqualTo(2);
+
+        TopicPartitionOffset[] spanOffsets =
+        [
+            new("jobs", 0, 4, leaderEpoch: 4),
+            new("tasks", 0, 5, leaderEpoch: 5)
+        ];
+        consumer.StoreOffsets(spanOffsets.AsSpan());
+        await consumer.CommitAsync();
+        await Assert.That(cluster.GetCommittedOffsetInfo("workers", new TopicPartition("jobs", 0))!.Value.LeaderEpoch)
+            .IsEqualTo(4);
+        await Assert.That(cluster.GetCommittedOffsetInfo("workers", new TopicPartition("tasks", 0))!.Value.LeaderEpoch)
+            .IsEqualTo(5);
+
+        consumer.StoreOffset(new TopicPartitionOffset("jobs", 0, 6, leaderEpoch: -1));
+        await consumer.CommitAsync();
+        await Assert.That(cluster.GetCommittedOffsetInfo("workers", new TopicPartition("jobs", 0))!.Value.LeaderEpoch)
+            .IsEqualTo(-1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -250,12 +250,12 @@ public sealed class InMemoryKafkaClusterTests
         await consumer.CommitAsync();
         await Assert.That(await admin.ListConsumerGroupOffsetsAsync("workers")).IsEmpty();
 
-        TopicPartitionOffset[] offsets =
+        var offsets = new StructOffsetList(
         [
             new("jobs", 0, 1),
             new("tasks", 0, 2),
             new("jobs", 0, 3)
-        ];
+        ]);
         consumer.StoreOffsets(offsets);
         await consumer.CommitAsync();
 
@@ -890,5 +890,17 @@ public sealed class InMemoryKafkaClusterTests
             default:
                 throw new ArgumentOutOfRangeException(nameof(seekOperation), seekOperation, null);
         }
+    }
+
+    private readonly struct StructOffsetList(TopicPartitionOffset[] offsets) : IReadOnlyList<TopicPartitionOffset>
+    {
+        public int Count => offsets.Length;
+
+        public TopicPartitionOffset this[int index] => offsets[index];
+
+        public IEnumerator<TopicPartitionOffset> GetEnumerator() =>
+            ((IEnumerable<TopicPartitionOffset>)offsets).GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => offsets.GetEnumerator();
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/OffsetStoreBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/OffsetStoreBenchmarks.cs
@@ -34,6 +34,9 @@ public class OffsetStoreBenchmarks
         _consumer.StoreOffsets(_offsets);
     }
 
+    [GlobalCleanup]
+    public ValueTask Cleanup() => _consumer.DisposeAsync();
+
     [Benchmark(Baseline = true)]
     public void RepeatedSingle()
     {
@@ -99,6 +102,9 @@ public class ConsumeResultOffsetStoreBenchmarks
             valueDeserializer: null);
         _consumer.StoreOffset(_result);
     }
+
+    [GlobalCleanup]
+    public ValueTask Cleanup() => _consumer.DisposeAsync();
 
     [Benchmark]
     public void StoreOffset() => _consumer.StoreOffset(_result);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/OffsetStoreBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/OffsetStoreBenchmarks.cs
@@ -1,0 +1,88 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Consumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Compares allocation-free batch offset staging with the equivalent explicit single-offset loop.
+/// Setup pre-populates every dictionary key so measurements cover steady-state updates only.
+/// </summary>
+[MemoryDiagnoser]
+[ShortRunJob]
+public class OffsetStoreBenchmarks
+{
+    private IKafkaConsumer<byte[], byte[]> _consumer = null!;
+    private TopicPartitionOffset[] _offsets = null!;
+    private IReadOnlyList<TopicPartitionOffset> _offsetList = null!;
+
+    [Params(1, 8, 64)]
+    public int PartitionCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _consumer = Kafka.CreateConsumer<byte[], byte[]>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+        _offsets = new TopicPartitionOffset[PartitionCount];
+        for (var partition = 0; partition < _offsets.Length; partition++)
+            _offsets[partition] = new TopicPartitionOffset("offset-store-benchmark", partition, 42, leaderEpoch: 3);
+
+        _offsetList = _offsets.ToList();
+        _consumer.StoreOffsets(_offsets);
+    }
+
+    [Benchmark(Baseline = true)]
+    public void RepeatedSingle()
+    {
+        for (var index = 0; index < _offsets.Length; index++)
+            _consumer.StoreOffset(_offsets[index]);
+    }
+
+    [Benchmark]
+    public void SpanBatch() => _consumer.StoreOffsets(_offsets.AsSpan());
+
+    [Benchmark]
+    public void ArrayBatch() => _consumer.StoreOffsets(_offsets);
+
+    [Benchmark]
+    public void ListBatch() => _consumer.StoreOffsets(_offsetList);
+}
+
+/// <summary>
+/// Protects the common per-message manual-store path from validation overhead intended for
+/// caller-created <see cref="TopicPartitionOffset"/> values.
+/// </summary>
+[MemoryDiagnoser]
+[ShortRunJob]
+public class ConsumeResultOffsetStoreBenchmarks
+{
+    private IKafkaConsumer<byte[], byte[]> _consumer = null!;
+    private ConsumeResult<byte[], byte[]> _result;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _consumer = Kafka.CreateConsumer<byte[], byte[]>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+        _result = new ConsumeResult<byte[], byte[]>(
+            topic: "offset-store-benchmark",
+            partition: 0,
+            offset: 41,
+            keyData: ReadOnlyMemory<byte>.Empty,
+            isKeyNull: true,
+            valueData: ReadOnlyMemory<byte>.Empty,
+            isValueNull: true,
+            headers: null,
+            timestampMs: 0,
+            timestampType: TimestampType.NotAvailable,
+            leaderEpoch: 3,
+            keyDeserializer: null,
+            valueDeserializer: null);
+        _consumer.StoreOffset(_result);
+    }
+
+    [Benchmark]
+    public void StoreOffset() => _consumer.StoreOffset(_result);
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/OffsetStoreBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/OffsetStoreBenchmarks.cs
@@ -14,6 +14,7 @@ public class OffsetStoreBenchmarks
     private IKafkaConsumer<byte[], byte[]> _consumer = null!;
     private TopicPartitionOffset[] _offsets = null!;
     private IReadOnlyList<TopicPartitionOffset> _offsetList = null!;
+    private StructOffsetList _structOffsets;
 
     [Params(1, 8, 64)]
     public int PartitionCount { get; set; }
@@ -29,6 +30,7 @@ public class OffsetStoreBenchmarks
             _offsets[partition] = new TopicPartitionOffset("offset-store-benchmark", partition, 42, leaderEpoch: 3);
 
         _offsetList = _offsets.ToList();
+        _structOffsets = new StructOffsetList(_offsets);
         _consumer.StoreOffsets(_offsets);
     }
 
@@ -47,6 +49,21 @@ public class OffsetStoreBenchmarks
 
     [Benchmark]
     public void ListBatch() => _consumer.StoreOffsets(_offsetList);
+
+    [Benchmark]
+    public void StructListBatch() => _consumer.StoreOffsets(_structOffsets);
+
+    private readonly struct StructOffsetList(TopicPartitionOffset[] offsets) : IReadOnlyList<TopicPartitionOffset>
+    {
+        public int Count => offsets.Length;
+
+        public TopicPartitionOffset this[int index] => offsets[index];
+
+        public IEnumerator<TopicPartitionOffset> GetEnumerator() =>
+            ((IEnumerable<TopicPartitionOffset>)offsets).GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => offsets.GetEnumerator();
+    }
 }
 
 /// <summary>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicPartitionOffsetStoreBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicPartitionOffsetStoreBenchmarks.cs
@@ -1,0 +1,33 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Consumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Guards the public single-offset staging path used after each manually processed message.
+/// Setup pre-populates dictionary keys so the measurement covers steady-state updates.
+/// </summary>
+[MemoryDiagnoser]
+[OperationsPerSecond]
+[ShortRunJob]
+public class TopicPartitionOffsetStoreBenchmarks
+{
+    private IKafkaConsumer<byte[], byte[]> _consumer = null!;
+    private TopicPartitionOffset _offset;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _consumer = Kafka.CreateConsumer<byte[], byte[]>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+        _offset = new TopicPartitionOffset("offset-store-benchmark", 0, 42, leaderEpoch: 3);
+        _consumer.StoreOffset(_offset);
+    }
+
+    [GlobalCleanup]
+    public ValueTask Cleanup() => _consumer.DisposeAsync();
+
+    [Benchmark]
+    public void StoreOffset() => _consumer.StoreOffset(_offset);
+}


### PR DESCRIPTION
## Summary

- add allocation-free array, generic indexed-collection, and `ReadOnlySpan<T>` offset-staging extensions
- preserve binary compatibility by keeping `IKafkaConsumer<TKey, TValue>` unchanged and using an optional `IConsumerBatchOffsetStore` capability
- validate every batch before mutation; preserve ordered last-entry-wins and leader-epoch replace/clear semantics
- keep real consumer, in-memory consumer, legacy-implementation fallback, integration coverage, and benchmarks aligned

## Validation

- `dotnet build --configuration Release --no-restore` — passed, 0 warnings
- net10 unit suite — 6,743/6,743 passed
- focused batch/API/in-memory/runtime tests — 118/118 passed
- `StoreOffsets_MultiplePartitions_StagesLocallyThenCommitsBatch` — passed against Kafka 4.3.1
- `dotnet-inspect` — `IKafkaConsumer` remains 16 methods with no `StoreOffsets`; capability has 2 methods; extension class has 3 overloads
- `git diff --check origin/main...HEAD` — clean
- `/simplify` and self-review before push — clear

## Performance

`BenchmarkDotNet`, ShortRun, `[MemoryDiagnoser]`, .NET 10.0.11. All candidate single/span/array/list/struct-list paths allocate `0 B`.

| Partitions | Single control | Span | Array | List | Struct list | Allocated |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 70.85 ns | 70.09 ns | 70.21 ns | 71.30 ns | 70.07 ns | 0 B all |
| 8 | 618.15 ns | 582.11 ns | 634.41 ns | 608.95 ns | 617.06 ns | 0 B all |
| 64 | 4.559 us | 5.019 us | 4.551 us | 4.841 us | 5.244 us | 0 B all |

The old PR head boxed the struct-backed list and allocated 24 B/call at every partition count (75.96 ns, 576.38 ns, 4.538 us). The candidate removes that allocation. Two full candidate runs bracketed the noisy 64-partition struct result: 4.488 us (0.98x same-run single control) and 5.244 us (1.15x, with overlapping high-variance intervals); the stable 1/8-partition ratios are 0.99x/1.00x. No consistent throughput regression is demonstrated.

The protected `ConsumeResult` single-store path remains 0 B and measured 70.58 ns (prior PR result 69.28 ns; overlapping ShortRun intervals).

No broker call, collection copy, LINQ, consumer-wide lock, or async state machine was added to the production batch path.

Closes #2576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added batch offset storage for arrays, spans, and read-only lists.
- Added validation for topics, partitions, and offsets before storing.
- Batch storage supports duplicate partitions with last-write-wins behavior.
- Offsets are staged locally and persisted through automatic or explicit commits.
- Added optimized support for consumers with native batch-storage capabilities.

## Bug Fixes
- Improved offset validation and failure handling to prevent invalid state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->