### PR TITLE
test(producer): allow non-idempotent retry duplicates

### DIFF
--- a/tests/Dekaf.Tests.Integration/PartitionReassignmentIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/PartitionReassignmentIntegrationTests.cs
@@ -21,7 +21,7 @@ public sealed class PartitionReassignmentIntegrationTests(RackAwareKafkaContaine
     [Arguments(true)]
     [Arguments(false)]
     [Timeout(240_000)]
-    public async Task Producer_PartitionReassignment_ContinuesWithoutLossOrDuplicates(
+    public async Task Producer_PartitionReassignment_PreservesAllLogicalMessages(
         bool idempotent,
         CancellationToken cancellationToken)
     {
@@ -75,7 +75,7 @@ public sealed class PartitionReassignmentIntegrationTests(RackAwareKafkaContaine
                 .ConfigureAwait(false);
             await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
 
-            await AssertBrokerSequenceAsync(topic, cancellationToken).ConfigureAwait(false);
+            await AssertBrokerSequenceAsync(topic, idempotent, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -216,7 +216,7 @@ public sealed class PartitionReassignmentIntegrationTests(RackAwareKafkaContaine
                 .ConfigureAwait(false);
             await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
 
-            await AssertBrokerSequenceAsync(topic, cancellationToken).ConfigureAwait(false);
+            await AssertBrokerSequenceAsync(topic, idempotent: true, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -329,7 +329,10 @@ public sealed class PartitionReassignmentIntegrationTests(RackAwareKafkaContaine
         }
     }
 
-    private async Task AssertBrokerSequenceAsync(string topic, CancellationToken cancellationToken)
+    private async Task AssertBrokerSequenceAsync(
+        string topic,
+        bool idempotent,
+        CancellationToken cancellationToken)
     {
         await using var consumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(kafka.BootstrapServers)
@@ -341,31 +344,35 @@ public sealed class PartitionReassignmentIntegrationTests(RackAwareKafkaContaine
             .Select(partition => new TopicPartition(topic, partition))
             .ToArray());
 
-        var nextOffsets = new long[PartitionCount];
-        var remaining = PartitionCount * MessagesPerPartition;
-        while (remaining > 0)
+        var oracle = new ReassignmentSequenceOracle(
+            PartitionCount,
+            MessagesPerPartition,
+            allowDuplicates: !idempotent);
+        while (!oracle.IsComplete)
         {
             var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(10), cancellationToken)
                 .ConfigureAwait(false);
-            if (result is null)
-                throw new InvalidOperationException($"Timed out with {remaining} expected record(s) unread.");
+            if (result is not { } record)
+            {
+                oracle.EnsureComplete();
+                continue;
+            }
 
-            var record = result.Value;
-            var expectedOffset = nextOffsets[record.Partition];
-            AssertRecord(topic, record, expectedOffset);
-
-            nextOffsets[record.Partition]++;
-            remaining--;
+            oracle.Observe(topic, record.Partition, record.Offset, record.Key, record.Value);
         }
 
-        var duplicate = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(2), cancellationToken)
-            .ConfigureAwait(false);
-        if (duplicate is not null)
+        while (true)
         {
-            throw new InvalidOperationException(
-                $"Unexpected duplicate at {duplicate.Value.Topic}-{duplicate.Value.Partition}@" +
-                $"{duplicate.Value.Offset}.");
+            var trailing = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(2), cancellationToken)
+                .ConfigureAwait(false);
+            if (trailing is null)
+                break;
+
+            var record = trailing.Value;
+            oracle.Observe(topic, record.Partition, record.Offset, record.Key, record.Value);
         }
+
+        oracle.EnsureComplete();
     }
 
     private static void AssertRecord(

--- a/tests/Dekaf.Tests.Integration/ReassignmentSequenceOracle.cs
+++ b/tests/Dekaf.Tests.Integration/ReassignmentSequenceOracle.cs
@@ -1,0 +1,122 @@
+using System.Globalization;
+
+namespace Dekaf.Tests.Integration;
+
+internal sealed class ReassignmentSequenceOracle
+{
+    private readonly bool _allowDuplicates;
+    private readonly int _messagesPerPartition;
+    private readonly bool[][] _seenSequences;
+    private readonly int[] _nextLogicalSequences;
+    private readonly long[] _nextBrokerOffsets;
+    private int _remainingUnique;
+
+    public ReassignmentSequenceOracle(
+        int partitionCount,
+        int messagesPerPartition,
+        bool allowDuplicates)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(partitionCount, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(messagesPerPartition, 1);
+
+        _allowDuplicates = allowDuplicates;
+        _messagesPerPartition = messagesPerPartition;
+        _seenSequences = new bool[partitionCount][];
+        for (var partition = 0; partition < partitionCount; partition++)
+            _seenSequences[partition] = new bool[messagesPerPartition];
+
+        _nextLogicalSequences = new int[partitionCount];
+        _nextBrokerOffsets = new long[partitionCount];
+        _remainingUnique = checked(partitionCount * messagesPerPartition);
+    }
+
+    public bool IsComplete => _remainingUnique == 0;
+
+    public void Observe(
+        string topic,
+        int partition,
+        long offset,
+        string? key,
+        string? value)
+    {
+        if ((uint)partition >= (uint)_seenSequences.Length)
+            throw new InvalidOperationException($"Record for {topic} has invalid partition {partition}.");
+
+        var expectedOffset = _nextBrokerOffsets[partition];
+        if (offset != expectedOffset)
+        {
+            throw new InvalidOperationException(
+                $"Broker offset gap for {topic}-{partition}: expected {expectedOffset}, actual {offset}.");
+        }
+        _nextBrokerOffsets[partition] = expectedOffset + 1;
+
+        var sequence = ParseSequence(topic, partition, key, value);
+        if (_seenSequences[partition][sequence])
+        {
+            if (_allowDuplicates)
+                return;
+
+            throw new InvalidOperationException(
+                $"Unexpected duplicate for {topic}-{partition}@{offset}: sequence {sequence}.");
+        }
+
+        if (!_allowDuplicates)
+        {
+            var expectedSequence = _nextLogicalSequences[partition];
+            if (sequence != expectedSequence)
+            {
+                throw new InvalidOperationException(
+                    $"Unexpected logical sequence for {topic}-{partition}@{offset}: " +
+                    $"expected {expectedSequence}, actual {sequence}.");
+            }
+            _nextLogicalSequences[partition] = expectedSequence + 1;
+        }
+
+        _seenSequences[partition][sequence] = true;
+        _remainingUnique--;
+    }
+
+    public void EnsureComplete()
+    {
+        if (_remainingUnique != 0)
+        {
+            throw new InvalidOperationException(
+                $"Timed out with {_remainingUnique} logical record(s) unread.");
+        }
+    }
+
+    private int ParseSequence(
+        string topic,
+        int partition,
+        string? key,
+        string? value)
+    {
+        if (value is null || !string.Equals(key, value, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Corrupt record for {topic}-{partition}: key '{key}', value '{value}'.");
+        }
+
+        var separator = value.IndexOf(':', StringComparison.Ordinal);
+        if (separator <= 0
+            || separator == value.Length - 1
+            || !int.TryParse(
+                value.AsSpan(0, separator),
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out var encodedPartition)
+            || encodedPartition != partition
+            || !int.TryParse(
+                value.AsSpan(separator + 1),
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out var sequence)
+            || (uint)sequence >= (uint)_messagesPerPartition)
+        {
+            throw new InvalidOperationException(
+                $"Corrupt record for {topic}-{partition}: value '{value}'.");
+        }
+
+        return sequence;
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ReassignmentSequenceOracleTests.cs
+++ b/tests/Dekaf.Tests.Integration/ReassignmentSequenceOracleTests.cs
@@ -1,0 +1,76 @@
+namespace Dekaf.Tests.Integration;
+
+public sealed class ReassignmentSequenceOracleTests
+{
+    [Test]
+    public async Task ExactlyOnce_OrderedRecords_Completes()
+    {
+        var oracle = new ReassignmentSequenceOracle(1, 2, allowDuplicates: false);
+
+        oracle.Observe("topic", 0, 0, "0:0", "0:0");
+        oracle.Observe("topic", 0, 1, "0:1", "0:1");
+        oracle.EnsureComplete();
+
+        await Assert.That(oracle.IsComplete).IsTrue();
+    }
+
+    [Test]
+    public async Task ExactlyOnce_DuplicateRecord_Throws()
+    {
+        var oracle = new ReassignmentSequenceOracle(1, 2, allowDuplicates: false);
+        oracle.Observe("topic", 0, 0, "0:0", "0:0");
+
+        await Assert.That(() => oracle.Observe("topic", 0, 1, "0:0", "0:0"))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task AtLeastOnce_DuplicateAndReorderedRecords_Completes()
+    {
+        var oracle = new ReassignmentSequenceOracle(1, 3, allowDuplicates: true);
+
+        oracle.Observe("topic", 0, 0, "0:0", "0:0");
+        oracle.Observe("topic", 0, 1, "0:0", "0:0");
+        oracle.Observe("topic", 0, 2, "0:2", "0:2");
+        oracle.Observe("topic", 0, 3, "0:1", "0:1");
+        oracle.EnsureComplete();
+
+        await Assert.That(oracle.IsComplete).IsTrue();
+    }
+
+    [Test]
+    public async Task AtLeastOnce_MissingRecord_Throws()
+    {
+        var oracle = new ReassignmentSequenceOracle(1, 2, allowDuplicates: true);
+        oracle.Observe("topic", 0, 0, "0:0", "0:0");
+
+        await Assert.That(oracle.EnsureComplete).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task AtLeastOnce_CorruptRecord_Throws()
+    {
+        var oracle = new ReassignmentSequenceOracle(1, 2, allowDuplicates: true);
+
+        await Assert.That(() => oracle.Observe("topic", 0, 0, "0:0", "0:1"))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task AtLeastOnce_OutOfRangeRecord_Throws()
+    {
+        var oracle = new ReassignmentSequenceOracle(1, 2, allowDuplicates: true);
+
+        await Assert.That(() => oracle.Observe("topic", 0, 0, "0:2", "0:2"))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task AtLeastOnce_BrokerOffsetGap_Throws()
+    {
+        var oracle = new ReassignmentSequenceOracle(1, 2, allowDuplicates: true);
+
+        await Assert.That(() => oracle.Observe("topic", 0, 1, "0:0", "0:0"))
+            .Throws<InvalidOperationException>();
+    }
+}


### PR DESCRIPTION
Closes #2677

## Summary

- keeps exact ordered sequence validation for idempotent reassignment
- allows legal retry duplicates and reordering only when idempotence is disabled
- drains trailing broker records and still rejects missing, corrupt, out-of-range, or offset-gap records
- adds deterministic oracle coverage for both delivery semantics

## Validation

- `dotnet build --configuration Release`: 0 warnings, 0 errors
- `ReassignmentSequenceOracleTests`: 7/7 passed
- real three-broker `Producer_PartitionReassignment_PreservesAllLogicalMessages`: 2/2 passed (`idempotent=true` and `false`)

Tests only; no production hot path changed and no benchmark lane is required.