### PR TITLE
feat(schema-registry): manage compatibility levels

### DIFF
--- a/src/Dekaf.SchemaRegistry/Dekaf.SchemaRegistry.csproj
+++ b/src/Dekaf.SchemaRegistry/Dekaf.SchemaRegistry.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Dekaf.Tests.Unit" />
+    <InternalsVisibleTo Include="Dekaf.Tests.Aot" />
     <InternalsVisibleTo Include="Dekaf.SchemaRegistry.Avro" />
     <InternalsVisibleTo Include="Dekaf.SchemaRegistry.Protobuf" />
     <ProjectReference Include="..\Dekaf\Dekaf.csproj" />

--- a/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
@@ -125,6 +125,38 @@ public interface ISchemaRegistryClient : IDisposable
         => IsCompatibleAsync(subject, schema, version, cancellationToken);
 
     /// <summary>
+    /// Gets the global or subject-specific Schema Registry compatibility policy.
+    /// </summary>
+    /// <param name="subject">
+    /// Subject name, or <see langword="null" /> for the global policy. Empty or whitespace
+    /// values are invalid.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The current compatibility policy.</returns>
+    Task<SchemaCompatibilityLevel> GetCompatibilityAsync(
+        string? subject = null,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException(
+            $"{GetType().Name} does not support compatibility configuration reads.");
+
+    /// <summary>
+    /// Updates the global or subject-specific Schema Registry compatibility policy.
+    /// </summary>
+    /// <param name="level">Compatibility policy to apply.</param>
+    /// <param name="subject">
+    /// Subject name, or <see langword="null" /> for the global policy. Empty or whitespace
+    /// values are invalid.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The compatibility policy acknowledged by Schema Registry.</returns>
+    Task<SchemaCompatibilityLevel> UpdateCompatibilityAsync(
+        SchemaCompatibilityLevel level,
+        string? subject = null,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException(
+            $"{GetType().Name} does not support compatibility configuration updates.");
+
+    /// <summary>
     /// Deletes a subject and all associated schemas.
     /// </summary>
     /// <param name="subject">The subject name.</param>

--- a/src/Dekaf.SchemaRegistry/SchemaCompatibilityLevel.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaCompatibilityLevel.cs
@@ -1,0 +1,28 @@
+namespace Dekaf.SchemaRegistry;
+
+/// <summary>
+/// Schema Registry compatibility policy.
+/// </summary>
+public enum SchemaCompatibilityLevel
+{
+    /// <summary>No compatibility checks.</summary>
+    None,
+
+    /// <summary>New schemas can read data written with the latest schema.</summary>
+    Backward,
+
+    /// <summary>New schemas can read data written with every previous schema.</summary>
+    BackwardTransitive,
+
+    /// <summary>The latest schema can read data written with new schemas.</summary>
+    Forward,
+
+    /// <summary>Every previous schema can read data written with new schemas.</summary>
+    ForwardTransitive,
+
+    /// <summary>Backward and forward compatibility with the latest schema.</summary>
+    Full,
+
+    /// <summary>Backward and forward compatibility with every previous schema.</summary>
+    FullTransitive
+}

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -147,6 +147,15 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             baseUri => _httpClient.PostAsJsonAsync(new Uri(baseUri, path), value, jsonTypeInfo, cancellationToken),
             cancellationToken);
 
+    private Task<HttpResponseMessage> PutAsJsonWithFailoverAsync<T>(
+        string path,
+        T value,
+        JsonTypeInfo<T> jsonTypeInfo,
+        CancellationToken cancellationToken) =>
+        SendWithFailoverAsync(
+            baseUri => _httpClient.PutAsJsonAsync(new Uri(baseUri, path), value, jsonTypeInfo, cancellationToken),
+            cancellationToken);
+
     private async Task<HttpResponseMessage> SendWithFailoverAsync(
         Func<Uri, Task<HttpResponseMessage>> sendAsync,
         CancellationToken cancellationToken)
@@ -406,6 +415,45 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         return result?.IsCompatible ?? true;
     }
 
