### PR TITLE
fix(schema-registry): preserve Protobuf schema fidelity

### DIFF
--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -76,6 +76,13 @@ var producer = await Kafka.CreateProducer<string, OrderProto>()
     .BuildAsync();
 ```
 
+Protobuf imports use Schema Registry references by default. If you provide a custom
+`ISchemaRegistryClient`, implement `LookupSchemaAsync`; the serializer uses exact lookup to obtain
+the assigned version for every non-well-known imported `.proto` schema, including after automatic
+registration. The interface's default implementation throws `NotSupportedException` to identify
+custom clients that need updating. Set `UseSchemaReferences = false` only to retain the legacy
+registration behavior that omits references.
+
 ## Schema Registry Configuration
 
 ```csharp

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -1,6 +1,5 @@
 using System.Buffers;
 using System.Buffers.Binary;
-using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using Dekaf.Serialization;
 using Google.Protobuf;
@@ -35,9 +34,8 @@ public sealed class ProtobufSchemaRegistrySerializer<
     private readonly ProtobufSerializerConfig _config;
     private readonly bool _ownsClient;
     private readonly MessageDescriptor _descriptor;
-    private readonly ConcurrentDictionary<string, int> _schemaIdCache = new();
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
-    private readonly Schema _schema;
+    private readonly string _schemaString;
     private readonly byte[] _encodedMessageIndexes;
 
     /// <summary>
@@ -58,13 +56,8 @@ public sealed class ProtobufSchemaRegistrySerializer<
         // Get the message descriptor from the type
         _descriptor = GetMessageDescriptor();
 
-        // Generate the schema string from the descriptor
-        _schema = new Schema
-        {
-            SchemaType = SchemaType.Protobuf,
-            SchemaString = GenerateSchemaString(_descriptor),
-            References = _config.UseSchemaReferences ? GetSchemaReferences(_descriptor) : null
-        };
+        // Schema Registry's canonical Protobuf representation is the serialized FileDescriptorProto.
+        _schemaString = _descriptor.File.SerializedData.ToBase64();
 
         // Pre-encode the immutable message index path once per serializer.
         _encodedMessageIndexes = VarintEncoder.EncodeMessageIndexes(
@@ -125,43 +118,71 @@ public sealed class ProtobufSchemaRegistrySerializer<
         destination.Advance(totalSize);
     }
 
-    private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry GetSchemaForContext(string topic, bool isKey)
-        => _subjectSchemaIdCache.GetOrAdd(
+    private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry GetSchemaForContext(string topic, bool isKey) =>
+        _subjectSchemaIdCache.GetOrAdd(
             topic,
             isKey,
             this,
-            static (serializer, topic, isKey) => serializer.GetSubjectName(topic, isKey),
-            static (serializer, subject) => new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(
-                serializer.GetSchemaIdSync(subject),
-                serializer._schema));
+            static (serializer, resolvedTopic, resolvedIsKey) =>
+                serializer.ResolveSchemaSync(resolvedTopic, resolvedIsKey));
 
-    private int GetSchemaIdSync(string subject)
+    private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry ResolveSchemaSync(string topic, bool isKey)
     {
-        if (_schemaIdCache.TryGetValue(subject, out var cachedId))
-            return cachedId;
+        var subject = GetSubjectName(topic, isKey);
+        var resolved = ResolveSchemaAsync(subject, topic, isKey)
+            .WaitAsync(SchemaRegistryTimeout)
+            .ConfigureAwait(false)
+            .GetAwaiter()
+            .GetResult();
 
-        Task<int> task;
+        return new SubjectSchemaIdCache.SubjectSchemaIdCacheEntry(
+            new SubjectSchemaIdCache.SubjectSchemaIdCacheKey(topic, isKey),
+            subject,
+            resolved.SchemaId,
+            resolved.Schema);
+    }
+
+    private async Task<SubjectSchemaIdCache.SubjectSchemaIdCacheValue> ResolveSchemaAsync(
+        string subject,
+        string topic,
+        bool isKey)
+    {
         if (_config.UseLatestVersion)
         {
-            task = _schemaRegistry.GetSchemaBySubjectAsync(subject)
-                .ContinueWith(static t => t.GetAwaiter().GetResult().Id, TaskScheduler.Default);
-        }
-        else if (_config.AutoRegisterSchemas)
-        {
-            task = _config.NormalizeSchemas
-                ? _schemaRegistry.GetOrRegisterSchemaAsync(subject, _schema, normalize: true)
-                : _schemaRegistry.GetOrRegisterSchemaAsync(subject, _schema);
-        }
-        else
-        {
-            task = _schemaRegistry.GetSchemaBySubjectAsync(subject)
-                .ContinueWith(static t => t.GetAwaiter().GetResult().Id, TaskScheduler.Default);
+            var latest = await _schemaRegistry.GetSchemaBySubjectAsync(subject).ConfigureAwait(false);
+            return new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(latest.Id, latest.Schema);
         }
 
-        // Add timeout to prevent indefinite blocking
-        var id = task.WaitAsync(SchemaRegistryTimeout).ConfigureAwait(false).GetAwaiter().GetResult();
-        _schemaIdCache.TryAdd(subject, id);
-        return id;
+        IReadOnlyList<SchemaReference>? references = null;
+        if (_config.UseSchemaReferences)
+        {
+            references = await RegisterOrLookupReferencesAsync(
+                _descriptor.File,
+                topic,
+                isKey).ConfigureAwait(false);
+        }
+
+        var schema = new Schema
+        {
+            SchemaType = SchemaType.Protobuf,
+            SchemaString = _schemaString,
+            References = references
+        };
+
+        if (_config.AutoRegisterSchemas)
+        {
+            var id = _config.NormalizeSchemas
+                ? await _schemaRegistry.GetOrRegisterSchemaAsync(subject, schema, normalize: true).ConfigureAwait(false)
+                : await _schemaRegistry.GetOrRegisterSchemaAsync(subject, schema).ConfigureAwait(false);
+            return new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(id, schema);
+        }
+
+        var registered = await _schemaRegistry.LookupSchemaAsync(
+            subject,
+            schema,
+            ignoreDeletedSchemas: true,
+            normalize: _config.NormalizeSchemas).ConfigureAwait(false);
+        return new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(registered.Id, registered.Schema);
     }
 
     private string GetSubjectName(string topic, bool isKey)
@@ -196,179 +217,124 @@ public sealed class ProtobufSchemaRegistrySerializer<
         return descriptor;
     }
 
-    private static string GenerateSchemaString(MessageDescriptor descriptor)
+    private async Task<IReadOnlyList<SchemaReference>?> RegisterOrLookupReferencesAsync(
+        FileDescriptor root,
+        string topic,
+        bool isKey)
     {
-        // Generate proto schema from the file descriptor
-        var fileDescriptor = descriptor.File;
-        return GenerateProtoFromFileDescriptor(fileDescriptor);
+        var state = new ReferenceRegistrationState(topic, isKey);
+        return await ResolveDirectReferencesAsync(root, state).ConfigureAwait(false);
     }
 
