### PR TITLE
fix(consumer): suppress paused prefetched records

### DIFF
--- a/docs/docs/consumer/basics.md
+++ b/docs/docs/consumer/basics.md
@@ -264,7 +264,8 @@ consumer.Partitions.Resume(new TopicPartition("my-topic", 0));
 This is useful for backpressure - if your processing can't keep up, pause some partitions.
 
 `Pause` stops new fetches and suppresses records already present in Dekaf's pending or
-prefetch buffers for `ConsumeAsync`, `ConsumeBatchAsync`, and `ConsumeRawBatchAsync`.
+prefetch buffers for `ConsumeOneAsync`, `ConsumeAsync`, `ConsumeBatchAsync`, and
+`ConsumeRawBatchAsync`.
 Buffered records are retained: `Resume` delivers them with their original offsets and
 in their original per-partition order. Other assigned partitions continue consuming.
 A rebalance or explicit unassignment is different: records buffered for partitions no
@@ -274,6 +275,10 @@ Pause is applied at the record-delivery boundary. If `Pause` races a consume ope
 whose final internal delivery check has already completed, that one in-progress record
 may still reach the caller; the next record (or next record from an already-returned
 batch) is suppressed until `Resume`.
+
+When pause wins the final delivery check after deserialization or interceptor execution,
+Dekaf replays the suppressed record after resume. Deserializers and consume interceptors
+must tolerate running more than once for that record.
 
 ## Accessing Metadata
 

--- a/docs/docs/consumer/basics.md
+++ b/docs/docs/consumer/basics.md
@@ -263,6 +263,18 @@ consumer.Partitions.Resume(new TopicPartition("my-topic", 0));
 
 This is useful for backpressure - if your processing can't keep up, pause some partitions.
 