+    public async Task<SchemaCompatibilityLevel> GetCompatibilityAsync(
+        string? subject = null,
+        CancellationToken cancellationToken = default)
+    {
+        var path = GetCompatibilityPath(subject);
+        using var response = await GetWithFailoverAsync(path, cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var result = await response.Content.ReadFromJsonAsync<GetCompatibilityResponse>(
+            SchemaRegistryJsonContext.Default.GetCompatibilityResponse,
+            cancellationToken).ConfigureAwait(false);
+        return ParseCompatibilityLevel(result?.CompatibilityLevel);
+    }
+
+    public async Task<SchemaCompatibilityLevel> UpdateCompatibilityAsync(
+        SchemaCompatibilityLevel level,
+        string? subject = null,
+        CancellationToken cancellationToken = default)
+    {
+        var path = GetCompatibilityPath(subject);
+        var request = new UpdateCompatibilityRequest
+        {
+            Compatibility = GetCompatibilityWireValue(level)
+        };
+        using var response = await PutAsJsonWithFailoverAsync(
+            path,
+            request,
+            SchemaRegistryJsonContext.Default.UpdateCompatibilityRequest,
+            cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var result = await response.Content.ReadFromJsonAsync<UpdateCompatibilityResponse>(
+            SchemaRegistryJsonContext.Default.UpdateCompatibilityResponse,
+            cancellationToken).ConfigureAwait(false);
+        return ParseCompatibilityLevel(result?.Compatibility);
+    }
+
     public async Task<IReadOnlyList<int>> DeleteSubjectAsync(string subject, bool permanent = false, CancellationToken cancellationToken = default)
     {
         var url = $"subjects/{Uri.EscapeDataString(subject)}";
@@ -418,6 +466,43 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         return await response.Content.ReadFromJsonAsync<List<int>>(
             SchemaRegistryJsonContext.Default.ListInt32, cancellationToken).ConfigureAwait(false) ?? [];
     }
+
+    private static string GetCompatibilityPath(string? subject)
+    {
+        if (subject is null)
+            return "config";
+
+        if (string.IsNullOrWhiteSpace(subject))
+            throw new ArgumentException("Subject cannot be empty or whitespace. Use null for global configuration.", nameof(subject));
+
+        return $"config/{Uri.EscapeDataString(subject)}";
+    }
+
+    private static string GetCompatibilityWireValue(SchemaCompatibilityLevel level) => level switch
+    {
+        SchemaCompatibilityLevel.None => "NONE",
+        SchemaCompatibilityLevel.Backward => "BACKWARD",
+        SchemaCompatibilityLevel.BackwardTransitive => "BACKWARD_TRANSITIVE",
+        SchemaCompatibilityLevel.Forward => "FORWARD",
+        SchemaCompatibilityLevel.ForwardTransitive => "FORWARD_TRANSITIVE",
+        SchemaCompatibilityLevel.Full => "FULL",
+        SchemaCompatibilityLevel.FullTransitive => "FULL_TRANSITIVE",
+        _ => throw new ArgumentOutOfRangeException(nameof(level), level, "Unknown compatibility level.")
+    };
+
+    private static SchemaCompatibilityLevel ParseCompatibilityLevel(string? compatibility) => compatibility switch
+    {
+        "NONE" => SchemaCompatibilityLevel.None,
+        "BACKWARD" => SchemaCompatibilityLevel.Backward,
+        "BACKWARD_TRANSITIVE" => SchemaCompatibilityLevel.BackwardTransitive,
+        "FORWARD" => SchemaCompatibilityLevel.Forward,
+        "FORWARD_TRANSITIVE" => SchemaCompatibilityLevel.ForwardTransitive,
+        "FULL" => SchemaCompatibilityLevel.Full,
+        "FULL_TRANSITIVE" => SchemaCompatibilityLevel.FullTransitive,
+        _ => throw new SchemaRegistryException(
+            0,
+            $"Schema Registry returned unknown compatibility level '{compatibility ?? "<null>"}'.")
+    };
 
     public async Task<IReadOnlyList<string>> GetKekNamesAsync(
         bool deleted = false,

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryJsonContext.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryJsonContext.cs
@@ -19,6 +19,9 @@ namespace Dekaf.SchemaRegistry;
 [JsonSerializable(typeof(RegisterDekRequestDto))]
 [JsonSerializable(typeof(DekDto))]
 [JsonSerializable(typeof(CompatibilityResponse))]
+[JsonSerializable(typeof(GetCompatibilityResponse))]
+[JsonSerializable(typeof(UpdateCompatibilityRequest))]
+[JsonSerializable(typeof(UpdateCompatibilityResponse))]
 [JsonSerializable(typeof(ErrorResponse))]
 [JsonSerializable(typeof(List<string>))]
 [JsonSerializable(typeof(List<int>))]
@@ -145,6 +148,21 @@ internal sealed class CompatibilityResponse
 {
     [JsonPropertyName("is_compatible")]
     public bool IsCompatible { get; init; }
+}
+
+internal sealed class GetCompatibilityResponse
+{
+    public string? CompatibilityLevel { get; init; }
+}
+
+internal sealed class UpdateCompatibilityRequest
+{
+    public required string Compatibility { get; init; }
+}
+
+internal sealed class UpdateCompatibilityResponse
+{
+    public string? Compatibility { get; init; }
 }
 
 internal sealed class ErrorResponse

--- a/tests/Dekaf.Tests.Aot/Program.cs
+++ b/tests/Dekaf.Tests.Aot/Program.cs
@@ -35,6 +35,7 @@ internal static class AotSmoke
         RunCompressionSmoke();
         RunJsonSmoke();
         await RunSchemaRegistrySmokeAsync();
+        await RunSchemaRegistryCompatibilitySmokeAsync();
         await RunSchemaRegistryPackageSmokeAsync();
         await RunCoreSmokeAsync();
     }
@@ -107,6 +108,23 @@ internal static class AotSmoke
 
         var roundTrip = deserializer.Deserialize(buffer.WrittenMemory, ValueContext);
         Require(roundTrip == payload, "Schema Registry JSON round-trip failed.");
+    }
+
+    private static async Task RunSchemaRegistryCompatibilitySmokeAsync()
+    {
+        using var handler = new CompatibilityConfigurationHandler();
+        using var registry = new SchemaRegistryClient(
+            new SchemaRegistryConfig { Url = "https://schema-registry.example.test" },
+            handler);
+
+        var current = await registry.GetCompatibilityAsync();
+        var updated = await registry.UpdateCompatibilityAsync(
+            SchemaCompatibilityLevel.FullTransitive,
+            "aot/value");
+
+        Require(current == SchemaCompatibilityLevel.Backward, "Compatibility GET smoke failed.");
+        Require(updated == SchemaCompatibilityLevel.FullTransitive, "Compatibility PUT smoke failed.");
+        Require(handler.RequestCount == 2, "Compatibility request count mismatch.");
     }
 
     private static async Task RunSchemaRegistryPackageSmokeAsync()
@@ -253,6 +271,38 @@ internal static class AotSmoke
                 Content = new StringContent(json, Encoding.UTF8, "application/json")
             };
         }