-    private static string GenerateProtoFromFileDescriptor(FileDescriptor fileDescriptor)
+    private async Task<IReadOnlyList<SchemaReference>?> ResolveDirectReferencesAsync(
+        FileDescriptor file,
+        ReferenceRegistrationState state)
     {
-        var builder = new System.Text.StringBuilder();
-
-        // Syntax
-        builder.AppendLine("syntax = \"proto3\";");
-        builder.AppendLine();
-
-        // Package
-        if (!string.IsNullOrEmpty(fileDescriptor.Package))
+        List<SchemaReference>? references = null;
+        for (var index = 0; index < file.Dependencies.Count; index++)
         {
-            builder.AppendLine($"package {fileDescriptor.Package};");
-            builder.AppendLine();
-        }
-
-        // Dependencies
-        foreach (var dependency in fileDescriptor.Dependencies)
-        {
-            builder.AppendLine($"import \"{dependency.Name}\";");
-        }
-
-        if (fileDescriptor.Dependencies.Count > 0)
-            builder.AppendLine();
-
-        // Messages
-        foreach (var messageType in fileDescriptor.MessageTypes)
-        {
-            GenerateMessageProto(builder, messageType, 0);
-        }
-
-        // Enums at file level
-        foreach (var enumType in fileDescriptor.EnumTypes)
-        {
-            GenerateEnumProto(builder, enumType, 0);
-        }
-
-        return builder.ToString();
-    }
-
-    private static void GenerateMessageProto(System.Text.StringBuilder builder, MessageDescriptor message, int indent)
-    {
-        var indentStr = new string(' ', indent * 2);
-        builder.AppendLine($"{indentStr}message {message.Name} {{");
-
-        // Nested enums
-        foreach (var enumType in message.EnumTypes)
-        {
-            GenerateEnumProto(builder, enumType, indent + 1);
-        }
-
-        // Nested messages
-        foreach (var nestedMessage in message.NestedTypes)
-        {
-            // Skip map entry types
-            if (nestedMessage.GetOptions()?.MapEntry == true)
+            var dependency = file.Dependencies[index];
+            if (_config.SkipKnownTypes && IsKnownType(dependency.Name))
                 continue;
 
-            GenerateMessageProto(builder, nestedMessage, indent + 1);
-        }
-
-        // Fields
-        foreach (var field in message.Fields.InFieldNumberOrder())
-        {
-            var fieldIndent = new string(' ', (indent + 1) * 2);
-            var fieldType = GetProtoFieldType(field);
-            var repeated = field.IsRepeated && !field.IsMap ? "repeated " : "";
-            builder.AppendLine($"{fieldIndent}{repeated}{fieldType} {field.Name} = {field.FieldNumber};");
-        }
-
-        // Oneofs
-        foreach (var oneof in message.Oneofs)
-        {
-            if (oneof.IsSynthetic) continue; // Skip synthetic oneofs (for proto3 optional)
-
-            var oneofIndent = new string(' ', (indent + 1) * 2);
-            builder.AppendLine($"{oneofIndent}oneof {oneof.Name} {{");
-            foreach (var field in oneof.Fields)
-            {
-                var fieldIndent = new string(' ', (indent + 2) * 2);
-                var fieldType = GetProtoFieldType(field);
-                builder.AppendLine($"{fieldIndent}{fieldType} {field.Name} = {field.FieldNumber};");
-            }
-            builder.AppendLine($"{oneofIndent}}}");
-        }
-
-        builder.AppendLine($"{indentStr}}}");
-        builder.AppendLine();
-    }
-
-    private static void GenerateEnumProto(System.Text.StringBuilder builder, EnumDescriptor enumType, int indent)
-    {
-        var indentStr = new string(' ', indent * 2);
-        builder.AppendLine($"{indentStr}enum {enumType.Name} {{");
-
-        foreach (var value in enumType.Values)
-        {
-            var valueIndent = new string(' ', (indent + 1) * 2);
-            builder.AppendLine($"{valueIndent}{value.Name} = {value.Number};");
-        }
-
-        builder.AppendLine($"{indentStr}}}");
-        builder.AppendLine();
-    }
-
-    private static string GetProtoFieldType(FieldDescriptor field)
-    {
-        if (field.IsMap)
-        {
-            var keyType = GetProtoFieldType(field.MessageType.FindFieldByName("key"));
-            var valueType = GetProtoFieldType(field.MessageType.FindFieldByName("value"));
-            return $"map<{keyType}, {valueType}>";
-        }
-
-        return field.FieldType switch
-        {
-            FieldType.Double => "double",
-            FieldType.Float => "float",
-            FieldType.Int64 => "int64",
-            FieldType.UInt64 => "uint64",
-            FieldType.Int32 => "int32",
-            FieldType.Fixed64 => "fixed64",
-            FieldType.Fixed32 => "fixed32",
-            FieldType.Bool => "bool",
-            FieldType.String => "string",
-            FieldType.Group => field.MessageType.FullName,
-            FieldType.Message => field.MessageType.FullName,
-            FieldType.Bytes => "bytes",
-            FieldType.UInt32 => "uint32",
-            FieldType.SFixed32 => "sfixed32",
-            FieldType.SFixed64 => "sfixed64",
-            FieldType.SInt32 => "sint32",
-            FieldType.SInt64 => "sint64",
-            FieldType.Enum => field.EnumType.FullName,
-            _ => "bytes"
-        };
-    }
-
-    private IReadOnlyList<SchemaReference>? GetSchemaReferences(MessageDescriptor descriptor)
-    {
-        var references = new List<SchemaReference>();
-
-        foreach (var dependency in descriptor.File.Dependencies)
-        {
-            // Skip well-known types if configured
-            if (_config.SkipKnownTypes && IsWellKnownType(dependency))
-                continue;
-
-            var refName = _config.ReferenceSubjectNameStrategy == ReferenceSubjectNameStrategy.ReferenceName
-                ? dependency.Name
-                : dependency.Package;
-
-            references.Add(new SchemaReference
+            var registered = await RegisterOrLookupDependencyAsync(dependency, state).ConfigureAwait(false);
+            (references ??= []).Add(new SchemaReference
             {
                 Name = dependency.Name,
-                Subject = refName,
-                Version = 1 // Assuming version 1 for dependencies
+                Subject = registered.Subject,
+                Version = registered.Version
             });
         }
 
-        return references.Count > 0 ? references : null;
+        return references;
     }
 
-    private static bool IsWellKnownType(FileDescriptor fileDescriptor)
+    private async Task<RegisteredDependency> RegisterOrLookupDependencyAsync(
+        FileDescriptor dependency,
+        ReferenceRegistrationState state)
     {
-        return fileDescriptor.Name.StartsWith("google/protobuf/", StringComparison.Ordinal);
+        if (state.Completed.TryGetValue(dependency.Name, out var completed))
+            return completed;
+
+        if (!state.Visiting.Add(dependency.Name))
+            throw new InvalidOperationException($"Cyclic Protobuf schema reference detected at '{dependency.Name}'.");
+
+        try
+        {
+            var references = await ResolveDirectReferencesAsync(dependency, state).ConfigureAwait(false);
+            var schema = new Schema
+            {
+                SchemaType = SchemaType.Protobuf,
+                SchemaString = dependency.SerializedData.ToBase64(),
+                References = references
+            };
+            var subject = GetReferenceSubjectName(state.Topic, dependency.Name, state.IsKey);
+
+            if (_config.AutoRegisterSchemas)
+            {
+                if (_config.NormalizeSchemas)
+                {
+                    await _schemaRegistry.RegisterSchemaAsync(
+                        subject,
+                        schema,
+                        normalize: true).ConfigureAwait(false);
+                }
+                else
+                {
+                    await _schemaRegistry.RegisterSchemaAsync(subject, schema).ConfigureAwait(false);
+                }
+            }
+
+            var registered = await _schemaRegistry.LookupSchemaAsync(
+                subject,
+                schema,
+                ignoreDeletedSchemas: true,
+                normalize: _config.NormalizeSchemas).ConfigureAwait(false);
+            var result = new RegisteredDependency(subject, registered.Version);
+            state.Completed.Add(dependency.Name, result);
+            return result;
+        }
+        finally
+        {
+            state.Visiting.Remove(dependency.Name);
+        }
     }
+
+    private string GetReferenceSubjectName(string topic, string referenceName, bool isKey)
+    {
+        if (_config.CustomReferenceSubjectNameStrategy is not null)
+        {
+            return _config.CustomReferenceSubjectNameStrategy.GetSubjectName(
+                topic,
+                referenceName,
+                isKey);
+        }
+
+        return _config.ReferenceSubjectNameStrategy switch
+        {
+            ReferenceSubjectNameStrategy.ReferenceName => referenceName,
+            ReferenceSubjectNameStrategy.Qualified => referenceName
+                .Replace(".proto", string.Empty)
+                .Replace('/', '.'),
+            _ => throw new InvalidOperationException(
+                $"Unknown Protobuf reference subject name strategy: {_config.ReferenceSubjectNameStrategy}.")
+        };
+    }
+
+    private static bool IsKnownType(string referenceName) =>
+        referenceName.StartsWith("confluent/", StringComparison.Ordinal) ||
+        referenceName.StartsWith("google/protobuf/", StringComparison.Ordinal) ||
+        referenceName.StartsWith("google/type/", StringComparison.Ordinal);
+
+    private sealed class ReferenceRegistrationState(string topic, bool isKey)
+    {
+        internal string Topic { get; } = topic;
+        internal bool IsKey { get; } = isKey;
+        internal Dictionary<string, RegisteredDependency> Completed { get; } = new(StringComparer.Ordinal);
+        internal HashSet<string> Visiting { get; } = new(StringComparer.Ordinal);
+    }
+
+    private readonly record struct RegisteredDependency(string Subject, int Version);
 
     private static int[] CalculateMessageIndexes(MessageDescriptor descriptor)
     {

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -35,6 +35,7 @@ public sealed class ProtobufSchemaRegistrySerializer<
     private readonly bool _ownsClient;
     private readonly MessageDescriptor _descriptor;
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
+    private readonly SubjectSchemaIdCache _resolvedSubjectCache = new();
     private readonly string _schemaString;
     private readonly byte[] _encodedMessageIndexes;
 
@@ -129,6 +130,29 @@ public sealed class ProtobufSchemaRegistrySerializer<
     private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry ResolveSchemaSync(string topic, bool isKey)
     {
         var subject = GetSubjectName(topic, isKey);
+        // Built-in reference strategies depend only on the import name. A custom strategy may use topic/key.
+        if (!_config.UseSchemaReferences ||
+            _config.UseLatestVersion ||
+            _config.CustomReferenceSubjectNameStrategy is null)
+        {
+            return _resolvedSubjectCache.GetOrAdd(
+                subject,
+                false,
+                new SchemaResolutionState(this, subject, topic, isKey),
+                static (state, _, _) => state.Serializer.ResolveSubjectSchemaSync(
+                    state.Subject,
+                    state.Topic,
+                    state.IsKey));
+        }
+
+        return ResolveSubjectSchemaSync(subject, topic, isKey);
+    }
+
+    private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry ResolveSubjectSchemaSync(
+        string subject,
+        string topic,
+        bool isKey)
+    {
         using var timeoutSource = new CancellationTokenSource(SchemaRegistryTimeout);
         var resolutionTask = ResolveSchemaAsync(subject, topic, isKey, timeoutSource.Token);
         SubjectSchemaIdCache.SubjectSchemaIdCacheValue resolved;
@@ -359,10 +383,39 @@ public sealed class ProtobufSchemaRegistrySerializer<
         };
     }
 
+    // Keep this exact set aligned with Schema Registry's ProtobufSchema.KNOWN_DEPENDENCIES.
     private static bool IsKnownType(string referenceName) =>
-        referenceName.StartsWith("confluent/", StringComparison.Ordinal) ||
-        referenceName.StartsWith("google/protobuf/", StringComparison.Ordinal) ||
-        referenceName.StartsWith("google/type/", StringComparison.Ordinal);
+        referenceName is
+            "confluent/meta.proto" or
+            "confluent/type/decimal.proto" or
+            "confluent/type/variant.proto" or
+            "google/type/calendar_period.proto" or
+            "google/type/color.proto" or
+            "google/type/date.proto" or
+            "google/type/datetime.proto" or
+            "google/type/dayofweek.proto" or
+            "google/type/decimal.proto" or
+            "google/type/expr.proto" or
+            "google/type/fraction.proto" or
+            "google/type/interval.proto" or
+            "google/type/latlng.proto" or
+            "google/type/money.proto" or
+            "google/type/month.proto" or
+            "google/type/phone_number.proto" or
+            "google/type/postal_address.proto" or
+            "google/type/quaternion.proto" or
+            "google/type/timeofday.proto" or
+            "google/protobuf/any.proto" or
+            "google/protobuf/api.proto" or
+            "google/protobuf/descriptor.proto" or
+            "google/protobuf/duration.proto" or
+            "google/protobuf/empty.proto" or
+            "google/protobuf/field_mask.proto" or
+            "google/protobuf/source_context.proto" or
+            "google/protobuf/struct.proto" or
+            "google/protobuf/timestamp.proto" or
+            "google/protobuf/type.proto" or
+            "google/protobuf/wrappers.proto";
 
     private static void ObserveLateFault(Task task)
     {
@@ -388,6 +441,12 @@ public sealed class ProtobufSchemaRegistrySerializer<
     }
 
     private readonly record struct RegisteredDependency(string Subject, int Version);
+
+    private readonly record struct SchemaResolutionState(
+        ProtobufSchemaRegistrySerializer<T> Serializer,
+        string Subject,
+        string Topic,
+        bool IsKey);
 
     private static int[] CalculateMessageIndexes(MessageDescriptor descriptor)
     {

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -129,11 +129,22 @@ public sealed class ProtobufSchemaRegistrySerializer<
     private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry ResolveSchemaSync(string topic, bool isKey)
     {
         var subject = GetSubjectName(topic, isKey);
-        var resolved = ResolveSchemaAsync(subject, topic, isKey)
-            .WaitAsync(SchemaRegistryTimeout)
-            .ConfigureAwait(false)
-            .GetAwaiter()
-            .GetResult();
+        using var timeoutSource = new CancellationTokenSource(SchemaRegistryTimeout);
+        var resolutionTask = ResolveSchemaAsync(subject, topic, isKey, timeoutSource.Token);
+        SubjectSchemaIdCache.SubjectSchemaIdCacheValue resolved;
+        try
+        {
+            resolved = resolutionTask
+                .WaitAsync(timeoutSource.Token)
+                .ConfigureAwait(false)
+                .GetAwaiter()
+                .GetResult();
+        }
+        catch (OperationCanceledException exception) when (timeoutSource.IsCancellationRequested)
+        {
+            ObserveLateFault(resolutionTask);
+            throw new TimeoutException("Schema Registry resolution timed out.", exception);
+        }
 
         return new SubjectSchemaIdCache.SubjectSchemaIdCacheEntry(
             new SubjectSchemaIdCache.SubjectSchemaIdCacheKey(topic, isKey),
@@ -145,11 +156,14 @@ public sealed class ProtobufSchemaRegistrySerializer<
     private async Task<SubjectSchemaIdCache.SubjectSchemaIdCacheValue> ResolveSchemaAsync(
         string subject,
         string topic,
-        bool isKey)
+        bool isKey,
+        CancellationToken cancellationToken)
     {
         if (_config.UseLatestVersion)
         {
-            var latest = await _schemaRegistry.GetSchemaBySubjectAsync(subject).ConfigureAwait(false);
+            var latest = await _schemaRegistry.GetSchemaBySubjectAsync(
+                subject,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
             return new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(latest.Id, latest.Schema);
         }
 
@@ -159,7 +173,8 @@ public sealed class ProtobufSchemaRegistrySerializer<
             references = await RegisterOrLookupReferencesAsync(
                 _descriptor.File,
                 topic,
-                isKey).ConfigureAwait(false);
+                isKey,
+                cancellationToken).ConfigureAwait(false);
         }
 
         var schema = new Schema
@@ -172,8 +187,15 @@ public sealed class ProtobufSchemaRegistrySerializer<
         if (_config.AutoRegisterSchemas)
         {
             var id = _config.NormalizeSchemas
-                ? await _schemaRegistry.GetOrRegisterSchemaAsync(subject, schema, normalize: true).ConfigureAwait(false)
-                : await _schemaRegistry.GetOrRegisterSchemaAsync(subject, schema).ConfigureAwait(false);
+                ? await _schemaRegistry.GetOrRegisterSchemaAsync(
+                    subject,
+                    schema,
+                    normalize: true,
+                    cancellationToken).ConfigureAwait(false)
+                : await _schemaRegistry.GetOrRegisterSchemaAsync(
+                    subject,
+                    schema,
+                    cancellationToken).ConfigureAwait(false);
             return new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(id, schema);
         }
 
@@ -181,7 +203,8 @@ public sealed class ProtobufSchemaRegistrySerializer<
             subject,
             schema,
             ignoreDeletedSchemas: true,
-            normalize: _config.NormalizeSchemas).ConfigureAwait(false);
+            normalize: _config.NormalizeSchemas,
+            cancellationToken).ConfigureAwait(false);
         return new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(registered.Id, registered.Schema);
     }
 