+`Pause` stops new fetches and suppresses records already present in Dekaf's pending or
+prefetch buffers for `ConsumeAsync`, `ConsumeBatchAsync`, and `ConsumeRawBatchAsync`.
+Buffered records are retained: `Resume` delivers them with their original offsets and
+in their original per-partition order. Other assigned partitions continue consuming.
+A rebalance or explicit unassignment is different: records buffered for partitions no
+longer assigned may be discarded.
+
+Pause is applied at the record-delivery boundary. If `Pause` races a consume operation
+whose final internal delivery check has already completed, that one in-progress record
+may still reach the caller; the next record (or next record from an already-returned
+batch) is suppressed until `Resume`.
+
 ## Accessing Metadata
 
 ```csharp

--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -278,8 +278,14 @@ namespace Dekaf.Consumer
             {
                 PendingFetchData pending = _batch._pendingFetchData;
 
-                if (!_canContinue || !_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))
+                if (!_canContinue)
                     return false;
+
+                if (!_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))
+                {
+                    _canContinue = false;
+                    return false;
+                }
 
                 if (_recordsYielded >= _batch._maxRecords)
                 {

--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -303,6 +303,7 @@ namespace Dekaf.Consumer
 
                 if (!_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))
                 {
+                    _canContinue = false;
                     pending.BufferCurrentForRedelivery();
                     return false;
                 }

--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -302,7 +302,10 @@ namespace Dekaf.Consumer
                 }
 
                 if (!_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))
+                {
+                    pending.BufferCurrentForRedelivery();
                     return false;
+                }
 
                 pending.TrackConsumed(offset, messageBytes);
                 _batch._storeOffsetOnDelivery?.Invoke(

--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -66,19 +66,28 @@ namespace Dekaf.Consumer
         }
     }
 
+    internal enum BatchIterationStatus : byte
+    {
+        Continue,
+        Paused,
+        Stopped
+    }
+
+    internal delegate BatchIterationStatus BatchIterationContinuation(TopicPartition partition);
+
     internal readonly struct BatchIterationGuard(
         BatchIterationEpoch? epoch,
         int capturedVersion,
-        Func<TopicPartition, bool>? canContinue = null)
+        BatchIterationContinuation? getStatus = null)
     {
         public int CapturedVersion => capturedVersion;
 
         public bool CanStart(TopicPartition partition, ref int observedVersion)
         {
             if (epoch is null)
-                return canContinue is null || canContinue(partition);
+                return getStatus is null || getStatus(partition) == BatchIterationStatus.Continue;
 
-            if (canContinue is null)
+            if (getStatus is null)
             {
                 var currentVersion = Volatile.Read(ref epoch.Version);
                 return (currentVersion & 1) == 0 && currentVersion == observedVersion;
@@ -94,7 +103,7 @@ namespace Dekaf.Consumer
                     continue;
                 }
 
-                if (!canContinue(partition))
+                if (getStatus(partition) != BatchIterationStatus.Continue)
                     return false;
 
                 if (Volatile.Read(ref epoch.Version) == currentVersion)
@@ -109,7 +118,7 @@ namespace Dekaf.Consumer
         public bool IsCurrent(TopicPartition partition, ref int observedVersion)
         {
             if (epoch is null)
-                return canContinue is null || canContinue(partition);
+                return getStatus is null || getStatus(partition) == BatchIterationStatus.Continue;
 
             var spin = new SpinWait();
             while (true)
@@ -124,13 +133,42 @@ namespace Dekaf.Consumer
                 if (currentVersion == observedVersion)
                     return true;
 
-                if (canContinue is null || !canContinue(partition))
+                if (getStatus is null || getStatus(partition) != BatchIterationStatus.Continue)
                     return false;
 
                 if (Volatile.Read(ref epoch.Version) == currentVersion)
                 {
                     observedVersion = currentVersion;
                     return true;
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public BatchIterationStatus GetStatusAfterRead(TopicPartition partition, ref int observedVersion)
+        {
+            if (epoch is null)
+                return getStatus?.Invoke(partition) ?? BatchIterationStatus.Continue;
+
+            var spin = new SpinWait();
+            while (true)
+            {
+                var currentVersion = Volatile.Read(ref epoch.Version);
+                if ((currentVersion & 1) != 0)
+                {
+                    spin.SpinOnce();
+                    continue;
+                }
+
+                if (currentVersion == observedVersion)
+                    return BatchIterationStatus.Continue;
+
+                var status = getStatus?.Invoke(partition) ?? BatchIterationStatus.Stopped;
+                if (Volatile.Read(ref epoch.Version) == currentVersion)
+                {
+                    if (status == BatchIterationStatus.Continue)
+                        observedVersion = currentVersion;
+                    return status;
                 }
             }
         }
@@ -339,10 +377,14 @@ namespace Dekaf.Consumer
                     return false;
                 }
 
-                if (!_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))
+                var iterationStatus = _batch._iterationGuard.GetStatusAfterRead(
+                    pending.TopicPartition,
+                    ref _observedVersion);
+                if (iterationStatus != BatchIterationStatus.Continue)
                 {
                     _canContinue = false;
-                    pending.BufferCurrentForRedelivery();
+                    if (iterationStatus == BatchIterationStatus.Paused)
+                        pending.BufferCurrentForRedelivery();
                     return false;
                 }
 

--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -14,6 +14,9 @@ namespace Dekaf.Consumer
         // One-read hot-path marker. Cleared only after ConsumeOne applies every change from
         // a stable epoch, so validating one partition cannot hide a change for another.
         public int ConsumeOneDeliveryChangesPending;
+        // Set only when a batch iterator stops before reading because its partition paused.
+        // Batch completion probes once to distinguish a remaining record from exhaustion.
+        public int BatchExhaustionProbePending;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Invalidate()
@@ -103,8 +106,13 @@ namespace Dekaf.Consumer
                     continue;
                 }
 
-                if (getStatus(partition) != BatchIterationStatus.Continue)
+                var status = getStatus(partition);
+                if (status != BatchIterationStatus.Continue)
+                {
+                    if (status == BatchIterationStatus.Paused)
+                        Volatile.Write(ref epoch.BatchExhaustionProbePending, 1);
                     return false;
+                }
 
                 if (Volatile.Read(ref epoch.Version) == currentVersion)
                 {
@@ -133,8 +141,13 @@ namespace Dekaf.Consumer
                 if (currentVersion == observedVersion)
                     return true;
 
-                if (getStatus is null || getStatus(partition) != BatchIterationStatus.Continue)
+                var status = getStatus?.Invoke(partition) ?? BatchIterationStatus.Stopped;
+                if (status != BatchIterationStatus.Continue)
+                {
+                    if (status == BatchIterationStatus.Paused)
+                        Volatile.Write(ref epoch.BatchExhaustionProbePending, 1);
                     return false;
+                }
 
                 if (Volatile.Read(ref epoch.Version) == currentVersion)
                 {

--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -11,18 +11,25 @@ namespace Dekaf.Consumer
         // is being published and must not be adopted by a batch iterator.
         private readonly object _publicationLock = new();
         public int Version;
+        // One-read hot-path marker. Cleared only after ConsumeOne applies every change from
+        // a stable epoch, so validating one partition cannot hide a change for another.
+        public int ConsumeOneDeliveryChangesPending;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Invalidate()
         {
             lock (_publicationLock)
+            {
+                Volatile.Write(ref ConsumeOneDeliveryChangesPending, 1);
                 Interlocked.Add(ref Version, 2);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void BeginPublication()
         {
             Monitor.Enter(_publicationLock);
+            Volatile.Write(ref ConsumeOneDeliveryChangesPending, 1);
             Interlocked.Increment(ref Version);
         }
 
@@ -31,6 +38,31 @@ namespace Dekaf.Consumer
         {
             Interlocked.Increment(ref Version);
             Monitor.Exit(_publicationLock);
+        }
+
+        public int CaptureStableVersion()
+        {
+            var spin = new SpinWait();
+            while (true)
+            {
+                var version = Volatile.Read(ref Version);
+                if ((version & 1) == 0)
+                    return version;
+
+                spin.SpinOnce();
+            }
+        }
+
+        public bool TryAcknowledgeConsumeOneDeliveryChanges(int expectedVersion)
+        {
+            lock (_publicationLock)
+            {
+                if (Version != expectedVersion)
+                    return false;
+
+                Volatile.Write(ref ConsumeOneDeliveryChangesPending, 0);
+                return true;
+            }
         }
     }
 

--- a/src/Dekaf/Consumer/ConsumeRawBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeRawBatch.cs
@@ -174,6 +174,7 @@ namespace Dekaf.Consumer
 
                 if (!_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))
                 {
+                    _canContinue = false;
                     pending.BufferCurrentForRedelivery();
                     return false;
                 }

--- a/src/Dekaf/Consumer/ConsumeRawBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeRawBatch.cs
@@ -137,8 +137,14 @@ namespace Dekaf.Consumer
             {
                 PendingFetchData pending = _batch._pendingFetchData;
 
-                if (!_canContinue || !_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))
+                if (!_canContinue)
                     return false;
+
+                if (!_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))
+                {
+                    _canContinue = false;
+                    return false;
+                }
 
                 if (_recordsYielded >= _batch._maxRecords)
                 {

--- a/src/Dekaf/Consumer/ConsumeRawBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeRawBatch.cs
@@ -173,7 +173,10 @@ namespace Dekaf.Consumer
                     isValueNull: record.IsValueNull);
 
                 if (!_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))
+                {
+                    pending.BufferCurrentForRedelivery();
                     return false;
+                }
 
                 pending.TrackConsumed(offset, messageBytes);
                 _batch._storeOffsetOnDelivery?.Invoke(

--- a/src/Dekaf/Consumer/ConsumeRawBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeRawBatch.cs
@@ -178,10 +178,14 @@ namespace Dekaf.Consumer
                     isKeyNull: record.IsKeyNull,
                     isValueNull: record.IsValueNull);
 
-                if (!_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))
+                var iterationStatus = _batch._iterationGuard.GetStatusAfterRead(
+                    pending.TopicPartition,
+                    ref _observedVersion);
+                if (iterationStatus != BatchIterationStatus.Continue)
                 {
                     _canContinue = false;
-                    pending.BufferCurrentForRedelivery();
+                    if (iterationStatus == BatchIterationStatus.Paused)
+                        pending.BufferCurrentForRedelivery();
                     return false;
                 }
 

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -343,11 +343,24 @@ public interface IConsumerPartitions
     /// <summary>
     /// Pauses consumption from partitions.
     /// </summary>
+    /// <remarks>
+    /// Records already fetched for a paused partition are retained but suppressed by
+    /// <see cref="IKafkaConsumer{TKey,TValue}.ConsumeAsync"/>,
+    /// <see cref="IKafkaConsumer{TKey,TValue}.ConsumeBatchAsync"/>, and
+    /// <see cref="IKafkaConsumer{TKey,TValue}.ConsumeRawBatchAsync"/> until
+    /// <see cref="Resume"/> is called. Records whose final delivery check completed before
+    /// a concurrent pause belong to the in-progress consume operation; the pause applies
+    /// at the next record-delivery boundary.
+    /// </remarks>
     void Pause(params TopicPartition[] partitions);
 
     /// <summary>
     /// Resumes consumption from partitions.
     /// </summary>
+    /// <remarks>
+    /// Preserved prefetched records are delivered in their original per-partition order
+    /// and retain their original offsets.
+    /// </remarks>
     void Resume(params TopicPartition[] partitions);
 }
 

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -345,12 +345,15 @@ public interface IConsumerPartitions
     /// </summary>
     /// <remarks>
     /// Records already fetched for a paused partition are retained but suppressed by
+    /// <see cref="IKafkaConsumer{TKey,TValue}.ConsumeOneAsync"/>,
     /// <see cref="IKafkaConsumer{TKey,TValue}.ConsumeAsync"/>,
     /// <see cref="IKafkaConsumer{TKey,TValue}.ConsumeBatchAsync"/>, and
     /// <see cref="IKafkaConsumer{TKey,TValue}.ConsumeRawBatchAsync"/> until
     /// <see cref="Resume"/> is called. Records whose final delivery check completed before
     /// a concurrent pause belong to the in-progress consume operation; the pause applies
-    /// at the next record-delivery boundary.
+    /// at the next record-delivery boundary. If pause wins the final delivery check after
+    /// deserialization or interceptor execution, the suppressed record is replayed after
+    /// resume; deserializers and interceptors must therefore tolerate repeated execution.
     /// </remarks>
     void Pause(params TopicPartition[] partitions);
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1198,6 +1198,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private int _lastCoordinatorAssignmentVersion = -1;
     // Deterministic test seam for assignment/revocation snapshot races.
     internal Action? BeforeCoordinatorAssignmentSnapshotForTest { get; set; }
+    // Foreground-applied pause state. Keep at the cold field tail so the normal consume layout
+    // remains stable; only queue admission/reconciliation reads or writes it.
+    private TopicPartitionSet _deliveryPausedSnapshot = new HashSet<TopicPartition>();
+    // Prevent Resume from cancelling a pooled CTS after it has been returned and re-rented.
+    private readonly object _pausedDirectFetchCancellationSourceLock = new();
 
     private static readonly long s_preferredReadReplicaMaxAgeTimestampDelta =
         (long)(TimeSpan.FromMinutes(5).TotalSeconds * Stopwatch.Frequency);
@@ -4481,6 +4486,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             System.Diagnostics.Activity? activity = null;
             var pendingDisposed = false;
+            var pendingRemoved = false;
             try
             {
                 while (true)
@@ -4554,8 +4560,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         if (iterationStatus != RecordIterationStatus.Continue)
                         {
                             var pausedDuringDelivery = iterationStatus == RecordIterationStatus.Paused;
-                            StopConsumeOneDelivery(pending, pausedDuringDelivery);
-                            return false;
+                            pendingRemoved = StopConsumeOneDelivery(pending, pausedDuringDelivery);
+                            break;
                         }
 
                         if (hasInterceptors)
@@ -4573,8 +4579,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             if (iterationStatus != RecordIterationStatus.Continue)
                             {
                                 var pausedDuringDelivery = iterationStatus == RecordIterationStatus.Paused;
-                                StopConsumeOneDelivery(pending, pausedDuringDelivery);
-                                return false;
+                                pendingRemoved = StopConsumeOneDelivery(pending, pausedDuringDelivery);
+                                break;
                             }
                         }
 
@@ -4611,7 +4617,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 activity?.Dispose();
             }
 
-            if (pendingDisposed)
+            if (pendingDisposed || pendingRemoved)
                 continue;
 
             FlushConsumedPositions(pending);
@@ -4666,6 +4672,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             System.Diagnostics.Activity? activity = null;
             var pendingDisposed = false;
+            var pendingRemoved = false;
             try
             {
                 while (true)
@@ -4734,8 +4741,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         if (iterationStatus != RecordIterationStatus.Continue)
                         {
                             var pausedDuringDelivery = iterationStatus == RecordIterationStatus.Paused;
-                            StopConsumeOneDelivery(pending, pausedDuringDelivery);
-                            return null;
+                            pendingRemoved = StopConsumeOneDelivery(pending, pausedDuringDelivery);
+                            break;
                         }
 
                         if (hasInterceptors)
@@ -4751,8 +4758,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             if (iterationStatus != RecordIterationStatus.Continue)
                             {
                                 var pausedDuringDelivery = iterationStatus == RecordIterationStatus.Paused;
-                                StopConsumeOneDelivery(pending, pausedDuringDelivery);
-                                return null;
+                                pendingRemoved = StopConsumeOneDelivery(pending, pausedDuringDelivery);
+                                break;
                             }
                         }
 
@@ -4796,7 +4803,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 activity?.Dispose();
             }
 
-            if (pendingDisposed)
+            if (pendingDisposed || pendingRemoved)
                 continue;
 
             FlushConsumedPositions(pending);
@@ -5466,7 +5473,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void EnqueuePendingFetch(PendingFetchData pending)
     {
-        if (_pausedSnapshot.Contains(pending.TopicPartition))
+        // Route from the foreground-applied snapshot, not the concurrently published one.
+        // A publication that splits a multi-item drain is reconciled afterward as one ordered
+        // queue transition, preserving per-partition FIFO across the pause boundary.
+        if (_deliveryPausedSnapshot.Contains(pending.TopicPartition))
             _pausedPendingFetches.Enqueue(pending);
         else
             _pendingFetches.Enqueue(pending);
@@ -5557,6 +5567,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 _pendingFetches.Enqueue(_pendingFetches.Dequeue());
         }
 
+        _deliveryPausedSnapshot = paused;
         _observedPausedSnapshotVersion = pausedSnapshotVersion;
     }
 
@@ -5639,14 +5650,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void StopConsumeOneDelivery(PendingFetchData pending, bool paused)
+    private bool StopConsumeOneDelivery(PendingFetchData pending, bool paused)
     {
         HandleStoppedRecordIteration(pending.TopicPartition, paused);
         if (!paused)
-            return;
+        {
+            return _pendingFetches.Count == 0
+                   || !ReferenceEquals(_pendingFetches.Peek(), pending);
+        }
 
         pending.BufferCurrentForRedelivery();
         MovePendingFetchToPaused(pending);
+        return true;
     }
 
     private void StagePendingFetchClear(TopicPartition partition)
@@ -5718,6 +5733,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (removeSet.Count == 0)
             return;
 
+        // Freeze pause routing for this ordered drain. A concurrent Pause/Resume is
+        // reconciled at the next delivery boundary instead of splitting retained
+        // fetches between the active and paused queues.
+        PreparePendingFetchesForDelivery();
+
         foreach (var partition in removeSet)
         {
             ClearActiveConsumedPosition(partition);
@@ -5780,7 +5800,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Without this, stale data from revoked partitions sitting in the prefetch
         // buffer would be consumed after an incremental unassign (cooperative rebalance),
         // causing data for partitions no longer owned by this consumer to be yielded.
-        DrainPrefetchBufferForPartitions(removeSet);
+        DrainPrefetchBufferForPartitionsCore(removeSet);
 
         ClearPendingEofEventsForPartitions(removeSet);
     }
@@ -6121,8 +6141,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             return false;
         }
 
+        if (!IsCurrentlyAssigned(partition))
+        {
+            paused = false;
+            return false;
+        }
+
         paused = _pausedSnapshot.Contains(partition);
-        return !paused && IsCurrentlyAssigned(partition);
+        return !paused;
     }
 
     private bool IsFetchBufferEpochStale(TopicPartition partition, int fetchBufferEpoch) =>
@@ -6205,6 +6231,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void DrainPrefetchBufferForPartitions(HashSet<TopicPartition> partitionsToRemove)
     {
+        PreparePendingFetchesForDelivery();
+        DrainPrefetchBufferForPartitionsCore(partitionsToRemove);
+    }
+
+    private void DrainPrefetchBufferForPartitionsCore(HashSet<TopicPartition> partitionsToRemove)
+    {
         // O(n) over the prefetch buffer is acceptable on this infrequent rebalance path.
         while (_prefetchBuffer.TryRead(out var prefetched))
         {
@@ -6262,12 +6294,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void WakePausedDirectFetch()
     {
-        var consumeCts = Volatile.Read(ref _pausedDirectFetchCancellationSource);
-        if (consumeCts is null)
-            return;
-
-        try { consumeCts.Cancel(); }
-        catch (ObjectDisposedException) { return; }
+        lock (_pausedDirectFetchCancellationSourceLock)
+        {
+            _pausedDirectFetchCancellationSource?.Cancel();
+        }
     }
 
     private void CancelActiveConsumeOperations()
@@ -7218,7 +7248,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         finally
         {
             _activeConsumeCancellationSources.TryRemove(consumeCts, out _);
-            consumeCts.Dispose();
+            lock (_pausedDirectFetchCancellationSourceLock)
+            {
+                if (ReferenceEquals(_pausedDirectFetchCancellationSource, consumeCts))
+                    _pausedDirectFetchCancellationSource = null;
+
+                consumeCts.Dispose();
+            }
             _coordinator?.EndForegroundPollActivity();
         }
     }
@@ -7228,31 +7264,25 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         CancellationTokenSource consumeCts,
         CancellationToken cancellationToken)
     {
-        Volatile.Write(ref _pausedDirectFetchCancellationSource, consumeCts);
+        lock (_pausedDirectFetchCancellationSourceLock)
+        {
+            _pausedDirectFetchCancellationSource = consumeCts;
+        }
+
+        // Resume may publish before the waiter is visible. The version check closes
+        // that race; a later Resume cancels consumeCts through the published field.
+        if (Volatile.Read(ref _pausedSnapshotVersion) != pausedSnapshotVersion)
+            return;
+
         try
         {
-            // Resume may publish before the waiter is visible. The version check closes
-            // that race; a later Resume cancels consumeCts through the published field.
-            if (Volatile.Read(ref _pausedSnapshotVersion) != pausedSnapshotVersion)
-                return;
-
-            try
-            {
-                await Task.Delay(AllPartitionsPausedDelayMs, consumeCts.Token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (
-                !cancellationToken.IsCancellationRequested
-                && Volatile.Read(ref _pausedSnapshotVersion) != pausedSnapshotVersion)
-            {
-                // Resume is a control-plane wake, not caller cancellation.
-            }
+            await Task.Delay(AllPartitionsPausedDelayMs, consumeCts.Token).ConfigureAwait(false);
         }
-        finally
+        catch (OperationCanceledException) when (
+            !cancellationToken.IsCancellationRequested
+            && Volatile.Read(ref _pausedSnapshotVersion) != pausedSnapshotVersion)
         {
-            Interlocked.CompareExchange(
-                ref _pausedDirectFetchCancellationSource,
-                null,
-                consumeCts);
+            // Resume is a control-plane wake, not caller cancellation.
         }
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1047,6 +1047,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly Queue<PendingFetchData> _pendingFetchScratch = new();
     private int _observedPausedSnapshotVersion;
     private int _recordIterationEpochSeed;
+    // Foreground ConsumeOne calls are single-threaded. This stays at a validated even
+    // epoch so the steady-state delivery boundary is one volatile read and comparison.
+    private int _consumeOneIterationEpoch;
     private int _pendingFetchDepth;
     // ConsumeOne callbacks run on the documented single application thread. If one
     // reentrantly clears the queue, defer this fetch's disposal until all borrowed
@@ -2208,11 +2211,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                     while (true)
                     {
-                        if (!CanContinueRecordIteration(
-                                pending.TopicPartition,
-                                ref recordIterationVersion))
+                        var iterationStatus = GetRecordIterationStatus(
+                            pending.TopicPartition,
+                            ref recordIterationVersion);
+                        if (iterationStatus != RecordIterationStatus.Continue)
                         {
-                            pausedDuringDelivery = HandleStoppedRecordIteration(pending.TopicPartition);
+                            pausedDuringDelivery = iterationStatus == RecordIterationStatus.Paused;
+                            HandleStoppedRecordIteration(pending.TopicPartition, pausedDuringDelivery);
                             break;
                         }
 
@@ -2306,9 +2311,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                     keyDeserializer: _keyDeserializer,
                                     valueDeserializer: _valueDeserializer);
 
-                            if (!CanContinueRecordIteration(topicPartition, ref recordIterationVersion))
+                            iterationStatus = GetRecordIterationStatus(
+                                topicPartition,
+                                ref recordIterationVersion);
+                            if (iterationStatus != RecordIterationStatus.Continue)
                             {
-                                pausedDuringDelivery = HandleStoppedRecordIteration(topicPartition);
+                                pausedDuringDelivery = iterationStatus == RecordIterationStatus.Paused;
+                                HandleStoppedRecordIteration(topicPartition, pausedDuringDelivery);
                                 if (pausedDuringDelivery)
                                     pending.BufferCurrentForRedelivery();
                                 break;
@@ -2324,9 +2333,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                                 // An interceptor can run long enough for background prefetch to
                                 // publish a divergence reset. Do not mark that stale record consumed.
-                                if (!CanContinueRecordIteration(topicPartition, ref recordIterationVersion))
+                                iterationStatus = GetRecordIterationStatus(
+                                    topicPartition,
+                                    ref recordIterationVersion);
+                                if (iterationStatus != RecordIterationStatus.Continue)
                                 {
-                                    pausedDuringDelivery = HandleStoppedRecordIteration(topicPartition);
+                                    pausedDuringDelivery = iterationStatus == RecordIterationStatus.Paused;
+                                    HandleStoppedRecordIteration(topicPartition, pausedDuringDelivery);
                                     if (pausedDuringDelivery)
                                         pending.BufferCurrentForRedelivery();
                                     break;
@@ -4068,8 +4081,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (_prefetchBuffer.HasDataAvailable())
                 return true;
 
-            return await _prefetchBuffer.WaitToReadAsync(_options.FetchMaxWaitMs, cancellationToken)
-                .ConfigureAwait(false);
+            var observedPausedSnapshotVersion = _observedPausedSnapshotVersion;
+            var wait = _prefetchBuffer.WaitToReadAsync(_options.FetchMaxWaitMs, cancellationToken);
+            if (!wait.IsCompleted
+                && Volatile.Read(ref _pausedSnapshotVersion) != observedPausedSnapshotVersion)
+            {
+                // Resume can publish immediately before the buffer installs its waiter.
+                // Recheck after registration so that race cannot delay retained data.
+                _prefetchBuffer.SignalReader();
+            }
+
+            return await wait.ConfigureAwait(false);
         }
         finally
         {
@@ -4343,6 +4365,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 continue;
             }
 
+            PreparePendingFetchesForDelivery();
+
             if (_pendingFetches.Count == 0)
             {
                 if (!await FillPendingFetchesForSingleConsumeAsync(prefetchEnabled, cancellationToken)
@@ -4543,10 +4567,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             valueDeserializer: _valueDeserializer);
                         pendingDisposed |= EndConsumeOneFetchUse(pending);
 
-                        if (pendingDisposed || HasPendingFetchClear(pending.TopicPartition))
-                        {
-                            pendingDisposed = true;
+                        if (pendingDisposed)
                             break;
+
+                        var iterationStatus = GetConsumeOneDeliveryStatus(pending.TopicPartition);
+                        if (iterationStatus != RecordIterationStatus.Continue)
+                        {
+                            var pausedDuringDelivery = iterationStatus == RecordIterationStatus.Paused;
+                            StopConsumeOneDelivery(pending, pausedDuringDelivery);
+                            return false;
                         }
 
                         if (hasInterceptors)
@@ -4557,10 +4586,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             runningInterceptor = false;
                             pendingDisposed |= EndConsumeOneFetchUse(pending);
 
-                            if (pendingDisposed || HasPendingFetchClear(pending.TopicPartition))
-                            {
-                                pendingDisposed = true;
+                            if (pendingDisposed)
                                 break;
+
+                            iterationStatus = GetConsumeOneDeliveryStatus(pending.TopicPartition);
+                            if (iterationStatus != RecordIterationStatus.Continue)
+                            {
+                                var pausedDuringDelivery = iterationStatus == RecordIterationStatus.Paused;
+                                StopConsumeOneDelivery(pending, pausedDuringDelivery);
+                                return false;
                             }
                         }
 
@@ -4713,10 +4747,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             cancellationToken).ConfigureAwait(false);
                         pendingDisposed |= EndConsumeOneFetchUse(pending);
 
-                        if (pendingDisposed || HasPendingFetchClear(pending.TopicPartition))
-                        {
-                            pendingDisposed = true;
+                        if (pendingDisposed)
                             break;
+
+                        var iterationStatus = GetConsumeOneDeliveryStatus(pending.TopicPartition);
+                        if (iterationStatus != RecordIterationStatus.Continue)
+                        {
+                            var pausedDuringDelivery = iterationStatus == RecordIterationStatus.Paused;
+                            StopConsumeOneDelivery(pending, pausedDuringDelivery);
+                            return null;
                         }
 
                         if (hasInterceptors)
@@ -4725,10 +4764,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             result = ApplyOnConsumeInterceptors(result);
                             pendingDisposed |= EndConsumeOneFetchUse(pending);
 
-                            if (pendingDisposed || HasPendingFetchClear(pending.TopicPartition))
-                            {
-                                pendingDisposed = true;
+                            if (pendingDisposed)
                                 break;
+
+                            iterationStatus = GetConsumeOneDeliveryStatus(pending.TopicPartition);
+                            if (iterationStatus != RecordIterationStatus.Continue)
+                            {
+                                var pausedDuringDelivery = iterationStatus == RecordIterationStatus.Paused;
+                                StopConsumeOneDelivery(pending, pausedDuringDelivery);
+                                return null;
                             }
                         }
 
@@ -5515,17 +5559,41 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool CanContinueRecordIteration(TopicPartition partition, ref int observedVersion)
+    private RecordIterationStatus GetRecordIterationStatus(
+        TopicPartition partition,
+        ref int observedVersion)
     {
         var currentVersion = Volatile.Read(ref _batchIterationEpoch.Version);
         if ((currentVersion & 1) == 0 && currentVersion == observedVersion)
-            return true;
+            return RecordIterationStatus.Continue;
 
-        return CanContinueRecordIterationSlow(partition, ref observedVersion);
+        return GetRecordIterationStatusSlow(partition, ref observedVersion);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private RecordIterationStatus GetConsumeOneDeliveryStatus(TopicPartition partition)
+    {
+        var currentVersion = Volatile.Read(ref _batchIterationEpoch.Version);
+        if (currentVersion == _consumeOneIterationEpoch)
+            return RecordIterationStatus.Continue;
+
+        return GetConsumeOneDeliveryStatusSlow(partition);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private bool CanContinueRecordIterationSlow(TopicPartition partition, ref int observedVersion)
+    private RecordIterationStatus GetConsumeOneDeliveryStatusSlow(TopicPartition partition)
+    {
+        var observedVersion = _consumeOneIterationEpoch;
+        var status = GetRecordIterationStatusSlow(partition, ref observedVersion);
+        if (status == RecordIterationStatus.Continue)
+            _consumeOneIterationEpoch = observedVersion;
+        return status;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private RecordIterationStatus GetRecordIterationStatusSlow(
+        TopicPartition partition,
+        ref int observedVersion)
     {
         var spin = new SpinWait();
         while (true)
@@ -5537,27 +5605,50 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 continue;
             }
 
-            if (!CanContinueBatchIteration(partition))
-                return false;
+            var canContinue = CanContinueBatchIterationWithPause(partition, out var pausedAtVersion);
 
             if (Volatile.Read(ref _batchIterationEpoch.Version) == currentVersion)
             {
+                if (!canContinue)
+                {
+                    return pausedAtVersion
+                        ? RecordIterationStatus.Paused
+                        : RecordIterationStatus.Stopped;
+                }
+
                 observedVersion = currentVersion;
-                return true;
+                return RecordIterationStatus.Continue;
             }
         }
     }
 
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private bool HandleStoppedRecordIteration(TopicPartition partition)
+    private enum RecordIterationStatus : byte
     {
-        if (!HasPendingFetchClear(partition))
-            return _pausedSnapshot.Contains(partition);
+        Continue,
+        Paused,
+        Stopped
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void HandleStoppedRecordIteration(TopicPartition partition, bool paused)
+    {
+        if (paused || !HasPendingFetchClear(partition))
+            return;
 
         // Preserve the existing revocation/divergence recovery path. It owns discard;
         // Pause owns preservation only while the partition remains assigned.
         ClearFetchBufferForPendingCoordinatorRevocations();
-        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void StopConsumeOneDelivery(PendingFetchData pending, bool paused)
+    {
+        HandleStoppedRecordIteration(pending.TopicPartition, paused);
+        if (!paused)
+            return;
+
+        pending.BufferCurrentForRedelivery();
+        MovePendingFetchToPaused(pending);
     }
 
     private void StagePendingFetchClear(TopicPartition partition)
@@ -6013,9 +6104,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     private bool CanContinueBatchIteration(TopicPartition partition) =>
-        !HasPendingFetchClear(partition)
-        && !_pausedSnapshot.Contains(partition)
-        && IsCurrentlyAssigned(partition);
+        CanContinueBatchIterationWithPause(partition, out _);
+
+    private bool CanContinueBatchIterationWithPause(TopicPartition partition, out bool paused)
+    {
+        paused = _pausedSnapshot.Contains(partition);
+        return !HasPendingFetchClear(partition)
+            && !paused
+            && IsCurrentlyAssigned(partition);
+    }
 
     private bool IsFetchBufferEpochStale(TopicPartition partition, int fetchBufferEpoch) =>
         fetchBufferEpoch < Volatile.Read(ref _minimumFetchBufferEpoch)
@@ -6097,45 +6194,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void DrainPrefetchBufferForPartitions(HashSet<TopicPartition> partitionsToRemove)
     {
-        DrainBufferForPartitions(
-            _prefetchBuffer,
-            partitionsToRemove,
-            _pendingFetches,
-            pending => TrackPrefetchedBytes(pending, release: true));
-    }
-
-    /// <summary>
-    /// Drains a prefetch buffer, disposing items whose partition is in <paramref name="partitionsToRemove"/>
-    /// and enqueuing retained items into <paramref name="retainedQueue"/>.
-    /// </summary>
-    /// <remarks>
-    /// O(n) over prefetch buffer items — acceptable because rebalance is infrequent (not hot path).
-    /// Items for retained partitions move to <paramref name="retainedQueue"/>; revoked items are disposed.
-    /// Retained items are appended after existing queue items. This is acceptable
-    /// because Kafka consumption is sequential per partition and cross-partition ordering is
-    /// not guaranteed — so the relative order between partitions does not matter.
-    /// </remarks>
-    internal static void DrainBufferForPartitions(
-        MpscFetchBuffer buffer,
-        HashSet<TopicPartition> partitionsToRemove,
-        Queue<PendingFetchData> retainedQueue,
-        Action<PendingFetchData> onItemRemoved)
-    {
-        while (buffer.TryRead(out var prefetched))
+        // O(n) over the prefetch buffer is acceptable on this infrequent rebalance path.
+        while (_prefetchBuffer.TryRead(out var prefetched))
         {
+            TrackPrefetchedBytes(prefetched, release: true);
             if (partitionsToRemove.Contains(prefetched.TopicPartition))
-            {
-                onItemRemoved(prefetched);
                 prefetched.Dispose();
-            }
             else
-            {
-                // Retained items are appended after existing queue items. This is safe because
-                // fetch positions are tracked independently (_fetchPositions), not inferred from
-                // queue order — so interleaving with existing _pendingFetches items is harmless.
-                retainedQueue.Enqueue(prefetched);
-                onItemRemoved(prefetched);
-            }
+                EnqueuePendingFetch(prefetched);
         }
     }
 
@@ -6179,6 +6245,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         PublishPausedSnapshot();
         UpdateCachesForResumedPartitions(changedPartitions);
+        _prefetchBuffer.SignalReader();
     }
 
     private void CancelActiveConsumeOperations()

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -5499,6 +5499,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private void MovePendingFetchToPaused(PendingFetchData pending)
     {
         Debug.Assert(_pendingFetches.Count > 0 && ReferenceEquals(_pendingFetches.Peek(), pending));
+        pending.MarkYieldedProcessed();
+        FlushConsumedPositions(pending);
         _pausedPendingFetches.Enqueue(_pendingFetches.Dequeue());
     }
 
@@ -5563,11 +5565,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         count = _pendingFetches.Count;
         for (var i = 0; i < count; i++)
         {
-            var pending = _pendingFetches.Dequeue();
+            var pending = _pendingFetches.Peek();
             if (paused.Contains(pending.TopicPartition))
-                _pausedPendingFetches.Enqueue(pending);
+                MovePendingFetchToPaused(pending);
             else
-                _pendingFetches.Enqueue(pending);
+                _pendingFetches.Enqueue(_pendingFetches.Dequeue());
         }
 
         _observedPausedSnapshotVersion = pausedSnapshotVersion;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1047,9 +1047,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly Queue<PendingFetchData> _pendingFetchScratch = new();
     private int _observedPausedSnapshotVersion;
     private int _recordIterationEpochSeed;
-    // Foreground ConsumeOne calls are single-threaded. This stays at a validated even
-    // epoch so the steady-state delivery boundary is one volatile read and comparison.
-    private int _consumeOneIterationEpoch;
     private int _pendingFetchDepth;
     // ConsumeOne callbacks run on the documented single application thread. If one
     // reentrantly clears the queue, defer this fetch's disposal until all borrowed
@@ -4270,7 +4267,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             || Volatile.Read(ref _consumerDisposed) != 0
             || !_initialized
             || _pendingFetches.Count == 0
-            || Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0)
+            || Volatile.Read(ref _batchIterationEpoch.ConsumeOneDeliveryChangesPending) != 0)
         {
             return false;
         }
@@ -4357,15 +4354,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
 
             await EnsureAssignmentForPollAsync(cancellationToken).ConfigureAwait(false);
-            RecoverAndClearFetchBufferForPendingCoordinatorRevocations();
+            PrepareConsumeOneDelivery();
 
             if (_assignmentSnapshot.Count == 0)
             {
                 await DelayForForegroundPollAsync(100, cancellationToken).ConfigureAwait(false);
                 continue;
             }
-
-            PreparePendingFetchesForDelivery();
 
             if (_pendingFetches.Count == 0)
             {
@@ -5520,6 +5515,26 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    private void PrepareConsumeOneDelivery()
+    {
+        if (Volatile.Read(ref _batchIterationEpoch.ConsumeOneDeliveryChangesPending) == 0)
+        {
+            RecoverAndClearFetchBufferForPendingCoordinatorRevocations();
+            PreparePendingFetchesForDelivery();
+            return;
+        }
+
+        while (true)
+        {
+            var expectedVersion = _batchIterationEpoch.CaptureStableVersion();
+            RecoverAndClearFetchBufferForPendingCoordinatorRevocations();
+            PreparePendingFetchesForDelivery();
+            if (_batchIterationEpoch.TryAcknowledgeConsumeOneDeliveryChanges(expectedVersion))
+                return;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private void ApplyPausedSnapshotToPendingFetches(int pausedSnapshotVersion)
     {
         var paused = _pausedSnapshot;
@@ -5573,8 +5588,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private RecordIterationStatus GetConsumeOneDeliveryStatus(TopicPartition partition)
     {
-        var currentVersion = Volatile.Read(ref _batchIterationEpoch.Version);
-        if (currentVersion == _consumeOneIterationEpoch)
+        if (Volatile.Read(ref _batchIterationEpoch.ConsumeOneDeliveryChangesPending) == 0)
             return RecordIterationStatus.Continue;
 
         return GetConsumeOneDeliveryStatusSlow(partition);
@@ -5583,11 +5597,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     [MethodImpl(MethodImplOptions.NoInlining)]
     private RecordIterationStatus GetConsumeOneDeliveryStatusSlow(TopicPartition partition)
     {
-        var observedVersion = _consumeOneIterationEpoch;
-        var status = GetRecordIterationStatusSlow(partition, ref observedVersion);
-        if (status == RecordIterationStatus.Continue)
-            _consumeOneIterationEpoch = observedVersion;
-        return status;
+        var observedVersion = 0;
+        return GetRecordIterationStatusSlow(partition, ref observedVersion);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -542,6 +542,17 @@ internal sealed class PendingFetchData : IDisposable
         return true;
     }
 
+    /// <summary>
+    /// Makes the next <see cref="MoveNext"/> replay the current record. Used when a
+    /// concurrent control-plane change suppresses delivery after the record was read.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void BufferCurrentForRedelivery()
+    {
+        Debug.Assert(!_hasBufferedCurrent, "Current record is already buffered.");
+        _hasBufferedCurrent = true;
+    }
+
     private bool HasCurrentRecordOrMarkExhausted()
     {
         if (HasCurrentRecord())
@@ -996,6 +1007,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly ConcurrentDictionary<TopicPartition, byte> _paused = new();
     private volatile StringSet _subscriptionSnapshot = new HashSet<string>();
     private volatile TopicPartitionSet _pausedSnapshot = new HashSet<TopicPartition>();
+    private int _pausedSnapshotVersion;
 
     // Pattern subscription support
     private volatile Func<string, bool>? _topicFilter;
@@ -1029,6 +1041,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     // Pending fetch responses for lazy record iteration
     private readonly Queue<PendingFetchData> _pendingFetches = new();
+    // Foreground-owned holding queue for already-fetched paused partitions. Moving a fetch
+    // here preserves its iterator, pooled storage, offsets, and per-partition order.
+    private readonly Queue<PendingFetchData> _pausedPendingFetches = new();
+    private readonly Queue<PendingFetchData> _pendingFetchScratch = new();
+    private int _observedPausedSnapshotVersion;
     private int _pendingFetchDepth;
     // ConsumeOne callbacks run on the documented single application thread. If one
     // reentrantly clears the queue, defer this fetch's disposal until all borrowed
@@ -2078,6 +2095,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 continue;
             }
 
+            PreparePendingFetchesForDelivery();
+
             // Get pending data - either from prefetch channel or direct fetch
             if (_pendingFetches.Count == 0)
             {
@@ -2152,6 +2171,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                 while (_pendingFetches.Count > 0)
                 {
+                    // Capture before applying the snapshot. A concurrent Pause either
+                    // appears in that snapshot or changes the epoch after this capture.
+                    var recordIterationVersion = Volatile.Read(ref _batchIterationEpoch.Version);
+                    PreparePendingFetchesForDelivery();
+                    if (_pendingFetches.Count == 0)
+                        break;
+
                     var pending = _pendingFetches.Peek();
                     // Retain once per fetch, not per record. A deserializer can synchronously
                     // Seek/Assign and dispose the queued owner while its record bytes are in use.
@@ -2160,6 +2186,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // record retained when a previous stream was disposed at its yield point.
                     pending.MarkYieldedProcessed();
                     var pendingFetchesVersion = Volatile.Read(ref _pendingFetchesVersion);
+                    var pausedDuringDelivery = false;
                     long? batchProcessingStarted = _adaptiveFetchSizer is not null
                         ? Stopwatch.GetTimestamp() : null;
 
@@ -2174,9 +2201,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                     while (true)
                     {
-                        if (ClearFetchBufferForPendingCoordinatorRevocations()
-                            && Volatile.Read(ref _pendingFetchesVersion) != pendingFetchesVersion)
+                        if (!CanContinueRecordIteration(
+                                pending.TopicPartition,
+                                ref recordIterationVersion))
                         {
+                            pausedDuringDelivery = HandleStoppedRecordIteration(pending.TopicPartition);
                             break;
                         }
 
@@ -2270,8 +2299,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                     keyDeserializer: _keyDeserializer,
                                     valueDeserializer: _valueDeserializer);
 
-                            if (HasPendingFetchClear(topicPartition))
+                            if (!CanContinueRecordIteration(topicPartition, ref recordIterationVersion))
+                            {
+                                pausedDuringDelivery = HandleStoppedRecordIteration(topicPartition);
+                                if (pausedDuringDelivery)
+                                    pending.BufferCurrentForRedelivery();
                                 break;
+                            }
 
                             // Apply OnConsume interceptors before yielding to user
                             // Uses hoisted hasInterceptors to skip method call when no interceptors
@@ -2283,8 +2317,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                                 // An interceptor can run long enough for background prefetch to
                                 // publish a divergence reset. Do not mark that stale record consumed.
-                                if (HasPendingFetchClear(topicPartition))
+                                if (!CanContinueRecordIteration(topicPartition, ref recordIterationVersion))
+                                {
+                                    pausedDuringDelivery = HandleStoppedRecordIteration(topicPartition);
+                                    if (pausedDuringDelivery)
+                                        pending.BufferCurrentForRedelivery();
                                     break;
+                                }
                             }
 
                             TrackConsumedPosition(pending, offset, messageBytes);
@@ -2370,6 +2409,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         ReportAdaptiveProcessingComplete(processingDuration);
                     }
 
+                    if (pausedDuringDelivery)
+                    {
+                        // Preserve the current iterator and any buffered current record.
+                        MovePendingFetchToPaused(pending);
+                        continue;
+                    }
+
                     // Dequeue and dispose the pending fetch (releases pooled network buffer memory)
                     DequeuePendingFetch().Dispose();
                 }
@@ -2449,6 +2495,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 continue;
             }
 
+            PreparePendingFetchesForDelivery();
+
             // Get pending data - either from prefetch channel or direct fetch
             if (_pendingFetches.Count == 0)
             {
@@ -2506,6 +2554,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             while (_pendingFetches.Count > 0)
             {
+                PreparePendingFetchesForDelivery();
+                if (_pendingFetches.Count == 0)
+                    break;
+
                 if (ClearFetchBufferForPendingCoordinatorRevocations())
                     continue;
 
@@ -2603,6 +2655,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 continue;
             }
 
+            PreparePendingFetchesForDelivery();
+
             // Get pending data - either from prefetch channel or direct fetch
             if (_pendingFetches.Count == 0)
             {
@@ -2660,6 +2714,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             while (_pendingFetches.Count > 0)
             {
+                PreparePendingFetchesForDelivery();
+                if (_pendingFetches.Count == 0)
+                    break;
+
                 if (ClearFetchBufferForPendingCoordinatorRevocations())
                     continue;
 
@@ -5377,7 +5435,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void EnqueuePendingFetch(PendingFetchData pending)
     {
-        _pendingFetches.Enqueue(pending);
+        if (_pausedSnapshot.Contains(pending.TopicPartition))
+            _pausedPendingFetches.Enqueue(pending);
+        else
+            _pendingFetches.Enqueue(pending);
         Interlocked.Increment(ref _pendingFetchDepth);
     }
 
@@ -5386,6 +5447,110 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var pending = _pendingFetches.Dequeue();
         Interlocked.Decrement(ref _pendingFetchDepth);
         return pending;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void MovePendingFetchToPaused(PendingFetchData pending)
+    {
+        Debug.Assert(_pendingFetches.Count > 0 && ReferenceEquals(_pendingFetches.Peek(), pending));
+        _pausedPendingFetches.Enqueue(_pendingFetches.Dequeue());
+    }
+
+    /// <summary>
+    /// Applies pause/resume changes on the foreground consumer thread. Queues are scanned
+    /// only after a control-plane snapshot change; the steady-state path is one version read.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void PreparePendingFetchesForDelivery()
+    {
+        var pausedSnapshotVersion = Volatile.Read(ref _pausedSnapshotVersion);
+        if (pausedSnapshotVersion != _observedPausedSnapshotVersion)
+            ApplyPausedSnapshotToPendingFetches(pausedSnapshotVersion);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ApplyPausedSnapshotToPendingFetches(int pausedSnapshotVersion)
+    {
+        var paused = _pausedSnapshot;
+
+        // Older deferred fetches must precede any newer fetches for the same partition.
+        // Cross-partition order is unspecified, so temporarily move the active queue aside,
+        // restore resumed data first, then append the active queue without allocating.
+        while (_pendingFetches.TryDequeue(out var activePending))
+            _pendingFetchScratch.Enqueue(activePending);
+
+        var count = _pausedPendingFetches.Count;
+        for (var i = 0; i < count; i++)
+        {
+            var pending = _pausedPendingFetches.Dequeue();
+            if (paused.Contains(pending.TopicPartition))
+                _pausedPendingFetches.Enqueue(pending);
+            else
+                _pendingFetches.Enqueue(pending);
+        }
+
+        while (_pendingFetchScratch.TryDequeue(out var retainedPending))
+            _pendingFetches.Enqueue(retainedPending);
+
+        // Pause changes are infrequent control-plane operations. Scan once here so all
+        // already-queued fetches for newly paused partitions retain their original order.
+        count = _pendingFetches.Count;
+        for (var i = 0; i < count; i++)
+        {
+            var pending = _pendingFetches.Dequeue();
+            if (paused.Contains(pending.TopicPartition))
+                _pausedPendingFetches.Enqueue(pending);
+            else
+                _pendingFetches.Enqueue(pending);
+        }
+
+        _observedPausedSnapshotVersion = pausedSnapshotVersion;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool CanContinueRecordIteration(TopicPartition partition, ref int observedVersion)
+    {
+        var currentVersion = Volatile.Read(ref _batchIterationEpoch.Version);
+        if ((currentVersion & 1) == 0 && currentVersion == observedVersion)
+            return true;
+
+        return CanContinueRecordIterationSlow(partition, ref observedVersion);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool CanContinueRecordIterationSlow(TopicPartition partition, ref int observedVersion)
+    {
+        var spin = new SpinWait();
+        while (true)
+        {
+            var currentVersion = Volatile.Read(ref _batchIterationEpoch.Version);
+            if ((currentVersion & 1) != 0)
+            {
+                spin.SpinOnce();
+                continue;
+            }
+
+            if (!CanContinueBatchIteration(partition))
+                return false;
+
+            if (Volatile.Read(ref _batchIterationEpoch.Version) == currentVersion)
+            {
+                observedVersion = currentVersion;
+                return true;
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool HandleStoppedRecordIteration(TopicPartition partition)
+    {
+        if (!HasPendingFetchClear(partition))
+            return _pausedSnapshot.Contains(partition);
+
+        // Preserve the existing revocation/divergence recovery path. It owns discard;
+        // Pause owns preservation only while the partition remains assigned.
+        ClearFetchBufferForPendingCoordinatorRevocations();
+        return false;
     }
 
     private void StagePendingFetchClear(TopicPartition partition)
@@ -5426,6 +5591,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             Interlocked.Decrement(ref _pendingFetchDepth);
             StagePendingFetchClear(pending.TopicPartition);
             DisposeQueuedFetch(pending);
+        }
+        while (_pausedPendingFetches.TryDequeue(out var pausedPending))
+        {
+            Interlocked.Decrement(ref _pendingFetchDepth);
+            StagePendingFetchClear(pausedPending.TopicPartition);
+            DisposeQueuedFetch(pausedPending);
         }
         // Also drain prefetched items that haven't been moved to _pendingFetches yet.
         // Without this, stale data from old partitions would surface after reassignment.
@@ -5486,6 +5657,23 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             else
             {
                 // Dispose removed items to release pooled memory
+                if (stagePendingClear)
+                    StagePendingFetchClear(pending.TopicPartition);
+                DisposeQueuedFetch(pending);
+            }
+        }
+
+        count = _pausedPendingFetches.Count;
+        for (var i = 0; i < count; i++)
+        {
+            var pending = _pausedPendingFetches.Dequeue();
+            if (!removeSet.Contains(pending.TopicPartition))
+            {
+                _pausedPendingFetches.Enqueue(pending);
+            }
+            else
+            {
+                Interlocked.Decrement(ref _pendingFetchDepth);
                 if (stagePendingClear)
                     StagePendingFetchClear(pending.TopicPartition);
                 DisposeQueuedFetch(pending);
@@ -5711,6 +5899,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 }
             }
 
+            foreach (var pending in _pausedPendingFetches)
+            {
+                if (TryGetConsumedPosition(
+                        pending,
+                        out var pendingPartition,
+                        out var nextOffset,
+                        out var pendingLeaderEpoch)
+                    && pendingPartition.Equals(partition))
+                {
+                    resumeOffset = Math.Max(
+                        resumeOffset,
+                        BoundDivergingResumeOffset(nextOffset, pendingLeaderEpoch, reset));
+                }
+            }
+
             _fetchPositions[partition] = resumeOffset;
             SetPosition(partition, resumeOffset, dirty: false);
             // Clearing the pending fetch bypasses its normal position flush. Discard the
@@ -5804,6 +6007,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private bool CanContinueBatchIteration(TopicPartition partition) =>
         !HasPendingFetchClear(partition)
+        && !_pausedSnapshot.Contains(partition)
         && IsCurrentlyAssigned(partition);
 
     private bool IsFetchBufferEpochStale(TopicPartition partition, int fetchBufferEpoch) =>
@@ -6998,7 +7202,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// </summary>
     private void PublishPausedSnapshot()
     {
-        _pausedSnapshot = _paused.Keys.ToHashSet();
+        var snapshot = _paused.Keys.ToHashSet();
+        _batchIterationEpoch.BeginPublication();
+        try
+        {
+            _pausedSnapshot = snapshot;
+            Interlocked.Increment(ref _pausedSnapshotVersion);
+        }
+        finally
+        {
+            _batchIterationEpoch.EndPublication();
+        }
     }
 
     /// <summary>
@@ -9105,6 +9319,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             Interlocked.Decrement(ref _pendingFetchDepth);
             pending.Dispose();
         }
+        while (_pausedPendingFetches.TryDequeue(out var pausedPending))
+        {
+            Interlocked.Decrement(ref _pendingFetchDepth);
+            pausedPending.Dispose();
+        }
         while (_prefetchBuffer.TryRead(out var prefetched))
         {
             TrackPrefetchedBytes(prefetched, release: true);
@@ -9422,6 +9641,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             Interlocked.Decrement(ref _pendingFetchDepth);
             pending.Dispose();
+        }
+        while (_pausedPendingFetches.TryDequeue(out var pausedPending))
+        {
+            Interlocked.Decrement(ref _pendingFetchDepth);
+            pausedPending.Dispose();
         }
 
         // Drain and dispose prefetch buffer items

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3701,6 +3701,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         return flushed;
     }
 
+    /// <summary>
+    /// An explicit commit vouches for delivered records even when pause reconciliation
+    /// has moved their fetches out of the active queue. This control path may scan the
+    /// paused queue; normal delivery never pays this cost.
+    /// </summary>
+    private void FlushPausedConsumedPositions()
+    {
+        foreach (var pending in _pausedPendingFetches)
+        {
+            pending.MarkYieldedProcessed();
+            FlushConsumedPositions(pending);
+        }
+    }
+
     private bool TryGetActiveConsumedPosition(TopicPartition partition, out long position, out int leaderEpoch)
     {
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
@@ -5032,6 +5046,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Explicit commit: the caller vouches for everything yielded so far, including
         // a record still being processed.
         FlushActiveConsumedPosition();
+        FlushPausedConsumedPositions();
 
         if (_coordinator is null)
             return;
@@ -5501,6 +5516,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private void MovePendingFetchToPaused(PendingFetchData pending)
     {
         Debug.Assert(_pendingFetches.Count > 0 && ReferenceEquals(_pendingFetches.Peek(), pending));
+
+        // The inner batch iterator can discover pause only when probing past its final
+        // record. Complete that probe before parking so resume does not expose an empty
+        // batch. The outer iterator will observe the queue-version change and return
+        // without touching the parked fetch.
+        if (Interlocked.Exchange(ref _batchIterationEpoch.BatchExhaustionProbePending, 0) != 0)
+            pending.TryBufferNext();
+
         FlushConsumedPositions(pending);
         _pausedPendingFetches.Enqueue(_pendingFetches.Dequeue());
     }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1046,6 +1046,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly Queue<PendingFetchData> _pausedPendingFetches = new();
     private readonly Queue<PendingFetchData> _pendingFetchScratch = new();
     private int _observedPausedSnapshotVersion;
+    private int _recordIterationEpochSeed;
     private int _pendingFetchDepth;
     // ConsumeOne callbacks run on the documented single application thread. If one
     // reentrantly clears the queue, defer this fetch's disposal until all borrowed
@@ -2088,6 +2089,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             await EnsureAssignmentForPollAsync(cancellationToken).ConfigureAwait(false);
             RecoverAndClearFetchBufferForPendingCoordinatorRevocations();
+            // An odd seed forces slow validation when a marker is published but not yet clearable.
+            // A later publication changes the captured epoch and reaches the same slow path.
+            var recordIterationEpochSeed = Volatile.Read(ref _batchIterationEpoch.Version);
+            if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0)
+                recordIterationEpochSeed |= 1;
+            _recordIterationEpochSeed = recordIterationEpochSeed;
 
             if (_assignmentSnapshot.Count == 0)
             {
@@ -2171,9 +2178,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                 while (_pendingFetches.Count > 0)
                 {
-                    // Capture before applying the snapshot. A concurrent Pause either
-                    // appears in that snapshot or changes the epoch after this capture.
-                    var recordIterationVersion = Volatile.Read(ref _batchIterationEpoch.Version);
+                    // Start from the last recovered epoch. A control-plane publication during
+                    // a prefetch wait then forces validation before the first record is delivered.
+                    var recordIterationVersion = _recordIterationEpochSeed;
                     PreparePendingFetchesForDelivery();
                     if (_pendingFetches.Count == 0)
                         break;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -6267,7 +6267,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             return;
 
         try { consumeCts.Cancel(); }
-        catch (ObjectDisposedException) { }
+        catch (ObjectDisposedException) { return; }
     }
 
     private void CancelActiveConsumeOperations()
@@ -6275,7 +6275,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         foreach (var cts in _activeConsumeCancellationSources.Keys)
         {
             try { cts.Cancel(); }
-            catch (ObjectDisposedException) { }
+            catch (ObjectDisposedException) { continue; }
         }
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -6108,10 +6108,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private bool CanContinueBatchIterationWithPause(TopicPartition partition, out bool paused)
     {
+        if (HasPendingFetchClear(partition))
+        {
+            paused = false;
+            return false;
+        }
+
         paused = _pausedSnapshot.Contains(partition);
-        return !HasPendingFetchClear(partition)
-            && !paused
-            && IsCurrentlyAssigned(partition);
+        return !paused && IsCurrentlyAssigned(partition);
     }
 
     private bool IsFetchBufferEpochStale(TopicPartition partition, int fetchBufferEpoch) =>
@@ -7276,11 +7280,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// </summary>
     private void PublishPausedSnapshot()
     {
-        var snapshot = _paused.Keys.ToHashSet();
         _batchIterationEpoch.BeginPublication();
         try
         {
-            _pausedSnapshot = snapshot;
+            _pausedSnapshot = _paused.Keys.ToHashSet();
             Interlocked.Increment(ref _pausedSnapshotVersion);
         }
         finally

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2133,10 +2133,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                     TrackPrefetchedBytes(fetched, release: true);
                                     DrainPrefetchBuffer();
                                 }
-                                else
-                                {
-                                    System.Diagnostics.Debug.Fail("WaitToRead signalled data available but TryRead returned false");
-                                }
                             }
                             else if (_prefetchBuffer.IsCompleted)
                             {
@@ -2542,10 +2538,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                     TrackPrefetchedBytes(fetched, release: true);
                                     DrainPrefetchBuffer();
                                 }
-                                else
-                                {
-                                    System.Diagnostics.Debug.Fail("WaitToRead signalled data available but TryRead returned false");
-                                }
                             }
                             else if (_prefetchBuffer.IsCompleted)
                             {
@@ -2701,10 +2693,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                     EnqueuePendingFetch(fetched);
                                     TrackPrefetchedBytes(fetched, release: true);
                                     DrainPrefetchBuffer();
-                                }
-                                else
-                                {
-                                    System.Diagnostics.Debug.Fail("WaitToRead signalled data available but TryRead returned false");
                                 }
                             }
                             else if (_prefetchBuffer.IsCompleted)
@@ -4431,10 +4419,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     EnqueuePendingFetch(fetched);
                     TrackPrefetchedBytes(fetched, release: true);
                     DrainPrefetchBuffer();
-                }
-                else
-                {
-                    System.Diagnostics.Debug.Fail("WaitToRead signalled data available but TryRead returned false");
                 }
             }
             else if (_prefetchBuffer.IsCompleted)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1124,6 +1124,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly SemaphoreSlim _assignmentLock = new(1, 1);
 
     private readonly ConcurrentDictionary<CancellationTokenSource, byte> _activeConsumeCancellationSources = new();
+    private CancellationTokenSource? _pausedDirectFetchCancellationSource;
     private readonly CancellationTokenSource _leaderRefreshCts = new();
     private readonly object _autoCommitStartLock = new();
     private CancellationTokenSource? _autoCommitCts;
@@ -2595,7 +2596,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         new BatchIterationGuard(
                             _batchIterationEpoch,
                             batchIterationVersion,
-                            CanContinueBatchIteration),
+                            GetBatchIterationStatus),
                         _storeOffsetOnDelivery,
                         _options.MaxPollRecords,
                         _rewindBatchAfterDeliveryFailure);
@@ -2749,7 +2750,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         new BatchIterationGuard(
                             _batchIterationEpoch,
                             batchIterationVersion,
-                            CanContinueBatchIteration),
+                            GetBatchIterationStatus),
                         _storeOffsetOnDelivery,
                         _options.MaxPollRecords);
                     batchYielded = true;
@@ -6100,11 +6101,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         return recovered;
     }
 
-    private bool CanContinueBatchIteration(TopicPartition partition) =>
-        CanContinueBatchIterationWithPause(partition, out _);
+    private BatchIterationStatus GetBatchIterationStatus(TopicPartition partition)
+    {
+        var canContinue = CanContinueBatchIterationWithPause(partition, out var paused);
+        return canContinue
+            ? BatchIterationStatus.Continue
+            : paused
+                ? BatchIterationStatus.Paused
+                : BatchIterationStatus.Stopped;
+    }
 
     private bool CanContinueBatchIterationWithPause(TopicPartition partition, out bool paused)
     {
+        // Revocation/diverging-epoch discard owns invalid data even when Pause also
+        // contains the partition. Only a still-valid paused record may be redelivered.
         if (HasPendingFetchClear(partition))
         {
             paused = false;
@@ -6246,7 +6256,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         PublishPausedSnapshot();
         UpdateCachesForResumedPartitions(changedPartitions);
+        WakePausedDirectFetch();
         _prefetchBuffer.SignalReader();
+    }
+
+    private void WakePausedDirectFetch()
+    {
+        var consumeCts = Volatile.Read(ref _pausedDirectFetchCancellationSource);
+        if (consumeCts is null)
+            return;
+
+        try { consumeCts.Cancel(); }
+        catch (ObjectDisposedException) { }
     }
 
     private void CancelActiveConsumeOperations()
@@ -7077,6 +7098,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (cancellationToken.IsCancellationRequested)
                 consumeCts.Cancel();
 
+            var pausedSnapshotVersion = Volatile.Read(ref _pausedSnapshotVersion);
             var partitionsByBroker = await GroupPartitionsByBrokerAsync(cancellationToken).ConfigureAwait(false);
             var fetchBufferEpoch = Volatile.Read(ref _fetchBufferEpoch);
             var fetchSessionSnapshot = ShouldUseFetchSessions && !_fetchSessions.IsEmpty
@@ -7088,7 +7110,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             var brokerCount = partitionsByBroker.Count;
             if (brokerCount == 0 && fetchSessionSnapshot.Length == 0)
             {
-                await Task.Delay(AllPartitionsPausedDelayMs, cancellationToken).ConfigureAwait(false);
+                await DelayPausedDirectFetchAsync(
+                    pausedSnapshotVersion,
+                    consumeCts,
+                    cancellationToken).ConfigureAwait(false);
                 return;
             }
 
@@ -7129,7 +7154,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                 if (taskCount == 0)
                 {
-                    await Task.Delay(AllPartitionsPausedDelayMs, cancellationToken).ConfigureAwait(false);
+                    await DelayPausedDirectFetchAsync(
+                        pausedSnapshotVersion,
+                        consumeCts,
+                        cancellationToken).ConfigureAwait(false);
                     return;
                 }
 
@@ -7192,6 +7220,39 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             _activeConsumeCancellationSources.TryRemove(consumeCts, out _);
             consumeCts.Dispose();
             _coordinator?.EndForegroundPollActivity();
+        }
+    }
+
+    private async ValueTask DelayPausedDirectFetchAsync(
+        int pausedSnapshotVersion,
+        CancellationTokenSource consumeCts,
+        CancellationToken cancellationToken)
+    {
+        Volatile.Write(ref _pausedDirectFetchCancellationSource, consumeCts);
+        try
+        {
+            // Resume may publish before the waiter is visible. The version check closes
+            // that race; a later Resume cancels consumeCts through the published field.
+            if (Volatile.Read(ref _pausedSnapshotVersion) != pausedSnapshotVersion)
+                return;
+
+            try
+            {
+                await Task.Delay(AllPartitionsPausedDelayMs, consumeCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (
+                !cancellationToken.IsCancellationRequested
+                && Volatile.Read(ref _pausedSnapshotVersion) != pausedSnapshotVersion)
+            {
+                // Resume is a control-plane wake, not caller cancellation.
+            }
+        }
+        finally
+        {
+            Interlocked.CompareExchange(
+                ref _pausedDirectFetchCancellationSource,
+                null,
+                consumeCts);
         }
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2794,14 +2794,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         bool disposePending,
         bool yieldedBatchProcessed)
     {
-        if (Interlocked.Exchange(ref _batchIterationEpoch.BatchExhaustionProbePending, 0) != 0)
-            pending.TryBufferNext();
+        var exhaustionProbePending = Interlocked.Exchange(
+            ref _batchIterationEpoch.BatchExhaustionProbePending,
+            0) != 0;
 
         if (Volatile.Read(ref _pendingFetchesVersion) != pendingFetchesVersion)
             return;
 
         if (_pendingFetches.Count == 0 || !ReferenceEquals(_pendingFetches.Peek(), pending))
             return;
+
+        if (exhaustionProbePending)
+            pending.TryBufferNext();
 
         if (yieldedBatchProcessed)
             pending.MarkYieldedProcessed();
@@ -5497,7 +5501,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private void MovePendingFetchToPaused(PendingFetchData pending)
     {
         Debug.Assert(_pendingFetches.Count > 0 && ReferenceEquals(_pendingFetches.Peek(), pending));
-        pending.MarkYieldedProcessed();
         FlushConsumedPositions(pending);
         _pausedPendingFetches.Enqueue(_pendingFetches.Dequeue());
     }
@@ -5523,6 +5526,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             PreparePendingFetchesForDelivery();
             return;
         }
+
+        // A new ConsumeOne call proves the prior result before pause reconciliation can
+        // move its fetch out of the active queue. Generic queue reconciliation must not
+        // infer processing for streaming APIs, whose continuation owns that proof.
+        if (_pendingFetches.Count > 0)
+            _pendingFetches.Peek().MarkYieldedProcessed();
 
         while (true)
         {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2794,6 +2794,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         bool disposePending,
         bool yieldedBatchProcessed)
     {
+        if (Interlocked.Exchange(ref _batchIterationEpoch.BatchExhaustionProbePending, 0) != 0)
+            pending.TryBufferNext();
+
         if (Volatile.Read(ref _pendingFetchesVersion) != pendingFetchesVersion)
             return;
 

--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -355,6 +355,12 @@ internal sealed class MpscFetchBuffer
 
     public bool IsCompleted => _completed;
 
+    /// <summary>
+    /// Wakes the single reader for a control-plane change that may make externally
+    /// retained data readable without publishing a new buffer item.
+    /// </summary>
+    internal void SignalReader() => SignalConsumerWaitingForData();
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal bool HasDataAvailable()
     {

--- a/tests/Dekaf.Tests.Integration/ConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerTests.cs
@@ -626,6 +626,143 @@ public class ConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
     }
 
     [Test]
+    public async Task ConsumeAsync_PauseSuppressesPrefetchedRecordsUntilResume()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);
+        var pausedPartition = new TopicPartition(topic, 0);
+        var activePartition = new TopicPartition(topic, 1);
+        await using var producer = await CreatePauseTestProducerAsync();
+        await ProducePauseTestRecordsAsync(producer, topic, partition: 0, start: 0, count: 3);
+        await using var consumer = await CreatePauseTestConsumerAsync();
+        consumer.Assign(pausedPartition, activePartition);
+        consumer.Seek(new TopicPartitionOffset(topic, 0, 0));
+        consumer.Seek(new TopicPartitionOffset(topic, 1, 0));
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await using var records = consumer.ConsumeAsync(cancellation.Token).GetAsyncEnumerator();
+
+        await Assert.That(await records.MoveNextAsync()).IsTrue();
+        await Assert.That(records.Current.Partition).IsEqualTo(0);
+        await Assert.That(records.Current.Offset).IsEqualTo(0);
+
+        consumer.Pause(pausedPartition);
+        await ProducePauseTestRecordsAsync(producer, topic, partition: 1, start: 100, count: 1);
+
+        await Assert.That(await records.MoveNextAsync()).IsTrue();
+        await Assert.That(records.Current.Partition).IsEqualTo(1);
+        await Assert.That(records.Current.Offset).IsEqualTo(0);
+
+        consumer.Resume(pausedPartition);
+
+        await Assert.That(await records.MoveNextAsync()).IsTrue();
+        await Assert.That(records.Current.Partition).IsEqualTo(0);
+        await Assert.That(records.Current.Offset).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ConsumeBatchAsync_PauseSuppressesPrefetchedRecordsUntilResume()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);
+        var pausedPartition = new TopicPartition(topic, 0);
+        var activePartition = new TopicPartition(topic, 1);
+        await using var producer = await CreatePauseTestProducerAsync();
+        await ProducePauseTestRecordsAsync(producer, topic, partition: 0, start: 0, count: 3);
+        await using var consumer = await CreatePauseTestConsumerAsync(maxPollRecords: 1);
+        consumer.Assign(pausedPartition, activePartition);
+        consumer.Seek(new TopicPartitionOffset(topic, 0, 0));
+        consumer.Seek(new TopicPartitionOffset(topic, 1, 0));
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await using var batches = consumer.ConsumeBatchAsync(cancellation.Token).GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        var first = batches.Current.Single();
+        await Assert.That(batches.Current.Partition).IsEqualTo(0);
+        await Assert.That(first.Offset).IsEqualTo(0);
+
+        consumer.Pause(pausedPartition);
+        await ProducePauseTestRecordsAsync(producer, topic, partition: 1, start: 100, count: 1);
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.Partition).IsEqualTo(1);
+        await Assert.That(batches.Current.Single().Offset).IsEqualTo(0);
+
+        consumer.Resume(pausedPartition);
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.Partition).IsEqualTo(0);
+        await Assert.That(batches.Current.Single().Offset).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ConsumeRawBatchAsync_PauseSuppressesPrefetchedRecordsUntilResume()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);
+        var pausedPartition = new TopicPartition(topic, 0);
+        var activePartition = new TopicPartition(topic, 1);
+        await using var producer = await CreatePauseTestProducerAsync();
+        await ProducePauseTestRecordsAsync(producer, topic, partition: 0, start: 0, count: 3);
+        await using var consumer = await CreatePauseTestConsumerAsync(maxPollRecords: 1);
+        consumer.Assign(pausedPartition, activePartition);
+        consumer.Seek(new TopicPartitionOffset(topic, 0, 0));
+        consumer.Seek(new TopicPartitionOffset(topic, 1, 0));
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await using var batches = consumer.ConsumeRawBatchAsync(cancellation.Token).GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        var first = batches.Current.Single();
+        await Assert.That(batches.Current.Partition).IsEqualTo(0);
+        await Assert.That(first.Offset).IsEqualTo(0);
+
+        consumer.Pause(pausedPartition);
+        await ProducePauseTestRecordsAsync(producer, topic, partition: 1, start: 100, count: 1);
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.Partition).IsEqualTo(1);
+        await Assert.That(batches.Current.Single().Offset).IsEqualTo(0);
+
+        consumer.Resume(pausedPartition);
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.Partition).IsEqualTo(0);
+        await Assert.That(batches.Current.Single().Offset).IsEqualTo(1);
+    }
+
+    private ValueTask<IKafkaProducer<string, string>> CreatePauseTestProducerAsync() =>
+        Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("pause-prefetch-producer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+    private ValueTask<IKafkaConsumer<string, string>> CreatePauseTestConsumerAsync(
+        int maxPollRecords = int.MaxValue) =>
+        Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("pause-prefetch-consumer")
+            .WithQueuedMinMessages(100)
+            .WithMaxPollRecords(maxPollRecords)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+    private static async Task ProducePauseTestRecordsAsync(
+        IKafkaProducer<string, string> producer,
+        string topic,
+        int partition,
+        int start,
+        int count)
+    {
+        for (var i = start; i < start + count; i++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = partition,
+                Key = $"key-{i}",
+                Value = $"value-{i}"
+            }, CancellationToken.None);
+        }
+    }
+
+    [Test]
     public async Task Consumer_Unsubscribe_ClearsSubscription()
     {
         // Arrange

--- a/tests/Dekaf.Tests.Integration/ConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerTests.cs
@@ -728,6 +728,43 @@ public class ConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
     }
 
     [Test]
+    public async Task ConsumeBatchAsync_PauseDuringDeserialization_RedeliversAfterResume()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var partition = new TopicPartition(topic, 0);
+        await using var producer = await CreatePauseTestProducerAsync();
+        await ProducePauseTestRecordsAsync(producer, topic, partition: 0, start: 0, count: 2);
+        var deserializer = new CallbackOnceStringDeserializer();
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("pause-during-batch-deserialization-consumer")
+            .WithQueuedMinMessages(100)
+            .WithValueDeserializer(deserializer)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+        consumer.Assign(partition);
+        consumer.Seek(new TopicPartitionOffset(topic, 0, 0));
+        deserializer.SetCallback(() => consumer.Pause(partition));
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await using var batches = consumer.ConsumeBatchAsync(cancellation.Token).GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        using (var interrupted = batches.Current.GetEnumerator())
+        {
+            await Assert.That(interrupted.MoveNext()).IsFalse();
+        }
+
+        await Assert.That(deserializer.CallbackCount).IsEqualTo(1);
+        consumer.Resume(partition);
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        using var redelivered = batches.Current.GetEnumerator();
+        await Assert.That(redelivered.MoveNext()).IsTrue();
+        await Assert.That(redelivered.Current.Offset).IsEqualTo(0L);
+        await Assert.That(redelivered.Current.Value).IsEqualTo("value-0");
+    }
+
+    [Test]
     public async Task ConsumeRawBatchAsync_PauseSuppressesPrefetchedRecordsUntilResume()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);

--- a/tests/Dekaf.Tests.Integration/ConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerTests.cs
@@ -659,6 +659,41 @@ public class ConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
     }
 
     [Test]
+    public async Task ConsumeOneAsync_PauseSuppressesPrefetchedRecordsUntilResume()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);
+        var pausedPartition = new TopicPartition(topic, 0);
+        var activePartition = new TopicPartition(topic, 1);
+        await using var producer = await CreatePauseTestProducerAsync();
+        await ProducePauseTestRecordsAsync(producer, topic, partition: 0, start: 0, count: 3);
+        await using var consumer = await CreatePauseTestConsumerAsync();
+        consumer.Assign(pausedPartition, activePartition);
+        consumer.Seek(new TopicPartitionOffset(topic, 0, 0));
+        consumer.Seek(new TopicPartitionOffset(topic, 1, 0));
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var first = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cancellation.Token);
+        await Assert.That(first).IsNotNull();
+        await Assert.That(first!.Value.Partition).IsEqualTo(0);
+        await Assert.That(first.Value.Offset).IsEqualTo(0);
+
+        consumer.Pause(pausedPartition);
+        await ProducePauseTestRecordsAsync(producer, topic, partition: 1, start: 100, count: 1);
+
+        var active = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cancellation.Token);
+        await Assert.That(active).IsNotNull();
+        await Assert.That(active!.Value.Partition).IsEqualTo(1);
+        await Assert.That(active.Value.Offset).IsEqualTo(0);
+
+        consumer.Resume(pausedPartition);
+
+        var resumed = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cancellation.Token);
+        await Assert.That(resumed).IsNotNull();
+        await Assert.That(resumed!.Value.Partition).IsEqualTo(0);
+        await Assert.That(resumed.Value.Offset).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ConsumeBatchAsync_PauseSuppressesPrefetchedRecordsUntilResume()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
@@ -115,21 +115,26 @@ public class ConsumeBatchTests
     }
 
     [Test]
-    public async Task ConsumeBatch_StopsEnumerationWhenPartitionIsNoLongerAssigned()
+    public async Task ConsumeBatch_RemainsCompletedAfterPartitionReturns()
     {
         using var pending = CreatePendingFetchData("test-topic", partitionIndex: 0, baseOffset: 0, messageCount: 3);
         var assignmentEpoch = new BatchIterationEpoch();
+        var canContinue = true;
         var batch = new ConsumeBatch<string, string>(
             pending,
             Serializers.String,
             Serializers.String,
-            new BatchIterationGuard(assignmentEpoch, assignmentEpoch.Version));
+            new BatchIterationGuard(assignmentEpoch, assignmentEpoch.Version, _ => canContinue));
 
         using var enumerator = batch.GetEnumerator();
 
         await Assert.That(enumerator.MoveNext()).IsTrue();
+        canContinue = false;
         assignmentEpoch.Invalidate();
 
+        await Assert.That(enumerator.MoveNext()).IsFalse();
+        canContinue = true;
+        assignmentEpoch.Invalidate();
         await Assert.That(enumerator.MoveNext()).IsFalse();
         await Assert.That(batch.Count).IsEqualTo(1);
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
@@ -124,7 +124,8 @@ public class ConsumeBatchTests
             pending,
             Serializers.String,
             Serializers.String,
-            new BatchIterationGuard(assignmentEpoch, assignmentEpoch.Version, _ => canContinue));
+            new BatchIterationGuard(assignmentEpoch, assignmentEpoch.Version,
+                _ => canContinue ? BatchIterationStatus.Continue : BatchIterationStatus.Stopped));
 
         using var enumerator = batch.GetEnumerator();
 
@@ -155,7 +156,7 @@ public class ConsumeBatchTests
                 _ =>
                 {
                     membershipChecks++;
-                    return true;
+                    return BatchIterationStatus.Continue;
                 }));
         using var enumerator = batch.GetEnumerator();
 
@@ -166,6 +167,30 @@ public class ConsumeBatchTests
         await Assert.That(enumerator.Current.Offset).IsEqualTo(1);
         await Assert.That(batch.Count).IsEqualTo(2);
         await Assert.That(membershipChecks).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ConsumeBatch_RevocationDuringDeserialization_DoesNotBufferCurrentRecord()
+    {
+        using var pending = CreatePendingFetchData("test-topic", partitionIndex: 0, baseOffset: 0, messageCount: 1);
+        var assignmentEpoch = new BatchIterationEpoch();
+        var canContinue = true;
+        var deserializer = new CallbackDeserializer(() =>
+        {
+            canContinue = false;
+            assignmentEpoch.Invalidate();
+        });
+        var batch = new ConsumeBatch<string, string>(
+            pending,
+            Serializers.String,
+            deserializer,
+            new BatchIterationGuard(assignmentEpoch, assignmentEpoch.Version,
+                _ => canContinue ? BatchIterationStatus.Continue : BatchIterationStatus.Stopped));
+
+        using var enumerator = batch.GetEnumerator();
+
+        await Assert.That(enumerator.MoveNext()).IsFalse();
+        await Assert.That(pending.MoveNext()).IsFalse();
     }
 
     [Test]
@@ -221,5 +246,14 @@ public class ConsumeBatchTests
         var pending = PendingFetchData.Create(topic, partitionIndex, new List<RecordBatch> { recordBatch });
         pending.EagerParseAll();
         return pending;
+    }
+
+    private sealed class CallbackDeserializer(Action callback) : IDeserializer<string>
+    {
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            callback();
+            return Serializers.String.Deserialize(data, context);
+        }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
@@ -194,6 +194,30 @@ public class ConsumeBatchTests
     }
 
     [Test]
+    public async Task ConsumeBatch_PauseDuringDeserialization_BuffersCurrentRecordForRedelivery()
+    {
+        using var pending = CreatePendingFetchData("test-topic", partitionIndex: 0, baseOffset: 7, messageCount: 1);
+        var assignmentEpoch = new BatchIterationEpoch();
+        var status = BatchIterationStatus.Continue;
+        var deserializer = new CallbackDeserializer(() =>
+        {
+            status = BatchIterationStatus.Paused;
+            assignmentEpoch.Invalidate();
+        });
+        var batch = new ConsumeBatch<string, string>(
+            pending,
+            Serializers.String,
+            deserializer,
+            new BatchIterationGuard(assignmentEpoch, assignmentEpoch.Version, _ => status));
+
+        using var enumerator = batch.GetEnumerator();
+
+        await Assert.That(enumerator.MoveNext()).IsFalse();
+        await Assert.That(pending.MoveNext()).IsTrue();
+        await Assert.That(pending.CurrentBaseOffset + pending.CurrentRecord.OffsetDelta).IsEqualTo(7L);
+    }
+
+    [Test]
     public async Task BatchIterationGuard_DoesNotAdoptInProgressPublication()
     {
         var assignmentEpoch = new BatchIterationEpoch();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -727,7 +727,14 @@ public sealed class ConsumeOneFastPathTests
         if (fetches.Length == 0)
             return consumer;
 
-        AssignTestPartition(consumer);
+        var partitions = fetches
+            .Select(static fetch => fetch.TopicPartition)
+            .Distinct()
+            .ToArray();
+        consumer.Assign(partitions);
+        var fetchPositions = GetFetchPositions(consumer);
+        foreach (var partition in partitions)
+            fetchPositions[partition] = 0;
         var pendingFetches = GetPendingFetches(consumer);
         foreach (var fetch in fetches)
             pendingFetches.Enqueue(fetch);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeRawBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeRawBatchTests.cs
@@ -147,19 +147,24 @@ public class ConsumeRawBatchTests
     }
 
     [Test]
-    public async Task ConsumeRawBatch_StopsEnumerationWhenPartitionIsNoLongerAssigned()
+    public async Task ConsumeRawBatch_RemainsCompletedAfterPartitionReturns()
     {
         using var pending = CreatePendingFetchData("test-topic", partitionIndex: 0, baseOffset: 0, messageCount: 3);
         var assignmentEpoch = new BatchIterationEpoch();
+        var canContinue = true;
         var batch = new ConsumeRawBatch(
             pending,
-            new BatchIterationGuard(assignmentEpoch, assignmentEpoch.Version));
+            new BatchIterationGuard(assignmentEpoch, assignmentEpoch.Version, _ => canContinue));
 
         using var enumerator = batch.GetEnumerator();
 
         await Assert.That(enumerator.MoveNext()).IsTrue();
+        canContinue = false;
         assignmentEpoch.Invalidate();
 
+        await Assert.That(enumerator.MoveNext()).IsFalse();
+        canContinue = true;
+        assignmentEpoch.Invalidate();
         await Assert.That(enumerator.MoveNext()).IsFalse();
         await Assert.That(batch.Count).IsEqualTo(1);
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeRawBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeRawBatchTests.cs
@@ -154,7 +154,8 @@ public class ConsumeRawBatchTests
         var canContinue = true;
         var batch = new ConsumeRawBatch(
             pending,
-            new BatchIterationGuard(assignmentEpoch, assignmentEpoch.Version, _ => canContinue));
+            new BatchIterationGuard(assignmentEpoch, assignmentEpoch.Version,
+                _ => canContinue ? BatchIterationStatus.Continue : BatchIterationStatus.Stopped));
 
         using var enumerator = batch.GetEnumerator();
 
@@ -187,7 +188,7 @@ public class ConsumeRawBatchTests
                 _ =>
                 {
                     membershipChecks++;
-                    return true;
+                    return BatchIterationStatus.Continue;
                 }));
 
         foreach (var _ in batch)
@@ -216,7 +217,7 @@ public class ConsumeRawBatchTests
                 _ =>
                 {
                     membershipChecks++;
-                    return true;
+                    return BatchIterationStatus.Continue;
                 }));
         using var enumerator = batch.GetEnumerator();
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -897,17 +897,20 @@ public sealed class ConsumerLeaderDiscoveryTests
     {
         var consumerType = typeof(KafkaConsumer<string, string>);
         var assignmentMethod = consumerType.GetMethod(
-            "CanContinueBatchIteration",
+            "GetBatchIterationStatus",
             BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("CanContinueBatchIteration method not found");
+            ?? throw new InvalidOperationException("GetBatchIterationStatus method not found");
         var epochField = consumerType.GetField(
             "_batchIterationEpoch",
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("_batchIterationEpoch field not found");
 
-        var isAssigned = assignmentMethod.CreateDelegate<Func<TopicPartition, bool>>(consumer);
+        var getStatus = assignmentMethod.CreateDelegate<BatchIterationContinuation>(consumer);
         var epoch = (BatchIterationEpoch)epochField.GetValue(consumer)!;
-        return new BatchIterationGuard(epoch, Volatile.Read(ref epoch.Version), isAssigned);
+        return new BatchIterationGuard(
+            epoch,
+            Volatile.Read(ref epoch.Version),
+            getStatus);
     }
 
     private static async ValueTask InvokeHandleLeaderEpochRefreshAsync(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -79,6 +79,87 @@ public sealed class ConsumerPauseResumeCacheTests
     }
 
     [Test]
+    public async Task PauseSnapshot_CapturesMutationAfterWaitingForPublication()
+    {
+        var partition0 = new TopicPartition("topic-a", 0);
+        var partition1 = new TopicPartition("topic-a", 1);
+        var pool = Substitute.For<IConnectionPool>();
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.Assign(partition0, partition1);
+        var paused = (ConcurrentDictionary<TopicPartition, byte>)GetField("_paused").GetValue(consumer)!;
+        var epoch = (BatchIterationEpoch)GetField("_batchIterationEpoch").GetValue(consumer)!;
+        Exception? publisherFailure = null;
+        var publisher = new Thread(() =>
+        {
+            try
+            {
+                consumer.Pause(partition0);
+            }
+            catch (Exception exception)
+            {
+                publisherFailure = exception;
+            }
+        })
+        {
+            IsBackground = true
+        };
+
+        bool publisherWaiting;
+        epoch.BeginPublication();
+        try
+        {
+            publisher.Start();
+            publisherWaiting = SpinWait.SpinUntil(
+                () => paused.ContainsKey(partition0)
+                    && (publisher.ThreadState & ThreadState.WaitSleepJoin) != 0,
+                TimeSpan.FromSeconds(5));
+            paused.TryAdd(partition1, 0);
+        }
+        finally
+        {
+            epoch.EndPublication();
+        }
+
+        var publisherCompleted = publisher.Join(TimeSpan.FromSeconds(5));
+        var snapshot = (HashSet<TopicPartition>)GetField("_pausedSnapshot").GetValue(consumer)!;
+
+        await Assert.That(publisherWaiting).IsTrue();
+        await Assert.That(publisherCompleted).IsTrue();
+        await Assert.That(publisherFailure).IsNull();
+        await Assert.That(snapshot.Contains(partition0)).IsTrue();
+        await Assert.That(snapshot.Contains(partition1)).IsTrue();
+    }
+
+    [Test]
+    public async Task PausedPartition_WithPendingClear_UsesDiscardPriority()
+    {
+        var partition = new TopicPartition("topic-a", 0);
+        var pool = Substitute.For<IConnectionPool>();
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.Assign(partition);
+        consumer.Pause(partition);
+        var stagePendingClear = typeof(KafkaConsumer<string, string>).GetMethod(
+            "StagePendingFetchClear",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("StagePendingFetchClear method not found");
+        var canContinueWithPause = typeof(KafkaConsumer<string, string>).GetMethod(
+            "CanContinueBatchIterationWithPause",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("CanContinueBatchIterationWithPause method not found");
+        stagePendingClear.Invoke(consumer, [partition]);
+        object?[] arguments = [partition, false];
+
+        var canContinue = (bool)canContinueWithPause.Invoke(consumer, arguments)!;
+
+        await Assert.That(canContinue).IsFalse();
+        await Assert.That((bool)arguments[1]!).IsFalse();
+    }
+
+    [Test]
     public async Task PauseResume_UpdatesPartitionBrokerCacheIncrementally()
     {
         var partition0 = new TopicPartition("topic-a", 0);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -437,6 +437,32 @@ public sealed class ConsumerPauseResumeCacheTests
     }
 
     [Test]
+    public async Task ConsumeOneAsync_ResumeDuringDirectPausedDelay_WakesRetainedRecord()
+    {
+        var partition = new TopicPartition(PrefetchedTopic, 0);
+        await using var consumer = CreatePrefetchedConsumer(CreatePendingFetch(partition, 10, 1));
+        consumer.Pause(partition);
+
+        using var cancellationSource = new CancellationTokenSource();
+        var consume = consumer.ConsumeOneAsync(
+            Timeout.InfiniteTimeSpan,
+            cancellationSource.Token).AsTask();
+        var pausedDirectFetchCancellationSource = GetField("_pausedDirectFetchCancellationSource");
+        await Assert.That(SpinWait.SpinUntil(
+            () => pausedDirectFetchCancellationSource.GetValue(consumer) is not null,
+            TimeSpan.FromSeconds(5))).IsTrue();
+
+        cancellationSource.CancelAfter(TimeSpan.FromMilliseconds(75));
+        consumer.Resume(partition);
+
+        var resumed = await consume;
+        await Assert.That(resumed).IsNotNull();
+        await Assert.That(resumed!.Value.Topic).IsEqualTo(partition.Topic);
+        await Assert.That(resumed.Value.Partition).IsEqualTo(partition.Partition);
+        await Assert.That(resumed.Value.Offset).IsEqualTo(10);
+    }
+
+    [Test]
     public async Task ConsumeOneAsync_PauseDuringDeserialization_ReplaysSuppressedRecordAfterResume()
     {
         var pausedPartition = new TopicPartition(PrefetchedTopic, 0);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -106,14 +106,13 @@ public sealed class ConsumerPauseResumeCacheTests
             IsBackground = true
         };
 
-        bool publisherWaiting;
+        bool publisherMutated;
         epoch.BeginPublication();
         try
         {
             publisher.Start();
-            publisherWaiting = SpinWait.SpinUntil(
-                () => paused.ContainsKey(partition0)
-                    && (publisher.ThreadState & ThreadState.WaitSleepJoin) != 0,
+            publisherMutated = SpinWait.SpinUntil(
+                () => paused.ContainsKey(partition0),
                 TimeSpan.FromSeconds(5));
             paused.TryAdd(partition1, 0);
         }
@@ -125,7 +124,7 @@ public sealed class ConsumerPauseResumeCacheTests
         var publisherCompleted = publisher.Join(TimeSpan.FromSeconds(5));
         var snapshot = (HashSet<TopicPartition>)GetField("_pausedSnapshot").GetValue(consumer)!;
 
-        await Assert.That(publisherWaiting).IsTrue();
+        await Assert.That(publisherMutated).IsTrue();
         await Assert.That(publisherCompleted).IsTrue();
         await Assert.That(publisherFailure).IsNull();
         await Assert.That(snapshot.Contains(partition0)).IsTrue();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -466,6 +466,38 @@ public sealed class ConsumerPauseResumeCacheTests
     }
 
     [Test]
+    public async Task ConsumeOneAsync_PauseOtherPartitionDuringDeserialization_SuppressesItsNextRecord()
+    {
+        var firstActivePartition = new TopicPartition(PrefetchedTopic, 0);
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 1);
+        var secondActivePartition = new TopicPartition(PrefetchedTopic, 2);
+        KafkaConsumer<string, string>? consumer = null;
+        var deserializer = new CallbackOnceDeserializer(() => consumer!.Pause(pausedPartition));
+        var createdConsumer = CreatePrefetchedConsumer(
+            deserializer,
+            CreatePendingFetch(firstActivePartition, 10, 1),
+            CreatePendingFetch(pausedPartition, 20, 1),
+            CreatePendingFetch(secondActivePartition, 30, 1));
+        consumer = createdConsumer;
+        await using var ownedConsumer = createdConsumer;
+
+        var first = await createdConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(first).IsNotNull();
+        await Assert.That(first!.Value.Partition).IsEqualTo(firstActivePartition.Partition);
+
+        var second = await createdConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(second).IsNotNull();
+        await Assert.That(second!.Value.Partition).IsEqualTo(secondActivePartition.Partition);
+
+        createdConsumer.Resume(pausedPartition);
+
+        var resumed = await createdConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(resumed).IsNotNull();
+        await Assert.That(resumed!.Value.Partition).IsEqualTo(pausedPartition.Partition);
+        await Assert.That(resumed.Value.Offset).IsEqualTo(20);
+    }
+
+    [Test]
     public async Task ConsumeOneAsync_PauseDuringAsyncDeserialization_ReplaysSuppressedRecordAfterResume()
     {
         var pausedPartition = new TopicPartition(PrefetchedTopic, 0);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -1,9 +1,12 @@
+using System.Collections.Concurrent;
 using System.Reflection;
+using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 using NSubstitute;
 
@@ -11,6 +14,19 @@ namespace Dekaf.Tests.Unit.Consumer;
 
 public sealed class ConsumerPauseResumeCacheTests
 {
+    private const string PrefetchedTopic = "prefetched-topic";
+
+    private sealed class CallbackOnceDeserializer(Action callback) : IDeserializer<string>
+    {
+        private Action? _callback = callback;
+
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            Interlocked.Exchange(ref _callback, null)?.Invoke();
+            return Serializers.String.Deserialize(data, context);
+        }
+    }
+
     private static readonly MethodInfo BuildFetchRequestTopicsMethod =
         typeof(KafkaConsumer<string, string>).GetMethod(
             "BuildFetchRequestTopics",
@@ -243,6 +259,148 @@ public sealed class ConsumerPauseResumeCacheTests
         await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(0);
     }
 
+    [Test]
+    public async Task ConsumeAsync_PausedPrefetchedPartition_PreservesRecordsAndAllowsOtherPartition()
+    {
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var activePartition = new TopicPartition(PrefetchedTopic, 1);
+        await using var consumer = CreatePrefetchedConsumer(
+            CreatePendingFetch(pausedPartition, 10, 2),
+            CreatePendingFetch(activePartition, 20, 1),
+            CreatePendingFetch(pausedPartition, 12, 1));
+
+        consumer.Pause(pausedPartition);
+        await using var records = consumer.ConsumeAsync().GetAsyncEnumerator();
+
+        await Assert.That(await records.MoveNextAsync()).IsTrue();
+        await Assert.That(records.Current.Topic).IsEqualTo(activePartition.Topic);
+        await Assert.That(records.Current.Partition).IsEqualTo(activePartition.Partition);
+
+        consumer.Resume(pausedPartition);
+
+        await Assert.That(await records.MoveNextAsync()).IsTrue();
+        await Assert.That(records.Current.Topic).IsEqualTo(pausedPartition.Topic);
+        await Assert.That(records.Current.Partition).IsEqualTo(pausedPartition.Partition);
+        await Assert.That(records.Current.Offset).IsEqualTo(10);
+        await Assert.That(await records.MoveNextAsync()).IsTrue();
+        await Assert.That(records.Current.Topic).IsEqualTo(pausedPartition.Topic);
+        await Assert.That(records.Current.Partition).IsEqualTo(pausedPartition.Partition);
+        await Assert.That(records.Current.Offset).IsEqualTo(11);
+        await Assert.That(await records.MoveNextAsync()).IsTrue();
+        await Assert.That(records.Current.Offset).IsEqualTo(12);
+    }
+
+    [Test]
+    public async Task ConsumeAsync_PauseDuringDeserialization_ReplaysSuppressedRecordAfterResume()
+    {
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var activePartition = new TopicPartition(PrefetchedTopic, 1);
+        KafkaConsumer<string, string>? consumer = null;
+        var deserializer = new CallbackOnceDeserializer(() => consumer!.Pause(pausedPartition));
+        var createdConsumer = CreatePrefetchedConsumer(
+            deserializer,
+            CreatePendingFetch(pausedPartition, 10, 1),
+            CreatePendingFetch(activePartition, 20, 1));
+        consumer = createdConsumer;
+        await using var ownedConsumer = createdConsumer;
+        await using var records = createdConsumer.ConsumeAsync().GetAsyncEnumerator();
+
+        await Assert.That(await records.MoveNextAsync()).IsTrue();
+        await Assert.That(records.Current.Partition).IsEqualTo(activePartition.Partition);
+
+        createdConsumer.Resume(pausedPartition);
+
+        await Assert.That(await records.MoveNextAsync()).IsTrue();
+        await Assert.That(records.Current.Partition).IsEqualTo(pausedPartition.Partition);
+        await Assert.That(records.Current.Offset).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task ConsumeBatchAsync_PausedPrefetchedPartition_PreservesRecordsAndAllowsOtherPartition()
+    {
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var activePartition = new TopicPartition(PrefetchedTopic, 1);
+        await using var consumer = CreatePrefetchedConsumer(
+            CreatePendingFetch(pausedPartition, 10, 2),
+            CreatePendingFetch(activePartition, 20, 1),
+            CreatePendingFetch(pausedPartition, 12, 1));
+
+        consumer.Pause(pausedPartition);
+        await using var batches = consumer.ConsumeBatchAsync().GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.TopicPartition).IsEqualTo(activePartition);
+        _ = batches.Current.ToArray();
+
+        consumer.Resume(pausedPartition);
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.TopicPartition).IsEqualTo(pausedPartition);
+        var resumedOffsets = batches.Current.Select(static record => record.Offset).ToArray();
+        await Assert.That(resumedOffsets.Length).IsEqualTo(2);
+        await Assert.That(resumedOffsets[0]).IsEqualTo(10);
+        await Assert.That(resumedOffsets[1]).IsEqualTo(11);
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.Single().Offset).IsEqualTo(12);
+    }
+
+    [Test]
+    public async Task ConsumeBatchAsync_PauseDuringDeserialization_ReplaysSuppressedRecordAfterResume()
+    {
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var activePartition = new TopicPartition(PrefetchedTopic, 1);
+        KafkaConsumer<string, string>? consumer = null;
+        var deserializer = new CallbackOnceDeserializer(() => consumer!.Pause(pausedPartition));
+        var createdConsumer = CreatePrefetchedConsumer(
+            deserializer,
+            CreatePendingFetch(pausedPartition, 10, 1),
+            CreatePendingFetch(activePartition, 20, 1));
+        consumer = createdConsumer;
+        await using var ownedConsumer = createdConsumer;
+        await using var batches = createdConsumer.ConsumeBatchAsync().GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.ToArray()).IsEmpty();
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.Partition).IsEqualTo(activePartition.Partition);
+        _ = batches.Current.ToArray();
+
+        createdConsumer.Resume(pausedPartition);
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.Partition).IsEqualTo(pausedPartition.Partition);
+        await Assert.That(batches.Current.Single().Offset).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task ConsumeRawBatchAsync_PausedPrefetchedPartition_PreservesRecordsAndAllowsOtherPartition()
+    {
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var activePartition = new TopicPartition(PrefetchedTopic, 1);
+        await using var consumer = CreatePrefetchedConsumer(
+            CreatePendingFetch(pausedPartition, 10, 2),
+            CreatePendingFetch(activePartition, 20, 1),
+            CreatePendingFetch(pausedPartition, 12, 1));
+
+        consumer.Pause(pausedPartition);
+        await using var batches = consumer.ConsumeRawBatchAsync().GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.TopicPartition).IsEqualTo(activePartition);
+        _ = batches.Current.ToArray();
+
+        consumer.Resume(pausedPartition);
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.TopicPartition).IsEqualTo(pausedPartition);
+        var resumedOffsets = batches.Current.Select(static record => record.Offset).ToArray();
+        await Assert.That(resumedOffsets.Length).IsEqualTo(2);
+        await Assert.That(resumedOffsets[0]).IsEqualTo(10);
+        await Assert.That(resumedOffsets[1]).IsEqualTo(11);
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.Single().Offset).IsEqualTo(12);
+    }
+
     private static KafkaConsumer<string, string> CreateConsumer(
         IConnectionPool pool,
         MetadataManager metadataManager)
@@ -257,6 +415,75 @@ public sealed class ConsumerPauseResumeCacheTests
             Serializers.String,
             pool,
             metadataManager);
+
+    private static KafkaConsumer<string, string> CreatePrefetchedConsumer(params PendingFetchData[] fetches) =>
+        CreatePrefetchedConsumer(Serializers.String, fetches);
+
+    private static KafkaConsumer<string, string> CreatePrefetchedConsumer(
+        IDeserializer<string> valueDeserializer,
+        params PendingFetchData[] fetches)
+    {
+        var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                QueuedMinMessages = 1
+            },
+            Serializers.String,
+            valueDeserializer);
+        var partitions = fetches
+            .Select(static fetch => fetch.TopicPartition)
+            .Distinct()
+            .ToArray();
+        consumer.Assign(partitions);
+
+        GetField("_initialized").SetValue(consumer, true);
+        var fetchPositions = (ConcurrentDictionary<TopicPartition, long>)
+            GetField("_fetchPositions").GetValue(consumer)!;
+        var pendingFetches = (Queue<PendingFetchData>)
+            GetField("_pendingFetches").GetValue(consumer)!;
+
+        foreach (var partition in partitions)
+            fetchPositions[partition] = 0;
+        foreach (var fetch in fetches)
+            pendingFetches.Enqueue(fetch);
+        GetField("_pendingFetchDepth").SetValue(consumer, fetches.Length);
+
+        return consumer;
+    }
+
+    private static PendingFetchData CreatePendingFetch(
+        TopicPartition partition,
+        long baseOffset,
+        int recordCount)
+    {
+        var records = new Record[recordCount];
+        for (var i = 0; i < records.Length; i++)
+        {
+            records[i] = new Record
+            {
+                OffsetDelta = i,
+                Key = Encoding.UTF8.GetBytes($"key-{i}"),
+                Value = Encoding.UTF8.GetBytes($"value-{i}"),
+                IsKeyNull = false,
+                IsValueNull = false
+            };
+        }
+
+        return PendingFetchData.Create(partition.Topic, partition.Partition,
+        [
+            new RecordBatch
+            {
+                BaseOffset = baseOffset,
+                BaseTimestamp = 1_700_000_000_000,
+                Records = records
+            }
+        ]);
+    }
+
+    private static FieldInfo GetField(string name) =>
+        typeof(KafkaConsumer<string, string>).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException($"{name} field not found");
 
     private static MetadataManager CreateMetadataManager(IConnectionPool pool)
         => CreateMetadataManager(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -315,6 +315,193 @@ public sealed class ConsumerPauseResumeCacheTests
         await Assert.That(records.Current.Offset).IsEqualTo(10);
     }
 
+    private sealed class AsyncCallbackOnceDeserializer(Action callback) : IAsyncDeserializer<string>
+    {
+        private Action? _callback = callback;
+
+        public ValueTask<string> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Interlocked.Exchange(ref _callback, null)?.Invoke();
+            return new ValueTask<string>(Serializers.String.Deserialize(data, context));
+        }
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_PausedPrefetchedPartition_PreservesRecordAndAllowsOtherPartition()
+    {
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var activePartition = new TopicPartition(PrefetchedTopic, 1);
+        await using var consumer = CreatePrefetchedConsumer(
+            CreatePendingFetch(pausedPartition, 10, 1),
+            CreatePendingFetch(activePartition, 20, 1));
+
+        consumer.Pause(pausedPartition);
+
+        var active = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(active).IsNotNull();
+        await Assert.That(active!.Value.Topic).IsEqualTo(activePartition.Topic);
+        await Assert.That(active.Value.Partition).IsEqualTo(activePartition.Partition);
+        await Assert.That(active.Value.Offset).IsEqualTo(20);
+
+        consumer.Resume(pausedPartition);
+
+        var resumed = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(resumed).IsNotNull();
+        await Assert.That(resumed!.Value.Topic).IsEqualTo(pausedPartition.Topic);
+        await Assert.That(resumed.Value.Partition).IsEqualTo(pausedPartition.Partition);
+        await Assert.That(resumed.Value.Offset).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_PauseDuringDeserialization_ReplaysSuppressedRecordAfterResume()
+    {
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var activePartition = new TopicPartition(PrefetchedTopic, 1);
+        KafkaConsumer<string, string>? consumer = null;
+        var deserializer = new CallbackOnceDeserializer(() => consumer!.Pause(pausedPartition));
+        var createdConsumer = CreatePrefetchedConsumer(
+            deserializer,
+            CreatePendingFetch(pausedPartition, 10, 1),
+            CreatePendingFetch(activePartition, 20, 1));
+        consumer = createdConsumer;
+        await using var ownedConsumer = createdConsumer;
+
+        var active = await createdConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(active).IsNotNull();
+        await Assert.That(active!.Value.Topic).IsEqualTo(activePartition.Topic);
+        await Assert.That(active.Value.Partition).IsEqualTo(activePartition.Partition);
+
+        createdConsumer.Resume(pausedPartition);
+
+        var resumed = await createdConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(resumed).IsNotNull();
+        await Assert.That(resumed!.Value.Topic).IsEqualTo(pausedPartition.Topic);
+        await Assert.That(resumed.Value.Partition).IsEqualTo(pausedPartition.Partition);
+        await Assert.That(resumed.Value.Offset).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_PauseDuringAsyncDeserialization_ReplaysSuppressedRecordAfterResume()
+    {
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var activePartition = new TopicPartition(PrefetchedTopic, 1);
+        KafkaConsumer<string, string>? consumer = null;
+        var deserializer = new AsyncCallbackOnceDeserializer(() => consumer!.Pause(pausedPartition));
+        var createdConsumer = CreatePrefetchedConsumer(
+            deserializer,
+            CreatePendingFetch(pausedPartition, 10, 1),
+            CreatePendingFetch(activePartition, 20, 1));
+        consumer = createdConsumer;
+        await using var ownedConsumer = createdConsumer;
+
+        var active = await createdConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(active).IsNotNull();
+        await Assert.That(active!.Value.Topic).IsEqualTo(activePartition.Topic);
+        await Assert.That(active.Value.Partition).IsEqualTo(activePartition.Partition);
+
+        createdConsumer.Resume(pausedPartition);
+
+        var resumed = await createdConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(resumed).IsNotNull();
+        await Assert.That(resumed!.Value.Topic).IsEqualTo(pausedPartition.Topic);
+        await Assert.That(resumed.Value.Partition).IsEqualTo(pausedPartition.Partition);
+        await Assert.That(resumed.Value.Offset).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task ConsumeAsync_ResumeBeforePrefetchWaitRegistration_WakesRetainedRecord()
+    {
+        var partition = new TopicPartition(PrefetchedTopic, 0);
+        using var waitEntered = new ManualResetEventSlim();
+        using var releaseWait = new ManualResetEventSlim();
+        var prefetchBuffer = new MpscFetchBuffer(
+            4,
+            afterProducerWaiterCountIncrementedForTesting: null,
+            beforeConsumerWaitSpinForTesting: () =>
+            {
+                waitEntered.Set();
+                releaseWait.Wait();
+            });
+        var retained = CreatePendingFetch(partition, 10, 1);
+        var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                QueuedMinMessages = 2
+            },
+            Serializers.String,
+            Serializers.String);
+        consumer.Assign(partition);
+        GetField("_initialized").SetValue(consumer, true);
+        var fetchPositions = (ConcurrentDictionary<TopicPartition, long>)
+            GetField("_fetchPositions").GetValue(consumer)!;
+        fetchPositions[partition] = 0;
+        var pendingFetches = (Queue<PendingFetchData>)GetField("_pendingFetches").GetValue(consumer)!;
+        pendingFetches.Enqueue(retained);
+        GetField("_pendingFetchDepth").SetValue(consumer, 1);
+        consumer.Pause(partition);
+        GetField("_prefetchTask").SetValue(consumer, Task.CompletedTask);
+        var prefetchBufferField = GetField("_prefetchBuffer");
+        var originalPrefetchBuffer = (MpscFetchBuffer)prefetchBufferField.GetValue(consumer)!;
+        prefetchBufferField.SetValue(consumer, prefetchBuffer);
+        originalPrefetchBuffer.Dispose();
+
+        await using var ownedConsumer = consumer;
+        await using var records = consumer.ConsumeAsync().GetAsyncEnumerator();
+        var moveNext = Task.Run(() => records.MoveNextAsync().AsTask());
+
+        try
+        {
+            await Assert.That(waitEntered.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            consumer.Resume(partition);
+        }
+        finally
+        {
+            releaseWait.Set();
+        }
+
+        await Assert.That(await moveNext.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+        await Assert.That(records.Current.Topic).IsEqualTo(partition.Topic);
+        await Assert.That(records.Current.Partition).IsEqualTo(partition.Partition);
+        await Assert.That(records.Current.Offset).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task RebalanceDrain_RoutesRetainedPausedFetchToPausedQueue()
+    {
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var revokedPartition = new TopicPartition(PrefetchedTopic, 1);
+        await using var consumer = CreatePrefetchedConsumer();
+        consumer.Assign(pausedPartition, revokedPartition);
+        consumer.Pause(pausedPartition);
+        var prefetchBuffer = (MpscFetchBuffer)GetField("_prefetchBuffer").GetValue(consumer)!;
+        var retained = CreatePendingFetch(pausedPartition, 10, 1);
+        var revoked = CreatePendingFetch(revokedPartition, 20, 1);
+        await Assert.That(prefetchBuffer.TryWrite(retained)).IsTrue();
+        await Assert.That(prefetchBuffer.TryWrite(revoked)).IsTrue();
+        GetField("_prefetchedBytes").SetValue(
+            consumer,
+            KafkaConsumer<string, string>.EstimatePendingFetchBytes(retained)
+            + KafkaConsumer<string, string>.EstimatePendingFetchBytes(revoked));
+        var drain = typeof(KafkaConsumer<string, string>).GetMethod(
+            "DrainPrefetchBufferForPartitions",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("DrainPrefetchBufferForPartitions method not found");
+
+        drain.Invoke(consumer, [new HashSet<TopicPartition> { revokedPartition }]);
+
+        var active = (Queue<PendingFetchData>)GetField("_pendingFetches").GetValue(consumer)!;
+        var paused = (Queue<PendingFetchData>)GetField("_pausedPendingFetches").GetValue(consumer)!;
+        await Assert.That(active).IsEmpty();
+        await Assert.That(paused.Count).IsEqualTo(1);
+        await Assert.That(paused.Peek().TopicPartition).IsEqualTo(pausedPartition);
+        await Assert.That((int)GetField("_pendingFetchDepth").GetValue(consumer)!).IsEqualTo(1);
+    }
+
     [Test]
     public async Task ConsumeAsync_RevocationDuringPrefetchWait_SuppressesRevokedPartition()
     {
@@ -421,16 +608,17 @@ public sealed class ConsumerPauseResumeCacheTests
         await using var batches = createdConsumer.ConsumeBatchAsync().GetAsyncEnumerator();
 
         await Assert.That(await batches.MoveNextAsync()).IsTrue();
-        await Assert.That(batches.Current.ToArray()).IsEmpty();
-        await Assert.That(await batches.MoveNextAsync()).IsTrue();
-        await Assert.That(batches.Current.Partition).IsEqualTo(activePartition.Partition);
-        _ = batches.Current.ToArray();
-
+        var interrupted = batches.Current.GetEnumerator();
+        await Assert.That(interrupted.MoveNext()).IsFalse();
         createdConsumer.Resume(pausedPartition);
-
+        await Assert.That(interrupted.MoveNext()).IsFalse();
         await Assert.That(await batches.MoveNextAsync()).IsTrue();
         await Assert.That(batches.Current.Partition).IsEqualTo(pausedPartition.Partition);
         await Assert.That(batches.Current.Single().Offset).IsEqualTo(10);
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.Partition).IsEqualTo(activePartition.Partition);
+        _ = batches.Current.ToArray();
     }
 
     [Test]
@@ -483,6 +671,17 @@ public sealed class ConsumerPauseResumeCacheTests
     private static KafkaConsumer<string, string> CreatePrefetchedConsumer(
         IDeserializer<string> valueDeserializer,
         params PendingFetchData[] fetches)
+        => CreatePrefetchedConsumer(valueDeserializer, null, fetches);
+
+    private static KafkaConsumer<string, string> CreatePrefetchedConsumer(
+        IAsyncDeserializer<string> asyncValueDeserializer,
+        params PendingFetchData[] fetches)
+        => CreatePrefetchedConsumer(Serializers.String, asyncValueDeserializer, fetches);
+
+    private static KafkaConsumer<string, string> CreatePrefetchedConsumer(
+        IDeserializer<string> valueDeserializer,
+        IAsyncDeserializer<string>? asyncValueDeserializer,
+        params PendingFetchData[] fetches)
     {
         var consumer = new KafkaConsumer<string, string>(
             new ConsumerOptions
@@ -491,7 +690,8 @@ public sealed class ConsumerPauseResumeCacheTests
                 QueuedMinMessages = 1
             },
             Serializers.String,
-            valueDeserializer);
+            valueDeserializer,
+            asyncValueDeserializer: asyncValueDeserializer);
         var partitions = fetches
             .Select(static fetch => fetch.TopicPartition)
             .Distinct()

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -316,6 +316,67 @@ public sealed class ConsumerPauseResumeCacheTests
     }
 
     [Test]
+    public async Task ConsumeAsync_RevocationDuringPrefetchWait_SuppressesRevokedPartition()
+    {
+        var revokedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var activePartition = new TopicPartition(PrefetchedTopic, 1);
+        using var waitEntered = new ManualResetEventSlim();
+        using var releaseWait = new ManualResetEventSlim();
+        var prefetchBuffer = new MpscFetchBuffer(
+            4,
+            afterProducerWaiterCountIncrementedForTesting: null,
+            beforeConsumerWaitSpinForTesting: () =>
+            {
+                waitEntered.Set();
+                releaseWait.Wait();
+            });
+        var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                QueuedMinMessages = 2
+            },
+            Serializers.String,
+            Serializers.String);
+        consumer.Assign([revokedPartition, activePartition]);
+        GetField("_initialized").SetValue(consumer, true);
+        GetField("_prefetchTask").SetValue(consumer, Task.CompletedTask);
+        var fetchPositions = (ConcurrentDictionary<TopicPartition, long>)
+            GetField("_fetchPositions").GetValue(consumer)!;
+        fetchPositions[revokedPartition] = 0;
+        fetchPositions[activePartition] = 0;
+        var prefetchBufferField = GetField("_prefetchBuffer");
+        var originalPrefetchBuffer = (MpscFetchBuffer)prefetchBufferField.GetValue(consumer)!;
+        prefetchBufferField.SetValue(consumer, prefetchBuffer);
+        originalPrefetchBuffer.Dispose();
+
+        await using var ownedConsumer = consumer;
+        await using var records = consumer.ConsumeAsync().GetAsyncEnumerator();
+        var moveNext = Task.Run(() => records.MoveNextAsync().AsTask());
+        var stagePendingClear = typeof(KafkaConsumer<string, string>).GetMethod(
+            "StagePendingFetchClear",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("StagePendingFetchClear method not found");
+
+        try
+        {
+            await Assert.That(waitEntered.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            stagePendingClear.Invoke(consumer, [revokedPartition]);
+            await Assert.That(prefetchBuffer.TryWrite(CreatePendingFetch(revokedPartition, 10, 1))).IsTrue();
+            await Assert.That(prefetchBuffer.TryWrite(CreatePendingFetch(activePartition, 20, 1))).IsTrue();
+        }
+        finally
+        {
+            releaseWait.Set();
+        }
+
+        await Assert.That(await moveNext.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+        await Assert.That(records.Current.Topic).IsEqualTo(activePartition.Topic);
+        await Assert.That(records.Current.Partition).IsEqualTo(activePartition.Partition);
+        await Assert.That(records.Current.Offset).IsEqualTo(20);
+    }
+
+    [Test]
     public async Task ConsumeBatchAsync_PausedPrefetchedPartition_PreservesRecordsAndAllowsOtherPartition()
     {
         var pausedPartition = new TopicPartition(PrefetchedTopic, 0);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -859,6 +859,31 @@ public sealed class ConsumerPauseResumeCacheTests
     }
 
     [Test]
+    public async Task ConsumeBatchAsync_PauseAfterFinalRecord_SkipsExhaustedBatchAfterResume()
+    {
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var activePartition = new TopicPartition(PrefetchedTopic, 1);
+        await using var consumer = CreatePrefetchedConsumer(
+            CreatePendingFetch(pausedPartition, 10, 1),
+            CreatePendingFetch(activePartition, 20, 1));
+        await using var batches = consumer.ConsumeBatchAsync().GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        using (var records = batches.Current.GetEnumerator())
+        {
+            await Assert.That(records.MoveNext()).IsTrue();
+            consumer.Pause(pausedPartition);
+            await Assert.That(records.MoveNext()).IsFalse();
+        }
+
+        consumer.Resume(pausedPartition);
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.TopicPartition).IsEqualTo(activePartition);
+        await Assert.That(batches.Current.Single().Offset).IsEqualTo(20);
+    }
+
+    [Test]
     public async Task ConsumeRawBatchAsync_PausedPrefetchedPartition_PreservesRecordsAndAllowsOtherPartition()
     {
         var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
@@ -885,6 +910,31 @@ public sealed class ConsumerPauseResumeCacheTests
         await Assert.That(resumedOffsets[1]).IsEqualTo(11);
         await Assert.That(await batches.MoveNextAsync()).IsTrue();
         await Assert.That(batches.Current.Single().Offset).IsEqualTo(12);
+    }
+
+    [Test]
+    public async Task ConsumeRawBatchAsync_PauseAfterFinalRecord_SkipsExhaustedBatchAfterResume()
+    {
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var activePartition = new TopicPartition(PrefetchedTopic, 1);
+        await using var consumer = CreatePrefetchedConsumer(
+            CreatePendingFetch(pausedPartition, 10, 1),
+            CreatePendingFetch(activePartition, 20, 1));
+        await using var batches = consumer.ConsumeRawBatchAsync().GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        using (var records = batches.Current.GetEnumerator())
+        {
+            await Assert.That(records.MoveNext()).IsTrue();
+            consumer.Pause(pausedPartition);
+            await Assert.That(records.MoveNext()).IsFalse();
+        }
+
+        consumer.Resume(pausedPartition);
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.TopicPartition).IsEqualTo(activePartition);
+        await Assert.That(batches.Current.Single().Offset).IsEqualTo(20);
     }
 
     private static KafkaConsumer<string, string> CreateConsumer(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -371,6 +371,62 @@ public sealed class ConsumerPauseResumeCacheTests
     }
 
     [Test]
+    public async Task PrefetchDrain_PausePublicationBetweenSamePartitionFetches_PreservesFifo()
+    {
+        var partition = new TopicPartition(PrefetchedTopic, 0);
+        await using var consumer = CreatePrefetchedConsumer();
+        consumer.Assign(partition);
+        var fetchPositions = (ConcurrentDictionary<TopicPartition, long>)
+            GetField("_fetchPositions").GetValue(consumer)!;
+        fetchPositions[partition] = 0;
+        var enqueue = typeof(KafkaConsumer<string, string>).GetMethod(
+            "EnqueuePendingFetch",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("EnqueuePendingFetch method not found");
+        var prepare = typeof(KafkaConsumer<string, string>).GetMethod(
+            "PreparePendingFetchesForDelivery",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("PreparePendingFetchesForDelivery method not found");
+
+        enqueue.Invoke(consumer, [CreatePendingFetch(partition, 10, 1)]);
+        consumer.Pause(partition);
+        enqueue.Invoke(consumer, [CreatePendingFetch(partition, 20, 1)]);
+        consumer.Resume(partition);
+        prepare.Invoke(consumer, null);
+
+        var active = (Queue<PendingFetchData>)GetField("_pendingFetches").GetValue(consumer)!;
+        var ordered = active.ToArray();
+        await Assert.That(ordered).Count().IsEqualTo(2);
+        await Assert.That(ordered[0].GetBatches()[0].BaseOffset).IsEqualTo(10L);
+        await Assert.That(ordered[1].GetBatches()[0].BaseOffset).IsEqualTo(20L);
+    }
+
+    [Test]
+    public async Task BatchIteration_UnassignedPartitionWithStalePause_IsStoppedNotPaused()
+    {
+        var partition = new TopicPartition(PrefetchedTopic, 0);
+        await using var consumer = CreatePrefetchedConsumer(CreatePendingFetch(partition, 10, 1));
+        consumer.Pause(partition);
+        var assignment = (HashSet<TopicPartition>)GetField("_assignment").GetValue(consumer)!;
+        assignment.Remove(partition);
+        var publishAssignment = typeof(KafkaConsumer<string, string>).GetMethod(
+            "PublishAssignmentSnapshot",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("PublishAssignmentSnapshot method not found");
+        publishAssignment.Invoke(consumer, null);
+        var canContinue = typeof(KafkaConsumer<string, string>).GetMethod(
+            "CanContinueBatchIterationWithPause",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("CanContinueBatchIterationWithPause method not found");
+        object?[] arguments = [partition, false];
+
+        var result = (bool)canContinue.Invoke(consumer, arguments)!;
+
+        await Assert.That(result).IsFalse();
+        await Assert.That((bool)arguments[1]!).IsFalse();
+    }
+
+    [Test]
     public async Task ConsumeAsync_PauseDuringDeserialization_ReplaysSuppressedRecordAfterResume()
     {
         var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
@@ -460,6 +516,7 @@ public sealed class ConsumerPauseResumeCacheTests
         await Assert.That(resumed!.Value.Topic).IsEqualTo(partition.Topic);
         await Assert.That(resumed.Value.Partition).IsEqualTo(partition.Partition);
         await Assert.That(resumed.Value.Offset).IsEqualTo(10);
+        await Assert.That(pausedDirectFetchCancellationSource.GetValue(consumer)).IsNull();
     }
 
     [Test]
@@ -488,6 +545,27 @@ public sealed class ConsumerPauseResumeCacheTests
         await Assert.That(resumed!.Value.Topic).IsEqualTo(pausedPartition.Topic);
         await Assert.That(resumed.Value.Partition).IsEqualTo(pausedPartition.Partition);
         await Assert.That(resumed.Value.Offset).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task ConsumeOneBuffered_PausedHeadContinuesToActiveFetchSynchronously()
+    {
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var activePartition = new TopicPartition(PrefetchedTopic, 1);
+        KafkaConsumer<string, string>? consumer = null;
+        var deserializer = new CallbackOnceDeserializer(() => consumer!.Pause(pausedPartition));
+        var createdConsumer = CreatePrefetchedConsumer(
+            deserializer,
+            CreatePendingFetch(pausedPartition, 10, 1),
+            CreatePendingFetch(activePartition, 20, 1));
+        consumer = createdConsumer;
+        await using var ownedConsumer = createdConsumer;
+
+        var consumed = TryConsumeOneFromPendingFetches(createdConsumer, out var result);
+
+        await Assert.That(consumed).IsTrue();
+        await Assert.That(result.Partition).IsEqualTo(activePartition.Partition);
+        await Assert.That(result.Offset).IsEqualTo(20L);
     }
 
     [Test]
@@ -548,6 +626,27 @@ public sealed class ConsumerPauseResumeCacheTests
         await Assert.That(resumed!.Value.Topic).IsEqualTo(pausedPartition.Topic);
         await Assert.That(resumed.Value.Partition).IsEqualTo(pausedPartition.Partition);
         await Assert.That(resumed.Value.Offset).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task ConsumeOneBuffered_PausedHeadContinuesToActiveFetchWithAsyncDeserializer()
+    {
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var activePartition = new TopicPartition(PrefetchedTopic, 1);
+        KafkaConsumer<string, string>? consumer = null;
+        var deserializer = new AsyncCallbackOnceDeserializer(() => consumer!.Pause(pausedPartition));
+        var createdConsumer = CreatePrefetchedConsumer(
+            deserializer,
+            CreatePendingFetch(pausedPartition, 10, 1),
+            CreatePendingFetch(activePartition, 20, 1));
+        consumer = createdConsumer;
+        await using var ownedConsumer = createdConsumer;
+
+        var result = await ConsumeOneFromPendingFetchesAsync(createdConsumer);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Partition).IsEqualTo(activePartition.Partition);
+        await Assert.That(result.Value.Offset).IsEqualTo(20L);
     }
 
     [Test]
@@ -883,6 +982,34 @@ public sealed class ConsumerPauseResumeCacheTests
     private static FieldInfo GetField(string name) =>
         typeof(KafkaConsumer<string, string>).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
         ?? throw new InvalidOperationException($"{name} field not found");
+
+    private static bool TryConsumeOneFromPendingFetches(
+        KafkaConsumer<string, string> consumer,
+        out ConsumeResult<string, string> result)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "TryConsumeOneFromPendingFetches",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("TryConsumeOneFromPendingFetches method not found");
+        object?[] arguments = [null];
+        var consumed = (bool)method.Invoke(consumer, arguments)!;
+        result = arguments[0] is ConsumeResult<string, string> consumeResult
+            ? consumeResult
+            : default;
+        return consumed;
+    }
+
+    private static ValueTask<ConsumeResult<string, string>?> ConsumeOneFromPendingFetchesAsync(
+        KafkaConsumer<string, string> consumer)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "ConsumeOneFromPendingFetchesAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("ConsumeOneFromPendingFetchesAsync method not found");
+        return (ValueTask<ConsumeResult<string, string>?>)method.Invoke(
+            consumer,
+            [CancellationToken.None])!;
+    }
 
     private static MetadataManager CreateMetadataManager(IConnectionPool pool)
         => CreateMetadataManager(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -884,6 +884,32 @@ public sealed class ConsumerPauseResumeCacheTests
     }
 
     [Test]
+    public async Task ConsumeBatchAsync_ControlChangeAfterPausedFinalRecord_RetainsExhaustionProbe()
+    {
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var activePartition = new TopicPartition(PrefetchedTopic, 1);
+        await using var consumer = CreatePrefetchedConsumer(
+            CreatePendingFetch(pausedPartition, 10, 1),
+            CreatePendingFetch(activePartition, 20, 1));
+        await using var batches = consumer.ConsumeBatchAsync().GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        using (var records = batches.Current.GetEnumerator())
+        {
+            await Assert.That(records.MoveNext()).IsTrue();
+            consumer.Pause(pausedPartition);
+            await Assert.That(records.MoveNext()).IsFalse();
+        }
+
+        consumer.Seek(new TopicPartitionOffset(PrefetchedTopic, 2, 100));
+        consumer.Resume(pausedPartition);
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.TopicPartition).IsEqualTo(activePartition);
+        await Assert.That(batches.Current.Single().Offset).IsEqualTo(20);
+    }
+
+    [Test]
     public async Task ConsumeBatchAsync_SeekAfterPausedFinalRecord_DoesNotProbeDisposedFetch()
     {
         var partition = new TopicPartition(PrefetchedTopic, 0);
@@ -949,6 +975,32 @@ public sealed class ConsumerPauseResumeCacheTests
             await Assert.That(records.MoveNext()).IsFalse();
         }
 
+        consumer.Resume(pausedPartition);
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.TopicPartition).IsEqualTo(activePartition);
+        await Assert.That(batches.Current.Single().Offset).IsEqualTo(20);
+    }
+
+    [Test]
+    public async Task ConsumeRawBatchAsync_ControlChangeAfterPausedFinalRecord_RetainsExhaustionProbe()
+    {
+        var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
+        var activePartition = new TopicPartition(PrefetchedTopic, 1);
+        await using var consumer = CreatePrefetchedConsumer(
+            CreatePendingFetch(pausedPartition, 10, 1),
+            CreatePendingFetch(activePartition, 20, 1));
+        await using var batches = consumer.ConsumeRawBatchAsync().GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        using (var records = batches.Current.GetEnumerator())
+        {
+            await Assert.That(records.MoveNext()).IsTrue();
+            consumer.Pause(pausedPartition);
+            await Assert.That(records.MoveNext()).IsFalse();
+        }
+
+        consumer.Seek(new TopicPartitionOffset(PrefetchedTopic, 2, 100));
         consumer.Resume(pausedPartition);
 
         await Assert.That(await batches.MoveNextAsync()).IsTrue();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -884,6 +884,25 @@ public sealed class ConsumerPauseResumeCacheTests
     }
 
     [Test]
+    public async Task ConsumeBatchAsync_SeekAfterPausedFinalRecord_DoesNotProbeDisposedFetch()
+    {
+        var partition = new TopicPartition(PrefetchedTopic, 0);
+        await using var consumer = CreatePrefetchedConsumer(CreatePendingFetch(partition, 10, 1));
+        var batches = consumer.ConsumeBatchAsync().GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        using (var records = batches.Current.GetEnumerator())
+        {
+            await Assert.That(records.MoveNext()).IsTrue();
+            consumer.Pause(partition);
+            await Assert.That(records.MoveNext()).IsFalse();
+        }
+
+        consumer.Seek(new TopicPartitionOffset(partition.Topic, partition.Partition, 100));
+        await batches.DisposeAsync();
+    }
+
+    [Test]
     public async Task ConsumeRawBatchAsync_PausedPrefetchedPartition_PreservesRecordsAndAllowsOtherPartition()
     {
         var pausedPartition = new TopicPartition(PrefetchedTopic, 0);
@@ -935,6 +954,25 @@ public sealed class ConsumerPauseResumeCacheTests
         await Assert.That(await batches.MoveNextAsync()).IsTrue();
         await Assert.That(batches.Current.TopicPartition).IsEqualTo(activePartition);
         await Assert.That(batches.Current.Single().Offset).IsEqualTo(20);
+    }
+
+    [Test]
+    public async Task ConsumeRawBatchAsync_SeekAfterPausedFinalRecord_DoesNotProbeDisposedFetch()
+    {
+        var partition = new TopicPartition(PrefetchedTopic, 0);
+        await using var consumer = CreatePrefetchedConsumer(CreatePendingFetch(partition, 10, 1));
+        var batches = consumer.ConsumeRawBatchAsync().GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        using (var records = batches.Current.GetEnumerator())
+        {
+            await Assert.That(records.MoveNext()).IsTrue();
+            consumer.Pause(partition);
+            await Assert.That(records.MoveNext()).IsFalse();
+        }
+
+        consumer.Seek(new TopicPartitionOffset(partition.Topic, partition.Partition, 100));
+        await batches.DisposeAsync();
     }
 
     private static KafkaConsumer<string, string> CreateConsumer(

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -103,6 +103,29 @@ public sealed class OffsetStoreTimingTests
     }
 
     [Test]
+    public async Task CommitAsync_ManualModeAfterPauseReconciliation_VouchesForInDoubtRecord()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Manual, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+        await using var records = consumer.ConsumeAsync(CancellationToken.None).GetAsyncEnumerator();
+
+        await Assert.That(await records.MoveNextAsync()).IsTrue();
+        await Assert.That(records.Current.Offset).IsEqualTo(20L);
+
+        consumer.Pause(tp);
+        consumer.Seek(new TopicPartitionOffset(Topic, Partition + 1, 100));
+        await consumer.CommitAsync(CancellationToken.None);
+
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
+    }
+
+    [Test]
     public async Task ConsumeOne_DeserializerFailure_RewindsForRedelivery()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -81,6 +81,28 @@ public sealed class OffsetStoreTimingTests
     }
 
     [Test]
+    public async Task ConsumeAsync_PauseThenSeekOtherPartition_DoesNotStageInDoubtRecord()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+        await using var records = consumer.ConsumeAsync(CancellationToken.None).GetAsyncEnumerator();
+
+        await Assert.That(await records.MoveNextAsync()).IsTrue();
+        await Assert.That(records.Current.Offset).IsEqualTo(20L);
+
+        consumer.Pause(tp);
+        consumer.Seek(new TopicPartitionOffset(Topic, Partition + 1, 100));
+
+        await Assert.That(GetDirtyStoredOffsets(consumer).ContainsKey(tp)).IsFalse();
+    }
+
+    [Test]
     public async Task ConsumeOne_DeserializerFailure_RewindsForRedelivery()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -710,6 +710,26 @@ public sealed class OffsetStoreTimingTests
     }
 
     [Test]
+    public async Task ConsumeOneAsync_PauseBeforeNextPoll_StagesProcessedRecord()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None)).IsNotNull();
+
+        consumer.Pause(tp);
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(100), CancellationToken.None)).IsNull();
+
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
+    }
+
+    [Test]
     public async Task CommitAsync_ThenClose_DoesNotRegressActiveConsumedOffset()
     {
         var requests = new List<OffsetCommitRequest>();

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -1376,7 +1376,12 @@ public sealed class PartitionedConsumerRuntimeTests
                     pending,
                     Serializers.String,
                     Serializers.String,
-                    new BatchIterationGuard(null, 0, IsAssigned));
+                    new BatchIterationGuard(
+                        null,
+                        0,
+                        partition => IsAssigned(partition)
+                            ? BatchIterationStatus.Continue
+                            : BatchIterationStatus.Stopped));
             }
         }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerHotPathBenchmarks.cs
@@ -20,6 +20,9 @@ public class ConsumerHotPathBenchmarks
     private const int MessageCount = 1_000;
 
     private readonly SingleRecordBatchList _batchList = new();
+    private readonly BatchIterationEpoch _batchIterationEpoch = new();
+    private readonly BatchIterationContinuation _canContinueBatchIteration =
+        static _ => BatchIterationStatus.Continue;
     private readonly CachingStringDeserializer _cachedRepeatedStringValueDeserializer =
         new(Serializers.String, maxCachedBytes: 4 * 1024, maxCachedEntries: 128);
     private CachingStringDeserializer _uniqueValuesCachedStringDeserializer = null!;
@@ -91,6 +94,26 @@ public class ConsumerHotPathBenchmarks
     {
         using var pending = CreatePendingFetchData();
         var batch = new ConsumeRawBatch(pending);
+        var bytes = 0;
+
+        foreach (var record in batch)
+        {
+            bytes += record.Value.Length;
+        }
+
+        return bytes;
+    }
+
+    [Benchmark(OperationsPerInvoke = MessageCount, Description = "Raw batch guarded enumerate")]
+    public int ConsumeRawBatch_GuardedEnumerate()
+    {
+        using var pending = CreatePendingFetchData();
+        var batch = new ConsumeRawBatch(
+            pending,
+            new BatchIterationGuard(
+                _batchIterationEpoch,
+                _batchIterationEpoch.Version,
+                _canContinueBatchIteration));
         var bytes = 0;
 
         foreach (var record in batch)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerHotPathBenchmarks.cs
@@ -142,6 +142,28 @@ public class ConsumerHotPathBenchmarks
         return bytes;
     }
 
+    [Benchmark(OperationsPerInvoke = MessageCount, Description = "Typed batch raw bytes guarded enumerate")]
+    public int ConsumeBatch_RawBytes_GuardedEnumerate()
+    {
+        using var pending = CreatePendingFetchData();
+        var batch = new ConsumeBatch<Ignore, ReadOnlyMemory<byte>>(
+            pending,
+            Serializers.Ignore,
+            Serializers.RawBytes,
+            new BatchIterationGuard(
+                _batchIterationEpoch,
+                _batchIterationEpoch.Version,
+                _canContinueBatchIteration));
+        var bytes = 0;
+
+        foreach (var result in batch)
+        {
+            bytes += result.Value.Length;
+        }
+
+        return bytes;
+    }
+
     [Benchmark(OperationsPerInvoke = MessageCount, Description = "Typed batch string deserialize")]
     public int ConsumeBatch_String_Deserialize()
     {


### PR DESCRIPTION
## Summary
- suppress already-buffered records for paused partitions across `ConsumeAsync`, `ConsumeBatchAsync`, and `ConsumeRawBatchAsync`
- retain deferred fetch owners and replay them on resume in original per-partition order and offsets
- preserve revocation/divergence discard semantics and document the concurrent-pause delivery boundary
- add deterministic unit tests and real-Kafka coverage for all three APIs

## Performance
Exact same-machine comparison against `1d2f7c91` using `ConsumeAsyncBufferedFastPathBenchmarks` (`MemoryDiagnoser`, 15 warmups, 10 measured iterations):

| Message | Baseline | Candidate | Delta | Allocated |
|---|---:|---:|---:|---:|
| 100 B | 67.99 ns | 64.41 ns | -5.3% latency / +5.6% throughput | 0 B |
| 1000 B | 68.46 ns | 64.89 ns | -5.2% latency / +5.5% throughput | 0 B |

The steady-state delivery path adds only a pause-version read. O(n) queue rearrangement occurs only when the pause snapshot changes.

## Validation
- `dotnet build tests/Dekaf.Tests.Unit --configuration Release --no-restore`
- full unit suite: 6749 passed
- integration build: 0 warnings, 0 errors
- focused Kafka integration: 3 passed (`ConsumeAsync`, typed batch, raw batch)
- `npm run build` in `docs`
- `git diff --check`
- final self-review: no findings

Closes #2563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paused partitions now suppress prefetched records until resumed while preserving offsets and per-partition order.
  * Interrupted records are replayed after resuming.
  * Other assigned partitions continue consuming during a pause.

* **Bug Fixes**
  * Improved record retention across asynchronous, batch, and raw-batch consumption when pausing interrupts delivery.

* **Documentation**
  * Clarified pause and resume behavior, including rebalances and in-progress deliveries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->