### PR TITLE
fix(producer): prevent late batch publication after disposal

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1279,6 +1279,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     internal Action? PurgeAppendWaitObservedForTest;
     internal Action? AfterLingerQueueSnapshotForTest;
     internal Action<TopicPartition>? AfterFlushPartitionVisitedForTest;
+    internal Action? BeforeCompletedBatchEnqueueForTest;
 
     /// <summary>
     /// True after CloseAsync has been called. Used by the sender loop to know
@@ -4816,6 +4817,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private ReadyBatch? CompleteDetachedBatchAndEnqueue(PartitionDeque pd, PartitionBatch batchToComplete)
     {
         ReadyBatch? readyBatch;
+        ReadyBatch? rejectedBatch = null;
         var bytesToRelease = 0;
         try
         {
@@ -4838,19 +4840,49 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     pd,
                     readyBatch.TopicPartition.Topic,
                     readyBatch.TopicPartition.Partition));
+
+            BeforeCompletedBatchEnqueueForTest?.Invoke();
         }
 
         {
             using var guard = new SpinLockGuard(ref pd.Lock);
             if (readyBatch is not null)
-                EnqueueCompletedBatchUnderLock(pd, readyBatch);
+            {
+                // Disposal's final deque drain takes this same lock. Either publication wins
+                // first and that drain owns the batch, or disposal wins and we fail it here.
+                if (Volatile.Read(ref _disposed) != 0)
+                {
+                    rejectedBatch = readyBatch;
+                    readyBatch = null;
+                }
+                else
+                {
+                    EnqueueCompletedBatchUnderLock(pd, readyBatch);
+                }
+            }
             ClearRotationInProgressUnderLock(pd);
         }
+
+        if (rejectedBatch is not null)
+            FailCompletedBatchRejectedByDisposal(rejectedBatch);
 
         if (bytesToRelease > 0)
             ReleaseMemory(bytesToRelease);
 
         return readyBatch;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void FailCompletedBatchRejectedByDisposal(ReadyBatch batch)