@@ -220,15 +243,17 @@ public sealed class ProtobufSchemaRegistrySerializer<
     private async Task<IReadOnlyList<SchemaReference>?> RegisterOrLookupReferencesAsync(
         FileDescriptor root,
         string topic,
-        bool isKey)
+        bool isKey,
+        CancellationToken cancellationToken)
     {
         var state = new ReferenceRegistrationState(topic, isKey);
-        return await ResolveDirectReferencesAsync(root, state).ConfigureAwait(false);
+        return await ResolveDirectReferencesAsync(root, state, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<IReadOnlyList<SchemaReference>?> ResolveDirectReferencesAsync(
         FileDescriptor file,
-        ReferenceRegistrationState state)
+        ReferenceRegistrationState state,
+        CancellationToken cancellationToken)
     {
         List<SchemaReference>? references = null;
         for (var index = 0; index < file.Dependencies.Count; index++)
@@ -237,7 +262,10 @@ public sealed class ProtobufSchemaRegistrySerializer<
             if (_config.SkipKnownTypes && IsKnownType(dependency.Name))
                 continue;
 
-            var registered = await RegisterOrLookupDependencyAsync(dependency, state).ConfigureAwait(false);
+            var registered = await RegisterOrLookupDependencyAsync(
+                dependency,
+                state,
+                cancellationToken).ConfigureAwait(false);
             (references ??= []).Add(new SchemaReference
             {
                 Name = dependency.Name,
@@ -251,7 +279,8 @@ public sealed class ProtobufSchemaRegistrySerializer<
 
     private async Task<RegisteredDependency> RegisterOrLookupDependencyAsync(
         FileDescriptor dependency,
-        ReferenceRegistrationState state)
+        ReferenceRegistrationState state,
+        CancellationToken cancellationToken)
     {
         if (state.Completed.TryGetValue(dependency.Name, out var completed))
             return completed;
@@ -261,7 +290,10 @@ public sealed class ProtobufSchemaRegistrySerializer<
 
         try
         {
-            var references = await ResolveDirectReferencesAsync(dependency, state).ConfigureAwait(false);
+            var references = await ResolveDirectReferencesAsync(
+                dependency,
+                state,
+                cancellationToken).ConfigureAwait(false);
             var schema = new Schema
             {
                 SchemaType = SchemaType.Protobuf,
@@ -277,11 +309,15 @@ public sealed class ProtobufSchemaRegistrySerializer<
                     await _schemaRegistry.RegisterSchemaAsync(
                         subject,
                         schema,
-                        normalize: true).ConfigureAwait(false);
+                        normalize: true,
+                        cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    await _schemaRegistry.RegisterSchemaAsync(subject, schema).ConfigureAwait(false);
+                    await _schemaRegistry.RegisterSchemaAsync(
+                        subject,
+                        schema,
+                        cancellationToken).ConfigureAwait(false);
                 }
             }
 
@@ -289,7 +325,8 @@ public sealed class ProtobufSchemaRegistrySerializer<
                 subject,
                 schema,
                 ignoreDeletedSchemas: true,
-                normalize: _config.NormalizeSchemas).ConfigureAwait(false);
+                normalize: _config.NormalizeSchemas,
+                cancellationToken).ConfigureAwait(false);
             var result = new RegisteredDependency(subject, registered.Version);
             state.Completed.Add(dependency.Name, result);
             return result;
@@ -313,8 +350,9 @@ public sealed class ProtobufSchemaRegistrySerializer<
         return _config.ReferenceSubjectNameStrategy switch
         {
             ReferenceSubjectNameStrategy.ReferenceName => referenceName,
-            ReferenceSubjectNameStrategy.Qualified => referenceName
-                .Replace(".proto", string.Empty)
+            ReferenceSubjectNameStrategy.Qualified => (referenceName.EndsWith(".proto", StringComparison.Ordinal)
+                    ? referenceName[..^".proto".Length]
+                    : referenceName)
                 .Replace('/', '.'),
             _ => throw new InvalidOperationException(
                 $"Unknown Protobuf reference subject name strategy: {_config.ReferenceSubjectNameStrategy}.")
@@ -325,6 +363,21 @@ public sealed class ProtobufSchemaRegistrySerializer<
         referenceName.StartsWith("confluent/", StringComparison.Ordinal) ||
         referenceName.StartsWith("google/protobuf/", StringComparison.Ordinal) ||
         referenceName.StartsWith("google/type/", StringComparison.Ordinal);
+
+    private static void ObserveLateFault(Task task)
+    {
+        if (task.IsCompleted)
+        {
+            _ = task.Exception;
+            return;
+        }
+
+        _ = task.ContinueWith(
+            static completed => _ = completed.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
 
     private sealed class ReferenceRegistrationState(string topic, bool isKey)
     {

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -35,7 +35,6 @@ public sealed class ProtobufSchemaRegistrySerializer<
     private readonly bool _ownsClient;
     private readonly MessageDescriptor _descriptor;
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
-    private readonly SubjectSchemaIdCache _resolvedSubjectCache = new();
     private readonly string _schemaString;
     private readonly byte[] _encodedMessageIndexes;
 
@@ -130,29 +129,6 @@ public sealed class ProtobufSchemaRegistrySerializer<
     private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry ResolveSchemaSync(string topic, bool isKey)
     {
         var subject = GetSubjectName(topic, isKey);
-        // Built-in reference strategies depend only on the import name. A custom strategy may use topic/key.
-        if (!_config.UseSchemaReferences ||
-            _config.UseLatestVersion ||
-            _config.CustomReferenceSubjectNameStrategy is null)
-        {
-            return _resolvedSubjectCache.GetOrAdd(
-                subject,
-                false,
-                new SchemaResolutionState(this, subject, topic, isKey),
-                static (state, _, _) => state.Serializer.ResolveSubjectSchemaSync(
-                    state.Subject,
-                    state.Topic,
-                    state.IsKey));
-        }
-
-        return ResolveSubjectSchemaSync(subject, topic, isKey);
-    }
-
-    private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry ResolveSubjectSchemaSync(
-        string subject,
-        string topic,
-        bool isKey)
-    {
         using var timeoutSource = new CancellationTokenSource(SchemaRegistryTimeout);
         var resolutionTask = ResolveSchemaAsync(subject, topic, isKey, timeoutSource.Token);
         SubjectSchemaIdCache.SubjectSchemaIdCacheValue resolved;
@@ -383,39 +359,10 @@ public sealed class ProtobufSchemaRegistrySerializer<
         };
     }
 
-    // Keep this exact set aligned with Schema Registry's ProtobufSchema.KNOWN_DEPENDENCIES.
     private static bool IsKnownType(string referenceName) =>
-        referenceName is
-            "confluent/meta.proto" or
-            "confluent/type/decimal.proto" or
-            "confluent/type/variant.proto" or
-            "google/type/calendar_period.proto" or
-            "google/type/color.proto" or
-            "google/type/date.proto" or
-            "google/type/datetime.proto" or
-            "google/type/dayofweek.proto" or
-            "google/type/decimal.proto" or
-            "google/type/expr.proto" or
-            "google/type/fraction.proto" or
-            "google/type/interval.proto" or
-            "google/type/latlng.proto" or
-            "google/type/money.proto" or
-            "google/type/month.proto" or
-            "google/type/phone_number.proto" or
-            "google/type/postal_address.proto" or
-            "google/type/quaternion.proto" or
-            "google/type/timeofday.proto" or
-            "google/protobuf/any.proto" or
-            "google/protobuf/api.proto" or
-            "google/protobuf/descriptor.proto" or
-            "google/protobuf/duration.proto" or
-            "google/protobuf/empty.proto" or
-            "google/protobuf/field_mask.proto" or
-            "google/protobuf/source_context.proto" or
-            "google/protobuf/struct.proto" or
-            "google/protobuf/timestamp.proto" or
-            "google/protobuf/type.proto" or
-            "google/protobuf/wrappers.proto";
+        referenceName.StartsWith("confluent/", StringComparison.Ordinal) ||
+        referenceName.StartsWith("google/protobuf/", StringComparison.Ordinal) ||
+        referenceName.StartsWith("google/type/", StringComparison.Ordinal);
 
     private static void ObserveLateFault(Task task)
     {
@@ -441,12 +388,6 @@ public sealed class ProtobufSchemaRegistrySerializer<
     }
 
     private readonly record struct RegisteredDependency(string Subject, int Version);
-
-    private readonly record struct SchemaResolutionState(
-        ProtobufSchemaRegistrySerializer<T> Serializer,
-        string Subject,
-        string Topic,
-        bool IsKey);
 
     private static int[] CalculateMessageIndexes(MessageDescriptor descriptor)
     {

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -37,6 +37,7 @@ public sealed class ProtobufSchemaRegistrySerializer<
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
     private readonly string _schemaString;
     private readonly byte[] _encodedMessageIndexes;
+    private readonly SubjectSchemaIdCache _resolvedSubjectCache = new();
 
     /// <summary>
     /// Creates a new Protobuf Schema Registry serializer.
@@ -129,6 +130,29 @@ public sealed class ProtobufSchemaRegistrySerializer<
     private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry ResolveSchemaSync(string topic, bool isKey)
     {
         var subject = GetSubjectName(topic, isKey);
+        // Built-in reference strategies depend only on the import name. A custom strategy may use topic/key.
+        if (!_config.UseSchemaReferences ||
+            _config.UseLatestVersion ||
+            _config.CustomReferenceSubjectNameStrategy is null)
+        {
+            return _resolvedSubjectCache.GetOrAdd(
+                subject,
+                false,
+                new SchemaResolutionState(this, subject, topic, isKey),
+                static (state, _, _) => state.Serializer.ResolveSubjectSchemaSync(
+                    state.Subject,
+                    state.Topic,
+                    state.IsKey));
+        }
+
+        return ResolveSubjectSchemaSync(subject, topic, isKey);
+    }
+
+    private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry ResolveSubjectSchemaSync(
+        string subject,
+        string topic,
+        bool isKey)
+    {
         using var timeoutSource = new CancellationTokenSource(SchemaRegistryTimeout);
         var resolutionTask = ResolveSchemaAsync(subject, topic, isKey, timeoutSource.Token);
         SubjectSchemaIdCache.SubjectSchemaIdCacheValue resolved;
@@ -359,10 +383,39 @@ public sealed class ProtobufSchemaRegistrySerializer<
         };
     }
 
+    // Keep this exact set aligned with Schema Registry's ProtobufSchema.KNOWN_DEPENDENCIES.
     private static bool IsKnownType(string referenceName) =>
-        referenceName.StartsWith("confluent/", StringComparison.Ordinal) ||
-        referenceName.StartsWith("google/protobuf/", StringComparison.Ordinal) ||
-        referenceName.StartsWith("google/type/", StringComparison.Ordinal);
+        referenceName is
+            "confluent/meta.proto" or
+            "confluent/type/decimal.proto" or
+            "confluent/type/variant.proto" or
+            "google/type/calendar_period.proto" or
+            "google/type/color.proto" or
+            "google/type/date.proto" or
+            "google/type/datetime.proto" or
+            "google/type/dayofweek.proto" or
+            "google/type/decimal.proto" or
+            "google/type/expr.proto" or
+            "google/type/fraction.proto" or
+            "google/type/interval.proto" or
+            "google/type/latlng.proto" or
+            "google/type/money.proto" or
+            "google/type/month.proto" or
+            "google/type/phone_number.proto" or
+            "google/type/postal_address.proto" or
+            "google/type/quaternion.proto" or
+            "google/type/timeofday.proto" or
+            "google/protobuf/any.proto" or
+            "google/protobuf/api.proto" or
+            "google/protobuf/descriptor.proto" or
+            "google/protobuf/duration.proto" or
+            "google/protobuf/empty.proto" or
+            "google/protobuf/field_mask.proto" or
+            "google/protobuf/source_context.proto" or
+            "google/protobuf/struct.proto" or
+            "google/protobuf/timestamp.proto" or
+            "google/protobuf/type.proto" or
+            "google/protobuf/wrappers.proto";
 
     private static void ObserveLateFault(Task task)
     {
@@ -388,6 +441,12 @@ public sealed class ProtobufSchemaRegistrySerializer<
     }
 
     private readonly record struct RegisteredDependency(string Subject, int Version);
+
+    private readonly record struct SchemaResolutionState(
+        ProtobufSchemaRegistrySerializer<T> Serializer,
+        string Subject,
+        string Topic,
+        bool IsKey);
 
     private static int[] CalculateMessageIndexes(MessageDescriptor descriptor)
     {

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
@@ -76,7 +76,7 @@ public sealed class ProtobufSerializerConfig
     /// Optional custom strategy for dependent-schema subjects. When set, this takes precedence
     /// over <see cref="ReferenceSubjectNameStrategy"/>.
     /// </summary>
-    public ICustomReferenceSubjectNameStrategy? CustomReferenceSubjectNameStrategy { get; init; }
+    public IReferenceSubjectNameStrategy? CustomReferenceSubjectNameStrategy { get; init; }
 
     /// <summary>
     /// Optional rule executor applied to Protobuf message bytes before the Schema Registry envelope is written.
@@ -110,7 +110,7 @@ public enum ReferenceSubjectNameStrategy
 /// <summary>
 /// Determines the subject under which a referenced Protobuf schema is registered or looked up.
 /// </summary>
-public interface ICustomReferenceSubjectNameStrategy
+public interface IReferenceSubjectNameStrategy
 {
     /// <summary>
     /// Gets the reference subject for a serialization context.

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
@@ -55,9 +55,10 @@ public sealed class ProtobufSerializerConfig
 
     /// <summary>
     /// Whether to skip known types when serializing.
-    /// Default is false.
+    /// Default is true, matching Confluent's Protobuf serializer. Imports under
+    /// confluent/, google/protobuf/, and google/type/ are resolved as built-ins.
     /// </summary>
-    public bool SkipKnownTypes { get; init; }
+    public bool SkipKnownTypes { get; init; } = true;
 
     /// <summary>
     /// Whether to include references to dependent schemas when registering.
@@ -70,6 +71,12 @@ public sealed class ProtobufSerializerConfig
     /// Default is <see cref="ReferenceSubjectNameStrategy.ReferenceName"/>.
     /// </summary>
     public ReferenceSubjectNameStrategy ReferenceSubjectNameStrategy { get; init; } = ReferenceSubjectNameStrategy.ReferenceName;
+
+    /// <summary>
+    /// Optional custom strategy for dependent-schema subjects. When set, this takes precedence
+    /// over <see cref="ReferenceSubjectNameStrategy"/>.
+    /// </summary>
+    public ICustomReferenceSubjectNameStrategy? CustomReferenceSubjectNameStrategy { get; init; }
 
     /// <summary>
     /// Optional rule executor applied to Protobuf message bytes before the Schema Registry envelope is written.
@@ -89,7 +96,28 @@ public enum ReferenceSubjectNameStrategy
     ReferenceName,
 
     /// <summary>
-    /// Use the qualified record name as the subject name.
+    /// Replace path separators with dots and remove the .proto suffix.
     /// </summary>
-    QualifiedRecordName
+    Qualified,
+
+    /// <summary>
+    /// Use the qualified reference path as the subject name.
+    /// </summary>
+    [Obsolete($"Use {nameof(Qualified)}.")]
+    QualifiedRecordName = Qualified
+}
+
+/// <summary>
+/// Determines the subject under which a referenced Protobuf schema is registered or looked up.
+/// </summary>
+public interface ICustomReferenceSubjectNameStrategy
+{
+    /// <summary>
+    /// Gets the reference subject for a serialization context.
+    /// </summary>
+    /// <param name="topic">Kafka topic.</param>
+    /// <param name="referenceName">Import path from the parent descriptor.</param>
+    /// <param name="isKey">Whether the serialized component is a key.</param>
+    /// <returns>The dependent schema subject.</returns>
+    string GetSubjectName(string topic, string referenceName, bool isKey);
 }

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
@@ -55,8 +55,7 @@ public sealed class ProtobufSerializerConfig
 
     /// <summary>
     /// Whether to skip known types when serializing.
-    /// Default is true, matching Confluent's Protobuf serializer. Imports under
-    /// confluent/, google/protobuf/, and google/type/ are resolved as built-ins.
+    /// Default is true, matching Confluent Schema Registry's exact built-in dependency set.
     /// </summary>
     public bool SkipKnownTypes { get; init; } = true;
 

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
@@ -55,7 +55,8 @@ public sealed class ProtobufSerializerConfig
 
     /// <summary>
     /// Whether to skip known types when serializing.
-    /// Default is true, matching Confluent Schema Registry's exact built-in dependency set.
+    /// Default is true, matching Confluent's Protobuf serializer. Imports under
+    /// confluent/, google/protobuf/, and google/type/ are resolved as built-ins.
     /// </summary>
     public bool SkipKnownTypes { get; init; } = true;
 

--- a/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
@@ -51,6 +51,24 @@ public interface ISchemaRegistryClient : IDisposable
     Task<RegisteredSchema> GetSchemaBySubjectAsync(string subject, string version = "latest", CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Looks up an exact schema under a subject without registering it.
+    /// </summary>
+    /// <param name="subject">The subject name.</param>
+    /// <param name="schema">The schema to find.</param>
+    /// <param name="ignoreDeletedSchemas">Whether deleted schemas are excluded from the lookup.</param>
+    /// <param name="normalize">Whether to request Schema Registry normalization.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The matching registered schema, including its actual subject version.</returns>
+    Task<RegisteredSchema> LookupSchemaAsync(
+        string subject,
+        Schema schema,
+        bool ignoreDeletedSchemas = true,
+        bool normalize = false,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException(
+            $"{GetType().Name} does not support exact schema lookup. Implement {nameof(LookupSchemaAsync)} to use Protobuf schema references.");
+
+    /// <summary>
     /// Gets or registers a schema, returning its ID.
     /// This is a convenience method that first checks if the schema exists.
     /// </summary>

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -288,6 +288,46 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         };
     }
 
+    public async Task<RegisteredSchema> LookupSchemaAsync(
+        string subject,
+        Schema schema,
+        bool ignoreDeletedSchemas = true,
+        bool normalize = false,
+        CancellationToken cancellationToken = default)
+    {
+        var effectiveNormalize = normalize || _config.NormalizeSchemas;
+        var request = CreateRegisterSchemaRequest(schema);
+        var path = WithQuery(
+            $"subjects/{Uri.EscapeDataString(subject)}",
+            ("normalize", effectiveNormalize ? "true" : "false"),
+            ("deleted", ignoreDeletedSchemas ? "false" : "true"));
+
+        using var response = await PostAsJsonWithFailoverAsync(
+            path,
+            request,
+            SchemaRegistryJsonContext.Default.RegisterSchemaRequest,
+            cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var result = await response.Content.ReadFromJsonAsync<GetSubjectVersionResponse>(
+            SchemaRegistryJsonContext.Default.GetSubjectVersionResponse,
+            cancellationToken).ConfigureAwait(false);
+        if (result is null)
+            throw new SchemaRegistryException((int)response.StatusCode, "Schema Registry returned an empty schema response");
+
+        var registeredSchema = CreateSchema(result);
+        CacheSchema(result.Id, subject, schema, effectiveNormalize);
+
+        return new RegisteredSchema
+        {
+            Id = result.Id,
+            Subject = result.Subject,
+            Version = result.Version,
+            Schema = registeredSchema
+        };
+    }
+
     public Task<int> GetOrRegisterSchemaAsync(
         string subject,
         Schema schema,

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -317,7 +317,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             throw new SchemaRegistryException((int)response.StatusCode, "Schema Registry returned an empty schema response");
 
         var registeredSchema = CreateSchema(result);
-        CacheSchema(result.Id, subject, schema, effectiveNormalize);
+        CacheSchema(result.Id, subject, schema, effectiveNormalize, schemaById: registeredSchema);
 
         return new RegisteredSchema
         {
@@ -378,7 +378,12 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         return id;
     }
 
-    internal void CacheSchema(int id, string? subject, Schema schema, bool normalize = false)
+    internal void CacheSchema(
+        int id,
+        string? subject,
+        Schema schema,
+        bool normalize = false,
+        Schema? schemaById = null)
     {
         if (_maxCachedSchemas == 0)
             return;
@@ -391,7 +396,10 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
                 _idBySchemaCache.Clear();
             }
 
-            _schemaByIdCache.TryAdd(id, schema);
+            if (schemaById is not null)
+                _schemaByIdCache[id] = schemaById;
+            else
+                _schemaByIdCache.TryAdd(id, schema);
             if (subject is not null)
             {
                 _idBySchemaCache.TryAdd((subject, schema, normalize), id);

--- a/tests/Dekaf.Tests.Integration/Protos/reference_common.proto
+++ b/tests/Dekaf.Tests.Integration/Protos/reference_common.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package dekaf.tests.references;
+
+option csharp_namespace = "Dekaf.Tests.Integration.Protos";
+
+message SchemaReferenceCommon {
+  string name = 1;
+  int32 revision = 2;
+}

--- a/tests/Dekaf.Tests.Integration/Protos/reference_root.proto
+++ b/tests/Dekaf.Tests.Integration/Protos/reference_root.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package dekaf.tests.references;
+
+option csharp_namespace = "Dekaf.Tests.Integration.Protos";
+
+import "Protos/reference_common.proto";
+
+message SchemaReferenceEnvelope {
+  string id = 1;
+  SchemaReferenceCommon common = 2;
+}

--- a/tests/Dekaf.Tests.Integration/SchemaRegistrySubjectCompatibilityTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistrySubjectCompatibilityTests.cs
@@ -6,6 +6,7 @@ using Dekaf.SchemaRegistry.Avro;
 using Dekaf.SchemaRegistry.Protobuf;
 using Dekaf.Serialization;
 using Dekaf.Tests.Integration.Protos;
+using Google.Protobuf;
 using AvroSchema = Avro.Schema;
 using ConfluentSubjectNameStrategy = Confluent.SchemaRegistry.SubjectNameStrategy;
 using DekafSubjectNameStrategy = Dekaf.SchemaRegistry.SubjectNameStrategy;
@@ -101,6 +102,48 @@ public sealed class SchemaRegistrySubjectCompatibilityTests(KafkaWithSchemaRegis
             });
         var destination = new ArrayBufferWriter<byte>();
         dekafSerializer.Serialize(value, ref destination, CreateDekafContext(topic));
+    }
+
+    [Test]
+    public async Task Protobuf_DekafRegisteredReferences_CanBeConsumedByConfluent()
+    {
+        var topic = $"proto-reference-{Guid.NewGuid():N}";
+        using var registryClient = CreateDekafClient();
+        var versionOne = SchemaReferenceCommon.Descriptor.File.ToProto();
+        versionOne.MessageType[0].Field.RemoveAt(1);
+        await registryClient.RegisterSchemaAsync("Protos/reference_common.proto", new Schema
+        {
+            SchemaType = SchemaType.Protobuf,
+            SchemaString = versionOne.ToByteString().ToBase64()
+        });
+
+        await using var serializer = new ProtobufSchemaRegistrySerializer<SchemaReferenceEnvelope>(registryClient);
+        var destination = new ArrayBufferWriter<byte>();
+        var value = new SchemaReferenceEnvelope
+        {
+            Id = "envelope-1",
+            Common = new SchemaReferenceCommon { Name = "shared", Revision = 2 }
+        };
+        serializer.Serialize(value, ref destination, CreateDekafContext(topic));
+
+        var dependency = await registryClient.GetSchemaBySubjectAsync("Protos/reference_common.proto");
+        var root = await registryClient.GetSchemaBySubjectAsync($"{topic}-value");
+        await Assert.That(dependency.Version).IsEqualTo(2);
+        await Assert.That(root.Schema.References).Count().IsEqualTo(1);
+        await Assert.That(root.Schema.References![0].Name).IsEqualTo("Protos/reference_common.proto");
+        await Assert.That(root.Schema.References[0].Version).IsEqualTo(2);
+
+        using var confluentRegistry = CreateConfluentClient();
+        var confluentDeserializer =
+            new Confluent.SchemaRegistry.Serdes.ProtobufDeserializer<SchemaReferenceEnvelope>(confluentRegistry);
+        var roundTrip = await confluentDeserializer.DeserializeAsync(
+            destination.WrittenMemory,
+            isNull: false,
+            new Confluent.Kafka.SerializationContext(MessageComponentType.Value, topic));
+
+        await Assert.That(roundTrip.Id).IsEqualTo(value.Id);
+        await Assert.That(roundTrip.Common.Name).IsEqualTo(value.Common.Name);
+        await Assert.That(roundTrip.Common.Revision).IsEqualTo(value.Common.Revision);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/MockSchemaRegistryClient.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/MockSchemaRegistryClient.cs
@@ -131,6 +131,31 @@ internal sealed class MockSchemaRegistryClient : ISchemaRegistryClient, ISchemaR
         });
     }
 
+    public Task<RegisteredSchema> LookupSchemaAsync(
+        string subject,
+        Schema schema,
+        bool ignoreDeletedSchemas = true,
+        bool normalize = false,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        if (!_schemasBySubject.TryGetValue(subject, out var list))
+            throw new SchemaRegistryException(40401, $"Subject '{subject}' not found");
+
+        var entry = list.FirstOrDefault(candidate => SchemasAreEquivalent(candidate.Schema, schema));
+        if (entry == default)
+            throw new SchemaRegistryException(40403, $"Schema not found under subject '{subject}'");
+
+        return Task.FromResult(new RegisteredSchema
+        {
+            Id = entry.Id,
+            Subject = subject,
+            Version = entry.Version,
+            Schema = entry.Schema
+        });
+    }
+
     public async Task<int> GetOrRegisterSchemaAsync(string subject, Schema schema, CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
@@ -148,16 +173,46 @@ internal sealed class MockSchemaRegistryClient : ISchemaRegistryClient, ISchemaR
             throw new SchemaRegistryException(50002, "Transient schema registration failure");
         }
 
-        // Check if schema already exists (using semantic comparison for JSON schemas)
+        // Check whether an equivalent schema is already registered under this subject.
         if (_schemasBySubject.TryGetValue(subject, out var list))
         {
-            var existing = list.FirstOrDefault(e => SchemasAreEquivalent(e.Schema.SchemaString, schema.SchemaString));
+            var existing = list.FirstOrDefault(e => SchemasAreEquivalent(e.Schema, schema));
             if (existing != default)
                 return existing.Id;
         }
 
         // Register new schema
         return await RegisterSchemaAsync(subject, schema, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool SchemasAreEquivalent(Schema left, Schema right)
+    {
+        if (left.SchemaType != right.SchemaType ||
+            !SchemasAreEquivalent(left.SchemaString, right.SchemaString))
+        {
+            return false;
+        }
+
+        var leftReferences = left.References;
+        var rightReferences = right.References;
+        if (leftReferences is null || rightReferences is null)
+            return leftReferences is null && rightReferences is null;
+        if (leftReferences.Count != rightReferences.Count)
+            return false;
+
+        for (var index = 0; index < leftReferences.Count; index++)
+        {
+            var leftReference = leftReferences[index];
+            var rightReference = rightReferences[index];
+            if (leftReference.Name != rightReference.Name ||
+                leftReference.Subject != rightReference.Subject ||
+                leftReference.Version != rightReference.Version)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public Task<IReadOnlyList<string>> GetAllSubjectsAsync(CancellationToken cancellationToken = default)

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaReferenceTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaReferenceTests.cs
@@ -45,13 +45,12 @@ public sealed class ProtobufSchemaReferenceTests
                 "deps/right.proto",
                 "vendor.proto/common/user.proto",
                 "beta/common.proto",
-                "google/type/company_event.proto",
                 "graph-value"
             ])).IsTrue();
         await Assert.That(registrations.Count(static registration => registration.Subject == "shared/base.proto"))
             .IsEqualTo(1);
         await Assert.That(registrations.Any(static registration =>
-            registration.Subject == TimestampReflection.Descriptor.Name)).IsFalse();
+            registration.Subject.StartsWith("google/", StringComparison.Ordinal))).IsFalse();
 
         var rootRegistration = registrations[^1];
         await Assert.That(rootRegistration.Schema.SchemaString)
@@ -60,8 +59,7 @@ public sealed class ProtobufSchemaReferenceTests
                 "deps/left.proto",
                 "deps/right.proto",
                 "vendor.proto/common/user.proto",
-                "beta/common.proto",
-                "google/type/company_event.proto"
+                "beta/common.proto"
             ])).IsTrue();
 
         var left = registrations.Single(static registration => registration.Subject == "deps/left.proto");
