### PR TITLE
perf(avro): eliminate GenericRecord allocations

### DIFF
--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -70,7 +70,10 @@ For zero-allocation `GenericRecord` serialization, Avro map values must use
 `Dictionary<string, object>`. Other `IDictionary<string, object>` implementations are rejected
 because their enumeration can allocate per message. Value-type arrays and lists are specialized
 for Avro primitives and built-in logical types; unsupported value-type element representations
-fail instead of silently boxing each element.
+fail instead of silently boxing each element. Custom logical branches in unions must declare one
+sealed CLR type and have at most one value-dependent candidate for that type. Assignable or
+multi-candidate custom logical dispatch is rejected during writer construction because it would
+require a per-message candidate scan.
 
 ## Protobuf Serialization
 

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -473,6 +473,12 @@ These formats match Confluent serializers. Avro `GenericRecord` subjects use the
 record's runtime schema, JSON Schema subjects use the schema `title` when present, and Protobuf
 subjects use the message descriptor's full name.
 
+Avro generated `ISpecificRecord` types serialize without per-message allocations when their record
+fields are scalar `null`, `boolean`, `int`, `long`, `float`, `double`, `string`, or `bytes` fields
+exposed by matching public properties. Unsupported SpecificRecord shapes fail when the serializer is
+created instead of silently falling back to Apache Avro's allocating `Get(int): object` path. Use
+`GenericRecord` for collection, union, enum, fixed, logical, or nested record fields.
+
 When using the generic `SchemaRegistrySerializer` with a record-based strategy, prefer its
 subject-independent `Func<Schema>` schema factory overload. The subject-aware `Func<string, Schema>`
 overload may be called again with the schema-derived subject until the callback and schema name agree.

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -66,6 +66,12 @@ record.Add("total", 99.99);
 await producer.ProduceAsync("orders", "order-123", record);
 ```
 
+For zero-allocation `GenericRecord` serialization, Avro map values must use
+`Dictionary<string, object>`. Other `IDictionary<string, object>` implementations are rejected
+because their enumeration can allocate per message. Value-type arrays and lists are specialized
+for Avro primitives and built-in logical types; unsupported value-type element representations
+fail instead of silently boxing each element.
+
 ## Protobuf Serialization
 
 ```csharp

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeBinaryEncoder.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeBinaryEncoder.cs
@@ -48,17 +48,29 @@ internal sealed class AllocationFreeBinaryEncoder(Stream stream) : global::Avro.
 
     public void WriteBytes(byte[] value)
     {
+        if (value is null)
+            throw new global::Avro.AvroTypeException("Null cannot be written as Avro bytes.");
+
         WriteLong(value.Length);
         _stream.Write(value, 0, value.Length);
     }
 
     public void WriteBytes(byte[] value, int offset, int length)
     {
+        if (value is null)
+            throw new global::Avro.AvroTypeException("Null cannot be written as Avro bytes.");
+
         WriteLong(length);
         _stream.Write(value, offset, length);
     }
 
-    public void WriteString(string value) => WriteString(value.AsSpan());
+    public void WriteString(string value)
+    {
+        if (value is null)
+            throw new global::Avro.AvroTypeException("Null cannot be written as an Avro string.");
+
+        WriteString(value.AsSpan());
+    }
 
     internal void WriteString(ReadOnlySpan<char> value)
     {

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeBinaryEncoder.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeBinaryEncoder.cs
@@ -8,6 +8,8 @@ namespace Dekaf.SchemaRegistry.Avro;
 internal sealed class AllocationFreeBinaryEncoder(Stream stream) : global::Avro.IO.Encoder
 {
     private const int StackBufferSize = 256;
+    private const int MaxUtf8BytesPerChar = 3;
+    private const int MaxStackChars = StackBufferSize / MaxUtf8BytesPerChar;
     private readonly Stream _stream = stream;
 
     public void WriteNull() { }
@@ -60,7 +62,7 @@ internal sealed class AllocationFreeBinaryEncoder(Stream stream) : global::Avro.
 
     internal void WriteString(ReadOnlySpan<char> value)
     {
-        if (value.Length <= StackBufferSize / 3)
+        if (value.Length <= MaxStackChars)
         {
             Span<byte> bytes = stackalloc byte[StackBufferSize];
             var written = Encoding.UTF8.GetBytes(value, bytes);

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeBinaryEncoder.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeBinaryEncoder.cs
@@ -1,0 +1,110 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Dekaf.SchemaRegistry.Avro;
+
+internal sealed class AllocationFreeBinaryEncoder(Stream stream) : global::Avro.IO.Encoder
+{
+    private const int StackBufferSize = 256;
+    private readonly Stream _stream = stream;
+
+    public void WriteNull() { }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteBoolean(bool value) => _stream.WriteByte(value ? (byte)1 : (byte)0);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteInt(int value) => WriteLong(value);
+
+    public void WriteLong(long value)
+    {
+        var encoded = (ulong)((value << 1) ^ (value >> 63));
+        while ((encoded & ~0x7FUL) != 0)
+        {
+            _stream.WriteByte((byte)((encoded & 0x7F) | 0x80));
+            encoded >>= 7;
+        }
+
+        _stream.WriteByte((byte)encoded);
+    }
+
+    public void WriteFloat(float value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(float)];
+        BinaryPrimitives.WriteSingleLittleEndian(bytes, value);
+        _stream.Write(bytes);
+    }
+
+    public void WriteDouble(double value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(double)];
+        BinaryPrimitives.WriteDoubleLittleEndian(bytes, value);
+        _stream.Write(bytes);
+    }
+
+    public void WriteBytes(byte[] value)
+    {
+        WriteLong(value.Length);
+        _stream.Write(value, 0, value.Length);
+    }
+
+    public void WriteBytes(byte[] value, int offset, int length)
+    {
+        WriteLong(length);
+        _stream.Write(value, offset, length);
+    }
+
+    public void WriteString(string value) => WriteString(value.AsSpan());
+
+    internal void WriteString(ReadOnlySpan<char> value)
+    {
+        if (value.Length <= StackBufferSize / 3)
+        {
+            Span<byte> bytes = stackalloc byte[StackBufferSize];
+            var written = Encoding.UTF8.GetBytes(value, bytes);
+            WriteLong(written);
+            _stream.Write(bytes.Slice(0, written));
+            return;
+        }
+
+        var byteCount = Encoding.UTF8.GetByteCount(value);
+        var rented = ArrayPool<byte>.Shared.Rent(byteCount);
+        try
+        {
+            var written = Encoding.UTF8.GetBytes(value, rented);
+            WriteLong(written);
+            _stream.Write(rented.AsSpan(0, written));
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    internal void WriteBytes(ReadOnlySpan<byte> value)
+    {
+        WriteLong(value.Length);
+        _stream.Write(value);
+    }
+
+    internal void WriteFixed(ReadOnlySpan<byte> value) => _stream.Write(value);
+
+    public void WriteEnum(int value) => WriteLong(value);
+    public void SetItemCount(long value)
+    {
+        if (value > 0)
+            WriteLong(value);
+    }
+
+    public void StartItem() { }
+    public void WriteArrayStart() { }
+    public void WriteArrayEnd() => WriteLong(0);
+    public void WriteMapStart() { }
+    public void WriteMapEnd() => WriteLong(0);
+    public void WriteUnionIndex(int value) => WriteLong(value);
+    public void WriteFixed(byte[] data) => _stream.Write(data, 0, data.Length);
+    public void WriteFixed(byte[] data, int start, int length) => _stream.Write(data, start, length);
+    public void Flush() => _stream.Flush();
+}

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -162,10 +162,10 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
 
     private void WriteTypedArray(global::Avro.Schema itemSchema, Array array, AllocationFreeBinaryEncoder encoder)
     {
-        if (itemSchema is global::Avro.UnionSchema unionSchema)
+        if (itemSchema is global::Avro.UnionSchema unionSchema
+            && TryWriteValueTypeUnionArray(unionSchema, array, encoder))
         {
-            if (TryWriteValueTypeUnionArray(unionSchema, array, encoder))
-                return;
+            return;
         }
 
         switch (itemSchema.Tag)

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Collections;
 using System.Globalization;
 using global::Avro.Generic;
 using global::Avro.Util;
@@ -9,6 +10,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
 {
     private const int StackBufferSize = 256;
     private static readonly DateTime UnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime LocalUnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
     private readonly global::Avro.RecordSchema _schema = schema;
 
     internal void Write(GenericRecord record, AllocationFreeBinaryEncoder encoder) =>
@@ -134,19 +136,32 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
 
     private static void WriteArray(global::Avro.ArraySchema schema, object? value, AllocationFreeBinaryEncoder encoder)
     {
-        if (value is not Array array)
-            throw TypeMismatch(value, "array");
-
         encoder.WriteArrayStart();
-        encoder.SetItemCount(array.Length);
-
-        WriteTypedArray(schema.ItemSchema, array, encoder);
+        switch (value)
+        {
+            case Array array:
+                encoder.SetItemCount(array.Length);
+                WriteTypedArray(schema.ItemSchema, array, encoder);
+                break;
+            case IList list:
+                encoder.SetItemCount(list.Count);
+                WriteTypedList(schema.ItemSchema, list, encoder);
+                break;
+            default:
+                throw TypeMismatch(value, "array");
+        }
 
         encoder.WriteArrayEnd();
     }
 
     private static void WriteTypedArray(global::Avro.Schema itemSchema, Array array, AllocationFreeBinaryEncoder encoder)
     {
+        if (itemSchema is global::Avro.UnionSchema unionSchema &&
+            TryWriteValueTypeUnionArray(unionSchema, array, encoder))
+        {
+            return;
+        }
+
         switch (itemSchema.Tag)
         {
             case global::Avro.Schema.Type.Boolean when array is bool[] booleans:
@@ -248,11 +263,382 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             return;
         }
 
+        if (array.GetType().GetElementType()?.IsValueType == true)
+        {
+            throw new global::Avro.AvroTypeException(
+                $"Array element type {array.GetType().GetElementType()} is not supported for Avro {itemSchema.Tag} items.");
+        }
+
         for (var i = 0; i < array.Length; i++)
         {
             encoder.StartItem();
             WriteValue(itemSchema, array.GetValue(i), encoder);
         }
+    }
+
+    private static void WriteTypedList(global::Avro.Schema itemSchema, IList list, AllocationFreeBinaryEncoder encoder)
+    {
+        if (itemSchema is global::Avro.UnionSchema unionSchema &&
+            TryWriteValueTypeUnionList(unionSchema, list, encoder))
+        {
+            return;
+        }
+
+        switch (itemSchema.Tag)
+        {
+            case global::Avro.Schema.Type.Boolean when list is List<bool> values:
+                WriteListItems<bool, BooleanValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Int when list is List<int> values:
+                WriteListItems<int, IntValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Long when list is List<long> values:
+                WriteListItems<long, LongValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Float when list is List<float> values:
+                WriteListItems<float, FloatValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Double when list is List<double> values:
+                WriteListItems<double, DoubleValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.String when list is List<string> values:
+                WriteListItems<string, StringValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Bytes when list is List<byte[]> values:
+                WriteListItems<byte[], BytesValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Logical when list is List<DateTime> values:
+                WriteListItems<DateTime, DateTimeValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Logical when list is List<TimeSpan> values:
+                WriteListItems<TimeSpan, TimeSpanValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Logical when list is List<Guid> values:
+                WriteListItems<Guid, GuidValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Logical when list is List<global::Avro.AvroDecimal> values:
+                WriteListItems<global::Avro.AvroDecimal, DecimalValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Boolean when list is IList<bool> values:
+                WriteListItems<bool, BooleanValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Int when list is IList<int> values:
+                WriteListItems<int, IntValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Long when list is IList<long> values:
+                WriteListItems<long, LongValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Float when list is IList<float> values:
+                WriteListItems<float, FloatValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Double when list is IList<double> values:
+                WriteListItems<double, DoubleValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.String when list is IList<string> values:
+                WriteListItems<string, StringValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Bytes when list is IList<byte[]> values:
+                WriteListItems<byte[], BytesValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Logical when list is IList<DateTime> values:
+                WriteListItems<DateTime, DateTimeValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Logical when list is IList<TimeSpan> values:
+                WriteListItems<TimeSpan, TimeSpanValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Logical when list is IList<Guid> values:
+                WriteListItems<Guid, GuidValueWriter>(itemSchema, values, encoder);
+                return;
+            case global::Avro.Schema.Type.Logical when list is IList<global::Avro.AvroDecimal> values:
+                WriteListItems<global::Avro.AvroDecimal, DecimalValueWriter>(itemSchema, values, encoder);
+                return;
+        }
+
+        for (var i = 0; i < list.Count; i++)
+        {
+            encoder.StartItem();
+            WriteValue(itemSchema, list[i], encoder);
+        }
+    }
+
+    private static void WriteListItems<T, TWriter>(
+        global::Avro.Schema itemSchema,
+        List<T> values,
+        AllocationFreeBinaryEncoder encoder)
+        where TWriter : struct, IValueWriter<T>
+    {
+        for (var i = 0; i < values.Count; i++)
+        {
+            encoder.StartItem();
+            TWriter.Write(itemSchema, values[i], encoder);
+        }
+    }
+
+    private static void WriteListItems<T, TWriter>(
+        global::Avro.Schema itemSchema,
+        IList<T> values,
+        AllocationFreeBinaryEncoder encoder)
+        where TWriter : struct, IValueWriter<T>
+    {
+        for (var i = 0; i < values.Count; i++)
+        {
+            encoder.StartItem();
+            TWriter.Write(itemSchema, values[i], encoder);
+        }
+    }
+
+    private static bool TryWriteValueTypeUnionArray(
+        global::Avro.UnionSchema schema,
+        Array array,
+        AllocationFreeBinaryEncoder encoder)
+    {
+        switch (array)
+        {
+            case bool[] values: WriteUnionArray<bool, BooleanValueWriter>(schema, values, encoder); return true;
+            case bool?[] values: WriteNullableUnionArray<bool, BooleanValueWriter>(schema, values, encoder); return true;
+            case int[] values: WriteUnionArray<int, IntValueWriter>(schema, values, encoder); return true;
+            case int?[] values: WriteNullableUnionArray<int, IntValueWriter>(schema, values, encoder); return true;
+            case long[] values: WriteUnionArray<long, LongValueWriter>(schema, values, encoder); return true;
+            case long?[] values: WriteNullableUnionArray<long, LongValueWriter>(schema, values, encoder); return true;
+            case float[] values: WriteUnionArray<float, FloatValueWriter>(schema, values, encoder); return true;
+            case float?[] values: WriteNullableUnionArray<float, FloatValueWriter>(schema, values, encoder); return true;
+            case double[] values: WriteUnionArray<double, DoubleValueWriter>(schema, values, encoder); return true;
+            case double?[] values: WriteNullableUnionArray<double, DoubleValueWriter>(schema, values, encoder); return true;
+            case DateTime[] values: WriteUnionArray<DateTime, DateTimeValueWriter>(schema, values, encoder); return true;
+            case DateTime?[] values: WriteNullableUnionArray<DateTime, DateTimeValueWriter>(schema, values, encoder); return true;
+            case TimeSpan[] values: WriteUnionArray<TimeSpan, TimeSpanValueWriter>(schema, values, encoder); return true;
+            case TimeSpan?[] values: WriteNullableUnionArray<TimeSpan, TimeSpanValueWriter>(schema, values, encoder); return true;
+            case Guid[] values: WriteUnionArray<Guid, GuidValueWriter>(schema, values, encoder); return true;
+            case Guid?[] values: WriteNullableUnionArray<Guid, GuidValueWriter>(schema, values, encoder); return true;
+            case global::Avro.AvroDecimal[] values: WriteUnionArray<global::Avro.AvroDecimal, DecimalValueWriter>(schema, values, encoder); return true;
+            case global::Avro.AvroDecimal?[] values: WriteNullableUnionArray<global::Avro.AvroDecimal, DecimalValueWriter>(schema, values, encoder); return true;
+            default: return false;
+        }
+    }
+
+    private static bool TryWriteValueTypeUnionList(
+        global::Avro.UnionSchema schema,
+        IList list,
+        AllocationFreeBinaryEncoder encoder)
+    {
+        switch (list)
+        {
+            case List<bool> values: WriteUnionList<bool, BooleanValueWriter>(schema, values, encoder); return true;
+            case List<bool?> values: WriteNullableUnionList<bool, BooleanValueWriter>(schema, values, encoder); return true;
+            case List<int> values: WriteUnionList<int, IntValueWriter>(schema, values, encoder); return true;
+            case List<int?> values: WriteNullableUnionList<int, IntValueWriter>(schema, values, encoder); return true;
+            case List<long> values: WriteUnionList<long, LongValueWriter>(schema, values, encoder); return true;
+            case List<long?> values: WriteNullableUnionList<long, LongValueWriter>(schema, values, encoder); return true;
+            case List<float> values: WriteUnionList<float, FloatValueWriter>(schema, values, encoder); return true;
+            case List<float?> values: WriteNullableUnionList<float, FloatValueWriter>(schema, values, encoder); return true;
+            case List<double> values: WriteUnionList<double, DoubleValueWriter>(schema, values, encoder); return true;
+            case List<double?> values: WriteNullableUnionList<double, DoubleValueWriter>(schema, values, encoder); return true;
+            case List<DateTime> values: WriteUnionList<DateTime, DateTimeValueWriter>(schema, values, encoder); return true;
+            case List<DateTime?> values: WriteNullableUnionList<DateTime, DateTimeValueWriter>(schema, values, encoder); return true;
+            case List<TimeSpan> values: WriteUnionList<TimeSpan, TimeSpanValueWriter>(schema, values, encoder); return true;
+            case List<TimeSpan?> values: WriteNullableUnionList<TimeSpan, TimeSpanValueWriter>(schema, values, encoder); return true;
+            case List<Guid> values: WriteUnionList<Guid, GuidValueWriter>(schema, values, encoder); return true;
+            case List<Guid?> values: WriteNullableUnionList<Guid, GuidValueWriter>(schema, values, encoder); return true;
+            case List<global::Avro.AvroDecimal> values: WriteUnionList<global::Avro.AvroDecimal, DecimalValueWriter>(schema, values, encoder); return true;
+            case List<global::Avro.AvroDecimal?> values: WriteNullableUnionList<global::Avro.AvroDecimal, DecimalValueWriter>(schema, values, encoder); return true;
+            default: return false;
+        }
+    }
+
+    private static void WriteUnionArray<T, TWriter>(
+        global::Avro.UnionSchema schema,
+        T[] values,
+        AllocationFreeBinaryEncoder encoder)
+        where T : struct
+        where TWriter : struct, IValueWriter<T>
+    {
+        FindUnionBranches<T, TWriter>(schema, out _, out var valueIndex, out var valueSchema);
+        for (var i = 0; i < values.Length; i++)
+        {
+            encoder.StartItem();
+            encoder.WriteUnionIndex(valueIndex);
+            TWriter.Write(valueSchema, values[i], encoder);
+        }
+    }
+
+    private static void WriteNullableUnionArray<T, TWriter>(
+        global::Avro.UnionSchema schema,
+        T?[] values,
+        AllocationFreeBinaryEncoder encoder)
+        where T : struct
+        where TWriter : struct, IValueWriter<T>
+    {
+        FindUnionBranches<T, TWriter>(schema, out var nullIndex, out var valueIndex, out var valueSchema);
+        for (var i = 0; i < values.Length; i++)
+        {
+            encoder.StartItem();
+            var value = values[i];
+            if (!value.HasValue)
+            {
+                if (nullIndex < 0)
+                    throw TypeMismatch(null, "union");
+                encoder.WriteUnionIndex(nullIndex);
+                continue;
+            }
+
+            encoder.WriteUnionIndex(valueIndex);
+            TWriter.Write(valueSchema, value.GetValueOrDefault(), encoder);
+        }
+    }
+
+    private static void WriteUnionList<T, TWriter>(
+        global::Avro.UnionSchema schema,
+        List<T> values,
+        AllocationFreeBinaryEncoder encoder)
+        where T : struct
+        where TWriter : struct, IValueWriter<T>
+    {
+        FindUnionBranches<T, TWriter>(schema, out _, out var valueIndex, out var valueSchema);
+        for (var i = 0; i < values.Count; i++)
+        {
+            encoder.StartItem();
+            encoder.WriteUnionIndex(valueIndex);
+            TWriter.Write(valueSchema, values[i], encoder);
+        }
+    }
+
+    private static void WriteNullableUnionList<T, TWriter>(
+        global::Avro.UnionSchema schema,
+        List<T?> values,
+        AllocationFreeBinaryEncoder encoder)
+        where T : struct
+        where TWriter : struct, IValueWriter<T>
+    {
+        FindUnionBranches<T, TWriter>(schema, out var nullIndex, out var valueIndex, out var valueSchema);
+        for (var i = 0; i < values.Count; i++)
+        {
+            encoder.StartItem();
+            var value = values[i];
+            if (!value.HasValue)
+            {
+                if (nullIndex < 0)
+                    throw TypeMismatch(null, "union");
+                encoder.WriteUnionIndex(nullIndex);
+                continue;
+            }
+
+            encoder.WriteUnionIndex(valueIndex);
+            TWriter.Write(valueSchema, value.GetValueOrDefault(), encoder);
+        }
+    }
+
+    private static void FindUnionBranches<T, TWriter>(
+        global::Avro.UnionSchema schema,
+        out int nullIndex,
+        out int valueIndex,
+        out global::Avro.Schema valueSchema)
+        where T : struct
+        where TWriter : struct, IValueWriter<T>
+    {
+        nullIndex = -1;
+        valueIndex = -1;
+        valueSchema = null!;
+        for (var i = 0; i < schema.Count; i++)
+        {
+            var branch = schema[i];
+            if (branch.Tag == global::Avro.Schema.Type.Null)
+                nullIndex = i;
+            else if (valueIndex < 0 && TWriter.Matches(branch))
+            {
+                valueIndex = i;
+                valueSchema = branch;
+            }
+        }
+
+        if (valueIndex < 0)
+            throw new global::Avro.AvroTypeException($"Union {schema} has no branch for {typeof(T)}.");
+    }
+
+    private interface IValueWriter<T>
+    {
+        static abstract bool Matches(global::Avro.Schema schema);
+        static abstract void Write(global::Avro.Schema schema, T value, AllocationFreeBinaryEncoder encoder);
+    }
+
+    private readonly struct BooleanValueWriter : IValueWriter<bool>
+    {
+        public static bool Matches(global::Avro.Schema schema) => schema.Tag == global::Avro.Schema.Type.Boolean;
+        public static void Write(global::Avro.Schema schema, bool value, AllocationFreeBinaryEncoder encoder) => encoder.WriteBoolean(value);
+    }
+
+    private readonly struct IntValueWriter : IValueWriter<int>
+    {
+        public static bool Matches(global::Avro.Schema schema) => schema.Tag == global::Avro.Schema.Type.Int;
+        public static void Write(global::Avro.Schema schema, int value, AllocationFreeBinaryEncoder encoder) => encoder.WriteInt(value);
+    }
+
+    private readonly struct LongValueWriter : IValueWriter<long>
+    {
+        public static bool Matches(global::Avro.Schema schema) => schema.Tag == global::Avro.Schema.Type.Long;
+        public static void Write(global::Avro.Schema schema, long value, AllocationFreeBinaryEncoder encoder) => encoder.WriteLong(value);
+    }
+
+    private readonly struct FloatValueWriter : IValueWriter<float>
+    {
+        public static bool Matches(global::Avro.Schema schema) => schema.Tag == global::Avro.Schema.Type.Float;
+        public static void Write(global::Avro.Schema schema, float value, AllocationFreeBinaryEncoder encoder) => encoder.WriteFloat(value);
+    }
+
+    private readonly struct DoubleValueWriter : IValueWriter<double>
+    {
+        public static bool Matches(global::Avro.Schema schema) => schema.Tag == global::Avro.Schema.Type.Double;
+        public static void Write(global::Avro.Schema schema, double value, AllocationFreeBinaryEncoder encoder) => encoder.WriteDouble(value);
+    }
+
+    private readonly struct StringValueWriter : IValueWriter<string>
+    {
+        public static bool Matches(global::Avro.Schema schema) => schema.Tag == global::Avro.Schema.Type.String;
+        public static void Write(global::Avro.Schema schema, string value, AllocationFreeBinaryEncoder encoder) => encoder.WriteString(value);
+    }
+
+    private readonly struct BytesValueWriter : IValueWriter<byte[]>
+    {
+        public static bool Matches(global::Avro.Schema schema) => schema.Tag == global::Avro.Schema.Type.Bytes;
+        public static void Write(global::Avro.Schema schema, byte[] value, AllocationFreeBinaryEncoder encoder) => encoder.WriteBytes(value);
+    }
+
+    private readonly struct DateTimeValueWriter : IValueWriter<DateTime>
+    {
+        public static bool Matches(global::Avro.Schema schema) =>
+            schema is global::Avro.LogicalSchema logicalSchema &&
+            logicalSchema.LogicalType is Date or TimestampMillisecond or LocalTimestampMillisecond or
+                TimestampMicrosecond or LocalTimestampMicrosecond;
+
+        public static void Write(global::Avro.Schema schema, DateTime value, AllocationFreeBinaryEncoder encoder) =>
+            WriteDateTime((global::Avro.LogicalSchema)schema, value, encoder);
+    }
+
+    private readonly struct TimeSpanValueWriter : IValueWriter<TimeSpan>
+    {
+        public static bool Matches(global::Avro.Schema schema) =>
+            schema is global::Avro.LogicalSchema logicalSchema &&
+            logicalSchema.LogicalType is TimeMillisecond or TimeMicrosecond;
+
+        public static void Write(global::Avro.Schema schema, TimeSpan value, AllocationFreeBinaryEncoder encoder) =>
+            WriteTimeSpan((global::Avro.LogicalSchema)schema, value, encoder);
+    }
+
+    private readonly struct GuidValueWriter : IValueWriter<Guid>
+    {
+        public static bool Matches(global::Avro.Schema schema) =>
+            schema is global::Avro.LogicalSchema { LogicalType: Uuid };
+
+        public static void Write(global::Avro.Schema schema, Guid value, AllocationFreeBinaryEncoder encoder) =>
+            WriteUuid((global::Avro.LogicalSchema)schema, value, encoder);
+    }
+
+    private readonly struct DecimalValueWriter : IValueWriter<global::Avro.AvroDecimal>
+    {
+        public static bool Matches(global::Avro.Schema schema) =>
+            schema is global::Avro.LogicalSchema { LogicalType: global::Avro.Util.Decimal };
+
+        public static void Write(global::Avro.Schema schema, global::Avro.AvroDecimal value, AllocationFreeBinaryEncoder encoder) =>
+            WriteDecimal((global::Avro.LogicalSchema)schema, value, encoder);
     }
 
     private static void WriteMap(global::Avro.MapSchema schema, object? value, AllocationFreeBinaryEncoder encoder)
@@ -334,7 +720,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             global::Avro.Schema.Type.Enumeration =>
                 value is GenericEnum genericEnum &&
                 genericEnum.Schema.SchemaName.Equals(((global::Avro.EnumSchema)schema).SchemaName),
-            global::Avro.Schema.Type.Array => value is Array and not byte[],
+            global::Avro.Schema.Type.Array => value is (Array or IList) and not byte[],
             global::Avro.Schema.Type.Map => value is IDictionary<string, object>,
             global::Avro.Schema.Type.Union => false,
             global::Avro.Schema.Type.Fixed =>
@@ -396,11 +782,17 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             case Date:
                 encoder.WriteInt((value.Date - UnixEpoch).Days);
                 return;
-            case TimestampMillisecond or LocalTimestampMillisecond:
+            case TimestampMillisecond:
                 encoder.WriteLong((long)(value.ToUniversalTime() - UnixEpoch).TotalMilliseconds);
                 return;
-            case TimestampMicrosecond or LocalTimestampMicrosecond:
+            case TimestampMicrosecond:
                 encoder.WriteLong((value.ToUniversalTime() - UnixEpoch).Ticks / 10);
+                return;
+            case LocalTimestampMillisecond:
+                encoder.WriteLong((long)(AsLocalWallClock(value) - LocalUnixEpoch).TotalMilliseconds);
+                return;
+            case LocalTimestampMicrosecond:
+                encoder.WriteLong((AsLocalWallClock(value) - LocalUnixEpoch).Ticks / 10);
                 return;
             default:
                 throw TypeMismatch(value, schema.LogicalTypeName);
@@ -448,7 +840,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         var scaleProperty = schema.GetProperty("scale");
         var schemaScale = string.IsNullOrEmpty(scaleProperty)
             ? 0
-            : int.Parse(scaleProperty, CultureInfo.CurrentCulture);
+            : int.Parse(scaleProperty, CultureInfo.InvariantCulture);
         if (value.Scale != schemaScale)
         {
             throw new ArgumentOutOfRangeException(
@@ -477,8 +869,15 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                 return;
             }
 
+            if (written > fixedSize)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    $"The decimal value requires {written} bytes and cannot fit in a fixed size of {fixedSize} bytes.");
+            }
+
             var fixedBytes = bytes.Slice(0, fixedSize);
-            var source = raw.Slice(Math.Max(0, written - fixedSize), Math.Min(written, fixedSize));
+            var source = raw.Slice(0, written);
             var paddingLength = fixedSize - source.Length;
             source.CopyTo(fixedBytes.Slice(paddingLength));
             fixedBytes.Slice(0, paddingLength).Fill(value.UnscaledValue.Sign < 0 ? byte.MaxValue : (byte)0);
@@ -490,6 +889,9 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                 ArrayPool<byte>.Shared.Return(rented);
         }
     }
+
+    private static DateTime AsLocalWallClock(DateTime value) =>
+        DateTime.SpecifyKind(value, DateTimeKind.Unspecified);
 
     private static void ValidateTime(TimeSpan value)
     {

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using global::Avro.Generic;
@@ -12,8 +13,10 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
     private const int StackBufferSize = 256;
     private static readonly DateTime UnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
     private static readonly DateTime LocalUnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+    private static readonly ConditionalWeakTable<Type, ValueTypeListElement> ValueTypeListElements = new();
     private readonly global::Avro.RecordSchema _schema = schema;
     private readonly WriterCache _writerCache = WriterCache.Create(schema);
+    private ValueTypeListElement? _lastValueTypeListElement;
 
     internal void Write(GenericRecord record, AllocationFreeBinaryEncoder encoder) =>
         WriteRecord(_schema, record, encoder, validateSchema: false);
@@ -361,7 +364,28 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         }
 
         var listType = list.GetType();
-        if (listType.IsGenericType && listType.GetGenericArguments()[0] is { IsValueType: true } elementType)
+        Type? elementType = null;
+        if (listType.IsGenericType)
+        {
+            elementType = listType.GetGenericArguments()[0];
+            if (!elementType.IsValueType)
+                elementType = null;
+        }
+        else if (itemSchema.Tag is global::Avro.Schema.Type.Logical)
+        {
+            var cache = Volatile.Read(ref _lastValueTypeListElement);
+            if (cache is null || !ReferenceEquals(cache.ListType, listType))
+            {
+                cache = ValueTypeListElements.GetValue(
+                    listType,
+                    static type => new ValueTypeListElement(type, FindValueTypeListElement(type)));
+                Volatile.Write(ref _lastValueTypeListElement, cache);
+            }
+
+            elementType = cache.ElementType;
+        }
+
+        if (elementType is not null)
         {
             throw new global::Avro.AvroTypeException(
                 $"List element type {elementType} is not supported for Avro {itemSchema.Tag} items.");
@@ -372,6 +396,30 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             encoder.StartItem();
             WriteValue(itemSchema, list[i], encoder);
         }
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2070",
+        Justification = "A live IList instance retains the implemented interface needed for this rejection check.")]
+    private static Type? FindValueTypeListElement(Type listType)
+    {
+        var interfaces = listType.GetInterfaces();
+        for (var index = 0; index < interfaces.Length; index++)
+        {
+            var candidate = interfaces[index];
+            if (!candidate.IsGenericType
+                || candidate.GetGenericTypeDefinition() != typeof(IList<>))
+            {
+                continue;
+            }
+
+            var elementType = candidate.GetGenericArguments()[0];
+            if (elementType.IsValueType)
+                return elementType;
+        }
+
+        return null;
     }
 
     private static void WriteListItems<T, TWriter>(
@@ -1405,6 +1453,12 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
     {
         public List<ConditionalUnionCandidate> Candidates { get; } = [];
         public UnionBranch Fallback { get; set; }
+    }
+
+    private sealed class ValueTypeListElement(Type listType, Type? elementType)
+    {
+        internal Type ListType { get; } = listType;
+        internal Type? ElementType { get; } = elementType;
     }
 
     private sealed class ReferenceComparer<T> : IEqualityComparer<T>

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -1,0 +1,503 @@
+using System.Buffers;
+using System.Globalization;
+using global::Avro.Generic;
+using global::Avro.Util;
+
+namespace Dekaf.SchemaRegistry.Avro;
+
+internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchema schema)
+{
+    private const int StackBufferSize = 256;
+    private static readonly DateTime UnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private readonly global::Avro.RecordSchema _schema = schema;
+
+    internal void Write(GenericRecord record, AllocationFreeBinaryEncoder encoder) =>
+        WriteRecord(ReferenceEquals(record.Schema, _schema) ? _schema : record.Schema, record, encoder);
+
+    private static void WriteValue(global::Avro.Schema schema, object? value, AllocationFreeBinaryEncoder encoder)
+    {
+        switch (schema.Tag)
+        {
+            case global::Avro.Schema.Type.Null:
+                if (value is not null)
+                    throw TypeMismatch(value, "null");
+                encoder.WriteNull();
+                return;
+
+            case global::Avro.Schema.Type.Boolean:
+                if (value is not bool boolean)
+                    throw TypeMismatch(value, "boolean");
+                encoder.WriteBoolean(boolean);
+                return;
+
+            case global::Avro.Schema.Type.Int:
+                if (value is not int integer)
+                    throw TypeMismatch(value, "int");
+                encoder.WriteInt(integer);
+                return;
+
+            case global::Avro.Schema.Type.Long:
+                if (value is not long longInteger)
+                    throw TypeMismatch(value, "long");
+                encoder.WriteLong(longInteger);
+                return;
+
+            case global::Avro.Schema.Type.Float:
+                if (value is not float single)
+                    throw TypeMismatch(value, "float");
+                encoder.WriteFloat(single);
+                return;
+
+            case global::Avro.Schema.Type.Double:
+                if (value is not double doubleValue)
+                    throw TypeMismatch(value, "double");
+                encoder.WriteDouble(doubleValue);
+                return;
+
+            case global::Avro.Schema.Type.String:
+                if (value is not string text)
+                    throw TypeMismatch(value, "string");
+                encoder.WriteString(text);
+                return;
+
+            case global::Avro.Schema.Type.Bytes:
+                if (value is not byte[] bytes)
+                    throw TypeMismatch(value, "bytes");
+                encoder.WriteBytes(bytes);
+                return;
+
+            case global::Avro.Schema.Type.Record:
+            case global::Avro.Schema.Type.Error:
+                WriteRecord((global::Avro.RecordSchema)schema, value, encoder);
+                return;
+
+            case global::Avro.Schema.Type.Enumeration:
+                WriteEnum((global::Avro.EnumSchema)schema, value, encoder);
+                return;
+
+            case global::Avro.Schema.Type.Fixed:
+                WriteFixed((global::Avro.FixedSchema)schema, value, encoder);
+                return;
+
+            case global::Avro.Schema.Type.Array:
+                WriteArray((global::Avro.ArraySchema)schema, value, encoder);
+                return;
+
+            case global::Avro.Schema.Type.Map:
+                WriteMap((global::Avro.MapSchema)schema, value, encoder);
+                return;
+
+            case global::Avro.Schema.Type.Union:
+                WriteUnion((global::Avro.UnionSchema)schema, value, encoder);
+                return;
+
+            case global::Avro.Schema.Type.Logical:
+                WriteLogical((global::Avro.LogicalSchema)schema, value, encoder);
+                return;
+
+            default:
+                throw new global::Avro.AvroTypeException($"Unsupported Avro schema type {schema.Tag}.");
+        }
+    }
+
+    private static void WriteRecord(global::Avro.RecordSchema schema, object? value, AllocationFreeBinaryEncoder encoder)
+    {
+        if (value is not GenericRecord record ||
+            (!ReferenceEquals(record.Schema, schema) && !record.Schema.Equals(schema)))
+            throw TypeMismatch(value, "record");
+
+        var fields = schema.Fields;
+        for (var i = 0; i < fields.Count; i++)
+        {
+            var field = fields[i];
+            WriteValue(field.Schema, record.GetValue(field.Pos), encoder);
+        }
+    }
+
+    private static void WriteEnum(global::Avro.EnumSchema schema, object? value, AllocationFreeBinaryEncoder encoder)
+    {
+        if (value is not GenericEnum genericEnum ||
+            (!ReferenceEquals(genericEnum.Schema, schema) && !genericEnum.Schema.Equals(schema)))
+            throw TypeMismatch(value, "enum");
+
+        encoder.WriteEnum(schema.Ordinal(genericEnum.Value));
+    }
+
+    private static void WriteFixed(global::Avro.FixedSchema schema, object? value, AllocationFreeBinaryEncoder encoder)
+    {
+        if (value is not GenericFixed fixedValue ||
+            (!ReferenceEquals(fixedValue.Schema, schema) && !fixedValue.Schema.Equals(schema)))
+            throw TypeMismatch(value, "fixed");
+
+        encoder.WriteFixed(fixedValue.Value);
+    }
+
+    private static void WriteArray(global::Avro.ArraySchema schema, object? value, AllocationFreeBinaryEncoder encoder)
+    {
+        if (value is not Array array)
+            throw TypeMismatch(value, "array");
+
+        encoder.WriteArrayStart();
+        encoder.SetItemCount(array.Length);
+
+        WriteTypedArray(schema.ItemSchema, array, encoder);
+
+        encoder.WriteArrayEnd();
+    }
+
+    private static void WriteTypedArray(global::Avro.Schema itemSchema, Array array, AllocationFreeBinaryEncoder encoder)
+    {
+        switch (itemSchema.Tag)
+        {
+            case global::Avro.Schema.Type.Boolean when array is bool[] booleans:
+                for (var i = 0; i < booleans.Length; i++)
+                {
+                    encoder.StartItem();
+                    encoder.WriteBoolean(booleans[i]);
+                }
+                return;
+
+            case global::Avro.Schema.Type.Int when array is int[] integers:
+                for (var i = 0; i < integers.Length; i++)
+                {
+                    encoder.StartItem();
+                    encoder.WriteInt(integers[i]);
+                }
+                return;
+
+            case global::Avro.Schema.Type.Long when array is long[] longIntegers:
+                for (var i = 0; i < longIntegers.Length; i++)
+                {
+                    encoder.StartItem();
+                    encoder.WriteLong(longIntegers[i]);
+                }
+                return;
+
+            case global::Avro.Schema.Type.Float when array is float[] singles:
+                for (var i = 0; i < singles.Length; i++)
+                {
+                    encoder.StartItem();
+                    encoder.WriteFloat(singles[i]);
+                }
+                return;
+
+            case global::Avro.Schema.Type.Double when array is double[] doubles:
+                for (var i = 0; i < doubles.Length; i++)
+                {
+                    encoder.StartItem();
+                    encoder.WriteDouble(doubles[i]);
+                }
+                return;
+
+            case global::Avro.Schema.Type.String when array is string[] strings:
+                for (var i = 0; i < strings.Length; i++)
+                {
+                    encoder.StartItem();
+                    encoder.WriteString(strings[i]);
+                }
+                return;
+
+            case global::Avro.Schema.Type.Bytes when array is byte[][] byteArrays:
+                for (var i = 0; i < byteArrays.Length; i++)
+                {
+                    encoder.StartItem();
+                    encoder.WriteBytes(byteArrays[i]);
+                }
+                return;
+
+            case global::Avro.Schema.Type.Logical when array is DateTime[] dateTimes:
+                for (var i = 0; i < dateTimes.Length; i++)
+                {
+                    encoder.StartItem();
+                    WriteDateTime((global::Avro.LogicalSchema)itemSchema, dateTimes[i], encoder);
+                }
+                return;
+
+            case global::Avro.Schema.Type.Logical when array is TimeSpan[] timeSpans:
+                for (var i = 0; i < timeSpans.Length; i++)
+                {
+                    encoder.StartItem();
+                    WriteTimeSpan((global::Avro.LogicalSchema)itemSchema, timeSpans[i], encoder);
+                }
+                return;
+
+            case global::Avro.Schema.Type.Logical when array is Guid[] guids:
+                for (var i = 0; i < guids.Length; i++)
+                {
+                    encoder.StartItem();
+                    WriteUuid((global::Avro.LogicalSchema)itemSchema, guids[i], encoder);
+                }
+                return;
+
+            case global::Avro.Schema.Type.Logical when array is global::Avro.AvroDecimal[] decimals:
+                for (var i = 0; i < decimals.Length; i++)
+                {
+                    encoder.StartItem();
+                    WriteDecimal((global::Avro.LogicalSchema)itemSchema, decimals[i], encoder);
+                }
+                return;
+        }
+
+        if (array is object?[] objects)
+        {
+            for (var i = 0; i < objects.Length; i++)
+            {
+                encoder.StartItem();
+                WriteValue(itemSchema, objects[i], encoder);
+            }
+            return;
+        }
+
+        for (var i = 0; i < array.Length; i++)
+        {
+            encoder.StartItem();
+            WriteValue(itemSchema, array.GetValue(i), encoder);
+        }
+    }
+
+    private static void WriteMap(global::Avro.MapSchema schema, object? value, AllocationFreeBinaryEncoder encoder)
+    {
+        if (value is not IDictionary<string, object> map)
+            throw TypeMismatch(value, "map");
+
+        encoder.WriteMapStart();
+        encoder.SetItemCount(map.Count);
+
+        if (value is Dictionary<string, object> dictionary)
+        {
+            foreach (var entry in dictionary)
+            {
+                encoder.StartItem();
+                encoder.WriteString(entry.Key);
+                WriteValue(schema.ValueSchema, entry.Value, encoder);
+            }
+        }
+        else
+        {
+            var count = map.Count;
+            var entries = ArrayPool<KeyValuePair<string, object>>.Shared.Rent(count);
+            try
+            {
+                map.CopyTo(entries, 0);
+                for (var i = 0; i < count; i++)
+                {
+                    var entry = entries[i];
+                    encoder.StartItem();
+                    encoder.WriteString(entry.Key);
+                    WriteValue(schema.ValueSchema, entry.Value, encoder);
+                }
+            }
+            finally
+            {
+                entries.AsSpan(0, count).Clear();
+                ArrayPool<KeyValuePair<string, object>>.Shared.Return(entries);
+            }
+        }
+
+        encoder.WriteMapEnd();
+    }
+
+    private static void WriteUnion(global::Avro.UnionSchema schema, object? value, AllocationFreeBinaryEncoder encoder)
+    {
+        for (var i = 0; i < schema.Count; i++)
+        {
+            var branch = schema[i];
+            if (!Matches(branch, value))
+                continue;
+
+            encoder.WriteUnionIndex(i);
+            WriteValue(branch, value, encoder);
+            return;
+        }
+
+        throw new global::Avro.AvroException($"Cannot find a union match for {value?.GetType()} in {schema}.");
+    }
+
+    private static bool Matches(global::Avro.Schema schema, object? value)
+    {
+        if (value is null)
+            return schema.Tag == global::Avro.Schema.Type.Null;
+
+        return schema.Tag switch
+        {
+            global::Avro.Schema.Type.Null => false,
+            global::Avro.Schema.Type.Boolean => value is bool,
+            global::Avro.Schema.Type.Int => value is int,
+            global::Avro.Schema.Type.Long => value is long,
+            global::Avro.Schema.Type.Float => value is float,
+            global::Avro.Schema.Type.Double => value is double,
+            global::Avro.Schema.Type.Bytes => value is byte[],
+            global::Avro.Schema.Type.String => value is string,
+            global::Avro.Schema.Type.Record or global::Avro.Schema.Type.Error =>
+                value is GenericRecord record &&
+                record.Schema.SchemaName.Equals(((global::Avro.RecordSchema)schema).SchemaName),
+            global::Avro.Schema.Type.Enumeration =>
+                value is GenericEnum genericEnum &&
+                genericEnum.Schema.SchemaName.Equals(((global::Avro.EnumSchema)schema).SchemaName),
+            global::Avro.Schema.Type.Array => value is Array and not byte[],
+            global::Avro.Schema.Type.Map => value is IDictionary<string, object>,
+            global::Avro.Schema.Type.Union => false,
+            global::Avro.Schema.Type.Fixed =>
+                value is GenericFixed fixedValue &&
+                fixedValue.Schema.SchemaName.Equals(((global::Avro.FixedSchema)schema).SchemaName),
+            global::Avro.Schema.Type.Logical => ((global::Avro.LogicalSchema)schema).LogicalType.IsInstanceOfLogicalType(value),
+            _ => throw new global::Avro.AvroException($"Unknown Avro schema type {schema.Tag}.")
+        };
+    }
+
+    private static void WriteLogical(
+        global::Avro.LogicalSchema schema,
+        object? value,
+        AllocationFreeBinaryEncoder encoder)
+    {
+        switch (schema.LogicalType)
+        {
+            case Date or TimestampMillisecond or LocalTimestampMillisecond or
+                TimestampMicrosecond or LocalTimestampMicrosecond:
+                if (value is not DateTime date)
+                    throw TypeMismatch(value, schema.LogicalTypeName);
+                WriteDateTime(schema, date, encoder);
+                return;
+
+            case TimeMillisecond or TimeMicrosecond:
+                if (value is not TimeSpan time)
+                    throw TypeMismatch(value, schema.LogicalTypeName);
+                WriteTimeSpan(schema, time, encoder);
+                return;
+
+            case Uuid:
+                if (value is not Guid guid)
+                    throw TypeMismatch(value, "uuid");
+                WriteUuid(schema, guid, encoder);
+                return;
+
+            case global::Avro.Util.Decimal:
+                if (value is not global::Avro.AvroDecimal decimalValue)
+                    throw TypeMismatch(value, "decimal");
+                WriteDecimal(schema, decimalValue, encoder);
+                return;
+
+            default:
+                WriteValue(
+                    schema.BaseSchema,
+                    schema.LogicalType.ConvertToBaseValue(value, schema),
+                    encoder);
+                return;
+        }
+    }
+
+    private static void WriteDateTime(
+        global::Avro.LogicalSchema schema,
+        DateTime value,
+        AllocationFreeBinaryEncoder encoder)
+    {
+        switch (schema.LogicalType)
+        {
+            case Date:
+                encoder.WriteInt((value.Date - UnixEpoch).Days);
+                return;
+            case TimestampMillisecond or LocalTimestampMillisecond:
+                encoder.WriteLong((long)(value.ToUniversalTime() - UnixEpoch).TotalMilliseconds);
+                return;
+            case TimestampMicrosecond or LocalTimestampMicrosecond:
+                encoder.WriteLong((value.ToUniversalTime() - UnixEpoch).Ticks / 10);
+                return;
+            default:
+                throw TypeMismatch(value, schema.LogicalTypeName);
+        }
+    }
+
+    private static void WriteTimeSpan(
+        global::Avro.LogicalSchema schema,
+        TimeSpan value,
+        AllocationFreeBinaryEncoder encoder)
+    {
+        ValidateTime(value);
+        switch (schema.LogicalType)
+        {
+            case TimeMillisecond:
+                encoder.WriteInt((int)value.TotalMilliseconds);
+                return;
+            case TimeMicrosecond:
+                encoder.WriteLong(value.Ticks / 10);
+                return;
+            default:
+                throw TypeMismatch(value, schema.LogicalTypeName);
+        }
+    }
+
+    private static void WriteUuid(
+        global::Avro.LogicalSchema schema,
+        Guid value,
+        AllocationFreeBinaryEncoder encoder)
+    {
+        if (schema.LogicalType is not Uuid)
+            throw TypeMismatch(value, schema.LogicalTypeName);
+
+        Span<char> uuid = stackalloc char[36];
+        if (!value.TryFormat(uuid, out var charsWritten, "D"))
+            throw new InvalidOperationException("Unable to format an Avro UUID.");
+        encoder.WriteString(uuid.Slice(0, charsWritten));
+    }
+
+    private static void WriteDecimal(
+        global::Avro.LogicalSchema schema,
+        global::Avro.AvroDecimal value,
+        AllocationFreeBinaryEncoder encoder)
+    {
+        var scaleProperty = schema.GetProperty("scale");
+        var schemaScale = string.IsNullOrEmpty(scaleProperty)
+            ? 0
+            : int.Parse(scaleProperty, CultureInfo.CurrentCulture);
+        if (value.Scale != schemaScale)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                $"The decimal value has a scale of {value.Scale} which cannot be encoded against " +
+                $"a logical 'decimal' with a scale of {schemaScale}");
+        }
+
+        var byteCount = value.UnscaledValue.GetByteCount(isUnsigned: false);
+        var fixedSize = schema.BaseSchema is global::Avro.FixedSchema fixedSchema ? fixedSchema.Size : 0;
+        var bufferSize = Math.Max(byteCount, fixedSize);
+        byte[]? rented = null;
+        Span<byte> bytes = bufferSize <= StackBufferSize
+            ? stackalloc byte[StackBufferSize]
+            : (rented = ArrayPool<byte>.Shared.Rent(bufferSize));
+
+        try
+        {
+            var raw = bytes.Slice(0, byteCount);
+            if (!value.UnscaledValue.TryWriteBytes(raw, out var written, isUnsigned: false, isBigEndian: true))
+                throw new InvalidOperationException("Unable to encode an Avro decimal.");
+
+            if (fixedSize == 0)
+            {
+                encoder.WriteBytes(raw.Slice(0, written));
+                return;
+            }
+
+            var fixedBytes = bytes.Slice(0, fixedSize);
+            var source = raw.Slice(Math.Max(0, written - fixedSize), Math.Min(written, fixedSize));
+            var paddingLength = fixedSize - source.Length;
+            source.CopyTo(fixedBytes.Slice(paddingLength));
+            fixedBytes.Slice(0, paddingLength).Fill(value.UnscaledValue.Sign < 0 ? byte.MaxValue : (byte)0);
+            encoder.WriteFixed(fixedBytes);
+        }
+        finally
+        {
+            if (rented is not null)
+                ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    private static void ValidateTime(TimeSpan value)
+    {
+        if (value < TimeSpan.Zero || value >= TimeSpan.FromDays(1))
+            throw new ArgumentOutOfRangeException(nameof(value), "Avro time values must be within one day.");
+    }
+
+    private static global::Avro.AvroException TypeMismatch(object? value, string schemaType) =>
+        new(
+            $"Value of type {value?.GetType().ToString() ?? "null"} cannot be written as Avro {schemaType}.");
+}

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -441,6 +441,24 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             case List<Guid?> values: WriteNullableUnionList<Guid, GuidValueWriter>(schema, values, encoder); return true;
             case List<global::Avro.AvroDecimal> values: WriteUnionList<global::Avro.AvroDecimal, DecimalValueWriter>(schema, values, encoder); return true;
             case List<global::Avro.AvroDecimal?> values: WriteNullableUnionList<global::Avro.AvroDecimal, DecimalValueWriter>(schema, values, encoder); return true;
+            case IList<bool> values: WriteUnionList<bool, BooleanValueWriter>(schema, values, encoder); return true;
+            case IList<bool?> values: WriteNullableUnionList<bool, BooleanValueWriter>(schema, values, encoder); return true;
+            case IList<int> values: WriteUnionList<int, IntValueWriter>(schema, values, encoder); return true;
+            case IList<int?> values: WriteNullableUnionList<int, IntValueWriter>(schema, values, encoder); return true;
+            case IList<long> values: WriteUnionList<long, LongValueWriter>(schema, values, encoder); return true;
+            case IList<long?> values: WriteNullableUnionList<long, LongValueWriter>(schema, values, encoder); return true;
+            case IList<float> values: WriteUnionList<float, FloatValueWriter>(schema, values, encoder); return true;
+            case IList<float?> values: WriteNullableUnionList<float, FloatValueWriter>(schema, values, encoder); return true;
+            case IList<double> values: WriteUnionList<double, DoubleValueWriter>(schema, values, encoder); return true;
+            case IList<double?> values: WriteNullableUnionList<double, DoubleValueWriter>(schema, values, encoder); return true;
+            case IList<DateTime> values: WriteUnionList<DateTime, DateTimeValueWriter>(schema, values, encoder); return true;
+            case IList<DateTime?> values: WriteNullableUnionList<DateTime, DateTimeValueWriter>(schema, values, encoder); return true;
+            case IList<TimeSpan> values: WriteUnionList<TimeSpan, TimeSpanValueWriter>(schema, values, encoder); return true;
+            case IList<TimeSpan?> values: WriteNullableUnionList<TimeSpan, TimeSpanValueWriter>(schema, values, encoder); return true;
+            case IList<Guid> values: WriteUnionList<Guid, GuidValueWriter>(schema, values, encoder); return true;
+            case IList<Guid?> values: WriteNullableUnionList<Guid, GuidValueWriter>(schema, values, encoder); return true;
+            case IList<global::Avro.AvroDecimal> values: WriteUnionList<global::Avro.AvroDecimal, DecimalValueWriter>(schema, values, encoder); return true;
+            case IList<global::Avro.AvroDecimal?> values: WriteNullableUnionList<global::Avro.AvroDecimal, DecimalValueWriter>(schema, values, encoder); return true;
             default: return false;
         }
     }
@@ -505,6 +523,47 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
     private static void WriteNullableUnionList<T, TWriter>(
         global::Avro.UnionSchema schema,
         List<T?> values,
+        AllocationFreeBinaryEncoder encoder)
+        where T : struct
+        where TWriter : struct, IValueWriter<T>
+    {
+        FindUnionBranches<T, TWriter>(schema, out var nullIndex, out var valueIndex, out var valueSchema);
+        for (var i = 0; i < values.Count; i++)
+        {
+            encoder.StartItem();
+            var value = values[i];
+            if (!value.HasValue)
+            {
+                if (nullIndex < 0)
+                    throw TypeMismatch(null, "union");
+                encoder.WriteUnionIndex(nullIndex);
+                continue;
+            }
+
+            encoder.WriteUnionIndex(valueIndex);
+            TWriter.Write(valueSchema, value.GetValueOrDefault(), encoder);
+        }
+    }
+
+    private static void WriteUnionList<T, TWriter>(
+        global::Avro.UnionSchema schema,
+        IList<T> values,
+        AllocationFreeBinaryEncoder encoder)
+        where T : struct
+        where TWriter : struct, IValueWriter<T>
+    {
+        FindUnionBranches<T, TWriter>(schema, out _, out var valueIndex, out var valueSchema);
+        for (var i = 0; i < values.Count; i++)
+        {
+            encoder.StartItem();
+            encoder.WriteUnionIndex(valueIndex);
+            TWriter.Write(valueSchema, values[i], encoder);
+        }
+    }
+
+    private static void WriteNullableUnionList<T, TWriter>(
+        global::Avro.UnionSchema schema,
+        IList<T?> values,
         AllocationFreeBinaryEncoder encoder)
         where T : struct
         where TWriter : struct, IValueWriter<T>

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -166,9 +166,6 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         {
             if (TryWriteValueTypeUnionArray(unionSchema, array, encoder))
                 return;
-
-            if (_writerCache.GetUnion(unionSchema).HasAssignableConditionalBranches)
-                ThrowAssignableConditionalCollection(array.GetType());
         }
 
         switch (itemSchema.Tag)
@@ -293,9 +290,6 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                 return;
 
             var union = _writerCache.GetUnion(unionSchema);
-            if (union.HasAssignableConditionalBranches)
-                ThrowAssignableConditionalCollection(list.GetType());
-
             if (union.HasConditionalValueTypeBranch &&
                 list is not IEnumerable<object?> &&
                 list is not ArrayList)
@@ -391,11 +385,6 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             WriteValue(itemSchema, list[i], encoder);
         }
     }
-
-    private static void ThrowAssignableConditionalCollection(Type collectionType) =>
-        throw new global::Avro.AvroTypeException(
-            $"Collection type {collectionType} is not supported for assignable value-dependent Avro union items; " +
-            "per-item candidate scans are forbidden in allocation-free serialization.");
 
     private static void WriteListItems<T, TWriter>(
         global::Avro.Schema itemSchema,
@@ -1011,9 +1000,6 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         private readonly Dictionary<global::Avro.SchemaName, UnionBranch> _enumBranches = new();
         private readonly Dictionary<global::Avro.SchemaName, UnionBranch> _fixedBranches = new();
         private readonly Dictionary<Type, ConditionalUnionBranch>? _conditionalBranches;
-        private readonly Dictionary<Type, MultipleConditionalUnionBranches>? _multipleConditionalBranches;
-        private readonly ConditionalUnionCandidateByType[]? _conditionalCandidates;
-        private readonly ConditionalUnionCandidateByType[]? _assignableConditionalCandidates;
         private readonly ValueTypeFlags _conditionalValueTypes;
         private readonly bool _hasPotentialConditionalValueTypeBranch;
         private readonly UnionBranch _arrayBranch;
@@ -1103,9 +1089,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                         if (conditional is not null)
                         {
                             conditionalValueTypes |= GetAssignableValueTypes(type);
-                            hasPotentialConditionalValueTypeBranch |=
-                                type.IsValueType || type.IsInterface ||
-                                type == typeof(object) || type == typeof(ValueType) || type == typeof(Enum);
+                            hasPotentialConditionalValueTypeBranch |= type.IsValueType;
                         }
                         if (type == typeof(bool))
                         {
@@ -1177,12 +1161,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             _timeSpanBranch = timeSpanBranch;
             _guidBranch = guidBranch;
             _decimalBranch = decimalBranch;
-            _conditionalBranches = BuildConditionalBranches(
-                conditionalBranchBuilders,
-                out _multipleConditionalBranches);
-            _conditionalCandidates = BuildConditionalCandidates(
-                conditionalBranchBuilders,
-                out _assignableConditionalCandidates);
+            _conditionalBranches = BuildConditionalBranches(conditionalBranchBuilders, schema);
             _conditionalValueTypes = conditionalValueTypes;
             _hasPotentialConditionalValueTypeBranch = hasPotentialConditionalValueTypeBranch;
         }
@@ -1192,8 +1171,6 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         public bool HasConditionalBranches => _conditionalBranches is not null;
 
         public bool HasConditionalValueTypeBranch => _hasPotentialConditionalValueTypeBranch;
-
-        public bool HasAssignableConditionalBranches => _assignableConditionalCandidates is not null;
 
         public int NullIndex { get; }
 
@@ -1287,10 +1264,6 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                 var runtimeType = value.GetType();
                 if (_conditionalBranches!.TryGetValue(runtimeType, out var conditional))
                 {
-                    if (_assignableConditionalCandidates is not null &&
-                        HasAssignableConditionalCandidate(value, runtimeType))
-                        return ResolveCombinedConditional(value, runtimeType);
-
                     var fallback = GetConditionalFallback(value, conditional.Fallback);
                     if (fallback.Schema is not null && fallback.Index < conditional.Primary.Index)
                         return fallback;
@@ -1302,134 +1275,10 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                         return fallback;
                     throw NoMatch(value);
                 }
-
-                if (_multipleConditionalBranches?.TryGetValue(runtimeType, out var multiple) == true)
-                {
-                    if (_assignableConditionalCandidates is not null &&
-                        HasAssignableConditionalCandidate(value, runtimeType))
-                        return ResolveCombinedConditional(value, runtimeType);
-
-                    var candidates = multiple.Candidates;
-                    var fallback = GetConditionalFallback(value, multiple.Fallback);
-                    for (var i = 0; i < candidates.Length; i++)
-                    {
-                        var candidate = candidates[i];
-                        if (fallback.Schema is not null && fallback.Index < candidate.Branch.Index)
-                            return fallback;
-                        if (candidate.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
-                            return candidate.Branch;
-                    }
-                    if (fallback.Schema is not null)
-                        return fallback;
-                    throw NoMatch(value);
-                }
-
-                if (_assignableConditionalCandidates is not null)
-                    return ResolveAssignableConditional(value, runtimeType);
             }
 
             return Resolve(value);
         }
-
-        private bool HasAssignableConditionalCandidate(object value, Type runtimeType)
-        {
-            var candidates = _assignableConditionalCandidates!;
-            for (var i = 0; i < candidates.Length; i++)
-            {
-                var candidate = candidates[i];
-                if (candidate.DeclaredType != runtimeType && candidate.DeclaredType.IsInstanceOfType(value))
-                    return true;
-            }
-
-            return false;
-        }
-
-        private UnionBranch ResolveAssignableConditional(object value, Type runtimeType)
-        {
-            var fallback = ResolveStructuralBranch(value);
-            if (fallback.Schema is null)
-                fallback = ResolveCompatibleNonStructuralBranch(value, runtimeType);
-
-            var matched = false;
-            var candidates = _assignableConditionalCandidates!;
-            for (var i = 0; i < candidates.Length; i++)
-            {
-                var candidate = candidates[i];
-                if (!candidate.DeclaredType.IsInstanceOfType(value))
-                    continue;
-
-                matched = true;
-                fallback = Earlier(fallback, candidate.Fallback);
-                if (fallback.Schema is not null && fallback.Index < candidate.Branch.Index)
-                    return fallback;
-                if (candidate.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
-                    return candidate.Branch;
-            }
-
-            if (fallback.Schema is not null)
-                return fallback;
-            if (matched)
-                throw NoMatch(value);
-            return Resolve(value);
-        }
-
-        private UnionBranch ResolveCombinedConditional(object value, Type runtimeType)
-        {
-            var fallback = Earlier(
-                ResolveCompatibleNonStructuralBranch(value, runtimeType),
-                ResolveStructuralBranch(value));
-            if (_conditionalBranches!.TryGetValue(runtimeType, out var conditional))
-                fallback = Earlier(fallback, conditional.Fallback);
-            if (_multipleConditionalBranches?.TryGetValue(runtimeType, out var multiple) == true)
-                fallback = Earlier(fallback, multiple.Fallback);
-
-            var matched = false;
-            var candidates = _conditionalCandidates!;
-            for (var i = 0; i < candidates.Length; i++)
-            {
-                var candidate = candidates[i];
-                if (!candidate.DeclaredType.IsInstanceOfType(value))
-                    continue;
-
-                matched = true;
-                fallback = Earlier(fallback, candidate.Fallback);
-                if (fallback.Schema is not null && fallback.Index < candidate.Branch.Index)
-                    return fallback;
-                if (candidate.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
-                    return candidate.Branch;
-            }
-
-            if (fallback.Schema is not null)
-                return fallback;
-            if (matched)
-                throw NoMatch(value);
-            return Resolve(value);
-        }
-
-        private UnionBranch ResolveCompatibleNonStructuralBranch(object value, Type runtimeType)
-        {
-            if (HasConditionalValueBranch(runtimeType))
-                return default;
-
-            return value switch
-            {
-                bool => _booleanBranch,
-                int => _intBranch,
-                long => _longBranch,
-                float => _floatBranch,
-                double => _doubleBranch,
-                byte[] => _bytesBranch,
-                string => _stringBranch,
-                DateTime => _dateTimeBranch,
-                TimeSpan => _timeSpanBranch,
-                Guid => _guidBranch,
-                global::Avro.AvroDecimal => _decimalBranch,
-                _ => _typedBranches.TryGetValue(runtimeType, out var branch) ? branch : default
-            };
-        }
-
-        private static UnionBranch Earlier(UnionBranch left, UnionBranch right) =>
-            right.Schema is not null && (left.Schema is null || right.Index < left.Index) ? right : left;
 
         private UnionBranch FirstCompatibleTypedBranch(Type type, UnionBranch schemaBranch) =>
             _typedBranches.TryGetValue(type, out var typedBranch) && typedBranch.Index < schemaBranch.Index
@@ -1491,74 +1340,28 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
 
         private static Dictionary<Type, ConditionalUnionBranch>? BuildConditionalBranches(
             Dictionary<Type, ConditionalUnionBranchBuilder>? builders,
-            out Dictionary<Type, MultipleConditionalUnionBranches>? multipleBranches)
+            global::Avro.UnionSchema schema)
         {
-            multipleBranches = null;
             if (builders is null)
                 return null;
 
             var branches = new Dictionary<Type, ConditionalUnionBranch>(builders.Count);
             foreach (var (type, builder) in builders)
             {
-                if (builder.Candidates.Count == 1)
+                if (!type.IsSealed || builder.Candidates.Count != 1)
                 {
-                    var candidate = builder.Candidates[0];
-                    branches.Add(
-                        type,
-                        new ConditionalUnionBranch(candidate.Branch, candidate.LogicalSchema, builder.Fallback));
-                    continue;
+                    throw new global::Avro.AvroTypeException(
+                        $"Union {schema} uses value-dependent custom logical branches for {type}; " +
+                        "assignable or multi-candidate dispatch would require forbidden per-message scans.");
                 }
 
-                multipleBranches ??= new Dictionary<Type, MultipleConditionalUnionBranches>();
-                multipleBranches.Add(
+                var candidate = builder.Candidates[0];
+                branches.Add(
                     type,
-                    new MultipleConditionalUnionBranches(builder.Candidates.ToArray(), builder.Fallback));
+                    new ConditionalUnionBranch(candidate.Branch, candidate.LogicalSchema, builder.Fallback));
             }
 
             return branches;
-        }
-
-        private static ConditionalUnionCandidateByType[]? BuildConditionalCandidates(
-            Dictionary<Type, ConditionalUnionBranchBuilder>? builders,
-            out ConditionalUnionCandidateByType[]? assignableCandidates)
-        {
-            assignableCandidates = null;
-            if (builders is null)
-                return null;
-
-            List<ConditionalUnionCandidateByType>? candidates = null;
-            List<ConditionalUnionCandidateByType>? assignable = null;
-            foreach (var (type, builder) in builders)
-            {
-                candidates ??= [];
-                var isAssignableType = !type.IsSealed;
-                if (isAssignableType)
-                    assignable ??= [];
-
-                for (var i = 0; i < builder.Candidates.Count; i++)
-                {
-                    var candidate = builder.Candidates[i];
-                    var candidateByType = new ConditionalUnionCandidateByType(
-                        type,
-                        candidate.Branch,
-                        candidate.LogicalSchema,
-                        builder.Fallback);
-                    candidates.Add(candidateByType);
-                    if (isAssignableType)
-                        assignable!.Add(candidateByType);
-                }
-            }
-
-            if (candidates is null)
-                return null;
-
-            candidates.Sort(static (left, right) => left.Branch.Index.CompareTo(right.Branch.Index));
-            if (assignable is not null)
-            {
-                assignable.Sort(static (left, right) => left.Branch.Index.CompareTo(right.Branch.Index));
-                assignableCandidates = assignable.ToArray();
-            }
-            return candidates.ToArray();
         }
 
         private void ThrowIfConditionalValueBranch(Type type)
@@ -1576,8 +1379,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             var valueType = GetValueType(type);
             return valueType != ValueTypeFlags.None
                 ? (_conditionalValueTypes & valueType) != 0
-                : _conditionalBranches?.ContainsKey(type) == true ||
-                  _multipleConditionalBranches?.ContainsKey(type) == true;
+                : _conditionalBranches?.ContainsKey(type) == true;
         }
 
         private static ValueTypeFlags GetAssignableValueTypes(Type type)
@@ -1641,16 +1443,6 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
 
     private readonly record struct ConditionalUnionBranch(
         UnionBranch Primary,
-        global::Avro.LogicalSchema LogicalSchema,
-        UnionBranch Fallback);
-
-    private readonly record struct MultipleConditionalUnionBranches(
-        ConditionalUnionCandidate[] Candidates,
-        UnionBranch Fallback);
-
-    private readonly record struct ConditionalUnionCandidateByType(
-        Type DeclaredType,
-        UnionBranch Branch,
         global::Avro.LogicalSchema LogicalSchema,
         UnionBranch Fallback);
 

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -736,7 +736,10 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
 
     private void WriteUnion(global::Avro.UnionSchema schema, object? value, AllocationFreeBinaryEncoder encoder)
     {
-        var branch = _writerCache.GetUnion(schema).Resolve(value);
+        var union = _writerCache.GetUnion(schema);
+        var branch = union.HasConditionalBranches
+            ? union.ResolveConditional(value)
+            : union.Resolve(value);
         encoder.WriteUnionIndex(branch.Index);
         WriteValue(branch.Schema, value, encoder);
     }
@@ -980,6 +983,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         private readonly Dictionary<global::Avro.SchemaName, UnionBranch> _recordBranches = new();
         private readonly Dictionary<global::Avro.SchemaName, UnionBranch> _enumBranches = new();
         private readonly Dictionary<global::Avro.SchemaName, UnionBranch> _fixedBranches = new();
+        private readonly Dictionary<Type, ConditionalUnionBranch>? _conditionalBranches;
         private readonly UnionBranch _arrayBranch;
         private readonly UnionBranch _booleanBranch;
         private readonly UnionBranch _bytesBranch;
@@ -1009,6 +1013,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             UnionBranch longBranch = default;
             UnionBranch stringBranch = default;
             UnionBranch timeSpanBranch = default;
+            Dictionary<Type, ConditionalUnionBranch>? conditionalBranches = null;
             for (var i = 0; i < schema.Count; i++)
             {
                 var branch = schema[i];
@@ -1019,25 +1024,25 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                         NullIndex = i;
                         break;
                     case global::Avro.Schema.Type.Boolean:
-                        SetFirst(ref booleanBranch, resolved);
+                        SetCompatibleBranch(typeof(bool), ref booleanBranch, resolved, null, ref conditionalBranches);
                         break;
                     case global::Avro.Schema.Type.Int:
-                        SetFirst(ref intBranch, resolved);
+                        SetCompatibleBranch(typeof(int), ref intBranch, resolved, null, ref conditionalBranches);
                         break;
                     case global::Avro.Schema.Type.Long:
-                        SetFirst(ref longBranch, resolved);
+                        SetCompatibleBranch(typeof(long), ref longBranch, resolved, null, ref conditionalBranches);
                         break;
                     case global::Avro.Schema.Type.Float:
-                        SetFirst(ref floatBranch, resolved);
+                        SetCompatibleBranch(typeof(float), ref floatBranch, resolved, null, ref conditionalBranches);
                         break;
                     case global::Avro.Schema.Type.Double:
-                        SetFirst(ref doubleBranch, resolved);
+                        SetCompatibleBranch(typeof(double), ref doubleBranch, resolved, null, ref conditionalBranches);
                         break;
                     case global::Avro.Schema.Type.Bytes:
-                        SetFirst(ref bytesBranch, resolved);
+                        SetCompatibleBranch(typeof(byte[]), ref bytesBranch, resolved, null, ref conditionalBranches);
                         break;
                     case global::Avro.Schema.Type.String:
-                        SetFirst(ref stringBranch, resolved);
+                        SetCompatibleBranch(typeof(string), ref stringBranch, resolved, null, ref conditionalBranches);
                         break;
                     case global::Avro.Schema.Type.Record:
                     case global::Avro.Schema.Type.Error:
@@ -1058,54 +1063,63 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                             _mapBranch = resolved;
                         break;
                     case global::Avro.Schema.Type.Logical:
-                        var type = ((global::Avro.LogicalSchema)branch).LogicalType.GetCSharpType(nullible: false);
+                        var logical = (global::Avro.LogicalSchema)branch;
+                        var type = logical.LogicalType.GetCSharpType(nullible: false);
+                        var conditional = IsSpecializedLogicalType(logical.LogicalType) ? null : logical;
                         if (type == typeof(bool))
                         {
-                            SetFirst(ref booleanBranch, resolved);
+                            SetCompatibleBranch(type, ref booleanBranch, resolved, conditional, ref conditionalBranches);
                         }
                         else if (type == typeof(int))
                         {
-                            SetFirst(ref intBranch, resolved);
+                            SetCompatibleBranch(type, ref intBranch, resolved, conditional, ref conditionalBranches);
                         }
                         else if (type == typeof(long))
                         {
-                            SetFirst(ref longBranch, resolved);
+                            SetCompatibleBranch(type, ref longBranch, resolved, conditional, ref conditionalBranches);
                         }
                         else if (type == typeof(float))
                         {
-                            SetFirst(ref floatBranch, resolved);
+                            SetCompatibleBranch(type, ref floatBranch, resolved, conditional, ref conditionalBranches);
                         }
                         else if (type == typeof(double))
                         {
-                            SetFirst(ref doubleBranch, resolved);
+                            SetCompatibleBranch(type, ref doubleBranch, resolved, conditional, ref conditionalBranches);
                         }
                         else if (type == typeof(byte[]))
                         {
-                            SetFirst(ref bytesBranch, resolved);
+                            SetCompatibleBranch(type, ref bytesBranch, resolved, conditional, ref conditionalBranches);
                         }
                         else if (type == typeof(string))
                         {
-                            SetFirst(ref stringBranch, resolved);
+                            SetCompatibleBranch(type, ref stringBranch, resolved, conditional, ref conditionalBranches);
                         }
                         else if (type == typeof(DateTime))
                         {
-                            SetFirst(ref dateTimeBranch, resolved);
+                            SetCompatibleBranch(type, ref dateTimeBranch, resolved, conditional, ref conditionalBranches);
                         }
                         else if (type == typeof(TimeSpan))
                         {
-                            SetFirst(ref timeSpanBranch, resolved);
+                            SetCompatibleBranch(type, ref timeSpanBranch, resolved, conditional, ref conditionalBranches);
                         }
                         else if (type == typeof(Guid))
                         {
-                            SetFirst(ref guidBranch, resolved);
+                            SetCompatibleBranch(type, ref guidBranch, resolved, conditional, ref conditionalBranches);
                         }
                         else if (type == typeof(global::Avro.AvroDecimal))
                         {
-                            SetFirst(ref decimalBranch, resolved);
+                            SetCompatibleBranch(type, ref decimalBranch, resolved, conditional, ref conditionalBranches);
                         }
                         else
                         {
-                            _typedBranches.TryAdd(type, resolved);
+                            if (!_typedBranches.TryAdd(type, resolved) && conditional is not null)
+                                throw UnsupportedConditionalBranches(type);
+
+                            if (conditional is not null)
+                            {
+                                conditionalBranches ??= new Dictionary<Type, ConditionalUnionBranch>();
+                                conditionalBranches.Add(type, new ConditionalUnionBranch(resolved, conditional, default));
+                            }
                         }
                         break;
                 }
@@ -1122,14 +1136,19 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             _timeSpanBranch = timeSpanBranch;
             _guidBranch = guidBranch;
             _decimalBranch = decimalBranch;
+            _conditionalBranches = conditionalBranches;
         }
 
         public global::Avro.UnionSchema Schema => _schema;
+
+        public bool HasConditionalBranches => _conditionalBranches is not null;
 
         public int NullIndex { get; }
 
         public bool TryGetValueBranch(Type type, out UnionBranch branch)
         {
+            ThrowIfConditionalValueBranch(type);
+
             if (type == typeof(bool)) branch = _booleanBranch;
             else if (type == typeof(int)) branch = _intBranch;
             else if (type == typeof(long)) branch = _longBranch;
@@ -1146,6 +1165,8 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
 
         public UnionBranch GetValueBranch(Type type)
         {
+            ThrowIfConditionalValueBranch(type);
+
             UnionBranch branch;
             if (type == typeof(bool)) branch = _booleanBranch;
             else if (type == typeof(int)) branch = _intBranch;
@@ -1203,22 +1224,83 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             }
         }
 
+        public UnionBranch ResolveConditional(object? value)
+        {
+            if (value is not null &&
+                _conditionalBranches!.TryGetValue(value.GetType(), out var conditional))
+            {
+                if (conditional.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
+                    return conditional.Primary;
+                if (conditional.Fallback.Schema is not null)
+                    return conditional.Fallback;
+                throw NoMatch(value);
+            }
+
+            return Resolve(value);
+        }
+
         private UnionBranch FirstCompatibleTypedBranch(Type type, UnionBranch schemaBranch) =>
             _typedBranches.TryGetValue(type, out var typedBranch) && typedBranch.Index < schemaBranch.Index
                 ? typedBranch
                 : schemaBranch;
 
-        private static void SetFirst(ref UnionBranch target, UnionBranch branch)
+        private static void SetCompatibleBranch(
+            Type type,
+            ref UnionBranch target,
+            UnionBranch branch,
+            global::Avro.LogicalSchema? conditional,
+            ref Dictionary<Type, ConditionalUnionBranch>? conditionalBranches)
         {
             if (target.Schema is null)
+            {
                 target = branch;
+                if (conditional is not null)
+                {
+                    conditionalBranches ??= new Dictionary<Type, ConditionalUnionBranch>();
+                    conditionalBranches.Add(type, new ConditionalUnionBranch(branch, conditional, default));
+                }
+                return;
+            }
+
+            if (conditionalBranches is null ||
+                !conditionalBranches.TryGetValue(type, out var existing) ||
+                existing.Fallback.Schema is not null)
+                return;
+
+            if (conditional is not null)
+                throw UnsupportedConditionalBranches(type);
+
+            conditionalBranches[type] = existing with { Fallback = branch };
         }
+
+        private void ThrowIfConditionalValueBranch(Type type)
+        {
+            if (_conditionalBranches?.ContainsKey(type) == true)
+            {
+                throw new global::Avro.AvroTypeException(
+                    $"Union {_schema} uses a value-dependent custom logical branch for {type}; " +
+                    "allocation-free value-type collection serialization cannot evaluate it without boxing.");
+            }
+        }
+
+        private static bool IsSpecializedLogicalType(global::Avro.Util.LogicalType logicalType) =>
+            logicalType is Date or TimestampMillisecond or LocalTimestampMillisecond or
+                TimestampMicrosecond or LocalTimestampMicrosecond or
+                TimeMillisecond or TimeMicrosecond or Uuid or global::Avro.Util.Decimal;
+
+        private static global::Avro.AvroTypeException UnsupportedConditionalBranches(Type type) =>
+            new($"Union contains multiple value-dependent custom logical branches for {type}.");
 
         private global::Avro.AvroException NoMatch(object? value) =>
             new($"Cannot find a union match for {value?.GetType()} in {_schema}.");
     }
 
     private readonly record struct UnionBranch(int Index, global::Avro.Schema Schema);
+
+    private readonly record struct ConditionalUnionBranch(
+        UnionBranch Primary,
+        global::Avro.LogicalSchema LogicalSchema,
+        UnionBranch Fallback);
 
     private sealed class ReferenceComparer<T> : IEqualityComparer<T>
         where T : class

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -984,6 +984,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         private readonly Dictionary<global::Avro.SchemaName, UnionBranch> _enumBranches = new();
         private readonly Dictionary<global::Avro.SchemaName, UnionBranch> _fixedBranches = new();
         private readonly Dictionary<Type, ConditionalUnionBranch>? _conditionalBranches;
+        private readonly Dictionary<Type, MultipleConditionalUnionBranches>? _multipleConditionalBranches;
         private readonly UnionBranch _arrayBranch;
         private readonly UnionBranch _booleanBranch;
         private readonly UnionBranch _bytesBranch;
@@ -1013,7 +1014,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             UnionBranch longBranch = default;
             UnionBranch stringBranch = default;
             UnionBranch timeSpanBranch = default;
-            Dictionary<Type, ConditionalUnionBranch>? conditionalBranches = null;
+            Dictionary<Type, ConditionalUnionBranchBuilder>? conditionalBranchBuilders = null;
             for (var i = 0; i < schema.Count; i++)
             {
                 var branch = schema[i];
@@ -1024,25 +1025,25 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                         NullIndex = i;
                         break;
                     case global::Avro.Schema.Type.Boolean:
-                        SetCompatibleBranch(typeof(bool), ref booleanBranch, resolved, null, ref conditionalBranches);
+                        SetCompatibleBranch(typeof(bool), ref booleanBranch, resolved, null, ref conditionalBranchBuilders);
                         break;
                     case global::Avro.Schema.Type.Int:
-                        SetCompatibleBranch(typeof(int), ref intBranch, resolved, null, ref conditionalBranches);
+                        SetCompatibleBranch(typeof(int), ref intBranch, resolved, null, ref conditionalBranchBuilders);
                         break;
                     case global::Avro.Schema.Type.Long:
-                        SetCompatibleBranch(typeof(long), ref longBranch, resolved, null, ref conditionalBranches);
+                        SetCompatibleBranch(typeof(long), ref longBranch, resolved, null, ref conditionalBranchBuilders);
                         break;
                     case global::Avro.Schema.Type.Float:
-                        SetCompatibleBranch(typeof(float), ref floatBranch, resolved, null, ref conditionalBranches);
+                        SetCompatibleBranch(typeof(float), ref floatBranch, resolved, null, ref conditionalBranchBuilders);
                         break;
                     case global::Avro.Schema.Type.Double:
-                        SetCompatibleBranch(typeof(double), ref doubleBranch, resolved, null, ref conditionalBranches);
+                        SetCompatibleBranch(typeof(double), ref doubleBranch, resolved, null, ref conditionalBranchBuilders);
                         break;
                     case global::Avro.Schema.Type.Bytes:
-                        SetCompatibleBranch(typeof(byte[]), ref bytesBranch, resolved, null, ref conditionalBranches);
+                        SetCompatibleBranch(typeof(byte[]), ref bytesBranch, resolved, null, ref conditionalBranchBuilders);
                         break;
                     case global::Avro.Schema.Type.String:
-                        SetCompatibleBranch(typeof(string), ref stringBranch, resolved, null, ref conditionalBranches);
+                        SetCompatibleBranch(typeof(string), ref stringBranch, resolved, null, ref conditionalBranchBuilders);
                         break;
                     case global::Avro.Schema.Type.Record:
                     case global::Avro.Schema.Type.Error:
@@ -1068,58 +1069,58 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                         var conditional = IsSpecializedLogicalType(logical.LogicalType) ? null : logical;
                         if (type == typeof(bool))
                         {
-                            SetCompatibleBranch(type, ref booleanBranch, resolved, conditional, ref conditionalBranches);
+                            SetCompatibleBranch(type, ref booleanBranch, resolved, conditional, ref conditionalBranchBuilders);
                         }
                         else if (type == typeof(int))
                         {
-                            SetCompatibleBranch(type, ref intBranch, resolved, conditional, ref conditionalBranches);
+                            SetCompatibleBranch(type, ref intBranch, resolved, conditional, ref conditionalBranchBuilders);
                         }
                         else if (type == typeof(long))
                         {
-                            SetCompatibleBranch(type, ref longBranch, resolved, conditional, ref conditionalBranches);
+                            SetCompatibleBranch(type, ref longBranch, resolved, conditional, ref conditionalBranchBuilders);
                         }
                         else if (type == typeof(float))
                         {
-                            SetCompatibleBranch(type, ref floatBranch, resolved, conditional, ref conditionalBranches);
+                            SetCompatibleBranch(type, ref floatBranch, resolved, conditional, ref conditionalBranchBuilders);
                         }
                         else if (type == typeof(double))
                         {
-                            SetCompatibleBranch(type, ref doubleBranch, resolved, conditional, ref conditionalBranches);
+                            SetCompatibleBranch(type, ref doubleBranch, resolved, conditional, ref conditionalBranchBuilders);
                         }
                         else if (type == typeof(byte[]))
                         {
-                            SetCompatibleBranch(type, ref bytesBranch, resolved, conditional, ref conditionalBranches);
+                            SetCompatibleBranch(type, ref bytesBranch, resolved, conditional, ref conditionalBranchBuilders);
                         }
                         else if (type == typeof(string))
                         {
-                            SetCompatibleBranch(type, ref stringBranch, resolved, conditional, ref conditionalBranches);
+                            SetCompatibleBranch(type, ref stringBranch, resolved, conditional, ref conditionalBranchBuilders);
                         }
                         else if (type == typeof(DateTime))
                         {
-                            SetCompatibleBranch(type, ref dateTimeBranch, resolved, conditional, ref conditionalBranches);
+                            SetCompatibleBranch(type, ref dateTimeBranch, resolved, conditional, ref conditionalBranchBuilders);
                         }
                         else if (type == typeof(TimeSpan))
                         {
-                            SetCompatibleBranch(type, ref timeSpanBranch, resolved, conditional, ref conditionalBranches);
+                            SetCompatibleBranch(type, ref timeSpanBranch, resolved, conditional, ref conditionalBranchBuilders);
                         }
                         else if (type == typeof(Guid))
                         {
-                            SetCompatibleBranch(type, ref guidBranch, resolved, conditional, ref conditionalBranches);
+                            SetCompatibleBranch(type, ref guidBranch, resolved, conditional, ref conditionalBranchBuilders);
                         }
                         else if (type == typeof(global::Avro.AvroDecimal))
                         {
-                            SetCompatibleBranch(type, ref decimalBranch, resolved, conditional, ref conditionalBranches);
+                            SetCompatibleBranch(type, ref decimalBranch, resolved, conditional, ref conditionalBranchBuilders);
                         }
                         else
                         {
-                            if (!_typedBranches.TryAdd(type, resolved) && conditional is not null)
-                                throw UnsupportedConditionalBranches(type);
-
-                            if (conditional is not null)
-                            {
-                                conditionalBranches ??= new Dictionary<Type, ConditionalUnionBranch>();
-                                conditionalBranches.Add(type, new ConditionalUnionBranch(resolved, conditional, default));
-                            }
+                            _typedBranches.TryGetValue(type, out var typedBranch);
+                            SetCompatibleBranch(
+                                type,
+                                ref typedBranch,
+                                resolved,
+                                conditional,
+                                ref conditionalBranchBuilders);
+                            _typedBranches[type] = typedBranch;
                         }
                         break;
                 }
@@ -1136,7 +1137,9 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             _timeSpanBranch = timeSpanBranch;
             _guidBranch = guidBranch;
             _decimalBranch = decimalBranch;
-            _conditionalBranches = conditionalBranches;
+            _conditionalBranches = BuildConditionalBranches(
+                conditionalBranchBuilders,
+                out _multipleConditionalBranches);
         }
 
         public global::Avro.UnionSchema Schema => _schema;
@@ -1231,8 +1234,24 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             {
                 if (conditional.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
                     return conditional.Primary;
+
                 if (conditional.Fallback.Schema is not null)
                     return conditional.Fallback;
+                throw NoMatch(value);
+            }
+
+            if (value is not null &&
+                _multipleConditionalBranches?.TryGetValue(value.GetType(), out var multiple) == true)
+            {
+                var candidates = multiple.Candidates;
+                for (var i = 0; i < candidates.Length; i++)
+                {
+                    var candidate = candidates[i];
+                    if (candidate.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
+                        return candidate.Branch;
+                }
+                if (multiple.Fallback.Schema is not null)
+                    return multiple.Fallback;
                 throw NoMatch(value);
             }
 
@@ -1249,33 +1268,68 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             ref UnionBranch target,
             UnionBranch branch,
             global::Avro.LogicalSchema? conditional,
-            ref Dictionary<Type, ConditionalUnionBranch>? conditionalBranches)
+            ref Dictionary<Type, ConditionalUnionBranchBuilder>? conditionalBranchBuilders)
         {
             if (target.Schema is null)
             {
                 target = branch;
                 if (conditional is not null)
                 {
-                    conditionalBranches ??= new Dictionary<Type, ConditionalUnionBranch>();
-                    conditionalBranches.Add(type, new ConditionalUnionBranch(branch, conditional, default));
+                    conditionalBranchBuilders ??= new Dictionary<Type, ConditionalUnionBranchBuilder>();
+                    var builder = new ConditionalUnionBranchBuilder();
+                    builder.Candidates.Add(new ConditionalUnionCandidate(branch, conditional));
+                    conditionalBranchBuilders.Add(type, builder);
                 }
                 return;
             }
 
-            if (conditionalBranches is null ||
-                !conditionalBranches.TryGetValue(type, out var existing) ||
+            if (conditionalBranchBuilders is null ||
+                !conditionalBranchBuilders.TryGetValue(type, out var existing) ||
                 existing.Fallback.Schema is not null)
                 return;
 
             if (conditional is not null)
-                throw UnsupportedConditionalBranches(type);
+            {
+                existing.Candidates.Add(new ConditionalUnionCandidate(branch, conditional));
+                return;
+            }
 
-            conditionalBranches[type] = existing with { Fallback = branch };
+            existing.Fallback = branch;
+        }
+
+        private static Dictionary<Type, ConditionalUnionBranch>? BuildConditionalBranches(
+            Dictionary<Type, ConditionalUnionBranchBuilder>? builders,
+            out Dictionary<Type, MultipleConditionalUnionBranches>? multipleBranches)
+        {
+            multipleBranches = null;
+            if (builders is null)
+                return null;
+
+            var branches = new Dictionary<Type, ConditionalUnionBranch>(builders.Count);
+            foreach (var (type, builder) in builders)
+            {
+                if (builder.Candidates.Count == 1)
+                {
+                    var candidate = builder.Candidates[0];
+                    branches.Add(
+                        type,
+                        new ConditionalUnionBranch(candidate.Branch, candidate.LogicalSchema, builder.Fallback));
+                    continue;
+                }
+
+                multipleBranches ??= new Dictionary<Type, MultipleConditionalUnionBranches>();
+                multipleBranches.Add(
+                    type,
+                    new MultipleConditionalUnionBranches(builder.Candidates.ToArray(), builder.Fallback));
+            }
+
+            return branches;
         }
 
         private void ThrowIfConditionalValueBranch(Type type)
         {
-            if (_conditionalBranches?.ContainsKey(type) == true)
+            if (_conditionalBranches?.ContainsKey(type) == true ||
+                _multipleConditionalBranches?.ContainsKey(type) == true)
             {
                 throw new global::Avro.AvroTypeException(
                     $"Union {_schema} uses a value-dependent custom logical branch for {type}; " +
@@ -1288,19 +1342,30 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                 TimestampMicrosecond or LocalTimestampMicrosecond or
                 TimeMillisecond or TimeMicrosecond or Uuid or global::Avro.Util.Decimal;
 
-        private static global::Avro.AvroTypeException UnsupportedConditionalBranches(Type type) =>
-            new($"Union contains multiple value-dependent custom logical branches for {type}.");
-
         private global::Avro.AvroException NoMatch(object? value) =>
             new($"Cannot find a union match for {value?.GetType()} in {_schema}.");
     }
 
     private readonly record struct UnionBranch(int Index, global::Avro.Schema Schema);
 
+    private readonly record struct ConditionalUnionCandidate(
+        UnionBranch Branch,
+        global::Avro.LogicalSchema LogicalSchema);
+
     private readonly record struct ConditionalUnionBranch(
         UnionBranch Primary,
         global::Avro.LogicalSchema LogicalSchema,
         UnionBranch Fallback);
+
+    private readonly record struct MultipleConditionalUnionBranches(
+        ConditionalUnionCandidate[] Candidates,
+        UnionBranch Fallback);
+
+    private sealed class ConditionalUnionBranchBuilder
+    {
+        public List<ConditionalUnionCandidate> Candidates { get; } = [];
+        public UnionBranch Fallback { get; set; }
+    }
 
     private sealed class ReferenceComparer<T> : IEqualityComparer<T>
         where T : class

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -1,6 +1,5 @@
 using System.Buffers;
 using System.Collections;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using global::Avro.Generic;
@@ -13,10 +12,8 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
     private const int StackBufferSize = 256;
     private static readonly DateTime UnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
     private static readonly DateTime LocalUnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
-    private static readonly ConditionalWeakTable<Type, ListElement> ListElements = new();
     private readonly global::Avro.RecordSchema _schema = schema;
     private readonly WriterCache _writerCache = WriterCache.Create(schema);
-    private ListElement? _lastListElement;
 
     internal void Write(GenericRecord record, AllocationFreeBinaryEncoder encoder) =>
         WriteRecord(_schema, record, encoder, validateSchema: false);
@@ -363,20 +360,14 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                 return;
         }
 
-        var listType = list.GetType();
-        var cache = Volatile.Read(ref _lastListElement);
-        if (cache is null || !ReferenceEquals(cache.ListType, listType))
+        if (itemSchema is global::Avro.LogicalSchema logicalSchema)
         {
-            cache = ListElements.GetValue(
-                listType,
-                static type => new ListElement(type, FindListElement(type)));
-            Volatile.Write(ref _lastListElement, cache);
-        }
-
-        if (cache.ElementType is { IsValueType: true } elementType)
-        {
-            throw new global::Avro.AvroTypeException(
-                $"List element type {elementType} is not supported for Avro {itemSchema.Tag} items.");
+            var elementType = logicalSchema.LogicalType.GetCSharpType(nullible: false);
+            if (elementType.IsValueType)
+            {
+                throw new global::Avro.AvroTypeException(
+                    $"List element type {elementType} is not supported for Avro {itemSchema.Tag} items.");
+            }
         }
 
         for (var i = 0; i < list.Count; i++)
@@ -384,28 +375,6 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             encoder.StartItem();
             WriteValue(itemSchema, list[i], encoder);
         }
-    }
-
-    [UnconditionalSuppressMessage(
-        "Trimming",
-        "IL2070",
-        Justification = "A live IList instance retains the implemented interface needed for this rejection check.")]
-    private static Type? FindListElement(Type listType)
-    {
-        var interfaces = listType.GetInterfaces();
-        for (var index = 0; index < interfaces.Length; index++)
-        {
-            var candidate = interfaces[index];
-            if (!candidate.IsGenericType
-                || candidate.GetGenericTypeDefinition() != typeof(IList<>))
-            {
-                continue;
-            }
-
-            return candidate.GetGenericArguments()[0];
-        }
-
-        return null;
     }
 
     private static void WriteListItems<T, TWriter>(
@@ -1026,6 +995,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         private readonly Dictionary<global::Avro.SchemaName, UnionBranch> _fixedBranches = new();
         private readonly Dictionary<Type, ConditionalUnionBranch>? _conditionalBranches;
         private readonly Dictionary<Type, MultipleConditionalUnionBranches>? _multipleConditionalBranches;
+        private readonly AssignableConditionalUnionCandidate[]? _assignableConditionalCandidates;
         private readonly UnionBranch _arrayBranch;
         private readonly UnionBranch _booleanBranch;
         private readonly UnionBranch _bytesBranch;
@@ -1181,6 +1151,8 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             _conditionalBranches = BuildConditionalBranches(
                 conditionalBranchBuilders,
                 out _multipleConditionalBranches);
+            _assignableConditionalCandidates = BuildAssignableConditionalCandidates(
+                conditionalBranchBuilders);
         }
 
         public global::Avro.UnionSchema Schema => _schema;
@@ -1307,6 +1279,37 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                 throw NoMatch(value);
             }
 
+            if (value is not null && _assignableConditionalCandidates is not null)
+            {
+                var fallback = ResolveStructuralBranch(value);
+                var matched = false;
+                for (var i = 0; i < _assignableConditionalCandidates.Length; i++)
+                {
+                    var candidate = _assignableConditionalCandidates[i];
+                    if (!candidate.DeclaredType.IsInstanceOfType(value))
+                        continue;
+
+                    matched = true;
+                    if (candidate.Fallback.Schema is not null
+                        && (fallback.Schema is null || candidate.Fallback.Index < fallback.Index))
+                    {
+                        fallback = candidate.Fallback;
+                    }
+
+                    if (fallback.Schema is not null && fallback.Index < candidate.Branch.Index)
+                        return fallback;
+                    if (candidate.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
+                        return candidate.Branch;
+                }
+
+                if (matched)
+                {
+                    if (fallback.Schema is not null)
+                        return fallback;
+                    throw NoMatch(value);
+                }
+            }
+
             return Resolve(value);
         }
 
@@ -1397,6 +1400,37 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             return branches;
         }
 
+        private static AssignableConditionalUnionCandidate[]? BuildAssignableConditionalCandidates(
+            Dictionary<Type, ConditionalUnionBranchBuilder>? builders)
+        {
+            if (builders is null)
+                return null;
+
+            List<AssignableConditionalUnionCandidate>? assignable = null;
+            foreach (var (type, builder) in builders)
+            {
+                if (type.IsSealed)
+                    continue;
+
+                assignable ??= [];
+                for (var i = 0; i < builder.Candidates.Count; i++)
+                {
+                    var candidate = builder.Candidates[i];
+                    assignable.Add(new AssignableConditionalUnionCandidate(
+                        type,
+                        candidate.Branch,
+                        candidate.LogicalSchema,
+                        builder.Fallback));
+                }
+            }
+
+            if (assignable is null)
+                return null;
+
+            assignable.Sort(static (left, right) => left.Branch.Index.CompareTo(right.Branch.Index));
+            return assignable.ToArray();
+        }
+
         private void ThrowIfConditionalValueBranch(Type type)
         {
             if (HasConditionalValueBranch(type))
@@ -1435,16 +1469,16 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         ConditionalUnionCandidate[] Candidates,
         UnionBranch Fallback);
 
+    private readonly record struct AssignableConditionalUnionCandidate(
+        Type DeclaredType,
+        UnionBranch Branch,
+        global::Avro.LogicalSchema LogicalSchema,
+        UnionBranch Fallback);
+
     private sealed class ConditionalUnionBranchBuilder
     {
         public List<ConditionalUnionCandidate> Candidates { get; } = [];
         public UnionBranch Fallback { get; set; }
-    }
-
-    private sealed class ListElement(Type listType, Type? elementType)
-    {
-        internal Type ListType { get; } = listType;
-        internal Type? ElementType { get; } = elementType;
     }
 
     private sealed class ReferenceComparer<T> : IEqualityComparer<T>

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -289,7 +289,9 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             if (TryWriteValueTypeUnionList(unionSchema, list, encoder))
                 return;
 
-            if (_writerCache.GetUnion(unionSchema).HasConditionalValueTypeBranch)
+            if (_writerCache.GetUnion(unionSchema).HasConditionalValueTypeBranch &&
+                list is not IEnumerable<object?> &&
+                list is not ArrayList)
             {
                 throw new global::Avro.AvroTypeException(
                     $"List type {list.GetType()} is not supported for value-dependent Avro union items.");
@@ -760,7 +762,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         WriteValue(branch.Schema, value, encoder);
     }
 
-    private void WriteLogical(
+    private static void WriteLogical(
         global::Avro.LogicalSchema schema,
         object? value,
         AllocationFreeBinaryEncoder encoder)
@@ -793,11 +795,8 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                 return;
 
             default:
-                WriteValue(
-                    schema.BaseSchema,
-                    schema.LogicalType.ConvertToBaseValue(value, schema),
-                    encoder);
-                return;
+                throw new global::Avro.AvroTypeException(
+                    $"Custom logical type '{schema.LogicalTypeName}' is not supported by the allocation-free writer.");
         }
     }
 

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -371,7 +371,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             if (!elementType.IsValueType)
                 elementType = null;
         }
-        else if (itemSchema.Tag is global::Avro.Schema.Type.Logical)
+        else
         {
             var cache = Volatile.Read(ref _lastValueTypeListElement);
             if (cache is null || !ReferenceEquals(cache.ListType, listType))

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -162,10 +162,13 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
 
     private void WriteTypedArray(global::Avro.Schema itemSchema, Array array, AllocationFreeBinaryEncoder encoder)
     {
-        if (itemSchema is global::Avro.UnionSchema unionSchema &&
-            TryWriteValueTypeUnionArray(unionSchema, array, encoder))
+        if (itemSchema is global::Avro.UnionSchema unionSchema)
         {
-            return;
+            if (TryWriteValueTypeUnionArray(unionSchema, array, encoder))
+                return;
+
+            if (_writerCache.GetUnion(unionSchema).HasAssignableConditionalBranches)
+                ThrowAssignableConditionalCollection(array.GetType());
         }
 
         switch (itemSchema.Tag)
@@ -289,7 +292,11 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             if (TryWriteValueTypeUnionList(unionSchema, list, encoder))
                 return;
 
-            if (_writerCache.GetUnion(unionSchema).HasConditionalValueTypeBranch &&
+            var union = _writerCache.GetUnion(unionSchema);
+            if (union.HasAssignableConditionalBranches)
+                ThrowAssignableConditionalCollection(list.GetType());
+
+            if (union.HasConditionalValueTypeBranch &&
                 list is not IEnumerable<object?> &&
                 list is not ArrayList)
             {
@@ -384,6 +391,11 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             WriteValue(itemSchema, list[i], encoder);
         }
     }
+
+    private static void ThrowAssignableConditionalCollection(Type collectionType) =>
+        throw new global::Avro.AvroTypeException(
+            $"Collection type {collectionType} is not supported for assignable value-dependent Avro union items; " +
+            "per-item candidate scans are forbidden in allocation-free serialization.");
 
     private static void WriteListItems<T, TWriter>(
         global::Avro.Schema itemSchema,
@@ -1180,6 +1192,8 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         public bool HasConditionalBranches => _conditionalBranches is not null;
 
         public bool HasConditionalValueTypeBranch => _hasPotentialConditionalValueTypeBranch;
+
+        public bool HasAssignableConditionalBranches => _assignableConditionalCandidates is not null;
 
         public int NullIndex { get; }
 

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -1002,7 +1002,8 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         private readonly Dictionary<Type, MultipleConditionalUnionBranches>? _multipleConditionalBranches;
         private readonly ConditionalUnionCandidateByType[]? _conditionalCandidates;
         private readonly ConditionalUnionCandidateByType[]? _assignableConditionalCandidates;
-        private readonly bool _hasConditionalValueTypeBranch;
+        private readonly ValueTypeFlags _conditionalValueTypes;
+        private readonly bool _hasPotentialConditionalValueTypeBranch;
         private readonly UnionBranch _arrayBranch;
         private readonly UnionBranch _booleanBranch;
         private readonly UnionBranch _bytesBranch;
@@ -1033,7 +1034,8 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             UnionBranch stringBranch = default;
             UnionBranch timeSpanBranch = default;
             Dictionary<Type, ConditionalUnionBranchBuilder>? conditionalBranchBuilders = null;
-            var hasConditionalValueTypeBranch = false;
+            var conditionalValueTypes = ValueTypeFlags.None;
+            var hasPotentialConditionalValueTypeBranch = false;
             for (var i = 0; i < schema.Count; i++)
             {
                 var branch = schema[i];
@@ -1086,7 +1088,13 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                         var logical = (global::Avro.LogicalSchema)branch;
                         var type = logical.LogicalType.GetCSharpType(nullible: false);
                         var conditional = IsSpecializedLogicalType(logical.LogicalType) ? null : logical;
-                        hasConditionalValueTypeBranch |= conditional is not null && type.IsValueType;
+                        if (conditional is not null)
+                        {
+                            conditionalValueTypes |= GetAssignableValueTypes(type);
+                            hasPotentialConditionalValueTypeBranch |=
+                                type.IsValueType || type.IsInterface ||
+                                type == typeof(object) || type == typeof(ValueType) || type == typeof(Enum);
+                        }
                         if (type == typeof(bool))
                         {
                             SetCompatibleBranch(type, ref booleanBranch, resolved, conditional, ref conditionalBranchBuilders);
@@ -1163,14 +1171,15 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             _conditionalCandidates = BuildConditionalCandidates(
                 conditionalBranchBuilders,
                 out _assignableConditionalCandidates);
-            _hasConditionalValueTypeBranch = hasConditionalValueTypeBranch;
+            _conditionalValueTypes = conditionalValueTypes;
+            _hasPotentialConditionalValueTypeBranch = hasPotentialConditionalValueTypeBranch;
         }
 
         public global::Avro.UnionSchema Schema => _schema;
 
         public bool HasConditionalBranches => _conditionalBranches is not null;
 
-        public bool HasConditionalValueTypeBranch => _hasConditionalValueTypeBranch;
+        public bool HasConditionalValueTypeBranch => _hasPotentialConditionalValueTypeBranch;
 
         public int NullIndex { get; }
 
@@ -1548,9 +1557,43 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             }
         }
 
-        private bool HasConditionalValueBranch(Type type) =>
-            _conditionalBranches?.ContainsKey(type) == true ||
-            _multipleConditionalBranches?.ContainsKey(type) == true;
+        private bool HasConditionalValueBranch(Type type)
+        {
+            var valueType = GetValueType(type);
+            return valueType != ValueTypeFlags.None
+                ? (_conditionalValueTypes & valueType) != 0
+                : _conditionalBranches?.ContainsKey(type) == true ||
+                  _multipleConditionalBranches?.ContainsKey(type) == true;
+        }
+
+        private static ValueTypeFlags GetAssignableValueTypes(Type type)
+        {
+            var flags = ValueTypeFlags.None;
+            if (type.IsAssignableFrom(typeof(bool))) flags |= ValueTypeFlags.Boolean;
+            if (type.IsAssignableFrom(typeof(int))) flags |= ValueTypeFlags.Int;
+            if (type.IsAssignableFrom(typeof(long))) flags |= ValueTypeFlags.Long;
+            if (type.IsAssignableFrom(typeof(float))) flags |= ValueTypeFlags.Float;
+            if (type.IsAssignableFrom(typeof(double))) flags |= ValueTypeFlags.Double;
+            if (type.IsAssignableFrom(typeof(DateTime))) flags |= ValueTypeFlags.DateTime;
+            if (type.IsAssignableFrom(typeof(TimeSpan))) flags |= ValueTypeFlags.TimeSpan;
+            if (type.IsAssignableFrom(typeof(Guid))) flags |= ValueTypeFlags.Guid;
+            if (type.IsAssignableFrom(typeof(global::Avro.AvroDecimal))) flags |= ValueTypeFlags.Decimal;
+            return flags;
+        }
+
+        private static ValueTypeFlags GetValueType(Type type)
+        {
+            if (type == typeof(bool)) return ValueTypeFlags.Boolean;
+            if (type == typeof(int)) return ValueTypeFlags.Int;
+            if (type == typeof(long)) return ValueTypeFlags.Long;
+            if (type == typeof(float)) return ValueTypeFlags.Float;
+            if (type == typeof(double)) return ValueTypeFlags.Double;
+            if (type == typeof(DateTime)) return ValueTypeFlags.DateTime;
+            if (type == typeof(TimeSpan)) return ValueTypeFlags.TimeSpan;
+            if (type == typeof(Guid)) return ValueTypeFlags.Guid;
+            if (type == typeof(global::Avro.AvroDecimal)) return ValueTypeFlags.Decimal;
+            return ValueTypeFlags.None;
+        }
 
         private static bool IsSpecializedLogicalType(global::Avro.Util.LogicalType logicalType) =>
             logicalType is Date or TimestampMillisecond or LocalTimestampMillisecond or
@@ -1559,6 +1602,21 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
 
         private global::Avro.AvroException NoMatch(object? value) =>
             new($"Cannot find a union match for {value?.GetType()} in {_schema}.");
+    }
+
+    [Flags]
+    private enum ValueTypeFlags : ushort
+    {
+        None = 0,
+        Boolean = 1 << 0,
+        Int = 1 << 1,
+        Long = 1 << 2,
+        Float = 1 << 3,
+        Double = 1 << 4,
+        DateTime = 1 << 5,
+        TimeSpan = 1 << 6,
+        Guid = 1 << 7,
+        Decimal = 1 << 8
     }
 
     private readonly record struct UnionBranch(int Index, global::Avro.Schema Schema);

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -1135,10 +1135,26 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         private void AddLogicalBranch(global::Avro.LogicalSchema schema, UnionBranch branch)
         {
             var type = schema.LogicalType.GetCSharpType(nullible: false);
-            if (type == typeof(DateTime)) _dateTimeBranch = branch;
-            else if (type == typeof(TimeSpan)) _timeSpanBranch = branch;
-            else if (type == typeof(Guid)) _guidBranch = branch;
-            else if (type == typeof(global::Avro.AvroDecimal)) _decimalBranch = branch;
+            if (type == typeof(DateTime))
+            {
+                if (_dateTimeBranch.Schema is null)
+                    _dateTimeBranch = branch;
+            }
+            else if (type == typeof(TimeSpan))
+            {
+                if (_timeSpanBranch.Schema is null)
+                    _timeSpanBranch = branch;
+            }
+            else if (type == typeof(Guid))
+            {
+                if (_guidBranch.Schema is null)
+                    _guidBranch = branch;
+            }
+            else if (type == typeof(global::Avro.AvroDecimal))
+            {
+                if (_decimalBranch.Schema is null)
+                    _decimalBranch = branch;
+            }
             else _typedBranches.TryAdd(type, branch);
         }
 

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -493,7 +493,12 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         where TWriter : struct, IValueWriter<T>
     {
         var union = _writerCache.GetUnion(schema);
-        var branch = union.GetValueBranch(typeof(T));
+        if (!union.TryGetValueBranch(typeof(T), out var branch))
+        {
+            WriteNullableUnionArrayWithoutValueBranch(union, values, encoder);
+            return;
+        }
+
         for (var i = 0; i < values.Length; i++)
         {
             encoder.StartItem();
@@ -505,7 +510,6 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                 encoder.WriteUnionIndex(union.NullIndex);
                 continue;
             }
-
             encoder.WriteUnionIndex(branch.Index);
             TWriter.Write(branch.Schema, value.GetValueOrDefault(), encoder);
         }
@@ -535,7 +539,12 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         where TWriter : struct, IValueWriter<T>
     {
         var union = _writerCache.GetUnion(schema);
-        var branch = union.GetValueBranch(typeof(T));
+        if (!union.TryGetValueBranch(typeof(T), out var branch))
+        {
+            WriteNullableUnionListWithoutValueBranch(union, values, encoder);
+            return;
+        }
+
         for (var i = 0; i < values.Count; i++)
         {
             encoder.StartItem();
@@ -547,7 +556,6 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                 encoder.WriteUnionIndex(union.NullIndex);
                 continue;
             }
-
             encoder.WriteUnionIndex(branch.Index);
             TWriter.Write(branch.Schema, value.GetValueOrDefault(), encoder);
         }
@@ -577,7 +585,12 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         where TWriter : struct, IValueWriter<T>
     {
         var union = _writerCache.GetUnion(schema);
-        var branch = union.GetValueBranch(typeof(T));
+        if (!union.TryGetValueBranch(typeof(T), out var branch))
+        {
+            WriteNullableUnionListWithoutValueBranch(union, values, encoder);
+            return;
+        }
+
         for (var i = 0; i < values.Count; i++)
         {
             encoder.StartItem();
@@ -589,9 +602,42 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                 encoder.WriteUnionIndex(union.NullIndex);
                 continue;
             }
-
             encoder.WriteUnionIndex(branch.Index);
             TWriter.Write(branch.Schema, value.GetValueOrDefault(), encoder);
+        }
+    }
+
+    private static void WriteNullableUnionArrayWithoutValueBranch<T>(
+        UnionBranchCache union,
+        T?[] values,
+        AllocationFreeBinaryEncoder encoder)
+        where T : struct
+    {
+        for (var i = 0; i < values.Length; i++)
+        {
+            encoder.StartItem();
+            if (values[i].HasValue)
+                _ = union.GetValueBranch(typeof(T));
+            if (union.NullIndex < 0)
+                throw TypeMismatch(null, "union");
+            encoder.WriteUnionIndex(union.NullIndex);
+        }
+    }
+
+    private static void WriteNullableUnionListWithoutValueBranch<T>(
+        UnionBranchCache union,
+        IList<T?> values,
+        AllocationFreeBinaryEncoder encoder)
+        where T : struct
+    {
+        for (var i = 0; i < values.Count; i++)
+        {
+            encoder.StartItem();
+            if (values[i].HasValue)
+                _ = union.GetValueBranch(typeof(T));
+            if (union.NullIndex < 0)
+                throw TypeMismatch(null, "union");
+            encoder.WriteUnionIndex(union.NullIndex);
         }
     }
 
@@ -947,18 +993,18 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         private readonly Dictionary<global::Avro.SchemaName, UnionBranch> _recordBranches = new();
         private readonly Dictionary<global::Avro.SchemaName, UnionBranch> _enumBranches = new();
         private readonly Dictionary<global::Avro.SchemaName, UnionBranch> _fixedBranches = new();
-        private UnionBranch _arrayBranch;
-        private UnionBranch _booleanBranch;
-        private UnionBranch _bytesBranch;
+        private readonly UnionBranch _arrayBranch;
+        private readonly UnionBranch _booleanBranch;
+        private readonly UnionBranch _bytesBranch;
         private UnionBranch _dateTimeBranch;
         private UnionBranch _decimalBranch;
-        private UnionBranch _doubleBranch;
-        private UnionBranch _floatBranch;
+        private readonly UnionBranch _doubleBranch;
+        private readonly UnionBranch _floatBranch;
         private UnionBranch _guidBranch;
-        private UnionBranch _intBranch;
-        private UnionBranch _longBranch;
-        private UnionBranch _mapBranch;
-        private UnionBranch _stringBranch;
+        private readonly UnionBranch _intBranch;
+        private readonly UnionBranch _longBranch;
+        private readonly UnionBranch _mapBranch;
+        private readonly UnionBranch _stringBranch;
         private UnionBranch _timeSpanBranch;
 
         public UnionBranchCache(global::Avro.UnionSchema schema)
@@ -1024,6 +1070,22 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
 
         public int NullIndex { get; }
 
+        public bool TryGetValueBranch(Type type, out UnionBranch branch)
+        {
+            if (type == typeof(bool)) branch = _booleanBranch;
+            else if (type == typeof(int)) branch = _intBranch;
+            else if (type == typeof(long)) branch = _longBranch;
+            else if (type == typeof(float)) branch = _floatBranch;
+            else if (type == typeof(double)) branch = _doubleBranch;
+            else if (type == typeof(DateTime)) branch = _dateTimeBranch;
+            else if (type == typeof(TimeSpan)) branch = _timeSpanBranch;
+            else if (type == typeof(Guid)) branch = _guidBranch;
+            else if (type == typeof(global::Avro.AvroDecimal)) branch = _decimalBranch;
+            else if (!_typedBranches.TryGetValue(type, out branch)) branch = default;
+
+            return branch.Schema is not null;
+        }
+
         public UnionBranch GetValueBranch(Type type)
         {
             UnionBranch branch;
@@ -1076,10 +1138,10 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                     return _arrayBranch;
                 case IDictionary<string, object> when _mapBranch.Schema is not null:
                     return _mapBranch;
-                case var custom when _typedBranches.TryGetValue(custom.GetType(), out var branch):
-                    return branch;
                 default:
-                    throw NoMatch(value);
+                    return _typedBranches.TryGetValue(value.GetType(), out var typedBranch)
+                        ? typedBranch
+                        : throw NoMatch(value);
             }
         }
 

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -360,6 +360,13 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                 return;
         }
 
+        var listType = list.GetType();
+        if (listType.IsGenericType && listType.GetGenericArguments()[0] is { IsValueType: true } elementType)
+        {
+            throw new global::Avro.AvroTypeException(
+                $"List element type {elementType} is not supported for Avro {itemSchema.Tag} items.");
+        }
+
         for (var i = 0; i < list.Count; i++)
         {
             encoder.StartItem();
@@ -1150,7 +1157,11 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
 
         public bool TryGetValueBranch(Type type, out UnionBranch branch)
         {
-            ThrowIfConditionalValueBranch(type);
+            if (HasConditionalValueBranch(type))
+            {
+                branch = default;
+                return false;
+            }
 
             if (type == typeof(bool)) branch = _booleanBranch;
             else if (type == typeof(int)) branch = _intBranch;
@@ -1232,11 +1243,15 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             if (value is not null &&
                 _conditionalBranches!.TryGetValue(value.GetType(), out var conditional))
             {
+                var fallback = GetConditionalFallback(value, conditional.Fallback);
+                if (fallback.Schema is not null && fallback.Index < conditional.Primary.Index)
+                    return fallback;
+
                 if (conditional.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
                     return conditional.Primary;
 
-                if (conditional.Fallback.Schema is not null)
-                    return conditional.Fallback;
+                if (fallback.Schema is not null)
+                    return fallback;
                 throw NoMatch(value);
             }
 
@@ -1244,14 +1259,17 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                 _multipleConditionalBranches?.TryGetValue(value.GetType(), out var multiple) == true)
             {
                 var candidates = multiple.Candidates;
+                var fallback = GetConditionalFallback(value, multiple.Fallback);
                 for (var i = 0; i < candidates.Length; i++)
                 {
                     var candidate = candidates[i];
+                    if (fallback.Schema is not null && fallback.Index < candidate.Branch.Index)
+                        return fallback;
                     if (candidate.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
                         return candidate.Branch;
                 }
-                if (multiple.Fallback.Schema is not null)
-                    return multiple.Fallback;
+                if (fallback.Schema is not null)
+                    return fallback;
                 throw NoMatch(value);
             }
 
@@ -1262,6 +1280,25 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             _typedBranches.TryGetValue(type, out var typedBranch) && typedBranch.Index < schemaBranch.Index
                 ? typedBranch
                 : schemaBranch;
+
+        private UnionBranch GetConditionalFallback(object value, UnionBranch fallback)
+        {
+            var structural = ResolveStructuralBranch(value);
+            return structural.Schema is not null &&
+                   (fallback.Schema is null || structural.Index < fallback.Index)
+                ? structural
+                : fallback;
+        }
+
+        private UnionBranch ResolveStructuralBranch(object value) => value switch
+        {
+            GenericRecord record when _recordBranches.TryGetValue(record.Schema.SchemaName, out var branch) => branch,
+            GenericEnum genericEnum when _enumBranches.TryGetValue(genericEnum.Schema.SchemaName, out var branch) => branch,
+            GenericFixed fixedValue when _fixedBranches.TryGetValue(fixedValue.Schema.SchemaName, out var branch) => branch,
+            (Array or IList) and not byte[] => _arrayBranch,
+            IDictionary<string, object> => _mapBranch,
+            _ => default
+        };
 
         private static void SetCompatibleBranch(
             Type type,
@@ -1328,14 +1365,17 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
 
         private void ThrowIfConditionalValueBranch(Type type)
         {
-            if (_conditionalBranches?.ContainsKey(type) == true ||
-                _multipleConditionalBranches?.ContainsKey(type) == true)
+            if (HasConditionalValueBranch(type))
             {
                 throw new global::Avro.AvroTypeException(
                     $"Union {_schema} uses a value-dependent custom logical branch for {type}; " +
                     "allocation-free value-type collection serialization cannot evaluate it without boxing.");
             }
         }
+
+        private bool HasConditionalValueBranch(Type type) =>
+            _conditionalBranches?.ContainsKey(type) == true ||
+            _multipleConditionalBranches?.ContainsKey(type) == true;
 
         private static bool IsSpecializedLogicalType(global::Avro.Util.LogicalType logicalType) =>
             logicalType is Date or TimestampMillisecond or LocalTimestampMillisecond or

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -983,21 +983,32 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         private readonly UnionBranch _arrayBranch;
         private readonly UnionBranch _booleanBranch;
         private readonly UnionBranch _bytesBranch;
-        private UnionBranch _dateTimeBranch;
-        private UnionBranch _decimalBranch;
+        private readonly UnionBranch _dateTimeBranch;
+        private readonly UnionBranch _decimalBranch;
         private readonly UnionBranch _doubleBranch;
         private readonly UnionBranch _floatBranch;
-        private UnionBranch _guidBranch;
+        private readonly UnionBranch _guidBranch;
         private readonly UnionBranch _intBranch;
         private readonly UnionBranch _longBranch;
         private readonly UnionBranch _mapBranch;
         private readonly UnionBranch _stringBranch;
-        private UnionBranch _timeSpanBranch;
+        private readonly UnionBranch _timeSpanBranch;
 
         public UnionBranchCache(global::Avro.UnionSchema schema)
         {
             _schema = schema;
             NullIndex = -1;
+            UnionBranch booleanBranch = default;
+            UnionBranch bytesBranch = default;
+            UnionBranch dateTimeBranch = default;
+            UnionBranch decimalBranch = default;
+            UnionBranch doubleBranch = default;
+            UnionBranch floatBranch = default;
+            UnionBranch guidBranch = default;
+            UnionBranch intBranch = default;
+            UnionBranch longBranch = default;
+            UnionBranch stringBranch = default;
+            UnionBranch timeSpanBranch = default;
             for (var i = 0; i < schema.Count; i++)
             {
                 var branch = schema[i];
@@ -1008,25 +1019,25 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                         NullIndex = i;
                         break;
                     case global::Avro.Schema.Type.Boolean:
-                        _booleanBranch = resolved;
+                        SetFirst(ref booleanBranch, resolved);
                         break;
                     case global::Avro.Schema.Type.Int:
-                        _intBranch = resolved;
+                        SetFirst(ref intBranch, resolved);
                         break;
                     case global::Avro.Schema.Type.Long:
-                        _longBranch = resolved;
+                        SetFirst(ref longBranch, resolved);
                         break;
                     case global::Avro.Schema.Type.Float:
-                        _floatBranch = resolved;
+                        SetFirst(ref floatBranch, resolved);
                         break;
                     case global::Avro.Schema.Type.Double:
-                        _doubleBranch = resolved;
+                        SetFirst(ref doubleBranch, resolved);
                         break;
                     case global::Avro.Schema.Type.Bytes:
-                        _bytesBranch = resolved;
+                        SetFirst(ref bytesBranch, resolved);
                         break;
                     case global::Avro.Schema.Type.String:
-                        _stringBranch = resolved;
+                        SetFirst(ref stringBranch, resolved);
                         break;
                     case global::Avro.Schema.Type.Record:
                     case global::Avro.Schema.Type.Error:
@@ -1047,10 +1058,70 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                             _mapBranch = resolved;
                         break;
                     case global::Avro.Schema.Type.Logical:
-                        AddLogicalBranch((global::Avro.LogicalSchema)branch, resolved);
+                        var type = ((global::Avro.LogicalSchema)branch).LogicalType.GetCSharpType(nullible: false);
+                        if (type == typeof(bool))
+                        {
+                            SetFirst(ref booleanBranch, resolved);
+                        }
+                        else if (type == typeof(int))
+                        {
+                            SetFirst(ref intBranch, resolved);
+                        }
+                        else if (type == typeof(long))
+                        {
+                            SetFirst(ref longBranch, resolved);
+                        }
+                        else if (type == typeof(float))
+                        {
+                            SetFirst(ref floatBranch, resolved);
+                        }
+                        else if (type == typeof(double))
+                        {
+                            SetFirst(ref doubleBranch, resolved);
+                        }
+                        else if (type == typeof(byte[]))
+                        {
+                            SetFirst(ref bytesBranch, resolved);
+                        }
+                        else if (type == typeof(string))
+                        {
+                            SetFirst(ref stringBranch, resolved);
+                        }
+                        else if (type == typeof(DateTime))
+                        {
+                            SetFirst(ref dateTimeBranch, resolved);
+                        }
+                        else if (type == typeof(TimeSpan))
+                        {
+                            SetFirst(ref timeSpanBranch, resolved);
+                        }
+                        else if (type == typeof(Guid))
+                        {
+                            SetFirst(ref guidBranch, resolved);
+                        }
+                        else if (type == typeof(global::Avro.AvroDecimal))
+                        {
+                            SetFirst(ref decimalBranch, resolved);
+                        }
+                        else
+                        {
+                            _typedBranches.TryAdd(type, resolved);
+                        }
                         break;
                 }
             }
+
+            _booleanBranch = booleanBranch;
+            _intBranch = intBranch;
+            _longBranch = longBranch;
+            _floatBranch = floatBranch;
+            _doubleBranch = doubleBranch;
+            _bytesBranch = bytesBranch;
+            _stringBranch = stringBranch;
+            _dateTimeBranch = dateTimeBranch;
+            _timeSpanBranch = timeSpanBranch;
+            _guidBranch = guidBranch;
+            _decimalBranch = decimalBranch;
         }
 
         public global::Avro.UnionSchema Schema => _schema;
@@ -1116,15 +1187,15 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                 case Guid when _guidBranch.Schema is not null: return _guidBranch;
                 case global::Avro.AvroDecimal when _decimalBranch.Schema is not null: return _decimalBranch;
                 case GenericRecord record when _recordBranches.TryGetValue(record.Schema.SchemaName, out var branch):
-                    return branch;
+                    return FirstCompatibleTypedBranch(value.GetType(), branch);
                 case GenericEnum genericEnum when _enumBranches.TryGetValue(genericEnum.Schema.SchemaName, out var branch):
-                    return branch;
+                    return FirstCompatibleTypedBranch(value.GetType(), branch);
                 case GenericFixed fixedValue when _fixedBranches.TryGetValue(fixedValue.Schema.SchemaName, out var branch):
-                    return branch;
+                    return FirstCompatibleTypedBranch(value.GetType(), branch);
                 case (Array or IList) and not byte[] when _arrayBranch.Schema is not null:
-                    return _arrayBranch;
+                    return FirstCompatibleTypedBranch(value.GetType(), _arrayBranch);
                 case IDictionary<string, object> when _mapBranch.Schema is not null:
-                    return _mapBranch;
+                    return FirstCompatibleTypedBranch(value.GetType(), _mapBranch);
                 default:
                     return _typedBranches.TryGetValue(value.GetType(), out var typedBranch)
                         ? typedBranch
@@ -1132,30 +1203,15 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             }
         }
 
-        private void AddLogicalBranch(global::Avro.LogicalSchema schema, UnionBranch branch)
+        private UnionBranch FirstCompatibleTypedBranch(Type type, UnionBranch schemaBranch) =>
+            _typedBranches.TryGetValue(type, out var typedBranch) && typedBranch.Index < schemaBranch.Index
+                ? typedBranch
+                : schemaBranch;
+
+        private static void SetFirst(ref UnionBranch target, UnionBranch branch)
         {
-            var type = schema.LogicalType.GetCSharpType(nullible: false);
-            if (type == typeof(DateTime))
-            {
-                if (_dateTimeBranch.Schema is null)
-                    _dateTimeBranch = branch;
-            }
-            else if (type == typeof(TimeSpan))
-            {
-                if (_timeSpanBranch.Schema is null)
-                    _timeSpanBranch = branch;
-            }
-            else if (type == typeof(Guid))
-            {
-                if (_guidBranch.Schema is null)
-                    _guidBranch = branch;
-            }
-            else if (type == typeof(global::Avro.AvroDecimal))
-            {
-                if (_decimalBranch.Schema is null)
-                    _decimalBranch = branch;
-            }
-            else _typedBranches.TryAdd(type, branch);
+            if (target.Schema is null)
+                target = branch;
         }
 
         private global::Avro.AvroException NoMatch(object? value) =>

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -13,10 +13,10 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
     private const int StackBufferSize = 256;
     private static readonly DateTime UnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
     private static readonly DateTime LocalUnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
-    private static readonly ConditionalWeakTable<Type, ValueTypeListElement> ValueTypeListElements = new();
+    private static readonly ConditionalWeakTable<Type, ListElement> ListElements = new();
     private readonly global::Avro.RecordSchema _schema = schema;
     private readonly WriterCache _writerCache = WriterCache.Create(schema);
-    private ValueTypeListElement? _lastValueTypeListElement;
+    private ListElement? _lastListElement;
 
     internal void Write(GenericRecord record, AllocationFreeBinaryEncoder encoder) =>
         WriteRecord(_schema, record, encoder, validateSchema: false);
@@ -364,28 +364,16 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         }
 
         var listType = list.GetType();
-        Type? elementType = null;
-        if (listType.IsGenericType)
+        var cache = Volatile.Read(ref _lastListElement);
+        if (cache is null || !ReferenceEquals(cache.ListType, listType))
         {
-            elementType = listType.GetGenericArguments()[0];
-            if (!elementType.IsValueType)
-                elementType = null;
-        }
-        else
-        {
-            var cache = Volatile.Read(ref _lastValueTypeListElement);
-            if (cache is null || !ReferenceEquals(cache.ListType, listType))
-            {
-                cache = ValueTypeListElements.GetValue(
-                    listType,
-                    static type => new ValueTypeListElement(type, FindValueTypeListElement(type)));
-                Volatile.Write(ref _lastValueTypeListElement, cache);
-            }
-
-            elementType = cache.ElementType;
+            cache = ListElements.GetValue(
+                listType,
+                static type => new ListElement(type, FindListElement(type)));
+            Volatile.Write(ref _lastListElement, cache);
         }
 
-        if (elementType is not null)
+        if (cache.ElementType is { IsValueType: true } elementType)
         {
             throw new global::Avro.AvroTypeException(
                 $"List element type {elementType} is not supported for Avro {itemSchema.Tag} items.");
@@ -402,7 +390,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         "Trimming",
         "IL2070",
         Justification = "A live IList instance retains the implemented interface needed for this rejection check.")]
-    private static Type? FindValueTypeListElement(Type listType)
+    private static Type? FindListElement(Type listType)
     {
         var interfaces = listType.GetInterfaces();
         for (var index = 0; index < interfaces.Length; index++)
@@ -414,9 +402,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                 continue;
             }
 
-            var elementType = candidate.GetGenericArguments()[0];
-            if (elementType.IsValueType)
-                return elementType;
+            return candidate.GetGenericArguments()[0];
         }
 
         return null;
@@ -1455,7 +1441,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         public UnionBranch Fallback { get; set; }
     }
 
-    private sealed class ValueTypeListElement(Type listType, Type? elementType)
+    private sealed class ListElement(Type listType, Type? elementType)
     {
         internal Type ListType { get; } = listType;
         internal Type? ElementType { get; } = elementType;

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Collections;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using global::Avro.Generic;
 using global::Avro.Util;
 
@@ -12,11 +13,12 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
     private static readonly DateTime UnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
     private static readonly DateTime LocalUnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
     private readonly global::Avro.RecordSchema _schema = schema;
+    private readonly WriterCache _writerCache = WriterCache.Create(schema);
 
     internal void Write(GenericRecord record, AllocationFreeBinaryEncoder encoder) =>
-        WriteRecord(ReferenceEquals(record.Schema, _schema) ? _schema : record.Schema, record, encoder);
+        WriteRecord(_schema, record, encoder, validateSchema: false);
 
-    private static void WriteValue(global::Avro.Schema schema, object? value, AllocationFreeBinaryEncoder encoder)
+    private void WriteValue(global::Avro.Schema schema, object? value, AllocationFreeBinaryEncoder encoder)
     {
         switch (schema.Tag)
         {
@@ -102,10 +104,14 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         }
     }
 
-    private static void WriteRecord(global::Avro.RecordSchema schema, object? value, AllocationFreeBinaryEncoder encoder)
+    private void WriteRecord(
+        global::Avro.RecordSchema schema,
+        object? value,
+        AllocationFreeBinaryEncoder encoder,
+        bool validateSchema = true)
     {
         if (value is not GenericRecord record ||
-            (!ReferenceEquals(record.Schema, schema) && !record.Schema.Equals(schema)))
+            (validateSchema && !ReferenceEquals(record.Schema, schema) && !record.Schema.Equals(schema)))
             throw TypeMismatch(value, "record");
 
         var fields = schema.Fields;
@@ -134,7 +140,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         encoder.WriteFixed(fixedValue.Value);
     }
 
-    private static void WriteArray(global::Avro.ArraySchema schema, object? value, AllocationFreeBinaryEncoder encoder)
+    private void WriteArray(global::Avro.ArraySchema schema, object? value, AllocationFreeBinaryEncoder encoder)
     {
         encoder.WriteArrayStart();
         switch (value)
@@ -154,7 +160,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         encoder.WriteArrayEnd();
     }
 
-    private static void WriteTypedArray(global::Avro.Schema itemSchema, Array array, AllocationFreeBinaryEncoder encoder)
+    private void WriteTypedArray(global::Avro.Schema itemSchema, Array array, AllocationFreeBinaryEncoder encoder)
     {
         if (itemSchema is global::Avro.UnionSchema unionSchema &&
             TryWriteValueTypeUnionArray(unionSchema, array, encoder))
@@ -276,7 +282,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         }
     }
 
-    private static void WriteTypedList(global::Avro.Schema itemSchema, IList list, AllocationFreeBinaryEncoder encoder)
+    private void WriteTypedList(global::Avro.Schema itemSchema, IList list, AllocationFreeBinaryEncoder encoder)
     {
         if (itemSchema is global::Avro.UnionSchema unionSchema &&
             TryWriteValueTypeUnionList(unionSchema, list, encoder))
@@ -387,7 +393,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         }
     }
 
-    private static bool TryWriteValueTypeUnionArray(
+    private bool TryWriteValueTypeUnionArray(
         global::Avro.UnionSchema schema,
         Array array,
         AllocationFreeBinaryEncoder encoder)
@@ -416,7 +422,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         }
     }
 
-    private static bool TryWriteValueTypeUnionList(
+    private bool TryWriteValueTypeUnionList(
         global::Avro.UnionSchema schema,
         IList list,
         AllocationFreeBinaryEncoder encoder)
@@ -463,244 +469,197 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         }
     }
 
-    private static void WriteUnionArray<T, TWriter>(
+    private void WriteUnionArray<T, TWriter>(
         global::Avro.UnionSchema schema,
         T[] values,
         AllocationFreeBinaryEncoder encoder)
         where T : struct
         where TWriter : struct, IValueWriter<T>
     {
-        FindUnionBranches<T, TWriter>(schema, out _, out var valueIndex, out var valueSchema);
+        var branch = _writerCache.GetUnion(schema).GetValueBranch(typeof(T));
         for (var i = 0; i < values.Length; i++)
         {
             encoder.StartItem();
-            encoder.WriteUnionIndex(valueIndex);
-            TWriter.Write(valueSchema, values[i], encoder);
+            encoder.WriteUnionIndex(branch.Index);
+            TWriter.Write(branch.Schema, values[i], encoder);
         }
     }
 
-    private static void WriteNullableUnionArray<T, TWriter>(
+    private void WriteNullableUnionArray<T, TWriter>(
         global::Avro.UnionSchema schema,
         T?[] values,
         AllocationFreeBinaryEncoder encoder)
         where T : struct
         where TWriter : struct, IValueWriter<T>
     {
-        FindUnionBranches<T, TWriter>(schema, out var nullIndex, out var valueIndex, out var valueSchema);
+        var union = _writerCache.GetUnion(schema);
+        var branch = union.GetValueBranch(typeof(T));
         for (var i = 0; i < values.Length; i++)
         {
             encoder.StartItem();
             var value = values[i];
             if (!value.HasValue)
             {
-                if (nullIndex < 0)
+                if (union.NullIndex < 0)
                     throw TypeMismatch(null, "union");
-                encoder.WriteUnionIndex(nullIndex);
+                encoder.WriteUnionIndex(union.NullIndex);
                 continue;
             }
 
-            encoder.WriteUnionIndex(valueIndex);
-            TWriter.Write(valueSchema, value.GetValueOrDefault(), encoder);
+            encoder.WriteUnionIndex(branch.Index);
+            TWriter.Write(branch.Schema, value.GetValueOrDefault(), encoder);
         }
     }
 
-    private static void WriteUnionList<T, TWriter>(
+    private void WriteUnionList<T, TWriter>(
         global::Avro.UnionSchema schema,
         List<T> values,
         AllocationFreeBinaryEncoder encoder)
         where T : struct
         where TWriter : struct, IValueWriter<T>
     {
-        FindUnionBranches<T, TWriter>(schema, out _, out var valueIndex, out var valueSchema);
+        var branch = _writerCache.GetUnion(schema).GetValueBranch(typeof(T));
         for (var i = 0; i < values.Count; i++)
         {
             encoder.StartItem();
-            encoder.WriteUnionIndex(valueIndex);
-            TWriter.Write(valueSchema, values[i], encoder);
+            encoder.WriteUnionIndex(branch.Index);
+            TWriter.Write(branch.Schema, values[i], encoder);
         }
     }
 
-    private static void WriteNullableUnionList<T, TWriter>(
+    private void WriteNullableUnionList<T, TWriter>(
         global::Avro.UnionSchema schema,
         List<T?> values,
         AllocationFreeBinaryEncoder encoder)
         where T : struct
         where TWriter : struct, IValueWriter<T>
     {
-        FindUnionBranches<T, TWriter>(schema, out var nullIndex, out var valueIndex, out var valueSchema);
+        var union = _writerCache.GetUnion(schema);
+        var branch = union.GetValueBranch(typeof(T));
         for (var i = 0; i < values.Count; i++)
         {
             encoder.StartItem();
             var value = values[i];
             if (!value.HasValue)
             {
-                if (nullIndex < 0)
+                if (union.NullIndex < 0)
                     throw TypeMismatch(null, "union");
-                encoder.WriteUnionIndex(nullIndex);
+                encoder.WriteUnionIndex(union.NullIndex);
                 continue;
             }
 
-            encoder.WriteUnionIndex(valueIndex);
-            TWriter.Write(valueSchema, value.GetValueOrDefault(), encoder);
+            encoder.WriteUnionIndex(branch.Index);
+            TWriter.Write(branch.Schema, value.GetValueOrDefault(), encoder);
         }
     }
 
-    private static void WriteUnionList<T, TWriter>(
+    private void WriteUnionList<T, TWriter>(
         global::Avro.UnionSchema schema,
         IList<T> values,
         AllocationFreeBinaryEncoder encoder)
         where T : struct
         where TWriter : struct, IValueWriter<T>
     {
-        FindUnionBranches<T, TWriter>(schema, out _, out var valueIndex, out var valueSchema);
+        var branch = _writerCache.GetUnion(schema).GetValueBranch(typeof(T));
         for (var i = 0; i < values.Count; i++)
         {
             encoder.StartItem();
-            encoder.WriteUnionIndex(valueIndex);
-            TWriter.Write(valueSchema, values[i], encoder);
+            encoder.WriteUnionIndex(branch.Index);
+            TWriter.Write(branch.Schema, values[i], encoder);
         }
     }
 
-    private static void WriteNullableUnionList<T, TWriter>(
+    private void WriteNullableUnionList<T, TWriter>(
         global::Avro.UnionSchema schema,
         IList<T?> values,
         AllocationFreeBinaryEncoder encoder)
         where T : struct
         where TWriter : struct, IValueWriter<T>
     {
-        FindUnionBranches<T, TWriter>(schema, out var nullIndex, out var valueIndex, out var valueSchema);
+        var union = _writerCache.GetUnion(schema);
+        var branch = union.GetValueBranch(typeof(T));
         for (var i = 0; i < values.Count; i++)
         {
             encoder.StartItem();
             var value = values[i];
             if (!value.HasValue)
             {
-                if (nullIndex < 0)
+                if (union.NullIndex < 0)
                     throw TypeMismatch(null, "union");
-                encoder.WriteUnionIndex(nullIndex);
+                encoder.WriteUnionIndex(union.NullIndex);
                 continue;
             }
 
-            encoder.WriteUnionIndex(valueIndex);
-            TWriter.Write(valueSchema, value.GetValueOrDefault(), encoder);
+            encoder.WriteUnionIndex(branch.Index);
+            TWriter.Write(branch.Schema, value.GetValueOrDefault(), encoder);
         }
-    }
-
-    private static void FindUnionBranches<T, TWriter>(
-        global::Avro.UnionSchema schema,
-        out int nullIndex,
-        out int valueIndex,
-        out global::Avro.Schema valueSchema)
-        where T : struct
-        where TWriter : struct, IValueWriter<T>
-    {
-        nullIndex = -1;
-        valueIndex = -1;
-        valueSchema = null!;
-        for (var i = 0; i < schema.Count; i++)
-        {
-            var branch = schema[i];
-            if (branch.Tag == global::Avro.Schema.Type.Null)
-                nullIndex = i;
-            else if (valueIndex < 0 && TWriter.Matches(branch))
-            {
-                valueIndex = i;
-                valueSchema = branch;
-            }
-        }
-
-        if (valueIndex < 0)
-            throw new global::Avro.AvroTypeException($"Union {schema} has no branch for {typeof(T)}.");
     }
 
     private interface IValueWriter<T>
     {
-        static abstract bool Matches(global::Avro.Schema schema);
         static abstract void Write(global::Avro.Schema schema, T value, AllocationFreeBinaryEncoder encoder);
     }
 
     private readonly struct BooleanValueWriter : IValueWriter<bool>
     {
-        public static bool Matches(global::Avro.Schema schema) => schema.Tag == global::Avro.Schema.Type.Boolean;
         public static void Write(global::Avro.Schema schema, bool value, AllocationFreeBinaryEncoder encoder) => encoder.WriteBoolean(value);
     }
 
     private readonly struct IntValueWriter : IValueWriter<int>
     {
-        public static bool Matches(global::Avro.Schema schema) => schema.Tag == global::Avro.Schema.Type.Int;
         public static void Write(global::Avro.Schema schema, int value, AllocationFreeBinaryEncoder encoder) => encoder.WriteInt(value);
     }
 
     private readonly struct LongValueWriter : IValueWriter<long>
     {
-        public static bool Matches(global::Avro.Schema schema) => schema.Tag == global::Avro.Schema.Type.Long;
         public static void Write(global::Avro.Schema schema, long value, AllocationFreeBinaryEncoder encoder) => encoder.WriteLong(value);
     }
 
     private readonly struct FloatValueWriter : IValueWriter<float>
     {
-        public static bool Matches(global::Avro.Schema schema) => schema.Tag == global::Avro.Schema.Type.Float;
         public static void Write(global::Avro.Schema schema, float value, AllocationFreeBinaryEncoder encoder) => encoder.WriteFloat(value);
     }
 
     private readonly struct DoubleValueWriter : IValueWriter<double>
     {
-        public static bool Matches(global::Avro.Schema schema) => schema.Tag == global::Avro.Schema.Type.Double;
         public static void Write(global::Avro.Schema schema, double value, AllocationFreeBinaryEncoder encoder) => encoder.WriteDouble(value);
     }
 
     private readonly struct StringValueWriter : IValueWriter<string>
     {
-        public static bool Matches(global::Avro.Schema schema) => schema.Tag == global::Avro.Schema.Type.String;
         public static void Write(global::Avro.Schema schema, string value, AllocationFreeBinaryEncoder encoder) => encoder.WriteString(value);
     }
 
     private readonly struct BytesValueWriter : IValueWriter<byte[]>
     {
-        public static bool Matches(global::Avro.Schema schema) => schema.Tag == global::Avro.Schema.Type.Bytes;
         public static void Write(global::Avro.Schema schema, byte[] value, AllocationFreeBinaryEncoder encoder) => encoder.WriteBytes(value);
     }
 
     private readonly struct DateTimeValueWriter : IValueWriter<DateTime>
     {
-        public static bool Matches(global::Avro.Schema schema) =>
-            schema is global::Avro.LogicalSchema logicalSchema &&
-            logicalSchema.LogicalType is Date or TimestampMillisecond or LocalTimestampMillisecond or
-                TimestampMicrosecond or LocalTimestampMicrosecond;
-
         public static void Write(global::Avro.Schema schema, DateTime value, AllocationFreeBinaryEncoder encoder) =>
             WriteDateTime((global::Avro.LogicalSchema)schema, value, encoder);
     }
 
     private readonly struct TimeSpanValueWriter : IValueWriter<TimeSpan>
     {
-        public static bool Matches(global::Avro.Schema schema) =>
-            schema is global::Avro.LogicalSchema logicalSchema &&
-            logicalSchema.LogicalType is TimeMillisecond or TimeMicrosecond;
-
         public static void Write(global::Avro.Schema schema, TimeSpan value, AllocationFreeBinaryEncoder encoder) =>
             WriteTimeSpan((global::Avro.LogicalSchema)schema, value, encoder);
     }
 
     private readonly struct GuidValueWriter : IValueWriter<Guid>
     {
-        public static bool Matches(global::Avro.Schema schema) =>
-            schema is global::Avro.LogicalSchema { LogicalType: Uuid };
-
         public static void Write(global::Avro.Schema schema, Guid value, AllocationFreeBinaryEncoder encoder) =>
             WriteUuid((global::Avro.LogicalSchema)schema, value, encoder);
     }
 
     private readonly struct DecimalValueWriter : IValueWriter<global::Avro.AvroDecimal>
     {
-        public static bool Matches(global::Avro.Schema schema) =>
-            schema is global::Avro.LogicalSchema { LogicalType: global::Avro.Util.Decimal };
-
         public static void Write(global::Avro.Schema schema, global::Avro.AvroDecimal value, AllocationFreeBinaryEncoder encoder) =>
             WriteDecimal((global::Avro.LogicalSchema)schema, value, encoder);
     }
 
-    private static void WriteMap(global::Avro.MapSchema schema, object? value, AllocationFreeBinaryEncoder encoder)
+    private void WriteMap(global::Avro.MapSchema schema, object? value, AllocationFreeBinaryEncoder encoder)
     {
         if (value is not IDictionary<string, object> map)
             throw TypeMismatch(value, "map");
@@ -742,55 +701,14 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         encoder.WriteMapEnd();
     }
 
-    private static void WriteUnion(global::Avro.UnionSchema schema, object? value, AllocationFreeBinaryEncoder encoder)
+    private void WriteUnion(global::Avro.UnionSchema schema, object? value, AllocationFreeBinaryEncoder encoder)
     {
-        for (var i = 0; i < schema.Count; i++)
-        {
-            var branch = schema[i];
-            if (!Matches(branch, value))
-                continue;
-
-            encoder.WriteUnionIndex(i);
-            WriteValue(branch, value, encoder);
-            return;
-        }
-
-        throw new global::Avro.AvroException($"Cannot find a union match for {value?.GetType()} in {schema}.");
+        var branch = _writerCache.GetUnion(schema).Resolve(value);
+        encoder.WriteUnionIndex(branch.Index);
+        WriteValue(branch.Schema, value, encoder);
     }
 
-    private static bool Matches(global::Avro.Schema schema, object? value)
-    {
-        if (value is null)
-            return schema.Tag == global::Avro.Schema.Type.Null;
-
-        return schema.Tag switch
-        {
-            global::Avro.Schema.Type.Null => false,
-            global::Avro.Schema.Type.Boolean => value is bool,
-            global::Avro.Schema.Type.Int => value is int,
-            global::Avro.Schema.Type.Long => value is long,
-            global::Avro.Schema.Type.Float => value is float,
-            global::Avro.Schema.Type.Double => value is double,
-            global::Avro.Schema.Type.Bytes => value is byte[],
-            global::Avro.Schema.Type.String => value is string,
-            global::Avro.Schema.Type.Record or global::Avro.Schema.Type.Error =>
-                value is GenericRecord record &&
-                record.Schema.SchemaName.Equals(((global::Avro.RecordSchema)schema).SchemaName),
-            global::Avro.Schema.Type.Enumeration =>
-                value is GenericEnum genericEnum &&
-                genericEnum.Schema.SchemaName.Equals(((global::Avro.EnumSchema)schema).SchemaName),
-            global::Avro.Schema.Type.Array => value is (Array or IList) and not byte[],
-            global::Avro.Schema.Type.Map => value is IDictionary<string, object>,
-            global::Avro.Schema.Type.Union => false,
-            global::Avro.Schema.Type.Fixed =>
-                value is GenericFixed fixedValue &&
-                fixedValue.Schema.SchemaName.Equals(((global::Avro.FixedSchema)schema).SchemaName),
-            global::Avro.Schema.Type.Logical => ((global::Avro.LogicalSchema)schema).LogicalType.IsInstanceOfLogicalType(value),
-            _ => throw new global::Avro.AvroException($"Unknown Avro schema type {schema.Tag}.")
-        };
-    }
-
-    private static void WriteLogical(
+    private void WriteLogical(
         global::Avro.LogicalSchema schema,
         object? value,
         AllocationFreeBinaryEncoder encoder)
@@ -956,6 +874,239 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
     {
         if (value < TimeSpan.Zero || value >= TimeSpan.FromDays(1))
             throw new ArgumentOutOfRangeException(nameof(value), "Avro time values must be within one day.");
+    }
+
+    private sealed class WriterCache
+    {
+        private readonly Dictionary<global::Avro.UnionSchema, UnionBranchCache> _unions =
+            new(ReferenceComparer<global::Avro.UnionSchema>.Instance);
+        private UnionBranchCache? _lastUnion;
+
+        public static WriterCache Create(global::Avro.Schema schema)
+        {
+            var cache = new WriterCache();
+            var visited = new HashSet<global::Avro.Schema>(ReferenceComparer<global::Avro.Schema>.Instance);
+            cache.AddSchema(schema, visited);
+            return cache;
+        }
+
+        public UnionBranchCache GetUnion(global::Avro.UnionSchema schema)
+        {
+            var last = Volatile.Read(ref _lastUnion);
+            if (last is not null && ReferenceEquals(last.Schema, schema))
+                return last;
+
+            var union = _unions[schema];
+            Volatile.Write(ref _lastUnion, union);
+            return union;
+        }
+
+        private void AddSchema(
+            global::Avro.Schema schema,
+            HashSet<global::Avro.Schema> visited)
+        {
+            if (!visited.Add(schema))
+                return;
+
+            switch (schema.Tag)
+            {
+                case global::Avro.Schema.Type.Record:
+                case global::Avro.Schema.Type.Error:
+                    var fields = ((global::Avro.RecordSchema)schema).Fields;
+                    for (var i = 0; i < fields.Count; i++)
+                        AddSchema(fields[i].Schema, visited);
+                    break;
+
+                case global::Avro.Schema.Type.Array:
+                    AddSchema(((global::Avro.ArraySchema)schema).ItemSchema, visited);
+                    break;
+
+                case global::Avro.Schema.Type.Map:
+                    AddSchema(((global::Avro.MapSchema)schema).ValueSchema, visited);
+                    break;
+
+                case global::Avro.Schema.Type.Union:
+                    var union = (global::Avro.UnionSchema)schema;
+                    _unions.Add(union, new UnionBranchCache(union));
+                    for (var i = 0; i < union.Count; i++)
+                        AddSchema(union[i], visited);
+                    break;
+
+                case global::Avro.Schema.Type.Logical:
+                    var logical = (global::Avro.LogicalSchema)schema;
+                    AddSchema(logical.BaseSchema, visited);
+                    break;
+            }
+        }
+    }
+
+    private sealed class UnionBranchCache
+    {
+        private readonly global::Avro.UnionSchema _schema;
+        private readonly Dictionary<Type, UnionBranch> _typedBranches = new();
+        private readonly Dictionary<global::Avro.SchemaName, UnionBranch> _recordBranches = new();
+        private readonly Dictionary<global::Avro.SchemaName, UnionBranch> _enumBranches = new();
+        private readonly Dictionary<global::Avro.SchemaName, UnionBranch> _fixedBranches = new();
+        private UnionBranch _arrayBranch;
+        private UnionBranch _booleanBranch;
+        private UnionBranch _bytesBranch;
+        private UnionBranch _dateTimeBranch;
+        private UnionBranch _decimalBranch;
+        private UnionBranch _doubleBranch;
+        private UnionBranch _floatBranch;
+        private UnionBranch _guidBranch;
+        private UnionBranch _intBranch;
+        private UnionBranch _longBranch;
+        private UnionBranch _mapBranch;
+        private UnionBranch _stringBranch;
+        private UnionBranch _timeSpanBranch;
+
+        public UnionBranchCache(global::Avro.UnionSchema schema)
+        {
+            _schema = schema;
+            NullIndex = -1;
+            for (var i = 0; i < schema.Count; i++)
+            {
+                var branch = schema[i];
+                var resolved = new UnionBranch(i, branch);
+                switch (branch.Tag)
+                {
+                    case global::Avro.Schema.Type.Null:
+                        NullIndex = i;
+                        break;
+                    case global::Avro.Schema.Type.Boolean:
+                        _booleanBranch = resolved;
+                        break;
+                    case global::Avro.Schema.Type.Int:
+                        _intBranch = resolved;
+                        break;
+                    case global::Avro.Schema.Type.Long:
+                        _longBranch = resolved;
+                        break;
+                    case global::Avro.Schema.Type.Float:
+                        _floatBranch = resolved;
+                        break;
+                    case global::Avro.Schema.Type.Double:
+                        _doubleBranch = resolved;
+                        break;
+                    case global::Avro.Schema.Type.Bytes:
+                        _bytesBranch = resolved;
+                        break;
+                    case global::Avro.Schema.Type.String:
+                        _stringBranch = resolved;
+                        break;
+                    case global::Avro.Schema.Type.Record:
+                    case global::Avro.Schema.Type.Error:
+                        _recordBranches.TryAdd(((global::Avro.RecordSchema)branch).SchemaName, resolved);
+                        break;
+                    case global::Avro.Schema.Type.Enumeration:
+                        _enumBranches.TryAdd(((global::Avro.EnumSchema)branch).SchemaName, resolved);
+                        break;
+                    case global::Avro.Schema.Type.Fixed:
+                        _fixedBranches.TryAdd(((global::Avro.FixedSchema)branch).SchemaName, resolved);
+                        break;
+                    case global::Avro.Schema.Type.Array:
+                        if (_arrayBranch.Schema is null)
+                            _arrayBranch = resolved;
+                        break;
+                    case global::Avro.Schema.Type.Map:
+                        if (_mapBranch.Schema is null)
+                            _mapBranch = resolved;
+                        break;
+                    case global::Avro.Schema.Type.Logical:
+                        AddLogicalBranch((global::Avro.LogicalSchema)branch, resolved);
+                        break;
+                }
+            }
+        }
+
+        public global::Avro.UnionSchema Schema => _schema;
+
+        public int NullIndex { get; }
+
+        public UnionBranch GetValueBranch(Type type)
+        {
+            UnionBranch branch;
+            if (type == typeof(bool)) branch = _booleanBranch;
+            else if (type == typeof(int)) branch = _intBranch;
+            else if (type == typeof(long)) branch = _longBranch;
+            else if (type == typeof(float)) branch = _floatBranch;
+            else if (type == typeof(double)) branch = _doubleBranch;
+            else if (type == typeof(DateTime)) branch = _dateTimeBranch;
+            else if (type == typeof(TimeSpan)) branch = _timeSpanBranch;
+            else if (type == typeof(Guid)) branch = _guidBranch;
+            else if (type == typeof(global::Avro.AvroDecimal)) branch = _decimalBranch;
+            else if (!_typedBranches.TryGetValue(type, out branch)) branch = default;
+
+            if (branch.Schema is not null)
+                return branch;
+
+            throw new global::Avro.AvroTypeException($"Union {_schema} has no branch for {type}.");
+        }
+
+        public UnionBranch Resolve(object? value)
+        {
+            if (value is null)
+            {
+                if (NullIndex >= 0)
+                    return new UnionBranch(NullIndex, _schema[NullIndex]);
+                throw NoMatch(value);
+            }
+
+            switch (value)
+            {
+                case bool when _booleanBranch.Schema is not null: return _booleanBranch;
+                case int when _intBranch.Schema is not null: return _intBranch;
+                case long when _longBranch.Schema is not null: return _longBranch;
+                case float when _floatBranch.Schema is not null: return _floatBranch;
+                case double when _doubleBranch.Schema is not null: return _doubleBranch;
+                case byte[] when _bytesBranch.Schema is not null: return _bytesBranch;
+                case string when _stringBranch.Schema is not null: return _stringBranch;
+                case DateTime when _dateTimeBranch.Schema is not null: return _dateTimeBranch;
+                case TimeSpan when _timeSpanBranch.Schema is not null: return _timeSpanBranch;
+                case Guid when _guidBranch.Schema is not null: return _guidBranch;
+                case global::Avro.AvroDecimal when _decimalBranch.Schema is not null: return _decimalBranch;
+                case GenericRecord record when _recordBranches.TryGetValue(record.Schema.SchemaName, out var branch):
+                    return branch;
+                case GenericEnum genericEnum when _enumBranches.TryGetValue(genericEnum.Schema.SchemaName, out var branch):
+                    return branch;
+                case GenericFixed fixedValue when _fixedBranches.TryGetValue(fixedValue.Schema.SchemaName, out var branch):
+                    return branch;
+                case (Array or IList) and not byte[] when _arrayBranch.Schema is not null:
+                    return _arrayBranch;
+                case IDictionary<string, object> when _mapBranch.Schema is not null:
+                    return _mapBranch;
+                case var custom when _typedBranches.TryGetValue(custom.GetType(), out var branch):
+                    return branch;
+                default:
+                    throw NoMatch(value);
+            }
+        }
+
+        private void AddLogicalBranch(global::Avro.LogicalSchema schema, UnionBranch branch)
+        {
+            var type = schema.LogicalType.GetCSharpType(nullible: false);
+            if (type == typeof(DateTime)) _dateTimeBranch = branch;
+            else if (type == typeof(TimeSpan)) _timeSpanBranch = branch;
+            else if (type == typeof(Guid)) _guidBranch = branch;
+            else if (type == typeof(global::Avro.AvroDecimal)) _decimalBranch = branch;
+            else _typedBranches.TryAdd(type, branch);
+        }
+
+        private global::Avro.AvroException NoMatch(object? value) =>
+            new($"Cannot find a union match for {value?.GetType()} in {_schema}.");
+    }
+
+    private readonly record struct UnionBranch(int Index, global::Avro.Schema Schema);
+
+    private sealed class ReferenceComparer<T> : IEqualityComparer<T>
+        where T : class
+    {
+        public static readonly ReferenceComparer<T> Instance = new();
+
+        public bool Equals(T? left, T? right) => ReferenceEquals(left, right);
+
+        public int GetHashCode(T value) => RuntimeHelpers.GetHashCode(value);
     }
 
     private static global::Avro.AvroException TypeMismatch(object? value, string schemaType) =>

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -284,10 +284,16 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
 
     private void WriteTypedList(global::Avro.Schema itemSchema, IList list, AllocationFreeBinaryEncoder encoder)
     {
-        if (itemSchema is global::Avro.UnionSchema unionSchema &&
-            TryWriteValueTypeUnionList(unionSchema, list, encoder))
+        if (itemSchema is global::Avro.UnionSchema unionSchema)
         {
-            return;
+            if (TryWriteValueTypeUnionList(unionSchema, list, encoder))
+                return;
+
+            if (_writerCache.GetUnion(unionSchema).HasConditionalValueTypeBranch)
+            {
+                throw new global::Avro.AvroTypeException(
+                    $"List type {list.GetType()} is not supported for value-dependent Avro union items.");
+            }
         }
 
         switch (itemSchema.Tag)
@@ -995,7 +1001,9 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         private readonly Dictionary<global::Avro.SchemaName, UnionBranch> _fixedBranches = new();
         private readonly Dictionary<Type, ConditionalUnionBranch>? _conditionalBranches;
         private readonly Dictionary<Type, MultipleConditionalUnionBranches>? _multipleConditionalBranches;
-        private readonly AssignableConditionalUnionCandidate[]? _assignableConditionalCandidates;
+        private readonly ConditionalUnionCandidateByType[]? _conditionalCandidates;
+        private readonly ConditionalUnionCandidateByType[]? _assignableConditionalCandidates;
+        private readonly bool _hasConditionalValueTypeBranch;
         private readonly UnionBranch _arrayBranch;
         private readonly UnionBranch _booleanBranch;
         private readonly UnionBranch _bytesBranch;
@@ -1026,6 +1034,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             UnionBranch stringBranch = default;
             UnionBranch timeSpanBranch = default;
             Dictionary<Type, ConditionalUnionBranchBuilder>? conditionalBranchBuilders = null;
+            var hasConditionalValueTypeBranch = false;
             for (var i = 0; i < schema.Count; i++)
             {
                 var branch = schema[i];
@@ -1078,6 +1087,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
                         var logical = (global::Avro.LogicalSchema)branch;
                         var type = logical.LogicalType.GetCSharpType(nullible: false);
                         var conditional = IsSpecializedLogicalType(logical.LogicalType) ? null : logical;
+                        hasConditionalValueTypeBranch |= conditional is not null && type.IsValueType;
                         if (type == typeof(bool))
                         {
                             SetCompatibleBranch(type, ref booleanBranch, resolved, conditional, ref conditionalBranchBuilders);
@@ -1151,13 +1161,17 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             _conditionalBranches = BuildConditionalBranches(
                 conditionalBranchBuilders,
                 out _multipleConditionalBranches);
-            _assignableConditionalCandidates = BuildAssignableConditionalCandidates(
-                conditionalBranchBuilders);
+            _conditionalCandidates = BuildConditionalCandidates(
+                conditionalBranchBuilders,
+                out _assignableConditionalCandidates);
+            _hasConditionalValueTypeBranch = hasConditionalValueTypeBranch;
         }
 
         public global::Avro.UnionSchema Schema => _schema;
 
         public bool HasConditionalBranches => _conditionalBranches is not null;
+
+        public bool HasConditionalValueTypeBranch => _hasConditionalValueTypeBranch;
 
         public int NullIndex { get; }
 
@@ -1246,72 +1260,154 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
 
         public UnionBranch ResolveConditional(object? value)
         {
-            if (value is not null &&
-                _conditionalBranches!.TryGetValue(value.GetType(), out var conditional))
+            if (value is not null)
             {
-                var fallback = GetConditionalFallback(value, conditional.Fallback);
-                if (fallback.Schema is not null && fallback.Index < conditional.Primary.Index)
-                    return fallback;
-
-                if (conditional.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
-                    return conditional.Primary;
-
-                if (fallback.Schema is not null)
-                    return fallback;
-                throw NoMatch(value);
-            }
-
-            if (value is not null &&
-                _multipleConditionalBranches?.TryGetValue(value.GetType(), out var multiple) == true)
-            {
-                var candidates = multiple.Candidates;
-                var fallback = GetConditionalFallback(value, multiple.Fallback);
-                for (var i = 0; i < candidates.Length; i++)
+                var runtimeType = value.GetType();
+                if (_conditionalBranches!.TryGetValue(runtimeType, out var conditional))
                 {
-                    var candidate = candidates[i];
-                    if (fallback.Schema is not null && fallback.Index < candidate.Branch.Index)
+                    if (_assignableConditionalCandidates is not null &&
+                        HasAssignableConditionalCandidate(value, runtimeType))
+                        return ResolveCombinedConditional(value, runtimeType);
+
+                    var fallback = GetConditionalFallback(value, conditional.Fallback);
+                    if (fallback.Schema is not null && fallback.Index < conditional.Primary.Index)
                         return fallback;
-                    if (candidate.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
-                        return candidate.Branch;
-                }
-                if (fallback.Schema is not null)
-                    return fallback;
-                throw NoMatch(value);
-            }
 
-            if (value is not null && _assignableConditionalCandidates is not null)
-            {
-                var fallback = ResolveStructuralBranch(value);
-                var matched = false;
-                for (var i = 0; i < _assignableConditionalCandidates.Length; i++)
-                {
-                    var candidate = _assignableConditionalCandidates[i];
-                    if (!candidate.DeclaredType.IsInstanceOfType(value))
-                        continue;
+                    if (conditional.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
+                        return conditional.Primary;
 
-                    matched = true;
-                    if (candidate.Fallback.Schema is not null
-                        && (fallback.Schema is null || candidate.Fallback.Index < fallback.Index))
-                    {
-                        fallback = candidate.Fallback;
-                    }
-
-                    if (fallback.Schema is not null && fallback.Index < candidate.Branch.Index)
-                        return fallback;
-                    if (candidate.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
-                        return candidate.Branch;
-                }
-
-                if (matched)
-                {
                     if (fallback.Schema is not null)
                         return fallback;
                     throw NoMatch(value);
                 }
+
+                if (_multipleConditionalBranches?.TryGetValue(runtimeType, out var multiple) == true)
+                {
+                    if (_assignableConditionalCandidates is not null &&
+                        HasAssignableConditionalCandidate(value, runtimeType))
+                        return ResolveCombinedConditional(value, runtimeType);
+
+                    var candidates = multiple.Candidates;
+                    var fallback = GetConditionalFallback(value, multiple.Fallback);
+                    for (var i = 0; i < candidates.Length; i++)
+                    {
+                        var candidate = candidates[i];
+                        if (fallback.Schema is not null && fallback.Index < candidate.Branch.Index)
+                            return fallback;
+                        if (candidate.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
+                            return candidate.Branch;
+                    }
+                    if (fallback.Schema is not null)
+                        return fallback;
+                    throw NoMatch(value);
+                }
+
+                if (_assignableConditionalCandidates is not null)
+                    return ResolveAssignableConditional(value, runtimeType);
             }
 
             return Resolve(value);
         }
+
+        private bool HasAssignableConditionalCandidate(object value, Type runtimeType)
+        {
+            var candidates = _assignableConditionalCandidates!;
+            for (var i = 0; i < candidates.Length; i++)
+            {
+                var candidate = candidates[i];
+                if (candidate.DeclaredType != runtimeType && candidate.DeclaredType.IsInstanceOfType(value))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private UnionBranch ResolveAssignableConditional(object value, Type runtimeType)
+        {
+            var fallback = ResolveStructuralBranch(value);
+            if (fallback.Schema is null)
+                fallback = ResolveCompatibleNonStructuralBranch(value, runtimeType);
+
+            var matched = false;
+            var candidates = _assignableConditionalCandidates!;
+            for (var i = 0; i < candidates.Length; i++)
+            {
+                var candidate = candidates[i];
+                if (!candidate.DeclaredType.IsInstanceOfType(value))
+                    continue;
+
+                matched = true;
+                fallback = Earlier(fallback, candidate.Fallback);
+                if (fallback.Schema is not null && fallback.Index < candidate.Branch.Index)
+                    return fallback;
+                if (candidate.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
+                    return candidate.Branch;
+            }
+
+            if (fallback.Schema is not null)
+                return fallback;
+            if (matched)
+                throw NoMatch(value);
+            return Resolve(value);
+        }
+
+        private UnionBranch ResolveCombinedConditional(object value, Type runtimeType)
+        {
+            var fallback = Earlier(
+                ResolveCompatibleNonStructuralBranch(value, runtimeType),
+                ResolveStructuralBranch(value));
+            if (_conditionalBranches!.TryGetValue(runtimeType, out var conditional))
+                fallback = Earlier(fallback, conditional.Fallback);
+            if (_multipleConditionalBranches?.TryGetValue(runtimeType, out var multiple) == true)
+                fallback = Earlier(fallback, multiple.Fallback);
+
+            var matched = false;
+            var candidates = _conditionalCandidates!;
+            for (var i = 0; i < candidates.Length; i++)
+            {
+                var candidate = candidates[i];
+                if (!candidate.DeclaredType.IsInstanceOfType(value))
+                    continue;
+
+                matched = true;
+                fallback = Earlier(fallback, candidate.Fallback);
+                if (fallback.Schema is not null && fallback.Index < candidate.Branch.Index)
+                    return fallback;
+                if (candidate.LogicalSchema.LogicalType.IsInstanceOfLogicalType(value))
+                    return candidate.Branch;
+            }
+
+            if (fallback.Schema is not null)
+                return fallback;
+            if (matched)
+                throw NoMatch(value);
+            return Resolve(value);
+        }
+
+        private UnionBranch ResolveCompatibleNonStructuralBranch(object value, Type runtimeType)
+        {
+            if (HasConditionalValueBranch(runtimeType))
+                return default;
+
+            return value switch
+            {
+                bool => _booleanBranch,
+                int => _intBranch,
+                long => _longBranch,
+                float => _floatBranch,
+                double => _doubleBranch,
+                byte[] => _bytesBranch,
+                string => _stringBranch,
+                DateTime => _dateTimeBranch,
+                TimeSpan => _timeSpanBranch,
+                Guid => _guidBranch,
+                global::Avro.AvroDecimal => _decimalBranch,
+                _ => _typedBranches.TryGetValue(runtimeType, out var branch) ? branch : default
+            };
+        }
+
+        private static UnionBranch Earlier(UnionBranch left, UnionBranch right) =>
+            right.Schema is not null && (left.Schema is null || right.Index < left.Index) ? right : left;
 
         private UnionBranch FirstCompatibleTypedBranch(Type type, UnionBranch schemaBranch) =>
             _typedBranches.TryGetValue(type, out var typedBranch) && typedBranch.Index < schemaBranch.Index
@@ -1400,35 +1496,47 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
             return branches;
         }
 
-        private static AssignableConditionalUnionCandidate[]? BuildAssignableConditionalCandidates(
-            Dictionary<Type, ConditionalUnionBranchBuilder>? builders)
+        private static ConditionalUnionCandidateByType[]? BuildConditionalCandidates(
+            Dictionary<Type, ConditionalUnionBranchBuilder>? builders,
+            out ConditionalUnionCandidateByType[]? assignableCandidates)
         {
+            assignableCandidates = null;
             if (builders is null)
                 return null;
 
-            List<AssignableConditionalUnionCandidate>? assignable = null;
+            List<ConditionalUnionCandidateByType>? candidates = null;
+            List<ConditionalUnionCandidateByType>? assignable = null;
             foreach (var (type, builder) in builders)
             {
-                if (type.IsSealed)
-                    continue;
+                candidates ??= [];
+                var isAssignableType = !type.IsSealed;
+                if (isAssignableType)
+                    assignable ??= [];
 
-                assignable ??= [];
                 for (var i = 0; i < builder.Candidates.Count; i++)
                 {
                     var candidate = builder.Candidates[i];
-                    assignable.Add(new AssignableConditionalUnionCandidate(
+                    var candidateByType = new ConditionalUnionCandidateByType(
                         type,
                         candidate.Branch,
                         candidate.LogicalSchema,
-                        builder.Fallback));
+                        builder.Fallback);
+                    candidates.Add(candidateByType);
+                    if (isAssignableType)
+                        assignable!.Add(candidateByType);
                 }
             }
 
-            if (assignable is null)
+            if (candidates is null)
                 return null;
 
-            assignable.Sort(static (left, right) => left.Branch.Index.CompareTo(right.Branch.Index));
-            return assignable.ToArray();
+            candidates.Sort(static (left, right) => left.Branch.Index.CompareTo(right.Branch.Index));
+            if (assignable is not null)
+            {
+                assignable.Sort(static (left, right) => left.Branch.Index.CompareTo(right.Branch.Index));
+                assignableCandidates = assignable.ToArray();
+            }
+            return candidates.ToArray();
         }
 
         private void ThrowIfConditionalValueBranch(Type type)
@@ -1469,7 +1577,7 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         ConditionalUnionCandidate[] Candidates,
         UnionBranch Fallback);
 
-    private readonly record struct AssignableConditionalUnionCandidate(
+    private readonly record struct ConditionalUnionCandidateByType(
         Type DeclaredType,
         UnionBranch Branch,
         global::Avro.LogicalSchema LogicalSchema,

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeGenericRecordWriter.cs
@@ -476,6 +476,9 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         where T : struct
         where TWriter : struct, IValueWriter<T>
     {
+        if (values.Length == 0)
+            return;
+
         var branch = _writerCache.GetUnion(schema).GetValueBranch(typeof(T));
         for (var i = 0; i < values.Length; i++)
         {
@@ -522,6 +525,9 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         where T : struct
         where TWriter : struct, IValueWriter<T>
     {
+        if (values.Count == 0)
+            return;
+
         var branch = _writerCache.GetUnion(schema).GetValueBranch(typeof(T));
         for (var i = 0; i < values.Count; i++)
         {
@@ -568,6 +574,9 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
         where T : struct
         where TWriter : struct, IValueWriter<T>
     {
+        if (values.Count == 0)
+            return;
+
         var branch = _writerCache.GetUnion(schema).GetValueBranch(typeof(T));
         for (var i = 0; i < values.Count; i++)
         {
@@ -707,41 +716,19 @@ internal sealed class AllocationFreeGenericRecordWriter(global::Avro.RecordSchem
 
     private void WriteMap(global::Avro.MapSchema schema, object? value, AllocationFreeBinaryEncoder encoder)
     {
-        if (value is not IDictionary<string, object> map)
-            throw TypeMismatch(value, "map");
+        if (value is not Dictionary<string, object> map)
+        {
+            throw new global::Avro.AvroTypeException(
+                $"Avro map values must use {typeof(Dictionary<string, object>)} to preserve zero-allocation serialization; received {value?.GetType()}.");
+        }
 
         encoder.WriteMapStart();
         encoder.SetItemCount(map.Count);
-
-        if (value is Dictionary<string, object> dictionary)
+        foreach (var entry in map)
         {
-            foreach (var entry in dictionary)
-            {
-                encoder.StartItem();
-                encoder.WriteString(entry.Key);
-                WriteValue(schema.ValueSchema, entry.Value, encoder);
-            }
-        }
-        else
-        {
-            var count = map.Count;
-            var entries = ArrayPool<KeyValuePair<string, object>>.Shared.Rent(count);
-            try
-            {
-                map.CopyTo(entries, 0);
-                for (var i = 0; i < count; i++)
-                {
-                    var entry = entries[i];
-                    encoder.StartItem();
-                    encoder.WriteString(entry.Key);
-                    WriteValue(schema.ValueSchema, entry.Value, encoder);
-                }
-            }
-            finally
-            {
-                entries.AsSpan(0, count).Clear();
-                ArrayPool<KeyValuePair<string, object>>.Shared.Return(entries);
-            }
+            encoder.StartItem();
+            encoder.WriteString(entry.Key);
+            WriteValue(schema.ValueSchema, entry.Value, encoder);
         }
 
         encoder.WriteMapEnd();

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeSpecificRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeSpecificRecordWriter.cs
@@ -1,0 +1,237 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Dekaf.SchemaRegistry.Avro;
+
+internal sealed unsafe class AllocationFreeSpecificRecordWriter<
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
+{
+    private readonly FieldPlan[] _fields;
+
+    private AllocationFreeSpecificRecordWriter(FieldPlan[] fields) => _fields = fields;
+
+    internal static AllocationFreeSpecificRecordWriter<T> Create(global::Avro.Schema schema)
+    {
+        var recordType = typeof(T);
+        if (recordType.IsValueType)
+        {
+            throw new NotSupportedException(
+                $"SpecificRecord type {recordType} must be a reference type for allocation-free serialization.");
+        }
+
+        if (schema is not global::Avro.RecordSchema recordSchema)
+        {
+            throw new NotSupportedException(
+                $"SpecificRecord type {recordType} must expose an Avro record schema.");
+        }
+
+        var fields = new FieldPlan[recordSchema.Fields.Count];
+        var properties = recordType.GetProperties();
+        var claimedProperties = new HashSet<PropertyInfo>();
+        for (var i = 0; i < fields.Length; i++)
+        {
+            fields[i] = CreateFieldPlan(
+                recordSchema.Fields[i],
+                recordType,
+                properties,
+                claimedProperties);
+        }
+
+        return new AllocationFreeSpecificRecordWriter<T>(fields);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void Write(T value, AllocationFreeBinaryEncoder encoder)
+    {
+        var fields = _fields;
+        for (var i = 0; i < fields.Length; i++)
+        {
+            ref readonly var field = ref fields[i];
+            switch (field.Kind)
+            {
+                case FieldKind.Null:
+                    encoder.WriteNull();
+                    break;
+                case FieldKind.Boolean:
+                    encoder.WriteBoolean(((delegate* managed<T, bool>)field.Getter)(value));
+                    break;
+                case FieldKind.Int:
+                    encoder.WriteInt(((delegate* managed<T, int>)field.Getter)(value));
+                    break;
+                case FieldKind.Long:
+                    encoder.WriteLong(((delegate* managed<T, long>)field.Getter)(value));
+                    break;
+                case FieldKind.Float:
+                    encoder.WriteFloat(((delegate* managed<T, float>)field.Getter)(value));
+                    break;
+                case FieldKind.Double:
+                    encoder.WriteDouble(((delegate* managed<T, double>)field.Getter)(value));
+                    break;
+                case FieldKind.String:
+                {
+                    var fieldValue = ((delegate* managed<T, string>)field.Getter)(value);
+                    if (fieldValue is null)
+                        ThrowNullValue(field.Kind);
+                    encoder.WriteString(fieldValue);
+                    break;
+                }
+                case FieldKind.Bytes:
+                {
+                    var fieldValue = ((delegate* managed<T, byte[]>)field.Getter)(value);
+                    if (fieldValue is null)
+                        ThrowNullValue(field.Kind);
+                    encoder.WriteBytes(fieldValue);
+                    break;
+                }
+                default:
+                    throw new InvalidOperationException($"Unknown SpecificRecord field kind {field.Kind}.");
+            }
+        }
+    }
+
+    private static FieldPlan CreateFieldPlan(
+        global::Avro.Field field,
+        Type recordType,
+        PropertyInfo[] properties,
+        HashSet<PropertyInfo> claimedProperties)
+    {
+        var kind = GetFieldKind(field, recordType);
+        if (kind == FieldKind.Null)
+            return new FieldPlan(kind, 0);
+
+        var property = FindProperty(recordType, field, properties);
+        if (property?.GetMethod is not { IsStatic: false, IsAbstract: false } getter ||
+            property.GetIndexParameters().Length != 0)
+        {
+            throw UnsupportedField(
+                recordType,
+                field,
+                $"a readable public property named '{field.Name}' was not found");
+        }
+
+        if (getter is { IsVirtual: true, IsFinal: false })
+        {
+            throw UnsupportedField(
+                recordType,
+                field,
+                $"property '{property.Name}' has an overridable getter");
+        }
+
+        var expectedType = GetExpectedType(kind);
+        if (property.PropertyType != expectedType)
+        {
+            throw UnsupportedField(
+                recordType,
+                field,
+                $"property '{property.Name}' has type {property.PropertyType}, expected {expectedType}");
+        }
+
+        if (!claimedProperties.Add(property))
+        {
+            throw UnsupportedField(
+                recordType,
+                field,
+                $"property '{property.Name}' also matches another schema field");
+        }
+
+        return new FieldPlan(kind, getter.MethodHandle.GetFunctionPointer());
+    }
+
+    private static PropertyInfo? FindProperty(
+        Type recordType,
+        global::Avro.Field field,
+        PropertyInfo[] properties)
+    {
+        PropertyInfo? match = null;
+        for (var i = 0; i < properties.Length; i++)
+        {
+            if (!string.Equals(properties[i].Name, field.Name, StringComparison.Ordinal))
+                continue;
+
+            if (match is not null)
+            {
+                throw UnsupportedField(
+                    recordType,
+                    field,
+                    $"multiple public properties named '{field.Name}' were found");
+            }
+
+            match = properties[i];
+        }
+
+        if (match is not null)
+            return match;
+
+        for (var i = 0; i < properties.Length; i++)
+        {
+            if (!string.Equals(properties[i].Name, field.Name, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (match is not null)
+            {
+                throw UnsupportedField(
+                    recordType,
+                    field,
+                    $"multiple public properties match '{field.Name}' ignoring case");
+            }
+
+            match = properties[i];
+        }
+
+        return match;
+    }
+
+    private static FieldKind GetFieldKind(global::Avro.Field field, Type recordType) => field.Schema.Tag switch
+    {
+        global::Avro.Schema.Type.Null => FieldKind.Null,
+        global::Avro.Schema.Type.Boolean => FieldKind.Boolean,
+        global::Avro.Schema.Type.Int => FieldKind.Int,
+        global::Avro.Schema.Type.Long => FieldKind.Long,
+        global::Avro.Schema.Type.Float => FieldKind.Float,
+        global::Avro.Schema.Type.Double => FieldKind.Double,
+        global::Avro.Schema.Type.String => FieldKind.String,
+        global::Avro.Schema.Type.Bytes => FieldKind.Bytes,
+        _ => throw UnsupportedField(recordType, field, $"schema type {field.Schema.Tag} is not supported")
+    };
+
+    private static Type GetExpectedType(FieldKind kind) => kind switch
+    {
+        FieldKind.Boolean => typeof(bool),
+        FieldKind.Int => typeof(int),
+        FieldKind.Long => typeof(long),
+        FieldKind.Float => typeof(float),
+        FieldKind.Double => typeof(double),
+        FieldKind.String => typeof(string),
+        FieldKind.Bytes => typeof(byte[]),
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
+    };
+
+    private static NotSupportedException UnsupportedField(
+        Type recordType,
+        global::Avro.Field field,
+        string reason) =>
+        new(
+            $"SpecificRecord field '{field.Name}' on {recordType} cannot use allocation-free serialization: " +
+            $"{reason}. Use GenericRecord or a supported scalar SpecificRecord shape.");
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowNullValue(FieldKind kind) =>
+        throw new global::Avro.AvroTypeException(
+            $"SpecificRecord {kind} fields cannot be null when the Avro schema is non-nullable.");
+
+    private readonly record struct FieldPlan(FieldKind Kind, nint Getter);
+
+    private enum FieldKind : byte
+    {
+        Null,
+        Boolean,
+        Int,
+        Long,
+        Float,
+        Double,
+        String,
+        Bytes
+    }
+}

--- a/src/Dekaf.SchemaRegistry.Avro/AvroCodecCache.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroCodecCache.cs
@@ -439,15 +439,15 @@ internal sealed class AvroSerializationThreadState
     internal AvroSerializationThreadState()
     {
         BufferedStream = new PooledMemoryStream([]);
-        BufferedEncoder = new BinaryEncoder(BufferedStream);
+        BufferedEncoder = new AllocationFreeBinaryEncoder(BufferedStream);
         DirectStream = new FixedMemoryStream();
-        DirectEncoder = new BinaryEncoder(DirectStream);
+        DirectEncoder = new AllocationFreeBinaryEncoder(DirectStream);
     }
 
     internal PooledMemoryStream BufferedStream { get; }
-    internal BinaryEncoder BufferedEncoder { get; }
+    internal AllocationFreeBinaryEncoder BufferedEncoder { get; }
     internal FixedMemoryStream DirectStream { get; }
-    internal BinaryEncoder DirectEncoder { get; }
+    internal AllocationFreeBinaryEncoder DirectEncoder { get; }
     internal int PayloadSizeHint { get; set; } = 1024;
 }
 

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryExtensions.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryExtensions.cs
@@ -20,7 +20,9 @@ public static class AvroSchemaRegistryExtensions
     /// <returns>The builder for chaining.</returns>
     public static ProducerBuilder<TKey, TValue> UseAvroSchemaRegistry<
         TKey,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TValue>(
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicFields |
+            DynamicallyAccessedMemberTypes.PublicProperties)] TValue>(
         this ProducerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,
         AvroSerializerConfig? config = null)
@@ -41,7 +43,9 @@ public static class AvroSchemaRegistryExtensions
     /// <param name="config">Optional Avro serializer configuration.</param>
     /// <returns>The builder for chaining.</returns>
     public static ProducerBuilder<TKey, TValue> UseAvroSchemaRegistryKey<
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TKey,
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicFields |
+            DynamicallyAccessedMemberTypes.PublicProperties)] TKey,
         TValue>(
         this ProducerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -341,7 +341,7 @@ public sealed class AvroSchemaRegistrySerializer<
         string subject,
         AvroSchema avroSchema) => ResolveSchemaCached(subject, CreateRegistrySchema(avroSchema));
 
-    private void WriteAvroValue(T value, BinaryEncoder encoder)
+    private void WriteAvroValue(T value, AllocationFreeBinaryEncoder encoder)
     {
         switch (value)
         {
@@ -465,7 +465,7 @@ public sealed class AvroSchemaRegistrySerializer<
         return GetDynamicSchemaCache(schema).SubjectSchemaIdCache;
     }
 
-    private GenericDatumWriter<GenericRecord> GetGenericWriter(AvroSchema schema) =>
+    private AllocationFreeGenericRecordWriter GetGenericWriter(AvroSchema schema) =>
         GetDynamicSchemaCache(schema).Writer;
 
     private DynamicSchemaCache GetDynamicSchemaCache(AvroSchema schema)
@@ -488,12 +488,12 @@ public sealed class AvroSchemaRegistrySerializer<
         {
             LastSeenSchema = schema;
             SubjectSchemaIdCache = new SubjectSchemaIdCache();
-            Writer = new GenericDatumWriter<GenericRecord>(schema);
+            Writer = new AllocationFreeGenericRecordWriter((global::Avro.RecordSchema)schema);
         }
 
         internal AvroSchema LastSeenSchema;
         internal SubjectSchemaIdCache SubjectSchemaIdCache { get; }
-        internal GenericDatumWriter<GenericRecord> Writer { get; }
+        internal AllocationFreeGenericRecordWriter Writer { get; }
     }
 
     private static AvroSchema? GetSchemaFromType()

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -3,7 +3,6 @@ using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using Avro.Generic;
-using Avro.IO;
 using Avro.Specific;
 using Dekaf.Serialization;
 using AvroSchema = Avro.Schema;
@@ -32,9 +31,14 @@ namespace Dekaf.SchemaRegistry.Avro;
 /// blocks on Schema Registry calls.
 /// </para>
 /// </remarks>
-/// <typeparam name="T">The type to serialize. Must be either an Avro ISpecificRecord or GenericRecord.</typeparam>
+/// <typeparam name="T">
+/// The type to serialize. Must be either a concrete Avro ISpecificRecord type with a statically
+/// discoverable schema or GenericRecord. Runtime SpecificRecord type discovery is unsupported.
+/// </typeparam>
 public sealed class AvroSchemaRegistrySerializer<
-    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>
+    [DynamicallyAccessedMembers(
+        DynamicallyAccessedMemberTypes.PublicFields |
+        DynamicallyAccessedMemberTypes.PublicProperties)] T>
     : ISerializer<T>, IAsyncSerializerPreparer<T>, IAsyncDisposable
 {
     private const byte MagicByte = 0x00;
@@ -50,8 +54,7 @@ public sealed class AvroSchemaRegistrySerializer<
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
     private readonly ConcurrentDictionary<AvroSchema, DynamicSchemaCache> _dynamicSchemaCaches =
         new(AvroSchemaLogicalComparer.Instance);
-    private readonly ConcurrentDictionary<AvroSchema, SpecificDefaultWriter> _specificWriters =
-        new(AvroSchemaReferenceComparer.Instance);
+    private readonly AllocationFreeSpecificRecordWriter<T>? _specificWriter;
     private readonly AvroSchema? _writerSchema;
     private DynamicSchemaCache? _lastDynamicSchemaCache;
 
@@ -72,10 +75,17 @@ public sealed class AvroSchemaRegistrySerializer<
 
         // Try to get schema from type T if it's a specific record
         _writerSchema = GetSchemaFromType();
+        if (_writerSchema is not null)
+            _specificWriter = AllocationFreeSpecificRecordWriter<T>.Create(_writerSchema);
+        else if (typeof(ISpecificRecord).IsAssignableFrom(typeof(T)))
+        {
+            throw new NotSupportedException(
+                $"Allocation-free SpecificRecord serialization requires a concrete type with a statically discoverable schema; {typeof(T)} requires trimming-unsafe runtime type discovery.");
+        }
     }
 
     internal int CachedGenericWriterCount => _dynamicSchemaCaches.Count;
-    internal int CachedSpecificWriterCount => _specificWriters.Count;
+    internal int CachedSpecificWriterCount => _specificWriter is null ? 0 : 1;
     internal int CachedDynamicSubjectSchemaCount => _dynamicSchemaCaches.Count;
 
     /// <summary>
@@ -345,16 +355,15 @@ public sealed class AvroSchemaRegistrySerializer<
     {
         switch (value)
         {
-            case ISpecificRecord specificRecord:
-                var specificWriter = _specificWriters.GetOrAdd(
-                    specificRecord.Schema,
-                    static schema => new SpecificDefaultWriter(schema));
-                specificWriter.Write(specificRecord.Schema, specificRecord, encoder);
-                break;
-
             case GenericRecord genericRecord:
                 var genericWriter = GetGenericWriter(genericRecord.Schema);
                 genericWriter.Write(genericRecord, encoder);
+                break;
+
+            case ISpecificRecord:
+                (_specificWriter ?? throw new InvalidOperationException(
+                    $"SpecificRecord type {typeof(T)} does not have a prepared allocation-free writer."))
+                    .Write(value, encoder);
                 break;
 
             default:

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -488,7 +488,10 @@ public sealed class AvroSchemaRegistrySerializer<
         {
             LastSeenSchema = schema;
             SubjectSchemaIdCache = new SubjectSchemaIdCache();
-            Writer = new AllocationFreeGenericRecordWriter((global::Avro.RecordSchema)schema);
+            Writer = schema is global::Avro.RecordSchema recordSchema
+                ? new AllocationFreeGenericRecordWriter(recordSchema)
+                : throw new global::Avro.AvroException(
+                    $"GenericRecord serialization requires a record schema but received {schema.Tag}.");
         }
 
         internal AvroSchema LastSeenSchema;

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -215,7 +215,7 @@ public sealed class AvroSchemaRegistrySerializer<
                 destination.Advance(WireHeaderSize + payloadLength);
                 codecState.PayloadSizeHint = payloadLength > MaxRetainedAvroPayloadBufferSize
                     ? InitialAvroPayloadBufferSize
-                    : Math.Max(InitialAvroPayloadBufferSize, payloadLength);
+                    : Math.Max(codecState.PayloadSizeHint, payloadLength);
                 stream.Reset(default);
                 return;
             }

--- a/src/Dekaf.SchemaRegistry.Avro/CompatibilitySuppressions.xml
+++ b/src/Dekaf.SchemaRegistry.Avro/CompatibilitySuppressions.xml
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<!--
+  SpecificRecord serialization now binds concrete public property getters once during serializer
+  construction so primitive fields remain allocation-free per message. PublicProperties is therefore
+  an intentional addition to the existing trimming contract; removing it would make NativeAOT unsafe.
+  Keep these suppressions limited to that attribute-argument change on the three affected APIs.
+-->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0015</DiagnosticId>
+    <Target>M:Dekaf.SchemaRegistry.Avro.AvroSchemaRegistryExtensions.UseAvroSchemaRegistry``2(Dekaf.ProducerBuilder{``0,``1},Dekaf.SchemaRegistry.ISchemaRegistryClient,Dekaf.SchemaRegistry.Avro.AvroSerializerConfig)&lt;1&gt;:[T:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute]</Target>
+    <Left>lib/net10.0/Dekaf.SchemaRegistry.Avro.dll</Left>
+    <Right>lib/net10.0/Dekaf.SchemaRegistry.Avro.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0015</DiagnosticId>
+    <Target>M:Dekaf.SchemaRegistry.Avro.AvroSchemaRegistryExtensions.UseAvroSchemaRegistryKey``2(Dekaf.ProducerBuilder{``0,``1},Dekaf.SchemaRegistry.ISchemaRegistryClient,Dekaf.SchemaRegistry.Avro.AvroSerializerConfig)&lt;0&gt;:[T:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute]</Target>
+    <Left>lib/net10.0/Dekaf.SchemaRegistry.Avro.dll</Left>
+    <Right>lib/net10.0/Dekaf.SchemaRegistry.Avro.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0015</DiagnosticId>
+    <Target>T:Dekaf.SchemaRegistry.Avro.AvroSchemaRegistrySerializer`1&lt;0&gt;:[T:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute]</Target>
+    <Left>lib/net10.0/Dekaf.SchemaRegistry.Avro.dll</Left>
+    <Right>lib/net10.0/Dekaf.SchemaRegistry.Avro.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0015</DiagnosticId>
+    <Target>M:Dekaf.SchemaRegistry.Avro.AvroSchemaRegistryExtensions.UseAvroSchemaRegistry``2(Dekaf.ProducerBuilder{``0,``1},Dekaf.SchemaRegistry.ISchemaRegistryClient,Dekaf.SchemaRegistry.Avro.AvroSerializerConfig)&lt;1&gt;:[T:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute]</Target>
+    <Left>lib/net8.0/Dekaf.SchemaRegistry.Avro.dll</Left>
+    <Right>lib/net8.0/Dekaf.SchemaRegistry.Avro.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0015</DiagnosticId>
+    <Target>M:Dekaf.SchemaRegistry.Avro.AvroSchemaRegistryExtensions.UseAvroSchemaRegistryKey``2(Dekaf.ProducerBuilder{``0,``1},Dekaf.SchemaRegistry.ISchemaRegistryClient,Dekaf.SchemaRegistry.Avro.AvroSerializerConfig)&lt;0&gt;:[T:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute]</Target>
+    <Left>lib/net8.0/Dekaf.SchemaRegistry.Avro.dll</Left>
+    <Right>lib/net8.0/Dekaf.SchemaRegistry.Avro.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0015</DiagnosticId>
+    <Target>T:Dekaf.SchemaRegistry.Avro.AvroSchemaRegistrySerializer`1&lt;0&gt;:[T:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute]</Target>
+    <Left>lib/net8.0/Dekaf.SchemaRegistry.Avro.dll</Left>
+    <Right>lib/net8.0/Dekaf.SchemaRegistry.Avro.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/src/Dekaf.SchemaRegistry.Avro/Dekaf.SchemaRegistry.Avro.csproj
+++ b/src/Dekaf.SchemaRegistry.Avro/Dekaf.SchemaRegistry.Avro.csproj
@@ -4,6 +4,7 @@
     <PackageId>Dekaf.SchemaRegistry.Avro</PackageId>
     <Description>Apache Avro serialization with Schema Registry integration for Dekaf Kafka client</Description>
     <PackageTags>kafka;schema-registry;avro;serialization</PackageTags>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dekaf.SchemaRegistry.Avro/FixedMemoryStream.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/FixedMemoryStream.cs
@@ -34,6 +34,16 @@ internal sealed class FixedMemoryStream : Stream
         _position = newPosition;
     }
 
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        var newPosition = _position + buffer.Length;
+        if (newPosition > _memory.Length)
+            throw new FixedMemoryStreamOverflowException(newPosition);
+
+        buffer.CopyTo(_memory.Span.Slice(_position));
+        _position = newPosition;
+    }
+
     public override void WriteByte(byte value)
     {
         var newPosition = _position + 1;

--- a/src/Dekaf.SchemaRegistry.Avro/PooledMemoryStream.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/PooledMemoryStream.cs
@@ -126,6 +126,21 @@ internal sealed class PooledMemoryStream : Stream
             _length = _position;
     }
 
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var newPosition = (long)_position + buffer.Length;
+        if (newPosition > Array.MaxLength)
+            throw new NotSupportedException($"PooledMemoryStream does not support streams larger than {Array.MaxLength} bytes.");
+
+        EnsureCapacity((int)newPosition);
+        buffer.CopyTo(_buffer.AsSpan(_origin + _position));
+        _position += buffer.Length;
+        if (_position > _length)
+            _length = _position;
+    }
+
     public override void WriteByte(byte value)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);

--- a/tests/Dekaf.Tests.Aot/Program.cs
+++ b/tests/Dekaf.Tests.Aot/Program.cs
@@ -191,6 +191,8 @@ internal static class AotSmoke
 
     private static async Task RunAvroSchemaRegistryPackageSmokeAsync(InMemorySchemaRegistry registry)
     {
+        RequireInterfaceTypedAvroSerializerRejected(registry);
+
         await using var serializer = new AvroSchemaRegistrySerializer<AotAvroRecord>(registry);
         await using var deserializer = new AvroSchemaRegistryDeserializer<AotAvroRecord>(registry);
 
@@ -203,6 +205,21 @@ internal static class AotSmoke
         var roundTrip = deserializer.Deserialize(buffer.WrittenMemory, ValueContext);
         Require(roundTrip.Id == payload.Id, "Avro Schema Registry ID mismatch.");
         Require(roundTrip.Name == payload.Name, "Avro Schema Registry name mismatch.");
+    }
+
+    private static void RequireInterfaceTypedAvroSerializerRejected(InMemorySchemaRegistry registry)
+    {
+        try
+        {
+            _ = new AvroSchemaRegistrySerializer<ISpecificRecord>(registry);
+        }
+        catch (NotSupportedException)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "Interface-typed Avro serialization must reject trimming-unsafe runtime type discovery.");
     }
 
     private static async Task RunProtobufSchemaRegistryPackageSmokeAsync(InMemorySchemaRegistry registry)

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -19,6 +19,8 @@ namespace Dekaf.Tests.Unit.SchemaRegistry;
 [NotInParallel("AvroSerialization")]
 public sealed class AvroSerializerTests
 {
+    private static readonly int[] CustomLogicalValueTypeValues = [1, 2];
+
     private const string SimpleRecordSchema = """
         {
             "type": "record",
@@ -355,6 +357,45 @@ public sealed class AvroSerializerTests
         record.Add("value", "logical-value");
 
         await AssertSerializedPayloadMatchesApache(serializer, schema, record);
+
+        var primitiveRecord = new GenericRecord(schema);
+        primitiveRecord.Add("value", "primitive-value");
+        await AssertSerializedPayloadMatchesApache(serializer, schema, primitiveRecord);
+    }
+
+    [Test]
+    public async Task Serializer_GenericRecord_CustomLogicalValueTypeUnionArray_IsRejected()
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new IntBytesLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "CustomLogicalValueTypeArrayRecord",
+                "fields": [{
+                    "name": "values",
+                    "type": {
+                        "type": "array",
+                        "items": [
+                            { "type": "bytes", "logicalType": "{{IntBytesLogicalType.LogicalName}}" },
+                            "int"
+                        ]
+                    }
+                }]
+            }
+            """);
+        var record = new GenericRecord(schema);
+        record.Add("values", CustomLogicalValueTypeValues);
+
+        await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
+
+        void Serialize()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
     }
 
     [Test]
@@ -1166,6 +1207,22 @@ public sealed class AvroSerializerTests
 
         public override Type GetCSharpType(bool nullible) => typeof(string);
 
-        public override bool IsInstanceOfLogicalType(object logicalValue) => logicalValue is string;
+        public override bool IsInstanceOfLogicalType(object logicalValue) =>
+            logicalValue is string value && value.StartsWith("logical-", StringComparison.Ordinal);
+    }
+
+    private sealed class IntBytesLogicalType() : Avro.Util.LogicalType(LogicalName)
+    {
+        internal const string LogicalName = "dekaf-int-bytes";
+
+        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
+            BitConverter.GetBytes((int)logicalValue);
+
+        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
+            BitConverter.ToInt32((byte[])baseValue);
+
+        public override Type GetCSharpType(bool nullible) => typeof(int);
+
+        public override bool IsInstanceOfLogicalType(object logicalValue) => logicalValue is int;
     }
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.ObjectModel;
 using System.Numerics;
+using System.Text;
 using Avro.Generic;
 using Avro.IO;
 using Dekaf.SchemaRegistry;
@@ -326,6 +327,32 @@ public sealed class AvroSerializerTests
             """);
         var record = new GenericRecord(schema);
         record.Add("value", new DateTime(2026, 8, 16, 0, 0, 0, DateTimeKind.Utc));
+
+        await AssertSerializedPayloadMatchesApache(serializer, schema, record);
+    }
+
+    [Test]
+    public async Task Serializer_GenericRecord_CustomLogicalUnion_PrecedesPrimitiveBranch()
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new StringBytesLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "CustomLogicalUnionRecord",
+                "fields": [{
+                    "name": "value",
+                    "type": [
+                        { "type": "bytes", "logicalType": "{{StringBytesLogicalType.LogicalName}}" },
+                        "string"
+                    ]
+                }]
+            }
+            """);
+        var record = new GenericRecord(schema);
+        record.Add("value", "logical-value");
 
         await AssertSerializedPayloadMatchesApache(serializer, schema, record);
     }
@@ -1125,5 +1152,20 @@ public sealed class AvroSerializerTests
         serializer.Serialize(actualRecord, ref buffer, CreateContext());
 
         await Assert.That(buffer.WrittenSpan.Slice(5).SequenceEqual(expected)).IsTrue();
+    }
+
+    private sealed class StringBytesLogicalType() : Avro.Util.LogicalType(LogicalName)
+    {
+        internal const string LogicalName = "dekaf-string-bytes";
+
+        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
+            Encoding.UTF8.GetBytes((string)logicalValue);
+
+        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
+            Encoding.UTF8.GetString((byte[])baseValue);
+
+        public override Type GetCSharpType(bool nullible) => typeof(string);
+
+        public override bool IsInstanceOfLogicalType(object logicalValue) => logicalValue is string;
     }
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Collections.ObjectModel;
 using System.Numerics;
 using Avro.Generic;
 using Avro.IO;
@@ -305,6 +306,22 @@ public sealed class AvroSerializerTests
         record.Add("values", useList
             ? new List<int?> { int.MinValue, null, 0, int.MaxValue }
             : new int?[] { int.MinValue, null, 0, int.MaxValue });
+        var expectedRecord = new GenericRecord(schema);
+        expectedRecord.Add("values", new int?[] { int.MinValue, null, 0, int.MaxValue });
+
+        await AssertSerializedPayloadMatches(serializer, schema, record, expectedRecord);
+    }
+
+    [Test]
+    public async Task Serializer_GenericRecord_NullableUnionCollectionIList_MatchesApacheAvroBytes()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(NullableIntArraySchema);
+        var record = new GenericRecord(schema);
+        record.Add(
+            "values",
+            new Collection<int?>([int.MinValue, null, 0, int.MaxValue]));
         var expectedRecord = new GenericRecord(schema);
         expectedRecord.Add("values", new int?[] { int.MinValue, null, 0, int.MaxValue });
 

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -429,9 +429,10 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
-    [Arguments(false)]
-    [Arguments(true)]
-    public async Task Serializer_GenericRecord_CustomLogicalValueTypeList_IsRejected(bool useCollection)
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(2)]
+    public async Task Serializer_GenericRecord_CustomLogicalValueTypeList_IsRejected(int collectionKind)
     {
         Avro.Util.LogicalTypeFactory.Instance.Register(new IntBytesLogicalType());
         using var schemaRegistry = new MockSchemaRegistryClient();
@@ -450,9 +451,13 @@ public sealed class AvroSerializerTests
                 }]
             }
             """);
-        object values = useCollection
-            ? new Collection<int>([1, 2])
-            : new List<int> { 1, 2 };
+        object values = collectionKind switch
+        {
+            0 => new List<int> { 1, 2 },
+            1 => new Collection<int>([1, 2]),
+            2 => new NonGenericIntValues(),
+            _ => throw new ArgumentOutOfRangeException(nameof(collectionKind))
+        };
         var record = new GenericRecord(schema);
         record.Add("values", values);
 
@@ -1367,6 +1372,13 @@ public sealed class AvroSerializerTests
         public override Type GetCSharpType(bool nullible) => typeof(int);
 
         public override bool IsInstanceOfLogicalType(object logicalValue) => logicalValue is int;
+    }
+
+    private sealed class NonGenericIntValues : Collection<int>
+    {
+        internal NonGenericIntValues() : base(new List<int> { 1, 2 })
+        {
+        }
     }
 
     private sealed class IntListBytesLogicalType() : Avro.Util.LogicalType(LogicalName)

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -99,6 +99,52 @@ public sealed class AvroSerializerTests
         }
         """;
 
+    private const string IntListSchema = """
+        {
+            "type": "record",
+            "name": "IntListRecord",
+            "fields": [{ "name": "values", "type": { "type": "array", "items": "int" } }]
+        }
+        """;
+
+    private const string NullableIntArraySchema = """
+        {
+            "type": "record",
+            "name": "NullableIntArrayRecord",
+            "fields": [{ "name": "values", "type": { "type": "array", "items": ["null", "int"] } }]
+        }
+        """;
+
+    private const string LocalTimestampSchema = """
+        {
+            "type": "record",
+            "name": "LocalTimestampRecord",
+            "fields": [{
+                "name": "value",
+                "type": { "type": "long", "logicalType": "local-timestamp-micros" }
+            }]
+        }
+        """;
+
+    private const string TinyDecimalSchema = """
+        {
+            "type": "record",
+            "name": "TinyDecimalRecord",
+            "fields": [
+                { "name": "seed", "type": { "type": "fixed", "name": "TinyDecimal", "size": 1 } },
+                {
+                    "name": "value",
+                    "type": {
+                        "type": "TinyDecimal",
+                        "logicalType": "decimal",
+                        "precision": 2,
+                        "scale": 0
+                    }
+                }
+            ]
+        }
+        """;
+
     private static SerializationContext CreateContext(string topic = "test-topic", bool isKey = false) =>
         new()
         {
@@ -231,6 +277,79 @@ public sealed class AvroSerializerTests
         record.Add("decimalFixedValue", new Avro.AvroDecimal(new BigInteger(98_765), 2));
 
         await AssertSerializedPayloadMatchesApache(serializer, schema, record);
+    }
+
+    [Test]
+    public async Task Serializer_GenericRecord_ListArray_MatchesApacheAvroBytes()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(IntListSchema);
+        var record = new GenericRecord(schema);
+        record.Add("values", new List<int> { int.MinValue, -1, 0, 1, int.MaxValue });
+        var expectedRecord = new GenericRecord(schema);
+        expectedRecord.Add("values", new[] { int.MinValue, -1, 0, 1, int.MaxValue });
+
+        await AssertSerializedPayloadMatches(serializer, schema, record, expectedRecord);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Serializer_GenericRecord_NullableUnionCollection_MatchesApacheAvroBytes(bool useList)
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(NullableIntArraySchema);
+        var record = new GenericRecord(schema);
+        record.Add("values", useList
+            ? new List<int?> { int.MinValue, null, 0, int.MaxValue }
+            : new int?[] { int.MinValue, null, 0, int.MaxValue });
+        var expectedRecord = new GenericRecord(schema);
+        expectedRecord.Add("values", new int?[] { int.MinValue, null, 0, int.MaxValue });
+
+        await AssertSerializedPayloadMatches(serializer, schema, record, expectedRecord);
+    }
+
+    [Test]
+    public async Task Serializer_GenericRecord_LocalTimestamp_PreservesWallClock()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(LocalTimestampSchema);
+        var value = new DateTime(2026, 8, 16, 14, 23, 45, 678, DateTimeKind.Local).AddTicks(9_010);
+        var record = new GenericRecord(schema);
+        record.Add("value", value);
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(record, ref buffer, CreateContext());
+
+        using var payload = new MemoryStream(buffer.WrittenSpan.Slice(5).ToArray());
+        var decoder = new BinaryDecoder(payload);
+        var expected = (DateTime.SpecifyKind(value, DateTimeKind.Unspecified) -
+                        new DateTime(1970, 1, 1)).Ticks / 10;
+        await Assert.That(decoder.ReadLong()).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments(128)]
+    [Arguments(-129)]
+    public async Task Serializer_GenericRecord_FixedDecimalOverflow_IsRejected(int unscaledValue)
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(TinyDecimalSchema);
+        var record = new GenericRecord(schema);
+        record.Add("seed", new GenericFixed((Avro.FixedSchema)schema["seed"].Schema, [0]));
+        record.Add("value", new Avro.AvroDecimal(new BigInteger(unscaledValue), 0));
+
+        await Assert.That(Serialize).Throws<ArgumentOutOfRangeException>();
+
+        void Serialize()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
     }
 
     [Test]
@@ -868,6 +987,20 @@ public sealed class AvroSerializerTests
         var buffer = new ArrayBufferWriter<byte>();
 
         serializer.Serialize(record, ref buffer, CreateContext());
+
+        await Assert.That(buffer.WrittenSpan.Slice(5).SequenceEqual(expected)).IsTrue();
+    }
+
+    private static async Task AssertSerializedPayloadMatches(
+        AvroSchemaRegistrySerializer<GenericRecord> serializer,
+        Avro.RecordSchema schema,
+        GenericRecord actualRecord,
+        GenericRecord expectedRecord)
+    {
+        var expected = SerializeAvroRecord(expectedRecord, schema);
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(actualRecord, ref buffer, CreateContext());
 
         await Assert.That(buffer.WrittenSpan.Slice(5).SequenceEqual(expected)).IsTrue();
     }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -524,6 +524,41 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Serializer_GenericRecord_CustomStructUnionList_IsRejectedBeforeIndexing()
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new CustomStructBytesLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "CustomStructUnionListRecord",
+                "fields": [{
+                    "name": "values",
+                    "type": {
+                        "type": "array",
+                        "items": [
+                            { "type": "bytes", "logicalType": "{{CustomStructBytesLogicalType.LogicalName}}" },
+                            "string"
+                        ]
+                    }
+                }]
+            }
+            """);
+        var record = new GenericRecord(schema);
+        record.Add("values", new Collection<CustomLogicalValue>([new(1)]));
+
+        await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
+
+        void Serialize()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
+    }
+
+    [Test]
     [Arguments(0, false)]
     [Arguments(0, true)]
     [Arguments(1, false)]
@@ -615,6 +650,60 @@ public sealed class AvroSerializerTests
                     "type": [
                         { "type": "bytes", "logicalType": "{{IntListBytesLogicalType.LogicalName}}" },
                         { "type": "array", "items": "int" }
+                    ]
+                }]
+            }
+            """);
+        var record = new GenericRecord(schema);
+        record.Add("value", new List<int> { -1, 2 });
+
+        await AssertSerializedPayloadMatchesApache(serializer, schema, record);
+    }
+
+    [Test]
+    [Arguments(false, "plain-value")]
+    [Arguments(false, "logical-value")]
+    [Arguments(true, "logical-value")]
+    public async Task Serializer_GenericRecord_AssignableLogicalAndPrimitiveBranches_UseSchemaOrder(
+        bool stringFirst,
+        string value)
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new ComparableBytesLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var logicalBranch = $$"""{ "type": "bytes", "logicalType": "{{ComparableBytesLogicalType.LogicalName}}" }""";
+        var branches = stringFirst ? $"\"string\", {logicalBranch}" : $"{logicalBranch}, \"string\"";
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "AssignableLogicalPrimitiveUnionRecord",
+                "fields": [{ "name": "value", "type": [{{branches}}] }]
+            }
+            """);
+        var record = new GenericRecord(schema);
+        record.Add("value", value);
+
+        await AssertSerializedPayloadMatchesApache(serializer, schema, record);
+    }
+
+    [Test]
+    public async Task Serializer_GenericRecord_ExactAndAssignableLogicalBranches_UseSchemaOrder()
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new IntListBytesLogicalType());
+        Avro.Util.LogicalTypeFactory.Instance.Register(new IntListStringLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "ExactAndAssignableLogicalUnionRecord",
+                "fields": [{
+                    "name": "value",
+                    "type": [
+                        { "type": "bytes", "logicalType": "{{IntListBytesLogicalType.LogicalName}}" },
+                        { "type": "string", "logicalType": "{{IntListStringLogicalType.LogicalName}}" }
                     ]
                 }]
             }
@@ -1537,6 +1626,53 @@ public sealed class AvroSerializerTests
 
         public override bool IsInstanceOfLogicalType(object logicalValue) =>
             logicalValue is IList<int> { Count: > 0 } values && values[0] < 0;
+    }
+
+    private readonly record struct CustomLogicalValue(int Value);
+
+    private sealed class CustomStructBytesLogicalType() : Avro.Util.LogicalType(LogicalName)
+    {
+        internal const string LogicalName = "dekaf-custom-struct-bytes";
+
+        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
+            BitConverter.GetBytes(((CustomLogicalValue)logicalValue).Value);
+
+        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
+            new CustomLogicalValue(BitConverter.ToInt32((byte[])baseValue));
+
+        public override Type GetCSharpType(bool nullible) => typeof(CustomLogicalValue);
+
+        public override bool IsInstanceOfLogicalType(object logicalValue) => logicalValue is CustomLogicalValue;
+    }
+
+    private sealed class ComparableBytesLogicalType() : Avro.Util.LogicalType(LogicalName)
+    {
+        internal const string LogicalName = "dekaf-comparable-bytes";
+
+        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
+            Encoding.UTF8.GetBytes((string)logicalValue);
+
+        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
+            Encoding.UTF8.GetString((byte[])baseValue);
+
+        public override Type GetCSharpType(bool nullible) => typeof(IComparable);
+
+        public override bool IsInstanceOfLogicalType(object logicalValue) =>
+            logicalValue is string value && value.StartsWith("logical-", StringComparison.Ordinal);
+    }
+
+    private sealed class IntListStringLogicalType() : Avro.Util.LogicalType(LogicalName)
+    {
+        internal const string LogicalName = "dekaf-int-list-string";
+
+        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) => "list";
+
+        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
+            throw new NotSupportedException();
+
+        public override Type GetCSharpType(bool nullible) => typeof(List<int>);
+
+        public override bool IsInstanceOfLogicalType(object logicalValue) => logicalValue is List<int>;
     }
 
     private sealed class StringTextLogicalType() : Avro.Util.LogicalType(LogicalName)

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -571,6 +571,41 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Serializer_GenericRecord_CustomStructInterfaceUnionList_IsRejectedBeforeIndexing()
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new CustomStructInterfaceBytesLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "CustomStructInterfaceUnionListRecord",
+                "fields": [{
+                    "name": "values",
+                    "type": {
+                        "type": "array",
+                        "items": [
+                            { "type": "bytes", "logicalType": "{{CustomStructInterfaceBytesLogicalType.LogicalName}}" },
+                            "string"
+                        ]
+                    }
+                }]
+            }
+            """);
+        var record = new GenericRecord(schema);
+        record.Add("values", new ThrowingNonGenericIndexerValues());
+
+        await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
+
+        void Serialize()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
+    }
+
+    [Test]
     [Arguments(0, false)]
     [Arguments(0, true)]
     [Arguments(1, false)]
@@ -745,6 +780,41 @@ public sealed class AvroSerializerTests
             """);
         var record = new GenericRecord(schema);
         record.Add("value", new List<int> { -1, 2 });
+
+        await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
+
+        void Serialize()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
+    }
+
+    [Test]
+    public async Task Serializer_GenericRecord_AssignableLogicalValueTypeArray_IsRejected()
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new ComparableBytesLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "AssignableLogicalValueTypeArrayRecord",
+                "fields": [{
+                    "name": "values",
+                    "type": {
+                        "type": "array",
+                        "items": [
+                            { "type": "bytes", "logicalType": "{{ComparableBytesLogicalType.LogicalName}}" },
+                            "int"
+                        ]
+                    }
+                }]
+            }
+            """);
+        var record = new GenericRecord(schema);
+        record.Add("values", CustomLogicalValueTypeValues);
 
         await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
 
@@ -1742,7 +1812,19 @@ public sealed class AvroSerializerTests
             logicalValue is IList<int> { Count: > 0 } values && values[0] < 0;
     }
 
-    private readonly record struct CustomLogicalValue(int Value);
+    private interface ICustomLogicalValue;
+
+    private readonly record struct CustomLogicalValue(int Value) : ICustomLogicalValue;
+
+    private sealed class ThrowingNonGenericIndexerValues()
+        : Collection<CustomLogicalValue>([new(1)]), System.Collections.IList
+    {
+        object? System.Collections.IList.this[int index]
+        {
+            get => throw new InvalidOperationException("The non-generic indexer must not be read.");
+            set => throw new NotSupportedException();
+        }
+    }
 
     private sealed class CustomStructBytesLogicalType() : Avro.Util.LogicalType(LogicalName)
     {
@@ -1755,6 +1837,21 @@ public sealed class AvroSerializerTests
             new CustomLogicalValue(BitConverter.ToInt32((byte[])baseValue));
 
         public override Type GetCSharpType(bool nullible) => typeof(CustomLogicalValue);
+
+        public override bool IsInstanceOfLogicalType(object logicalValue) => logicalValue is CustomLogicalValue;
+    }
+
+    private sealed class CustomStructInterfaceBytesLogicalType() : Avro.Util.LogicalType(LogicalName)
+    {
+        internal const string LogicalName = "dekaf-custom-struct-interface-bytes";
+
+        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
+            BitConverter.GetBytes(((CustomLogicalValue)logicalValue).Value);
+
+        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
+            new CustomLogicalValue(BitConverter.ToInt32((byte[])baseValue));
+
+        public override Type GetCSharpType(bool nullible) => typeof(ICustomLogicalValue);
 
         public override bool IsInstanceOfLogicalType(object logicalValue) => logicalValue is CustomLogicalValue;
     }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -471,6 +471,41 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Serializer_GenericRecord_CustomLogicalUnionNonGenericValueTypeList_IsRejected()
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new IntBytesLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "CustomLogicalUnionNonGenericValueTypeListRecord",
+                "fields": [{
+                    "name": "values",
+                    "type": {
+                        "type": "array",
+                        "items": [
+                            { "type": "bytes", "logicalType": "{{IntBytesLogicalType.LogicalName}}" },
+                            "string"
+                        ]
+                    }
+                }]
+            }
+            """);
+        var record = new GenericRecord(schema);
+        record.Add("values", new NonGenericIntValues());
+
+        await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
+
+        void Serialize()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
+    }
+
+    [Test]
     [Arguments(0, false)]
     [Arguments(0, true)]
     [Arguments(1, false)]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -352,7 +352,7 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
-    public async Task Serializer_GenericRecord_CustomLogicalUnion_PrecedesPrimitiveBranch()
+    public async Task Serializer_GenericRecord_SelectedCustomLogicalBranch_IsRejected()
     {
         Avro.Util.LogicalTypeFactory.Instance.Register(new StringBytesLogicalType());
         using var schemaRegistry = new MockSchemaRegistryClient();
@@ -374,15 +374,21 @@ public sealed class AvroSerializerTests
         var record = new GenericRecord(schema);
         record.Add("value", "logical-value");
 
-        await AssertSerializedPayloadMatchesApache(serializer, schema, record);
+        await Assert.That(SerializeLogical).Throws<Avro.AvroTypeException>();
 
         var primitiveRecord = new GenericRecord(schema);
         primitiveRecord.Add("value", "primitive-value");
         await AssertSerializedPayloadMatchesApache(serializer, schema, primitiveRecord);
+
+        void SerializeLogical()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
     }
 
     [Test]
-    public async Task Serializer_GenericRecord_MultipleCustomLogicalBranchesUseFirstMatchingPredicate()
+    public async Task Serializer_GenericRecord_SelectedMultipleCustomLogicalBranches_AreRejected()
     {
         Avro.Util.LogicalTypeFactory.Instance.Register(new StringBytesLogicalType());
         Avro.Util.LogicalTypeFactory.Instance.Register(new StringTextLogicalType());
@@ -407,8 +413,14 @@ public sealed class AvroSerializerTests
         var textRecord = new GenericRecord(schema);
         textRecord.Add("value", "text-value");
 
-        await AssertSerializedPayloadMatchesApache(serializer, schema, bytesRecord);
-        await AssertSerializedPayloadMatchesApache(serializer, schema, textRecord);
+        await Assert.That(() => Serialize(bytesRecord)).Throws<Avro.AvroTypeException>();
+        await Assert.That(() => Serialize(textRecord)).Throws<Avro.AvroTypeException>();
+
+        void Serialize(GenericRecord record)
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
     }
 
     [Test]
@@ -563,6 +575,83 @@ public sealed class AvroSerializerTests
     [Arguments(0, true)]
     [Arguments(1, false)]
     [Arguments(1, true)]
+    public async Task Serializer_GenericRecord_CustomStructUnionReferenceList_Serializes(
+        int collectionKind,
+        bool includeValue)
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new CustomStructBytesLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "CustomStructUnionReferenceListRecord",
+                "fields": [{
+                    "name": "values",
+                    "type": {
+                        "type": "array",
+                        "items": [
+                            { "type": "bytes", "logicalType": "{{CustomStructBytesLogicalType.LogicalName}}" },
+                            "string"
+                        ]
+                    }
+                }]
+            }
+            """);
+        System.Collections.IList values = collectionKind switch
+        {
+            0 => includeValue ? new List<string> { "value" } : new List<string>(),
+            1 => includeValue ? new System.Collections.ArrayList { "value" } : [],
+            _ => throw new ArgumentOutOfRangeException(nameof(collectionKind))
+        };
+        var record = new GenericRecord(schema);
+        record.Add("values", values);
+        var expectedRecord = new GenericRecord(schema);
+        expectedRecord.Add("values", includeValue ? new object[] { "value" } : []);
+
+        await AssertSerializedPayloadMatches(serializer, schema, record, expectedRecord);
+    }
+
+    [Test]
+    public async Task Serializer_GenericRecord_CustomStructUnionGenericRecordList_Serializes()
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new CustomStructBytesLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "CustomStructUnionGenericRecordListRecord",
+                "fields": [{
+                    "name": "values",
+                    "type": {
+                        "type": "array",
+                        "items": [
+                            { "type": "bytes", "logicalType": "{{CustomStructBytesLogicalType.LogicalName}}" },
+                            { "type": "record", "name": "Nested", "fields": [{ "name": "id", "type": "int" }] }
+                        ]
+                    }
+                }]
+            }
+            """);
+        var nestedSchema = (Avro.RecordSchema)((Avro.UnionSchema)((Avro.ArraySchema)schema.Fields[0].Schema).ItemSchema)[1];
+        var nested = new GenericRecord(nestedSchema);
+        nested.Add("id", 42);
+        var record = new GenericRecord(schema);
+        record.Add("values", new List<GenericRecord> { nested });
+        var expectedRecord = new GenericRecord(schema);
+        expectedRecord.Add("values", new object[] { nested });
+
+        await AssertSerializedPayloadMatches(serializer, schema, record, expectedRecord);
+    }
+
+    [Test]
+    [Arguments(0, false)]
+    [Arguments(0, true)]
+    [Arguments(1, false)]
+    [Arguments(1, true)]
     [Arguments(2, false)]
     [Arguments(2, true)]
     public async Task Serializer_GenericRecord_ConditionalNullableUnionCollection_AcceptsEmptyOrNulls(
@@ -635,7 +724,7 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
-    public async Task Serializer_GenericRecord_AssignableCustomLogicalBranch_MatchesApacheAvroBytes()
+    public async Task Serializer_GenericRecord_SelectedAssignableCustomLogicalBranch_IsRejected()
     {
         Avro.Util.LogicalTypeFactory.Instance.Register(new IntListBytesLogicalType());
         using var schemaRegistry = new MockSchemaRegistryClient();
@@ -657,16 +746,23 @@ public sealed class AvroSerializerTests
         var record = new GenericRecord(schema);
         record.Add("value", new List<int> { -1, 2 });
 
-        await AssertSerializedPayloadMatchesApache(serializer, schema, record);
+        await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
+
+        void Serialize()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
     }
 
     [Test]
-    [Arguments(false, "plain-value")]
-    [Arguments(false, "logical-value")]
-    [Arguments(true, "logical-value")]
+    [Arguments(false, "plain-value", false)]
+    [Arguments(false, "logical-value", true)]
+    [Arguments(true, "logical-value", false)]
     public async Task Serializer_GenericRecord_AssignableLogicalAndPrimitiveBranches_UseSchemaOrder(
         bool stringFirst,
-        string value)
+        string value,
+        bool rejectsCustomLogicalBranch)
     {
         Avro.Util.LogicalTypeFactory.Instance.Register(new ComparableBytesLogicalType());
         using var schemaRegistry = new MockSchemaRegistryClient();
@@ -684,11 +780,23 @@ public sealed class AvroSerializerTests
         var record = new GenericRecord(schema);
         record.Add("value", value);
 
+        if (rejectsCustomLogicalBranch)
+        {
+            await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
+            return;
+        }
+
         await AssertSerializedPayloadMatchesApache(serializer, schema, record);
+
+        void Serialize()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
     }
 
     [Test]
-    public async Task Serializer_GenericRecord_ExactAndAssignableLogicalBranches_UseSchemaOrder()
+    public async Task Serializer_GenericRecord_SelectedExactAndAssignableLogicalBranch_IsRejected()
     {
         Avro.Util.LogicalTypeFactory.Instance.Register(new IntListBytesLogicalType());
         Avro.Util.LogicalTypeFactory.Instance.Register(new IntListStringLogicalType());
@@ -711,7 +819,13 @@ public sealed class AvroSerializerTests
         var record = new GenericRecord(schema);
         record.Add("value", new List<int> { -1, 2 });
 
-        await AssertSerializedPayloadMatchesApache(serializer, schema, record);
+        await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
+
+        void Serialize()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -364,6 +364,36 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Serializer_GenericRecord_MultipleCustomLogicalBranchesUseFirstMatchingPredicate()
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new StringBytesLogicalType());
+        Avro.Util.LogicalTypeFactory.Instance.Register(new StringTextLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "MultipleCustomLogicalUnionRecord",
+                "fields": [{
+                    "name": "value",
+                    "type": [
+                        { "type": "bytes", "logicalType": "{{StringBytesLogicalType.LogicalName}}" },
+                        { "type": "string", "logicalType": "{{StringTextLogicalType.LogicalName}}" }
+                    ]
+                }]
+            }
+            """);
+        var bytesRecord = new GenericRecord(schema);
+        bytesRecord.Add("value", "logical-bytes");
+        var textRecord = new GenericRecord(schema);
+        textRecord.Add("value", "text-value");
+
+        await AssertSerializedPayloadMatchesApache(serializer, schema, bytesRecord);
+        await AssertSerializedPayloadMatchesApache(serializer, schema, textRecord);
+    }
+
+    [Test]
     public async Task Serializer_GenericRecord_CustomLogicalValueTypeUnionArray_IsRejected()
     {
         Avro.Util.LogicalTypeFactory.Instance.Register(new IntBytesLogicalType());
@@ -1224,5 +1254,19 @@ public sealed class AvroSerializerTests
         public override Type GetCSharpType(bool nullible) => typeof(int);
 
         public override bool IsInstanceOfLogicalType(object logicalValue) => logicalValue is int;
+    }
+
+    private sealed class StringTextLogicalType() : Avro.Util.LogicalType(LogicalName)
+    {
+        internal const string LogicalName = "dekaf-string-text";
+
+        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) => logicalValue;
+
+        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) => baseValue;
+
+        public override Type GetCSharpType(bool nullible) => typeof(string);
+
+        public override bool IsInstanceOfLogicalType(object logicalValue) =>
+            logicalValue is string value && value.StartsWith("text-", StringComparison.Ordinal);
     }
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -335,6 +335,43 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Serializer_DirectPath_RetainsPayloadSizeHighWaterMark()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(SimpleRecordSchema);
+        var largeRecord = new GenericRecord(schema);
+        largeRecord.Add("id", 1);
+        largeRecord.Add("name", new string('x', 4096));
+        var smallRecord = new GenericRecord(schema);
+        smallRecord.Add("id", 2);
+        smallRecord.Add("name", "small");
+        var buffer = new ArrayBufferWriter<byte>();
+        var context = CreateContext();
+        var previousState = AvroCodecThreadStateCache.Serialization;
+        int largePayloadHint;
+        int smallPayloadHint;
+
+        try
+        {
+            AvroCodecThreadStateCache.Serialization = new AvroSerializationThreadState();
+            serializer.Serialize(largeRecord, ref buffer, context);
+            largePayloadHint = AvroCodecThreadStateCache.Serialization.PayloadSizeHint;
+            buffer.ResetWrittenCount();
+
+            serializer.Serialize(smallRecord, ref buffer, context);
+            smallPayloadHint = AvroCodecThreadStateCache.Serialization.PayloadSizeHint;
+        }
+        finally
+        {
+            AvroCodecThreadStateCache.Serialization = previousState;
+        }
+
+        await Assert.That(largePayloadHint).IsGreaterThan(1024);
+        await Assert.That(smallPayloadHint).IsEqualTo(largePayloadHint);
+    }
+
+    [Test]
     public async Task Serializer_GenericRecord_AllFieldTypes_MatchesApacheAvroBytes()
     {
         using var schemaRegistry = new MockSchemaRegistryClient();

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -826,6 +826,48 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    [Arguments(false, false)]
+    [Arguments(false, true)]
+    [Arguments(true, false)]
+    [Arguments(true, true)]
+    public async Task Serializer_GenericRecord_AssignableLogicalReferenceCollection_IsRejected(
+        bool useList,
+        bool empty)
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new ComparableBytesLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "AssignableLogicalReferenceCollectionRecord",
+                "fields": [{
+                    "name": "values",
+                    "type": {
+                        "type": "array",
+                        "items": [
+                            { "type": "bytes", "logicalType": "{{ComparableBytesLogicalType.LogicalName}}" },
+                            "string"
+                        ]
+                    }
+                }]
+            }
+            """);
+        var values = empty ? [] : new[] { "plain-value" };
+        var record = new GenericRecord(schema);
+        record.Add("values", useList ? new List<string>(values) : values);
+
+        await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
+
+        void Serialize()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
+    }
+
+    [Test]
     [Arguments(false, "plain-value", false)]
     [Arguments(false, "logical-value", true)]
     [Arguments(true, "logical-value", false)]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -429,6 +429,119 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Serializer_GenericRecord_CustomLogicalValueTypeList_IsRejected(bool useCollection)
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new IntBytesLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "CustomLogicalValueTypeListRecord",
+                "fields": [{
+                    "name": "values",
+                    "type": {
+                        "type": "array",
+                        "items": { "type": "bytes", "logicalType": "{{IntBytesLogicalType.LogicalName}}" }
+                    }
+                }]
+            }
+            """);
+        object values = useCollection
+            ? new Collection<int>([1, 2])
+            : new List<int> { 1, 2 };
+        var record = new GenericRecord(schema);
+        record.Add("values", values);
+
+        await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
+
+        void Serialize()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
+    }
+
+    [Test]
+    [Arguments(0, false)]
+    [Arguments(0, true)]
+    [Arguments(1, false)]
+    [Arguments(1, true)]
+    [Arguments(2, false)]
+    [Arguments(2, true)]
+    public async Task Serializer_GenericRecord_ConditionalNullableUnionCollection_AcceptsEmptyOrNulls(
+        int collectionKind,
+        bool includeNull)
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new IntBytesLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "ConditionalNullableUnionCollectionRecord",
+                "fields": [{
+                    "name": "values",
+                    "type": {
+                        "type": "array",
+                        "items": [
+                            "null",
+                            { "type": "bytes", "logicalType": "{{IntBytesLogicalType.LogicalName}}" }
+                        ]
+                    }
+                }]
+            }
+            """);
+        var nullableValues = includeNull ? new int?[] { null } : [];
+        object values = collectionKind switch
+        {
+            0 => nullableValues,
+            1 => new List<int?>(nullableValues),
+            2 => new Collection<int?>(nullableValues),
+            _ => throw new ArgumentOutOfRangeException(nameof(collectionKind))
+        };
+        var record = new GenericRecord(schema);
+        record.Add("values", values);
+        var expectedRecord = new GenericRecord(schema);
+        expectedRecord.Add("values", includeNull ? new object?[] { null } : []);
+
+        await AssertSerializedPayloadMatches(serializer, schema, record, expectedRecord);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Serializer_GenericRecord_CustomLogicalAndStructuralBranches_UseSchemaOrder(
+        bool arrayFirst)
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new IntListBytesLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var branches = arrayFirst
+            ? $$"""{ "type": "array", "items": "int" }, { "type": "bytes", "logicalType": "{{IntListBytesLogicalType.LogicalName}}" }"""
+            : $$"""{ "type": "bytes", "logicalType": "{{IntListBytesLogicalType.LogicalName}}" }, { "type": "array", "items": "int" }""";
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "CustomLogicalStructuralUnionRecord",
+                "fields": [{ "name": "value", "type": [{{branches}}] }]
+            }
+            """);
+        var record = new GenericRecord(schema);
+        var values = arrayFirst ? new[] { -1, 2 } : new[] { 1, 2 };
+        record.Add("value", new List<int>(values));
+        var expectedRecord = new GenericRecord(schema);
+        expectedRecord.Add("value", values);
+
+        await AssertSerializedPayloadMatches(serializer, schema, record, expectedRecord);
+    }
+
+    [Test]
     public async Task Serializer_GenericRecord_ListArray_MatchesApacheAvroBytes()
     {
         using var schemaRegistry = new MockSchemaRegistryClient();
@@ -1254,6 +1367,22 @@ public sealed class AvroSerializerTests
         public override Type GetCSharpType(bool nullible) => typeof(int);
 
         public override bool IsInstanceOfLogicalType(object logicalValue) => logicalValue is int;
+    }
+
+    private sealed class IntListBytesLogicalType() : Avro.Util.LogicalType(LogicalName)
+    {
+        internal const string LogicalName = "dekaf-int-list-bytes";
+
+        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
+            new byte[] { (byte)((List<int>)logicalValue).Count };
+
+        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
+            throw new NotSupportedException();
+
+        public override Type GetCSharpType(bool nullible) => typeof(List<int>);
+
+        public override bool IsInstanceOfLogicalType(object logicalValue) =>
+            logicalValue is List<int> { Count: > 0 } values && values[0] < 0;
     }
 
     private sealed class StringTextLogicalType() : Avro.Util.LogicalType(LogicalName)

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -5,6 +5,7 @@ using System.Numerics;
 using System.Text;
 using Avro.Generic;
 using Avro.IO;
+using Avro.Specific;
 using Dekaf.SchemaRegistry;
 using Dekaf.SchemaRegistry.Avro;
 using Dekaf.Serialization;
@@ -28,6 +29,92 @@ public sealed class AvroSerializerTests
             "namespace": "test",
             "fields": [
                 { "name": "id", "type": "int" },
+                { "name": "name", "type": "string" }
+            ]
+        }
+        """;
+
+    private const string SpecificScalarRecordSchema = """
+        {
+            "type": "record",
+            "name": "SpecificScalarRecord",
+            "namespace": "test",
+            "fields": [
+                { "name": "nothing", "type": "null" },
+                { "name": "enabled", "type": "boolean" },
+                { "name": "count", "type": "int" },
+                { "name": "sequence", "type": "long" },
+                { "name": "ratio", "type": "float" },
+                { "name": "total", "type": "double" },
+                { "name": "name", "type": "string" },
+                { "name": "payload", "type": "bytes" }
+            ]
+        }
+        """;
+
+    private const string SpecificArrayRecordSchema = """
+        {
+            "type": "record",
+            "name": "SpecificArrayRecord",
+            "namespace": "test",
+            "fields": [
+                { "name": "values", "type": { "type": "array", "items": "int" } }
+            ]
+        }
+        """;
+
+    private const string SpecificMissingPropertySchema = """
+        {
+            "type": "record",
+            "name": "SpecificMissingPropertyRecord",
+            "namespace": "test",
+            "fields": [{ "name": "missing", "type": "int" }]
+        }
+        """;
+
+    private const string SpecificMismatchedPropertySchema = """
+        {
+            "type": "record",
+            "name": "SpecificMismatchedPropertyRecord",
+            "namespace": "test",
+            "fields": [{ "name": "count", "type": "int" }]
+        }
+        """;
+
+    private const string SpecificCaseInsensitivePropertySchema = """
+        {
+            "type": "record",
+            "name": "SpecificCaseInsensitivePropertyRecord",
+            "namespace": "test",
+            "fields": [{ "name": "userId", "type": "int" }]
+        }
+        """;
+
+    private const string SpecificVirtualPropertySchema = """
+        {
+            "type": "record",
+            "name": "SpecificVirtualPropertyRecord",
+            "namespace": "test",
+            "fields": [{ "name": "count", "type": "int" }]
+        }
+        """;
+
+    private const string SpecificAmbiguousPropertySchema = """
+        {
+            "type": "record",
+            "name": "SpecificAmbiguousPropertyRecord",
+            "namespace": "test",
+            "fields": [{ "name": "count", "type": "int" }]
+        }
+        """;
+
+    private const string SpecificAliasedPropertySchema = """
+        {
+            "type": "record",
+            "name": "SpecificAliasedPropertyRecord",
+            "namespace": "test",
+            "fields": [
+                { "name": "Name", "type": "string" },
                 { "name": "name", "type": "string" }
             ]
         }
@@ -1412,6 +1499,144 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Serializer_SpecificRecord_ScalarFieldsMatchApacheAvroBytes()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<SpecificScalarRecord>(schemaRegistry);
+        var record = new SpecificScalarRecord
+        {
+            Enabled = true,
+            Count = -42,
+            Sequence = long.MaxValue,
+            Ratio = 1.25f,
+            Total = -123.5,
+            Name = "specific",
+            Payload = [0, 1, 127, 255]
+        };
+        var expected = SerializeSpecificAvroRecord(record);
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(record, ref buffer, CreateContext());
+
+        await Assert.That(buffer.WrittenSpan.Slice(5).SequenceEqual(expected)).IsTrue();
+        await Assert.That(serializer.CachedSpecificWriterCount).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Serializer_SpecificRecord_NonNullableReferenceFieldRejectsNull(bool nullBytes)
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<SpecificScalarRecord>(schemaRegistry);
+        var record = new SpecificScalarRecord
+        {
+            Name = nullBytes ? "specific" : null!,
+            Payload = nullBytes ? null! : []
+        };
+
+        await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
+
+        void Serialize()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
+    }
+
+    [Test]
+    public async Task Serializer_InterfaceTypedSpecificRecord_FailsDuringPreparation()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => GC.KeepAlive(new AvroSchemaRegistrySerializer<ISpecificRecord>(schemaRegistry)));
+
+        await Assert.That(exception!.Message).Contains("trimming-unsafe runtime type discovery");
+    }
+
+    [Test]
+    public async Task Serializer_SpecificRecord_UnsupportedFieldFailsDuringPreparation()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => GC.KeepAlive(new AvroSchemaRegistrySerializer<SpecificArrayRecord>(schemaRegistry)));
+
+        await Assert.That(exception!.Message).Contains("schema type Array is not supported");
+    }
+
+    [Test]
+    public async Task Serializer_SpecificRecord_MissingPropertyFailsDuringPreparation()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => GC.KeepAlive(new AvroSchemaRegistrySerializer<SpecificMissingPropertyRecord>(schemaRegistry)));
+
+        await Assert.That(exception!.Message).Contains("a readable public property named 'missing' was not found");
+    }
+
+    [Test]
+    public async Task Serializer_SpecificRecord_MismatchedPropertyTypeFailsDuringPreparation()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => GC.KeepAlive(new AvroSchemaRegistrySerializer<SpecificMismatchedPropertyRecord>(schemaRegistry)));
+
+        await Assert.That(exception!.Message).Contains("has type System.Int64, expected System.Int32");
+    }
+
+    [Test]
+    public async Task Serializer_SpecificRecord_CaseInsensitivePropertyMatchesSchemaField()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<SpecificCaseInsensitivePropertyRecord>(schemaRegistry);
+        var record = new SpecificCaseInsensitivePropertyRecord { UserId = 7 };
+        var expected = SerializeSpecificAvroRecord(record);
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(record, ref buffer, CreateContext());
+
+        await Assert.That(buffer.WrittenSpan.Slice(5).SequenceEqual(expected)).IsTrue();
+    }
+
+    [Test]
+    public async Task Serializer_SpecificRecord_OverridablePropertyFailsDuringPreparation()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        GC.KeepAlive(new SpecificVirtualPropertyDerivedRecord());
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => GC.KeepAlive(new AvroSchemaRegistrySerializer<SpecificVirtualPropertyRecord>(schemaRegistry)));
+
+        await Assert.That(exception!.Message).Contains("property 'Count' has an overridable getter");
+    }
+
+    [Test]
+    public async Task Serializer_SpecificRecord_AmbiguousPropertyFailsDuringPreparation()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => GC.KeepAlive(new AvroSchemaRegistrySerializer<SpecificAmbiguousPropertyRecord>(schemaRegistry)));
+
+        await Assert.That(exception!.Message).Contains("multiple public properties match 'count' ignoring case");
+    }
+
+    [Test]
+    public async Task Serializer_SpecificRecord_PropertyCannotMatchMultipleSchemaFields()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => GC.KeepAlive(new AvroSchemaRegistrySerializer<SpecificAliasedPropertyRecord>(schemaRegistry)));
+
+        await Assert.That(exception!.Message).Contains("property 'Name' also matches another schema field");
+    }
+
+    [Test]
     public async Task Serializer_UsesTopicNameStrategy_ByDefault()
     {
         // Arrange
@@ -1786,6 +2011,14 @@ public sealed class AvroSerializerTests
         await Assert.That(buffer.WrittenSpan.Slice(5).SequenceEqual(expected)).IsTrue();
     }
 
+    private static byte[] SerializeSpecificAvroRecord(ISpecificRecord record)
+    {
+        using var stream = new MemoryStream();
+        var writer = new SpecificDefaultWriter(record.Schema);
+        writer.Write(record.Schema, record, new BinaryEncoder(stream));
+        return stream.ToArray();
+    }
+
     private static async Task AssertSerializedPayloadMatches(
         AvroSchemaRegistrySerializer<GenericRecord> serializer,
         Avro.RecordSchema schema,
@@ -1940,5 +2173,127 @@ public sealed class AvroSerializerTests
 
         public override bool IsInstanceOfLogicalType(object logicalValue) =>
             logicalValue is string value && value.StartsWith("text-", StringComparison.Ordinal);
+    }
+
+    private sealed class SpecificScalarRecord : ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificScalarRecordSchema);
+
+        public bool Enabled { get; init; }
+        public int Count { get; init; }
+        public long Sequence { get; init; }
+        public float Ratio { get; init; }
+        public double Total { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public byte[] Payload { get; init; } = [];
+        public AvroSchema Schema => _SCHEMA;
+
+        public object? Get(int fieldPos) => fieldPos switch
+        {
+            0 => null,
+            1 => Enabled,
+            2 => Count,
+            3 => Sequence,
+            4 => Ratio,
+            5 => Total,
+            6 => Name,
+            7 => Payload,
+            _ => throw new ArgumentOutOfRangeException(nameof(fieldPos))
+        };
+
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
+    }
+
+    private sealed class SpecificArrayRecord : ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificArrayRecordSchema);
+
+        public int[] Values { get; init; } = [];
+        public AvroSchema Schema => _SCHEMA;
+
+        public object Get(int fieldPos) => fieldPos == 0
+            ? Values
+            : throw new ArgumentOutOfRangeException(nameof(fieldPos));
+
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
+    }
+
+    private sealed class SpecificMissingPropertyRecord : ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificMissingPropertySchema);
+
+        public AvroSchema Schema => _SCHEMA;
+        public object Get(int fieldPos) => throw new ArgumentOutOfRangeException(nameof(fieldPos));
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
+    }
+
+    private sealed class SpecificMismatchedPropertyRecord : ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificMismatchedPropertySchema);
+
+        public long Count { get; init; }
+        public AvroSchema Schema => _SCHEMA;
+        public object Get(int fieldPos) => fieldPos == 0
+            ? Count
+            : throw new ArgumentOutOfRangeException(nameof(fieldPos));
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
+    }
+
+    private sealed class SpecificCaseInsensitivePropertyRecord : ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificCaseInsensitivePropertySchema);
+
+        public int UserId { get; init; }
+        public AvroSchema Schema => _SCHEMA;
+        public object Get(int fieldPos) => fieldPos == 0
+            ? UserId
+            : throw new ArgumentOutOfRangeException(nameof(fieldPos));
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
+    }
+
+    private class SpecificVirtualPropertyRecord : ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificVirtualPropertySchema);
+
+        public virtual int Count { get; init; }
+        public AvroSchema Schema => _SCHEMA;
+        public object Get(int fieldPos) => fieldPos == 0
+            ? Count
+            : throw new ArgumentOutOfRangeException(nameof(fieldPos));
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
+    }
+
+    private sealed class SpecificVirtualPropertyDerivedRecord : SpecificVirtualPropertyRecord
+    {
+        public override int Count { get; init; }
+    }
+
+    private class SpecificAmbiguousPropertyBase
+    {
+        public long Count { get; init; }
+    }
+
+    private sealed class SpecificAmbiguousPropertyRecord : SpecificAmbiguousPropertyBase, ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificAmbiguousPropertySchema);
+
+        public new int Count { get; init; }
+        public AvroSchema Schema => _SCHEMA;
+        public object Get(int fieldPos) => fieldPos == 0
+            ? Count
+            : throw new ArgumentOutOfRangeException(nameof(fieldPos));
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
+    }
+
+    private sealed class SpecificAliasedPropertyRecord : ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificAliasedPropertySchema);
+
+        public string Name { get; init; } = string.Empty;
+        public AvroSchema Schema => _SCHEMA;
+        public object Get(int fieldPos) => fieldPos is 0 or 1
+            ? Name
+            : throw new ArgumentOutOfRangeException(nameof(fieldPos));
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
     }
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -119,6 +119,24 @@ public sealed class AvroSerializerTests
         }
         """;
 
+    private const string NestedRecordListSchema = """
+        {
+            "type": "record",
+            "name": "NestedRecordList",
+            "fields": [{
+                "name": "values",
+                "type": {
+                    "type": "array",
+                    "items": {
+                        "type": "record",
+                        "name": "NestedListValue",
+                        "fields": [{ "name": "id", "type": "int" }]
+                    }
+                }
+            }]
+        }
+        """;
+
     private const string NullableNonIntArraySchema = """
         {
           "type": "record",
@@ -625,6 +643,25 @@ public sealed class AvroSerializerTests
             new Collection<int?>([int.MinValue, null, 0, int.MaxValue]));
         var expectedRecord = new GenericRecord(schema);
         expectedRecord.Add("values", new int?[] { int.MinValue, null, 0, int.MaxValue });
+
+        await AssertSerializedPayloadMatches(serializer, schema, record, expectedRecord);
+    }
+
+    [Test]
+    public async Task Serializer_GenericRecord_NestedRecordList_MatchesApacheAvroBytes()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(NestedRecordListSchema);
+        var itemSchema = (Avro.RecordSchema)((Avro.ArraySchema)schema.Fields[0].Schema).ItemSchema;
+        var first = new GenericRecord(itemSchema);
+        first.Add("id", 1);
+        var second = new GenericRecord(itemSchema);
+        second.Add("id", 2);
+        var record = new GenericRecord(schema);
+        record.Add("values", new List<GenericRecord> { first, second });
+        var expectedRecord = new GenericRecord(schema);
+        expectedRecord.Add("values", new[] { first, second });
 
         await AssertSerializedPayloadMatches(serializer, schema, record, expectedRecord);
     }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -648,6 +648,50 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    [Arguments("string", 0)]
+    [Arguments("string", 1)]
+    [Arguments("string", 2)]
+    [Arguments("bytes", 0)]
+    [Arguments("bytes", 1)]
+    [Arguments("bytes", 2)]
+    public async Task Serializer_GenericRecord_NullInNonNullableReferenceCollection_IsRejected(
+        string itemType,
+        int collectionKind)
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "NonNullableReferenceArray",
+                "fields": [{ "name": "values", "type": { "type": "array", "items": "{{itemType}}" } }]
+            }
+            """);
+        object values = (itemType, collectionKind) switch
+        {
+            ("string", 0) => new string?[] { "first", null, "second" },
+            ("string", 1) => new List<string?> { "first", null, "second" },
+            ("string", 2) => new Collection<string?>(["first", null, "second"]),
+            ("bytes", 0) => new byte[]?[] { new byte[] { 1 }, null, new byte[] { 2 } },
+            ("bytes", 1) => new List<byte[]?> { new byte[] { 1 }, null, new byte[] { 2 } },
+            ("bytes", 2) => new Collection<byte[]?>(
+                new byte[]?[] { new byte[] { 1 }, null, new byte[] { 2 } }),
+            _ => throw new ArgumentOutOfRangeException(nameof(collectionKind))
+        };
+        var record = new GenericRecord(schema);
+        record.Add("values", values);
+
+        await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
+
+        void Serialize()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
+    }
+
+    [Test]
     public async Task Serializer_GenericRecord_NestedRecordList_MatchesApacheAvroBytes()
     {
         using var schemaRegistry = new MockSchemaRegistryClient();

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -248,7 +248,7 @@ public sealed class AvroSerializerTests
         record.Add("enumValue", new GenericEnum((Avro.EnumSchema)schema["enumValue"].Schema, "OFF"));
         record.Add("fixedValue", new GenericFixed((Avro.FixedSchema)schema["fixedValue"].Schema, [1, 2, 3, 4]));
         record.Add("arrayValue", new[] { int.MinValue, -1, 0, 1, int.MaxValue });
-        record.Add("mapValue", new SortedDictionary<string, object>
+        record.Add("mapValue", new Dictionary<string, object>
         {
             ["first"] = "alpha",
             ["second"] = "βeta"
@@ -257,6 +257,21 @@ public sealed class AvroSerializerTests
         record.Add("nestedValue", nested);
 
         await AssertSerializedPayloadMatchesApache(serializer, schema, record);
+    }
+
+    [Test]
+    public async Task Serializer_GenericRecord_NonDictionaryMap_IsRejected()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            """{"type":"record","name":"MapRecord","fields":[{"name":"mapValue","type":{"type":"map","values":"string"}}]}""");
+        var record = new GenericRecord(schema);
+        record.Add("mapValue", new SortedDictionary<string, object>());
+        var buffer = new ArrayBufferWriter<byte>();
+
+        Assert.Throws<Avro.AvroTypeException>(
+            () => serializer.Serialize(record, ref buffer, CreateContext()));
     }
 
     [Test]
@@ -364,6 +379,31 @@ public sealed class AvroSerializerTests
         record.Add("values", values);
         var expectedRecord = new GenericRecord(schema);
         expectedRecord.Add("values", includeNull ? new object?[] { null } : []);
+
+        await AssertSerializedPayloadMatches(serializer, schema, record, expectedRecord);
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(2)]
+    public async Task Serializer_GenericRecord_NonNullableUnionWithoutValueBranch_AcceptsEmpty(
+        int collectionKind)
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(NullableNonIntArraySchema);
+        object values = collectionKind switch
+        {
+            0 => Array.Empty<int>(),
+            1 => new List<int>(),
+            2 => new Collection<int>(),
+            _ => throw new ArgumentOutOfRangeException(nameof(collectionKind))
+        };
+        var record = new GenericRecord(schema);
+        record.Add("values", values);
+        var expectedRecord = new GenericRecord(schema);
+        expectedRecord.Add("values", Array.Empty<object>());
 
         await AssertSerializedPayloadMatches(serializer, schema, record, expectedRecord);
     }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -306,6 +306,31 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Serializer_GenericRecord_LogicalUnion_UsesFirstCompatibleBranch()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            """
+            {
+                "type": "record",
+                "name": "LogicalUnionRecord",
+                "fields": [{
+                    "name": "value",
+                    "type": [
+                        { "type": "int", "logicalType": "date" },
+                        { "type": "long", "logicalType": "timestamp-millis" }
+                    ]
+                }]
+            }
+            """);
+        var record = new GenericRecord(schema);
+        record.Add("value", new DateTime(2026, 8, 16, 0, 0, 0, DateTimeKind.Utc));
+
+        await AssertSerializedPayloadMatchesApache(serializer, schema, record);
+    }
+
+    [Test]
     public async Task Serializer_GenericRecord_ListArray_MatchesApacheAvroBytes()
     {
         using var schemaRegistry = new MockSchemaRegistryClient();

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -819,7 +819,7 @@ public sealed class AvroSerializerTests
     [Test]
     [Arguments(false)]
     [Arguments(true)]
-    public async Task Serializer_GenericRecord_CustomLogicalAndStructuralBranches_UseSchemaOrder(
+    public async Task Serializer_GenericRecord_AssignableCustomLogicalBranches_AreRejected(
         bool arrayFirst)
     {
         Avro.Util.LogicalTypeFactory.Instance.Register(new IntListBytesLogicalType());
@@ -839,10 +839,14 @@ public sealed class AvroSerializerTests
         var record = new GenericRecord(schema);
         var values = arrayFirst ? new[] { -1, 2 } : new[] { 1, 2 };
         record.Add("value", new List<int>(values));
-        var expectedRecord = new GenericRecord(schema);
-        expectedRecord.Add("value", values);
 
-        await AssertSerializedPayloadMatches(serializer, schema, record, expectedRecord);
+        await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
+
+        void Serialize()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
     }
 
     [Test]
@@ -955,13 +959,12 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
-    [Arguments(false, "plain-value", false)]
-    [Arguments(false, "logical-value", true)]
-    [Arguments(true, "logical-value", false)]
-    public async Task Serializer_GenericRecord_AssignableLogicalAndPrimitiveBranches_UseSchemaOrder(
+    [Arguments(false, "plain-value")]
+    [Arguments(false, "logical-value")]
+    [Arguments(true, "logical-value")]
+    public async Task Serializer_GenericRecord_AssignableLogicalAndPrimitiveBranches_AreRejected(
         bool stringFirst,
-        string value,
-        bool rejectsCustomLogicalBranch)
+        string value)
     {
         Avro.Util.LogicalTypeFactory.Instance.Register(new ComparableBytesLogicalType());
         using var schemaRegistry = new MockSchemaRegistryClient();
@@ -979,13 +982,7 @@ public sealed class AvroSerializerTests
         var record = new GenericRecord(schema);
         record.Add("value", value);
 
-        if (rejectsCustomLogicalBranch)
-        {
-            await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
-            return;
-        }
-
-        await AssertSerializedPayloadMatchesApache(serializer, schema, record);
+        await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
 
         void Serialize()
         {

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Numerics;
 using Avro.Generic;
 using Avro.IO;
 using Dekaf.SchemaRegistry;
@@ -24,6 +25,76 @@ public sealed class AvroSerializerTests
             "fields": [
                 { "name": "id", "type": "int" },
                 { "name": "name", "type": "string" }
+            ]
+        }
+        """;
+
+    private const string AllFieldTypesSchema = """
+        {
+            "type": "record",
+            "name": "AllFieldTypes",
+            "namespace": "test",
+            "fields": [
+                { "name": "nullValue", "type": "null" },
+                { "name": "booleanValue", "type": "boolean" },
+                { "name": "intValue", "type": "int" },
+                { "name": "longValue", "type": "long" },
+                { "name": "floatValue", "type": "float" },
+                { "name": "doubleValue", "type": "double" },
+                { "name": "bytesValue", "type": "bytes" },
+                { "name": "stringValue", "type": "string" },
+                { "name": "enumValue", "type": { "type": "enum", "name": "State", "symbols": ["ON", "OFF"] } },
+                { "name": "fixedValue", "type": { "type": "fixed", "name": "Hash", "size": 4 } },
+                { "name": "arrayValue", "type": { "type": "array", "items": "int" } },
+                { "name": "mapValue", "type": { "type": "map", "values": "string" } },
+                { "name": "unionValue", "type": ["null", "string"] },
+                {
+                    "name": "nestedValue",
+                    "type": {
+                        "type": "record",
+                        "name": "Nested",
+                        "fields": [{ "name": "value", "type": "long" }]
+                    }
+                }
+            ]
+        }
+        """;
+
+    private const string LogicalFieldTypesSchema = """
+        {
+            "type": "record",
+            "name": "LogicalFieldTypes",
+            "namespace": "test",
+            "fields": [
+                { "name": "dateValue", "type": { "type": "int", "logicalType": "date" } },
+                { "name": "timeMillisValue", "type": { "type": "int", "logicalType": "time-millis" } },
+                { "name": "timeMicrosValue", "type": { "type": "long", "logicalType": "time-micros" } },
+                { "name": "timestampMillisValue", "type": { "type": "long", "logicalType": "timestamp-millis" } },
+                { "name": "timestampMicrosValue", "type": { "type": "long", "logicalType": "timestamp-micros" } },
+                { "name": "localTimestampMillisValue", "type": { "type": "long", "logicalType": "local-timestamp-millis" } },
+                { "name": "localTimestampMicrosValue", "type": { "type": "long", "logicalType": "local-timestamp-micros" } },
+                { "name": "uuidValue", "type": { "type": "string", "logicalType": "uuid" } },
+                {
+                    "name": "dateArrayValue",
+                    "type": { "type": "array", "items": { "type": "int", "logicalType": "date" } }
+                },
+                {
+                    "name": "decimalBytesValue",
+                    "type": { "type": "bytes", "logicalType": "decimal", "precision": 8, "scale": 2 }
+                },
+                {
+                    "name": "fixedSeedValue",
+                    "type": { "type": "fixed", "name": "DecimalFixed", "size": 8 }
+                },
+                {
+                    "name": "decimalFixedValue",
+                    "type": {
+                        "type": "DecimalFixed",
+                        "logicalType": "decimal",
+                        "precision": 16,
+                        "scale": 2
+                    }
+                }
             ]
         }
         """;
@@ -96,6 +167,70 @@ public sealed class AvroSerializerTests
 
         var schemaId = BinaryPrimitives.ReadInt32BigEndian(data.Span.Slice(1, 4));
         await Assert.That(schemaId).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Serializer_GenericRecord_AllFieldTypes_MatchesApacheAvroBytes()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(AllFieldTypesSchema);
+        var record = new GenericRecord(schema);
+        var nestedSchema = (Avro.RecordSchema)schema["nestedValue"].Schema;
+        var nested = new GenericRecord(nestedSchema);
+        nested.Add("value", 9_876_543_210L);
+
+        record.Add("nullValue", null!);
+        record.Add("booleanValue", true);
+        record.Add("intValue", -123_456);
+        record.Add("longValue", 9_876_543_210L);
+        record.Add("floatValue", -123.25f);
+        record.Add("doubleValue", Math.PI);
+        record.Add("bytesValue", new byte[] { 0, 1, 127, 128, 255 });
+        record.Add("stringValue", string.Concat(Enumerable.Repeat("Grüße 🌍 ", 40)));
+        record.Add("enumValue", new GenericEnum((Avro.EnumSchema)schema["enumValue"].Schema, "OFF"));
+        record.Add("fixedValue", new GenericFixed((Avro.FixedSchema)schema["fixedValue"].Schema, [1, 2, 3, 4]));
+        record.Add("arrayValue", new[] { int.MinValue, -1, 0, 1, int.MaxValue });
+        record.Add("mapValue", new SortedDictionary<string, object>
+        {
+            ["first"] = "alpha",
+            ["second"] = "βeta"
+        });
+        record.Add("unionValue", "selected");
+        record.Add("nestedValue", nested);
+
+        await AssertSerializedPayloadMatchesApache(serializer, schema, record);
+    }
+
+    [Test]
+    public async Task Serializer_GenericRecord_LogicalFieldTypes_MatchesApacheAvroBytes()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(LogicalFieldTypesSchema);
+        var record = new GenericRecord(schema);
+        var timestamp = new DateTime(2026, 8, 16, 14, 23, 45, 678, DateTimeKind.Utc).AddTicks(9_010);
+
+        record.Add("dateValue", new DateTime(2026, 8, 16, 0, 0, 0, DateTimeKind.Utc));
+        record.Add("timeMillisValue", new TimeSpan(0, 14, 23, 45, 678));
+        record.Add("timeMicrosValue", new TimeSpan(0, 14, 23, 45, 678).Add(TimeSpan.FromTicks(9_010)));
+        record.Add("timestampMillisValue", timestamp);
+        record.Add("timestampMicrosValue", timestamp);
+        record.Add("localTimestampMillisValue", timestamp);
+        record.Add("localTimestampMicrosValue", timestamp);
+        record.Add("uuidValue", Guid.Parse("00112233-4455-6677-8899-aabbccddeeff"));
+        record.Add("dateArrayValue", new[]
+        {
+            new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 8, 16, 0, 0, 0, DateTimeKind.Utc)
+        });
+        record.Add("decimalBytesValue", new Avro.AvroDecimal(new BigInteger(-12_345), 2));
+        record.Add(
+            "fixedSeedValue",
+            new GenericFixed((Avro.FixedSchema)schema["fixedSeedValue"].Schema, new byte[8]));
+        record.Add("decimalFixedValue", new Avro.AvroDecimal(new BigInteger(98_765), 2));
+
+        await AssertSerializedPayloadMatchesApache(serializer, schema, record);
     }
 
     [Test]
@@ -722,5 +857,18 @@ public sealed class AvroSerializerTests
         BinaryPrimitives.WriteInt32BigEndian(wireFormat.AsSpan(1, 4), schemaId);
         avroPayload.CopyTo(wireFormat.AsSpan(5));
         return wireFormat;
+    }
+
+    private static async Task AssertSerializedPayloadMatchesApache(
+        AvroSchemaRegistrySerializer<GenericRecord> serializer,
+        Avro.RecordSchema schema,
+        GenericRecord record)
+    {
+        var expected = SerializeAvroRecord(record, schema);
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(record, ref buffer, CreateContext());
+
+        await Assert.That(buffer.WrittenSpan.Slice(5).SequenceEqual(expected)).IsTrue();
     }
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -116,6 +116,16 @@ public sealed class AvroSerializerTests
         }
         """;
 
+    private const string NullableNonIntArraySchema = """
+        {
+          "type": "record",
+          "name": "NullableNonIntArrayRecord",
+          "fields": [
+            { "name": "values", "type": { "type": "array", "items": ["null", "string"] } }
+          ]
+        }
+        """;
+
     private const string LocalTimestampSchema = """
         {
             "type": "record",
@@ -324,6 +334,36 @@ public sealed class AvroSerializerTests
             new Collection<int?>([int.MinValue, null, 0, int.MaxValue]));
         var expectedRecord = new GenericRecord(schema);
         expectedRecord.Add("values", new int?[] { int.MinValue, null, 0, int.MaxValue });
+
+        await AssertSerializedPayloadMatches(serializer, schema, record, expectedRecord);
+    }
+
+    [Test]
+    [Arguments(0, false)]
+    [Arguments(0, true)]
+    [Arguments(1, false)]
+    [Arguments(1, true)]
+    [Arguments(2, false)]
+    [Arguments(2, true)]
+    public async Task Serializer_GenericRecord_NullableUnionWithoutValueBranch_AcceptsEmptyOrNulls(
+        int collectionKind,
+        bool includeNull)
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(NullableNonIntArraySchema);
+        var nullableValues = includeNull ? new int?[] { null } : [];
+        object values = collectionKind switch
+        {
+            0 => nullableValues,
+            1 => new List<int?>(nullableValues),
+            2 => new Collection<int?>(nullableValues),
+            _ => throw new ArgumentOutOfRangeException(nameof(collectionKind))
+        };
+        var record = new GenericRecord(schema);
+        record.Add("values", values);
+        var expectedRecord = new GenericRecord(schema);
+        expectedRecord.Add("values", includeNull ? new object?[] { null } : []);
 
         await AssertSerializedPayloadMatches(serializer, schema, record, expectedRecord);
     }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -600,6 +600,32 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Serializer_GenericRecord_AssignableCustomLogicalBranch_MatchesApacheAvroBytes()
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new IntListBytesLogicalType());
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(
+            $$"""
+            {
+                "type": "record",
+                "name": "AssignableCustomLogicalUnionRecord",
+                "fields": [{
+                    "name": "value",
+                    "type": [
+                        { "type": "bytes", "logicalType": "{{IntListBytesLogicalType.LogicalName}}" },
+                        { "type": "array", "items": "int" }
+                    ]
+                }]
+            }
+            """);
+        var record = new GenericRecord(schema);
+        record.Add("value", new List<int> { -1, 2 });
+
+        await AssertSerializedPayloadMatchesApache(serializer, schema, record);
+    }
+
+    [Test]
     public async Task Serializer_GenericRecord_ListArray_MatchesApacheAvroBytes()
     {
         using var schemaRegistry = new MockSchemaRegistryClient();
@@ -1502,15 +1528,15 @@ public sealed class AvroSerializerTests
         internal const string LogicalName = "dekaf-int-list-bytes";
 
         public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
-            new byte[] { (byte)((List<int>)logicalValue).Count };
+            new byte[] { (byte)((IList<int>)logicalValue).Count };
 
         public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
             throw new NotSupportedException();
 
-        public override Type GetCSharpType(bool nullible) => typeof(List<int>);
+        public override Type GetCSharpType(bool nullible) => typeof(IList<int>);
 
         public override bool IsInstanceOfLogicalType(object logicalValue) =>
-            logicalValue is List<int> { Count: > 0 } values && values[0] < 0;
+            logicalValue is IList<int> { Count: > 0 } values && values[0] < 0;
     }
 
     private sealed class StringTextLogicalType() : Avro.Util.LogicalType(LogicalName)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -1,5 +1,7 @@
 using System.Buffers;
+using System.Collections.ObjectModel;
 using Avro.Generic;
+using Avro.Specific;
 using BenchmarkDotNet.Attributes;
 using Dekaf.SchemaRegistry;
 using Dekaf.SchemaRegistry.Avro;
@@ -49,9 +51,12 @@ public class AvroSchemaRegistrySerializerBenchmarks
         """;
 
     private AvroSchemaRegistrySerializer<GenericRecord> _serializer = null!;
+    private AvroSchemaRegistrySerializer<SpecificBenchmarkRecord> _specificSerializer = null!;
     private GenericRecord[] _equivalentRecords = null!;
     private GenericRecord _intRecord = null!;
     private GenericRecord _nullableIntArrayRecord = null!;
+    private GenericRecord _nullableIntCollectionRecord = null!;
+    private SpecificBenchmarkRecord _specificRecord = null!;
     private ArrayBufferWriter<byte> _serializeBuffer = null!;
     private GenericRecord _stableRecord = null!;
     private SerializationContext _context;
@@ -61,6 +66,8 @@ public class AvroSchemaRegistrySerializerBenchmarks
     public void Setup()
     {
         _serializer = new AvroSchemaRegistrySerializer<GenericRecord>(new BenchmarkSchemaRegistryClient());
+        _specificSerializer = new AvroSchemaRegistrySerializer<SpecificBenchmarkRecord>(
+            new BenchmarkSchemaRegistryClient());
         _context = new SerializationContext
         {
             Topic = "avro-benchmark",
@@ -74,16 +81,24 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _stableRecord = _equivalentRecords[0];
         _intRecord = CreateIntRecord();
         _nullableIntArrayRecord = CreateNullableIntArrayRecord();
+        _nullableIntCollectionRecord = CreateNullableIntCollectionRecord();
+        _specificRecord = new SpecificBenchmarkRecord { Id = 42, Name = "benchmark" };
         _serializeBuffer = new ArrayBufferWriter<byte>();
         _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_intRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_nullableIntArrayRecord, ref _serializeBuffer, _context);
+        _serializeBuffer.ResetWrittenCount();
+        _specificSerializer.Serialize(_specificRecord, ref _serializeBuffer, _context);
     }
 
     [GlobalCleanup]
-    public ValueTask Cleanup() => _serializer.DisposeAsync();
+    public async ValueTask Cleanup()
+    {
+        await _serializer.DisposeAsync().ConfigureAwait(false);
+        await _specificSerializer.DisposeAsync().ConfigureAwait(false);
+    }
 
     [Benchmark(Baseline = true, Description = "Prepare stable generic Avro schema")]
     public ValueTask PrepareStableSchema() => _serializer.PrepareAsync(_stableRecord, _context);
@@ -116,6 +131,20 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_nullableIntArrayRecord, ref _serializeBuffer, _context);
     }
 
+    [Benchmark(Description = "Serialize nullable-int Collection<T> generic Avro record")]
+    public void SerializeNullableIntCollectionRecord()
+    {
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_nullableIntCollectionRecord, ref _serializeBuffer, _context);
+    }
+
+    [Benchmark(Description = "Serialize prepared SpecificRecord")]
+    public void SerializeSpecificRecord()
+    {
+        _serializeBuffer.ResetWrittenCount();
+        _specificSerializer.Serialize(_specificRecord, ref _serializeBuffer, _context);
+    }
+
     private static GenericRecord CreateRecord(int id)
     {
         var schema = (Avro.RecordSchema)AvroSchema.Parse(RecordSchema);
@@ -139,6 +168,35 @@ public class AvroSchemaRegistrySerializerBenchmarks
         var record = new GenericRecord(schema);
         record.Add("values", new int?[] { int.MinValue, null, -1, 0, 1, null, int.MaxValue });
         return record;
+    }
+
+    private static GenericRecord CreateNullableIntCollectionRecord()
+    {
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(NullableIntArraySchema);
+        var record = new GenericRecord(schema);
+        record.Add(
+            "values",
+            new Collection<int?>([int.MinValue, null, -1, 0, 1, null, int.MaxValue]));
+        return record;
+    }
+
+    private sealed class SpecificBenchmarkRecord : ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(RecordSchema);
+
+        public int Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public AvroSchema Schema => _SCHEMA;
+
+        public object Get(int fieldPos) => fieldPos switch
+        {
+            0 => Id,
+            1 => Name,
+            _ => throw new ArgumentOutOfRangeException(nameof(fieldPos))
+        };
+
+        public void Put(int fieldPos, object fieldValue) =>
+            throw new NotSupportedException();
     }
 
     private sealed class BenchmarkSchemaRegistryClient : ISchemaRegistryClient

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -159,6 +159,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
     private GenericRecord _logicalStringCollectionRecord = null!;
     private GenericRecord _conditionalLogicalStructuralUnionRecord = null!;
     private GenericRecord _nestedRecordCollectionRecord = null!;
+    private GenericRecord _nestedRecordListRecord = null!;
     private SpecificBenchmarkRecord _specificRecord = null!;
     private ArrayBufferWriter<byte> _serializeBuffer = null!;
     private GenericRecord _stableRecord = null!;
@@ -194,7 +195,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _conditionalLogicalUnionRecord = CreateConditionalLogicalUnionRecord();
         _logicalStringCollectionRecord = CreateLogicalStringCollectionRecord();
         _conditionalLogicalStructuralUnionRecord = CreateConditionalLogicalStructuralUnionRecord();
-        _nestedRecordCollectionRecord = CreateNestedRecordCollectionRecord();
+        (_nestedRecordCollectionRecord, _nestedRecordListRecord) = CreateNestedRecordCollectionRecords();
         _specificRecord = new SpecificBenchmarkRecord { Id = 42, Name = "benchmark" };
         _serializeBuffer = new ArrayBufferWriter<byte>();
         _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
@@ -216,6 +217,8 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_conditionalLogicalStructuralUnionRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_nestedRecordCollectionRecord, ref _serializeBuffer, _context);
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_nestedRecordListRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _specificSerializer.Serialize(_specificRecord, ref _serializeBuffer, _context);
     }
@@ -314,6 +317,13 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_nestedRecordCollectionRecord, ref _serializeBuffer, _context);
     }
 
+    [Benchmark(Description = "Serialize generic nested-record list")]
+    public void SerializeNestedRecordList()
+    {
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_nestedRecordListRecord, ref _serializeBuffer, _context);
+    }
+
     [Benchmark(Description = "Control: Apache writer prepared SpecificRecord")]
     public void SerializeSpecificRecord()
     {
@@ -410,7 +420,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
         return record;
     }
 
-    private static GenericRecord CreateNestedRecordCollectionRecord()
+    private static (GenericRecord Collection, GenericRecord List) CreateNestedRecordCollectionRecords()
     {
         var schema = (Avro.RecordSchema)AvroSchema.Parse(NestedRecordArraySchema);
         var arraySchema = (Avro.ArraySchema)schema.Fields[0].Schema;
@@ -419,9 +429,11 @@ public class AvroSchemaRegistrySerializerBenchmarks
         first.Add("id", 1);
         var second = new GenericRecord(itemSchema);
         second.Add("id", 2);
-        var record = new GenericRecord(schema);
-        record.Add("values", new NonGenericRecordCollection([first, second]));
-        return record;
+        var collectionRecord = new GenericRecord(schema);
+        collectionRecord.Add("values", new NonGenericRecordCollection([first, second]));
+        var listRecord = new GenericRecord(schema);
+        listRecord.Add("values", new List<GenericRecord> { first, second });
+        return (collectionRecord, listRecord);
     }
 
     private sealed class NonGenericRecordCollection(IList<GenericRecord> values)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -38,9 +38,20 @@ public class AvroSchemaRegistrySerializerBenchmarks
         }
         """;
 
+    private const string NullableIntArraySchema =
+        """
+        {
+          "type": "record",
+          "name": "NullableIntArrayBenchmarkRecord",
+          "namespace": "Dekaf.Benchmarks",
+          "fields": [{ "name": "values", "type": { "type": "array", "items": ["null", "int"] } }]
+        }
+        """;
+
     private AvroSchemaRegistrySerializer<GenericRecord> _serializer = null!;
     private GenericRecord[] _equivalentRecords = null!;
     private GenericRecord _intRecord = null!;
+    private GenericRecord _nullableIntArrayRecord = null!;
     private ArrayBufferWriter<byte> _serializeBuffer = null!;
     private GenericRecord _stableRecord = null!;
     private SerializationContext _context;
@@ -62,10 +73,13 @@ public class AvroSchemaRegistrySerializerBenchmarks
 
         _stableRecord = _equivalentRecords[0];
         _intRecord = CreateIntRecord();
+        _nullableIntArrayRecord = CreateNullableIntArrayRecord();
         _serializeBuffer = new ArrayBufferWriter<byte>();
         _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_intRecord, ref _serializeBuffer, _context);
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_nullableIntArrayRecord, ref _serializeBuffer, _context);
     }
 
     [GlobalCleanup]
@@ -95,6 +109,13 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
     }
 
+    [Benchmark(Description = "Serialize nullable-int array generic Avro record")]
+    public void SerializeNullableIntArrayRecord()
+    {
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_nullableIntArrayRecord, ref _serializeBuffer, _context);
+    }
+
     private static GenericRecord CreateRecord(int id)
     {
         var schema = (Avro.RecordSchema)AvroSchema.Parse(RecordSchema);
@@ -109,6 +130,14 @@ public class AvroSchemaRegistrySerializerBenchmarks
         var schema = (Avro.RecordSchema)AvroSchema.Parse(IntRecordSchema);
         var record = new GenericRecord(schema);
         record.Add("id", 42);
+        return record;
+    }
+
+    private static GenericRecord CreateNullableIntArrayRecord()
+    {
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(NullableIntArraySchema);
+        var record = new GenericRecord(schema);
+        record.Add("values", new int?[] { int.MinValue, null, -1, 0, 1, null, int.MaxValue });
         return record;
     }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -13,7 +13,7 @@ using RegistrySchema = Dekaf.SchemaRegistry.Schema;
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
 /// <summary>
-/// Measures the producer's generic Avro path and the unchanged Apache SpecificRecord control.
+/// Measures prepared GenericRecord and SpecificRecord serialization paths.
 /// </summary>
 [MemoryDiagnoser(displayGenColumns: false)]
 public class AvroSchemaRegistrySerializerBenchmarks
@@ -227,6 +227,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_nestedRecordListRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _specificSerializer.Serialize(_specificRecord, ref _serializeBuffer, _context);
+        _serializeBuffer.ResetWrittenCount();
     }
 
     [GlobalCleanup]
@@ -330,7 +331,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_nestedRecordListRecord, ref _serializeBuffer, _context);
     }
 
-    [Benchmark(Description = "Control: Apache writer prepared SpecificRecord")]
+    [Benchmark(Description = "Serialize prepared SpecificRecord (int + string)")]
     public void SerializeSpecificRecord()
     {
         _serializeBuffer.ResetWrittenCount();

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -87,6 +87,22 @@ public class AvroSchemaRegistrySerializerBenchmarks
         }
         """;
 
+    private const string ConditionalLogicalStructuralUnionSchema =
+        """
+        {
+          "type": "record",
+          "name": "ConditionalLogicalStructuralUnionBenchmarkRecord",
+          "namespace": "Dekaf.Benchmarks",
+          "fields": [{
+            "name": "value",
+            "type": [
+              { "type": "bytes", "logicalType": "dekaf-benchmark-int-list-bytes" },
+              { "type": "array", "items": "int" }
+            ]
+          }]
+        }
+        """;
+
     private AvroSchemaRegistrySerializer<GenericRecord> _serializer = null!;
     private AvroSchemaRegistrySerializer<SpecificBenchmarkRecord> _specificSerializer = null!;
     private GenericRecord[] _equivalentRecords = null!;
@@ -96,6 +112,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
     private GenericRecord _scalarUnionRecord = null!;
     private GenericRecord _dictionaryMapRecord = null!;
     private GenericRecord _conditionalLogicalUnionRecord = null!;
+    private GenericRecord _conditionalLogicalStructuralUnionRecord = null!;
     private SpecificBenchmarkRecord _specificRecord = null!;
     private ArrayBufferWriter<byte> _serializeBuffer = null!;
     private GenericRecord _stableRecord = null!;
@@ -106,6 +123,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
     public void Setup()
     {
         Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkStringBytesLogicalType());
+        Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkIntListBytesLogicalType());
         _serializer = new AvroSchemaRegistrySerializer<GenericRecord>(new BenchmarkSchemaRegistryClient());
         _specificSerializer = new AvroSchemaRegistrySerializer<SpecificBenchmarkRecord>(
             new BenchmarkSchemaRegistryClient());
@@ -126,6 +144,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _scalarUnionRecord = CreateScalarUnionRecord();
         _dictionaryMapRecord = CreateDictionaryMapRecord();
         _conditionalLogicalUnionRecord = CreateConditionalLogicalUnionRecord();
+        _conditionalLogicalStructuralUnionRecord = CreateConditionalLogicalStructuralUnionRecord();
         _specificRecord = new SpecificBenchmarkRecord { Id = 42, Name = "benchmark" };
         _serializeBuffer = new ArrayBufferWriter<byte>();
         _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
@@ -139,6 +158,8 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_dictionaryMapRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_conditionalLogicalUnionRecord, ref _serializeBuffer, _context);
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_conditionalLogicalStructuralUnionRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _specificSerializer.Serialize(_specificRecord, ref _serializeBuffer, _context);
     }
@@ -207,6 +228,13 @@ public class AvroSchemaRegistrySerializerBenchmarks
     {
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_conditionalLogicalUnionRecord, ref _serializeBuffer, _context);
+    }
+
+    [Benchmark(Description = "Serialize conditional-logical structural union fallback")]
+    public void SerializeConditionalLogicalStructuralUnionFallback()
+    {
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_conditionalLogicalStructuralUnionRecord, ref _serializeBuffer, _context);
     }
 
     [Benchmark(Description = "Control: Apache writer prepared SpecificRecord")]
@@ -281,6 +309,14 @@ public class AvroSchemaRegistrySerializerBenchmarks
         return record;
     }
 
+    private static GenericRecord CreateConditionalLogicalStructuralUnionRecord()
+    {
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(ConditionalLogicalStructuralUnionSchema);
+        var record = new GenericRecord(schema);
+        record.Add("value", new List<int> { 1, 2, 3, 4 });
+        return record;
+    }
+
     private sealed class BenchmarkStringBytesLogicalType()
         : Avro.Util.LogicalType("dekaf-benchmark-string-bytes")
     {
@@ -294,6 +330,21 @@ public class AvroSchemaRegistrySerializerBenchmarks
 
         public override bool IsInstanceOfLogicalType(object logicalValue) =>
             logicalValue is string value && value.StartsWith("logical-", StringComparison.Ordinal);
+    }
+
+    private sealed class BenchmarkIntListBytesLogicalType()
+        : Avro.Util.LogicalType("dekaf-benchmark-int-list-bytes")
+    {
+        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
+            new byte[] { (byte)((List<int>)logicalValue).Count };
+
+        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
+            throw new NotSupportedException();
+
+        public override Type GetCSharpType(bool nullible) => typeof(List<int>);
+
+        public override bool IsInstanceOfLogicalType(object logicalValue) =>
+            logicalValue is List<int> { Count: > 0 } values && values[0] < 0;
     }
 
     private sealed class SpecificBenchmarkRecord : ISpecificRecord

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -50,12 +50,23 @@ public class AvroSchemaRegistrySerializerBenchmarks
         }
         """;
 
+    private const string ScalarUnionSchema =
+        """
+        {
+          "type": "record",
+          "name": "ScalarUnionBenchmarkRecord",
+          "namespace": "Dekaf.Benchmarks",
+          "fields": [{ "name": "value", "type": ["null", "int", "string"] }]
+        }
+        """;
+
     private AvroSchemaRegistrySerializer<GenericRecord> _serializer = null!;
     private AvroSchemaRegistrySerializer<SpecificBenchmarkRecord> _specificSerializer = null!;
     private GenericRecord[] _equivalentRecords = null!;
     private GenericRecord _intRecord = null!;
     private GenericRecord _nullableIntArrayRecord = null!;
     private GenericRecord _nullableIntCollectionRecord = null!;
+    private GenericRecord _scalarUnionRecord = null!;
     private SpecificBenchmarkRecord _specificRecord = null!;
     private ArrayBufferWriter<byte> _serializeBuffer = null!;
     private GenericRecord _stableRecord = null!;
@@ -82,6 +93,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _intRecord = CreateIntRecord();
         _nullableIntArrayRecord = CreateNullableIntArrayRecord();
         _nullableIntCollectionRecord = CreateNullableIntCollectionRecord();
+        _scalarUnionRecord = CreateScalarUnionRecord();
         _specificRecord = new SpecificBenchmarkRecord { Id = 42, Name = "benchmark" };
         _serializeBuffer = new ArrayBufferWriter<byte>();
         _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
@@ -89,6 +101,8 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_intRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_nullableIntArrayRecord, ref _serializeBuffer, _context);
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_scalarUnionRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _specificSerializer.Serialize(_specificRecord, ref _serializeBuffer, _context);
     }
@@ -138,6 +152,13 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_nullableIntCollectionRecord, ref _serializeBuffer, _context);
     }
 
+    [Benchmark(Description = "Serialize scalar-union generic Avro record")]
+    public void SerializeScalarUnionRecord()
+    {
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_scalarUnionRecord, ref _serializeBuffer, _context);
+    }
+
     [Benchmark(Description = "Serialize prepared SpecificRecord")]
     public void SerializeSpecificRecord()
     {
@@ -177,6 +198,14 @@ public class AvroSchemaRegistrySerializerBenchmarks
         record.Add(
             "values",
             new Collection<int?>([int.MinValue, null, -1, 0, 1, null, int.MaxValue]));
+        return record;
+    }
+
+    private static GenericRecord CreateScalarUnionRecord()
+    {
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(ScalarUnionSchema);
+        var record = new GenericRecord(schema);
+        record.Add("value", 42);
         return record;
     }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -15,6 +15,16 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [MemoryDiagnoser(displayGenColumns: false)]
 public class AvroSchemaRegistrySerializerBenchmarks
 {
+    private const string IntRecordSchema =
+        """
+        {
+          "type": "record",
+          "name": "IntBenchmarkRecord",
+          "namespace": "Dekaf.Benchmarks",
+          "fields": [{ "name": "id", "type": "int" }]
+        }
+        """;
+
     private const string RecordSchema =
         """
         {
@@ -30,6 +40,8 @@ public class AvroSchemaRegistrySerializerBenchmarks
 
     private AvroSchemaRegistrySerializer<GenericRecord> _serializer = null!;
     private GenericRecord[] _equivalentRecords = null!;
+    private GenericRecord _intRecord = null!;
+    private ArrayBufferWriter<byte> _serializeBuffer = null!;
     private GenericRecord _stableRecord = null!;
     private SerializationContext _context;
     private int _recordIndex;
@@ -49,8 +61,11 @@ public class AvroSchemaRegistrySerializerBenchmarks
             _equivalentRecords[i] = CreateRecord(i);
 
         _stableRecord = _equivalentRecords[0];
-        var buffer = new ArrayBufferWriter<byte>();
-        _serializer.Serialize(_stableRecord, ref buffer, _context);
+        _intRecord = CreateIntRecord();
+        _serializeBuffer = new ArrayBufferWriter<byte>();
+        _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_intRecord, ref _serializeBuffer, _context);
     }
 
     [GlobalCleanup]
@@ -66,12 +81,34 @@ public class AvroSchemaRegistrySerializerBenchmarks
         return _serializer.PrepareAsync(_equivalentRecords[_recordIndex], _context);
     }
 
+    [Benchmark(Description = "Serialize prepared int-only generic Avro record")]
+    public void SerializeIntRecord()
+    {
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_intRecord, ref _serializeBuffer, _context);
+    }
+
+    [Benchmark(Description = "Serialize prepared int + string generic Avro record")]
+    public void SerializeIntStringRecord()
+    {
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
+    }
+
     private static GenericRecord CreateRecord(int id)
     {
         var schema = (Avro.RecordSchema)AvroSchema.Parse(RecordSchema);
         var record = new GenericRecord(schema);
         record.Add("id", id);
         record.Add("name", "benchmark");
+        return record;
+    }
+
+    private static GenericRecord CreateIntRecord()
+    {
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(IntRecordSchema);
+        var record = new GenericRecord(schema);
+        record.Add("id", 42);
         return record;
     }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -149,8 +149,10 @@ public class AvroSchemaRegistrySerializerBenchmarks
     private GenericRecord _conditionalValueLogicalStringArrayRecord = null!;
     private GenericRecord _nestedRecordCollectionRecord = null!;
     private GenericRecord _nestedRecordListRecord = null!;
+    private GenericRecord[] _variableSizeRecords = null!;
     private SpecificBenchmarkRecord _specificRecord = null!;
     private ArrayBufferWriter<byte> _serializeBuffer = null!;
+    private ExactSizeBufferWriter _exactSizeSerializeBuffer = null!;
     private GenericRecord _stableRecord = null!;
     private SerializationContext _context;
     private int _recordIndex;
@@ -183,8 +185,14 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _conditionalLogicalUnionRecord = CreateConditionalLogicalUnionRecord();
         _conditionalValueLogicalStringArrayRecord = CreateConditionalValueLogicalStringArrayRecord();
         (_nestedRecordCollectionRecord, _nestedRecordListRecord) = CreateNestedRecordCollectionRecords();
+        _variableSizeRecords =
+        [
+            CreateRecord(1, "small"),
+            CreateRecord(2, new string('x', 4096))
+        ];
         _specificRecord = new SpecificBenchmarkRecord { Id = 42, Name = "benchmark" };
         _serializeBuffer = new ArrayBufferWriter<byte>();
+        _exactSizeSerializeBuffer = new ExactSizeBufferWriter(8192);
         _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_intRecord, ref _serializeBuffer, _context);
@@ -207,6 +215,10 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializeBuffer.ResetWrittenCount();
         _specificSerializer.Serialize(_specificRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_variableSizeRecords[1], ref _exactSizeSerializeBuffer, _context);
+        _exactSizeSerializeBuffer.Reset();
+        _serializer.Serialize(_variableSizeRecords[0], ref _exactSizeSerializeBuffer, _context);
+        _exactSizeSerializeBuffer.Reset();
     }
 
     [GlobalCleanup]
@@ -310,12 +322,20 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _specificSerializer.Serialize(_specificRecord, ref _serializeBuffer, _context);
     }
 
-    private static GenericRecord CreateRecord(int id)
+    [Benchmark(Description = "Serialize alternating small/large generic Avro records")]
+    public void SerializeAlternatingSizeRecords()
+    {
+        _exactSizeSerializeBuffer.Reset();
+        _recordIndex ^= 1;
+        _serializer.Serialize(_variableSizeRecords[_recordIndex], ref _exactSizeSerializeBuffer, _context);
+    }
+
+    private static GenericRecord CreateRecord(int id, string name = "benchmark")
     {
         var schema = (Avro.RecordSchema)AvroSchema.Parse(RecordSchema);
         var record = new GenericRecord(schema);
         record.Add("id", id);
-        record.Add("name", "benchmark");
+        record.Add("name", name);
         return record;
     }
 
@@ -325,6 +345,22 @@ public class AvroSchemaRegistrySerializerBenchmarks
         var record = new GenericRecord(schema);
         record.Add("id", 42);
         return record;
+    }
+
+    private sealed class ExactSizeBufferWriter(int capacity) : IBufferWriter<byte>
+    {
+        private readonly byte[] _buffer = new byte[capacity];
+        private int _written;
+
+        public void Advance(int count) => _written += count;
+
+        public Memory<byte> GetMemory(int sizeHint = 0) =>
+            _buffer.AsMemory(_written, Math.Max(1, sizeHint));
+
+        public Span<byte> GetSpan(int sizeHint = 0) =>
+            _buffer.AsSpan(_written, Math.Max(1, sizeHint));
+
+        internal void Reset() => _written = 0;
     }
 
     private static GenericRecord CreateNullableIntArrayRecord()

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -476,15 +476,15 @@ public class AvroSchemaRegistrySerializerBenchmarks
         : Avro.Util.LogicalType("dekaf-benchmark-int-list-bytes")
     {
         public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
-            new byte[] { (byte)((List<int>)logicalValue).Count };
+            new byte[] { (byte)((IList<int>)logicalValue).Count };
 
         public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
             throw new NotSupportedException();
 
-        public override Type GetCSharpType(bool nullible) => typeof(List<int>);
+        public override Type GetCSharpType(bool nullible) => typeof(IList<int>);
 
         public override bool IsInstanceOfLogicalType(object logicalValue) =>
-            logicalValue is List<int> { Count: > 0 } values && values[0] < 0;
+            logicalValue is IList<int> { Count: > 0 } values && values[0] < 0;
     }
 
     private sealed class SpecificBenchmarkRecord : ISpecificRecord

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Collections.ObjectModel;
+using System.Text;
 using Avro.Generic;
 using Avro.Specific;
 using BenchmarkDotNet.Attributes;
@@ -70,6 +71,22 @@ public class AvroSchemaRegistrySerializerBenchmarks
         }
         """;
 
+    private const string ConditionalLogicalUnionSchema =
+        """
+        {
+          "type": "record",
+          "name": "ConditionalLogicalUnionBenchmarkRecord",
+          "namespace": "Dekaf.Benchmarks",
+          "fields": [{
+            "name": "value",
+            "type": [
+              { "type": "bytes", "logicalType": "dekaf-benchmark-string-bytes" },
+              "string"
+            ]
+          }]
+        }
+        """;
+
     private AvroSchemaRegistrySerializer<GenericRecord> _serializer = null!;
     private AvroSchemaRegistrySerializer<SpecificBenchmarkRecord> _specificSerializer = null!;
     private GenericRecord[] _equivalentRecords = null!;
@@ -78,6 +95,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
     private GenericRecord _nullableIntCollectionRecord = null!;
     private GenericRecord _scalarUnionRecord = null!;
     private GenericRecord _dictionaryMapRecord = null!;
+    private GenericRecord _conditionalLogicalUnionRecord = null!;
     private SpecificBenchmarkRecord _specificRecord = null!;
     private ArrayBufferWriter<byte> _serializeBuffer = null!;
     private GenericRecord _stableRecord = null!;
@@ -87,6 +105,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
     [GlobalSetup]
     public void Setup()
     {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkStringBytesLogicalType());
         _serializer = new AvroSchemaRegistrySerializer<GenericRecord>(new BenchmarkSchemaRegistryClient());
         _specificSerializer = new AvroSchemaRegistrySerializer<SpecificBenchmarkRecord>(
             new BenchmarkSchemaRegistryClient());
@@ -106,6 +125,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _nullableIntCollectionRecord = CreateNullableIntCollectionRecord();
         _scalarUnionRecord = CreateScalarUnionRecord();
         _dictionaryMapRecord = CreateDictionaryMapRecord();
+        _conditionalLogicalUnionRecord = CreateConditionalLogicalUnionRecord();
         _specificRecord = new SpecificBenchmarkRecord { Id = 42, Name = "benchmark" };
         _serializeBuffer = new ArrayBufferWriter<byte>();
         _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
@@ -117,6 +137,8 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_scalarUnionRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_dictionaryMapRecord, ref _serializeBuffer, _context);
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_conditionalLogicalUnionRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _specificSerializer.Serialize(_specificRecord, ref _serializeBuffer, _context);
     }
@@ -178,6 +200,13 @@ public class AvroSchemaRegistrySerializerBenchmarks
     {
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_dictionaryMapRecord, ref _serializeBuffer, _context);
+    }
+
+    [Benchmark(Description = "Serialize conditional-logical union fallback")]
+    public void SerializeConditionalLogicalUnionFallback()
+    {
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_conditionalLogicalUnionRecord, ref _serializeBuffer, _context);
     }
 
     [Benchmark(Description = "Control: Apache writer prepared SpecificRecord")]
@@ -244,6 +273,29 @@ public class AvroSchemaRegistrySerializerBenchmarks
         return record;
     }
 
+    private static GenericRecord CreateConditionalLogicalUnionRecord()
+    {
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(ConditionalLogicalUnionSchema);
+        var record = new GenericRecord(schema);
+        record.Add("value", "primitive-value");
+        return record;
+    }
+
+    private sealed class BenchmarkStringBytesLogicalType()
+        : Avro.Util.LogicalType("dekaf-benchmark-string-bytes")
+    {
+        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
+            Encoding.UTF8.GetBytes((string)logicalValue);
+
+        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
+            Encoding.UTF8.GetString((byte[])baseValue);
+
+        public override Type GetCSharpType(bool nullible) => typeof(string);
+
+        public override bool IsInstanceOfLogicalType(object logicalValue) =>
+            logicalValue is string value && value.StartsWith("logical-", StringComparison.Ordinal);
+    }
+
     private sealed class SpecificBenchmarkRecord : ISpecificRecord
     {
         public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(RecordSchema);
@@ -263,7 +315,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
             throw new NotSupportedException();
     }
 
-    private sealed class BenchmarkSchemaRegistryClient : ISchemaRegistryClient
+    internal sealed class BenchmarkSchemaRegistryClient : ISchemaRegistryClient
     {
         public Task<int> RegisterSchemaAsync(
             string subject,
@@ -302,5 +354,87 @@ public class AvroSchemaRegistrySerializerBenchmarks
             CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
         public void Dispose() { }
+    }
+}
+
+[MemoryDiagnoser(displayGenColumns: false)]
+public class AvroMultipleConditionalUnionBenchmarks
+{
+    private const string SchemaText =
+        """
+        {
+          "type": "record",
+          "name": "MultipleConditionalUnionBenchmarkRecord",
+          "namespace": "Dekaf.Benchmarks",
+          "fields": [{
+            "name": "value",
+            "type": [
+              { "type": "bytes", "logicalType": "dekaf-benchmark-multi-string-bytes" },
+              { "type": "string", "logicalType": "dekaf-benchmark-multi-string-text" }
+            ]
+          }]
+        }
+        """;
+
+    private AvroSchemaRegistrySerializer<GenericRecord> _serializer = null!;
+    private GenericRecord _record = null!;
+    private ArrayBufferWriter<byte> _buffer = null!;
+    private SerializationContext _context;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new MultiStringBytesLogicalType());
+        Avro.Util.LogicalTypeFactory.Instance.Register(new MultiStringTextLogicalType());
+        _serializer = new AvroSchemaRegistrySerializer<GenericRecord>(
+            new AvroSchemaRegistrySerializerBenchmarks.BenchmarkSchemaRegistryClient());
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(SchemaText);
+        _record = new GenericRecord(schema);
+        _record.Add("value", "text-value");
+        _buffer = new ArrayBufferWriter<byte>();
+        _context = new SerializationContext
+        {
+            Topic = "avro-multiple-conditional-benchmark",
+            Component = SerializationComponent.Value
+        };
+        _serializer.Serialize(_record, ref _buffer, _context);
+    }
+
+    [GlobalCleanup]
+    public async ValueTask Cleanup() => await _serializer.DisposeAsync().ConfigureAwait(false);
+
+    [Benchmark(Description = "Serialize second custom-logical union branch")]
+    public void SerializeSecondConditionalBranch()
+    {
+        _buffer.ResetWrittenCount();
+        _serializer.Serialize(_record, ref _buffer, _context);
+    }
+
+    private sealed class MultiStringBytesLogicalType()
+        : Avro.Util.LogicalType("dekaf-benchmark-multi-string-bytes")
+    {
+        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
+            Encoding.UTF8.GetBytes((string)logicalValue);
+
+        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
+            Encoding.UTF8.GetString((byte[])baseValue);
+
+        public override Type GetCSharpType(bool nullible) => typeof(string);
+
+        public override bool IsInstanceOfLogicalType(object logicalValue) =>
+            logicalValue is string value && value.StartsWith("bytes-", StringComparison.Ordinal);
+    }
+
+    private sealed class MultiStringTextLogicalType()
+        : Avro.Util.LogicalType("dekaf-benchmark-multi-string-text")
+    {
+        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) => logicalValue;
+
+        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) => baseValue;
+
+        public override Type GetCSharpType(bool nullible) => typeof(string);
+
+        public override bool IsInstanceOfLogicalType(object logicalValue) =>
+            logicalValue is string value && value.StartsWith("text-", StringComparison.Ordinal);
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -97,22 +97,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
         }
         """;
 
-    private const string ConditionalLogicalStructuralUnionSchema =
-        """
-        {
-          "type": "record",
-          "name": "ConditionalLogicalStructuralUnionBenchmarkRecord",
-          "namespace": "Dekaf.Benchmarks",
-          "fields": [{
-            "name": "value",
-            "type": [
-              { "type": "bytes", "logicalType": "dekaf-benchmark-int-list-bytes" },
-              { "type": "array", "items": "int" }
-            ]
-          }]
-        }
-        """;
-
     private const string ConditionalValueLogicalStringArraySchema =
         """
         {
@@ -162,7 +146,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
     private GenericRecord _scalarUnionRecord = null!;
     private GenericRecord _dictionaryMapRecord = null!;
     private GenericRecord _conditionalLogicalUnionRecord = null!;
-    private GenericRecord _conditionalLogicalStructuralUnionRecord = null!;
     private GenericRecord _conditionalValueLogicalStringArrayRecord = null!;
     private GenericRecord _nestedRecordCollectionRecord = null!;
     private GenericRecord _nestedRecordListRecord = null!;
@@ -176,7 +159,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
     public void Setup()
     {
         Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkStringBytesLogicalType());
-        Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkIntListBytesLogicalType());
         Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkIntBytesLogicalType());
         _serializer = new AvroSchemaRegistrySerializer<GenericRecord>(new BenchmarkSchemaRegistryClient());
         _specificSerializer = new AvroSchemaRegistrySerializer<SpecificBenchmarkRecord>(
@@ -199,7 +181,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _scalarUnionRecord = CreateScalarUnionRecord();
         _dictionaryMapRecord = CreateDictionaryMapRecord();
         _conditionalLogicalUnionRecord = CreateConditionalLogicalUnionRecord();
-        _conditionalLogicalStructuralUnionRecord = CreateConditionalLogicalStructuralUnionRecord();
         _conditionalValueLogicalStringArrayRecord = CreateConditionalValueLogicalStringArrayRecord();
         (_nestedRecordCollectionRecord, _nestedRecordListRecord) = CreateNestedRecordCollectionRecords();
         _specificRecord = new SpecificBenchmarkRecord { Id = 42, Name = "benchmark" };
@@ -217,8 +198,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_dictionaryMapRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_conditionalLogicalUnionRecord, ref _serializeBuffer, _context);
-        _serializeBuffer.ResetWrittenCount();
-        _serializer.Serialize(_conditionalLogicalStructuralUnionRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_conditionalValueLogicalStringArrayRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
@@ -301,13 +280,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
     {
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_conditionalLogicalUnionRecord, ref _serializeBuffer, _context);
-    }
-
-    [Benchmark(Description = "Serialize conditional-logical structural union fallback")]
-    public void SerializeConditionalLogicalStructuralUnionFallback()
-    {
-        _serializeBuffer.ResetWrittenCount();
-        _serializer.Serialize(_conditionalLogicalStructuralUnionRecord, ref _serializeBuffer, _context);
     }
 
     [Benchmark(Description = "Serialize value-logical union string list")]
@@ -411,14 +383,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
         return record;
     }
 
-    private static GenericRecord CreateConditionalLogicalStructuralUnionRecord()
-    {
-        var schema = (Avro.RecordSchema)AvroSchema.Parse(ConditionalLogicalStructuralUnionSchema);
-        var record = new GenericRecord(schema);
-        record.Add("value", new List<int> { 1, 2, 3, 4 });
-        return record;
-    }
-
     private static GenericRecord CreateConditionalValueLogicalStringArrayRecord()
     {
         var schema = (Avro.RecordSchema)AvroSchema.Parse(ConditionalValueLogicalStringArraySchema);
@@ -462,21 +426,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
 
         public override bool IsInstanceOfLogicalType(object logicalValue) =>
             logicalValue is string value && value.StartsWith("logical-", StringComparison.Ordinal);
-    }
-
-    private sealed class BenchmarkIntListBytesLogicalType()
-        : Avro.Util.LogicalType("dekaf-benchmark-int-list-bytes")
-    {
-        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
-            new byte[] { (byte)((IList<int>)logicalValue).Count };
-
-        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
-            throw new NotSupportedException();
-
-        public override Type GetCSharpType(bool nullible) => typeof(IList<int>);
-
-        public override bool IsInstanceOfLogicalType(object logicalValue) =>
-            logicalValue is IList<int> { Count: > 0 } values && values[0] < 0;
     }
 
     private sealed class BenchmarkIntBytesLogicalType()

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -97,19 +97,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
         }
         """;
 
-    private const string LogicalStringArraySchema =
-        """
-        {
-          "type": "record",
-          "name": "LogicalStringArrayBenchmarkRecord",
-          "namespace": "Dekaf.Benchmarks",
-          "fields": [{
-            "name": "values",
-            "type": { "type": "array", "items": { "type": "string", "logicalType": "dekaf-benchmark-string" } }
-          }]
-        }
-        """;
-
     private const string ConditionalLogicalStructuralUnionSchema =
         """
         {
@@ -122,6 +109,25 @@ public class AvroSchemaRegistrySerializerBenchmarks
               { "type": "bytes", "logicalType": "dekaf-benchmark-int-list-bytes" },
               { "type": "array", "items": "int" }
             ]
+          }]
+        }
+        """;
+
+    private const string ConditionalValueLogicalStringArraySchema =
+        """
+        {
+          "type": "record",
+          "name": "ConditionalValueLogicalStringArrayBenchmarkRecord",
+          "namespace": "Dekaf.Benchmarks",
+          "fields": [{
+            "name": "values",
+            "type": {
+              "type": "array",
+              "items": [
+                { "type": "bytes", "logicalType": "dekaf-benchmark-int-bytes" },
+                "string"
+              ]
+            }
           }]
         }
         """;
@@ -156,8 +162,8 @@ public class AvroSchemaRegistrySerializerBenchmarks
     private GenericRecord _scalarUnionRecord = null!;
     private GenericRecord _dictionaryMapRecord = null!;
     private GenericRecord _conditionalLogicalUnionRecord = null!;
-    private GenericRecord _logicalStringCollectionRecord = null!;
     private GenericRecord _conditionalLogicalStructuralUnionRecord = null!;
+    private GenericRecord _conditionalValueLogicalStringArrayRecord = null!;
     private GenericRecord _nestedRecordCollectionRecord = null!;
     private GenericRecord _nestedRecordListRecord = null!;
     private SpecificBenchmarkRecord _specificRecord = null!;
@@ -169,9 +175,9 @@ public class AvroSchemaRegistrySerializerBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkStringLogicalType());
         Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkStringBytesLogicalType());
         Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkIntListBytesLogicalType());
+        Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkIntBytesLogicalType());
         _serializer = new AvroSchemaRegistrySerializer<GenericRecord>(new BenchmarkSchemaRegistryClient());
         _specificSerializer = new AvroSchemaRegistrySerializer<SpecificBenchmarkRecord>(
             new BenchmarkSchemaRegistryClient());
@@ -193,8 +199,8 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _scalarUnionRecord = CreateScalarUnionRecord();
         _dictionaryMapRecord = CreateDictionaryMapRecord();
         _conditionalLogicalUnionRecord = CreateConditionalLogicalUnionRecord();
-        _logicalStringCollectionRecord = CreateLogicalStringCollectionRecord();
         _conditionalLogicalStructuralUnionRecord = CreateConditionalLogicalStructuralUnionRecord();
+        _conditionalValueLogicalStringArrayRecord = CreateConditionalValueLogicalStringArrayRecord();
         (_nestedRecordCollectionRecord, _nestedRecordListRecord) = CreateNestedRecordCollectionRecords();
         _specificRecord = new SpecificBenchmarkRecord { Id = 42, Name = "benchmark" };
         _serializeBuffer = new ArrayBufferWriter<byte>();
@@ -212,9 +218,9 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_conditionalLogicalUnionRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
-        _serializer.Serialize(_logicalStringCollectionRecord, ref _serializeBuffer, _context);
-        _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_conditionalLogicalStructuralUnionRecord, ref _serializeBuffer, _context);
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_conditionalValueLogicalStringArrayRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_nestedRecordCollectionRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
@@ -296,18 +302,18 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_conditionalLogicalUnionRecord, ref _serializeBuffer, _context);
     }
 
-    [Benchmark(Description = "Serialize logical-string non-generic collection")]
-    public void SerializeLogicalStringCollectionRecord()
-    {
-        _serializeBuffer.ResetWrittenCount();
-        _serializer.Serialize(_logicalStringCollectionRecord, ref _serializeBuffer, _context);
-    }
-
     [Benchmark(Description = "Serialize conditional-logical structural union fallback")]
     public void SerializeConditionalLogicalStructuralUnionFallback()
     {
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_conditionalLogicalStructuralUnionRecord, ref _serializeBuffer, _context);
+    }
+
+    [Benchmark(Description = "Serialize value-logical union string list")]
+    public void SerializeConditionalValueLogicalStringArray()
+    {
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_conditionalValueLogicalStringArrayRecord, ref _serializeBuffer, _context);
     }
 
     [Benchmark(Description = "Serialize non-generic nested-record collection")]
@@ -404,19 +410,19 @@ public class AvroSchemaRegistrySerializerBenchmarks
         return record;
     }
 
-    private static GenericRecord CreateLogicalStringCollectionRecord()
-    {
-        var schema = (Avro.RecordSchema)AvroSchema.Parse(LogicalStringArraySchema);
-        var record = new GenericRecord(schema);
-        record.Add("values", new NonGenericStringCollection(["logical-first", "logical-second"]));
-        return record;
-    }
-
     private static GenericRecord CreateConditionalLogicalStructuralUnionRecord()
     {
         var schema = (Avro.RecordSchema)AvroSchema.Parse(ConditionalLogicalStructuralUnionSchema);
         var record = new GenericRecord(schema);
         record.Add("value", new List<int> { 1, 2, 3, 4 });
+        return record;
+    }
+
+    private static GenericRecord CreateConditionalValueLogicalStringArrayRecord()
+    {
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(ConditionalValueLogicalStringArraySchema);
+        var record = new GenericRecord(schema);
+        record.Add("values", new List<string> { "first", "second" });
         return record;
     }
 
@@ -441,21 +447,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
 
     private sealed class NonGenericStringCollection(IList<string?> values)
         : Collection<string?>(values);
-
-    private sealed class BenchmarkStringLogicalType()
-        : Avro.Util.LogicalType("dekaf-benchmark-string")
-    {
-        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
-            logicalValue;
-
-        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
-            baseValue;
-
-        public override Type GetCSharpType(bool nullible) => typeof(string);
-
-        public override bool IsInstanceOfLogicalType(object logicalValue) =>
-            logicalValue is string value && value.StartsWith("logical-", StringComparison.Ordinal);
-    }
 
     private sealed class BenchmarkStringBytesLogicalType()
         : Avro.Util.LogicalType("dekaf-benchmark-string-bytes")
@@ -485,6 +476,20 @@ public class AvroSchemaRegistrySerializerBenchmarks
 
         public override bool IsInstanceOfLogicalType(object logicalValue) =>
             logicalValue is IList<int> { Count: > 0 } values && values[0] < 0;
+    }
+
+    private sealed class BenchmarkIntBytesLogicalType()
+        : Avro.Util.LogicalType("dekaf-benchmark-int-bytes")
+    {
+        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
+            BitConverter.GetBytes((int)logicalValue);
+
+        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
+            BitConverter.ToInt32((byte[])baseValue);
+
+        public override Type GetCSharpType(bool nullible) => typeof(int);
+
+        public override bool IsInstanceOfLogicalType(object logicalValue) => logicalValue is int;
     }
 
     private sealed class SpecificBenchmarkRecord : ISpecificRecord
@@ -545,87 +550,5 @@ public class AvroSchemaRegistrySerializerBenchmarks
             CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
         public void Dispose() { }
-    }
-}
-
-[MemoryDiagnoser(displayGenColumns: false)]
-public class AvroMultipleConditionalUnionBenchmarks
-{
-    private const string SchemaText =
-        """
-        {
-          "type": "record",
-          "name": "MultipleConditionalUnionBenchmarkRecord",
-          "namespace": "Dekaf.Benchmarks",
-          "fields": [{
-            "name": "value",
-            "type": [
-              { "type": "bytes", "logicalType": "dekaf-benchmark-multi-string-bytes" },
-              { "type": "string", "logicalType": "dekaf-benchmark-multi-string-text" }
-            ]
-          }]
-        }
-        """;
-
-    private AvroSchemaRegistrySerializer<GenericRecord> _serializer = null!;
-    private GenericRecord _record = null!;
-    private ArrayBufferWriter<byte> _buffer = null!;
-    private SerializationContext _context;
-
-    [GlobalSetup]
-    public void Setup()
-    {
-        Avro.Util.LogicalTypeFactory.Instance.Register(new MultiStringBytesLogicalType());
-        Avro.Util.LogicalTypeFactory.Instance.Register(new MultiStringTextLogicalType());
-        _serializer = new AvroSchemaRegistrySerializer<GenericRecord>(
-            new AvroSchemaRegistrySerializerBenchmarks.BenchmarkSchemaRegistryClient());
-        var schema = (Avro.RecordSchema)AvroSchema.Parse(SchemaText);
-        _record = new GenericRecord(schema);
-        _record.Add("value", "text-value");
-        _buffer = new ArrayBufferWriter<byte>();
-        _context = new SerializationContext
-        {
-            Topic = "avro-multiple-conditional-benchmark",
-            Component = SerializationComponent.Value
-        };
-        _serializer.Serialize(_record, ref _buffer, _context);
-    }
-
-    [GlobalCleanup]
-    public async ValueTask Cleanup() => await _serializer.DisposeAsync().ConfigureAwait(false);
-
-    [Benchmark(Description = "Serialize second custom-logical union branch")]
-    public void SerializeSecondConditionalBranch()
-    {
-        _buffer.ResetWrittenCount();
-        _serializer.Serialize(_record, ref _buffer, _context);
-    }
-
-    private sealed class MultiStringBytesLogicalType()
-        : Avro.Util.LogicalType("dekaf-benchmark-multi-string-bytes")
-    {
-        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
-            Encoding.UTF8.GetBytes((string)logicalValue);
-
-        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
-            Encoding.UTF8.GetString((byte[])baseValue);
-
-        public override Type GetCSharpType(bool nullible) => typeof(string);
-
-        public override bool IsInstanceOfLogicalType(object logicalValue) =>
-            logicalValue is string value && value.StartsWith("bytes-", StringComparison.Ordinal);
-    }
-
-    private sealed class MultiStringTextLogicalType()
-        : Avro.Util.LogicalType("dekaf-benchmark-multi-string-text")
-    {
-        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) => logicalValue;
-
-        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) => baseValue;
-
-        public override Type GetCSharpType(bool nullible) => typeof(string);
-
-        public override bool IsInstanceOfLogicalType(object logicalValue) =>
-            logicalValue is string value && value.StartsWith("text-", StringComparison.Ordinal);
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -12,7 +12,7 @@ using RegistrySchema = Dekaf.SchemaRegistry.Schema;
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
 /// <summary>
-/// Measures the producer's generic Avro preparation path for stable and equivalent schema instances.
+/// Measures the producer's generic Avro path and the unchanged Apache SpecificRecord control.
 /// </summary>
 [MemoryDiagnoser(displayGenColumns: false)]
 public class AvroSchemaRegistrySerializerBenchmarks
@@ -60,6 +60,16 @@ public class AvroSchemaRegistrySerializerBenchmarks
         }
         """;
 
+    private const string DictionaryMapSchema =
+        """
+        {
+          "type": "record",
+          "name": "DictionaryMapBenchmarkRecord",
+          "namespace": "Dekaf.Benchmarks",
+          "fields": [{ "name": "values", "type": { "type": "map", "values": "int" } }]
+        }
+        """;
+
     private AvroSchemaRegistrySerializer<GenericRecord> _serializer = null!;
     private AvroSchemaRegistrySerializer<SpecificBenchmarkRecord> _specificSerializer = null!;
     private GenericRecord[] _equivalentRecords = null!;
@@ -67,6 +77,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
     private GenericRecord _nullableIntArrayRecord = null!;
     private GenericRecord _nullableIntCollectionRecord = null!;
     private GenericRecord _scalarUnionRecord = null!;
+    private GenericRecord _dictionaryMapRecord = null!;
     private SpecificBenchmarkRecord _specificRecord = null!;
     private ArrayBufferWriter<byte> _serializeBuffer = null!;
     private GenericRecord _stableRecord = null!;
@@ -94,6 +105,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _nullableIntArrayRecord = CreateNullableIntArrayRecord();
         _nullableIntCollectionRecord = CreateNullableIntCollectionRecord();
         _scalarUnionRecord = CreateScalarUnionRecord();
+        _dictionaryMapRecord = CreateDictionaryMapRecord();
         _specificRecord = new SpecificBenchmarkRecord { Id = 42, Name = "benchmark" };
         _serializeBuffer = new ArrayBufferWriter<byte>();
         _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
@@ -103,6 +115,8 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_nullableIntArrayRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_scalarUnionRecord, ref _serializeBuffer, _context);
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_dictionaryMapRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _specificSerializer.Serialize(_specificRecord, ref _serializeBuffer, _context);
     }
@@ -159,7 +173,14 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_scalarUnionRecord, ref _serializeBuffer, _context);
     }
 
-    [Benchmark(Description = "Serialize prepared SpecificRecord")]
+    [Benchmark(Description = "Serialize dictionary-map generic Avro record")]
+    public void SerializeDictionaryMapRecord()
+    {
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_dictionaryMapRecord, ref _serializeBuffer, _context);
+    }
+
+    [Benchmark(Description = "Control: Apache writer prepared SpecificRecord")]
     public void SerializeSpecificRecord()
     {
         _serializeBuffer.ResetWrittenCount();
@@ -206,6 +227,20 @@ public class AvroSchemaRegistrySerializerBenchmarks
         var schema = (Avro.RecordSchema)AvroSchema.Parse(ScalarUnionSchema);
         var record = new GenericRecord(schema);
         record.Add("value", 42);
+        return record;
+    }
+
+    private static GenericRecord CreateDictionaryMapRecord()
+    {
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(DictionaryMapSchema);
+        var record = new GenericRecord(schema);
+        record.Add("values", new Dictionary<string, object>
+        {
+            ["first"] = 1,
+            ["second"] = 2,
+            ["third"] = 3,
+            ["fourth"] = 4
+        });
         return record;
     }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -61,6 +61,16 @@ public class AvroSchemaRegistrySerializerBenchmarks
         }
         """;
 
+    private const string NullableStringArraySchema =
+        """
+        {
+          "type": "record",
+          "name": "NullableStringArrayBenchmarkRecord",
+          "namespace": "Dekaf.Benchmarks",
+          "fields": [{ "name": "values", "type": { "type": "array", "items": ["null", "string"] } }]
+        }
+        """;
+
     private const string DictionaryMapSchema =
         """
         {
@@ -87,6 +97,19 @@ public class AvroSchemaRegistrySerializerBenchmarks
         }
         """;
 
+    private const string LogicalStringArraySchema =
+        """
+        {
+          "type": "record",
+          "name": "LogicalStringArrayBenchmarkRecord",
+          "namespace": "Dekaf.Benchmarks",
+          "fields": [{
+            "name": "values",
+            "type": { "type": "array", "items": { "type": "string", "logicalType": "dekaf-benchmark-string" } }
+          }]
+        }
+        """;
+
     private const string ConditionalLogicalStructuralUnionSchema =
         """
         {
@@ -103,16 +126,39 @@ public class AvroSchemaRegistrySerializerBenchmarks
         }
         """;
 
+    private const string NestedRecordArraySchema =
+        """
+        {
+          "type": "record",
+          "name": "NestedRecordArrayBenchmarkRecord",
+          "namespace": "Dekaf.Benchmarks",
+          "fields": [{
+            "name": "values",
+            "type": {
+              "type": "array",
+              "items": {
+                "type": "record",
+                "name": "NestedBenchmarkValue",
+                "fields": [{ "name": "id", "type": "int" }]
+              }
+            }
+          }]
+        }
+        """;
+
     private AvroSchemaRegistrySerializer<GenericRecord> _serializer = null!;
     private AvroSchemaRegistrySerializer<SpecificBenchmarkRecord> _specificSerializer = null!;
     private GenericRecord[] _equivalentRecords = null!;
     private GenericRecord _intRecord = null!;
     private GenericRecord _nullableIntArrayRecord = null!;
     private GenericRecord _nullableIntCollectionRecord = null!;
+    private GenericRecord _nullableStringCollectionRecord = null!;
     private GenericRecord _scalarUnionRecord = null!;
     private GenericRecord _dictionaryMapRecord = null!;
     private GenericRecord _conditionalLogicalUnionRecord = null!;
+    private GenericRecord _logicalStringCollectionRecord = null!;
     private GenericRecord _conditionalLogicalStructuralUnionRecord = null!;
+    private GenericRecord _nestedRecordCollectionRecord = null!;
     private SpecificBenchmarkRecord _specificRecord = null!;
     private ArrayBufferWriter<byte> _serializeBuffer = null!;
     private GenericRecord _stableRecord = null!;
@@ -122,6 +168,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
     [GlobalSetup]
     public void Setup()
     {
+        Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkStringLogicalType());
         Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkStringBytesLogicalType());
         Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkIntListBytesLogicalType());
         _serializer = new AvroSchemaRegistrySerializer<GenericRecord>(new BenchmarkSchemaRegistryClient());
@@ -141,10 +188,13 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _intRecord = CreateIntRecord();
         _nullableIntArrayRecord = CreateNullableIntArrayRecord();
         _nullableIntCollectionRecord = CreateNullableIntCollectionRecord();
+        _nullableStringCollectionRecord = CreateNullableStringCollectionRecord();
         _scalarUnionRecord = CreateScalarUnionRecord();
         _dictionaryMapRecord = CreateDictionaryMapRecord();
         _conditionalLogicalUnionRecord = CreateConditionalLogicalUnionRecord();
+        _logicalStringCollectionRecord = CreateLogicalStringCollectionRecord();
         _conditionalLogicalStructuralUnionRecord = CreateConditionalLogicalStructuralUnionRecord();
+        _nestedRecordCollectionRecord = CreateNestedRecordCollectionRecord();
         _specificRecord = new SpecificBenchmarkRecord { Id = 42, Name = "benchmark" };
         _serializeBuffer = new ArrayBufferWriter<byte>();
         _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
@@ -153,13 +203,19 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_nullableIntArrayRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_nullableStringCollectionRecord, ref _serializeBuffer, _context);
+        _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_scalarUnionRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_dictionaryMapRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_conditionalLogicalUnionRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_logicalStringCollectionRecord, ref _serializeBuffer, _context);
+        _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_conditionalLogicalStructuralUnionRecord, ref _serializeBuffer, _context);
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_nestedRecordCollectionRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _specificSerializer.Serialize(_specificRecord, ref _serializeBuffer, _context);
     }
@@ -216,6 +272,13 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_scalarUnionRecord, ref _serializeBuffer, _context);
     }
 
+    [Benchmark(Description = "Serialize nullable-string non-generic collection")]
+    public void SerializeNullableStringCollectionRecord()
+    {
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_nullableStringCollectionRecord, ref _serializeBuffer, _context);
+    }
+
     [Benchmark(Description = "Serialize dictionary-map generic Avro record")]
     public void SerializeDictionaryMapRecord()
     {
@@ -230,11 +293,25 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_conditionalLogicalUnionRecord, ref _serializeBuffer, _context);
     }
 
+    [Benchmark(Description = "Serialize logical-string non-generic collection")]
+    public void SerializeLogicalStringCollectionRecord()
+    {
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_logicalStringCollectionRecord, ref _serializeBuffer, _context);
+    }
+
     [Benchmark(Description = "Serialize conditional-logical structural union fallback")]
     public void SerializeConditionalLogicalStructuralUnionFallback()
     {
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_conditionalLogicalStructuralUnionRecord, ref _serializeBuffer, _context);
+    }
+
+    [Benchmark(Description = "Serialize non-generic nested-record collection")]
+    public void SerializeNestedRecordCollection()
+    {
+        _serializeBuffer.ResetWrittenCount();
+        _serializer.Serialize(_nestedRecordCollectionRecord, ref _serializeBuffer, _context);
     }
 
     [Benchmark(Description = "Control: Apache writer prepared SpecificRecord")]
@@ -287,6 +364,14 @@ public class AvroSchemaRegistrySerializerBenchmarks
         return record;
     }
 
+    private static GenericRecord CreateNullableStringCollectionRecord()
+    {
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(NullableStringArraySchema);
+        var record = new GenericRecord(schema);
+        record.Add("values", new NonGenericStringCollection(["first", null, "second"]));
+        return record;
+    }
+
     private static GenericRecord CreateDictionaryMapRecord()
     {
         var schema = (Avro.RecordSchema)AvroSchema.Parse(DictionaryMapSchema);
@@ -309,12 +394,55 @@ public class AvroSchemaRegistrySerializerBenchmarks
         return record;
     }
 
+    private static GenericRecord CreateLogicalStringCollectionRecord()
+    {
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(LogicalStringArraySchema);
+        var record = new GenericRecord(schema);
+        record.Add("values", new NonGenericStringCollection(["logical-first", "logical-second"]));
+        return record;
+    }
+
     private static GenericRecord CreateConditionalLogicalStructuralUnionRecord()
     {
         var schema = (Avro.RecordSchema)AvroSchema.Parse(ConditionalLogicalStructuralUnionSchema);
         var record = new GenericRecord(schema);
         record.Add("value", new List<int> { 1, 2, 3, 4 });
         return record;
+    }
+
+    private static GenericRecord CreateNestedRecordCollectionRecord()
+    {
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(NestedRecordArraySchema);
+        var arraySchema = (Avro.ArraySchema)schema.Fields[0].Schema;
+        var itemSchema = (Avro.RecordSchema)arraySchema.ItemSchema;
+        var first = new GenericRecord(itemSchema);
+        first.Add("id", 1);
+        var second = new GenericRecord(itemSchema);
+        second.Add("id", 2);
+        var record = new GenericRecord(schema);
+        record.Add("values", new NonGenericRecordCollection([first, second]));
+        return record;
+    }
+
+    private sealed class NonGenericRecordCollection(IList<GenericRecord> values)
+        : Collection<GenericRecord>(values);
+
+    private sealed class NonGenericStringCollection(IList<string?> values)
+        : Collection<string?>(values);
+
+    private sealed class BenchmarkStringLogicalType()
+        : Avro.Util.LogicalType("dekaf-benchmark-string")
+    {
+        public override object ConvertToBaseValue(object logicalValue, Avro.LogicalSchema schema) =>
+            logicalValue;
+
+        public override object ConvertToLogicalValue(object baseValue, Avro.LogicalSchema schema) =>
+            baseValue;
+
+        public override Type GetCSharpType(bool nullible) => typeof(string);
+
+        public override bool IsInstanceOfLogicalType(object logicalValue) =>
+            logicalValue is string value && value.StartsWith("logical-", StringComparison.Ordinal);
     }
 
     private sealed class BenchmarkStringBytesLogicalType()


### PR DESCRIPTION
Closes #2675.

## What changed
- replace Apache Avro's allocating GenericRecord writer path with an allocation-free schema walker
- add a wire-compatible encoder using stack spans / ArrayPool for UTF-8, float, logical, collection, and decimal values
- preserve the Schema Registry header, schema selection, rule-executor path, and SpecificRecord behavior
- add exact Apache Avro byte-parity tests across primitives, named/container types, built-in logical types, decimals, and logical arrays
- preserve `IList`-backed arrays and specialize value-type union arrays/lists without boxing
- preserve local timestamp wall-clock values, reject fixed-decimal overflow, and report non-record schemas clearly
- add prepared int, int+string, and nullable-int-array MemoryDiagnoser benchmarks

## Performance
BenchmarkDotNet DefaultJob, .NET 10.0.11, x64, exact benchmark code/config, base SHA `4cfa3da6` -> candidate `6ee77604`:

| Prepared GenericRecord | Base mean / median / max | Candidate mean / median / max | Delta mean | Allocated |
|---|---:|---:|---:|---:|
| int-only | 22.58 / 22.10 / 26.51 ns | 16.81 / 16.64 / 17.48 ns | -25.5% | 64 B -> 0 B |
| int + string | 38.10 / 37.78 / 39.70 ns | 29.06 / 28.19 / 35.30 ns | -23.7% | 104 B -> 0 B |

Post-review exact DefaultJob checks at `e67d1892` measured 17.676/27.034 ns, then 16.99/28.24 ns on the single permitted repeat (int-only/int+string), both 0 B. Relative to the accepted candidate, the repeat is +1.1%/-2.8%, consistent with run noise and Pareto-safe. The new nullable-union `int?[]` benchmark measured 54.428 ns and 0 B/op under ShortRun.

All protected measured metrics remain safe; every hot-path allocation column is zero.

## Validation
- `dotnet build -c Release`: 0 warnings, 0 errors
- unit tests net10: 6,778/6,778
- unit tests net8: 6,642/6,642
- focused Avro serializer tests: 34/34 on net10 and 34/34 on net8
- full BenchmarkDotNet control/candidate runs plus post-review exact repeat and nullable-union allocation benchmark
- `/simplify` and self-review completed before push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced temporary memory allocations during Avro serialization.
  * Optimized serialization of strings, collections, records, logical types, and binary data.

* **Compatibility**
  * Expanded support for primitive, complex, union, collection, and logical Avro types.
  * Added specific-record serialization with validation for supported schemas and properties.

* **Improvements**
  * Improved stream writing with span-based data handling, capacity checks, and overflow protection.
  * Enhanced validation for maps, nullable collections, fixed decimals, timestamps, UUIDs, and unions.
  * Added documentation and benchmarks for allocation-efficient serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->