### PR TITLE
fix(producer): serialize pending append disposal

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3735,16 +3735,21 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             completionSource, callback, recordSize, startTicks, deadline,
             this, _pendingAppendPool, cancellationToken);
 
-        bool wasQueueEmpty;
+        bool wasQueueEmpty = false;
+        bool enqueueRejected;
         lock (_pendingAppendQueueLock)
         {
-            wasQueueEmpty = _pendingAppends.IsEmpty;
-            _pendingAppends.Enqueue(op);
+            enqueueRejected = Volatile.Read(ref _disposed) != 0;
+            if (!enqueueRejected)
+            {
+                wasQueueEmpty = _pendingAppends.IsEmpty;
+                _pendingAppends.Enqueue(op);
+            }
         }
 
-        // Close TOCTOU window: if DisposeAsync ran between the _disposed check above and the
-        // Enqueue, this op would sit in the queue until its timer fires. Fail it promptly.
-        if (Volatile.Read(ref _disposed) != 0)
+        // DisposeAsync serializes its final drain with this check. Once disposal starts,
+        // ownership cannot enter the queue after that drain has completed.
+        if (enqueueRejected)
         {
             var disposedException = new ObjectDisposedException(nameof(RecordAccumulator));
             if (op.TryFail(disposedException))
@@ -7192,12 +7197,20 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         while (Interlocked.CompareExchange(ref _draining, 1, 0) != 0)
             spinWait.SpinOnce();
 
-        while (_pendingAppends.TryDequeue(out var op))
+        try
         {
-            op.TryFail(new ObjectDisposedException(nameof(RecordAccumulator)));
+            lock (_pendingAppendQueueLock)
+            {
+                while (_pendingAppends.TryDequeue(out var op))
+                {
+                    op.TryFail(new ObjectDisposedException(nameof(RecordAccumulator)));
+                }
+            }
         }
-
-        Volatile.Write(ref _draining, 0);
+        finally
+        {
+            Volatile.Write(ref _draining, 0);
+        }
 
         // Cancel the disposal token to interrupt any remaining blocked operations
         // (e.g., append workers, metadata waits). Do this AFTER graceful shutdown attempt

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -7202,13 +7202,17 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             lock (_pendingAppendQueueLock)
             {
                 while (_pendingAppends.TryDequeue(out var op))
-                {
-                    op.TryFail(new ObjectDisposedException(nameof(RecordAccumulator)));
-                }
+                    _pendingAppendScan.Add(op);
             }
+
+            // TryFail disposes cancellation registrations. Complete outside the queue lock:
+            // an in-flight cancellation callback may be waiting to inspect this queue.
+            foreach (var op in _pendingAppendScan)
+                op.TryFail(new ObjectDisposedException(nameof(RecordAccumulator)));
         }
         finally
         {
+            _pendingAppendScan.Clear();
             Volatile.Write(ref _draining, 0);
         }
 

--- a/tests/Dekaf.Tests.Integration/DynamicConfigurationIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/DynamicConfigurationIntegrationTests.cs
@@ -215,7 +215,11 @@ public sealed class DynamicConfigurationIntegrationTests(RackAwareKafkaContainer
             await Assert.That(failure.Exception.TimeoutKind).IsEqualTo(TimeoutKind.Delivery);
             await Assert.That(replicaError).IsEqualTo(ErrorCode.NotEnoughReplicas);
             await Assert.That(replicaError!.Value.IsRetriable()).IsTrue();
-            await Assert.That(recovered.Offset).IsEqualTo(failure.LastSuccessfulOffset + 1);
+            // A delivery timeout is ambiguous: the broker may have appended the idempotent
+            // record without returning a successful response. Recovery must therefore resume
+            // at either the next offset or one offset after that single timed-out record.
+            await Assert.That(recovered.Offset)
+                .IsBetween(failure.LastSuccessfulOffset + 1, failure.LastSuccessfulOffset + 2);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Integration/HostedServiceTests.cs
+++ b/tests/Dekaf.Tests.Integration/HostedServiceTests.cs
@@ -105,7 +105,7 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
         }
     }
 