@@ -142,64 +140,6 @@ public sealed class ProtobufSchemaReferenceTests
         await Assert.That(registrations.Select(static registration => registration.Subject).ToArray())
             .Contains("graph-key-shared/base.proto");
         await Assert.That(strategy.Calls).Contains(("graph", "shared/base.proto", true));
-    }
-
-    [Test]
-    public async Task Serialize_RecordNameStrategy_ReusesResolvedReferenceGraphAcrossTopics()
-    {
-        var registrations = new List<Registration>();
-        var schemaRegistry = CreateRegistry(registrations);
-        var config = new ProtobufSerializerConfig { SubjectNameStrategy = SubjectNameStrategy.RecordName };
-        await using var serializer = new ProtobufSchemaRegistrySerializer<ReferenceGraphMessage>(
-            schemaRegistry,
-            config);
-
-        var firstDestination = new ArrayBufferWriter<byte>();
-        serializer.Serialize(
-            new ReferenceGraphMessage(),
-            ref firstDestination,
-            new SerializationContext { Topic = "first", Component = SerializationComponent.Value });
-        var secondDestination = new ArrayBufferWriter<byte>();
-        serializer.Serialize(
-            new ReferenceGraphMessage(),
-            ref secondDestination,
-            new SerializationContext { Topic = "second", Component = SerializationComponent.Value });
-
-        await Assert.That(registrations.Count).IsEqualTo(7);
-        await Assert.That(registrations.Count(static registration =>
-            registration.Subject == ReferenceGraphMessage.Descriptor.FullName)).IsEqualTo(1);
-    }
-
-    [Test]
-    public async Task Serialize_CustomReferenceStrategy_DoesNotReuseGraphAcrossTopics()
-    {
-        var registrations = new List<Registration>();
-        var schemaRegistry = CreateRegistry(registrations);
-        var strategy = new RecordingReferenceStrategy();
-        var config = new ProtobufSerializerConfig
-        {
-            SubjectNameStrategy = SubjectNameStrategy.RecordName,
-            CustomReferenceSubjectNameStrategy = strategy
-        };
-        await using var serializer = new ProtobufSchemaRegistrySerializer<ReferenceGraphMessage>(
-            schemaRegistry,
-            config);
-
-        var firstDestination = new ArrayBufferWriter<byte>();
-        serializer.Serialize(
-            new ReferenceGraphMessage(),
-            ref firstDestination,
-            new SerializationContext { Topic = "first", Component = SerializationComponent.Value });
-        var secondDestination = new ArrayBufferWriter<byte>();
-        serializer.Serialize(
-            new ReferenceGraphMessage(),
-            ref secondDestination,
-            new SerializationContext { Topic = "second", Component = SerializationComponent.Value });
-
-        await Assert.That(strategy.Calls).Contains(("first", "shared/base.proto", false));
-        await Assert.That(strategy.Calls).Contains(("second", "shared/base.proto", false));
-        await Assert.That(registrations.Count(static registration =>
-            registration.Subject == ReferenceGraphMessage.Descriptor.FullName)).IsEqualTo(2);
     }
 
     [Test]