+    {
+        batch.ClearUnstartedPreSerializationTask();
+        ReleaseUntrackedBudget(batch);
+        FailBatchAndCleanup(
+            batch,
+            new ObjectDisposedException(nameof(RecordAccumulator)),
+            beforeFailure: null,
+            removeFromPipeline: false,
+            returnToPool: true);
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Integration/RealWorld/ErrorPropagationTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/ErrorPropagationTests.cs
@@ -270,18 +270,22 @@ public sealed class ErrorPropagationTests(KafkaTestContainer kafka) : KafkaInteg
 
         // Act - dispose and produce concurrently
         var produceExceptions = new List<Exception>();
+        var firstProduceStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var produceTask = Task.Run(async () =>
         {
             for (var i = 0; i < 100; i++)
             {
                 try
                 {
-                    await producer.ProduceAsync(new ProducerMessage<string, string>
+                    var produce = producer.ProduceAsync(new ProducerMessage<string, string>
                     {
                         Topic = topic,
                         Key = $"key-{i}",
                         Value = $"value-{i}"
-                    }, CancellationToken.None).ConfigureAwait(false);
+                    }, CancellationToken.None);
+                    if (i == 0)
+                        firstProduceStarted.TrySetResult();
+                    await produce.ConfigureAwait(false);
                 }
                 catch (ObjectDisposedException)
                 {
@@ -295,8 +299,7 @@ public sealed class ErrorPropagationTests(KafkaTestContainer kafka) : KafkaInteg
             }
         });
 
-        // Brief delay to let some produces start
-        await Task.Delay(10).ConfigureAwait(false);
+        await firstProduceStarted.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
         await producer.DisposeAsync().ConfigureAwait(false);
 
         await produceTask.ConfigureAwait(false);

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -18,7 +18,8 @@ namespace Dekaf.Tests.Unit.Producer;
 /// </summary>
 public class RecordAccumulatorTests
 {
-    private static ProducerOptions CreateTestOptions()
+    private static ProducerOptions CreateTestOptions(
+        CompressionType compressionType = CompressionType.None)
     {
         return new ProducerOptions
         {
@@ -26,7 +27,8 @@ public class RecordAccumulatorTests
             ClientId = "test-producer",
             BufferMemory = ulong.MaxValue, // Disable buffer limit for unit tests (no producer to drain)
             BatchSize = 1000,
-            LingerMs = 10
+            LingerMs = 10,
+            CompressionType = compressionType
         };
     }
 
@@ -663,6 +665,66 @@ public class RecordAccumulatorTests
             releaseHandoff.Set();
             if (!disposed)
                 await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Arguments(CompressionType.None)]
+    [Arguments(CompressionType.Gzip)]
+    public async Task DisposeAsync_CompletedBatchCannotPublishAfterFinalDrain(
+        CompressionType compressionType)
+    {
+        var accumulator = new RecordAccumulator(CreateTestOptions(compressionType));
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var topicPartition = new TopicPartition("test-topic", 0);
+        using var enqueueReached = new ManualResetEventSlim();
+        using var releaseEnqueue = new ManualResetEventSlim();
+        Task<bool>? appendTask = null;
+        var disposed = false;
+
+        accumulator.BeforeCompletedBatchEnqueueForTest = () =>
+        {
+            enqueueReached.Set();
+            if (!releaseEnqueue.Wait(TimeSpan.FromSeconds(10)))
+                throw new TimeoutException("Timed out waiting to release completed batch enqueue.");
+        };
+
+        try
+        {
+            var completion = pool.Rent();
+            var completionTask = completion.Task;
+            appendTask = RunOnDedicatedThread(() => accumulator.TryAppendFromSpansWithCompletion(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                "value"u8,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                completion));
+
+            await WaitUntilAsync(() => enqueueReached.IsSet, TimeSpan.FromSeconds(5));
+
+            await accumulator.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+            disposed = true;
+            releaseEnqueue.Set();
+
+            await Assert.That(await appendTask.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+                await completionTask.AsTask().WaitAsync(TimeSpan.FromSeconds(1)));
+            await Assert.That(accumulator.InFlightBatchCount).IsEqualTo(0);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            releaseEnqueue.Set();
+            if (appendTask is not null)
+                await appendTask.WaitAsync(TimeSpan.FromSeconds(5));
+            if (!disposed)
+                await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
         }
     }
 


### PR DESCRIPTION
## Summary
- close the disposal/final-drain TOCTOU by serializing completed-batch publication with the partition deque lock
- fail never-published batches with ObjectDisposedException while refunding broker budget, BufferMemory, completion sources, and pooled resources exactly once
- clear unstarted compression work before failure so Gzip disposal cannot block
- replace the concurrent integration test's arbitrary delay with a deterministic accepted-produce handoff

Fixes #2567.

## Causal proof

The new unit fault-injection barrier pauses a detached batch after completion but before deque publication. On the old code, DisposeAsync completed its final drain, the append then published into an ownerless deque, and its completion timed out. With this change, both uncompressed and Gzip variants fail the accepted completion with ObjectDisposedException and finish with zero in-flight batches and zero buffered bytes.

## Verification
- Release solution build: 0 warnings, 0 errors
- unit suite: 6,725 passed
- focused ownership/fault suites: 229 passed
- ErrorPropagationTests integration class (Kafka 4.3.1): 11 passed
- deterministic race: 2/2 passed (None and Gzip)

## Local performance gate

Identical AccumulatorAppendBenchmarks.AppendHotPath runs on commit ce816b17 and this candidate, .NET 10.0.11, 3 warmups / 3 iterations:

| Run | 100 B | 1000 B | Allocated |
|---|---:|---:|---:|
| baseline before | 70.73 ns | 146.72 ns | 0 B |
| candidate final | 70.33 ns | 150.93 ns | known drainer-behind noise at 100 B; 0 B at 1000 B |
| baseline after | 71.68 ns | 155.27 ns | 0 B |

Candidate versus adjacent baseline-after control: -1.88% at 100 B and -2.79% at 1000 B. The 100 B allocation sample hit the benchmark's explicitly documented stochastic cold-path drainer-behind exception; the earlier candidate run and both controls measured 0 B. No stable throughput or allocation regression was observed.

The exact-SHA producer stress lane will be recorded before merge for throughput, p50/p99/max latency, CPU, allocations, and stability.