-    [Test]
+    [Test, NotInParallel]
     public async Task RetryTopicMessages_NotDue_ResumeAndProcessAcrossPartitions()
     {
         var sourceTopic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -605,6 +605,81 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task DisposeAsync_SerializesPendingAppendEnqueueWithFinalDrain()
+    {
+        var accumulator = new RecordAccumulator(new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BufferMemory = 1,
+            BatchSize = 4096,
+            LingerMs = 10,
+            MaxBlockMs = 30_000
+        });
+        var queueLock = GetPrivateField<object>(accumulator, "_pendingAppendQueueLock");
+        var queueLockHeld = false;
+        Task<bool>? disposeTask = null;
+        try
+        {
+            Monitor.Enter(queueLock, ref queueLockHeld);
+            var (appendThread, appendTask) = StartOnDedicatedThread(() =>
+                AppendNullRecordAsync(accumulator).AsTask().GetAwaiter().GetResult());
+
+            var appendReachedQueueLock = SpinWait.SpinUntil(
+                () => accumulator.BufferPressureEvents > 0
+                    && appendThread.ThreadState.HasFlag(System.Threading.ThreadState.WaitSleepJoin),
+                TimeSpan.FromSeconds(5));
+
+            var (disposeThread, startedDisposeTask) = StartOnDedicatedThread(() =>
+            {
+                accumulator.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                return true;
+            });
+            disposeTask = startedDisposeTask;
+            var disposeReachedQueueLock = SpinWait.SpinUntil(
+                () => disposeTask.IsCompleted
+                    || GetPrivateField<int>(accumulator, "_draining") != 0
+                    && disposeThread.ThreadState.HasFlag(System.Threading.ThreadState.WaitSleepJoin),
+                TimeSpan.FromSeconds(5));
+            var disposeCompletedBeforeEnqueue = disposeTask.IsCompleted;
+
+            Monitor.Exit(queueLock);
+            queueLockHeld = false;
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+                await appendTask.WaitAsync(TimeSpan.FromSeconds(5)));
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(appendReachedQueueLock).IsTrue();
+            await Assert.That(disposeReachedQueueLock).IsTrue();
+            await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(0);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+            await Assert.That(disposeCompletedBeforeEnqueue).IsFalse()
+                .Because("the final pending-append drain must wait for an in-progress enqueue");
+        }
+        finally
+        {
+            if (queueLockHeld)
+                Monitor.Exit(queueLock);
+
+            if (disposeTask is null)
+            {
+                await accumulator.DisposeAsync();
+            }
+            else
+            {
+                try
+                {
+                    await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+                }
+                catch
+                {
+                    // Preserve the primary test failure while ensuring disposal was observed.
+                }
+            }
+        }
+    }
+
+    [Test]
     public async Task DisposeAsync_WaitsForAdmissionHandoffBeforeReturningCurrentBatch()
     {
         var accumulator = new RecordAccumulator(
@@ -4528,7 +4603,10 @@ public class RecordAccumulatorTests
         }
     }
 
-    private static Task<T> RunOnDedicatedThread<T>(Func<T> action)
+    private static Task<T> RunOnDedicatedThread<T>(Func<T> action) =>
+        StartOnDedicatedThread(action).Completion;
+
+    private static (Thread Thread, Task<T> Completion) StartOnDedicatedThread<T>(Func<T> action)
     {
         // These tests intentionally block one operation behind another. A dedicated
         // thread keeps that coordination independent of full-suite ThreadPool pressure.
@@ -4549,7 +4627,7 @@ public class RecordAccumulatorTests
             Name = "record-accumulator-test-worker"
         };
         thread.Start();