@@ -286,11 +226,7 @@ public sealed class ReferenceGraphMessage : IMessage<ReferenceGraphMessage>, IBu
         var right = CreateImportDescriptor("deps/right.proto", "graph.right", "Right", shared.Name);
         var vendor = CreateCommonDescriptor("vendor.proto/common/user.proto", "graph.vendor", "VendorCommon");
         var beta = CreateCommonDescriptor("beta/common.proto", "graph.beta", "BetaCommon");
-        var googleUser = CreateCommonDescriptor(
-            "google/type/company_event.proto",
-            "google.type.company",
-            "CompanyEvent");
-        var root = CreateRootDescriptor(left.Name, right.Name, vendor.Name, beta.Name, googleUser.Name);
+        var root = CreateRootDescriptor(left.Name, right.Name, vendor.Name, beta.Name);
         var descriptorBytes = new List<ByteString>
         {
             shared.ToByteString(),
@@ -298,7 +234,6 @@ public sealed class ReferenceGraphMessage : IMessage<ReferenceGraphMessage>, IBu
             right.ToByteString(),
             vendor.ToByteString(),
             beta.ToByteString(),
-            googleUser.ToByteString(),
             TimestampReflection.Descriptor.SerializedData,
             root.ToByteString()
         };
@@ -397,8 +332,7 @@ public sealed class ReferenceGraphMessage : IMessage<ReferenceGraphMessage>, IBu
         string leftName,
         string rightName,
         string vendorName,
-        string betaName,
-        string googleUserName)
+        string betaName)
     {
         var descriptor = new FileDescriptorProto
         {
@@ -411,7 +345,6 @@ public sealed class ReferenceGraphMessage : IMessage<ReferenceGraphMessage>, IBu
         descriptor.Dependency.Add(rightName);
         descriptor.Dependency.Add(vendorName);
         descriptor.Dependency.Add(betaName);
-        descriptor.Dependency.Add(googleUserName);
         descriptor.Dependency.Add(TimestampReflection.Descriptor.Name);
 
         var message = new DescriptorProto { Name = "ReferenceGraphMessage" };

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaReferenceTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaReferenceTests.cs
@@ -45,12 +45,13 @@ public sealed class ProtobufSchemaReferenceTests
                 "deps/right.proto",
                 "vendor.proto/common/user.proto",
                 "beta/common.proto",
+                "google/type/company_event.proto",
                 "graph-value"
             ])).IsTrue();
         await Assert.That(registrations.Count(static registration => registration.Subject == "shared/base.proto"))
             .IsEqualTo(1);
         await Assert.That(registrations.Any(static registration =>
-            registration.Subject.StartsWith("google/", StringComparison.Ordinal))).IsFalse();
+            registration.Subject == TimestampReflection.Descriptor.Name)).IsFalse();
 
         var rootRegistration = registrations[^1];
         await Assert.That(rootRegistration.Schema.SchemaString)
@@ -59,7 +60,8 @@ public sealed class ProtobufSchemaReferenceTests
                 "deps/left.proto",
                 "deps/right.proto",
                 "vendor.proto/common/user.proto",
-                "beta/common.proto"
+                "beta/common.proto",
+                "google/type/company_event.proto"
             ])).IsTrue();
 
         var left = registrations.Single(static registration => registration.Subject == "deps/left.proto");
@@ -140,6 +142,64 @@ public sealed class ProtobufSchemaReferenceTests
         await Assert.That(registrations.Select(static registration => registration.Subject).ToArray())
             .Contains("graph-key-shared/base.proto");
         await Assert.That(strategy.Calls).Contains(("graph", "shared/base.proto", true));
