### PR TITLE
docs(security): record Renovate ownership

### DIFF
--- a/.github/security-audits/2026-08-16.md
+++ b/.github/security-audits/2026-08-16.md
@@ -10,9 +10,11 @@ The following GitHub repository controls were enabled and verified through the
 repository API:
 
 - Dependabot vulnerability alerts
-- Dependabot security updates
 - Secret scanning
 - Secret scanning push protection
+
+Dependabot automated security fixes are disabled. Renovate remains the sole
+dependency update service.
 
 Secret scanning validity checks and non-provider patterns remain unavailable for
 this user-owned public repository. GitHub restricts those controls to eligible
@@ -45,5 +47,5 @@ Two underlying transitive packages remain:
 
 Both packages are build-time dependencies. The documentation deployment workflow
 runs only after reviewed changes reach `main`; it does not build untrusted pull
-request content. Dependabot security updates remain enabled to surface a safe
-upstream remediation as soon as one is available.
+request content. Renovate remains the sole dependency update service and will
+surface a safe upstream remediation when one becomes available.


### PR DESCRIPTION
## Summary
- correct the merged security audit to reflect Renovate-only dependency updates
- record that Dependabot vulnerability alerts stay enabled while automated security fixes stay disabled

## Validation
- repository API: vulnerability alerts enabled
- repository API: Dependabot automated security fixes disabled
- git diff --check origin/main...HEAD

Follow-up to #2664.
Closes #2653.