+    }
+
+    private sealed class CompatibilityConfigurationHandler : HttpMessageHandler
+    {
+        internal int RequestCount { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            if (RequestCount == 1)
+            {
+                Require(request.Method == HttpMethod.Get, "Compatibility GET method mismatch.");
+                Require(request.RequestUri!.AbsolutePath == "/config", "Compatibility GET path mismatch.");
+                return JsonResponse("""{ "compatibilityLevel": "BACKWARD" }""");
+            }
+
+            Require(request.Method == HttpMethod.Put, "Compatibility PUT method mismatch.");
+            Require(
+                request.RequestUri!.AbsolutePath == "/config/aot%2Fvalue",
+                "Compatibility PUT path mismatch.");
+            var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+            Require(body.Contains("\"compatibility\":\"FULL_TRANSITIVE\"", StringComparison.Ordinal),
+                "Compatibility PUT body mismatch.");
+            return JsonResponse("""{ "compatibility": "FULL_TRANSITIVE" }""");
+        }
+
+        private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
     }
 
     private const string AotPayloadJsonSchema = """

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryCompatibilityConfigurationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryCompatibilityConfigurationTests.cs
@@ -1,0 +1,55 @@
+using Dekaf.SchemaRegistry;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Serialization")]
+[NotInParallel]
+[ClassDataSource<KafkaWithSchemaRegistryContainer>(Shared = SharedType.PerTestSession)]
+public sealed class SchemaRegistryCompatibilityConfigurationTests(KafkaWithSchemaRegistryContainer testInfra)
+{
+    [Test]
+    public async Task CompatibilityConfiguration_GlobalAndSubjectPoliciesRoundTripIndependently()
+    {
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = testInfra.RegistryUrl
+        });
+        var originalGlobal = await client.GetCompatibilityAsync();
+
+        try
+        {
+            var globalAcknowledged = await client.UpdateCompatibilityAsync(
+                SchemaCompatibilityLevel.BackwardTransitive);
+            await Assert.That(globalAcknowledged).IsEqualTo(SchemaCompatibilityLevel.BackwardTransitive);
+            await Assert.That(await client.GetCompatibilityAsync())
+                .IsEqualTo(SchemaCompatibilityLevel.BackwardTransitive);
+
+            var subject = $"compatibility-{Guid.NewGuid():N}-value";
+            await client.RegisterSchemaAsync(subject, new Schema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = $$"""
+                    {
+                      "type": "record",
+                      "name": "Compatibility{{Guid.NewGuid():N}}",
+                      "fields": [ { "name": "id", "type": "long" } ]
+                    }
+                    """
+            });
+
+            var subjectAcknowledged = await client.UpdateCompatibilityAsync(
+                SchemaCompatibilityLevel.FullTransitive,
+                subject);
+
+            await Assert.That(subjectAcknowledged).IsEqualTo(SchemaCompatibilityLevel.FullTransitive);
+            await Assert.That(await client.GetCompatibilityAsync(subject))
+                .IsEqualTo(SchemaCompatibilityLevel.FullTransitive);
+            await Assert.That(await client.GetCompatibilityAsync())
+                .IsEqualTo(SchemaCompatibilityLevel.BackwardTransitive);
+        }
+        finally
+        {
+            await client.UpdateCompatibilityAsync(originalGlobal);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCompatibilityConfigurationTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCompatibilityConfigurationTests.cs
@@ -1,0 +1,229 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Dekaf.SchemaRegistry;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public sealed class SchemaRegistryCompatibilityConfigurationTests
+{
+    [Test]
+    [Arguments(SchemaCompatibilityLevel.None, "NONE")]
+    [Arguments(SchemaCompatibilityLevel.Backward, "BACKWARD")]
+    [Arguments(SchemaCompatibilityLevel.BackwardTransitive, "BACKWARD_TRANSITIVE")]
+    [Arguments(SchemaCompatibilityLevel.Forward, "FORWARD")]
+    [Arguments(SchemaCompatibilityLevel.ForwardTransitive, "FORWARD_TRANSITIVE")]
+    [Arguments(SchemaCompatibilityLevel.Full, "FULL")]
+    [Arguments(SchemaCompatibilityLevel.FullTransitive, "FULL_TRANSITIVE")]
+    public async Task GetCompatibilityAsync_ParsesEverySupportedGlobalLevel(
+        SchemaCompatibilityLevel expected,
+        string wireValue)
+    {
+        using var handler = new CapturingHandler()
+            .Enqueue(HttpStatusCode.OK, $$"""{ "compatibilityLevel": "{{wireValue}}" }""");
+        using var client = CreateClient(handler);
+
+        var result = await client.GetCompatibilityAsync();
+
+        await Assert.That(result).IsEqualTo(expected);
+        await Assert.That(handler.Requests).Count().IsEqualTo(1);
+        await Assert.That(handler.Requests[0].Method).IsEqualTo(HttpMethod.Get);
+        await Assert.That(handler.Requests[0].Uri.PathAndQuery).IsEqualTo("/config");
+    }
+
+    [Test]
+    public async Task GetCompatibilityAsync_EscapesSubjectAsSinglePathSegment()
+    {
+        using var handler = new CapturingHandler()
+            .Enqueue(HttpStatusCode.OK, """{ "compatibilityLevel": "FULL" }""");
+        using var client = CreateClient(handler);
+
+        var result = await client.GetCompatibilityAsync("orders/value?region=#eu west");
+
+        await Assert.That(result).IsEqualTo(SchemaCompatibilityLevel.Full);
+        await Assert.That(handler.Requests[0].Uri.PathAndQuery)
+            .IsEqualTo("/config/orders%2Fvalue%3Fregion%3D%23eu%20west");
+    }
+
+    [Test]
+    public async Task UpdateCompatibilityAsync_SendsWireValueAndReturnsAcknowledgedLevel()
+    {
+        using var handler = new CapturingHandler()
+            .Enqueue(HttpStatusCode.OK, """{ "compatibility": "FULL_TRANSITIVE" }""");
+        using var client = CreateClient(handler);
+
+        var result = await client.UpdateCompatibilityAsync(
+            SchemaCompatibilityLevel.Backward,
+            "orders-value");
+
+        await Assert.That(result).IsEqualTo(SchemaCompatibilityLevel.FullTransitive);
+        await Assert.That(handler.Requests[0].Method).IsEqualTo(HttpMethod.Put);
+        await Assert.That(handler.Requests[0].Uri.PathAndQuery).IsEqualTo("/config/orders-value");
+        using var body = JsonDocument.Parse(handler.Requests[0].Body!);
+        await Assert.That(body.RootElement.GetProperty("compatibility").GetString()).IsEqualTo("BACKWARD");
+        await Assert.That(body.RootElement.EnumerateObject().Count()).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments("")]
+    [Arguments(" ")]
+    [Arguments("\t")]
+    public async Task CompatibilityMethods_RejectEmptySubjectBeforeNetworkIo(string subject)
+    {
+        using var handler = new CapturingHandler();
+        using var client = CreateClient(handler);
+
+        _ = await Assert.ThrowsAsync<ArgumentException>(() => client.GetCompatibilityAsync(subject));
+        _ = await Assert.ThrowsAsync<ArgumentException>(() => client.UpdateCompatibilityAsync(
+            SchemaCompatibilityLevel.Backward,
+            subject));
+
+        await Assert.That(handler.Requests).IsEmpty();
+    }
+
+    [Test]
+    public async Task UpdateCompatibilityAsync_RejectsUnknownEnumBeforeNetworkIo()
+    {
+        using var handler = new CapturingHandler();
+        using var client = CreateClient(handler);
+
+        _ = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => client.UpdateCompatibilityAsync(
+            (SchemaCompatibilityLevel)int.MaxValue));
+
+        await Assert.That(handler.Requests).IsEmpty();
+    }
+
+    [Test]
+    public async Task GetCompatibilityAsync_RejectsUnknownServerValue()
+    {
+        using var handler = new CapturingHandler()
+            .Enqueue(HttpStatusCode.OK, """{ "compatibilityLevel": "FUTURE_MODE" }""");
+        using var client = CreateClient(handler);
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryException>(
+            () => client.GetCompatibilityAsync());
+
+        await Assert.That(exception!.Message).Contains("FUTURE_MODE");
+    }
+
+    [Test]
+    public async Task UpdateCompatibilityAsync_PreservesStructuredServerError()
+    {
+        using var handler = new CapturingHandler()
+            .Enqueue(HttpStatusCode.UnprocessableEntity, """
+                { "error_code": 42203, "message": "Invalid compatibility level" }
+                """);
+        using var client = CreateClient(handler);
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryException>(() => client.UpdateCompatibilityAsync(
+            SchemaCompatibilityLevel.Full));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(42203);
+        await Assert.That(exception.Message).Contains("Invalid compatibility level");
+    }
+
+    [Test]
+    public async Task GetCompatibilityAsync_UsesAuthenticationAndFailoverPipeline()
+    {
+        using var handler = new CapturingHandler()
+            .Enqueue(HttpStatusCode.ServiceUnavailable, "{}")
+            .Enqueue(HttpStatusCode.OK, """{ "compatibilityLevel": "FORWARD" }""");
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Urls = ["http://primary:8081", "http://secondary:8081"],
+            Url = "http://ignored:8081",
+            BasicAuthUserInfo = "user:secret"
+        }, handler);
+
+        var result = await client.GetCompatibilityAsync();
+
+        await Assert.That(result).IsEqualTo(SchemaCompatibilityLevel.Forward);
+        await Assert.That(handler.Requests).Count().IsEqualTo(2);
+        await Assert.That(handler.Requests[0].Uri.Host).IsEqualTo("primary");
+        await Assert.That(handler.Requests[1].Uri.Host).IsEqualTo("secondary");
+        await Assert.That(handler.Requests.All(static request =>
+            request.Authorization is { Scheme: "Basic", Parameter: "dXNlcjpzZWNyZXQ=" })).IsTrue();
+    }
+
+    [Test]
+    public async Task GetCompatibilityAsync_RespectsCallerCancellation()
+    {
+        using var handler = new BlockingHandler();
+        using var client = CreateClient(handler);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(
+            () => client.GetCompatibilityAsync(cancellationToken: cancellation.Token));
+    }
+
+    [Test]
+    public async Task GetCompatibilityAsync_UsesConfiguredRequestTimeout()
+    {
+        using var handler = new BlockingHandler();
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://schema-registry.local",
+            RequestTimeoutMs = 50
+        }, handler);
+
+        _ = await Assert.ThrowsAsync<TaskCanceledException>(() => client.GetCompatibilityAsync());
+    }
+
+    private static SchemaRegistryClient CreateClient(HttpMessageHandler handler) =>
+        new(new SchemaRegistryConfig { Url = "http://schema-registry.local" }, handler);
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        private readonly Queue<(HttpStatusCode StatusCode, string Content)> _responses = new();
+
+        internal List<CapturedRequest> Requests { get; } = [];
+
+        internal CapturingHandler Enqueue(HttpStatusCode statusCode, string content)
+        {
+            _responses.Enqueue((statusCode, content));
+            return this;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            Requests.Add(new CapturedRequest(
+                request.Method,
+                request.RequestUri!,
+                request.Headers.Authorization,
+                body));
+
+            var (statusCode, content) = _responses.Count == 0
+                ? (HttpStatusCode.OK, "{}")
+                : _responses.Dequeue();
+            return new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(content, Encoding.UTF8, "application/json")
+            };
+        }
+    }
+
+    private sealed class BlockingHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+            throw new UnreachableException();
+        }
+    }
+
+    private sealed record CapturedRequest(
+        HttpMethod Method,
+        Uri Uri,
+        AuthenticationHeaderValue? Authorization,
+        string? Body);
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryJsonAotTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryJsonAotTests.cs
@@ -114,10 +114,20 @@ public sealed class SchemaRegistryJsonAotTests
         var compatibilityJson = JsonSerializer.SerializeToUtf8Bytes(
             new CompatibilityResponse { IsCompatible = true },
             SchemaRegistryJsonContext.Default.CompatibilityResponse);
+        var updateCompatibilityJson = JsonSerializer.SerializeToUtf8Bytes(
+            new UpdateCompatibilityRequest { Compatibility = "FULL_TRANSITIVE" },
+            SchemaRegistryJsonContext.Default.UpdateCompatibilityRequest);
+        var getCompatibility = JsonSerializer.Deserialize(
+            """{ "compatibilityLevel": "BACKWARD" }""",
+            SchemaRegistryJsonContext.Default.GetCompatibilityResponse);
+        var updateCompatibility = JsonSerializer.Deserialize(
+            """{ "compatibility": "FORWARD" }""",
+            SchemaRegistryJsonContext.Default.UpdateCompatibilityResponse);
         var errorJson = JsonSerializer.SerializeToUtf8Bytes(
             new ErrorResponse { ErrorCode = 40401, Message = "missing" },
             SchemaRegistryJsonContext.Default.ErrorResponse);
         using var compatibilityDocument = JsonDocument.Parse(compatibilityJson);
+        using var updateCompatibilityDocument = JsonDocument.Parse(updateCompatibilityJson);
         using var errorDocument = JsonDocument.Parse(errorJson);
 
         await Assert.That(roundTrippedRequest!.SchemaType).IsEqualTo("JSON");
@@ -129,6 +139,10 @@ public sealed class SchemaRegistryJsonAotTests
         await Assert.That(subjectResponse.Metadata!.Properties!["owner"]).IsEqualTo("payments");
         await Assert.That(subjectResponse.RuleSet!.EncodingRules![0].Mode).IsEqualTo("WRITEREAD");
         await Assert.That(compatibilityDocument.RootElement.TryGetProperty("is_compatible", out _)).IsTrue();
+        await Assert.That(updateCompatibilityDocument.RootElement.GetProperty("compatibility").GetString())
+            .IsEqualTo("FULL_TRANSITIVE");
+        await Assert.That(getCompatibility!.CompatibilityLevel).IsEqualTo("BACKWARD");
+        await Assert.That(updateCompatibility!.Compatibility).IsEqualTo("FORWARD");
         await Assert.That(errorDocument.RootElement.TryGetProperty("error_code", out _)).IsTrue();
     }
 


### PR DESCRIPTION
## Summary
- add typed global and subject compatibility configuration APIs
- map all seven Schema Registry compatibility modes to exact wire values
- reuse authentication, failover, cancellation, timeout, and structured error handling
- add unit, integration, and NativeAOT smoke coverage

## Validation
- `dotnet build --configuration Release` — 0 warnings, 0 errors
- unit suite — 6,744 passed
- compatibility/AOT focused tests — 20 passed
- Schema Registry integration round-trip — passed
- AOT smoke executable — passed

## Performance
No producer, consumer, protocol, serialization, or other per-message hot path changed. Compatibility configuration is an administrative HTTP operation; benchmark gate does not apply.

Closes #2575

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading and updating global or subject-specific Schema Registry compatibility settings.
  * Added compatibility policies including backward, forward, full, transitive, and unrestricted modes.
  * Added request failover support for compatibility updates.

* **Bug Fixes**
  * Improved validation and handling of invalid compatibility values, subject paths, errors, authentication, cancellation, and timeouts.

* **Tests**
  * Added comprehensive unit, integration, and AOT coverage for compatibility configuration operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->