+    }
+
+    [Test]
+    public async Task Serialize_RecordNameStrategy_ReusesResolvedReferenceGraphAcrossTopics()
+    {
+        var registrations = new List<Registration>();
+        var schemaRegistry = CreateRegistry(registrations);
+        var config = new ProtobufSerializerConfig { SubjectNameStrategy = SubjectNameStrategy.RecordName };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<ReferenceGraphMessage>(
+            schemaRegistry,
+            config);
+
+        var firstDestination = new ArrayBufferWriter<byte>();
+        serializer.Serialize(
+            new ReferenceGraphMessage(),
+            ref firstDestination,
+            new SerializationContext { Topic = "first", Component = SerializationComponent.Value });
+        var secondDestination = new ArrayBufferWriter<byte>();
+        serializer.Serialize(
+            new ReferenceGraphMessage(),
+            ref secondDestination,
+            new SerializationContext { Topic = "second", Component = SerializationComponent.Value });
+
+        await Assert.That(registrations.Count).IsEqualTo(7);
+        await Assert.That(registrations.Count(static registration =>
+            registration.Subject == ReferenceGraphMessage.Descriptor.FullName)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Serialize_CustomReferenceStrategy_DoesNotReuseGraphAcrossTopics()
+    {
+        var registrations = new List<Registration>();
+        var schemaRegistry = CreateRegistry(registrations);
+        var strategy = new RecordingReferenceStrategy();
+        var config = new ProtobufSerializerConfig
+        {
+            SubjectNameStrategy = SubjectNameStrategy.RecordName,
+            CustomReferenceSubjectNameStrategy = strategy
+        };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<ReferenceGraphMessage>(
+            schemaRegistry,
+            config);
+
+        var firstDestination = new ArrayBufferWriter<byte>();
+        serializer.Serialize(
+            new ReferenceGraphMessage(),
+            ref firstDestination,
+            new SerializationContext { Topic = "first", Component = SerializationComponent.Value });
+        var secondDestination = new ArrayBufferWriter<byte>();
+        serializer.Serialize(
+            new ReferenceGraphMessage(),
+            ref secondDestination,
+            new SerializationContext { Topic = "second", Component = SerializationComponent.Value });
+
+        await Assert.That(strategy.Calls).Contains(("first", "shared/base.proto", false));
+        await Assert.That(strategy.Calls).Contains(("second", "shared/base.proto", false));
+        await Assert.That(registrations.Count(static registration =>
+            registration.Subject == ReferenceGraphMessage.Descriptor.FullName)).IsEqualTo(2);
     }
 
     [Test]
@@ -226,7 +286,11 @@ public sealed class ReferenceGraphMessage : IMessage<ReferenceGraphMessage>, IBu
         var right = CreateImportDescriptor("deps/right.proto", "graph.right", "Right", shared.Name);
         var vendor = CreateCommonDescriptor("vendor.proto/common/user.proto", "graph.vendor", "VendorCommon");
         var beta = CreateCommonDescriptor("beta/common.proto", "graph.beta", "BetaCommon");
-        var root = CreateRootDescriptor(left.Name, right.Name, vendor.Name, beta.Name);
+        var googleUser = CreateCommonDescriptor(
+            "google/type/company_event.proto",
+            "google.type.company",
+            "CompanyEvent");
+        var root = CreateRootDescriptor(left.Name, right.Name, vendor.Name, beta.Name, googleUser.Name);
         var descriptorBytes = new List<ByteString>
         {
             shared.ToByteString(),
@@ -234,6 +298,7 @@ public sealed class ReferenceGraphMessage : IMessage<ReferenceGraphMessage>, IBu
             right.ToByteString(),
             vendor.ToByteString(),
             beta.ToByteString(),
+            googleUser.ToByteString(),
             TimestampReflection.Descriptor.SerializedData,
             root.ToByteString()
         };
@@ -332,7 +397,8 @@ public sealed class ReferenceGraphMessage : IMessage<ReferenceGraphMessage>, IBu
         string leftName,
         string rightName,
         string vendorName,
-        string betaName)
+        string betaName,
+        string googleUserName)
     {
         var descriptor = new FileDescriptorProto
         {
@@ -345,6 +411,7 @@ public sealed class ReferenceGraphMessage : IMessage<ReferenceGraphMessage>, IBu
         descriptor.Dependency.Add(rightName);
         descriptor.Dependency.Add(vendorName);
         descriptor.Dependency.Add(betaName);
+        descriptor.Dependency.Add(googleUserName);
         descriptor.Dependency.Add(TimestampReflection.Descriptor.Name);
 
         var message = new DescriptorProto { Name = "ReferenceGraphMessage" };

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaReferenceTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaReferenceTests.cs
@@ -1,0 +1,427 @@
+using System.Buffers;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Protobuf;
+using Dekaf.Serialization;
+using Google.Protobuf;
+using Google.Protobuf.Reflection;
+using Google.Protobuf.WellKnownTypes;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public sealed class ProtobufSchemaReferenceTests
+{
+    [Test]
+    public async Task Serialize_RegistersDescriptorGraphWithExactVersionsAndFidelity()
+    {
+        var registrations = new List<Registration>();
+        var schemaRegistry = CreateRegistry(registrations);
+        await using var serializer = new ProtobufSchemaRegistrySerializer<ReferenceGraphMessage>(schemaRegistry);
+        var destination = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(
+            new ReferenceGraphMessage(),
+            ref destination,
+            new SerializationContext { Topic = "graph", Component = SerializationComponent.Value });
+
+        await Assert.That(registrations.Select(static registration => registration.Subject).SequenceEqual([
+                "shared/base.proto",
+                "deps/left.proto",
+                "deps/right.proto",
+                "alpha/common.proto",
+                "beta/common.proto",
+                "graph-value"
+            ])).IsTrue();
+        await Assert.That(registrations.Count(static registration => registration.Subject == "shared/base.proto"))
+            .IsEqualTo(1);
+        await Assert.That(registrations.Any(static registration =>
+            registration.Subject.StartsWith("google/", StringComparison.Ordinal))).IsFalse();
+
+        var rootRegistration = registrations[^1];
+        await Assert.That(rootRegistration.Schema.SchemaString)
+            .IsEqualTo(ReferenceGraphMessage.Descriptor.File.SerializedData.ToBase64());
+        await Assert.That(rootRegistration.Schema.References!.Select(static reference => reference.Name).SequenceEqual([
+                "deps/left.proto",
+                "deps/right.proto",
+                "alpha/common.proto",
+                "beta/common.proto"
+            ])).IsTrue();
+
+        var left = registrations.Single(static registration => registration.Subject == "deps/left.proto");
+        await Assert.That(left.Schema.References!.Single().Version).IsEqualTo(3);
+        var right = registrations.Single(static registration => registration.Subject == "deps/right.proto");
+        await Assert.That(right.Schema.References!.Single().Version).IsEqualTo(3);
+
+        var root = FileDescriptorProto.Parser.ParseFrom(
+            Convert.FromBase64String(rootRegistration.Schema.SchemaString));
+        var message = root.MessageType.Single(static descriptor => descriptor.Name == "ReferenceGraphMessage");
+        await Assert.That(root.Syntax).IsEqualTo("proto3");
+        await Assert.That(root.Options.JavaPackage).IsEqualTo("com.dekaf.graph");
+        await Assert.That(root.Service.Single().Name).IsEqualTo("GraphService");
+        await Assert.That(message.OneofDecl).Count().IsEqualTo(2);
+        await Assert.That(message.Field.Single(static field => field.Name == "nickname").Proto3Optional).IsTrue();
+        await Assert.That(message.NestedType.Single(static nested => nested.Name == "LabelsEntry").Options.MapEntry)
+            .IsTrue();
+        await Assert.That(message.NestedType).Contains(static nested => nested.Name == "Metadata");
+        await Assert.That(message.EnumType).Contains(static nested => nested.Name == "Kind");
+        await Assert.That(root.EnumType).Contains(static nested => nested.Name == "GraphState");
+        await Assert.That(message.ReservedRange.Single().Start).IsEqualTo(10);
+        await Assert.That(message.ReservedName).Contains("retired_field");
+
+        var sharedRegistration = registrations.Single(static registration => registration.Subject == "shared/base.proto");
+        var shared = FileDescriptorProto.Parser.ParseFrom(
+            Convert.FromBase64String(sharedRegistration.Schema.SchemaString));
+        await Assert.That(shared.Syntax).IsEqualTo("proto2");
+        await Assert.That(shared.MessageType[0].Field[0].DefaultValue).IsEqualTo("legacy");
+    }
+
+    [Test]
+    public async Task Serialize_QualifiedReferenceStrategy_TransformsImportPaths()
+    {
+        var registrations = new List<Registration>();
+        var schemaRegistry = CreateRegistry(registrations);
+        var config = new ProtobufSerializerConfig
+        {
+            ReferenceSubjectNameStrategy = ReferenceSubjectNameStrategy.Qualified
+        };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<ReferenceGraphMessage>(
+            schemaRegistry,
+            config);
+        var destination = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(
+            new ReferenceGraphMessage(),
+            ref destination,
+            new SerializationContext { Topic = "graph", Component = SerializationComponent.Value });
+
+        await Assert.That(registrations.Select(static registration => registration.Subject).ToArray())
+            .Contains("shared.base");
+        await Assert.That(registrations.Select(static registration => registration.Subject).ToArray())
+            .Contains("alpha.common");
+        await Assert.That(registrations.Select(static registration => registration.Subject).ToArray())
+            .Contains("beta.common");
+    }
+
+    [Test]
+    public async Task Serialize_CustomReferenceStrategy_ReceivesTopicReferenceAndComponent()
+    {
+        var registrations = new List<Registration>();
+        var schemaRegistry = CreateRegistry(registrations);
+        var strategy = new RecordingReferenceStrategy();
+        var config = new ProtobufSerializerConfig
+        {
+            CustomReferenceSubjectNameStrategy = strategy
+        };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<ReferenceGraphMessage>(
+            schemaRegistry,
+            config);
+        var destination = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(
+            new ReferenceGraphMessage(),
+            ref destination,
+            new SerializationContext { Topic = "graph", Component = SerializationComponent.Key });
+
+        await Assert.That(registrations.Select(static registration => registration.Subject).ToArray())
+            .Contains("graph-key-shared/base.proto");
+        await Assert.That(strategy.Calls).Contains(("graph", "shared/base.proto", true));
+    }
+
+    [Test]
+    public async Task SerializerConfig_DefaultsMatchConfluentKnownTypeBehavior()
+    {
+        var config = new ProtobufSerializerConfig();
+
+        await Assert.That(config.SkipKnownTypes).IsTrue();
+        await Assert.That(config.ReferenceSubjectNameStrategy)
+            .IsEqualTo(ReferenceSubjectNameStrategy.ReferenceName);
+    }
+
+    private static ISchemaRegistryClient CreateRegistry(List<Registration> registrations)
+    {
+        var schemaRegistry = Substitute.For<ISchemaRegistryClient>();
+        var nextId = 10;
+
+        schemaRegistry.RegisterSchemaAsync(
+                Arg.Any<string>(),
+                Arg.Any<Schema>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var subject = call.ArgAt<string>(0);
+                var schema = call.ArgAt<Schema>(1);
+                registrations.Add(new Registration(subject, schema));
+                return Task.FromResult(nextId++);
+            });
+        schemaRegistry.LookupSchemaAsync(
+                Arg.Any<string>(),
+                Arg.Any<Schema>(),
+                true,
+                false,
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var subject = call.ArgAt<string>(0);
+                var schema = call.ArgAt<Schema>(1);
+                return Task.FromResult(new RegisteredSchema
+                {
+                    Id = nextId,
+                    Subject = subject,
+                    Version = subject == "shared/base.proto" ? 3 : 1,
+                    Schema = schema
+                });
+            });
+        schemaRegistry.GetOrRegisterSchemaAsync(
+                Arg.Any<string>(),
+                Arg.Any<Schema>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                registrations.Add(new Registration(call.ArgAt<string>(0), call.ArgAt<Schema>(1)));
+                return Task.FromResult(nextId++);
+            });
+
+        return schemaRegistry;
+    }
+
+    private sealed record Registration(string Subject, Schema Schema);
+
+    private sealed class RecordingReferenceStrategy : ICustomReferenceSubjectNameStrategy
+    {
+        internal List<(string Topic, string ReferenceName, bool IsKey)> Calls { get; } = [];
+
+        public string GetSubjectName(string topic, string referenceName, bool isKey)
+        {
+            Calls.Add((topic, referenceName, isKey));
+            return $"{topic}-{(isKey ? "key" : "value")}-{referenceName}";
+        }
+    }
+}
+
+public sealed class ReferenceGraphMessage : IMessage<ReferenceGraphMessage>, IBufferMessage
+{
+    private static readonly MessageParser<ReferenceGraphMessage> MessageParser = new(
+        static () => new ReferenceGraphMessage());
+    private UnknownFieldSet? _unknownFields;
+
+    static ReferenceGraphMessage()
+    {
+        var shared = CreateSharedDescriptor();
+        var left = CreateImportDescriptor("deps/left.proto", "graph.left", "Left", shared.Name);
+        var right = CreateImportDescriptor("deps/right.proto", "graph.right", "Right", shared.Name);
+        var alpha = CreateCommonDescriptor("alpha/common.proto", "graph.alpha", "AlphaCommon");
+        var beta = CreateCommonDescriptor("beta/common.proto", "graph.beta", "BetaCommon");
+        var root = CreateRootDescriptor(left.Name, right.Name, alpha.Name, beta.Name);
+        var descriptorBytes = new List<ByteString>
+        {
+            shared.ToByteString(),
+            left.ToByteString(),
+            right.ToByteString(),
+            alpha.ToByteString(),
+            beta.ToByteString(),
+            TimestampReflection.Descriptor.SerializedData,
+            root.ToByteString()
+        };
+
+        var descriptors = FileDescriptor.BuildFromByteStrings(descriptorBytes);
+        Descriptor = descriptors.Single(static file => file.Name == "graph/root.proto").MessageTypes[0];
+    }
+
+    public static MessageDescriptor Descriptor { get; }
+    public static MessageParser<ReferenceGraphMessage> Parser => MessageParser;
+    MessageDescriptor IMessage.Descriptor => Descriptor;
+
+    public int CalculateSize() => 0;
+    public ReferenceGraphMessage Clone() => new();
+    public bool Equals(ReferenceGraphMessage? other) => other is not null;
+    public override bool Equals(object? obj) => obj is ReferenceGraphMessage;
+    public override int GetHashCode() => 0;
+    public void MergeFrom(ReferenceGraphMessage message) { }
+
+    public void MergeFrom(CodedInputStream input)
+    {
+        while (input.ReadTag() != 0)
+            input.SkipLastField();
+    }
+
+    public void WriteTo(CodedOutputStream output) { }
+
+    void IBufferMessage.InternalMergeFrom(ref ParseContext input)
+    {
+        while (input.ReadTag() != 0)
+            _unknownFields = UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+    }
+
+    void IBufferMessage.InternalWriteTo(ref WriteContext output) { }
+
+    private static FileDescriptorProto CreateSharedDescriptor()
+    {
+        var descriptor = new FileDescriptorProto
+        {
+            Name = "shared/base.proto",
+            Package = "graph.shared",
+            Syntax = "proto2"
+        };
+        var message = new DescriptorProto { Name = "SharedData" };
+        message.Field.Add(new FieldDescriptorProto
+        {
+            Name = "legacy_name",
+            Number = 1,
+            Label = FieldDescriptorProto.Types.Label.Optional,
+            Type = FieldDescriptorProto.Types.Type.String,
+            DefaultValue = "legacy"
+        });
+        descriptor.MessageType.Add(message);
+        return descriptor;
+    }
+
+    private static FileDescriptorProto CreateImportDescriptor(
+        string name,
+        string package,
+        string messageName,
+        string sharedName)
+    {
+        var descriptor = new FileDescriptorProto
+        {
+            Name = name,
+            Package = package,
+            Syntax = "proto3"
+        };
+        descriptor.Dependency.Add(sharedName);
+        var message = new DescriptorProto { Name = messageName };
+        message.Field.Add(new FieldDescriptorProto
+        {
+            Name = "shared",
+            Number = 1,
+            Label = FieldDescriptorProto.Types.Label.Optional,
+            Type = FieldDescriptorProto.Types.Type.Message,
+            TypeName = ".graph.shared.SharedData"
+        });
+        descriptor.MessageType.Add(message);
+        return descriptor;
+    }
+
+    private static FileDescriptorProto CreateCommonDescriptor(string name, string package, string messageName)
+    {
+        var descriptor = new FileDescriptorProto
+        {
+            Name = name,
+            Package = package,
+            Syntax = "proto3"
+        };
+        descriptor.MessageType.Add(new DescriptorProto { Name = messageName });
+        return descriptor;
+    }
+
+    private static FileDescriptorProto CreateRootDescriptor(
+        string leftName,
+        string rightName,
+        string alphaName,
+        string betaName)
+    {
+        var descriptor = new FileDescriptorProto
+        {
+            Name = "graph/root.proto",
+            Package = "graph.root",
+            Syntax = "proto3",
+            Options = new Google.Protobuf.Reflection.FileOptions { JavaPackage = "com.dekaf.graph" }
+        };
+        descriptor.Dependency.Add(leftName);
+        descriptor.Dependency.Add(rightName);
+        descriptor.Dependency.Add(alphaName);
+        descriptor.Dependency.Add(betaName);
+        descriptor.Dependency.Add(TimestampReflection.Descriptor.Name);
+
+        var message = new DescriptorProto { Name = "ReferenceGraphMessage" };
+        message.OneofDecl.Add(new OneofDescriptorProto { Name = "choice" });
+        message.OneofDecl.Add(new OneofDescriptorProto { Name = "_nickname" });
+        message.Field.Add(new FieldDescriptorProto
+        {
+            Name = "choice_text",
+            Number = 1,
+            Label = FieldDescriptorProto.Types.Label.Optional,
+            Type = FieldDescriptorProto.Types.Type.String,
+            OneofIndex = 0
+        });
+        message.Field.Add(new FieldDescriptorProto
+        {
+            Name = "choice_number",
+            Number = 2,
+            Label = FieldDescriptorProto.Types.Label.Optional,
+            Type = FieldDescriptorProto.Types.Type.Int32,
+            OneofIndex = 0
+        });
+        message.Field.Add(new FieldDescriptorProto
+        {
+            Name = "nickname",
+            Number = 3,
+            Label = FieldDescriptorProto.Types.Label.Optional,
+            Type = FieldDescriptorProto.Types.Type.String,
+            OneofIndex = 1,
+            Proto3Optional = true
+        });
+        var mapEntry = new DescriptorProto
+        {
+            Name = "LabelsEntry",
+            Options = new MessageOptions { MapEntry = true }
+        };
+        mapEntry.Field.Add(new FieldDescriptorProto
+        {
+            Name = "key",
+            Number = 1,
+            Label = FieldDescriptorProto.Types.Label.Optional,
+            Type = FieldDescriptorProto.Types.Type.String
+        });
+        mapEntry.Field.Add(new FieldDescriptorProto
+        {
+            Name = "value",
+            Number = 2,
+            Label = FieldDescriptorProto.Types.Label.Optional,
+            Type = FieldDescriptorProto.Types.Type.Int32
+        });
+        message.NestedType.Add(mapEntry);
+        message.NestedType.Add(new DescriptorProto { Name = "Metadata" });
+        message.EnumType.Add(new EnumDescriptorProto
+        {
+            Name = "Kind",
+            Value =
+            {
+                new EnumValueDescriptorProto { Name = "KIND_UNSPECIFIED", Number = 0 }
+            }
+        });
+        message.Field.Add(new FieldDescriptorProto
+        {
+            Name = "labels",
+            Number = 4,
+            Label = FieldDescriptorProto.Types.Label.Repeated,
+            Type = FieldDescriptorProto.Types.Type.Message,
+            TypeName = ".graph.root.ReferenceGraphMessage.LabelsEntry"
+        });
+        message.ReservedRange.Add(new DescriptorProto.Types.ReservedRange { Start = 10, End = 20 });
+        message.ReservedName.Add("retired_field");
+        descriptor.MessageType.Add(message);
+        descriptor.EnumType.Add(new EnumDescriptorProto
+        {
+            Name = "GraphState",
+            Value =
+            {
+                new EnumValueDescriptorProto { Name = "GRAPH_STATE_UNSPECIFIED", Number = 0 },
+                new EnumValueDescriptorProto { Name = "GRAPH_STATE_READY", Number = 1 }
+            }
+        });
+        descriptor.Service.Add(new ServiceDescriptorProto
+        {
+            Name = "GraphService",
+            Method =
+            {
+                new MethodDescriptorProto
+                {
+                    Name = "Resolve",
+                    InputType = ".graph.root.ReferenceGraphMessage",
+                    OutputType = ".graph.root.ReferenceGraphMessage"
+                }
+            }
+        });
+        return descriptor;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaReferenceTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaReferenceTests.cs
@@ -24,11 +24,26 @@ public sealed class ProtobufSchemaReferenceTests
             ref destination,
             new SerializationContext { Topic = "graph", Component = SerializationComponent.Value });
 
+        await schemaRegistry.Received().RegisterSchemaAsync(
+            Arg.Any<string>(),
+            Arg.Any<Schema>(),
+            Arg.Is<CancellationToken>(static token => token.CanBeCanceled));
+        await schemaRegistry.Received().LookupSchemaAsync(
+            Arg.Any<string>(),
+            Arg.Any<Schema>(),
+            true,
+            false,
+            Arg.Is<CancellationToken>(static token => token.CanBeCanceled));
+        await schemaRegistry.Received().GetOrRegisterSchemaAsync(
+            Arg.Any<string>(),
+            Arg.Any<Schema>(),
+            Arg.Is<CancellationToken>(static token => token.CanBeCanceled));
+
         await Assert.That(registrations.Select(static registration => registration.Subject).SequenceEqual([
                 "shared/base.proto",
                 "deps/left.proto",
                 "deps/right.proto",
-                "alpha/common.proto",
+                "vendor.proto/common/user.proto",
                 "beta/common.proto",
                 "graph-value"
             ])).IsTrue();
@@ -43,7 +58,7 @@ public sealed class ProtobufSchemaReferenceTests
         await Assert.That(rootRegistration.Schema.References!.Select(static reference => reference.Name).SequenceEqual([
                 "deps/left.proto",
                 "deps/right.proto",
-                "alpha/common.proto",
+                "vendor.proto/common/user.proto",
                 "beta/common.proto"
             ])).IsTrue();
 
@@ -97,7 +112,7 @@ public sealed class ProtobufSchemaReferenceTests
         await Assert.That(registrations.Select(static registration => registration.Subject).ToArray())
             .Contains("shared.base");
         await Assert.That(registrations.Select(static registration => registration.Subject).ToArray())
-            .Contains("alpha.common");
+            .Contains("vendor.proto.common.user");
         await Assert.That(registrations.Select(static registration => registration.Subject).ToArray())
             .Contains("beta.common");
     }
