### PR TITLE
fix(build): baseline Schema Registry APIs

### DIFF
--- a/src/Dekaf.SchemaRegistry.Protobuf/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry.Protobuf/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Dekaf.SchemaRegistry.Protobuf.IReferenceSubjectNameStrategy
+Dekaf.SchemaRegistry.Protobuf.IReferenceSubjectNameStrategy.GetSubjectName(string! topic, string! referenceName, bool isKey) -> string!
+Dekaf.SchemaRegistry.Protobuf.ProtobufSerializerConfig.CustomReferenceSubjectNameStrategy.get -> Dekaf.SchemaRegistry.Protobuf.IReferenceSubjectNameStrategy?
+Dekaf.SchemaRegistry.Protobuf.ProtobufSerializerConfig.CustomReferenceSubjectNameStrategy.init -> void
+Dekaf.SchemaRegistry.Protobuf.ReferenceSubjectNameStrategy.Qualified = 1 -> Dekaf.SchemaRegistry.Protobuf.ReferenceSubjectNameStrategy

--- a/src/Dekaf.SchemaRegistry/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 Dekaf.SchemaRegistry.ISchemaRegistryClient.GetCompatibilityAsync(string? subject = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Dekaf.SchemaRegistry.SchemaCompatibilityLevel>!
+Dekaf.SchemaRegistry.ISchemaRegistryClient.LookupSchemaAsync(string! subject, Dekaf.SchemaRegistry.Schema! schema, bool ignoreDeletedSchemas = true, bool normalize = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Dekaf.SchemaRegistry.RegisteredSchema!>!
 Dekaf.SchemaRegistry.ISchemaRegistryClient.UpdateCompatibilityAsync(Dekaf.SchemaRegistry.SchemaCompatibilityLevel level, string? subject = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Dekaf.SchemaRegistry.SchemaCompatibilityLevel>!
 Dekaf.SchemaRegistry.SchemaCompatibilityLevel
 Dekaf.SchemaRegistry.SchemaCompatibilityLevel.Backward = 1 -> Dekaf.SchemaRegistry.SchemaCompatibilityLevel
@@ -10,4 +11,5 @@ Dekaf.SchemaRegistry.SchemaCompatibilityLevel.Full = 5 -> Dekaf.SchemaRegistry.S
 Dekaf.SchemaRegistry.SchemaCompatibilityLevel.FullTransitive = 6 -> Dekaf.SchemaRegistry.SchemaCompatibilityLevel
 Dekaf.SchemaRegistry.SchemaCompatibilityLevel.None = 0 -> Dekaf.SchemaRegistry.SchemaCompatibilityLevel
 Dekaf.SchemaRegistry.SchemaRegistryClient.GetCompatibilityAsync(string? subject = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Dekaf.SchemaRegistry.SchemaCompatibilityLevel>!
+Dekaf.SchemaRegistry.SchemaRegistryClient.LookupSchemaAsync(string! subject, Dekaf.SchemaRegistry.Schema! schema, bool ignoreDeletedSchemas = true, bool normalize = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Dekaf.SchemaRegistry.RegisteredSchema!>!
 Dekaf.SchemaRegistry.SchemaRegistryClient.UpdateCompatibilityAsync(Dekaf.SchemaRegistry.SchemaCompatibilityLevel level, string? subject = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Dekaf.SchemaRegistry.SchemaCompatibilityLevel>!


### PR DESCRIPTION
Closes #2678

Summary:
- baseline Schema Registry lookup APIs added by #2667
- baseline Protobuf reference naming APIs added by #2667
- restore the public API analyzer gate on current main

Validation:
- dotnet build --configuration Release (0 warnings, 0 errors)
- pwsh scripts/Test-PublicApiGate.ps1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asynchronous schema lookup by subject and schema, with options for deleted schemas, normalization, and cancellation.
  * Added support for custom Protobuf reference subject naming strategies.
  * Added the qualified reference subject naming strategy option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->