-        return completion.Task;
+        return (thread, completion.Task);
     }
 
     private sealed class LockAssertingReadOnlyMemoryManager(

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -671,7 +671,7 @@ public class RecordAccumulatorTests
                 {
                     await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
                 }
-                catch
+                catch (TimeoutException)
                 {
                     // Preserve the primary test failure while ensuring disposal was observed.
                 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PendingAppendEnqueueBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PendingAppendEnqueueBenchmarks.cs
@@ -1,0 +1,85 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures the pooled pending-append enqueue path under BufferMemory backpressure.
+/// Accumulator setup, disposal, and failure observation run outside the measured operation.
+/// </summary>
+[MemoryDiagnoser(displayGenColumns: false)]
+[MedianColumn]
+[MaxColumn]
+[SimpleJob(
+    RunStrategy.Monitoring,
+    launchCount: 1,
+    warmupCount: 5,
+    iterationCount: 10,
+    invocationCount: 1)]
+public class PendingAppendEnqueueBenchmarks
+{
+    private const string Topic = "pending-append-benchmark";
+    private RecordAccumulator _accumulator = null!;
+    private ValueTask<bool> _warmupAppend;
+    private ValueTask<bool> _pendingAppend;
+
+    [IterationSetup]
+    public void Setup()
+    {
+        _accumulator = new RecordAccumulator(new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 4096,
+            BufferMemory = 1,
+            LingerMs = 0
+        });
+
+        _warmupAppend = Enqueue();
+        if (_warmupAppend.IsCompleted)
+            throw new InvalidOperationException("Warmup append bypassed BufferMemory backpressure.");
+    }
+
+    [IterationCleanup]
+    public void Cleanup()
+    {
+        _accumulator.DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+        ObserveDisposed(_warmupAppend);
+        ObserveDisposed(_pendingAppend);
+    }
+
+    [Benchmark]
+    public void EnqueuePendingAppend()
+    {
+        _pendingAppend = Enqueue();
+
+        if (_pendingAppend.IsCompleted)
+            throw new InvalidOperationException("Append bypassed BufferMemory backpressure.");
+    }
+
+    private ValueTask<bool> Enqueue() =>
+        _accumulator.AppendAsync(
+            Topic,
+            0,
+            0,
+            PooledMemory.Null,
+            PooledMemory.Null,
+            null,
+            0,
+            null,
+            null,
+            CancellationToken.None);
+
+    private static void ObserveDisposed(ValueTask<bool> pending)
+    {
+        try
+        {
+            pending.GetAwaiter().GetResult();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Expected: disposal drains and fails each pending append.
+        }
+    }
+}


### PR DESCRIPTION
Closes #2685

## Summary
- serialize pending-append disposal check/enqueue with disposal's final queue drain
- dequeue pending operations under the queue lock, then complete them outside it so cancellation-registration disposal cannot deadlock with a callback inspecting the queue
- add deterministic dedicated-thread coverage for the exact enqueue/dispose interleaving
- harden two unrelated CI failures exposed by the prior run: Kafka's ambiguous delivery-timeout offset and AOT runner contention in retry scheduling
- add a dedicated [MemoryDiagnoser] benchmark for the pooled backpressure enqueue path

## Validation
- Release build: 0 warnings, 0 errors
- unit: net10.0 6,804 passed; net8.0 6,668 passed
- focused disposal race: 1 passed
- targeted Docker integration:
  - Topic_MinInsyncRaisedMidRun_AcksAllReactsCorrectly: passed
  - RetryTopicMessages_NotDue_ResumeAndProcessAcrossPartitions: passed
- regression proof: deterministic test fails the old production interleaving and passes the fix

## Performance
Exact parent baseline: 5b4b3ea8. Candidate enqueue source: 67a2e825; later production adjustment only moves disposal completion outside the lock and is outside the measured operation.

### PendingAppendEnqueueBenchmarks
Single synchronous operation; setup/disposal/failure observation excluded. No I/O or thread hop, so elapsed time is direct CPU occupancy for the operation.

| Revision | Mean | p50 | Max observed | p50 throughput | Allocated |
|---|---:|---:|---:|---:|---:|
| baseline | 4.020 us | 4.000 us | 4.300 us | 250,000 ops/s | 0 B |
| candidate accepted repeat | 3.780 us | 3.850 us | 4.100 us | 259,740 ops/s | 0 B |

The first candidate sample was host-noisy (p50 6.400 us); the one permitted exact repeat was clean and Pareto-safe. Ten monitoring samples do not support a separate formal p99; max observed is reported instead.

### AccumulatorAppendBenchmarks
| Size | Revision | p50 | Max observed | Allocated |
|---|---|---:|---:|---:|
| 100 B | baseline | 72.641 ns | 73.469 ns | 0 B |
| 100 B | candidate accepted repeat | 71.093 ns | 71.235 ns | 0 B |
| 1,000 B | baseline | 171.226 ns | 174.440 ns | 0 B |
| 1,000 B | candidate accepted repeat | 148.436 ns | 158.903 ns | 0 B |

The first candidate 100 B sample was noisy; the permitted exact repeat improved both sizes and retained 0 B. No paid stress lane: the network producer path is unchanged, while the exact modified backpressure operation and existing accumulator hot path are covered locally.