@@ -186,7 +201,7 @@ public sealed class ProtobufSchemaReferenceTests
 
     private sealed record Registration(string Subject, Schema Schema);
 
-    private sealed class RecordingReferenceStrategy : ICustomReferenceSubjectNameStrategy
+    private sealed class RecordingReferenceStrategy : IReferenceSubjectNameStrategy
     {
         internal List<(string Topic, string ReferenceName, bool IsKey)> Calls { get; } = [];
 
@@ -209,15 +224,15 @@ public sealed class ReferenceGraphMessage : IMessage<ReferenceGraphMessage>, IBu
         var shared = CreateSharedDescriptor();
         var left = CreateImportDescriptor("deps/left.proto", "graph.left", "Left", shared.Name);
         var right = CreateImportDescriptor("deps/right.proto", "graph.right", "Right", shared.Name);
-        var alpha = CreateCommonDescriptor("alpha/common.proto", "graph.alpha", "AlphaCommon");
+        var vendor = CreateCommonDescriptor("vendor.proto/common/user.proto", "graph.vendor", "VendorCommon");
         var beta = CreateCommonDescriptor("beta/common.proto", "graph.beta", "BetaCommon");
-        var root = CreateRootDescriptor(left.Name, right.Name, alpha.Name, beta.Name);
+        var root = CreateRootDescriptor(left.Name, right.Name, vendor.Name, beta.Name);
         var descriptorBytes = new List<ByteString>
         {
             shared.ToByteString(),
             left.ToByteString(),
             right.ToByteString(),
-            alpha.ToByteString(),
+            vendor.ToByteString(),
             beta.ToByteString(),
             TimestampReflection.Descriptor.SerializedData,
             root.ToByteString()
@@ -316,7 +331,7 @@ public sealed class ReferenceGraphMessage : IMessage<ReferenceGraphMessage>, IBu
     private static FileDescriptorProto CreateRootDescriptor(
         string leftName,
         string rightName,
-        string alphaName,
+        string vendorName,
         string betaName)
     {
         var descriptor = new FileDescriptorProto
@@ -328,7 +343,7 @@ public sealed class ReferenceGraphMessage : IMessage<ReferenceGraphMessage>, IBu
         };
         descriptor.Dependency.Add(leftName);
         descriptor.Dependency.Add(rightName);
-        descriptor.Dependency.Add(alphaName);
+        descriptor.Dependency.Add(vendorName);
         descriptor.Dependency.Add(betaName);
         descriptor.Dependency.Add(TimestampReflection.Descriptor.Name);
 

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistrySerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistrySerializerTests.cs
@@ -416,6 +416,23 @@ public class ProtobufSchemaRegistrySerializerTests
         });
 
         await Assert.That(exception!.ErrorCode).IsEqualTo(errorCode);
+
+        if (config.UseLatestVersion)
+        {
+            await schemaRegistry.Received(1).GetSchemaBySubjectAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Is<CancellationToken>(static token => token.CanBeCanceled));
+        }
+        else
+        {
+            await schemaRegistry.Received(1).LookupSchemaAsync(
+                Arg.Any<string>(),
+                Arg.Any<Schema>(),
+                true,
+                false,
+                Arg.Is<CancellationToken>(static token => token.CanBeCanceled));
+        }
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistrySerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistrySerializerTests.cs
@@ -294,7 +294,8 @@ public class ProtobufSchemaRegistrySerializerTests
         // Assert
         await Assert.That(capturedSchema).IsNotNull();
         await Assert.That(capturedSchema!.SchemaType).IsEqualTo(SchemaType.Protobuf);
-        await Assert.That(capturedSchema.SchemaString).Contains("message TestMessage");
+        await Assert.That(capturedSchema.SchemaString)
+            .IsEqualTo(TestMessage.Descriptor.File.SerializedData.ToBase64());
     }
 
     [Test]
@@ -309,7 +310,12 @@ public class ProtobufSchemaRegistrySerializerTests
             Version = 1,
             Schema = new Schema { SchemaType = SchemaType.Protobuf, SchemaString = "syntax = \"proto3\";" }
         };
-        schemaRegistry.GetSchemaBySubjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        schemaRegistry.LookupSchemaAsync(
+                Arg.Any<string>(),
+                Arg.Any<Schema>(),
+                true,
+                false,
+                Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(registeredSchema));
 
         var config = new ProtobufSerializerConfig { AutoRegisterSchemas = false };
@@ -321,8 +327,13 @@ public class ProtobufSchemaRegistrySerializerTests
         var buffer = new ArrayBufferWriter<byte>();
         serializer.Serialize(message, ref buffer, CreateContext());
 
-        // Assert - should call GetSchemaBySubjectAsync, not GetOrRegisterSchemaAsync
-        await schemaRegistry.Received(1).GetSchemaBySubjectAsync(Arg.Any<string>(), "latest", Arg.Any<CancellationToken>());
+        // Assert - should look up the exact descriptor, not register or select an unrelated latest version.
+        await schemaRegistry.Received(1).LookupSchemaAsync(
+            Arg.Any<string>(),
+            Arg.Any<Schema>(),
+            true,
+            false,
+            Arg.Any<CancellationToken>());
         await schemaRegistry.DidNotReceive().GetOrRegisterSchemaAsync(Arg.Any<string>(), Arg.Any<Schema>(), Arg.Any<CancellationToken>());
     }
 
@@ -376,8 +387,21 @@ public class ProtobufSchemaRegistrySerializerTests
         int errorCode)
     {
         var schemaRegistry = Substitute.For<ISchemaRegistryClient>();
-        schemaRegistry.GetSchemaBySubjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<RegisteredSchema>(new SchemaRegistryException(errorCode, "lookup failed")));
+        if (config.UseLatestVersion)
+        {
+            schemaRegistry.GetSchemaBySubjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromException<RegisteredSchema>(new SchemaRegistryException(errorCode, "lookup failed")));
+        }
+        else
+        {
+            schemaRegistry.LookupSchemaAsync(
+                    Arg.Any<string>(),
+                    Arg.Any<Schema>(),
+                    true,
+                    false,
+                    Arg.Any<CancellationToken>())
+                .Returns(Task.FromException<RegisteredSchema>(new SchemaRegistryException(errorCode, "lookup failed")));
+        }
 
         await using var serializer = new ProtobufSchemaRegistrySerializer<TestMessage>(schemaRegistry, config);
 

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryDataContractTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryDataContractTests.cs
@@ -99,7 +99,7 @@ public sealed class SchemaRegistryDataContractTests
               "subject": "shared/common.proto",
               "version": 4,
               "id": 42,
-              "schema": "descriptor-base64",
+              "schema": "canonical-descriptor-base64",
               "schemaType": "PROTOBUF"
             }
             """);
@@ -110,8 +110,9 @@ public sealed class SchemaRegistryDataContractTests
         var schema = new Schema
         {
             SchemaType = SchemaType.Protobuf,
-            SchemaString = "descriptor-base64"
+            SchemaString = "request-descriptor-base64"
         };
+        client.CacheSchema(42, subject: null, schema);
 
         var registered = await client.LookupSchemaAsync(
             "shared/common.proto",
@@ -121,12 +122,15 @@ public sealed class SchemaRegistryDataContractTests
 
         await Assert.That(registered.Id).IsEqualTo(42);
         await Assert.That(registered.Version).IsEqualTo(4);
+        await Assert.That(registered.Schema.SchemaString).IsEqualTo("canonical-descriptor-base64");
+        await Assert.That(client.TryGetCachedSchema(42, out var cachedSchema)).IsTrue();
+        await Assert.That(cachedSchema.SchemaString).IsEqualTo("canonical-descriptor-base64");
         await Assert.That(handler.LastRequestUri!.AbsolutePath)
             .IsEqualTo("/subjects/shared%2Fcommon.proto");
         await Assert.That(handler.LastRequestUri.Query).IsEqualTo("?normalize=true&deleted=false");
         using var document = JsonDocument.Parse(handler.LastRequestBody!);
         await Assert.That(document.RootElement.GetProperty("schema").GetString())
-            .IsEqualTo("descriptor-base64");
+            .IsEqualTo("request-descriptor-base64");
         await Assert.That(document.RootElement.GetProperty("schemaType").GetString())
             .IsEqualTo("PROTOBUF");
     }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryDataContractTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryDataContractTests.cs
@@ -91,6 +91,46 @@ public sealed class SchemaRegistryDataContractTests
         await Assert.That(rule.Expr).IsEqualTo("message.name");
     }
 
+    [Test]
+    public async Task LookupSchemaAsync_PostsExactSchemaAndReturnsRegisteredVersion()
+    {
+        var handler = new CapturingSchemaRegistryHandler("""
+            {
+              "subject": "shared/common.proto",
+              "version": 4,
+              "id": 42,
+              "schema": "descriptor-base64",
+              "schemaType": "PROTOBUF"
+            }
+            """);
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://schema-registry.local"
+        }, handler);
+        var schema = new Schema
+        {
+            SchemaType = SchemaType.Protobuf,
+            SchemaString = "descriptor-base64"
+        };
+
+        var registered = await client.LookupSchemaAsync(
+            "shared/common.proto",
+            schema,
+            ignoreDeletedSchemas: true,
+            normalize: true);
+
+        await Assert.That(registered.Id).IsEqualTo(42);
+        await Assert.That(registered.Version).IsEqualTo(4);
+        await Assert.That(handler.LastRequestUri!.AbsolutePath)
+            .IsEqualTo("/subjects/shared%2Fcommon.proto");
+        await Assert.That(handler.LastRequestUri.Query).IsEqualTo("?normalize=true&deleted=false");
+        using var document = JsonDocument.Parse(handler.LastRequestBody!);
+        await Assert.That(document.RootElement.GetProperty("schema").GetString())
+            .IsEqualTo("descriptor-base64");
+        await Assert.That(document.RootElement.GetProperty("schemaType").GetString())
+            .IsEqualTo("PROTOBUF");
+    }
+
     private static Schema CreateDataContractSchema() => new()
     {
         SchemaType = SchemaType.Json,
@@ -131,11 +171,13 @@ public sealed class SchemaRegistryDataContractTests
     private sealed class CapturingSchemaRegistryHandler(string responseContent) : HttpMessageHandler
     {
         public string? LastRequestBody { get; private set; }
+        public Uri? LastRequestUri { get; private set; }
 
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+            LastRequestUri = request.RequestUri;
             if (request.Content is not null)
                 LastRequestBody = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtobufSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtobufSchemaRegistrySerializerBenchmarks.cs
@@ -1,0 +1,87 @@
+using System.Buffers;
+using BenchmarkDotNet.Attributes;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Protobuf;
+using Dekaf.Serialization;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Protects cached Protobuf Schema Registry serialization from steady-state allocations.
+/// Descriptor traversal and registration are deliberately completed during setup.
+/// </summary>
+[MemoryDiagnoser(displayGenColumns: false)]
+[ShortRunJob]
+public class ProtobufSchemaRegistrySerializerBenchmarks
+{
+    private ArrayBufferWriter<byte> _destination = new(256);
+    private ProtobufSchemaRegistrySerializer<StringValue> _serializer = null!;
+    private StringValue _value = null!;
+    private SerializationContext _context;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _serializer = new ProtobufSchemaRegistrySerializer<StringValue>(new BenchmarkSchemaRegistryClient());
+        _value = new StringValue { Value = "protobuf-benchmark" };
+        _context = new SerializationContext
+        {
+            Topic = "protobuf-benchmark",
+            Component = SerializationComponent.Value
+        };
+
+        _serializer.Serialize(_value, ref _destination, _context);
+    }
+
+    [GlobalCleanup]
+    public ValueTask Cleanup() => _serializer.DisposeAsync();
+
+    [Benchmark]
+    public void SerializeCached()
+    {
+        _destination.Clear();
+        _serializer.Serialize(_value, ref _destination, _context);
+    }
+
+    private sealed class BenchmarkSchemaRegistryClient : ISchemaRegistryClient
+    {
+        public Task<int> RegisterSchemaAsync(
+            string subject,
+            Schema schema,
+            CancellationToken cancellationToken = default) => Task.FromResult(1);
+
+        public Task<Schema> GetSchemaAsync(int id, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(
+            string subject,
+            string version = "latest",
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<int> GetOrRegisterSchemaAsync(
+            string subject,
+            Schema schema,
+            CancellationToken cancellationToken = default) => Task.FromResult(1);
+
+        public Task<IReadOnlyList<string>> GetAllSubjectsAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> GetVersionsAsync(
+            string subject,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<bool> IsCompatibleAsync(
+            string subject,
+            Schema schema,
+            string version = "latest",
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> DeleteSubjectAsync(
+            string subject,
+            bool permanent = false,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public void Dispose() { }
+    }
+}

--- a/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
+++ b/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\..\src\Dekaf.Compression.Zstd\Dekaf.Compression.Zstd.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Serialization.Json\Dekaf.Serialization.Json.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Avro\Dekaf.SchemaRegistry.Avro.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- preserve the exact `FileDescriptorProto` bytes used by Confluent Schema Registry
- register recursive dependencies before dependents, deduplicate shared imports, and reference their actual registered versions
- add exact schema lookup plus Confluent-compatible known-type and reference-subject strategies
- cover schema fidelity, deterministic dependency graphs, both interoperability directions, and steady-state allocations

## Breaking behavior

`SkipKnownTypes` now defaults to `true`. The obsolete `QualifiedRecordName` value now follows Confluent import-path qualification. Existing behavior remains available through `SkipKnownTypes = false` and a custom reference strategy. Custom `ISchemaRegistryClient` implementations must implement `LookupSchemaAsync` when referenced Protobuf schemas are enabled (the default).

## Validation

- `dotnet build --configuration Release --no-restore` — 0 warnings, 0 errors
- unit suite — 6,731 passed
- focused schema/reference units — 24 passed
- Dekaf registration → Confluent deserialization integration — passed
- Confluent registration → Dekaf exact lookup integration — passed
- NativeAOT integration compilation passed; local publish stopped at the unavailable Windows C++ linker prerequisite

## Performance

`ProtobufSchemaRegistrySerializerBenchmarks.SerializeCached`, BenchmarkDotNet ShortRun + MemoryDiagnoser, local Windows/.NET 10:

| Revision | Mean | Allocated |
|---|---:|---:|
| baseline `58099f1b` | 20.87 ns | 0 B/op |
| candidate `521d6f4a` | 19.98 ns | 0 B/op |

Delta: -4.3% mean time; confidence intervals overlap. No allocation or throughput regression detected.

Closes #2569


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Protobuf schemas now support automatic registration and lookup of imported schema references.
  * Added configurable subject naming for dependent schemas.
  * Added exact schema lookup support for Schema Registry clients.
  * Known Protobuf types are excluded by default from reference registration.
  * Added compatibility with Confluent consumers for referenced schemas.

* **Documentation**
  * Updated guidance on schema references, exact lookup, and legacy registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->