### PR TITLE
Expose Kafka client status snapshots

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -171,12 +171,22 @@ public sealed class AdminClient : IAdminClient, IKafkaClientStatusProvider
         }
 
         var snapshot = controllerMetadataManager.Snapshot;
+        IReadOnlyList<BrokerConnectionStatus> brokers = Array.Empty<BrokerConnectionStatus>();
+        if (_connectionPool is IConnectionPoolStatusSource statusSource)
+        {
+            var endpoints = new ConnectionStatusEndpoint[snapshot.Controllers.Count];
+            var index = 0;
+            foreach (var endpoint in snapshot.Controllers.Values)
+                endpoints[index++] = new ConnectionStatusEndpoint(endpoint.NodeId, endpoint.Host, endpoint.Port);
+            brokers = statusSource.GetEndpointConnectionStatus(endpoints);
+        }
         return KafkaClientStatusFactory.Capture(
             KafkaClientRole.Admin,
             _connectionPool,
             snapshot.ClusterId,
             snapshot.LastRefreshed,
-            stopped);
+            stopped,
+            brokers: brokers);
     }
 
     private static void ValidateBootstrapOptions(AdminClientOptions options)

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -3,6 +3,7 @@ using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Dekaf.Diagnostics;
 using Dekaf.Internal;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -19,7 +20,7 @@ namespace Dekaf.Admin;
 /// <summary>
 /// Kafka administrative client implementation.
 /// </summary>
-public sealed class AdminClient : IAdminClient
+public sealed class AdminClient : IAdminClient, IKafkaClientStatusProvider
 {
     private const string MetadataQuorumTopic = "__cluster_metadata";
     private const int MetadataQuorumPartition = 0;
@@ -150,6 +151,16 @@ public sealed class AdminClient : IAdminClient
     }
 
     public ClusterMetadata Metadata => _metadataManager.Metadata;
+
+    /// <inheritdoc />
+    public string? ClusterId => _metadataManager.ClusterId;
+
+    /// <inheritdoc />
+    public KafkaClientStatus GetStatus() => KafkaClientStatusFactory.Capture(
+        KafkaClientRole.Admin,
+        _connectionPool,
+        _metadataManager,
+        Volatile.Read(ref _disposed) != 0);
 
     private static void ValidateBootstrapOptions(AdminClientOptions options)
     {

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -177,7 +177,17 @@ public sealed class AdminClient : IAdminClient, IKafkaClientStatusProvider
             var endpoints = new ConnectionStatusEndpoint[snapshot.Controllers.Count];
             var index = 0;
             foreach (var endpoint in snapshot.Controllers.Values)
-                endpoints[index++] = new ConnectionStatusEndpoint(endpoint.NodeId, endpoint.Host, endpoint.Port);
+            {
+                var discoveryConnection = snapshot.DiscoveryConnection;
+                endpoints[index++] = discoveryConnection?.NodeId == endpoint.NodeId
+                    ? new ConnectionStatusEndpoint(
+                        endpoint.NodeId,
+                        endpoint.Host,
+                        endpoint.Port,
+                        discoveryConnection.Host,
+                        discoveryConnection.Port)
+                    : new ConnectionStatusEndpoint(endpoint.NodeId, endpoint.Host, endpoint.Port);
+            }
             brokers = statusSource.GetEndpointConnectionStatus(endpoints);
         }
         return KafkaClientStatusFactory.Capture(

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -153,14 +153,31 @@ public sealed class AdminClient : IAdminClient, IKafkaClientStatusProvider
     public ClusterMetadata Metadata => _metadataManager.Metadata;
 
     /// <inheritdoc />
-    public string? ClusterId => _metadataManager.ClusterId;
+    public string? ClusterId => _controllerMetadataManager is { } controllerMetadataManager
+        ? controllerMetadataManager.Snapshot.ClusterId
+        : _metadataManager.ClusterId;
 
     /// <inheritdoc />
-    public KafkaClientStatus GetStatus() => KafkaClientStatusFactory.Capture(
-        KafkaClientRole.Admin,
-        _connectionPool,
-        _metadataManager,
-        Volatile.Read(ref _disposed) != 0);
+    public KafkaClientStatus GetStatus()
+    {
+        var stopped = Volatile.Read(ref _disposed) != 0;
+        if (_controllerMetadataManager is not { } controllerMetadataManager)
+        {
+            return KafkaClientStatusFactory.Capture(
+                KafkaClientRole.Admin,
+                _connectionPool,
+                _metadataManager,
+                stopped);
+        }
+
+        var snapshot = controllerMetadataManager.Snapshot;
+        return KafkaClientStatusFactory.Capture(
+            KafkaClientRole.Admin,
+            _connectionPool,
+            snapshot.ClusterId,
+            snapshot.LastRefreshed,
+            stopped);
+    }
 
     private static void ValidateBootstrapOptions(AdminClientOptions options)
     {

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -183,15 +183,12 @@ public sealed class AdminClient : IAdminClient, IKafkaClientStatusProvider
             var index = 0;
             foreach (var endpoint in snapshot.Controllers.Values)
             {
-                var discoveryConnection = snapshot.DiscoveryConnection;
-                endpoints[index++] = discoveryConnection?.NodeId == endpoint.NodeId
-                    ? new ConnectionStatusEndpoint(
-                        endpoint.NodeId,
-                        endpoint.Host,
-                        endpoint.Port,
-                        discoveryConnection.Host,
-                        discoveryConnection.Port)
-                    : new ConnectionStatusEndpoint(endpoint.NodeId, endpoint.Host, endpoint.Port);
+                snapshot.DiscoveryConnections.TryGetValue(endpoint.NodeId, out var aliases);
+                endpoints[index++] = new ConnectionStatusEndpoint(
+                    endpoint.NodeId,
+                    endpoint.Host,
+                    endpoint.Port,
+                    aliases);
             }
             brokers = statusSource.GetEndpointConnectionStatus(endpoints);
         }

--- a/src/Dekaf/Admin/ControllerMetadataManager.cs
+++ b/src/Dekaf/Admin/ControllerMetadataManager.cs
@@ -378,16 +378,21 @@ internal sealed class ControllerMetadataManager : IDisposable
         left.Port == right.Port
         && string.Equals(left.Host, right.Host, StringComparison.OrdinalIgnoreCase);
 
-    private static IReadOnlyDictionary<int, ConnectionStatusEndpointAlias[]> BuildDiscoveryConnections(
+    private IReadOnlyDictionary<int, ConnectionStatusEndpointAlias[]> BuildDiscoveryConnections(
         ControllerMetadataSnapshot previous,
         ControllerEndpoint endpoint,
         IReadOnlyDictionary<int, ControllerEndpoint> controllers)
     {
         var result = new Dictionary<int, ConnectionStatusEndpointAlias[]>(previous.DiscoveryConnections.Count + 1);
+        var statusSource = _connectionPool as IConnectionPoolStatusSource;
         foreach (var pair in previous.DiscoveryConnections)
         {
-            if (controllers.ContainsKey(pair.Key))
-                result.Add(pair.Key, pair.Value);
+            if (!controllers.ContainsKey(pair.Key))
+                continue;
+
+            var liveAliases = RetainRepresentedAliases(pair.Value, statusSource);
+            if (liveAliases.Length > 0)
+                result.Add(pair.Key, liveAliases);
         }
 
         var discovery = IdentifyDiscoveryConnection(endpoint, controllers);
@@ -406,6 +411,45 @@ internal sealed class ControllerMetadataManager : IDisposable
         }
 
         return result;
+    }
+
+    private static ConnectionStatusEndpointAlias[] RetainRepresentedAliases(
+        ConnectionStatusEndpointAlias[] aliases,
+        IConnectionPoolStatusSource? statusSource)
+    {
+        if (statusSource is null)
+            return aliases;
+
+        var firstMissing = -1;
+        for (var i = 0; i < aliases.Length; i++)
+        {
+            var alias = aliases[i];
+            if (!statusSource.ContainsEndpointConnection(alias.Host, alias.Port))
+            {
+                firstMissing = i;
+                break;
+            }
+        }
+
+        if (firstMissing < 0)
+            return aliases;
+
+        var retained = new ConnectionStatusEndpointAlias[aliases.Length - 1];
+        Array.Copy(aliases, retained, firstMissing);
+        var destination = firstMissing;
+        for (var i = firstMissing + 1; i < aliases.Length; i++)
+        {
+            var alias = aliases[i];
+            if (statusSource.ContainsEndpointConnection(alias.Host, alias.Port))
+                retained[destination++] = alias;
+        }
+
+        if (destination == 0)
+            return [];
+        if (destination != retained.Length)
+            Array.Resize(ref retained, destination);
+
+        return retained;
     }
 
     private static bool ContainsAlias(

--- a/src/Dekaf/Admin/ControllerMetadataManager.cs
+++ b/src/Dekaf/Admin/ControllerMetadataManager.cs
@@ -358,20 +358,25 @@ internal sealed class ControllerMetadataManager : IDisposable
         ControllerEndpoint endpoint,
         IReadOnlyDictionary<int, ControllerEndpoint> controllers)
     {
-        if (endpoint.NodeId >= 0)
+        if (endpoint.NodeId >= 0
+            && controllers.TryGetValue(endpoint.NodeId, out var identifiedController)
+            && HasSameAddress(endpoint, identifiedController))
+        {
             return endpoint;
+        }
 
         foreach (var controller in controllers.Values)
         {
-            if (endpoint.Port == controller.Port &&
-                string.Equals(endpoint.Host, controller.Host, StringComparison.OrdinalIgnoreCase))
-            {
+            if (HasSameAddress(endpoint, controller))
                 return endpoint with { NodeId = controller.NodeId };
-            }
         }
 
-        return endpoint;
+        return endpoint with { NodeId = -1 };
     }
+
+    private static bool HasSameAddress(ControllerEndpoint left, ControllerEndpoint right) =>
+        left.Port == right.Port
+        && string.Equals(left.Host, right.Host, StringComparison.OrdinalIgnoreCase);
 
     private static IReadOnlyDictionary<int, ConnectionStatusEndpointAlias[]> BuildDiscoveryConnections(
         ControllerMetadataSnapshot previous,

--- a/src/Dekaf/Admin/ControllerMetadataManager.cs
+++ b/src/Dekaf/Admin/ControllerMetadataManager.cs
@@ -152,7 +152,7 @@ internal sealed class ControllerMetadataManager : IDisposable
                                     response.ClusterId,
                                     response.ControllerId,
                                     controllers,
-                                    IdentifyDiscoveryConnection(endpoint, controllers),
+                                    BuildDiscoveryConnections(snapshot, endpoint, controllers),
                                     DateTimeOffset.UtcNow));
                             return;
                         }
@@ -372,20 +372,63 @@ internal sealed class ControllerMetadataManager : IDisposable
 
         return endpoint;
     }
+
+    private static IReadOnlyDictionary<int, ConnectionStatusEndpointAlias[]> BuildDiscoveryConnections(
+        ControllerMetadataSnapshot previous,
+        ControllerEndpoint endpoint,
+        IReadOnlyDictionary<int, ControllerEndpoint> controllers)
+    {
+        var result = new Dictionary<int, ConnectionStatusEndpointAlias[]>(previous.DiscoveryConnections.Count + 1);
+        foreach (var pair in previous.DiscoveryConnections)
+        {
+            if (controllers.ContainsKey(pair.Key))
+                result.Add(pair.Key, pair.Value);
+        }
+
+        var discovery = IdentifyDiscoveryConnection(endpoint, controllers);
+        if (discovery.NodeId >= 0)
+        {
+            var alias = new ConnectionStatusEndpointAlias(discovery.Host, discovery.Port);
+            if (!result.TryGetValue(discovery.NodeId, out var aliases))
+                result.Add(discovery.NodeId, [alias]);
+            else if (!ContainsAlias(aliases, alias))
+            {
+                var expanded = new ConnectionStatusEndpointAlias[aliases.Length + 1];
+                aliases.CopyTo(expanded, 0);
+                expanded[^1] = alias;
+                result[discovery.NodeId] = expanded;
+            }
+        }
+
+        return result;
+    }
+
+    private static bool ContainsAlias(
+        ConnectionStatusEndpointAlias[] aliases,
+        ConnectionStatusEndpointAlias candidate)
+    {
+        for (var i = 0; i < aliases.Length; i++)
+        {
+            if (aliases[i] == candidate)
+                return true;
+        }
+
+        return false;
+    }
 }
 
 internal sealed record ControllerMetadataSnapshot(
     string? ClusterId,
     int ActiveControllerId,
     IReadOnlyDictionary<int, ControllerEndpoint> Controllers,
-    ControllerEndpoint? DiscoveryConnection,
+    IReadOnlyDictionary<int, ConnectionStatusEndpointAlias[]> DiscoveryConnections,
     DateTimeOffset LastRefreshed)
 {
     internal static ControllerMetadataSnapshot Empty { get; } = new(
         null,
         -1,
         new Dictionary<int, ControllerEndpoint>(),
-        null,
+        new Dictionary<int, ConnectionStatusEndpointAlias[]>(),
         default);
 }
 

--- a/src/Dekaf/Admin/ControllerMetadataManager.cs
+++ b/src/Dekaf/Admin/ControllerMetadataManager.cs
@@ -115,12 +115,7 @@ internal sealed class ControllerMetadataManager : IDisposable
                             response.ClusterId,
                             response.ControllerId,
                             controllers,
-                            endpoint with
-                            {
-                                NodeId = endpoint.NodeId >= 0
-                                    ? endpoint.NodeId
-                                    : response.ControllerId
-                            },
+                            IdentifyDiscoveryConnection(endpoint, controllers),
                             DateTimeOffset.UtcNow));
                     return;
                 }
@@ -277,6 +272,25 @@ internal sealed class ControllerMetadataManager : IDisposable
         }
 
         return result;
+    }
+
+    private static ControllerEndpoint IdentifyDiscoveryConnection(
+        ControllerEndpoint endpoint,
+        IReadOnlyDictionary<int, ControllerEndpoint> controllers)
+    {
+        if (endpoint.NodeId >= 0)
+            return endpoint;
+
+        foreach (var controller in controllers.Values)
+        {
+            if (endpoint.Port == controller.Port &&
+                string.Equals(endpoint.Host, controller.Host, StringComparison.OrdinalIgnoreCase))
+            {
+                return endpoint with { NodeId = controller.NodeId };
+            }
+        }
+
+        return endpoint;
     }
 }
 

--- a/src/Dekaf/Admin/ControllerMetadataManager.cs
+++ b/src/Dekaf/Admin/ControllerMetadataManager.cs
@@ -115,6 +115,12 @@ internal sealed class ControllerMetadataManager : IDisposable
                             response.ClusterId,
                             response.ControllerId,
                             controllers,
+                            endpoint with
+                            {
+                                NodeId = endpoint.NodeId >= 0
+                                    ? endpoint.NodeId
+                                    : response.ControllerId
+                            },
                             DateTimeOffset.UtcNow));
                     return;
                 }
@@ -278,9 +284,15 @@ internal sealed record ControllerMetadataSnapshot(
     string? ClusterId,
     int ActiveControllerId,
     IReadOnlyDictionary<int, ControllerEndpoint> Controllers,
+    ControllerEndpoint? DiscoveryConnection,
     DateTimeOffset LastRefreshed)
 {
-    internal static ControllerMetadataSnapshot Empty { get; } = new(null, -1, new Dictionary<int, ControllerEndpoint>(), default);
+    internal static ControllerMetadataSnapshot Empty { get; } = new(
+        null,
+        -1,
+        new Dictionary<int, ControllerEndpoint>(),
+        null,
+        default);
 }
 
 internal sealed record ControllerEndpoint(int NodeId, string Host, int Port, string? Rack);

--- a/src/Dekaf/CompatibilitySuppressions.xml
+++ b/src/Dekaf/CompatibilitySuppressions.xml
@@ -398,6 +398,18 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Dekaf.Diagnostics.BrokerConnectionState</Target>
+    <Left>lib/netstandard2.0/Dekaf.dll</Left>
+    <Right>lib/net10.0/Dekaf.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Dekaf.Diagnostics.KafkaClientRole</Target>
+    <Left>lib/netstandard2.0/Dekaf.dll</Left>
+    <Right>lib/net10.0/Dekaf.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
     <Target>T:Dekaf.Errors.DeserializationExceptionOrigin</Target>
     <Left>lib/netstandard2.0/Dekaf.dll</Left>
     <Right>lib/net10.0/Dekaf.dll</Right>

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using Dekaf.Diagnostics;
 using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -178,6 +179,26 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 : Stopwatch.GetElapsedTime(lastHeartbeatTimestamp),
             HeartbeatInterval: TimeSpan.FromMilliseconds(Math.Max(_heartbeatIntervalMs, 1)),
             LastHeartbeatFailure: Volatile.Read(ref _lastHeartbeatFailure));
+    }
+
+    internal ConsumerGroupStatus CaptureGroupStatus()
+    {
+        var assignment = _assignedPartitions;
+        var lastHeartbeatTimestamp = Volatile.Read(ref _lastSuccessfulHeartbeatTimestamp);
+        return new ConsumerGroupStatus
+        {
+            HasConsumerGroup = true,
+            State = _state,
+            CoordinatorId = _coordinatorId,
+            MemberId = _memberId,
+            GenerationOrMemberEpoch = _generationId,
+            HeartbeatInterval = TimeSpan.FromMilliseconds(Math.Max(_heartbeatIntervalMs, 1)),
+            TimeSinceLastHeartbeat = lastHeartbeatTimestamp == 0
+                ? null
+                : Stopwatch.GetElapsedTime(lastHeartbeatTimestamp),
+            LastHeartbeatFailure = Volatile.Read(ref _lastHeartbeatFailure),
+            Assignment = KafkaClientStatusFactory.CopyAssignment(assignment, assignment.Count)
+        };
     }
 
     internal ValueTask RecordPollAsync(CancellationToken cancellationToken)

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1922,10 +1922,19 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     _state = CoordinatorState.Joining;
                     LogCoordinatorStateTransition(CoordinatorState.Joining);
 
-                    heartbeatResult = await SendConsumerGroupHeartbeatAsync(
-                        isInitial: _memberId is null || _generationId <= 0,
-                        discardIfMembershipChanged: false,
-                        cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        heartbeatResult = await SendConsumerGroupHeartbeatAsync(
+                            isInitial: _memberId is null || _generationId <= 0,
+                            discardIfMembershipChanged: false,
+                            cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex) when (
+                        ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+                    {
+                        Volatile.Write(ref _lastHeartbeatFailure, ex.Message);
+                        throw;
+                    }
 
                     _state = CoordinatorState.Stable;
                     if (Volatile.Read(ref _foregroundPollActivityCount) != 0)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2037,7 +2037,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             LastHeartbeatFailure: null)
         : _coordinator.CaptureGroupLiveness(
             Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _consumerDisposed) != 0,
-            _topicPattern is not null || _subscriptionSnapshot.Count != 0);
+            _topicFilter is not null || _topicPattern is not null || _subscriptionSnapshot.Count != 0);
 
     IDisposable IConsumerRebalanceEventSource.RegisterRuntimeRebalanceListener(IRebalanceListener listener)
     {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2304,8 +2304,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                     pooledHeaderCount,
                                     pending,
                                     pending.HeaderGeneration);
-                                activity = StartConsumeActivity(pending, headers, offset,
-                                    valueData.Length, isValueNull, isProcessSpan: true);
+                                activity = StartConsumeActivity(
+                                    pending, headers, offset, isValueNull, isProcessSpan: true);
                                 if (activity is not null)
                                     previousActivity = activity;
                             }
@@ -4582,7 +4582,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 pooledHeaders,
                                 pooledHeaderCount,
                                 offset,
-                                valueData.Length,
                                 isValueNull,
                                 out pendingDisposed);
 
@@ -4766,7 +4765,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 pooledHeaders,
                                 pooledHeaderCount,
                                 offset,
-                                valueData.Length,
                                 isValueNull,
                                 out pendingDisposed);
 
@@ -5033,7 +5031,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         Header[]? pooledHeaders,
         int pooledHeaderCount,
         long offset,
-        int valueLength,
         bool isValueNull,
         out bool pendingDisposed)
     {
@@ -5049,7 +5046,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 pending,
                 headers,
                 offset,
-                valueLength,
                 isValueNull,
                 isProcessSpan: false);
         }
@@ -8289,7 +8285,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         PendingFetchData pending,
         IReadOnlyList<Header>? headers,
         long offset,
-        int valueLength,
         bool isTombstone,
         bool isProcessSpan)
     {
@@ -8352,7 +8347,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 : Diagnostics.DekafDiagnostics.OperationTypeReceive);
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingDestinationPartitionId, pending.PartitionIndex);
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingKafkaOffset, offset);
-            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingMessageBodySize, isTombstone ? 0 : valueLength);
+            // messaging.message.body.size is Opt-In in the OTel messaging conventions.
+            // Dekaf does not expose that opt-in, so avoid its tag node and per-record int box.
             if (isTombstone)
                 activity.SetTag(Diagnostics.DekafDiagnostics.MessagingKafkaTombstone, Diagnostics.DekafDiagnostics.BoxedTrue);
             var clusterId = _metadataManager.ClusterId;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -6,6 +6,7 @@ using Dekaf.Errors;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using Dekaf.Compression;
+using Dekaf.Diagnostics;
 using Dekaf.Internal;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -872,6 +873,7 @@ internal static class ConsumerFetchPools
 /// <typeparam name="TValue">Value type.</typeparam>
 public sealed partial class KafkaConsumer<TKey, TValue> :
     IKafkaConsumer<TKey, TValue>,
+    IKafkaClientStatusProvider,
     IConsumerGroupLiveness,
     IConsumerPositions,
     IConsumerPartitions,
@@ -1743,6 +1745,40 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     public string? MemberId => _coordinator?.MemberId;
+
+    /// <inheritdoc />
+    public string? ClusterId => _metadataManager.ClusterId;
+
+    /// <inheritdoc />
+    public KafkaClientStatus GetStatus()
+    {
+        var stopped = Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _consumerDisposed) != 0;
+        var hasConsumerGroup = _topicPattern is not null || _subscriptionSnapshot.Count != 0;
+        var consumerGroup = hasConsumerGroup
+            ? _coordinator?.CaptureGroupStatus()
+            : null;
+        if (consumerGroup is null)
+        {
+            var assignment = _assignmentSnapshot;
+            consumerGroup = new ConsumerGroupStatus
+            {
+                HasConsumerGroup = false,
+                State = CoordinatorState.Unjoined,
+                CoordinatorId = -1,
+                GenerationOrMemberEpoch = -1,
+                HeartbeatInterval = TimeSpan.Zero,
+                Assignment = KafkaClientStatusFactory.CopyAssignment(assignment, assignment.Count)
+            };
+        }
+
+        return KafkaClientStatusFactory.Capture(
+            KafkaClientRole.Consumer,
+            _connectionPool,
+            _metadataManager,
+            stopped,
+            consumerGroup: consumerGroup);
+    }
+
     public TopicPartitionSet Paused => _pausedSnapshot;
     public IConsumerPositions Positions => this;
     public IConsumerPartitions Partitions => this;
@@ -8317,6 +8353,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingMessageBodySize, isTombstone ? 0 : valueLength);
             if (isTombstone)
                 activity.SetTag(Diagnostics.DekafDiagnostics.MessagingKafkaTombstone, Diagnostics.DekafDiagnostics.BoxedTrue);
+            var clusterId = _metadataManager.ClusterId;
+            if (clusterId is not null)
+                activity.SetTag(Diagnostics.DekafDiagnostics.MessagingKafkaClusterId, clusterId);
             if (_options.ClientId is not null)
                 activity.SetTag(Diagnostics.DekafDiagnostics.MessagingClientId, _options.ClientId);
             if (_options.GroupId is not null)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1753,7 +1753,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     public KafkaClientStatus GetStatus()
     {
         var stopped = Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _consumerDisposed) != 0;
-        var hasConsumerGroup = _topicPattern is not null || _subscriptionSnapshot.Count != 0;
+        var hasConsumerGroup = _topicFilter is not null
+            || _topicPattern is not null
+            || _subscriptionSnapshot.Count != 0;
         var consumerGroup = hasConsumerGroup
             ? _coordinator?.CaptureGroupStatus()
             : null;

--- a/src/Dekaf/Diagnostics/DekafDiagnostics.cs
+++ b/src/Dekaf/Diagnostics/DekafDiagnostics.cs
@@ -33,6 +33,7 @@ public static class DekafDiagnostics
     internal const string MessagingDestinationPartitionId = "messaging.destination.partition.id";
     internal const string MessagingConsumerGroupName = "messaging.consumer.group.name";
     internal const string MessagingMessageKey = "messaging.kafka.message.key";
+    internal const string MessagingKafkaClusterId = "messaging.kafka.cluster.id";
     internal const string MessagingKafkaTombstone = "messaging.kafka.message.tombstone";
     internal const string MessagingClientId = "messaging.client.id";
 

--- a/src/Dekaf/Diagnostics/KafkaClientStatus.cs
+++ b/src/Dekaf/Diagnostics/KafkaClientStatus.cs
@@ -115,18 +115,18 @@ public sealed class BrokerConnectionStatus
 }
 
 /// <summary>Point-in-time producer backlog and capacity state.</summary>
+/// <param name="BufferedBytes">Bytes currently reserved by buffered records.</param>
+/// <param name="BufferCapacityBytes">Configured producer buffer capacity in bytes.</param>
+/// <param name="UnsealedBatchCount">Number of mutable batches accepting records.</param>
+/// <param name="QueuedBatchCount">Number of sealed batches queued for dispatch.</param>
+/// <param name="InFlightBatchCount">Number of batches dispatched and awaiting completion.</param>
+/// <param name="BufferPressureEventCount">Cumulative number of buffer-pressure events.</param>
 public readonly record struct ProducerBacklogStatus(
-    /// <summary>Bytes currently reserved by buffered records.</summary>
     long BufferedBytes,
-    /// <summary>Configured producer buffer capacity in bytes.</summary>
     ulong BufferCapacityBytes,
-    /// <summary>Number of mutable batches accepting records.</summary>
     int UnsealedBatchCount,
-    /// <summary>Number of sealed batches queued for dispatch.</summary>
     long QueuedBatchCount,
-    /// <summary>Number of batches dispatched and awaiting completion.</summary>
     long InFlightBatchCount,
-    /// <summary>Cumulative number of buffer-pressure events.</summary>
     long BufferPressureEventCount)
 {
     /// <summary>Current buffer utilization. Values above 1 are possible while limits shrink.</summary>

--- a/src/Dekaf/Diagnostics/KafkaClientStatus.cs
+++ b/src/Dekaf/Diagnostics/KafkaClientStatus.cs
@@ -1,0 +1,170 @@
+using Dekaf.Consumer;
+
+namespace Dekaf.Diagnostics;
+
+/// <summary>
+/// Optional capability exposing the cached identity of a Kafka client.
+/// </summary>
+/// <remarks>
+/// Dekaf's built-in producer, consumer, share consumer, and admin client implement this
+/// interface. The property is a non-blocking cache read and never starts network I/O.
+/// </remarks>
+public interface IKafkaClientIdentity
+{
+    /// <summary>
+    /// Gets the cluster ID from the latest accepted metadata, or <see langword="null"/>
+    /// before metadata supplies one.
+    /// </summary>
+    string? ClusterId { get; }
+}
+
+/// <summary>
+/// Optional capability exposing a low-frequency operational status snapshot.
+/// </summary>
+/// <remarks>
+/// Snapshot collection allocates and may enumerate the represented brokers and assigned
+/// partitions. It is intended for readiness checks, support bundles, and periodic monitoring,
+/// not per-message use. Individual fields are read lock-free and may reflect adjacent instants.
+/// </remarks>
+public interface IKafkaClientStatusProvider : IKafkaClientIdentity
+{
+    /// <summary>Captures the client's current operational status.</summary>
+    KafkaClientStatus GetStatus();
+}
+
+/// <summary>Identifies the built-in client role represented by a status snapshot.</summary>
+public enum KafkaClientRole
+{
+    Producer,
+    Consumer,
+    ShareConsumer,
+    Admin
+}
+
+/// <summary>Summarizes the physical connections currently represented for one broker.</summary>
+public enum BrokerConnectionState
+{
+    Disconnected,
+    PartiallyConnected,
+    Connected
+}
+
+/// <summary>A point-in-time operational snapshot for a Kafka client.</summary>
+public sealed class KafkaClientStatus
+{
+    /// <summary>UTC time at which collection began.</summary>
+    public required DateTimeOffset CapturedAtUtc { get; init; }
+
+    /// <summary>The built-in client role.</summary>
+    public required KafkaClientRole Role { get; init; }
+
+    /// <summary>The latest accepted Kafka cluster ID, when known.</summary>
+    public string? ClusterId { get; init; }
+
+    /// <summary>UTC time of the latest accepted metadata update, when available.</summary>
+    public DateTimeOffset? MetadataLastRefreshedAtUtc { get; init; }
+
+    /// <summary>Whether the client has been closed or disposed.</summary>
+    public bool IsStopped { get; init; }
+
+    /// <summary>Per-broker connection snapshots. Bootstrap-only endpoints are excluded.</summary>
+    public required IReadOnlyList<BrokerConnectionStatus> Brokers { get; init; }
+
+    /// <summary>Producer backlog state, populated only for producers.</summary>
+    public ProducerBacklogStatus? Producer { get; init; }
+
+    /// <summary>Consumer group state, populated for regular and share consumers.</summary>
+    public ConsumerGroupStatus? ConsumerGroup { get; init; }
+}
+
+/// <summary>Point-in-time connection state for one broker.</summary>
+public sealed class BrokerConnectionStatus
+{
+    /// <summary>Broker node ID from the latest metadata.</summary>
+    public required int BrokerId { get; init; }
+
+    /// <summary>Broker host from the latest metadata.</summary>
+    public required string Host { get; init; }
+
+    /// <summary>Broker port from the latest metadata.</summary>
+    public required int Port { get; init; }
+
+    /// <summary>Aggregate physical connection state.</summary>
+    public required BrokerConnectionState State { get; init; }
+
+    /// <summary>Number of physical connection slots currently represented.</summary>
+    public required int ConnectionCount { get; init; }
+
+    /// <summary>Number of represented physical connections currently connected.</summary>
+    public required int ConnectedConnectionCount { get; init; }
+
+    /// <summary>Number of requests awaiting responses across represented connections.</summary>
+    public required int PendingRequestCount { get; init; }
+
+    /// <summary>Approximate UTC time of the latest successful request.</summary>
+    public DateTimeOffset? LastSuccessfulRequestAtUtc { get; init; }
+
+    /// <summary>Approximate UTC time of the latest observed connection-state transition.</summary>
+    public DateTimeOffset? LastConnectionStateChangeAtUtc { get; init; }
+
+    /// <summary>Approximate UTC time of the latest connection-attempt failure.</summary>
+    public DateTimeOffset? LastErrorAtUtc { get; init; }
+
+    /// <summary>Latest connection-attempt failure summary.</summary>
+    public string? LastError { get; init; }
+}
+
+/// <summary>Point-in-time producer backlog and capacity state.</summary>
+public readonly record struct ProducerBacklogStatus(
+    /// <summary>Bytes currently reserved by buffered records.</summary>
+    long BufferedBytes,
+    /// <summary>Configured producer buffer capacity in bytes.</summary>
+    ulong BufferCapacityBytes,
+    /// <summary>Number of mutable batches accepting records.</summary>
+    int UnsealedBatchCount,
+    /// <summary>Number of sealed batches queued for dispatch.</summary>
+    long QueuedBatchCount,
+    /// <summary>Number of batches dispatched and awaiting completion.</summary>
+    long InFlightBatchCount,
+    /// <summary>Cumulative number of buffer-pressure events.</summary>
+    long BufferPressureEventCount)
+{
+    /// <summary>Current buffer utilization. Values above 1 are possible while limits shrink.</summary>
+    public double BufferUtilization => BufferCapacityBytes == 0
+        ? 0
+        : BufferedBytes / (double)BufferCapacityBytes;
+
+    /// <summary>Whether current usage has reached the configured capacity.</summary>
+    public bool IsAtCapacity => BufferCapacityBytes != 0 && (ulong)Math.Max(BufferedBytes, 0) >= BufferCapacityBytes;
+}
+
+/// <summary>Point-in-time regular or share consumer group state.</summary>
+public sealed class ConsumerGroupStatus
+{
+    /// <summary>Whether the consumer is participating in group coordination.</summary>
+    public required bool HasConsumerGroup { get; init; }
+
+    /// <summary>Current coordinator state.</summary>
+    public required CoordinatorState State { get; init; }
+
+    /// <summary>Current coordinator broker ID, or <c>-1</c> when unknown.</summary>
+    public required int CoordinatorId { get; init; }
+
+    /// <summary>Current group member ID, when assigned.</summary>
+    public string? MemberId { get; init; }
+
+    /// <summary>Classic generation ID or consumer/share member epoch.</summary>
+    public required int GenerationOrMemberEpoch { get; init; }
+
+    /// <summary>Configured group heartbeat interval.</summary>
+    public required TimeSpan HeartbeatInterval { get; init; }
+
+    /// <summary>Elapsed time since the latest successful heartbeat, when available.</summary>
+    public TimeSpan? TimeSinceLastHeartbeat { get; init; }
+
+    /// <summary>Latest heartbeat failure summary, when available.</summary>
+    public string? LastHeartbeatFailure { get; init; }
+
+    /// <summary>Immutable copy of the current partition assignment.</summary>
+    public required IReadOnlyList<TopicPartition> Assignment { get; init; }
+}

--- a/src/Dekaf/Diagnostics/KafkaClientStatusFactory.cs
+++ b/src/Dekaf/Diagnostics/KafkaClientStatusFactory.cs
@@ -29,7 +29,8 @@ internal static class KafkaClientStatusFactory
         DateTimeOffset metadataLastRefreshed,
         bool isStopped,
         ProducerBacklogStatus? producer = null,
-        ConsumerGroupStatus? consumerGroup = null)
+        ConsumerGroupStatus? consumerGroup = null,
+        IReadOnlyList<BrokerConnectionStatus>? brokers = null)
     {
         return new KafkaClientStatus
         {
@@ -40,9 +41,10 @@ internal static class KafkaClientStatusFactory
                 ? null
                 : metadataLastRefreshed,
             IsStopped = isStopped,
-            Brokers = connectionPool is IConnectionPoolStatusSource statusSource
-                ? statusSource.GetBrokerConnectionStatus()
-                : Array.Empty<BrokerConnectionStatus>(),
+            Brokers = brokers
+                ?? (connectionPool is IConnectionPoolStatusSource statusSource
+                    ? statusSource.GetBrokerConnectionStatus()
+                    : Array.Empty<BrokerConnectionStatus>()),
             Producer = producer,
             ConsumerGroup = consumerGroup
         };

--- a/src/Dekaf/Diagnostics/KafkaClientStatusFactory.cs
+++ b/src/Dekaf/Diagnostics/KafkaClientStatusFactory.cs
@@ -1,0 +1,56 @@
+using System.Collections.ObjectModel;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+
+namespace Dekaf.Diagnostics;
+
+internal static class KafkaClientStatusFactory
+{
+    public static KafkaClientStatus Capture(
+        KafkaClientRole role,
+        IConnectionPool connectionPool,
+        MetadataManager metadataManager,
+        bool isStopped,
+        ProducerBacklogStatus? producer = null,
+        ConsumerGroupStatus? consumerGroup = null)
+    {
+        var metadata = metadataManager.Metadata;
+        var lastRefreshed = metadata.LastRefreshed;
+        return new KafkaClientStatus
+        {
+            CapturedAtUtc = DateTimeOffset.UtcNow,
+            Role = role,
+            ClusterId = metadataManager.ClusterId,
+            MetadataLastRefreshedAtUtc = lastRefreshed == default ? null : lastRefreshed,
+            IsStopped = isStopped,
+            Brokers = connectionPool is IConnectionPoolStatusSource statusSource
+                ? statusSource.GetBrokerConnectionStatus()
+                : Array.Empty<BrokerConnectionStatus>(),
+            Producer = producer,
+            ConsumerGroup = consumerGroup
+        };
+    }
+
+    public static IReadOnlyList<TopicPartition> CopyAssignment(
+        IEnumerable<TopicPartition> assignment,
+        int count)
+    {
+        if (count == 0)
+            return Array.Empty<TopicPartition>();
+
+        var copy = new TopicPartition[count];
+        var index = 0;
+        foreach (var topicPartition in assignment)
+        {
+            if ((uint)index >= (uint)copy.Length)
+                break;
+
+            copy[index++] = topicPartition;
+        }
+
+        if (index != copy.Length)
+            Array.Resize(ref copy, index);
+
+        return new ReadOnlyCollection<TopicPartition>(copy);
+    }
+}

--- a/src/Dekaf/Diagnostics/KafkaClientStatusFactory.cs
+++ b/src/Dekaf/Diagnostics/KafkaClientStatusFactory.cs
@@ -12,16 +12,33 @@ internal static class KafkaClientStatusFactory
         MetadataManager metadataManager,
         bool isStopped,
         ProducerBacklogStatus? producer = null,
+        ConsumerGroupStatus? consumerGroup = null) =>
+        Capture(
+            role,
+            connectionPool,
+            metadataManager.ClusterId,
+            metadataManager.Metadata.LastRefreshed,
+            isStopped,
+            producer,
+            consumerGroup);
+
+    public static KafkaClientStatus Capture(
+        KafkaClientRole role,
+        IConnectionPool connectionPool,
+        string? clusterId,
+        DateTimeOffset metadataLastRefreshed,
+        bool isStopped,
+        ProducerBacklogStatus? producer = null,
         ConsumerGroupStatus? consumerGroup = null)
     {
-        var metadata = metadataManager.Metadata;
-        var lastRefreshed = metadata.LastRefreshed;
         return new KafkaClientStatus
         {
             CapturedAtUtc = DateTimeOffset.UtcNow,
             Role = role,
-            ClusterId = metadataManager.ClusterId,
-            MetadataLastRefreshedAtUtc = lastRefreshed == default ? null : lastRefreshed,
+            ClusterId = clusterId,
+            MetadataLastRefreshedAtUtc = metadataLastRefreshed == default
+                ? null
+                : metadataLastRefreshed,
             IsStopped = isStopped,
             Brokers = connectionPool is IConnectionPoolStatusSource statusSource
                 ? statusSource.GetBrokerConnectionStatus()

--- a/src/Dekaf/Diagnostics/TraceContextPropagator.cs
+++ b/src/Dekaf/Diagnostics/TraceContextPropagator.cs
@@ -13,7 +13,7 @@ internal static class TraceContextPropagator
 {
     private const string TraceparentHeader = "traceparent";
     private const string TracestateHeader = "tracestate";
-    private const int TraceparentLength = 55;
+    internal const int TraceparentLength = 55;
 
     /// <summary>
     /// Injects the current trace context into message headers.
@@ -33,24 +33,7 @@ internal static class TraceContextPropagator
     {
         headers ??= new Headers(2);
 
-        // W3C traceparent: 00-{traceId}-{spanId}-{traceFlags}
-        var traceparent = new byte[TraceparentLength];
-        traceparent[0] = (byte)'0';
-        traceparent[1] = (byte)'0';
-        traceparent[2] = (byte)'-';
-
-        Span<byte> traceId = stackalloc byte[16];
-        activity.TraceId.CopyTo(traceId);
-        WriteLowerHex(traceId, traceparent.AsSpan(3, 32));
-        traceparent[35] = (byte)'-';
-
-        Span<byte> spanId = stackalloc byte[8];
-        activity.SpanId.CopyTo(spanId);
-        WriteLowerHex(spanId, traceparent.AsSpan(36, 16));
-        traceparent[52] = (byte)'-';
-        traceparent[53] = (byte)'0';
-        traceparent[54] = activity.Recorded ? (byte)'1' : (byte)'0';
-        headers.Add(TraceparentHeader, traceparent);
+        headers.Add(Header.CreateDeferredTraceparent(TraceparentHeader, activity));
 
         var traceState = activity.TraceStateString;
         if (!string.IsNullOrEmpty(traceState))
@@ -61,6 +44,36 @@ internal static class TraceContextPropagator
         return headers;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void WriteTraceparent(Activity activity, Span<byte> destination)
+    {
+        if (destination.Length < TraceparentLength)
+            throw new ArgumentException("The traceparent destination must be at least 55 bytes.", nameof(destination));
+
+        WriteTraceparentUnchecked(activity, destination);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void WriteTraceparentUnchecked(Activity activity, Span<byte> destination)
+    {
+        destination[0] = (byte)'0';
+        destination[1] = (byte)'0';
+        destination[2] = (byte)'-';
+
+        Span<byte> traceId = stackalloc byte[16];
+        activity.TraceId.CopyTo(traceId);
+        WriteLowerHex(traceId, destination.Slice(3, 32));
+        destination[35] = (byte)'-';
+
+        Span<byte> spanId = stackalloc byte[8];
+        activity.SpanId.CopyTo(spanId);
+        WriteLowerHex(spanId, destination.Slice(36, 16));
+        destination[52] = (byte)'-';
+        destination[53] = (byte)'0';
+        destination[54] = activity.Recorded ? (byte)'1' : (byte)'0';
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void WriteLowerHex(ReadOnlySpan<byte> source, Span<byte> destination)
     {
         const string HexDigits = "0123456789abcdef";

--- a/src/Dekaf/Diagnostics/TraceContextPropagator.cs
+++ b/src/Dekaf/Diagnostics/TraceContextPropagator.cs
@@ -13,6 +13,7 @@ internal static class TraceContextPropagator
 {
     private const string TraceparentHeader = "traceparent";
     private const string TracestateHeader = "tracestate";
+    private const int TraceparentLength = 55;
 
     /// <summary>
     /// Injects the current trace context into message headers.
@@ -33,7 +34,22 @@ internal static class TraceContextPropagator
         headers ??= new Headers(2);
 
         // W3C traceparent: 00-{traceId}-{spanId}-{traceFlags}
-        var traceparent = $"00-{activity.TraceId}-{activity.SpanId}-{(activity.Recorded ? "01" : "00")}";
+        var traceparent = new byte[TraceparentLength];
+        traceparent[0] = (byte)'0';
+        traceparent[1] = (byte)'0';
+        traceparent[2] = (byte)'-';
+
+        Span<byte> traceId = stackalloc byte[16];
+        activity.TraceId.CopyTo(traceId);
+        WriteLowerHex(traceId, traceparent.AsSpan(3, 32));
+        traceparent[35] = (byte)'-';
+
+        Span<byte> spanId = stackalloc byte[8];
+        activity.SpanId.CopyTo(spanId);
+        WriteLowerHex(spanId, traceparent.AsSpan(36, 16));
+        traceparent[52] = (byte)'-';
+        traceparent[53] = (byte)'0';
+        traceparent[54] = activity.Recorded ? (byte)'1' : (byte)'0';
         headers.Add(TraceparentHeader, traceparent);
 
         var traceState = activity.TraceStateString;
@@ -43,6 +59,17 @@ internal static class TraceContextPropagator
         }
 
         return headers;
+    }
+
+    private static void WriteLowerHex(ReadOnlySpan<byte> source, Span<byte> destination)
+    {
+        const string HexDigits = "0123456789abcdef";
+        for (var i = 0; i < source.Length; i++)
+        {
+            var value = source[i];
+            destination[i * 2] = (byte)HexDigits[value >> 4];
+            destination[(i * 2) + 1] = (byte)HexDigits[value & 0x0f];
+        }
     }
 
     /// <summary>

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -218,6 +218,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
     /// </summary>
     public ClusterMetadata Metadata => _metadata;
 
+    internal string? ClusterId => Volatile.Read(ref _trustedMetadataClusterId);
+
     /// <summary>
     /// Returns true if the broker reported support for the given API key during version negotiation.
     /// </summary>

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -1070,13 +1070,16 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 // metadata for other topics. Full-cluster requests replace the snapshot.
                 // This matches the Java client's incremental metadata update behavior.
                 _metadata.Update(response, mergeTopics: topics is not null);
+                // The accepted fallback snapshot must remain usable for routing even when its
+                // cluster identity and diagnostic broker set are not trusted.
+                foreach (var broker in response.Brokers)
+                    RegisterBroker(broker.NodeId, broker.Host, broker.Port);
+
                 if (response.ErrorCode != ErrorCode.RebootstrapRequired)
                 {
                     UpdateMetadataClusterId(response.ClusterId);
 
                     // Only trusted metadata may replace connection-routing diagnostics.
-                    foreach (var broker in response.Brokers)
-                        RegisterBroker(broker.NodeId, broker.Host, broker.Port);
                     PublishBrokerStatusSnapshot(response.Brokers);
                 }
 

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -1071,14 +1071,14 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 // This matches the Java client's incremental metadata update behavior.
                 _metadata.Update(response, mergeTopics: topics is not null);
                 if (response.ErrorCode != ErrorCode.RebootstrapRequired)
+                {
                     UpdateMetadataClusterId(response.ClusterId);
 
-                // Register brokers with connection pool
-                foreach (var broker in response.Brokers)
-                {
-                    RegisterBroker(broker.NodeId, broker.Host, broker.Port);
+                    // Only trusted metadata may replace connection-routing diagnostics.
+                    foreach (var broker in response.Brokers)
+                        RegisterBroker(broker.NodeId, broker.Host, broker.Port);
+                    PublishBrokerStatusSnapshot(response.Brokers);
                 }
-                PublishBrokerStatusSnapshot(response.Brokers);
 
                 LogMetadataRefreshed(response.Brokers.Count, response.Topics.Count);
 

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -1078,6 +1078,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 {
                     RegisterBroker(broker.NodeId, broker.Host, broker.Port);
                 }
+                PublishBrokerStatusSnapshot(response.Brokers);
 
                 LogMetadataRefreshed(response.Brokers.Count, response.Topics.Count);
 
@@ -1334,6 +1335,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 {
                     RegisterBroker(broker.NodeId, broker.Host, broker.Port);
                 }
+                PublishBrokerStatusSnapshot(response.Brokers);
 
                 LogRebootstrapSuccessful(response.Brokers.Count, host, port);
 
@@ -1367,6 +1369,24 @@ public sealed partial class MetadataManager : IAsyncDisposable
     {
         _connectionPool.RegisterBroker(brokerId, host, port);
         Volatile.Read(ref _additionalBrokerRegistrationTarget)?.RegisterBroker(brokerId, host, port);
+    }
+
+    private void PublishBrokerStatusSnapshot(IReadOnlyList<BrokerMetadata> brokers)
+    {
+        var brokerIds = new int[brokers.Count];
+        for (var i = 0; i < brokers.Count; i++)
+            brokerIds[i] = brokers[i].NodeId;
+
+        UpdateBrokerStatusSnapshot(_connectionPool, brokerIds);
+        var additionalPool = Volatile.Read(ref _additionalBrokerRegistrationTarget);
+        if (additionalPool is not null)
+            UpdateBrokerStatusSnapshot(additionalPool, brokerIds);
+    }
+
+    private static void UpdateBrokerStatusSnapshot(IConnectionPool connectionPool, int[] brokerIds)
+    {
+        if (connectionPool is IConnectionPoolStatusSource statusSource)
+            statusSource.UpdateBrokerStatusSnapshot(brokerIds);
     }
 
     /// <summary>

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -73,6 +73,7 @@ public sealed partial class ConnectionPool :
     private int[]? _brokerStatusSnapshot;
     private readonly ConcurrentDictionary<int, BrokerConnectionRuntimeState> _brokerConnectionRuntimeStates = new();
     private readonly ConcurrentDictionary<EndpointKey, BrokerConnectionRuntimeState> _endpointConnectionRuntimeStates = new();
+    private long _connectionFailureSequence;
     private readonly ConcurrentDictionary<EndpointKey, IKafkaConnection> _connectionsByEndpoint = new();
     private readonly ConcurrentDictionary<int, IKafkaConnection> _connectionsById = new();
     // Per-endpoint semaphores to deduplicate concurrent single-connection creation
@@ -1545,10 +1546,11 @@ public sealed partial class ConnectionPool :
         int port,
         string error)
     {
+        var failureSequence = Interlocked.Increment(ref _connectionFailureSequence);
         if (brokerId >= 0)
-            GetBrokerConnectionRuntimeState(brokerId).RecordFailure(error);
+            GetBrokerConnectionRuntimeState(brokerId).RecordFailure(error, failureSequence);
         else
-            GetEndpointConnectionRuntimeState(new EndpointKey(host, port)).RecordFailure(error);
+            GetEndpointConnectionRuntimeState(new EndpointKey(host, port)).RecordFailure(error, failureSequence);
 
         var state = _reconnectBackoffs.GetOrAdd(setupKey, static _ => new ReconnectBackoffState());
 
@@ -1903,19 +1905,17 @@ public sealed partial class ConnectionPool :
                 AccumulateConnectionStatus(connection, ref connections);
             _endpointConnectionRuntimeStates.TryGetValue(endpointKey, out var runtimeState);
             AccumulateRuntimeState(runtimeState, ref connections);
-            if (endpoint.ConnectionHost is { } connectionHost &&
-                (endpoint.Port != endpoint.ConnectionPort ||
-                 !string.Equals(endpoint.Host, connectionHost, StringComparison.OrdinalIgnoreCase)))
+            if (endpoint.ConnectionHost is { } connectionHost)
             {
                 var connectionEndpointKey = new EndpointKey(connectionHost, endpoint.ConnectionPort);
-                if (_connectionsByEndpoint.TryGetValue(connectionEndpointKey, out connection))
-                    AccumulateConnectionStatus(connection, ref connections);
-                _endpointConnectionRuntimeStates.TryGetValue(connectionEndpointKey, out var connectionRuntimeState);
-                AccumulateRuntimeState(connectionRuntimeState, ref connections);
-                if (connectionRuntimeState?.LastErrorTimestampMs >
-                    (runtimeState?.LastErrorTimestampMs ?? 0))
+                if (connectionEndpointKey != endpointKey)
                 {
-                    runtimeState = connectionRuntimeState;
+                    if (_connectionsByEndpoint.TryGetValue(connectionEndpointKey, out connection))
+                        AccumulateConnectionStatus(connection, ref connections);
+                    _endpointConnectionRuntimeStates.TryGetValue(connectionEndpointKey, out var connectionRuntimeState);
+                    AccumulateRuntimeState(connectionRuntimeState, ref connections);
+                    if (HasLaterFailure(connectionRuntimeState, runtimeState))
+                        runtimeState = connectionRuntimeState;
                 }
             }
             result.Add(CreateBrokerConnectionStatus(
@@ -1928,6 +1928,20 @@ public sealed partial class ConnectionPool :
 
         result.Sort(static (left, right) => left.BrokerId.CompareTo(right.BrokerId));
         return result.AsReadOnly();
+    }
+
+    private static bool HasLaterFailure(
+        BrokerConnectionRuntimeState? candidate,
+        BrokerConnectionRuntimeState? current)
+    {
+        if (candidate is null)
+            return false;
+
+        var candidateTimestamp = candidate.LastErrorTimestampMs;
+        var currentTimestamp = current?.LastErrorTimestampMs ?? 0;
+        return candidateTimestamp > currentTimestamp ||
+               (candidateTimestamp == currentTimestamp &&
+                candidate.LastErrorSequence > (current?.LastErrorSequence ?? 0));
     }
 
     void IConnectionPoolStatusSource.UpdateBrokerStatusSnapshot(int[] brokerIds) =>
@@ -2554,20 +2568,23 @@ public sealed partial class ConnectionPool :
         private readonly Func<long> _timestampProvider = timestampProvider;
         private long _lastStateChangeTimestampMs = recordInitialState ? timestampProvider() : 0;
         private long _lastErrorTimestampMs;
+        private long _lastErrorSequence;
         private string? _lastError;
 
         public long LastStateChangeTimestampMs => Volatile.Read(ref _lastStateChangeTimestampMs);
         public long LastErrorTimestampMs => Volatile.Read(ref _lastErrorTimestampMs);
+        public long LastErrorSequence => Volatile.Read(ref _lastErrorSequence);
         public string? LastError => Volatile.Read(ref _lastError);
 
         public void RecordStateChange() =>
             Volatile.Write(ref _lastStateChangeTimestampMs, _timestampProvider());
 
-        public void RecordFailure(string error)
+        public void RecordFailure(string error, long sequence)
         {
             var timestampMs = _timestampProvider();
             Volatile.Write(ref _lastError, error);
             Volatile.Write(ref _lastErrorTimestampMs, timestampMs);
+            Volatile.Write(ref _lastErrorSequence, sequence);
         }
     }
 

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -2166,6 +2166,7 @@ public sealed partial class ConnectionPool :
                 _connectionsByEndpoint,
                 new EndpointKey(connection.Host, connection.Port),
                 connection);
+            PreserveSuccessfulRequest(connection, brokerId);
             RetireConnection(connection);
         }
 
@@ -2181,7 +2182,19 @@ public sealed partial class ConnectionPool :
         foreach (var groupedConnection in group)
         {
             if (groupedConnection is not null)
+            {
+                PreserveSuccessfulRequest(groupedConnection, brokerId);
                 RetireConnection(groupedConnection);
+            }
+        }
+    }
+
+    private void PreserveSuccessfulRequest(IKafkaConnection connection, int brokerId)
+    {
+        if (connection is IKafkaConnectionStatusSource statusSource)
+        {
+            GetBrokerConnectionRuntimeState(brokerId)
+                .RecordSuccessfulRequest(statusSource.LastSuccessfulRequestTimestampMs);
         }
     }
 

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1680,8 +1680,7 @@ public sealed partial class ConnectionPool :
             return false;
         }
 
-        if (connection.BrokerId >= 0)
-            RecordBrokerConnectionStateChange(connection.BrokerId);
+        PreserveRemovedConnectionState(connection, connection.BrokerId, endpoint);
         return true;
     }
 

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -69,6 +69,7 @@ public sealed partial class ConnectionPool :
     private readonly Func<long>? _timestampProvider;
 
     private readonly ConcurrentDictionary<int, BrokerInfo> _brokers = new();
+    private int[]? _brokerStatusSnapshot;
     private readonly ConcurrentDictionary<int, BrokerConnectionRuntimeState> _brokerConnectionRuntimeStates = new();
     private readonly ConcurrentDictionary<EndpointKey, IKafkaConnection> _connectionsByEndpoint = new();
     private readonly ConcurrentDictionary<int, IKafkaConnection> _connectionsById = new();
@@ -1825,55 +1826,82 @@ public sealed partial class ConnectionPool :
     {
         var capturedAtUtc = DateTimeOffset.UtcNow;
         var capturedAtTimestampMs = Dekaf.MonotonicClock.GetMilliseconds();
-        var result = new List<BrokerConnectionStatus>(_brokers.Count);
+        var brokerIds = Volatile.Read(ref _brokerStatusSnapshot);
+        var result = new List<BrokerConnectionStatus>(brokerIds?.Length ?? _brokers.Count);
 
-        foreach (var broker in _brokers.Values)
+        if (brokerIds is null)
         {
-            var connections = default(ConnectionStatusAccumulator);
-
-            _connectionGroupsById.TryGetValue(broker.BrokerId, out var group);
-            if (group is not null)
+            foreach (var broker in _brokers.Values)
             {
-                for (var i = 0; i < group.Length; i++)
-                    AccumulateConnectionStatus(group[i], ref connections);
+                result.Add(CaptureBrokerConnectionStatus(
+                    broker, capturedAtTimestampMs, capturedAtUtc));
             }
-            if (_connectionsById.TryGetValue(broker.BrokerId, out var connection)
-                && !ContainsReference(group, connection))
+        }
+        else
+        {
+            for (var i = 0; i < brokerIds.Length; i++)
             {
-                AccumulateConnectionStatus(connection, ref connections);
+                if (_brokers.TryGetValue(brokerIds[i], out var broker))
+                {
+                    result.Add(CaptureBrokerConnectionStatus(
+                        broker, capturedAtTimestampMs, capturedAtUtc));
+                }
             }
-
-            _brokerConnectionRuntimeStates.TryGetValue(broker.BrokerId, out var runtimeState);
-            var lastErrorTimestampMs = runtimeState?.LastErrorTimestampMs ?? 0;
-            connections.LastStateChangeTimestampMs = Math.Max(
-                connections.LastStateChangeTimestampMs,
-                runtimeState?.LastStateChangeTimestampMs ?? 0);
-
-            result.Add(new BrokerConnectionStatus
-            {
-                BrokerId = broker.BrokerId,
-                Host = broker.Host,
-                Port = broker.Port,
-                State = connections.ConnectedCount == 0
-                    ? BrokerConnectionState.Disconnected
-                    : connections.ConnectedCount == connections.ConnectionCount
-                        ? BrokerConnectionState.Connected
-                        : BrokerConnectionState.PartiallyConnected,
-                ConnectionCount = connections.ConnectionCount,
-                ConnectedConnectionCount = connections.ConnectedCount,
-                PendingRequestCount = connections.PendingRequestCount,
-                LastSuccessfulRequestAtUtc = ToUtcTimestamp(
-                    connections.LastSuccessfulRequestTimestampMs, capturedAtTimestampMs, capturedAtUtc),
-                LastConnectionStateChangeAtUtc = ToUtcTimestamp(
-                    connections.LastStateChangeTimestampMs, capturedAtTimestampMs, capturedAtUtc),
-                LastErrorAtUtc = ToUtcTimestamp(
-                    lastErrorTimestampMs, capturedAtTimestampMs, capturedAtUtc),
-                LastError = runtimeState?.LastError
-            });
         }
 
         result.Sort(static (left, right) => left.BrokerId.CompareTo(right.BrokerId));
         return result.AsReadOnly();
+    }
+
+    void IConnectionPoolStatusSource.UpdateBrokerStatusSnapshot(int[] brokerIds) =>
+        Volatile.Write(ref _brokerStatusSnapshot, brokerIds);
+
+    private BrokerConnectionStatus CaptureBrokerConnectionStatus(
+        BrokerInfo broker,
+        long capturedAtTimestampMs,
+        DateTimeOffset capturedAtUtc)
+    {
+        var connections = default(ConnectionStatusAccumulator);
+
+        _connectionGroupsById.TryGetValue(broker.BrokerId, out var group);
+        if (group is not null)
+        {
+            for (var i = 0; i < group.Length; i++)
+                AccumulateConnectionStatus(group[i], ref connections);
+        }
+        if (_connectionsById.TryGetValue(broker.BrokerId, out var connection)
+            && !ContainsReference(group, connection))
+        {
+            AccumulateConnectionStatus(connection, ref connections);
+        }
+
+        _brokerConnectionRuntimeStates.TryGetValue(broker.BrokerId, out var runtimeState);
+        var lastErrorTimestampMs = runtimeState?.LastErrorTimestampMs ?? 0;
+        connections.LastStateChangeTimestampMs = Math.Max(
+            connections.LastStateChangeTimestampMs,
+            runtimeState?.LastStateChangeTimestampMs ?? 0);
+
+        return new BrokerConnectionStatus
+        {
+            BrokerId = broker.BrokerId,
+            Host = broker.Host,
+            Port = broker.Port,
+            State = connections.ConnectedCount == 0
+                ? BrokerConnectionState.Disconnected
+                : connections.ConnectedCount == connections.ConnectionCount
+                    ? BrokerConnectionState.Connected
+                    : BrokerConnectionState.PartiallyConnected,
+            ConnectionCount = connections.ConnectionCount,
+            ConnectedConnectionCount = connections.ConnectedCount,
+            PendingRequestCount = connections.PendingRequestCount,
+            LastSuccessfulRequestAtUtc = ToUtcTimestamp(
+                connections.LastSuccessfulRequestTimestampMs, capturedAtTimestampMs, capturedAtUtc),
+            LastConnectionStateChangeAtUtc = ToUtcTimestamp(
+                connections.LastStateChangeTimestampMs, capturedAtTimestampMs, capturedAtUtc),
+            LastErrorAtUtc = ToUtcTimestamp(
+                lastErrorTimestampMs, capturedAtTimestampMs, capturedAtUtc),
+            LastError = runtimeState?.LastError
+        };
     }
 
     private static void AccumulateConnectionStatus(

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1927,11 +1927,16 @@ public sealed partial class ConnectionPool :
                 AccumulateConnectionStatus(connection, ref connections);
             _endpointConnectionRuntimeStates.TryGetValue(endpointKey, out var runtimeState);
             AccumulateRuntimeState(runtimeState, ref connections);
-            if (endpoint.ConnectionHost is { } connectionHost)
+            var aliases = endpoint.ConnectionAliases;
+            if (aliases is not null)
             {
-                var connectionEndpointKey = new EndpointKey(connectionHost, endpoint.ConnectionPort);
-                if (connectionEndpointKey != endpointKey)
+                for (var aliasIndex = 0; aliasIndex < aliases.Count; aliasIndex++)
                 {
+                    var alias = aliases[aliasIndex];
+                    var connectionEndpointKey = new EndpointKey(alias.Host, alias.Port);
+                    if (connectionEndpointKey == endpointKey || AliasAlreadyVisited(aliases, aliasIndex, connectionEndpointKey))
+                        continue;
+
                     if (_connectionsByEndpoint.TryGetValue(connectionEndpointKey, out connection))
                         AccumulateConnectionStatus(connection, ref connections);
                     _endpointConnectionRuntimeStates.TryGetValue(connectionEndpointKey, out var connectionRuntimeState);
@@ -1950,6 +1955,21 @@ public sealed partial class ConnectionPool :
 
         result.Sort(static (left, right) => left.BrokerId.CompareTo(right.BrokerId));
         return result.AsReadOnly();
+    }
+
+    private static bool AliasAlreadyVisited(
+        IReadOnlyList<ConnectionStatusEndpointAlias> aliases,
+        int currentIndex,
+        EndpointKey endpoint)
+    {
+        for (var i = 0; i < currentIndex; i++)
+        {
+            var alias = aliases[i];
+            if (new EndpointKey(alias.Host, alias.Port) == endpoint)
+                return true;
+        }
+
+        return false;
     }
 
     private static bool HasLaterFailure(

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1927,22 +1927,22 @@ public sealed partial class ConnectionPool :
                 AccumulateConnectionStatus(connection, ref connections);
             _endpointConnectionRuntimeStates.TryGetValue(endpointKey, out var runtimeState);
             AccumulateRuntimeState(runtimeState, ref connections);
+            var lastFailure = runtimeState?.LastFailure;
             var aliases = endpoint.ConnectionAliases;
             if (aliases is not null)
             {
                 for (var aliasIndex = 0; aliasIndex < aliases.Count; aliasIndex++)
                 {
                     var alias = aliases[aliasIndex];
-                    var connectionEndpointKey = new EndpointKey(alias.Host, alias.Port);
-                    if (connectionEndpointKey == endpointKey || AliasAlreadyVisited(aliases, aliasIndex, connectionEndpointKey))
+                    var aliasKey = new EndpointKey(alias.Host, alias.Port);
+                    if (aliasKey == endpointKey || AliasAlreadyVisited(aliases, aliasIndex, aliasKey))
                         continue;
 
-                    if (_connectionsByEndpoint.TryGetValue(connectionEndpointKey, out connection))
+                    if (_connectionsByEndpoint.TryGetValue(aliasKey, out connection))
                         AccumulateConnectionStatus(connection, ref connections);
-                    _endpointConnectionRuntimeStates.TryGetValue(connectionEndpointKey, out var connectionRuntimeState);
-                    AccumulateRuntimeState(connectionRuntimeState, ref connections);
-                    if (HasLaterFailure(connectionRuntimeState, runtimeState))
-                        runtimeState = connectionRuntimeState;
+                    _endpointConnectionRuntimeStates.TryGetValue(aliasKey, out var aliasRuntimeState);
+                    AccumulateRuntimeState(aliasRuntimeState, ref connections);
+                    lastFailure = GetLaterFailure(aliasRuntimeState?.LastFailure, lastFailure);
                 }
             }
             result.Add(CreateBrokerConnectionStatus(
@@ -1950,7 +1950,8 @@ public sealed partial class ConnectionPool :
                 ref connections,
                 capturedAtTimestampMs,
                 capturedAtUtc,
-                runtimeState));
+                runtimeState,
+                lastFailure));
         }
 
         result.Sort(static (left, right) => left.BrokerId.CompareTo(right.BrokerId));
@@ -1972,18 +1973,17 @@ public sealed partial class ConnectionPool :
         return false;
     }
 
-    private static bool HasLaterFailure(
-        BrokerConnectionRuntimeState? candidate,
-        BrokerConnectionRuntimeState? current)
+    private static FailureInfo? GetLaterFailure(FailureInfo? candidate, FailureInfo? current)
     {
         if (candidate is null)
-            return false;
+            return current;
+        if (current is null)
+            return candidate;
 
-        var candidateTimestamp = candidate.LastErrorTimestampMs;
-        var currentTimestamp = current?.LastErrorTimestampMs ?? 0;
-        return candidateTimestamp > currentTimestamp ||
-               (candidateTimestamp == currentTimestamp &&
-                candidate.LastErrorSequence > (current?.LastErrorSequence ?? 0));
+        return candidate.TimestampMs > current.TimestampMs ||
+               (candidate.TimestampMs == current.TimestampMs && candidate.Sequence > current.Sequence)
+            ? candidate
+            : current;
     }
 
     void IConnectionPoolStatusSource.UpdateBrokerStatusSnapshot(int[] brokerIds) =>
@@ -2024,12 +2024,13 @@ public sealed partial class ConnectionPool :
         ref ConnectionStatusAccumulator connections,
         long capturedAtTimestampMs,
         DateTimeOffset capturedAtUtc,
-        BrokerConnectionRuntimeState? runtimeState = null)
+        BrokerConnectionRuntimeState? runtimeState = null,
+        FailureInfo? lastFailure = null)
     {
         runtimeState ??= _brokerConnectionRuntimeStates.TryGetValue(broker.BrokerId, out var brokerRuntimeState)
             ? brokerRuntimeState
             : null;
-        var lastErrorTimestampMs = runtimeState?.LastErrorTimestampMs ?? 0;
+        lastFailure ??= runtimeState?.LastFailure;
         AccumulateRuntimeState(runtimeState, ref connections);
 
         return new BrokerConnectionStatus
@@ -2050,8 +2051,8 @@ public sealed partial class ConnectionPool :
             LastConnectionStateChangeAtUtc = ToUtcTimestamp(
                 connections.LastStateChangeTimestampMs, capturedAtTimestampMs, capturedAtUtc),
             LastErrorAtUtc = ToUtcTimestamp(
-                lastErrorTimestampMs, capturedAtTimestampMs, capturedAtUtc),
-            LastError = runtimeState?.LastError
+                lastFailure?.TimestampMs ?? 0, capturedAtTimestampMs, capturedAtUtc),
+            LastError = lastFailure?.Error
         };
     }
 
@@ -2642,15 +2643,11 @@ public sealed partial class ConnectionPool :
         private readonly Func<long> _timestampProvider = timestampProvider;
         private long _lastStateChangeTimestampMs = recordInitialState ? timestampProvider() : 0;
         private long _lastSuccessfulRequestTimestampMs;
-        private long _lastErrorTimestampMs;
-        private long _lastErrorSequence;
-        private string? _lastError;
+        private FailureInfo? _lastFailure;
 
         public long LastStateChangeTimestampMs => Volatile.Read(ref _lastStateChangeTimestampMs);
         public long LastSuccessfulRequestTimestampMs => Volatile.Read(ref _lastSuccessfulRequestTimestampMs);
-        public long LastErrorTimestampMs => Volatile.Read(ref _lastErrorTimestampMs);
-        public long LastErrorSequence => Volatile.Read(ref _lastErrorSequence);
-        public string? LastError => Volatile.Read(ref _lastError);
+        public FailureInfo? LastFailure => Volatile.Read(ref _lastFailure);
 
         public void RecordStateChange() => RecordStateChange(_timestampProvider());
 
@@ -2688,12 +2685,20 @@ public sealed partial class ConnectionPool :
 
         public void RecordFailure(string error, long sequence)
         {
-            var timestampMs = _timestampProvider();
-            Volatile.Write(ref _lastError, error);
-            Volatile.Write(ref _lastErrorTimestampMs, timestampMs);
-            Volatile.Write(ref _lastErrorSequence, sequence);
+            var failure = new FailureInfo(error, _timestampProvider(), sequence);
+            var current = Volatile.Read(ref _lastFailure);
+            while (current is null || sequence > current.Sequence)
+            {
+                var observed = Interlocked.CompareExchange(ref _lastFailure, failure, current);
+                if (ReferenceEquals(observed, current))
+                    return;
+
+                current = observed;
+            }
         }
     }
+
+    private sealed record FailureInfo(string Error, long TimestampMs, long Sequence);
 
     private readonly record struct EndpointKey(string Host, int Port);
     private readonly record struct ConnectionSetupKey(int BrokerId, string Host, int Port);

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -2284,8 +2284,9 @@ public sealed partial class ConnectionPool :
             // _connectionsPerBroker == 1). A pool configured for one connection can hold
             // BOTH a single connection and a connection group for the same broker once
             // adaptive scaling creates a group — both collections are disposed below.
-            foreach (var connection in _connectionsByEndpoint.Values)
+            foreach (var (endpoint, connection) in _connectionsByEndpoint)
             {
+                GetEndpointConnectionRuntimeState(endpoint).RecordStateChange();
                 tasks.Add(connection.DisposeAsync());
             }
 

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1867,7 +1867,11 @@ public sealed partial class ConnectionPool :
         if (group is not null)
         {
             for (var i = 0; i < group.Length; i++)
-                AccumulateConnectionStatus(group[i], ref connections);
+            {
+                var groupedConnection = Volatile.Read(ref group[i]);
+                if (groupedConnection is not null)
+                    AccumulateConnectionStatus(groupedConnection, ref connections);
+            }
         }
         if (_connectionsById.TryGetValue(broker.BrokerId, out var connection)
             && !ContainsReference(group, connection))

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1730,6 +1730,7 @@ public sealed partial class ConnectionPool :
             : GetEndpointConnectionRuntimeState(endpoint);
         if (connection is IKafkaConnectionStatusSource statusSource)
         {
+            runtimeState.RecordSuccessfulRequest(statusSource.LastSuccessfulRequestTimestampMs);
             var timestampMs = statusSource.LastConnectionStateChangeTimestampMs;
             if (timestampMs > 0)
             {
@@ -2010,9 +2011,7 @@ public sealed partial class ConnectionPool :
             ? brokerRuntimeState
             : null;
         var lastErrorTimestampMs = runtimeState?.LastErrorTimestampMs ?? 0;
-        connections.LastStateChangeTimestampMs = Math.Max(
-            connections.LastStateChangeTimestampMs,
-            runtimeState?.LastStateChangeTimestampMs ?? 0);
+        AccumulateRuntimeState(runtimeState, ref connections);
 
         return new BrokerConnectionStatus
         {
@@ -2065,6 +2064,9 @@ public sealed partial class ConnectionPool :
     {
         if (runtimeState is not null)
         {
+            status.LastSuccessfulRequestTimestampMs = Math.Max(
+                status.LastSuccessfulRequestTimestampMs,
+                runtimeState.LastSuccessfulRequestTimestampMs);
             status.LastStateChangeTimestampMs = Math.Max(
                 status.LastStateChangeTimestampMs,
                 runtimeState.LastStateChangeTimestampMs);
@@ -2299,8 +2301,10 @@ public sealed partial class ConnectionPool :
 
     public async ValueTask RemoveConnectionAsync(int brokerId)
     {
+        var removed = false;
         if (_connectionsById.TryRemove(brokerId, out var connection))
         {
+            removed = true;
             var endpoint = new EndpointKey(connection.Host, connection.Port);
             _connectionsByEndpoint.TryRemove(endpoint, out _);
             if (_connectionCreationLocks.TryRemove(endpoint, out var creationSem))
@@ -2311,6 +2315,7 @@ public sealed partial class ConnectionPool :
 
         if (_connectionGroupsById.TryRemove(brokerId, out var group))
         {
+            removed = true;
             // Iterate the group's actual size: adaptive scaling can grow a group beyond
             // the configured ConnectionsPerBroker.
             for (var i = 0; i < group.Length; i++)
@@ -2332,7 +2337,7 @@ public sealed partial class ConnectionPool :
             LogRemovedConnection(brokerId);
         }
 
-        if (_brokerConnectionRuntimeStates.TryGetValue(brokerId, out var runtimeState))
+        if (removed && _brokerConnectionRuntimeStates.TryGetValue(brokerId, out var runtimeState))
             runtimeState.RecordStateChange();
     }
 
@@ -2589,16 +2594,34 @@ public sealed partial class ConnectionPool :
     {
         private readonly Func<long> _timestampProvider = timestampProvider;
         private long _lastStateChangeTimestampMs = recordInitialState ? timestampProvider() : 0;
+        private long _lastSuccessfulRequestTimestampMs;
         private long _lastErrorTimestampMs;
         private long _lastErrorSequence;
         private string? _lastError;
 
         public long LastStateChangeTimestampMs => Volatile.Read(ref _lastStateChangeTimestampMs);
+        public long LastSuccessfulRequestTimestampMs => Volatile.Read(ref _lastSuccessfulRequestTimestampMs);
         public long LastErrorTimestampMs => Volatile.Read(ref _lastErrorTimestampMs);
         public long LastErrorSequence => Volatile.Read(ref _lastErrorSequence);
         public string? LastError => Volatile.Read(ref _lastError);
 
         public void RecordStateChange() => RecordStateChange(_timestampProvider());
+
+        public void RecordSuccessfulRequest(long timestampMs)
+        {
+            var current = Volatile.Read(ref _lastSuccessfulRequestTimestampMs);
+            while (timestampMs > current)
+            {
+                var observed = Interlocked.CompareExchange(
+                    ref _lastSuccessfulRequestTimestampMs,
+                    timestampMs,
+                    current);
+                if (observed == current)
+                    return;
+
+                current = observed;
+            }
+        }
 
         public void RecordStateChange(long timestampMs)
         {

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -2275,8 +2275,11 @@ public sealed partial class ConnectionPool :
         {
             LogClosingAllConnections();
 
-            foreach (var runtimeState in _brokerConnectionRuntimeStates.Values)
-                runtimeState.RecordStateChange();
+            foreach (var brokerId in _connectionsById.Keys)
+            {
+                if (_brokerConnectionRuntimeStates.TryGetValue(brokerId, out var runtimeState))
+                    runtimeState.RecordStateChange();
+            }
 
             var tasks = new List<ValueTask>();
 
@@ -2291,12 +2294,19 @@ public sealed partial class ConnectionPool :
             }
 
             // Close connection groups (used when _connectionsPerBroker > 1)
-            foreach (var connectionGroup in _connectionGroupsById.Values)
+            foreach (var (brokerId, connectionGroup) in _connectionGroupsById)
             {
+                var runtimeState = !_connectionsById.ContainsKey(brokerId)
+                    && _brokerConnectionRuntimeStates.TryGetValue(brokerId, out var trackedRuntimeState)
+                        ? trackedRuntimeState
+                        : null;
+
                 foreach (var connection in connectionGroup)
                 {
                     if (connection is not null)
                     {
+                        runtimeState?.RecordStateChange();
+                        runtimeState = null;
                         tasks.Add(connection.DisposeAsync());
                     }
                 }

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1675,6 +1675,8 @@ public sealed partial class ConnectionPool :
             return false;
         }
 
+        if (connection.BrokerId >= 0)
+            RecordBrokerConnectionStateChange(connection.BrokerId);
         return true;
     }
 
@@ -1704,9 +1706,17 @@ public sealed partial class ConnectionPool :
         var result = await DisposeIdleConnectionAsync(connection, index, now).ConfigureAwait(false);
         if (!result.Reaped && result.CanRestore && connection.IsConnected)
             Interlocked.CompareExchange(ref group[index], connection, null!);
+        else if (result.Reaped)
+            RecordBrokerConnectionStateChange(brokerId);
 
         return result.Reaped;
     }
+
+    private void RecordBrokerConnectionStateChange(int brokerId) =>
+        _brokerConnectionRuntimeStates.GetOrAdd(
+                brokerId,
+                static _ => new BrokerConnectionRuntimeState(Dekaf.MonotonicClock.GetMilliseconds()))
+            .RecordStateChange();
 
     private bool IsIdleReapable(IKafkaConnection connection, long now)
     {
@@ -1853,6 +1863,29 @@ public sealed partial class ConnectionPool :
         return result.AsReadOnly();
     }
 
+    IReadOnlyList<BrokerConnectionStatus> IConnectionPoolStatusSource.GetEndpointConnectionStatus(
+        IReadOnlyList<ConnectionStatusEndpoint> endpoints)
+    {
+        var capturedAtUtc = DateTimeOffset.UtcNow;
+        var capturedAtTimestampMs = Dekaf.MonotonicClock.GetMilliseconds();
+        var result = new List<BrokerConnectionStatus>(endpoints.Count);
+        for (var i = 0; i < endpoints.Count; i++)
+        {
+            var endpoint = endpoints[i];
+            var connections = default(ConnectionStatusAccumulator);
+            if (_connectionsByEndpoint.TryGetValue(new EndpointKey(endpoint.Host, endpoint.Port), out var connection))
+                AccumulateConnectionStatus(connection, ref connections);
+            result.Add(CreateBrokerConnectionStatus(
+                new BrokerInfo(endpoint.NodeId, endpoint.Host, endpoint.Port),
+                ref connections,
+                capturedAtTimestampMs,
+                capturedAtUtc));
+        }
+
+        result.Sort(static (left, right) => left.BrokerId.CompareTo(right.BrokerId));
+        return result.AsReadOnly();
+    }
+
     void IConnectionPoolStatusSource.UpdateBrokerStatusSnapshot(int[] brokerIds) =>
         Volatile.Write(ref _brokerStatusSnapshot, brokerIds);
 
@@ -1879,6 +1912,19 @@ public sealed partial class ConnectionPool :
             AccumulateConnectionStatus(connection, ref connections);
         }
 
+        return CreateBrokerConnectionStatus(
+            broker,
+            ref connections,
+            capturedAtTimestampMs,
+            capturedAtUtc);
+    }
+
+    private BrokerConnectionStatus CreateBrokerConnectionStatus(
+        BrokerInfo broker,
+        ref ConnectionStatusAccumulator connections,
+        long capturedAtTimestampMs,
+        DateTimeOffset capturedAtUtc)
+    {
         _brokerConnectionRuntimeStates.TryGetValue(broker.BrokerId, out var runtimeState);
         var lastErrorTimestampMs = runtimeState?.LastErrorTimestampMs ?? 0;
         connections.LastStateChangeTimestampMs = Math.Max(
@@ -2449,7 +2495,6 @@ public sealed partial class ConnectionPool :
             var timestampMs = Dekaf.MonotonicClock.GetMilliseconds();
             Volatile.Write(ref _lastError, error);
             Volatile.Write(ref _lastErrorTimestampMs, timestampMs);
-            Volatile.Write(ref _lastStateChangeTimestampMs, timestampMs);
         }
     }
 

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1962,6 +1962,9 @@ public sealed partial class ConnectionPool :
         return result.AsReadOnly();
     }
 
+    bool IConnectionPoolStatusSource.ContainsEndpointConnection(string host, int port) =>
+        _connectionsByEndpoint.ContainsKey(new EndpointKey(host, port));
+
     private static bool AliasAlreadyVisited(
         IReadOnlyList<ConnectionStatusEndpointAlias> aliases,
         int currentIndex,

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using Dekaf.Diagnostics;
 using Dekaf.Internal;
 using Dekaf.Protocol;
 using Dekaf.Retry;
@@ -16,6 +17,7 @@ namespace Dekaf.Networking;
 public sealed partial class ConnectionPool :
     IConnectionPool,
     IConnectionPoolDiagnostics,
+    IConnectionPoolStatusSource,
     IBrokerThrottleProvider,
     IConnectionCapabilityObserverPool,
     IMetadataClusterIdentityPool
@@ -67,6 +69,7 @@ public sealed partial class ConnectionPool :
     private readonly Func<long>? _timestampProvider;
 
     private readonly ConcurrentDictionary<int, BrokerInfo> _brokers = new();
+    private readonly ConcurrentDictionary<int, BrokerConnectionRuntimeState> _brokerConnectionRuntimeStates = new();
     private readonly ConcurrentDictionary<EndpointKey, IKafkaConnection> _connectionsByEndpoint = new();
     private readonly ConcurrentDictionary<int, IKafkaConnection> _connectionsById = new();
     // Per-endpoint semaphores to deduplicate concurrent single-connection creation
@@ -348,6 +351,7 @@ public sealed partial class ConnectionPool :
     public void RegisterBroker(int brokerId, string host, int port)
     {
         var brokerInfo = new BrokerInfo(brokerId, host, port);
+        var endpointChanged = false;
         while (true)
         {
             if (!_brokers.TryGetValue(brokerId, out var previous))
@@ -364,6 +368,7 @@ public sealed partial class ConnectionPool :
             if (!_brokers.TryUpdate(brokerId, brokerInfo, previous))
                 continue;
 
+            endpointChanged = true;
             var previousKey = new ConnectionSetupKey(brokerId, previous.Host, previous.Port);
             _connectionSetupTimeouts.TryRemove(previousKey, out _);
             RemoveReconnectBackoff(previousKey);
@@ -371,6 +376,12 @@ public sealed partial class ConnectionPool :
             RetireBrokerConnections(brokerId, previous);
             break;
         }
+
+        var runtimeState = _brokerConnectionRuntimeStates.GetOrAdd(
+            brokerId,
+            static _ => new BrokerConnectionRuntimeState(Dekaf.MonotonicClock.GetMilliseconds()));
+        if (endpointChanged)
+            runtimeState.RecordStateChange();
 
         GetBrokerThrottleState(brokerId, new EndpointKey(host, port));
         LogRegisteredBroker(brokerId, host, port);
@@ -1512,6 +1523,14 @@ public sealed partial class ConnectionPool :
 
     private void RecordReconnectFailure(ConnectionSetupKey setupKey, int brokerId, string host, int port)
     {
+        if (brokerId >= 0)
+        {
+            _brokerConnectionRuntimeStates.GetOrAdd(
+                    brokerId,
+                    static _ => new BrokerConnectionRuntimeState(Dekaf.MonotonicClock.GetMilliseconds()))
+                .RecordFailure();
+        }
+
         var state = _reconnectBackoffs.GetOrAdd(setupKey, static _ => new ReconnectBackoffState());
 
         TimeSpan delay;
@@ -1786,6 +1805,113 @@ public sealed partial class ConnectionPool :
         return maximum;
     }
 
+    IReadOnlyList<BrokerConnectionStatus> IConnectionPoolStatusSource.GetBrokerConnectionStatus()
+    {
+        var capturedAtUtc = DateTimeOffset.UtcNow;
+        var capturedAtTimestampMs = Dekaf.MonotonicClock.GetMilliseconds();
+        var result = new List<BrokerConnectionStatus>(_brokers.Count);
+
+        foreach (var broker in _brokers.Values)
+        {
+            var connectionCount = 0;
+            var connectedCount = 0;
+            var pendingRequestCount = 0;
+            var lastSuccessfulRequestTimestampMs = 0L;
+            var lastStateChangeTimestampMs = 0L;
+
+            if (_connectionGroupsById.TryGetValue(broker.BrokerId, out var group))
+            {
+                connectionCount = group.Length;
+                for (var i = 0; i < group.Length; i++)
+                {
+                    AccumulateConnectionStatus(
+                        group[i],
+                        ref connectedCount,
+                        ref pendingRequestCount,
+                        ref lastSuccessfulRequestTimestampMs,
+                        ref lastStateChangeTimestampMs);
+                }
+            }
+            else if (_connectionsById.TryGetValue(broker.BrokerId, out var connection))
+            {
+                connectionCount = 1;
+                AccumulateConnectionStatus(
+                    connection,
+                    ref connectedCount,
+                    ref pendingRequestCount,
+                    ref lastSuccessfulRequestTimestampMs,
+                    ref lastStateChangeTimestampMs);
+            }
+
+            _brokerConnectionRuntimeStates.TryGetValue(broker.BrokerId, out var runtimeState);
+            var lastErrorTimestampMs = runtimeState?.LastErrorTimestampMs ?? 0;
+            lastStateChangeTimestampMs = Math.Max(
+                lastStateChangeTimestampMs,
+                runtimeState?.LastStateChangeTimestampMs ?? 0);
+
+            result.Add(new BrokerConnectionStatus
+            {
+                BrokerId = broker.BrokerId,
+                Host = broker.Host,
+                Port = broker.Port,
+                State = connectedCount == 0
+                    ? BrokerConnectionState.Disconnected
+                    : connectedCount == connectionCount
+                        ? BrokerConnectionState.Connected
+                        : BrokerConnectionState.PartiallyConnected,
+                ConnectionCount = connectionCount,
+                ConnectedConnectionCount = connectedCount,
+                PendingRequestCount = pendingRequestCount,
+                LastSuccessfulRequestAtUtc = ToUtcTimestamp(
+                    lastSuccessfulRequestTimestampMs, capturedAtTimestampMs, capturedAtUtc),
+                LastConnectionStateChangeAtUtc = ToUtcTimestamp(
+                    lastStateChangeTimestampMs, capturedAtTimestampMs, capturedAtUtc),
+                LastErrorAtUtc = ToUtcTimestamp(
+                    lastErrorTimestampMs, capturedAtTimestampMs, capturedAtUtc),
+                LastError = runtimeState?.LastError
+            });
+        }
+
+        result.Sort(static (left, right) => left.BrokerId.CompareTo(right.BrokerId));
+        return result.AsReadOnly();
+    }
+
+    private static void AccumulateConnectionStatus(
+        IKafkaConnection connection,
+        ref int connectedCount,
+        ref int pendingRequestCount,
+        ref long lastSuccessfulRequestTimestampMs,
+        ref long lastStateChangeTimestampMs)
+    {
+        if (connection.IsConnected)
+            connectedCount++;
+
+        if (connection is IIdleTrackedKafkaConnection idleTracked)
+            pendingRequestCount += idleTracked.PendingRequestCount;
+
+        if (connection is not IKafkaConnectionStatusSource statusSource)
+            return;
+
+        lastSuccessfulRequestTimestampMs = Math.Max(
+            lastSuccessfulRequestTimestampMs,
+            statusSource.LastSuccessfulRequestTimestampMs);
+        lastStateChangeTimestampMs = Math.Max(
+            lastStateChangeTimestampMs,
+            statusSource.LastConnectionStateChangeTimestampMs);
+    }
+
+    private static DateTimeOffset? ToUtcTimestamp(
+        long timestampMs,
+        long capturedAtTimestampMs,
+        DateTimeOffset capturedAtUtc)
+    {
+        if (timestampMs <= 0)
+            return null;
+
+        var elapsedMs = Math.Max(capturedAtTimestampMs - timestampMs, 0);
+        return capturedAtUtc - TimeSpan.FromMilliseconds(elapsedMs);
+    }
+
     private void RecordConnectionReapDiagnostic(int brokerId, int connectionIndex, long idleDurationMs)
     {
         lock (_connectionReapDiagnosticsLock)
@@ -2011,6 +2137,9 @@ public sealed partial class ConnectionPool :
 
             LogRemovedConnection(brokerId);
         }
+
+        if (_brokerConnectionRuntimeStates.TryGetValue(brokerId, out var runtimeState))
+            runtimeState.RecordStateChange();
     }
 
     public async ValueTask CloseAllAsync()
@@ -2019,6 +2148,9 @@ public sealed partial class ConnectionPool :
         try
         {
             LogClosingAllConnections();
+
+            foreach (var runtimeState in _brokerConnectionRuntimeStates.Values)
+                runtimeState.RecordStateChange();
 
             var tasks = new List<ValueTask>();
 
@@ -2244,6 +2376,28 @@ public sealed partial class ConnectionPool :
     {
         public readonly object Sync = new();
         public int FailureCount;
+    }
+
+    private sealed class BrokerConnectionRuntimeState(long initialTimestampMs)
+    {
+        private long _lastStateChangeTimestampMs = initialTimestampMs;
+        private long _lastErrorTimestampMs;
+        private string? _lastError;
+
+        public long LastStateChangeTimestampMs => Volatile.Read(ref _lastStateChangeTimestampMs);
+        public long LastErrorTimestampMs => Volatile.Read(ref _lastErrorTimestampMs);
+        public string? LastError => Volatile.Read(ref _lastError);
+
+        public void RecordStateChange() =>
+            Volatile.Write(ref _lastStateChangeTimestampMs, Dekaf.MonotonicClock.GetMilliseconds());
+
+        public void RecordFailure()
+        {
+            var timestampMs = Dekaf.MonotonicClock.GetMilliseconds();
+            Volatile.Write(ref _lastError, "Connection attempt failed.");
+            Volatile.Write(ref _lastErrorTimestampMs, timestampMs);
+            Volatile.Write(ref _lastStateChangeTimestampMs, timestampMs);
+        }
     }
 
     private readonly record struct EndpointKey(string Host, int Port);

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1898,6 +1898,16 @@ public sealed partial class ConnectionPool :
             if (_connectionsByEndpoint.TryGetValue(endpointKey, out var connection))
                 AccumulateConnectionStatus(connection, ref connections);
             _endpointConnectionRuntimeStates.TryGetValue(endpointKey, out var runtimeState);
+            if (endpoint.ConnectionHost is { } connectionHost &&
+                (endpoint.Port != endpoint.ConnectionPort ||
+                 !string.Equals(endpoint.Host, connectionHost, StringComparison.OrdinalIgnoreCase)))
+            {
+                var connectionEndpointKey = new EndpointKey(connectionHost, endpoint.ConnectionPort);
+                if (_connectionsByEndpoint.TryGetValue(connectionEndpointKey, out connection))
+                    AccumulateConnectionStatus(connection, ref connections);
+                if (runtimeState is null)
+                    _endpointConnectionRuntimeStates.TryGetValue(connectionEndpointKey, out runtimeState);
+            }
             result.Add(CreateBrokerConnectionStatus(
                 new BrokerInfo(endpoint.NodeId, endpoint.Host, endpoint.Port),
                 ref connections,

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -616,9 +616,10 @@ public sealed partial class ConnectionPool :
             success = true;
             return connections[0];
         }
-        catch when (!cancellationToken.IsCancellationRequested)
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
         {
-            RecordConnectionAttemptFailure(setupKey, brokerId, brokerInfo.Host, brokerInfo.Port);
+            RecordConnectionAttemptFailure(
+                setupKey, brokerId, brokerInfo.Host, brokerInfo.Port, ex.Message);
             throw;
         }
         finally
@@ -741,13 +742,13 @@ public sealed partial class ConnectionPool :
                     ThrowIfGroupConnectionDisconnected(connection, brokerId);
                 }
             }
-            catch
+            catch (Exception ex)
             {
                 // Close any successfully created connections to avoid leaking TCP handles.
                 await DisposeCompletedTaskConnectionsAsync(tasks).ConfigureAwait(false);
                 if (!cancellationToken.IsCancellationRequested)
                     RecordConnectionAttemptFailure(
-                        setupKey, brokerId, brokerInfo.Host, brokerInfo.Port);
+                        setupKey, brokerId, brokerInfo.Host, brokerInfo.Port, ex.Message);
                 throw;
             }
 
@@ -916,12 +917,14 @@ public sealed partial class ConnectionPool :
                 try { await connection.DisposeAsync().ConfigureAwait(false); }
                 catch { /* best-effort cleanup of a disconnected replacement */ }
 
+                var exception = CreateDisconnectedGroupConnectionException(brokerId);
                 RecordReconnectFailure(
                     new ConnectionSetupKey(brokerId, brokerInfo.Host, brokerInfo.Port),
                     brokerId,
                     brokerInfo.Host,
-                    brokerInfo.Port);
-                throw CreateDisconnectedGroupConnectionException(brokerId);
+                    brokerInfo.Port,
+                    exception.Message);
+                throw exception;
             }
 
             // Acquire _scaleLock to protect the array write against concurrent
@@ -1179,7 +1182,12 @@ public sealed partial class ConnectionPool :
                 try { await connection.DisposeAsync().ConfigureAwait(false); }
                 catch { /* best-effort cleanup */ }
 
-                RecordReconnectFailure(setupKey, brokerId, host, port);
+                RecordReconnectFailure(
+                    setupKey,
+                    brokerId,
+                    host,
+                    port,
+                    "Connection closed during setup.");
             }
 
             throw new InvalidOperationException($"Failed to create connection after {MaxRetries} retries");
@@ -1311,22 +1319,24 @@ public sealed partial class ConnectionPool :
         {
             timeoutCts.Cancel();
             ObserveLateConnectionSetup(connectionTask);
+            var exception = CreateConnectionSetupTimeoutException(timeout, brokerId, host, port);
             if (recordFailure)
-                RecordConnectionAttemptFailure(setupKey, brokerId, host, port);
-            throw CreateConnectionSetupTimeoutException(timeout, brokerId, host, port);
+                RecordConnectionAttemptFailure(setupKey, brokerId, host, port, exception.Message);
+            throw exception;
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !callerCancellationToken.IsCancellationRequested)
         {
             ObserveLateConnectionSetup(connectionTask);
+            var exception = CreateConnectionSetupTimeoutException(timeout, brokerId, host, port);
             if (recordFailure)
-                RecordConnectionAttemptFailure(setupKey, brokerId, host, port);
-            throw CreateConnectionSetupTimeoutException(timeout, brokerId, host, port);
+                RecordConnectionAttemptFailure(setupKey, brokerId, host, port, exception.Message);
+            throw exception;
         }
-        catch (OperationCanceledException) when (operationCancellationToken.IsCancellationRequested && !callerCancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException ex) when (operationCancellationToken.IsCancellationRequested && !callerCancellationToken.IsCancellationRequested)
         {
             ObserveLateConnectionSetup(connectionTask);
             if (recordFailure)
-                RecordConnectionAttemptFailure(setupKey, brokerId, host, port);
+                RecordConnectionAttemptFailure(setupKey, brokerId, host, port, ex.Message);
             throw;
         }
         catch (OperationCanceledException) when (callerCancellationToken.IsCancellationRequested)
@@ -1336,11 +1346,11 @@ public sealed partial class ConnectionPool :
             ObserveLateConnectionSetup(connectionTask, trackDisposal: false);
             throw;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             ObserveLateConnectionSetup(connectionTask);
             if (recordFailure)
-                RecordConnectionAttemptFailure(setupKey, brokerId, host, port);
+                RecordConnectionAttemptFailure(setupKey, brokerId, host, port, ex.Message);
             throw;
         }
     }
@@ -1429,10 +1439,11 @@ public sealed partial class ConnectionPool :
         ConnectionSetupKey setupKey,
         int brokerId,
         string host,
-        int port)
+        int port,
+        string error)
     {
         RecordConnectionSetupFailure(setupKey);
-        RecordReconnectFailure(setupKey, brokerId, host, port);
+        RecordReconnectFailure(setupKey, brokerId, host, port, error);
     }
 
     private void ResetConnectionSetupTimeout(ConnectionSetupKey setupKey)
@@ -1521,14 +1532,19 @@ public sealed partial class ConnectionPool :
         }
     }
 
-    private void RecordReconnectFailure(ConnectionSetupKey setupKey, int brokerId, string host, int port)
+    private void RecordReconnectFailure(
+        ConnectionSetupKey setupKey,
+        int brokerId,
+        string host,
+        int port,
+        string error)
     {
         if (brokerId >= 0)
         {
             _brokerConnectionRuntimeStates.GetOrAdd(
                     brokerId,
                     static _ => new BrokerConnectionRuntimeState(Dekaf.MonotonicClock.GetMilliseconds()))
-                .RecordFailure();
+                .RecordFailure(error);
         }
 
         var state = _reconnectBackoffs.GetOrAdd(setupKey, static _ => new ReconnectBackoffState());
@@ -1819,9 +1835,10 @@ public sealed partial class ConnectionPool :
             var lastSuccessfulRequestTimestampMs = 0L;
             var lastStateChangeTimestampMs = 0L;
 
-            if (_connectionGroupsById.TryGetValue(broker.BrokerId, out var group))
+            _connectionGroupsById.TryGetValue(broker.BrokerId, out var group);
+            if (group is not null)
             {
-                connectionCount = group.Length;
+                connectionCount += group.Length;
                 for (var i = 0; i < group.Length; i++)
                 {
                     AccumulateConnectionStatus(
@@ -1832,9 +1849,10 @@ public sealed partial class ConnectionPool :
                         ref lastStateChangeTimestampMs);
                 }
             }
-            else if (_connectionsById.TryGetValue(broker.BrokerId, out var connection))
+            if (_connectionsById.TryGetValue(broker.BrokerId, out var connection)
+                && !ContainsReference(group, connection))
             {
-                connectionCount = 1;
+                connectionCount++;
                 AccumulateConnectionStatus(
                     connection,
                     ref connectedCount,
@@ -1898,6 +1916,20 @@ public sealed partial class ConnectionPool :
         lastStateChangeTimestampMs = Math.Max(
             lastStateChangeTimestampMs,
             statusSource.LastConnectionStateChangeTimestampMs);
+    }
+
+    private static bool ContainsReference(IKafkaConnection[]? connections, IKafkaConnection candidate)
+    {
+        if (connections is null)
+            return false;
+
+        for (var i = 0; i < connections.Length; i++)
+        {
+            if (ReferenceEquals(connections[i], candidate))
+                return true;
+        }
+
+        return false;
     }
 
     private static DateTimeOffset? ToUtcTimestamp(
@@ -2391,10 +2423,10 @@ public sealed partial class ConnectionPool :
         public void RecordStateChange() =>
             Volatile.Write(ref _lastStateChangeTimestampMs, Dekaf.MonotonicClock.GetMilliseconds());
 
-        public void RecordFailure()
+        public void RecordFailure(string error)
         {
             var timestampMs = Dekaf.MonotonicClock.GetMilliseconds();
-            Volatile.Write(ref _lastError, "Connection attempt failed.");
+            Volatile.Write(ref _lastError, error);
             Volatile.Write(ref _lastErrorTimestampMs, timestampMs);
             Volatile.Write(ref _lastStateChangeTimestampMs, timestampMs);
         }

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -67,10 +67,12 @@ public sealed partial class ConnectionPool :
     private readonly Action<TimeSpan>? _connectionSetupTimeoutObserver;
     private readonly Func<TimeSpan, CancellationToken, ValueTask>? _reconnectBackoffDelay;
     private readonly Func<long>? _timestampProvider;
+    private readonly Func<long> _statusTimestampProvider;
 
     private readonly ConcurrentDictionary<int, BrokerInfo> _brokers = new();
     private int[]? _brokerStatusSnapshot;
     private readonly ConcurrentDictionary<int, BrokerConnectionRuntimeState> _brokerConnectionRuntimeStates = new();
+    private readonly ConcurrentDictionary<EndpointKey, BrokerConnectionRuntimeState> _endpointConnectionRuntimeStates = new();
     private readonly ConcurrentDictionary<EndpointKey, IKafkaConnection> _connectionsByEndpoint = new();
     private readonly ConcurrentDictionary<int, IKafkaConnection> _connectionsById = new();
     // Per-endpoint semaphores to deduplicate concurrent single-connection creation
@@ -139,6 +141,7 @@ public sealed partial class ConnectionPool :
         _telemetryMetricCollector = telemetryMetricCollector;
         _idleReapDrainTimeout = idleReapDrainTimeout ?? DefaultIdleReapDrainTimeout;
         _randomDouble = randomDouble ?? SharedRandomDouble;
+        _statusTimestampProvider = static () => Dekaf.MonotonicClock.GetMilliseconds();
         var bucketCapacity = pipeMemoryBucketCapacity ?? ScaledBucketCapacity(_connectionsPerBroker);
         _sharedPipeMemoryPool = PipeMemoryPool.Create(maxArraysPerBucket: bucketCapacity);
         _currentPipeMemoryBucketCapacity = bucketCapacity;
@@ -159,7 +162,8 @@ public sealed partial class ConnectionPool :
         Action? brokerEndpointUpdated = null,
         Action<TimeSpan>? connectionSetupTimeoutObserver = null,
         Func<TimeSpan, CancellationToken, ValueTask>? reconnectBackoffDelay = null,
-        Func<long>? timestampProvider = null)
+        Func<long>? timestampProvider = null,
+        Func<long>? statusTimestampProvider = null)
     {
         _clientId = clientId;
         _connectionOptions = ConfigureSharedOAuthBearerProvider(
@@ -178,6 +182,8 @@ public sealed partial class ConnectionPool :
         _connectionSetupTimeoutObserver = connectionSetupTimeoutObserver;
         _reconnectBackoffDelay = reconnectBackoffDelay;
         _timestampProvider = timestampProvider;
+        _statusTimestampProvider = statusTimestampProvider ??
+            (static () => Dekaf.MonotonicClock.GetMilliseconds());
         // No shared pool needed: factory-created connections manage their own pools.
         StartIdleConnectionReaper();
     }
@@ -378,9 +384,7 @@ public sealed partial class ConnectionPool :
             break;
         }
 
-        var runtimeState = _brokerConnectionRuntimeStates.GetOrAdd(
-            brokerId,
-            static _ => new BrokerConnectionRuntimeState(Dekaf.MonotonicClock.GetMilliseconds()));
+        var runtimeState = GetBrokerConnectionRuntimeState(brokerId);
         if (endpointChanged)
             runtimeState.RecordStateChange();
 
@@ -803,6 +807,7 @@ public sealed partial class ConnectionPool :
 
             // Atomically swap the connection group
             _connectionGroupsById[brokerId] = shrunkGroup;
+            RecordBrokerConnectionStateChange(brokerId);
 
             // Clean up creation task slot for the removed index.
             // The semaphore is intentionally NOT disposed here: a concurrent
@@ -1541,12 +1546,9 @@ public sealed partial class ConnectionPool :
         string error)
     {
         if (brokerId >= 0)
-        {
-            _brokerConnectionRuntimeStates.GetOrAdd(
-                    brokerId,
-                    static _ => new BrokerConnectionRuntimeState(Dekaf.MonotonicClock.GetMilliseconds()))
-                .RecordFailure(error);
-        }
+            GetBrokerConnectionRuntimeState(brokerId).RecordFailure(error);
+        else
+            GetEndpointConnectionRuntimeState(new EndpointKey(host, port)).RecordFailure(error);
 
         var state = _reconnectBackoffs.GetOrAdd(setupKey, static _ => new ReconnectBackoffState());
 
@@ -1713,10 +1715,29 @@ public sealed partial class ConnectionPool :
     }
 
     private void RecordBrokerConnectionStateChange(int brokerId) =>
-        _brokerConnectionRuntimeStates.GetOrAdd(
-                brokerId,
-                static _ => new BrokerConnectionRuntimeState(Dekaf.MonotonicClock.GetMilliseconds()))
-            .RecordStateChange();
+        GetBrokerConnectionRuntimeState(brokerId).RecordStateChange();
+
+    private BrokerConnectionRuntimeState GetBrokerConnectionRuntimeState(int brokerId)
+    {
+        if (_brokerConnectionRuntimeStates.TryGetValue(brokerId, out var runtimeState))
+            return runtimeState;
+
+        return _brokerConnectionRuntimeStates.GetOrAdd(
+            brokerId,
+            static (_, timestampProvider) => new BrokerConnectionRuntimeState(timestampProvider),
+            _statusTimestampProvider);
+    }
+
+    private BrokerConnectionRuntimeState GetEndpointConnectionRuntimeState(EndpointKey endpoint)
+    {
+        if (_endpointConnectionRuntimeStates.TryGetValue(endpoint, out var runtimeState))
+            return runtimeState;
+
+        return _endpointConnectionRuntimeStates.GetOrAdd(
+            endpoint,
+            static (_, timestampProvider) => new BrokerConnectionRuntimeState(timestampProvider),
+            _statusTimestampProvider);
+    }
 
     private bool IsIdleReapable(IKafkaConnection connection, long now)
     {
@@ -1835,7 +1856,7 @@ public sealed partial class ConnectionPool :
     IReadOnlyList<BrokerConnectionStatus> IConnectionPoolStatusSource.GetBrokerConnectionStatus()
     {
         var capturedAtUtc = DateTimeOffset.UtcNow;
-        var capturedAtTimestampMs = Dekaf.MonotonicClock.GetMilliseconds();
+        var capturedAtTimestampMs = _statusTimestampProvider();
         var brokerIds = Volatile.Read(ref _brokerStatusSnapshot);
         var result = new List<BrokerConnectionStatus>(brokerIds?.Length ?? _brokers.Count);
 
@@ -1867,19 +1888,22 @@ public sealed partial class ConnectionPool :
         IReadOnlyList<ConnectionStatusEndpoint> endpoints)
     {
         var capturedAtUtc = DateTimeOffset.UtcNow;
-        var capturedAtTimestampMs = Dekaf.MonotonicClock.GetMilliseconds();
+        var capturedAtTimestampMs = _statusTimestampProvider();
         var result = new List<BrokerConnectionStatus>(endpoints.Count);
         for (var i = 0; i < endpoints.Count; i++)
         {
             var endpoint = endpoints[i];
+            var endpointKey = new EndpointKey(endpoint.Host, endpoint.Port);
             var connections = default(ConnectionStatusAccumulator);
-            if (_connectionsByEndpoint.TryGetValue(new EndpointKey(endpoint.Host, endpoint.Port), out var connection))
+            if (_connectionsByEndpoint.TryGetValue(endpointKey, out var connection))
                 AccumulateConnectionStatus(connection, ref connections);
+            _endpointConnectionRuntimeStates.TryGetValue(endpointKey, out var runtimeState);
             result.Add(CreateBrokerConnectionStatus(
                 new BrokerInfo(endpoint.NodeId, endpoint.Host, endpoint.Port),
                 ref connections,
                 capturedAtTimestampMs,
-                capturedAtUtc));
+                capturedAtUtc,
+                runtimeState));
         }
 
         result.Sort(static (left, right) => left.BrokerId.CompareTo(right.BrokerId));
@@ -1923,9 +1947,12 @@ public sealed partial class ConnectionPool :
         BrokerInfo broker,
         ref ConnectionStatusAccumulator connections,
         long capturedAtTimestampMs,
-        DateTimeOffset capturedAtUtc)
+        DateTimeOffset capturedAtUtc,
+        BrokerConnectionRuntimeState? runtimeState = null)
     {
-        _brokerConnectionRuntimeStates.TryGetValue(broker.BrokerId, out var runtimeState);
+        runtimeState ??= _brokerConnectionRuntimeStates.TryGetValue(broker.BrokerId, out var brokerRuntimeState)
+            ? brokerRuntimeState
+            : null;
         var lastErrorTimestampMs = runtimeState?.LastErrorTimestampMs ?? 0;
         connections.LastStateChangeTimestampMs = Math.Max(
             connections.LastStateChangeTimestampMs,
@@ -2477,9 +2504,10 @@ public sealed partial class ConnectionPool :
         public int FailureCount;
     }
 
-    private sealed class BrokerConnectionRuntimeState(long initialTimestampMs)
+    private sealed class BrokerConnectionRuntimeState(Func<long> timestampProvider)
     {
-        private long _lastStateChangeTimestampMs = initialTimestampMs;
+        private readonly Func<long> _timestampProvider = timestampProvider;
+        private long _lastStateChangeTimestampMs = timestampProvider();
         private long _lastErrorTimestampMs;
         private string? _lastError;
 
@@ -2488,11 +2516,11 @@ public sealed partial class ConnectionPool :
         public string? LastError => Volatile.Read(ref _lastError);
 
         public void RecordStateChange() =>
-            Volatile.Write(ref _lastStateChangeTimestampMs, Dekaf.MonotonicClock.GetMilliseconds());
+            Volatile.Write(ref _lastStateChangeTimestampMs, _timestampProvider());
 
         public void RecordFailure(string error)
         {
-            var timestampMs = Dekaf.MonotonicClock.GetMilliseconds();
+            var timestampMs = _timestampProvider();
             Volatile.Write(ref _lastError, error);
             Volatile.Write(ref _lastErrorTimestampMs, timestampMs);
         }

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1724,7 +1724,9 @@ public sealed partial class ConnectionPool :
 
         return _brokerConnectionRuntimeStates.GetOrAdd(
             brokerId,
-            static (_, timestampProvider) => new BrokerConnectionRuntimeState(timestampProvider),
+            static (_, timestampProvider) => new BrokerConnectionRuntimeState(
+                timestampProvider,
+                recordInitialState: true),
             _statusTimestampProvider);
     }
 
@@ -1735,7 +1737,9 @@ public sealed partial class ConnectionPool :
 
         return _endpointConnectionRuntimeStates.GetOrAdd(
             endpoint,
-            static (_, timestampProvider) => new BrokerConnectionRuntimeState(timestampProvider),
+            static (_, timestampProvider) => new BrokerConnectionRuntimeState(
+                timestampProvider,
+                recordInitialState: false),
             _statusTimestampProvider);
     }
 
@@ -1898,6 +1902,7 @@ public sealed partial class ConnectionPool :
             if (_connectionsByEndpoint.TryGetValue(endpointKey, out var connection))
                 AccumulateConnectionStatus(connection, ref connections);
             _endpointConnectionRuntimeStates.TryGetValue(endpointKey, out var runtimeState);
+            AccumulateRuntimeState(runtimeState, ref connections);
             if (endpoint.ConnectionHost is { } connectionHost &&
                 (endpoint.Port != endpoint.ConnectionPort ||
                  !string.Equals(endpoint.Host, connectionHost, StringComparison.OrdinalIgnoreCase)))
@@ -1905,8 +1910,13 @@ public sealed partial class ConnectionPool :
                 var connectionEndpointKey = new EndpointKey(connectionHost, endpoint.ConnectionPort);
                 if (_connectionsByEndpoint.TryGetValue(connectionEndpointKey, out connection))
                     AccumulateConnectionStatus(connection, ref connections);
-                if (runtimeState is null)
-                    _endpointConnectionRuntimeStates.TryGetValue(connectionEndpointKey, out runtimeState);
+                _endpointConnectionRuntimeStates.TryGetValue(connectionEndpointKey, out var connectionRuntimeState);
+                AccumulateRuntimeState(connectionRuntimeState, ref connections);
+                if (connectionRuntimeState?.LastErrorTimestampMs >
+                    (runtimeState?.LastErrorTimestampMs ?? 0))
+                {
+                    runtimeState = connectionRuntimeState;
+                }
             }
             result.Add(CreateBrokerConnectionStatus(
                 new BrokerInfo(endpoint.NodeId, endpoint.Host, endpoint.Port),
@@ -2011,6 +2021,18 @@ public sealed partial class ConnectionPool :
         status.LastStateChangeTimestampMs = Math.Max(
             status.LastStateChangeTimestampMs,
             statusSource.LastConnectionStateChangeTimestampMs);
+    }
+
+    private static void AccumulateRuntimeState(
+        BrokerConnectionRuntimeState? runtimeState,
+        ref ConnectionStatusAccumulator status)
+    {
+        if (runtimeState is not null)
+        {
+            status.LastStateChangeTimestampMs = Math.Max(
+                status.LastStateChangeTimestampMs,
+                runtimeState.LastStateChangeTimestampMs);
+        }
     }
 
     private struct ConnectionStatusAccumulator
@@ -2525,10 +2547,12 @@ public sealed partial class ConnectionPool :
         public int FailureCount;
     }
 
-    private sealed class BrokerConnectionRuntimeState(Func<long> timestampProvider)
+    private sealed class BrokerConnectionRuntimeState(
+        Func<long> timestampProvider,
+        bool recordInitialState)
     {
         private readonly Func<long> _timestampProvider = timestampProvider;
-        private long _lastStateChangeTimestampMs = timestampProvider();
+        private long _lastStateChangeTimestampMs = recordInitialState ? timestampProvider() : 0;
         private long _lastErrorTimestampMs;
         private string? _lastError;
 

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1157,6 +1157,7 @@ public sealed partial class ConnectionPool :
                 // Dispose disconnected connection before creating a new one to avoid socket/pipe leaks.
                 if (existing is not null)
                 {
+                    PreserveRemovedConnectionState(existing, brokerId, endpoint);
                     _connectionsByEndpoint.TryRemove(endpoint, out _);
                     if (brokerId >= 0)
                         _connectionsById.TryRemove(brokerId, out _);
@@ -1718,6 +1719,27 @@ public sealed partial class ConnectionPool :
 
     private void RecordBrokerConnectionStateChange(int brokerId) =>
         GetBrokerConnectionRuntimeState(brokerId).RecordStateChange();
+
+    private void PreserveRemovedConnectionState(
+        IKafkaConnection connection,
+        int brokerId,
+        EndpointKey endpoint)
+    {
+        var runtimeState = brokerId >= 0
+            ? GetBrokerConnectionRuntimeState(brokerId)
+            : GetEndpointConnectionRuntimeState(endpoint);
+        if (connection is IKafkaConnectionStatusSource statusSource)
+        {
+            var timestampMs = statusSource.LastConnectionStateChangeTimestampMs;
+            if (timestampMs > 0)
+            {
+                runtimeState.RecordStateChange(timestampMs);
+                return;
+            }
+        }
+
+        runtimeState.RecordStateChange();
+    }
 
     private BrokerConnectionRuntimeState GetBrokerConnectionRuntimeState(int brokerId)
     {
@@ -2576,8 +2598,23 @@ public sealed partial class ConnectionPool :
         public long LastErrorSequence => Volatile.Read(ref _lastErrorSequence);
         public string? LastError => Volatile.Read(ref _lastError);
 
-        public void RecordStateChange() =>
-            Volatile.Write(ref _lastStateChangeTimestampMs, _timestampProvider());
+        public void RecordStateChange() => RecordStateChange(_timestampProvider());
+
+        public void RecordStateChange(long timestampMs)
+        {
+            var current = Volatile.Read(ref _lastStateChangeTimestampMs);
+            while (timestampMs > current)
+            {
+                var observed = Interlocked.CompareExchange(
+                    ref _lastStateChangeTimestampMs,
+                    timestampMs,
+                    current);
+                if (observed == current)
+                    return;
+
+                current = observed;
+            }
+        }
 
         public void RecordFailure(string error, long sequence)
         {

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -807,6 +807,7 @@ public sealed partial class ConnectionPool :
             Array.Copy(currentGroup, shrunkGroup, shrunkGroup.Length);
 
             // Atomically swap the connection group
+            PreserveSuccessfulRequest(removedConnection, brokerId);
             _connectionGroupsById[brokerId] = shrunkGroup;
             RecordBrokerConnectionStateChange(brokerId);
 
@@ -1711,7 +1712,10 @@ public sealed partial class ConnectionPool :
         if (!result.Reaped && result.CanRestore && connection.IsConnected)
             Interlocked.CompareExchange(ref group[index], connection, null!);
         else if (result.Reaped)
+        {
+            PreserveSuccessfulRequest(connection, brokerId);
             RecordBrokerConnectionStateChange(brokerId);
+        }
 
         return result.Reaped;
     }

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1829,42 +1829,24 @@ public sealed partial class ConnectionPool :
 
         foreach (var broker in _brokers.Values)
         {
-            var connectionCount = 0;
-            var connectedCount = 0;
-            var pendingRequestCount = 0;
-            var lastSuccessfulRequestTimestampMs = 0L;
-            var lastStateChangeTimestampMs = 0L;
+            var connections = default(ConnectionStatusAccumulator);
 
             _connectionGroupsById.TryGetValue(broker.BrokerId, out var group);
             if (group is not null)
             {
-                connectionCount += group.Length;
                 for (var i = 0; i < group.Length; i++)
-                {
-                    AccumulateConnectionStatus(
-                        group[i],
-                        ref connectedCount,
-                        ref pendingRequestCount,
-                        ref lastSuccessfulRequestTimestampMs,
-                        ref lastStateChangeTimestampMs);
-                }
+                    AccumulateConnectionStatus(group[i], ref connections);
             }
             if (_connectionsById.TryGetValue(broker.BrokerId, out var connection)
                 && !ContainsReference(group, connection))
             {
-                connectionCount++;
-                AccumulateConnectionStatus(
-                    connection,
-                    ref connectedCount,
-                    ref pendingRequestCount,
-                    ref lastSuccessfulRequestTimestampMs,
-                    ref lastStateChangeTimestampMs);
+                AccumulateConnectionStatus(connection, ref connections);
             }
 
             _brokerConnectionRuntimeStates.TryGetValue(broker.BrokerId, out var runtimeState);
             var lastErrorTimestampMs = runtimeState?.LastErrorTimestampMs ?? 0;
-            lastStateChangeTimestampMs = Math.Max(
-                lastStateChangeTimestampMs,
+            connections.LastStateChangeTimestampMs = Math.Max(
+                connections.LastStateChangeTimestampMs,
                 runtimeState?.LastStateChangeTimestampMs ?? 0);
 
             result.Add(new BrokerConnectionStatus
@@ -1872,18 +1854,18 @@ public sealed partial class ConnectionPool :
                 BrokerId = broker.BrokerId,
                 Host = broker.Host,
                 Port = broker.Port,
-                State = connectedCount == 0
+                State = connections.ConnectedCount == 0
                     ? BrokerConnectionState.Disconnected
-                    : connectedCount == connectionCount
+                    : connections.ConnectedCount == connections.ConnectionCount
                         ? BrokerConnectionState.Connected
                         : BrokerConnectionState.PartiallyConnected,
-                ConnectionCount = connectionCount,
-                ConnectedConnectionCount = connectedCount,
-                PendingRequestCount = pendingRequestCount,
+                ConnectionCount = connections.ConnectionCount,
+                ConnectedConnectionCount = connections.ConnectedCount,
+                PendingRequestCount = connections.PendingRequestCount,
                 LastSuccessfulRequestAtUtc = ToUtcTimestamp(
-                    lastSuccessfulRequestTimestampMs, capturedAtTimestampMs, capturedAtUtc),
+                    connections.LastSuccessfulRequestTimestampMs, capturedAtTimestampMs, capturedAtUtc),
                 LastConnectionStateChangeAtUtc = ToUtcTimestamp(
-                    lastStateChangeTimestampMs, capturedAtTimestampMs, capturedAtUtc),
+                    connections.LastStateChangeTimestampMs, capturedAtTimestampMs, capturedAtUtc),
                 LastErrorAtUtc = ToUtcTimestamp(
                     lastErrorTimestampMs, capturedAtTimestampMs, capturedAtUtc),
                 LastError = runtimeState?.LastError
@@ -1896,26 +1878,33 @@ public sealed partial class ConnectionPool :
 
     private static void AccumulateConnectionStatus(
         IKafkaConnection connection,
-        ref int connectedCount,
-        ref int pendingRequestCount,
-        ref long lastSuccessfulRequestTimestampMs,
-        ref long lastStateChangeTimestampMs)
+        ref ConnectionStatusAccumulator status)
     {
+        status.ConnectionCount++;
         if (connection.IsConnected)
-            connectedCount++;
+            status.ConnectedCount++;
 
         if (connection is IIdleTrackedKafkaConnection idleTracked)
-            pendingRequestCount += idleTracked.PendingRequestCount;
+            status.PendingRequestCount += idleTracked.PendingRequestCount;
 
         if (connection is not IKafkaConnectionStatusSource statusSource)
             return;
 
-        lastSuccessfulRequestTimestampMs = Math.Max(
-            lastSuccessfulRequestTimestampMs,
+        status.LastSuccessfulRequestTimestampMs = Math.Max(
+            status.LastSuccessfulRequestTimestampMs,
             statusSource.LastSuccessfulRequestTimestampMs);
-        lastStateChangeTimestampMs = Math.Max(
-            lastStateChangeTimestampMs,
+        status.LastStateChangeTimestampMs = Math.Max(
+            status.LastStateChangeTimestampMs,
             statusSource.LastConnectionStateChangeTimestampMs);
+    }
+
+    private struct ConnectionStatusAccumulator
+    {
+        public int ConnectionCount;
+        public int ConnectedCount;
+        public int PendingRequestCount;
+        public long LastSuccessfulRequestTimestampMs;
+        public long LastStateChangeTimestampMs;
     }
 
     private static bool ContainsReference(IKafkaConnection[]? connections, IKafkaConnection candidate)

--- a/src/Dekaf/Networking/IConnectionPool.cs
+++ b/src/Dekaf/Networking/IConnectionPool.cs
@@ -78,6 +78,8 @@ internal interface IConnectionPoolStatusSource
     IReadOnlyList<Diagnostics.BrokerConnectionStatus> GetEndpointConnectionStatus(
         IReadOnlyList<ConnectionStatusEndpoint> endpoints);
 
+    bool ContainsEndpointConnection(string host, int port);
+
     void UpdateBrokerStatusSnapshot(int[] brokerIds);
 }
 

--- a/src/Dekaf/Networking/IConnectionPool.cs
+++ b/src/Dekaf/Networking/IConnectionPool.cs
@@ -81,7 +81,12 @@ internal interface IConnectionPoolStatusSource
     void UpdateBrokerStatusSnapshot(int[] brokerIds);
 }
 
-internal readonly record struct ConnectionStatusEndpoint(int NodeId, string Host, int Port);
+internal readonly record struct ConnectionStatusEndpoint(
+    int NodeId,
+    string Host,
+    int Port,
+    string? ConnectionHost = null,
+    int ConnectionPort = 0);
 
 internal interface IConnectionCapabilityObserverPool
 {

--- a/src/Dekaf/Networking/IConnectionPool.cs
+++ b/src/Dekaf/Networking/IConnectionPool.cs
@@ -71,6 +71,11 @@ internal interface IConnectionPoolDiagnostics
     int GetMaxObservedBrokerThrottleTimeMs();
 }
 
+internal interface IConnectionPoolStatusSource
+{
+    IReadOnlyList<Diagnostics.BrokerConnectionStatus> GetBrokerConnectionStatus();
+}
+
 internal interface IConnectionCapabilityObserverPool
 {
     void SetConnectionCapabilityObserver(Action<KafkaConnectionCapabilities> observer);

--- a/src/Dekaf/Networking/IConnectionPool.cs
+++ b/src/Dekaf/Networking/IConnectionPool.cs
@@ -85,8 +85,9 @@ internal readonly record struct ConnectionStatusEndpoint(
     int NodeId,
     string Host,
     int Port,
-    string? ConnectionHost = null,
-    int ConnectionPort = 0);
+    IReadOnlyList<ConnectionStatusEndpointAlias>? ConnectionAliases = null);
+
+internal readonly record struct ConnectionStatusEndpointAlias(string Host, int Port);
 
 internal interface IConnectionCapabilityObserverPool
 {

--- a/src/Dekaf/Networking/IConnectionPool.cs
+++ b/src/Dekaf/Networking/IConnectionPool.cs
@@ -75,8 +75,13 @@ internal interface IConnectionPoolStatusSource
 {
     IReadOnlyList<Diagnostics.BrokerConnectionStatus> GetBrokerConnectionStatus();
 
+    IReadOnlyList<Diagnostics.BrokerConnectionStatus> GetEndpointConnectionStatus(
+        IReadOnlyList<ConnectionStatusEndpoint> endpoints);
+
     void UpdateBrokerStatusSnapshot(int[] brokerIds);
 }
+
+internal readonly record struct ConnectionStatusEndpoint(int NodeId, string Host, int Port);
 
 internal interface IConnectionCapabilityObserverPool
 {

--- a/src/Dekaf/Networking/IConnectionPool.cs
+++ b/src/Dekaf/Networking/IConnectionPool.cs
@@ -74,6 +74,8 @@ internal interface IConnectionPoolDiagnostics
 internal interface IConnectionPoolStatusSource
 {
     IReadOnlyList<Diagnostics.BrokerConnectionStatus> GetBrokerConnectionStatus();
+
+    void UpdateBrokerStatusSnapshot(int[] brokerIds);
 }
 
 internal interface IConnectionCapabilityObserverPool

--- a/src/Dekaf/Networking/IIdleTrackedKafkaConnection.cs
+++ b/src/Dekaf/Networking/IIdleTrackedKafkaConnection.cs
@@ -8,3 +8,10 @@ internal interface IIdleTrackedKafkaConnection
 
     void Touch();
 }
+
+internal interface IKafkaConnectionStatusSource
+{
+    long LastSuccessfulRequestTimestampMs { get; }
+
+    long LastConnectionStateChangeTimestampMs { get; }
+}

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -79,6 +79,7 @@ public sealed partial class KafkaConnection :
     IKafkaConnection,
     IKafkaCapabilityProvider,
     IIdleTrackedKafkaConnection,
+    IKafkaConnectionStatusSource,
     IRetirableKafkaConnection,
     IKafkaPipelinedWriteCompletionConnection,
     IKafkaRequestWriteObserverConnection
@@ -168,6 +169,8 @@ public sealed partial class KafkaConnection :
     private readonly Action<KafkaConnectionCapabilities>? _capabilitiesObserver;
     private bool _hasReceivedResponse;
     private long _lastUsedTimestampMs = Dekaf.MonotonicClock.GetMilliseconds();
+    private long _lastSuccessfulRequestTimestampMs;
+    private long _lastConnectionStateChangeTimestampMs = Dekaf.MonotonicClock.GetMilliseconds();
     private readonly SemaphoreSlim _connectLock = new(1, 1);
 
     // SASL re-authentication (KIP-368)
@@ -195,6 +198,12 @@ public sealed partial class KafkaConnection :
     int IIdleTrackedKafkaConnection.PendingRequestCount => GetPendingRequestCount();
 
     void IIdleTrackedKafkaConnection.Touch() => Touch();
+
+    long IKafkaConnectionStatusSource.LastSuccessfulRequestTimestampMs =>
+        Volatile.Read(ref _lastSuccessfulRequestTimestampMs);
+
+    long IKafkaConnectionStatusSource.LastConnectionStateChangeTimestampMs =>
+        Volatile.Read(ref _lastConnectionStateChangeTimestampMs);
 
     int IRetirableKafkaConnection.LeaseCount => Volatile.Read(ref _leaseCount);
 
@@ -509,7 +518,9 @@ public sealed partial class KafkaConnection :
         _capabilitiesObserver?.Invoke(capabilities);
         Volatile.Write(ref _capabilities, capabilities);
 
-        Touch();
+        var connectedTimestampMs = Dekaf.MonotonicClock.GetMilliseconds();
+        Touch(connectedTimestampMs);
+        Volatile.Write(ref _lastConnectionStateChangeTimestampMs, connectedTimestampMs);
         Volatile.Write(ref _connected, 1);
         _telemetryMetricCollector?.RecordConnectionCreated();
 
@@ -691,7 +702,7 @@ public sealed partial class KafkaConnection :
             // Response phase: await response with timeout and parse
             var response = await AwaitAndParseResponseAsync<TRequest, TResponse>(
                 pending, correlationId, apiVersion, callerOwnsTimeout: false, cancellationToken).ConfigureAwait(false);
-            Touch();
+            TouchSuccessful();
             _telemetryMetricCollector?.RecordRequestLatency(BrokerId, telemetryStartTimestamp);
             return response;
         }
@@ -883,7 +894,7 @@ public sealed partial class KafkaConnection :
         await PreSerializeAndWriteAsync<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion, cancellationToken, callerOwnsTimeout)
             .ConfigureAwait(false);
 
-        Touch();
+        TouchSuccessful();
         LogFireAndForgetRequestSent(correlationId);
     }
 
@@ -1236,7 +1247,7 @@ public sealed partial class KafkaConnection :
                     pending.TakeResponseMemoryReservation());
                 connection.ObserveBrokerThrottle<TRequest, TResponse>(response, _apiVersion);
 
-                connection.Touch();
+                connection.TouchSuccessful();
                 connection._telemetryMetricCollector?.RecordRequestLatency(
                     connection.BrokerId,
                     _telemetryStartTimestamp);
@@ -2561,7 +2572,13 @@ public sealed partial class KafkaConnection :
 
     private void MarkDisposed()
     {
-        Volatile.Write(ref _disposed, 1);
+        if (Interlocked.Exchange(ref _disposed, 1) == 0)
+        {
+            Volatile.Write(
+                ref _lastConnectionStateChangeTimestampMs,
+                Dekaf.MonotonicClock.GetMilliseconds());
+        }
+
         DisarmReceiveTimeout();
         CancelPendingRequestSlotWaiters();
     }
@@ -2855,7 +2872,16 @@ public sealed partial class KafkaConnection :
     private long GetReceiveTimeoutDeadlineTimestamp()
         => Stopwatch.GetTimestamp() + _receiveTimeoutStopwatchTicks;
 
-    private void Touch() => Volatile.Write(ref _lastUsedTimestampMs, Dekaf.MonotonicClock.GetMilliseconds());
+    private void Touch() => Touch(Dekaf.MonotonicClock.GetMilliseconds());
+
+    private void Touch(long timestampMs) => Volatile.Write(ref _lastUsedTimestampMs, timestampMs);
+
+    private void TouchSuccessful()
+    {
+        var timestampMs = Dekaf.MonotonicClock.GetMilliseconds();
+        Volatile.Write(ref _lastUsedTimestampMs, timestampMs);
+        Volatile.Write(ref _lastSuccessfulRequestTimestampMs, timestampMs);
+    }
 
     /// <summary>
     /// After adding a pending request, double-check that the connection hasn't been disposed.

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -655,7 +655,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             {
                 // A preparer that throws synchronously must still stop and tag the started span,
                 // matching the invariant AwaitWithActivity enforces on every other completion path.
-                RecordActivityFault(activity, ex);
+                RecordActivityFault(activity, message.Headers, ex);
                 throw;
             }
 
@@ -676,8 +676,9 @@ public sealed partial class KafkaProducer<TKey, TValue> :
     // Stops and error-tags a started span when async serializer preparation fails before the
     // message is appended. ProduceAfterPrepare owns the activity on all post-preparation paths,
     // so this only runs when preparation itself throws or faults. No-op when tracing is disabled.
-    private static void RecordActivityFault(Activity? activity, Exception ex)
+    private static void RecordActivityFault(Activity? activity, Headers? headers, Exception ex)
     {
+        headers?.RemoveDeferredTraceContext();
         if (activity is null)
         {
             return;
@@ -745,7 +746,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         {
             // Preparation faulted (e.g. Schema Registry unreachable or cancelled mid-fetch) before the
             // message was appended. Stop and error-tag the span here; ProduceAfterPrepare never runs.
-            RecordActivityFault(activity, ex);
+            RecordActivityFault(activity, message.Headers, ex);
             throw;
         }
 
@@ -1264,6 +1265,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             {
                 // BufferMemory backpressure timeout must propagate
                 if (activity is not null) Diagnostics.DekafDiagnostics.RecordException(activity, ex);
+                message.Headers?.RemoveDeferredTraceContext();
                 activity?.Dispose();
                 throw;
             }
@@ -1271,6 +1273,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             {
                 // Fire-and-forget: swallow exception but log
                 LogFireAndForgetProduceFailed(ex, message.Topic);
+                message.Headers?.RemoveDeferredTraceContext();
                 activity?.Dispose();
                 return default;
             }
@@ -1560,6 +1563,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         catch (Exception ex)
         {
             RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray, headerCount);
+            headers?.RemoveDeferredTraceContext();
             customPartitionerKey.Return();
             customPartitionerValue.Return();
             if (ex is not ObjectDisposedException)
@@ -1848,6 +1852,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             key.Return();
             value.Return();
             RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray, headerCount);
+            message.Headers?.RemoveDeferredTraceContext();
             throw;
         }
     }
@@ -4482,6 +4487,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         }
         finally
         {
+            message.Headers?.RemoveDeferredTraceContext();
             activity?.Dispose();
         }
     }
@@ -5120,6 +5126,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         }
         finally
         {
+            message.Headers?.RemoveDeferredTraceContext();
             activity?.Dispose();
         }
     }
@@ -5223,6 +5230,8 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         // Use index-based iteration to avoid enumerator boxing allocation
         for (var i = 0; i < count; i++)
             result[i] = headers[i];
+
+        headers.RemoveDeferredTraceContext();
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1434,6 +1434,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         CancellationToken cancellationToken)
     {
         Header[]? pooledHeaderArray = null;
+        var headerCount = 0;
         var customPartitionerKey = PooledMemory.Null;
         var customPartitionerValue = PooledMemory.Null;
 
@@ -1501,7 +1502,6 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             var timestampMs = timestamp?.ToUnixTimeMilliseconds() ?? GetFastTimestampMs();
 
             // Convert headers
-            var headerCount = 0;
             if (headers is not null && headers.Count > 0)
             {
                 RentAndFillHeaders(headers, out pooledHeaderArray, out headerCount);
@@ -1559,7 +1559,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         }
         catch (Exception ex)
         {
-            RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray);
+            RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray, headerCount);
             customPartitionerKey.Return();
             customPartitionerValue.Return();
             if (ex is not ObjectDisposedException)
@@ -1790,6 +1790,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         var key = PooledMemory.Null;
         var value = PooledMemory.Null;
         Header[]? pooledHeaderArray = null;
+        var headerCount = 0;
         try
         {
             if (!keyIsNull)
@@ -1821,7 +1822,6 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             var timestampMs = timestamp.ToUnixTimeMilliseconds();
 
             // Convert headers with minimal allocations
-            var headerCount = 0;
             if (message.Headers is not null && message.Headers.Count > 0)
             {
                 RentAndFillHeaders(message.Headers, out pooledHeaderArray, out headerCount);
@@ -1847,7 +1847,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             // must return them here.
             key.Return();
             value.Return();
-            RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray);
+            RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray, headerCount);
             throw;
         }
     }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -24,7 +24,12 @@ namespace Dekaf.Producer;
 /// </summary>
 /// <typeparam name="TKey">Key type.</typeparam>
 /// <typeparam name="TValue">Value type.</typeparam>
-public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, TValue>, IProducerDiagnostics, IProducerFastPath<TKey, TValue>, IBudgetedInstance
+public sealed partial class KafkaProducer<TKey, TValue> :
+    IKafkaProducer<TKey, TValue>,
+    IKafkaClientStatusProvider,
+    IProducerDiagnostics,
+    IProducerFastPath<TKey, TValue>,
+    IBudgetedInstance
 {
     internal ValueTask CloseConnectionsForTestingAsync() => _connectionPool.CloseAllAsync();
 
@@ -92,6 +97,23 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private int _disposed;
 
     internal bool IsDisposed => Volatile.Read(ref _disposed) != 0;
+
+    /// <inheritdoc />
+    public string? ClusterId => _metadataManager.ClusterId;
+
+    /// <inheritdoc />
+    public KafkaClientStatus GetStatus() => KafkaClientStatusFactory.Capture(
+        KafkaClientRole.Producer,
+        _connectionPool,
+        _metadataManager,
+        Volatile.Read(ref _disposed) != 0,
+        producer: new ProducerBacklogStatus(
+            _accumulator.BufferedBytes,
+            _accumulator.MaxBufferMemory,
+            _accumulator.UnsealedBatchCount,
+            _accumulator.DispatchQueuedBatchCount,
+            _accumulator.InFlightBatchCount,
+            _accumulator.BufferPressureEvents));
 
     // Idempotent / transaction state
     // Memory ordering: _idempotentInitialized is volatile (acquire/release semantics).
@@ -1616,6 +1638,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingDestinationName, message.Topic);
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingOperationName, Diagnostics.DekafDiagnostics.OperationNameSend);
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingOperationType, Diagnostics.DekafDiagnostics.OperationTypeSend);
+            var clusterId = _metadataManager.ClusterId;
+            if (clusterId is not null)
+                activity.SetTag(Diagnostics.DekafDiagnostics.MessagingKafkaClusterId, clusterId);
             if (_options.ClientId is not null)
                 activity.SetTag(Diagnostics.DekafDiagnostics.MessagingClientId, _options.ClientId);
             if (message.Key is string stringKey)

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -5217,7 +5217,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
     /// Assumes headers is non-null and non-empty; callers must guard before invoking.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void RentAndFillHeaders(Headers headers, out Header[] pooledArray, out int headerCount)
+    internal static void RentAndFillHeaders(Headers headers, out Header[] pooledArray, out int headerCount)
     {
         var count = headers.Count;
         headerCount = count;

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -5222,15 +5222,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
 
         // Use index-based iteration to avoid enumerator boxing allocation
         for (var i = 0; i < count; i++)
-        {
-            var h = headers[i];
-            result[i] = new Header
-            {
-                Key = h.Key,
-                Value = h.Value,
-                IsValueNull = h.IsValueNull
-            };
-        }
+            result[i] = headers[i];
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -220,7 +220,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         // Clean up owned resources since drain will not process this operation
         _key.Return();
         _value.Return();
-        RecordAccumulator.ReturnPooledHeaders(_headers);
+        RecordAccumulator.ReturnPooledHeaders(_headers, _headerCount);
 
         _core.SetException(exception);
         return true;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3016,14 +3016,31 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         workItem.Key.Return();
         workItem.Value.Return();
-        ReturnPooledHeaders(workItem.Headers);
+        ReturnPooledHeaders(workItem.Headers, workItem.HeaderCount);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void ReturnPooledHeaders(Header[]? headers)
+    internal static void ReturnPooledHeaders(Header[]? headers, int headerCount)
     {
-        if (headers is not null)
-            ProducerContainerPools.Headers.Return(headers);
+        if (headers is null)
+            return;
+
+        // Trace injection appends traceparent followed only by optional tracestate. Clear the
+        // deferred Activity from that known slot without scanning or clearing the rented array.
+        var lastHeaderIndex = headerCount - 1;
+        if ((uint)lastHeaderIndex < (uint)headers.Length)
+        {
+            if (headers[lastHeaderIndex].HasDeferredTraceparent)
+            {
+                headers[lastHeaderIndex] = default;
+            }
+            else if (lastHeaderIndex > 0 && headers[lastHeaderIndex - 1].HasDeferredTraceparent)
+            {
+                headers[lastHeaderIndex - 1] = default;
+            }
+        }
+
+        ProducerContainerPools.Headers.Return(headers);
     }
 
     /// <summary>
@@ -3102,7 +3119,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             // throw (disposal race in worker startup) leaves ownership here.
             key.Return();
             value.Return();
-            ReturnPooledHeaders(headers);
+            ReturnPooledHeaders(headers, headerCount);
             throw;
         }
     }
@@ -3399,7 +3416,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             key.Return();
             value.Return();
-            ReturnPooledHeaders(headers);
+            ReturnPooledHeaders(headers, headerCount);
             throw;
         }
 
@@ -3471,7 +3488,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             {
                 key.Return();
                 value.Return();
-                ReturnPooledHeaders(headers);
+                ReturnPooledHeaders(headers, headerCount);
                 ownsRecordResources = false;
             }
         }
@@ -3716,7 +3733,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             key.Return();
             value.Return();
-            ReturnPooledHeaders(headers);
+            ReturnPooledHeaders(headers, headerCount);
             return new ValueTask<bool>(Task.FromException<bool>(new ObjectDisposedException(nameof(RecordAccumulator))));
         }
 
@@ -3724,7 +3741,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             key.Return();
             value.Return();
-            ReturnPooledHeaders(headers);
+            ReturnPooledHeaders(headers, headerCount);
             return new ValueTask<bool>(Task.FromException<bool>(new OperationCanceledException(cancellationToken)));
         }
 
@@ -3802,7 +3819,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             key.Return();
             value.Return();
-            ReturnPooledHeaders(headers);
+            ReturnPooledHeaders(headers, headerCount);
             throw;
         }
 
@@ -3928,7 +3945,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             }
             if (ownsHeaderResources)
             {
-                ReturnPooledHeaders(headers);
+                ReturnPooledHeaders(headers, headerCount);
                 ownsHeaderResources = false;
             }
         }
@@ -4106,6 +4123,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                      completionSource,
                                      callback,
                                      headers,
+                                     headerCount,
                                      recordSize);
                                 drainPendingAfterAppend = CommitAdmissionReservationUnderLock(
                                     reservedAppendBatch,
@@ -4289,7 +4307,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
         catch
         {
-            ReturnPooledHeaders(headers);
+            ReturnPooledHeaders(headers, headerCount);
             throw;
         }
 
@@ -7956,7 +7974,7 @@ internal sealed class PartitionBatch
         {
             key.Return();
             value.Return();
-            RecordAccumulator.ReturnPooledHeaders(headers);
+            RecordAccumulator.ReturnPooledHeaders(headers, headerCount);
         }
 
         return result;
@@ -8009,7 +8027,13 @@ internal sealed class PartitionBatch
                 throw;
             }
 
-            CommitReservedAppendFromSpans(reservedAppend, completionSource, callback, headers, estimatedSize);
+            CommitReservedAppendFromSpans(
+                reservedAppend,
+                completionSource,
+                callback,
+                headers,
+                headerCount,
+                estimatedSize);
         }
 
         return result;
@@ -8268,10 +8292,11 @@ internal sealed class PartitionBatch
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
         Header[]? headers,
+        int headerCount,
         int estimatedSize)
     {
         CommitReservedAppend(reservedAppend, completionSource, callback, estimatedSize);
-        RecordAccumulator.ReturnPooledHeaders(headers);
+        RecordAccumulator.ReturnPooledHeaders(headers, headerCount);
     }
 
     private void CommitReservedAppend(

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3025,8 +3025,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (headers is null)
             return;
 
-        // Trace injection appends traceparent followed only by optional tracestate. Clear the
-        // deferred Activity from that known slot without scanning or clearing the rented array.
+        // Headers keeps deferred tracing headers at the tail so cleanup remains O(1) without
+        // clearing every live element in the rented array.
         var lastHeaderIndex = headerCount - 1;
         if ((uint)lastHeaderIndex < (uint)headers.Length)
         {

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -11,3 +11,108 @@ Dekaf.Consumer.KafkaConsumer<TKey, TValue>.StoreOffsets<TOffsets>(TOffsets offse
 static Dekaf.Consumer.ConsumerOffsetStoreExtensions.StoreOffsets<TKey, TValue>(this Dekaf.Consumer.IKafkaConsumer<TKey, TValue>! consumer, Dekaf.TopicPartitionOffset[]! offsets) -> void
 static Dekaf.Consumer.ConsumerOffsetStoreExtensions.StoreOffsets<TKey, TValue>(this Dekaf.Consumer.IKafkaConsumer<TKey, TValue>! consumer, System.ReadOnlySpan<Dekaf.TopicPartitionOffset> offsets) -> void
 static Dekaf.Consumer.ConsumerOffsetStoreExtensions.StoreOffsets<TKey, TValue, TOffsets>(this Dekaf.Consumer.IKafkaConsumer<TKey, TValue>! consumer, TOffsets offsets) -> void
+Dekaf.Diagnostics.IKafkaClientIdentity
+Dekaf.Diagnostics.IKafkaClientStatusProvider
+Dekaf.Diagnostics.KafkaClientRole
+Dekaf.Diagnostics.BrokerConnectionState.Disconnected = 0 -> Dekaf.Diagnostics.BrokerConnectionState
+Dekaf.Diagnostics.BrokerConnectionState.PartiallyConnected = 1 -> Dekaf.Diagnostics.BrokerConnectionState
+Dekaf.Diagnostics.BrokerConnectionState
+Dekaf.Diagnostics.BrokerConnectionState.Connected = 2 -> Dekaf.Diagnostics.BrokerConnectionState
+Dekaf.Diagnostics.KafkaClientRole.Producer = 0 -> Dekaf.Diagnostics.KafkaClientRole
+Dekaf.Diagnostics.KafkaClientStatus
+Dekaf.Diagnostics.KafkaClientStatus.KafkaClientStatus() -> void
+Dekaf.Diagnostics.BrokerConnectionStatus
+Dekaf.Diagnostics.BrokerConnectionStatus.BrokerConnectionStatus() -> void
+Dekaf.Diagnostics.KafkaClientRole.Admin = 3 -> Dekaf.Diagnostics.KafkaClientRole
+Dekaf.Diagnostics.KafkaClientRole.ShareConsumer = 2 -> Dekaf.Diagnostics.KafkaClientRole
+Dekaf.Diagnostics.KafkaClientRole.Consumer = 1 -> Dekaf.Diagnostics.KafkaClientRole
+Dekaf.Diagnostics.ProducerBacklogStatus
+Dekaf.Diagnostics.ProducerBacklogStatus.ProducerBacklogStatus() -> void
+~override Dekaf.Diagnostics.ProducerBacklogStatus.ToString() -> string
+static Dekaf.Diagnostics.ProducerBacklogStatus.operator !=(Dekaf.Diagnostics.ProducerBacklogStatus left, Dekaf.Diagnostics.ProducerBacklogStatus right) -> bool
+static Dekaf.Diagnostics.ProducerBacklogStatus.operator ==(Dekaf.Diagnostics.ProducerBacklogStatus left, Dekaf.Diagnostics.ProducerBacklogStatus right) -> bool
+override Dekaf.Diagnostics.ProducerBacklogStatus.GetHashCode() -> int
+~override Dekaf.Diagnostics.ProducerBacklogStatus.Equals(object obj) -> bool
+Dekaf.Diagnostics.ProducerBacklogStatus.Equals(Dekaf.Diagnostics.ProducerBacklogStatus other) -> bool
+Dekaf.Diagnostics.ProducerBacklogStatus.Deconstruct(out long BufferedBytes, out ulong BufferCapacityBytes, out int UnsealedBatchCount, out long QueuedBatchCount, out long InFlightBatchCount, out long BufferPressureEventCount) -> void
+Dekaf.Diagnostics.ProducerBacklogStatus.BufferedBytes.get -> long
+Dekaf.Diagnostics.ProducerBacklogStatus.BufferedBytes.init -> void
+Dekaf.Diagnostics.ProducerBacklogStatus.BufferCapacityBytes.get -> ulong
+Dekaf.Diagnostics.ProducerBacklogStatus.BufferCapacityBytes.init -> void
+Dekaf.Diagnostics.ProducerBacklogStatus.UnsealedBatchCount.get -> int
+Dekaf.Diagnostics.ProducerBacklogStatus.UnsealedBatchCount.init -> void
+Dekaf.Diagnostics.ProducerBacklogStatus.QueuedBatchCount.get -> long
+Dekaf.Diagnostics.ProducerBacklogStatus.QueuedBatchCount.init -> void
+Dekaf.Diagnostics.ProducerBacklogStatus.InFlightBatchCount.get -> long
+Dekaf.Diagnostics.ProducerBacklogStatus.BufferPressureEventCount.get -> long
+Dekaf.Diagnostics.ProducerBacklogStatus.InFlightBatchCount.init -> void
+Dekaf.Diagnostics.ProducerBacklogStatus.BufferPressureEventCount.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus
+Dekaf.Diagnostics.ConsumerGroupStatus.ConsumerGroupStatus() -> void
+Dekaf.Admin.AdminClient.ClusterId.get -> string?
+Dekaf.Admin.AdminClient.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!
+Dekaf.Diagnostics.ConsumerGroupStatus.HasConsumerGroup.get -> bool
+Dekaf.Diagnostics.ConsumerGroupStatus.HasConsumerGroup.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.State.get -> Dekaf.Consumer.CoordinatorState
+Dekaf.Diagnostics.ConsumerGroupStatus.State.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.CoordinatorId.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.CoordinatorId.get -> int
+Dekaf.Diagnostics.ConsumerGroupStatus.MemberId.get -> string?
+Dekaf.Diagnostics.ConsumerGroupStatus.GenerationOrMemberEpoch.get -> int
+Dekaf.Diagnostics.ConsumerGroupStatus.MemberId.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.GenerationOrMemberEpoch.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.HeartbeatInterval.get -> System.TimeSpan
+Dekaf.Diagnostics.ConsumerGroupStatus.HeartbeatInterval.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.TimeSinceLastHeartbeat.get -> System.TimeSpan?
+Dekaf.Diagnostics.ConsumerGroupStatus.TimeSinceLastHeartbeat.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.LastHeartbeatFailure.get -> string?
+Dekaf.Diagnostics.ConsumerGroupStatus.LastHeartbeatFailure.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.Assignment.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.Assignment.get -> System.Collections.Generic.IReadOnlyList<Dekaf.TopicPartition>!
+Dekaf.Diagnostics.ProducerBacklogStatus.ProducerBacklogStatus(long BufferedBytes, ulong BufferCapacityBytes, int UnsealedBatchCount, long QueuedBatchCount, long InFlightBatchCount, long BufferPressureEventCount) -> void
+Dekaf.Diagnostics.ProducerBacklogStatus.BufferUtilization.get -> double
+Dekaf.Diagnostics.IKafkaClientIdentity.ClusterId.get -> string?
+Dekaf.Diagnostics.ProducerBacklogStatus.IsAtCapacity.get -> bool
+Dekaf.Diagnostics.BrokerConnectionStatus.BrokerId.get -> int
+Dekaf.Diagnostics.BrokerConnectionStatus.Host.get -> string!
+Dekaf.Diagnostics.BrokerConnectionStatus.BrokerId.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.Host.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.Port.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.Port.get -> int
+Dekaf.Diagnostics.BrokerConnectionStatus.State.get -> Dekaf.Diagnostics.BrokerConnectionState
+Dekaf.Diagnostics.BrokerConnectionStatus.State.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.ConnectionCount.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.ConnectedConnectionCount.get -> int
+Dekaf.Diagnostics.BrokerConnectionStatus.ConnectionCount.get -> int
+Dekaf.Diagnostics.BrokerConnectionStatus.ConnectedConnectionCount.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.PendingRequestCount.get -> int
+Dekaf.Diagnostics.BrokerConnectionStatus.PendingRequestCount.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.LastSuccessfulRequestAtUtc.get -> System.DateTimeOffset?
+Dekaf.Diagnostics.BrokerConnectionStatus.LastSuccessfulRequestAtUtc.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.LastErrorAtUtc.get -> System.DateTimeOffset?
+Dekaf.Diagnostics.BrokerConnectionStatus.LastConnectionStateChangeAtUtc.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.LastConnectionStateChangeAtUtc.get -> System.DateTimeOffset?
+Dekaf.Diagnostics.BrokerConnectionStatus.LastErrorAtUtc.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.LastError.get -> string?
+Dekaf.Diagnostics.BrokerConnectionStatus.LastError.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.CapturedAtUtc.get -> System.DateTimeOffset
+Dekaf.Diagnostics.KafkaClientStatus.Role.get -> Dekaf.Diagnostics.KafkaClientRole
+Dekaf.Diagnostics.KafkaClientStatus.CapturedAtUtc.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.Role.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.ClusterId.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.MetadataLastRefreshedAtUtc.get -> System.DateTimeOffset?
+Dekaf.Diagnostics.KafkaClientStatus.ClusterId.get -> string?
+Dekaf.Diagnostics.KafkaClientStatus.IsStopped.get -> bool
+Dekaf.Diagnostics.KafkaClientStatus.MetadataLastRefreshedAtUtc.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.Brokers.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Diagnostics.BrokerConnectionStatus!>!
+Dekaf.Diagnostics.KafkaClientStatus.Brokers.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.IsStopped.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.Producer.get -> Dekaf.Diagnostics.ProducerBacklogStatus?
+Dekaf.Diagnostics.KafkaClientStatus.Producer.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.ConsumerGroup.get -> Dekaf.Diagnostics.ConsumerGroupStatus?
+Dekaf.Diagnostics.KafkaClientStatus.ConsumerGroup.init -> void
+Dekaf.Diagnostics.IKafkaClientStatusProvider.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!
+Dekaf.Consumer.KafkaConsumer<TKey, TValue>.ClusterId.get -> string?
+Dekaf.Consumer.KafkaConsumer<TKey, TValue>.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!
+Dekaf.Producer.KafkaProducer<TKey, TValue>.ClusterId.get -> string?
+Dekaf.Producer.KafkaProducer<TKey, TValue>.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -11,3 +11,108 @@ Dekaf.Consumer.KafkaConsumer<TKey, TValue>.StoreOffsets<TOffsets>(TOffsets offse
 static Dekaf.Consumer.ConsumerOffsetStoreExtensions.StoreOffsets<TKey, TValue>(this Dekaf.Consumer.IKafkaConsumer<TKey, TValue>! consumer, Dekaf.TopicPartitionOffset[]! offsets) -> void
 static Dekaf.Consumer.ConsumerOffsetStoreExtensions.StoreOffsets<TKey, TValue>(this Dekaf.Consumer.IKafkaConsumer<TKey, TValue>! consumer, System.ReadOnlySpan<Dekaf.TopicPartitionOffset> offsets) -> void
 static Dekaf.Consumer.ConsumerOffsetStoreExtensions.StoreOffsets<TKey, TValue, TOffsets>(this Dekaf.Consumer.IKafkaConsumer<TKey, TValue>! consumer, TOffsets offsets) -> void
+Dekaf.Diagnostics.IKafkaClientStatusProvider
+Dekaf.Diagnostics.IKafkaClientIdentity
+Dekaf.Diagnostics.KafkaClientRole.Consumer = 1 -> Dekaf.Diagnostics.KafkaClientRole
+Dekaf.Diagnostics.KafkaClientRole
+Dekaf.Diagnostics.KafkaClientRole.Producer = 0 -> Dekaf.Diagnostics.KafkaClientRole
+Dekaf.Diagnostics.KafkaClientRole.ShareConsumer = 2 -> Dekaf.Diagnostics.KafkaClientRole
+Dekaf.Diagnostics.KafkaClientRole.Admin = 3 -> Dekaf.Diagnostics.KafkaClientRole
+Dekaf.Diagnostics.BrokerConnectionState.Disconnected = 0 -> Dekaf.Diagnostics.BrokerConnectionState
+Dekaf.Diagnostics.BrokerConnectionState.PartiallyConnected = 1 -> Dekaf.Diagnostics.BrokerConnectionState
+Dekaf.Diagnostics.BrokerConnectionState.Connected = 2 -> Dekaf.Diagnostics.BrokerConnectionState
+Dekaf.Diagnostics.BrokerConnectionState
+Dekaf.Diagnostics.KafkaClientStatus
+Dekaf.Diagnostics.KafkaClientStatus.KafkaClientStatus() -> void
+Dekaf.Diagnostics.BrokerConnectionStatus
+Dekaf.Diagnostics.BrokerConnectionStatus.BrokerConnectionStatus() -> void
+Dekaf.Diagnostics.ProducerBacklogStatus.BufferCapacityBytes.get -> ulong
+Dekaf.Diagnostics.ProducerBacklogStatus.BufferedBytes.get -> long
+Dekaf.Diagnostics.ProducerBacklogStatus.BufferCapacityBytes.init -> void
+Dekaf.Diagnostics.ProducerBacklogStatus.BufferedBytes.init -> void
+Dekaf.Diagnostics.ProducerBacklogStatus.QueuedBatchCount.get -> long
+Dekaf.Diagnostics.ProducerBacklogStatus.BufferPressureEventCount.get -> long
+Dekaf.Diagnostics.ProducerBacklogStatus.InFlightBatchCount.get -> long
+Dekaf.Diagnostics.ProducerBacklogStatus.QueuedBatchCount.init -> void
+Dekaf.Diagnostics.ProducerBacklogStatus.BufferPressureEventCount.init -> void
+Dekaf.Diagnostics.ProducerBacklogStatus.InFlightBatchCount.init -> void
+Dekaf.Diagnostics.ProducerBacklogStatus
+Dekaf.Diagnostics.ProducerBacklogStatus.ProducerBacklogStatus() -> void
+~override Dekaf.Diagnostics.ProducerBacklogStatus.ToString() -> string
+static Dekaf.Diagnostics.ProducerBacklogStatus.operator !=(Dekaf.Diagnostics.ProducerBacklogStatus left, Dekaf.Diagnostics.ProducerBacklogStatus right) -> bool
+static Dekaf.Diagnostics.ProducerBacklogStatus.operator ==(Dekaf.Diagnostics.ProducerBacklogStatus left, Dekaf.Diagnostics.ProducerBacklogStatus right) -> bool
+override Dekaf.Diagnostics.ProducerBacklogStatus.GetHashCode() -> int
+~override Dekaf.Diagnostics.ProducerBacklogStatus.Equals(object obj) -> bool
+Dekaf.Diagnostics.ProducerBacklogStatus.Equals(Dekaf.Diagnostics.ProducerBacklogStatus other) -> bool
+Dekaf.Diagnostics.ProducerBacklogStatus.Deconstruct(out long BufferedBytes, out ulong BufferCapacityBytes, out int UnsealedBatchCount, out long QueuedBatchCount, out long InFlightBatchCount, out long BufferPressureEventCount) -> void
+Dekaf.Diagnostics.ProducerBacklogStatus.UnsealedBatchCount.get -> int
+Dekaf.Diagnostics.ProducerBacklogStatus.UnsealedBatchCount.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus
+Dekaf.Diagnostics.ConsumerGroupStatus.ConsumerGroupStatus() -> void
+Dekaf.Admin.AdminClient.ClusterId.get -> string?
+Dekaf.Admin.AdminClient.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!
+Dekaf.Diagnostics.ConsumerGroupStatus.HasConsumerGroup.get -> bool
+Dekaf.Diagnostics.ConsumerGroupStatus.HasConsumerGroup.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.CoordinatorId.get -> int
+Dekaf.Diagnostics.ConsumerGroupStatus.State.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.State.get -> Dekaf.Consumer.CoordinatorState
+Dekaf.Diagnostics.ConsumerGroupStatus.MemberId.get -> string?
+Dekaf.Diagnostics.ConsumerGroupStatus.CoordinatorId.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.GenerationOrMemberEpoch.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.HeartbeatInterval.get -> System.TimeSpan
+Dekaf.Diagnostics.ConsumerGroupStatus.GenerationOrMemberEpoch.get -> int
+Dekaf.Diagnostics.ConsumerGroupStatus.MemberId.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.HeartbeatInterval.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.TimeSinceLastHeartbeat.get -> System.TimeSpan?
+Dekaf.Diagnostics.ConsumerGroupStatus.TimeSinceLastHeartbeat.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.LastHeartbeatFailure.get -> string?
+Dekaf.Diagnostics.ConsumerGroupStatus.LastHeartbeatFailure.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.Assignment.init -> void
+Dekaf.Diagnostics.ConsumerGroupStatus.Assignment.get -> System.Collections.Generic.IReadOnlyList<Dekaf.TopicPartition>!
+Dekaf.Diagnostics.ProducerBacklogStatus.ProducerBacklogStatus(long BufferedBytes, ulong BufferCapacityBytes, int UnsealedBatchCount, long QueuedBatchCount, long InFlightBatchCount, long BufferPressureEventCount) -> void
+Dekaf.Diagnostics.ProducerBacklogStatus.BufferUtilization.get -> double
+Dekaf.Diagnostics.ProducerBacklogStatus.IsAtCapacity.get -> bool
+Dekaf.Diagnostics.BrokerConnectionStatus.BrokerId.get -> int
+Dekaf.Diagnostics.BrokerConnectionStatus.BrokerId.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.Host.get -> string!
+Dekaf.Diagnostics.BrokerConnectionStatus.Port.get -> int
+Dekaf.Diagnostics.BrokerConnectionStatus.Host.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.State.get -> Dekaf.Diagnostics.BrokerConnectionState
+Dekaf.Diagnostics.BrokerConnectionStatus.Port.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.ConnectionCount.get -> int
+Dekaf.Diagnostics.BrokerConnectionStatus.ConnectionCount.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.State.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.ConnectedConnectionCount.get -> int
+Dekaf.Diagnostics.BrokerConnectionStatus.ConnectedConnectionCount.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.LastSuccessfulRequestAtUtc.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.PendingRequestCount.get -> int
+Dekaf.Diagnostics.BrokerConnectionStatus.LastSuccessfulRequestAtUtc.get -> System.DateTimeOffset?
+Dekaf.Diagnostics.BrokerConnectionStatus.PendingRequestCount.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.LastConnectionStateChangeAtUtc.get -> System.DateTimeOffset?
+Dekaf.Diagnostics.BrokerConnectionStatus.LastErrorAtUtc.get -> System.DateTimeOffset?
+Dekaf.Diagnostics.BrokerConnectionStatus.LastConnectionStateChangeAtUtc.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.LastErrorAtUtc.init -> void
+Dekaf.Diagnostics.BrokerConnectionStatus.LastError.get -> string?
+Dekaf.Diagnostics.BrokerConnectionStatus.LastError.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.CapturedAtUtc.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.Role.get -> Dekaf.Diagnostics.KafkaClientRole
+Dekaf.Diagnostics.KafkaClientStatus.Role.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.CapturedAtUtc.get -> System.DateTimeOffset
+Dekaf.Diagnostics.KafkaClientStatus.ClusterId.get -> string?
+Dekaf.Diagnostics.KafkaClientStatus.MetadataLastRefreshedAtUtc.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.MetadataLastRefreshedAtUtc.get -> System.DateTimeOffset?
+Dekaf.Diagnostics.KafkaClientStatus.ClusterId.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.IsStopped.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.IsStopped.get -> bool
+Dekaf.Diagnostics.KafkaClientStatus.Brokers.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Diagnostics.BrokerConnectionStatus!>!
+Dekaf.Diagnostics.KafkaClientStatus.Producer.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.Producer.get -> Dekaf.Diagnostics.ProducerBacklogStatus?
+Dekaf.Diagnostics.KafkaClientStatus.ConsumerGroup.get -> Dekaf.Diagnostics.ConsumerGroupStatus?
+Dekaf.Diagnostics.KafkaClientStatus.Brokers.init -> void
+Dekaf.Diagnostics.KafkaClientStatus.ConsumerGroup.init -> void
+Dekaf.Diagnostics.IKafkaClientStatusProvider.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!
+Dekaf.Diagnostics.IKafkaClientIdentity.ClusterId.get -> string?
+Dekaf.Consumer.KafkaConsumer<TKey, TValue>.ClusterId.get -> string?
+Dekaf.Consumer.KafkaConsumer<TKey, TValue>.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!
+Dekaf.Producer.KafkaProducer<TKey, TValue>.ClusterId.get -> string?
+Dekaf.Producer.KafkaProducer<TKey, TValue>.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!

--- a/src/Dekaf/Serialization/Headers.cs
+++ b/src/Dekaf/Serialization/Headers.cs
@@ -15,7 +15,7 @@ public sealed class Headers : IEnumerable<Header>
 {
     private readonly List<Header> _headers;
     private int _deferredTraceparentIndex = -1;
-    private bool _hasDeferredTracestate;
+    private int _deferredTracestateIndex = -1;
 
     /// <summary>
     /// Creates an empty headers collection.
@@ -78,7 +78,7 @@ public sealed class Headers : IEnumerable<Header>
     /// </summary>
     public Headers Add(string key, string value)
     {
-        _headers.Add(new Header(key, Encoding.UTF8.GetBytes(value)));
+        AddHeader(new Header(key, Encoding.UTF8.GetBytes(value)));
         return this;
     }
 
@@ -87,7 +87,7 @@ public sealed class Headers : IEnumerable<Header>
     /// </summary>
     public Headers Add(string key, byte[]? value)
     {
-        _headers.Add(new Header(key, value));
+        AddHeader(new Header(key, value));
         return this;
     }
 
@@ -96,7 +96,7 @@ public sealed class Headers : IEnumerable<Header>
     /// </summary>
     public Headers Add(Header header)
     {
-        _headers.Add(header);
+        AddHeader(header);
         return this;
     }
 
@@ -147,7 +147,7 @@ public sealed class Headers : IEnumerable<Header>
         for (var i = _headers.Count - 1; i >= 0; i--)
         {
             if (_headers[i].Key == key)
-                _headers.RemoveAt(i);
+                RemoveAt(i);
         }
         return this;
     }
@@ -158,41 +158,70 @@ public sealed class Headers : IEnumerable<Header>
     public void Clear()
     {
         _headers.Clear();
+        _deferredTraceparentIndex = -1;
+        _deferredTracestateIndex = -1;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void AddDeferredTraceContext(Activity activity, string? traceState)
     {
+        if (_deferredTraceparentIndex >= 0 || _deferredTracestateIndex >= 0)
+            RemoveDeferredTraceContext();
+
         _deferredTraceparentIndex = _headers.Count;
         _headers.Add(Header.CreateDeferredTraceparent("traceparent", activity));
         if (string.IsNullOrEmpty(traceState))
             return;
 
-        _hasDeferredTracestate = true;
-        Add("tracestate", traceState!);
+        _deferredTracestateIndex = _headers.Count;
+        _headers.Add(Header.CreateDeferredTracestate("tracestate", traceState!));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void RemoveDeferredTraceContext()
     {
         var traceparentIndex = _deferredTraceparentIndex;
-        if (traceparentIndex < 0)
+        var tracestateIndex = _deferredTracestateIndex;
+        if (traceparentIndex < 0 && tracestateIndex < 0)
             return;
 
         _deferredTraceparentIndex = -1;
-        var hasTracestate = _hasDeferredTracestate;
-        if (hasTracestate)
-            _hasDeferredTracestate = false;
+        _deferredTracestateIndex = -1;
 
-        if (hasTracestate
-            && traceparentIndex + 1 < _headers.Count
-            && _headers[traceparentIndex + 1].Key == "tracestate")
-            _headers.RemoveAt(traceparentIndex + 1);
+        if ((uint)tracestateIndex < (uint)_headers.Count)
+            _headers.RemoveAt(tracestateIndex);
 
-        if (traceparentIndex < _headers.Count
+        if ((uint)traceparentIndex < (uint)_headers.Count
             && _headers[traceparentIndex].HasDeferredTraceparent)
             _headers.RemoveAt(traceparentIndex);
     }
+
+    private void RemoveAt(int index)
+    {
+        _headers.RemoveAt(index);
+        _deferredTraceparentIndex = AdjustTrackedIndex(_deferredTraceparentIndex, index);
+        _deferredTracestateIndex = AdjustTrackedIndex(_deferredTracestateIndex, index);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void AddHeader(Header header)
+    {
+        var traceparentIndex = _deferredTraceparentIndex;
+        if (traceparentIndex < 0)
+        {
+            _headers.Add(header);
+            return;
+        }
+
+        _headers.Insert(traceparentIndex, header);
+        _deferredTraceparentIndex = traceparentIndex + 1;
+        if (_deferredTracestateIndex >= 0)
+            _deferredTracestateIndex++;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int AdjustTrackedIndex(int trackedIndex, int removedIndex) =>
+        trackedIndex == removedIndex ? -1 : trackedIndex > removedIndex ? trackedIndex - 1 : trackedIndex;
 
     /// <summary>
     /// Adds multiple headers from a collection of key-value pairs.
@@ -279,7 +308,7 @@ public readonly record struct Header
     private const int MaxCachedKeyBytes = 256;
     private static readonly Utf8StringInternCache s_keyCache = new(MaxCachedKeys, MaxCachedKeyBytes);
     private readonly ReadOnlyMemory<byte> _value;
-    private readonly Activity? _deferredTraceparentActivity;
+    private readonly object? _deferredValue;
 
     /// <summary>
     /// Creates a new header with a byte array value.
@@ -288,7 +317,7 @@ public readonly record struct Header
     {
         Key = key;
         _value = value.AsMemory();
-        _deferredTraceparentActivity = null;
+        _deferredValue = null;
         IsValueNull = value is null;
     }
 
@@ -299,22 +328,25 @@ public readonly record struct Header
     {
         Key = key;
         _value = value;
-        _deferredTraceparentActivity = null;
+        _deferredValue = null;
         IsValueNull = isNull;
     }
 
-    private Header(string key, Activity traceparentActivity)
+    private Header(string key, object deferredValue)
     {
         Key = key;
         _value = default;
-        _deferredTraceparentActivity = traceparentActivity;
+        _deferredValue = deferredValue;
         IsValueNull = false;
     }
 
     internal static Header CreateDeferredTraceparent(string key, Activity activity) =>
         new(key, activity);
 
-    internal bool HasDeferredTraceparent => _deferredTraceparentActivity is not null;
+    internal static Header CreateDeferredTracestate(string key, string traceState) =>
+        new(key, traceState);
+
+    internal bool HasDeferredTraceparent => _deferredValue is Activity;
 
     /// <summary>
     /// The header key.
@@ -330,15 +362,13 @@ public readonly record struct Header
         [CompilerGenerated]
         get
         {
-            if (_deferredTraceparentActivity is null)
-                return _value;
-
-            var value = GC.AllocateUninitializedArray<byte>(
-                Diagnostics.TraceContextPropagator.TraceparentLength);
-            Diagnostics.TraceContextPropagator.WriteTraceparentUnchecked(
-                _deferredTraceparentActivity,
-                value);
-            return value;
+            return _deferredValue switch
+            {
+                null => _value,
+                Activity activity => EncodeTraceparent(activity),
+                string traceState => Encoding.UTF8.GetBytes(traceState),
+                _ => throw new UnreachableException()
+            };
         }
         [CompilerGenerated]
         init => _value = value;
@@ -357,15 +387,13 @@ public readonly record struct Header
         if (IsValueNull)
             return null;
 
-        if (_deferredTraceparentActivity is null)
-            return _value.ToArray();
-
-        var value = GC.AllocateUninitializedArray<byte>(
-            Diagnostics.TraceContextPropagator.TraceparentLength);
-        Diagnostics.TraceContextPropagator.WriteTraceparentUnchecked(
-            _deferredTraceparentActivity,
-            value);
-        return value;
+        return _deferredValue switch
+        {
+            null => _value.ToArray(),
+            Activity activity => EncodeTraceparent(activity),
+            string traceState => Encoding.UTF8.GetBytes(traceState),
+            _ => throw new UnreachableException()
+        };
     }
 
     /// <summary>
@@ -376,11 +404,13 @@ public readonly record struct Header
         if (IsValueNull)
             return null;
 
-        if (_deferredTraceparentActivity is null)
+        if (_deferredValue is string traceState)
+            return traceState;
+        if (_deferredValue is null)
             return Encoding.UTF8.GetString(_value.Span);
 
         Span<byte> value = stackalloc byte[Diagnostics.TraceContextPropagator.TraceparentLength];
-        Diagnostics.TraceContextPropagator.WriteTraceparentUnchecked(_deferredTraceparentActivity, value);
+        Diagnostics.TraceContextPropagator.WriteTraceparentUnchecked((Activity)_deferredValue, value);
         return Encoding.UTF8.GetString(value);
     }
 
@@ -401,21 +431,30 @@ public readonly record struct Header
         }
         else
         {
-            if (_deferredTraceparentActivity is null)
+            switch (_deferredValue)
             {
-                writer.WriteVarInt(_value.Length);
-                writer.WriteRawBytes(_value.Span);
-            }
-            else
-            {
-                writer.WriteVarInt(Diagnostics.TraceContextPropagator.TraceparentLength);
-                var destination = writer.BufferWriter.GetSpan(
-                    Diagnostics.TraceContextPropagator.TraceparentLength);
-                Diagnostics.TraceContextPropagator.WriteTraceparentUnchecked(
-                    _deferredTraceparentActivity,
-                    destination);
-                writer.BufferWriter.Advance(Diagnostics.TraceContextPropagator.TraceparentLength);
-                writer.AddBytesWritten(Diagnostics.TraceContextPropagator.TraceparentLength);
+                case null:
+                    writer.WriteVarInt(_value.Length);
+                    writer.WriteRawBytes(_value.Span);
+                    break;
+                case Activity activity:
+                    writer.WriteVarInt(Diagnostics.TraceContextPropagator.TraceparentLength);
+                    var traceparentDestination = writer.BufferWriter.GetSpan(
+                        Diagnostics.TraceContextPropagator.TraceparentLength);
+                    Diagnostics.TraceContextPropagator.WriteTraceparentUnchecked(
+                        activity,
+                        traceparentDestination);
+                    writer.BufferWriter.Advance(Diagnostics.TraceContextPropagator.TraceparentLength);
+                    writer.AddBytesWritten(Diagnostics.TraceContextPropagator.TraceparentLength);
+                    break;
+                case string traceState:
+                    var traceStateLength = Encoding.UTF8.GetByteCount(traceState);
+                    writer.WriteVarInt(traceStateLength);
+                    var traceStateDestination = writer.BufferWriter.GetSpan(traceStateLength);
+                    Encoding.UTF8.GetBytes(traceState, traceStateDestination);
+                    writer.BufferWriter.Advance(traceStateLength);
+                    writer.AddBytesWritten(traceStateLength);
+                    break;
             }
         }
     }
@@ -496,19 +535,27 @@ public readonly record struct Header
         }
         else
         {
-            var valueLength = _deferredTraceparentActivity is null
-                ? _value.Length
-                : Diagnostics.TraceContextPropagator.TraceparentLength;
+            var valueLength = _deferredValue switch
+            {
+                null => _value.Length,
+                Activity => Diagnostics.TraceContextPropagator.TraceparentLength,
+                string traceState => Encoding.UTF8.GetByteCount(traceState),
+                _ => throw new UnreachableException()
+            };
             Record.WriteVarInt(destination, ref offset, valueLength);
-            if (_deferredTraceparentActivity is null)
+            switch (_deferredValue)
             {
-                _value.Span.CopyTo(destination[offset..]);
-            }
-            else
-            {
-                Diagnostics.TraceContextPropagator.WriteTraceparentUnchecked(
-                    _deferredTraceparentActivity,
-                    destination.Slice(offset, valueLength));
+                case null:
+                    _value.Span.CopyTo(destination[offset..]);
+                    break;
+                case Activity activity:
+                    Diagnostics.TraceContextPropagator.WriteTraceparentUnchecked(
+                        activity,
+                        destination.Slice(offset, valueLength));
+                    break;
+                case string traceState:
+                    Encoding.UTF8.GetBytes(traceState, destination[offset..]);
+                    break;
             }
             offset += valueLength;
         }
@@ -527,12 +574,24 @@ public readonly record struct Header
         }
         else
         {
-            var valueLength = _deferredTraceparentActivity is null
-                ? _value.Length
-                : Diagnostics.TraceContextPropagator.TraceparentLength;
+            var valueLength = _deferredValue switch
+            {
+                null => _value.Length,
+                Activity => Diagnostics.TraceContextPropagator.TraceparentLength,
+                string traceState => Encoding.UTF8.GetByteCount(traceState),
+                _ => throw new UnreachableException()
+            };
             size += Record.VarIntSize(valueLength) + valueLength;
         }
 
         return size;
+    }
+
+    private static byte[] EncodeTraceparent(Activity activity)
+    {
+        var value = GC.AllocateUninitializedArray<byte>(
+            Diagnostics.TraceContextPropagator.TraceparentLength);
+        Diagnostics.TraceContextPropagator.WriteTraceparentUnchecked(activity, value);
+        return value;
     }
 }

--- a/src/Dekaf/Serialization/Headers.cs
+++ b/src/Dekaf/Serialization/Headers.cs
@@ -383,7 +383,11 @@ public readonly record struct Header
             };
         }
         [CompilerGenerated]
-        init => _value = value;
+        init
+        {
+            _value = value;
+            _deferredValue = null;
+        }
     }
 
     /// <summary>

--- a/src/Dekaf/Serialization/Headers.cs
+++ b/src/Dekaf/Serialization/Headers.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Dekaf.Internal;
@@ -241,6 +242,8 @@ public readonly record struct Header
     private const int MaxCachedKeys = 128;
     private const int MaxCachedKeyBytes = 256;
     private static readonly Utf8StringInternCache s_keyCache = new(MaxCachedKeys, MaxCachedKeyBytes);
+    private readonly ReadOnlyMemory<byte> _value;
+    private readonly Activity? _deferredTraceparentActivity;
 
     /// <summary>
     /// Creates a new header with a byte array value.
@@ -248,7 +251,8 @@ public readonly record struct Header
     public Header(string key, byte[]? value)
     {
         Key = key;
-        Value = value.AsMemory();
+        _value = value.AsMemory();
+        _deferredTraceparentActivity = null;
         IsValueNull = value is null;
     }
 
@@ -258,9 +262,21 @@ public readonly record struct Header
     public Header(string key, ReadOnlyMemory<byte> value, bool isNull = false)
     {
         Key = key;
-        Value = value;
+        _value = value;
+        _deferredTraceparentActivity = null;
         IsValueNull = isNull;
     }
+
+    private Header(string key, Activity traceparentActivity)
+    {
+        Key = key;
+        _value = default;
+        _deferredTraceparentActivity = traceparentActivity;
+        IsValueNull = false;
+    }
+
+    internal static Header CreateDeferredTraceparent(string key, Activity activity) =>
+        new(key, activity);
 
     /// <summary>
     /// The header key.
@@ -270,7 +286,22 @@ public readonly record struct Header
     /// <summary>
     /// The header value as bytes. Check IsValueNull before accessing.
     /// </summary>
-    public ReadOnlyMemory<byte> Value { get; init; }
+    public ReadOnlyMemory<byte> Value
+    {
+        get
+        {
+            if (_deferredTraceparentActivity is null)
+                return _value;
+
+            var value = GC.AllocateUninitializedArray<byte>(
+                Diagnostics.TraceContextPropagator.TraceparentLength);
+            Diagnostics.TraceContextPropagator.WriteTraceparentUnchecked(
+                _deferredTraceparentActivity,
+                value);
+            return value;
+        }
+        init => _value = value;
+    }
 
     /// <summary>
     /// Returns true if the header value is null.
@@ -280,14 +311,36 @@ public readonly record struct Header
     /// <summary>
     /// Gets the value as a byte array. Prefer using Value property to avoid allocation.
     /// </summary>
-    public byte[]? GetValueAsArray() => IsValueNull ? null : Value.ToArray();
+    public byte[]? GetValueAsArray()
+    {
+        if (IsValueNull)
+            return null;
+
+        if (_deferredTraceparentActivity is null)
+            return _value.ToArray();
+
+        var value = GC.AllocateUninitializedArray<byte>(
+            Diagnostics.TraceContextPropagator.TraceparentLength);
+        Diagnostics.TraceContextPropagator.WriteTraceparentUnchecked(
+            _deferredTraceparentActivity,
+            value);
+        return value;
+    }
 
     /// <summary>
     /// Gets the value as a UTF-8 string.
     /// </summary>
     public string? GetValueAsString()
     {
-        return IsValueNull ? null : Encoding.UTF8.GetString(Value.Span);
+        if (IsValueNull)
+            return null;
+
+        if (_deferredTraceparentActivity is null)
+            return Encoding.UTF8.GetString(_value.Span);
+
+        Span<byte> value = stackalloc byte[Diagnostics.TraceContextPropagator.TraceparentLength];
+        Diagnostics.TraceContextPropagator.WriteTraceparentUnchecked(_deferredTraceparentActivity, value);
+        return Encoding.UTF8.GetString(value);
     }
 
     /// <inheritdoc/>
@@ -307,8 +360,22 @@ public readonly record struct Header
         }
         else
         {
-            writer.WriteVarInt(Value.Length);
-            writer.WriteRawBytes(Value.Span);
+            if (_deferredTraceparentActivity is null)
+            {
+                writer.WriteVarInt(_value.Length);
+                writer.WriteRawBytes(_value.Span);
+            }
+            else
+            {
+                writer.WriteVarInt(Diagnostics.TraceContextPropagator.TraceparentLength);
+                var destination = writer.BufferWriter.GetSpan(
+                    Diagnostics.TraceContextPropagator.TraceparentLength);
+                Diagnostics.TraceContextPropagator.WriteTraceparentUnchecked(
+                    _deferredTraceparentActivity,
+                    destination);
+                writer.BufferWriter.Advance(Diagnostics.TraceContextPropagator.TraceparentLength);
+                writer.AddBytesWritten(Diagnostics.TraceContextPropagator.TraceparentLength);
+            }
         }
     }
 
@@ -388,9 +455,21 @@ public readonly record struct Header
         }
         else
         {
-            Record.WriteVarInt(destination, ref offset, Value.Length);
-            Value.Span.CopyTo(destination[offset..]);
-            offset += Value.Length;
+            var valueLength = _deferredTraceparentActivity is null
+                ? _value.Length
+                : Diagnostics.TraceContextPropagator.TraceparentLength;
+            Record.WriteVarInt(destination, ref offset, valueLength);
+            if (_deferredTraceparentActivity is null)
+            {
+                _value.Span.CopyTo(destination[offset..]);
+            }
+            else
+            {
+                Diagnostics.TraceContextPropagator.WriteTraceparentUnchecked(
+                    _deferredTraceparentActivity,
+                    destination.Slice(offset, valueLength));
+            }
+            offset += valueLength;
         }
     }
 
@@ -407,7 +486,10 @@ public readonly record struct Header
         }
         else
         {
-            size += Record.VarIntSize(Value.Length) + Value.Length;
+            var valueLength = _deferredTraceparentActivity is null
+                ? _value.Length
+                : Diagnostics.TraceContextPropagator.TraceparentLength;
+            size += Record.VarIntSize(valueLength) + valueLength;
         }
 
         return size;

--- a/src/Dekaf/Serialization/Headers.cs
+++ b/src/Dekaf/Serialization/Headers.cs
@@ -288,6 +288,8 @@ public readonly record struct Header
     /// </summary>
     public ReadOnlyMemory<byte> Value
     {
+        // Preserve the metadata emitted by the previously shipped auto-property accessors.
+        [CompilerGenerated]
         get
         {
             if (_deferredTraceparentActivity is null)
@@ -300,6 +302,7 @@ public readonly record struct Header
                 value);
             return value;
         }
+        [CompilerGenerated]
         init => _value = value;
     }
 

--- a/src/Dekaf/Serialization/Headers.cs
+++ b/src/Dekaf/Serialization/Headers.cs
@@ -158,6 +158,29 @@ public sealed class Headers : IEnumerable<Header>
         _headers.Clear();
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void RemoveDeferredTraceContext()
+    {
+        var lastIndex = _headers.Count - 1;
+        if (lastIndex < 0)
+            return;
+
+        if (_headers[lastIndex].HasDeferredTraceparent)
+        {
+            _headers.RemoveAt(lastIndex);
+            return;
+        }
+
+        // Trace injection appends traceparent followed only by optional tracestate.
+        if (lastIndex > 0
+            && _headers[lastIndex - 1].HasDeferredTraceparent
+            && _headers[lastIndex].Key == "tracestate")
+        {
+            _headers.RemoveAt(lastIndex);
+            _headers.RemoveAt(lastIndex - 1);
+        }
+    }
+
     /// <summary>
     /// Adds multiple headers from a collection of key-value pairs.
     /// </summary>

--- a/src/Dekaf/Serialization/Headers.cs
+++ b/src/Dekaf/Serialization/Headers.cs
@@ -213,10 +213,22 @@ public sealed class Headers : IEnumerable<Header>
             return;
         }
 
-        _headers.Insert(traceparentIndex, header);
+        var traceparent = _headers[traceparentIndex];
+        var tracestateIndex = _deferredTracestateIndex;
+        if (tracestateIndex < 0)
+        {
+            _headers.Add(traceparent);
+            _headers[traceparentIndex] = header;
+            _deferredTraceparentIndex = traceparentIndex + 1;
+            return;
+        }
+
+        var tracestate = _headers[tracestateIndex];
+        _headers.Add(tracestate);
+        _headers[traceparentIndex] = header;
+        _headers[tracestateIndex] = traceparent;
         _deferredTraceparentIndex = traceparentIndex + 1;
-        if (_deferredTracestateIndex >= 0)
-            _deferredTracestateIndex++;
+        _deferredTracestateIndex = tracestateIndex + 1;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Serialization/Headers.cs
+++ b/src/Dekaf/Serialization/Headers.cs
@@ -278,6 +278,8 @@ public readonly record struct Header
     internal static Header CreateDeferredTraceparent(string key, Activity activity) =>
         new(key, activity);
 
+    internal bool HasDeferredTraceparent => _deferredTraceparentActivity is not null;
+
     /// <summary>
     /// The header key.
     /// </summary>

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using Dekaf.Compression;
+using Dekaf.Diagnostics;
 using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -24,7 +25,9 @@ namespace Dekaf.ShareConsumer;
 /// record-level acknowledgement. Records are acquired with locks and must be acknowledged
 /// (accepted, released, or rejected).
 /// </summary>
-internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareConsumer<TKey, TValue>
+internal sealed partial class KafkaShareConsumer<TKey, TValue> :
+    IKafkaShareConsumer<TKey, TValue>,
+    IKafkaClientStatusProvider
 {
     private readonly ShareConsumerOptions _options;
     private readonly IDeserializer<TKey> _keyDeserializer;
@@ -163,6 +166,22 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     public StringSet Subscription => _subscriptionSnapshot;
     public TopicPartitionSet Assignment => _assignmentSnapshot;
     public string? MemberId => _coordinator.MemberId;
+
+    /// <inheritdoc />
+    public string? ClusterId => _metadataManager.ClusterId;
+
+    /// <inheritdoc />
+    public KafkaClientStatus GetStatus()
+    {
+        var stopped = Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _disposed) != 0;
+        return KafkaClientStatusFactory.Capture(
+            KafkaClientRole.ShareConsumer,
+            _connectionPool,
+            _metadataManager,
+            stopped,
+            consumerGroup: _coordinator.CaptureGroupStatus());
+    }
+
     public int? AcquisitionLockTimeoutMs
     {
         get

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Dekaf.Consumer;
+using Dekaf.Diagnostics;
 using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -42,6 +43,8 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     private Task? _heartbeatTask;
 
     private volatile CoordinatorState _state = CoordinatorState.Unjoined;
+    private long _lastSuccessfulHeartbeatTimestamp;
+    private string? _lastHeartbeatFailure;
     private int _disposed;
     private readonly Func<int> _getCoordinationConnectionIndex;
 
@@ -76,6 +79,26 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     public int MemberEpoch => _memberEpoch;
     public CoordinatorState State => _state;
     public TopicPartitionSet Assignment => _assignedPartitions;
+
+    internal ConsumerGroupStatus CaptureGroupStatus()
+    {
+        var assignment = _assignedPartitions;
+        var lastHeartbeatTimestamp = Volatile.Read(ref _lastSuccessfulHeartbeatTimestamp);
+        return new ConsumerGroupStatus
+        {
+            HasConsumerGroup = true,
+            State = _state,
+            CoordinatorId = _coordinatorId,
+            MemberId = _memberId,
+            GenerationOrMemberEpoch = _memberEpoch,
+            HeartbeatInterval = TimeSpan.FromMilliseconds(Math.Max(_heartbeatIntervalMs, 1)),
+            TimeSinceLastHeartbeat = lastHeartbeatTimestamp == 0
+                ? null
+                : Stopwatch.GetElapsedTime(lastHeartbeatTimestamp),
+            LastHeartbeatFailure = Volatile.Read(ref _lastHeartbeatFailure),
+            Assignment = KafkaClientStatusFactory.CopyAssignment(assignment, assignment.Count)
+        };
+    }
 
     /// <summary>
     /// Forces the coordinator to rejoin the group on the next
@@ -323,13 +346,33 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
             SubscribedTopicNames = subscribedTopics
         };
 
-        var response = await connection.SendAsync<ShareGroupHeartbeatRequest, ShareGroupHeartbeatResponse>(
-            request, version, cancellationToken).ConfigureAwait(false);
+        ShareGroupHeartbeatResponse response;
+        try
+        {
+            response = await connection.SendAsync<ShareGroupHeartbeatRequest, ShareGroupHeartbeatResponse>(
+                request, version, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            Volatile.Write(ref _lastHeartbeatFailure, ex.Message);
+            throw;
+        }
 
         if (response.ErrorCode != ErrorCode.None)
         {
-            HandleShareGroupHeartbeatError(response);
+            try
+            {
+                HandleShareGroupHeartbeatError(response);
+            }
+            catch (Exception ex)
+            {
+                Volatile.Write(ref _lastHeartbeatFailure, ex.Message);
+                throw;
+            }
         }
+
+        Volatile.Write(ref _lastSuccessfulHeartbeatTimestamp, Stopwatch.GetTimestamp());
+        Volatile.Write(ref _lastHeartbeatFailure, null);
 
         if (response.MemberId is not null)
             _memberId = response.MemberId;

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -308,17 +308,9 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
         bool isInitial,
         CancellationToken cancellationToken)
     {
-        using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
-            _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
+        using var connectionLease = await LeaseHeartbeatConnectionAsync(cancellationToken)
             .ConfigureAwait(false);
         var connection = connectionLease.Connection;
-
-        if (!_metadataManager.HasApiKey(connection, ApiKey.ShareGroupHeartbeat))
-        {
-            throw new BrokerVersionException(
-                "The target Kafka broker does not support the ShareGroupHeartbeat API " +
-                "(KIP-932, introduced in Kafka 4.0). Share group consumption requires Kafka 4.0 or later.");
-        }
 
         var version = _metadataManager.GetNegotiatedApiVersion(
             connection,
@@ -393,6 +385,32 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
         }
 
         return false;
+    }
+
+    private async ValueTask<KafkaConnectionLease> LeaseHeartbeatConnectionAsync(
+        CancellationToken cancellationToken)
+    {
+        var connectionLease = default(KafkaConnectionLease);
+        try
+        {
+            connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
+                _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
+                .ConfigureAwait(false);
+            if (!_metadataManager.HasApiKey(connectionLease.Connection, ApiKey.ShareGroupHeartbeat))
+            {
+                throw new BrokerVersionException(
+                    "The target Kafka broker does not support the ShareGroupHeartbeat API " +
+                    "(KIP-932, introduced in Kafka 4.0). Share group consumption requires Kafka 4.0 or later.");
+            }
+
+            return connectionLease;
+        }
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            connectionLease.Dispose();
+            Volatile.Write(ref _lastHeartbeatFailure, ex.Message);
+            throw;
+        }
     }
 
     /// <summary>

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -312,12 +312,6 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
             .ConfigureAwait(false);
         var connection = connectionLease.Connection;
 
-        var version = _metadataManager.GetNegotiatedApiVersion(
-            connection,
-            ApiKey.ShareGroupHeartbeat,
-            ShareGroupHeartbeatRequest.LowestSupportedVersion,
-            ShareGroupHeartbeatRequest.HighestSupportedVersion);
-
         // Share groups always use client-generated UUID v4 member IDs.
         // Generate once when _memberId is null; subsequent heartbeats reuse the stored ID.
         _memberId ??= Guid.NewGuid().ToString();
@@ -341,10 +335,16 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
         ShareGroupHeartbeatResponse response;
         try
         {
+            var version = _metadataManager.GetNegotiatedApiVersion(
+                connection,
+                ApiKey.ShareGroupHeartbeat,
+                ShareGroupHeartbeatRequest.LowestSupportedVersion,
+                ShareGroupHeartbeatRequest.HighestSupportedVersion);
             response = await connection.SendAsync<ShareGroupHeartbeatRequest, ShareGroupHeartbeatResponse>(
                 request, version, cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        catch (Exception ex) when (
+            ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
         {
             Volatile.Write(ref _lastHeartbeatFailure, ex.Message);
             throw;
@@ -405,7 +405,8 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
 
             return connectionLease;
         }
-        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        catch (Exception ex) when (
+            ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
         {
             connectionLease.Dispose();
             Volatile.Write(ref _lastHeartbeatFailure, ex.Message);

--- a/tests/Dekaf.Tests.Integration/ClientStatusIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ClientStatusIntegrationTests.cs
@@ -1,5 +1,7 @@
+using System.Net.Sockets;
 using Dekaf.Consumer;
 using Dekaf.Diagnostics;
+using Dekaf.Errors;
 using Dekaf.Networking;
 using Dekaf.Producer;
 using Dekaf.Protocol.Messages;
@@ -185,7 +187,24 @@ public sealed class BrokerConnectionStatusIntegrationTests(RackAwareKafkaContain
             await kafka.StartBrokerAsync(1, cancellationToken);
             brokerStopped = false;
             await pool.RemoveConnectionAsync(1);
-            _ = await pool.GetConnectionAsync(1, cancellationToken);
+            await TestWait.WaitForConditionAsync(
+                async () =>
+                {
+                    try
+                    {
+                        _ = await pool.GetConnectionAsync(1, cancellationToken);
+                        return statusSource.GetBrokerConnectionStatus().Single().State
+                            == BrokerConnectionState.Connected;
+                    }
+                    catch (Exception ex) when (ex is KafkaException or SocketException)
+                    {
+                        return false;
+                    }
+                },
+                static connected => connected,
+                maxRetries: 10,
+                initialDelayMs: 250,
+                description: "client to reconnect after broker restart");
             var reconnected = statusSource.GetBrokerConnectionStatus().Single();
             await Assert.That(reconnected.State).IsEqualTo(BrokerConnectionState.Connected);
             var disconnectedAt = disconnected.LastConnectionStateChangeAtUtc

--- a/tests/Dekaf.Tests.Integration/ClientStatusIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ClientStatusIntegrationTests.cs
@@ -134,10 +134,12 @@ public sealed class ClientStatusIntegrationTests(KafkaTestContainer kafka) : Kaf
         {
             await foreach (var _ in consumer.ConsumeAsync(cancellationToken))
             {
+                // Polling drives group coordination; records are irrelevant to this status test.
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            return;
         }
     }
 }

--- a/tests/Dekaf.Tests.Integration/ClientStatusIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ClientStatusIntegrationTests.cs
@@ -1,0 +1,201 @@
+using Dekaf.Consumer;
+using Dekaf.Diagnostics;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Diagnostics")]
+public sealed class ClientStatusIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    [SupportsKafka(420)]
+    [Timeout(90_000)]
+    public async Task SharedClients_ReportSameClusterIdentity(CancellationToken cancellationToken)
+    {
+        await using var client = Kafka.Connect(KafkaContainer.BootstrapServers);
+        await using var producer = await client.CreateProducer<string, string>()
+            .BuildAsync(cancellationToken);
+        await using var consumer = await client.CreateConsumer<string, string>($"status-{Guid.NewGuid():N}")
+            .BuildAsync(cancellationToken);
+        await using var shareConsumer = await client.CreateShareConsumer<string, string>($"share-status-{Guid.NewGuid():N}")
+            .BuildAsync(cancellationToken);
+        await using var admin = client.CreateAdminClient().Build();
+        _ = await admin.ListTopicsAsync(cancellationToken: cancellationToken);
+
+        var identities = new IKafkaClientIdentity[]
+        {
+            (IKafkaClientIdentity)producer,
+            (IKafkaClientIdentity)consumer,
+            (IKafkaClientIdentity)shareConsumer,
+            (IKafkaClientIdentity)admin
+        };
+        var clusterId = identities[0].ClusterId;
+
+        await Assert.That(clusterId).IsNotNull();
+        foreach (var identity in identities)
+            await Assert.That(identity.ClusterId).IsEqualTo(clusterId);
+    }
+
+    [Test]
+    [Timeout(90_000)]
+    public async Task ProducerBacklogSnapshot_DrainsAfterFlush(CancellationToken cancellationToken)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLinger(TimeSpan.FromSeconds(10))
+            .WithBatchSize(1024 * 1024)
+            .BuildAsync(cancellationToken);
+        var statusProvider = (IKafkaClientStatusProvider)producer;
+
+        for (var i = 0; i < 100; i++)
+        {
+            await producer.FireAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = i.ToString(),
+                Value = new string('x', 128)
+            });
+        }
+
+        var buffered = statusProvider.GetStatus().Producer!.Value;
+        await Assert.That(buffered.BufferedBytes).IsGreaterThan(0);
+        await Assert.That(buffered.UnsealedBatchCount + buffered.QueuedBatchCount + buffered.InFlightBatchCount)
+            .IsGreaterThan(0);
+
+        await producer.FlushAsync(cancellationToken);
+        await WaitForConditionAsync(
+            () => statusProvider.GetStatus().Producer?.BufferedBytes == 0,
+            TimeSpan.FromSeconds(10),
+            description: "producer backlog to drain after FlushAsync");
+
+        var drained = statusProvider.GetStatus().Producer!.Value;
+        await Assert.That(drained.UnsealedBatchCount).IsEqualTo(0);
+        await Assert.That(drained.QueuedBatchCount).IsEqualTo(0);
+        await Assert.That(drained.InFlightBatchCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [Timeout(90_000)]
+    public async Task ConsumerGroupSnapshot_TracksStableAssignmentAndHeartbeat(
+        CancellationToken cancellationToken)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        await using (var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .BuildAsync(cancellationToken))
+        {
+            await producer.ProduceAsync(topic, "key", "value", cancellationToken);
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId($"status-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithHeartbeatInterval(TimeSpan.FromSeconds(1))
+            .BuildAsync(cancellationToken);
+        consumer.Subscribe(topic);
+        var statusProvider = (IKafkaClientStatusProvider)consumer;
+        using var pollCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var polling = PollUntilCancelledAsync(consumer, pollCancellation.Token);
+
+        try
+        {
+            await WaitForConditionAsync(
+                () => statusProvider.GetStatus().ConsumerGroup is
+                {
+                    State: CoordinatorState.Stable,
+                    Assignment.Count: > 0,
+                    TimeSinceLastHeartbeat: not null
+                },
+                TimeSpan.FromSeconds(30),
+                description: "consumer group status to become stable with a heartbeat");
+
+            var group = statusProvider.GetStatus().ConsumerGroup!;
+            await Assert.That(group.HasConsumerGroup).IsTrue();
+            await Assert.That(group.CoordinatorId).IsGreaterThanOrEqualTo(0);
+            await Assert.That(group.MemberId).IsNotNull();
+            await Assert.That(group.GenerationOrMemberEpoch).IsGreaterThanOrEqualTo(0);
+        }
+        finally
+        {
+            pollCancellation.Cancel();
+            await polling;
+        }
+    }
+
+    private static async Task PollUntilCancelledAsync(
+        IKafkaConsumer<string, string> consumer,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await foreach (var _ in consumer.ConsumeAsync(cancellationToken))
+            {
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+}
+
+[Category("Diagnostics")]
+[Category("Resilience")]
+[NotInParallel("RackAwareKafkaContainer")]
+[ClassDataSource<RackAwareKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class BrokerConnectionStatusIntegrationTests(RackAwareKafkaContainer kafka)
+{
+    [Test]
+    [Timeout(120_000)]
+    public async Task BrokerStatus_TracksDisconnectAndReconnect(CancellationToken cancellationToken)
+    {
+        var firstBootstrap = kafka.BootstrapServers.Split(',')[0];
+        var endpoint = BootstrapServerList.Parse(firstBootstrap);
+        await using var pool = new ConnectionPool(
+            "connection-status-integration",
+            new ConnectionOptions { RequestTimeout = TimeSpan.FromSeconds(5) });
+        pool.RegisterBroker(1, endpoint.Host, endpoint.Port);
+        var statusSource = (IConnectionPoolStatusSource)pool;
+        var brokerStopped = false;
+
+        try
+        {
+            _ = await pool.GetConnectionAsync(1, cancellationToken);
+            var connected = statusSource.GetBrokerConnectionStatus().Single();
+            await Assert.That(connected.State).IsEqualTo(BrokerConnectionState.Connected);
+            await Assert.That(connected.LastSuccessfulRequestAtUtc).IsNotNull();
+            var connectedAt = connected.LastConnectionStateChangeAtUtc
+                ?? throw new InvalidOperationException("Connect timestamp was not captured.");
+
+            await kafka.StopBrokerAsync(1, cancellationToken);
+            brokerStopped = true;
+            await TestWait.WaitForConditionAsync(
+                () => statusSource.GetBrokerConnectionStatus().Single().State == BrokerConnectionState.Disconnected,
+                TimeSpan.FromSeconds(15),
+                description: "client to observe broker disconnect");
+            var disconnected = statusSource.GetBrokerConnectionStatus().Single();
+            await Assert.That(disconnected.LastConnectionStateChangeAtUtc).IsNotNull();
+            await Assert.That(disconnected.LastConnectionStateChangeAtUtc!.Value).IsGreaterThan(connectedAt);
+
+            await kafka.StartBrokerAsync(1, cancellationToken);
+            brokerStopped = false;
+            await pool.RemoveConnectionAsync(1);
+            _ = await pool.GetConnectionAsync(1, cancellationToken);
+            var reconnected = statusSource.GetBrokerConnectionStatus().Single();
+            await Assert.That(reconnected.State).IsEqualTo(BrokerConnectionState.Connected);
+            var disconnectedAt = disconnected.LastConnectionStateChangeAtUtc
+                ?? throw new InvalidOperationException("Disconnect timestamp was not captured.");
+            var reconnectedAt = reconnected.LastConnectionStateChangeAtUtc
+                ?? throw new InvalidOperationException("Reconnect timestamp was not captured.");
+            await Assert.That(reconnectedAt).IsGreaterThanOrEqualTo(disconnectedAt);
+        }
+        finally
+        {
+            if (brokerStopped)
+                await kafka.StartBrokerAsync(1, CancellationToken.None);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
@@ -56,6 +56,27 @@ public sealed class AdminClientControllerBootstrapTests
     }
 
     [Test]
+    public async Task GetStatus_PreservesDiscoveryAliasAcrossAdvertisedEndpointRefresh()
+    {
+        await using var context = new ControllerAdminContext(
+            CreateDiscoveryResponse(
+                activeControllerId: 2,
+                controllerOneHost: "seed",
+                controllerOnePort: 9093),
+            refreshInterval: TimeSpan.Zero);
+        context.EnqueueDiscovery(CreateDiscoveryResponse(activeControllerId: 2));
+
+        _ = await context.Client.DescribeClusterAsync();
+        _ = await context.Client.DescribeClusterAsync();
+        var status = context.Client.GetStatus();
+        var follower = status.Brokers.Single(static broker => broker.BrokerId == 1);
+        var active = status.Brokers.Single(static broker => broker.BrokerId == 2);
+
+        await Assert.That(follower.ConnectionCount).IsEqualTo(1);
+        await Assert.That(active.ConnectionCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task DescribeClusterAsync_RefreshesStaleControllerTopology()
     {
         await using var context = new ControllerAdminContext(refreshInterval: TimeSpan.Zero);

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
@@ -16,14 +16,18 @@ public sealed class AdminClientControllerBootstrapTests
         await using var context = new ControllerAdminContext();
 
         var result = await context.Client.DescribeClusterAsync();
+        _ = await context.Pool.GetConnectionAsync("controller-2", 19094);
+        var status = context.Client.GetStatus();
 
         await Assert.That(result.ClusterId).IsEqualTo("cluster-a");
         await Assert.That(context.Client.ClusterId).IsEqualTo("cluster-a");
-        await Assert.That(context.Client.GetStatus().ClusterId).IsEqualTo("cluster-a");
-        await Assert.That(context.Client.GetStatus().MetadataLastRefreshedAtUtc).IsNotNull();
+        await Assert.That(status.ClusterId).IsEqualTo("cluster-a");
+        await Assert.That(status.MetadataLastRefreshedAtUtc).IsNotNull();
+        await Assert.That(status.Brokers.Select(static broker => broker.BrokerId)).IsEquivalentTo([1, 2]);
         await Assert.That(result.ControllerId).IsEqualTo(2);
         await Assert.That(result.Nodes.Select(static node => node.NodeId)).IsEquivalentTo([1, 2]);
-        context.Pool.DidNotReceiveWithAnyArgs().RegisterBroker(default, default!, default);
+        await Assert.That(async () => { _ = await context.Pool.GetConnectionAsync(1); })
+            .Throws<InvalidOperationException>();
         await Assert.That(context.DiscoveryRequests).IsEqualTo(1);
         await Assert.That(context.LastDiscoveryRequest!.EndpointType)
             .IsEqualTo(DescribeClusterEndpointType.Controller);
@@ -166,8 +170,6 @@ public sealed class AdminClientControllerBootstrapTests
             Arg.Any<DescribeQuorumRequest>(),
             Arg.Any<short>(),
             Arg.Any<CancellationToken>());
-        await context.Pool.DidNotReceiveWithAnyArgs()
-            .GetConnectionAsync(default(int), default);
     }
 
     [Test]
@@ -254,11 +256,12 @@ public sealed class AdminClientControllerBootstrapTests
             BootstrapController = CreateConnection("seed", 9093);
             ActiveController = CreateConnection("controller-2", 19094);
             OtherController = CreateConnection("controller-1", 19093);
-            Pool = Substitute.For<IConnectionPool>();
-            Pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-                .Returns(callInfo =>
+            Pool = new ConnectionPool(
+                "controller-admin-test",
+                new ConnectionOptions(),
+                connectionsPerBroker: 1,
+                connectionFactory: (_, host, _, _, _) =>
                 {
-                    var host = callInfo.ArgAt<string>(0);
                     return ValueTask.FromResult(host switch
                     {
                         "controller-1" => OtherController,

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
@@ -91,6 +91,27 @@ public sealed class AdminClientControllerBootstrapTests
     }
 
     [Test]
+    public async Task GetStatus_PreservesLiveDiscoveryAliasAcrossAdvertisedRefreshes()
+    {
+        await using var context = new ControllerAdminContext(
+            CreateDiscoveryResponse(
+                activeControllerId: 1,
+                controllerOneHost: "seed",
+                controllerOnePort: 9093),
+            refreshInterval: TimeSpan.Zero);
+        context.EnqueueDiscovery(CreateDiscoveryResponse(activeControllerId: 1));
+        context.EnqueueDiscovery(CreateDiscoveryResponse(activeControllerId: 1));
+
+        _ = await context.Client.DescribeClusterAsync();
+        _ = await context.Client.DescribeClusterAsync();
+        _ = await context.Client.DescribeClusterAsync();
+        var controller = context.Client.GetStatus().Brokers.Single(static broker => broker.BrokerId == 1);
+
+        await Assert.That(controller.ConnectionCount).IsEqualTo(2);
+        await Assert.That(controller.ConnectedConnectionCount).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task DescribeClusterAsync_RetriesWhileControllerElectionIsPending()
     {
         await using var context = new ControllerAdminContext(

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
@@ -112,6 +112,29 @@ public sealed class AdminClientControllerBootstrapTests
     }
 
     [Test]
+    public async Task GetStatus_RemapsDiscoveryAliasWhenEndpointGetsNewControllerId()
+    {
+        await using var context = new ControllerAdminContext(
+            CreateDiscoveryResponse(
+                activeControllerId: 1,
+                controllerOneHost: "seed",
+                controllerOnePort: 9093),
+            refreshInterval: TimeSpan.Zero);
+        context.EnqueueDiscovery(CreateDiscoveryResponse(
+            activeControllerId: 3,
+            controllerOneHost: "seed",
+            controllerOnePort: 9093,
+            controllerOneNodeId: 3));
+
+        _ = await context.Client.DescribeClusterAsync();
+        _ = await context.Client.DescribeClusterAsync();
+        var replacement = context.Client.GetStatus().Brokers.Single(static broker => broker.BrokerId == 3);
+
+        await Assert.That(replacement.ConnectionCount).IsEqualTo(1);
+        await Assert.That(replacement.ConnectedConnectionCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task DescribeClusterAsync_RetriesWhileControllerElectionIsPending()
     {
         await using var context = new ControllerAdminContext(
@@ -394,7 +417,8 @@ public sealed class AdminClientControllerBootstrapTests
     private static DescribeClusterResponse CreateDiscoveryResponse(
         int activeControllerId,
         string controllerOneHost = "controller-1",
-        int controllerOnePort = 19093) => new()
+        int controllerOnePort = 19093,
+        int controllerOneNodeId = 1) => new()
     {
         ErrorCode = ErrorCode.None,
         EndpointType = DescribeClusterEndpointType.Controller,
@@ -404,7 +428,7 @@ public sealed class AdminClientControllerBootstrapTests
         [
             new DescribeClusterNode
             {
-                NodeId = 1,
+                NodeId = controllerOneNodeId,
                 Host = controllerOneHost,
                 Port = controllerOnePort
             },

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
@@ -25,8 +25,8 @@ public sealed class AdminClientControllerBootstrapTests
         await Assert.That(status.ClusterId).IsEqualTo("cluster-a");
         await Assert.That(status.MetadataLastRefreshedAtUtc).IsNotNull();
         await Assert.That(status.Brokers.Select(static broker => broker.BrokerId)).IsEquivalentTo([1, 2]);
-        await Assert.That(activeControllerStatus.State).IsEqualTo(BrokerConnectionState.Connected);
-        await Assert.That(activeControllerStatus.ConnectionCount).IsEqualTo(1);
+        await Assert.That(activeControllerStatus.State).IsEqualTo(BrokerConnectionState.Disconnected);
+        await Assert.That(activeControllerStatus.ConnectionCount).IsEqualTo(0);
         await Assert.That(result.ControllerId).IsEqualTo(2);
         await Assert.That(result.Nodes.Select(static node => node.NodeId)).IsEquivalentTo([1, 2]);
         await Assert.That(async () => { _ = await context.Pool.GetConnectionAsync(1); })
@@ -35,6 +35,24 @@ public sealed class AdminClientControllerBootstrapTests
         await Assert.That(context.LastDiscoveryRequest!.EndpointType)
             .IsEqualTo(DescribeClusterEndpointType.Controller);
         await Assert.That(context.LastDiscoveryVersion).IsGreaterThanOrEqualTo((short)1);
+    }
+
+    [Test]
+    public async Task GetStatus_DoesNotProjectFollowerDiscoveryConnectionOntoActiveController()
+    {
+        await using var context = new ControllerAdminContext(
+            CreateDiscoveryResponse(
+                activeControllerId: 2,
+                controllerOneHost: "seed",
+                controllerOnePort: 9093));
+
+        _ = await context.Client.DescribeClusterAsync();
+        var status = context.Client.GetStatus();
+        var follower = status.Brokers.Single(static broker => broker.BrokerId == 1);
+        var active = status.Brokers.Single(static broker => broker.BrokerId == 2);
+
+        await Assert.That(follower.ConnectionCount).IsEqualTo(1);
+        await Assert.That(active.ConnectionCount).IsEqualTo(0);
     }
 
     [Test]
@@ -234,7 +252,10 @@ public sealed class AdminClientControllerBootstrapTests
         Nodes = []
     };
 
-    private static DescribeClusterResponse CreateDiscoveryResponse(int activeControllerId) => new()
+    private static DescribeClusterResponse CreateDiscoveryResponse(
+        int activeControllerId,
+        string controllerOneHost = "controller-1",
+        int controllerOnePort = 19093) => new()
     {
         ErrorCode = ErrorCode.None,
         EndpointType = DescribeClusterEndpointType.Controller,
@@ -242,7 +263,12 @@ public sealed class AdminClientControllerBootstrapTests
         ControllerId = activeControllerId,
         Nodes =
         [
-            new DescribeClusterNode { NodeId = 1, Host = "controller-1", Port = 19093 },
+            new DescribeClusterNode
+            {
+                NodeId = 1,
+                Host = controllerOneHost,
+                Port = controllerOnePort
+            },
             new DescribeClusterNode { NodeId = 2, Host = "controller-2", Port = 19094 }
         ]
     };

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
@@ -112,6 +112,32 @@ public sealed class AdminClientControllerBootstrapTests
     }
 
     [Test]
+    public async Task GetStatus_PrunesDiscoveryAliasAfterConnectionIsRemoved()
+    {
+        await using var context = new ControllerAdminContext(
+            CreateDiscoveryResponse(
+                activeControllerId: 1,
+                controllerOneHost: "seed",
+                controllerOnePort: 9093),
+            refreshInterval: TimeSpan.Zero);
+        context.EnqueueDiscovery(CreateDiscoveryResponse(activeControllerId: 1));
+        context.EnqueueDiscovery(CreateDiscoveryResponse(activeControllerId: 1));
+
+        _ = await context.Client.DescribeClusterAsync();
+        _ = await context.Client.DescribeClusterAsync();
+        await Assert.That(context.GetDiscoveryAliases(1)).IsEquivalentTo([
+            new ConnectionStatusEndpointAlias("seed", 9093)
+        ]);
+
+        await context.Pool.CloseAllAsync();
+        _ = await context.Client.DescribeClusterAsync();
+
+        await Assert.That(context.GetDiscoveryAliases(1)).IsEquivalentTo([
+            new ConnectionStatusEndpointAlias("controller-1", 19093)
+        ]);
+    }
+
+    [Test]
     public async Task GetStatus_RemapsDiscoveryAliasWhenEndpointGetsNewControllerId()
     {
         await using var context = new ControllerAdminContext(
@@ -507,6 +533,16 @@ public sealed class AdminClientControllerBootstrapTests
         internal int DiscoveryRequests { get; private set; }
         internal DescribeClusterRequest? LastDiscoveryRequest { get; private set; }
         internal short LastDiscoveryVersion { get; private set; }
+
+        internal ConnectionStatusEndpointAlias[] GetDiscoveryAliases(int controllerId)
+        {
+            var manager = (ControllerMetadataManager)typeof(AdminClient)
+                .GetField(
+                    "_controllerMetadataManager",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .GetValue(Client)!;
+            return manager.Snapshot.DiscoveryConnections[controllerId];
+        }
 
         internal void EnqueueDiscovery(DescribeClusterResponse response) => _discoveryOutcomes.Enqueue(response);
 

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
@@ -18,6 +18,9 @@ public sealed class AdminClientControllerBootstrapTests
         var result = await context.Client.DescribeClusterAsync();
 
         await Assert.That(result.ClusterId).IsEqualTo("cluster-a");
+        await Assert.That(context.Client.ClusterId).IsEqualTo("cluster-a");
+        await Assert.That(context.Client.GetStatus().ClusterId).IsEqualTo("cluster-a");
+        await Assert.That(context.Client.GetStatus().MetadataLastRefreshedAtUtc).IsNotNull();
         await Assert.That(result.ControllerId).IsEqualTo(2);
         await Assert.That(result.Nodes.Select(static node => node.NodeId)).IsEquivalentTo([1, 2]);
         context.Pool.DidNotReceiveWithAnyArgs().RegisterBroker(default, default!, default);

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
@@ -1,4 +1,5 @@
 using Dekaf.Admin;
+using Dekaf.Diagnostics;
 using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -16,14 +17,16 @@ public sealed class AdminClientControllerBootstrapTests
         await using var context = new ControllerAdminContext();
 
         var result = await context.Client.DescribeClusterAsync();
-        _ = await context.Pool.GetConnectionAsync("controller-2", 19094);
         var status = context.Client.GetStatus();
+        var activeControllerStatus = status.Brokers.Single(static broker => broker.BrokerId == 2);
 
         await Assert.That(result.ClusterId).IsEqualTo("cluster-a");
         await Assert.That(context.Client.ClusterId).IsEqualTo("cluster-a");
         await Assert.That(status.ClusterId).IsEqualTo("cluster-a");
         await Assert.That(status.MetadataLastRefreshedAtUtc).IsNotNull();
         await Assert.That(status.Brokers.Select(static broker => broker.BrokerId)).IsEquivalentTo([1, 2]);
+        await Assert.That(activeControllerStatus.State).IsEqualTo(BrokerConnectionState.Connected);
+        await Assert.That(activeControllerStatus.ConnectionCount).IsEqualTo(1);
         await Assert.That(result.ControllerId).IsEqualTo(2);
         await Assert.That(result.Nodes.Select(static node => node.NodeId)).IsEquivalentTo([1, 2]);
         await Assert.That(async () => { _ = await context.Pool.GetConnectionAsync(1); })

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeActivityTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeActivityTests.cs
@@ -8,12 +8,12 @@ using Dekaf.Serialization;
 namespace Dekaf.Tests.Unit.Consumer;
 
 // Drives the real KafkaConsumer.StartConsumeActivity to pin the semconv contract at the
-// call site (span kind, tombstone, body size), not just the constants it uses.
+// call site (span kind, tombstone, and operation), not just the constants it uses.
 [NotInParallel("ActivityListener")]
 public sealed class ConsumeActivityTests
 {
     [Test]
-    public async Task StartConsumeActivity_ProcessSpan_TombstoneRecord_SetsConsumerKindTombstoneAndZeroBodySize()
+    public async Task StartConsumeActivity_ProcessSpan_TombstoneRecord_SetsConsumerKindAndTombstone()
     {
         using var listener = CreateListener();
 
@@ -21,7 +21,7 @@ public sealed class ConsumeActivityTests
         using var pending = PendingFetchData.Create("orders", partitionIndex: 0, batches: Array.Empty<RecordBatch>());
 
         using var activity = InvokeStartConsumeActivity(
-            consumer, pending, offset: 42, valueLength: 0, isTombstone: true, isProcessSpan: true);
+            consumer, pending, offset: 42, isTombstone: true, isProcessSpan: true);
 
         await Assert.That(activity).IsNotNull();
         // Streaming-path process span: brackets the caller's handling of the record,
@@ -31,12 +31,12 @@ public sealed class ConsumeActivityTests
         await Assert.That(activity.GetTagItem("messaging.operation.name")).IsEqualTo("process");
         await Assert.That(activity.GetTagItem("messaging.operation.type")).IsEqualTo("process");
         await Assert.That((bool?)activity.GetTagItem("messaging.kafka.message.tombstone")).IsTrue();
-        await Assert.That(activity.GetTagItem("messaging.message.body.size")).IsEqualTo(0);
+        await Assert.That(activity.GetTagItem("messaging.message.body.size")).IsNull();
         await Assert.That(activity.GetTagItem("messaging.kafka.offset")).IsEqualTo(42L);
     }
 
     [Test]
-    public async Task StartConsumeActivity_ProcessSpan_RegularRecord_SetsBodySizeToValueLengthWithoutTombstone()
+    public async Task StartConsumeActivity_ProcessSpan_RegularRecord_OmitsOptInBodySizeAndTombstone()
     {
         using var listener = CreateListener();
 
@@ -44,11 +44,11 @@ public sealed class ConsumeActivityTests
         using var pending = PendingFetchData.Create("orders", partitionIndex: 0, batches: Array.Empty<RecordBatch>());
 
         using var activity = InvokeStartConsumeActivity(
-            consumer, pending, offset: 7, valueLength: 512, isTombstone: false, isProcessSpan: true);
+            consumer, pending, offset: 7, isTombstone: false, isProcessSpan: true);
 
         await Assert.That(activity).IsNotNull();
         await Assert.That(activity!.Kind).IsEqualTo(ActivityKind.Consumer);
-        await Assert.That(activity.GetTagItem("messaging.message.body.size")).IsEqualTo(512);
+        await Assert.That(activity.GetTagItem("messaging.message.body.size")).IsNull();
         await Assert.That(activity.GetTagItem("messaging.kafka.message.tombstone")).IsNull();
         await Assert.That(activity.GetTagItem("messaging.kafka.cluster.id")).IsNull();
     }
@@ -62,7 +62,7 @@ public sealed class ConsumeActivityTests
         using var pending = PendingFetchData.Create("orders", partitionIndex: 0, batches: Array.Empty<RecordBatch>());
 
         using var activity = InvokeStartConsumeActivity(
-            consumer, pending, offset: 9, valueLength: 64, isTombstone: false, isProcessSpan: false);
+            consumer, pending, offset: 9, isTombstone: false, isProcessSpan: false);
 
         await Assert.That(activity).IsNotNull();
         // ConsumeOne-path receive span: the activity ends before the record is
@@ -71,7 +71,7 @@ public sealed class ConsumeActivityTests
         await Assert.That(activity.OperationName).IsEqualTo("poll orders");
         await Assert.That(activity.GetTagItem("messaging.operation.name")).IsEqualTo("poll");
         await Assert.That(activity.GetTagItem("messaging.operation.type")).IsEqualTo("receive");
-        await Assert.That(activity.GetTagItem("messaging.message.body.size")).IsEqualTo(64);
+        await Assert.That(activity.GetTagItem("messaging.message.body.size")).IsNull();
         await Assert.That(activity.GetTagItem("messaging.kafka.offset")).IsEqualTo(9L);
     }
 
@@ -100,7 +100,6 @@ public sealed class ConsumeActivityTests
         KafkaConsumer<string, string> consumer,
         PendingFetchData pending,
         long offset,
-        int valueLength,
         bool isTombstone,
         bool isProcessSpan)
     {
@@ -110,6 +109,6 @@ public sealed class ConsumeActivityTests
 
         return (Activity?)method!.Invoke(
             consumer,
-            [pending, null, offset, valueLength, isTombstone, isProcessSpan]);
+            [pending, null, offset, isTombstone, isProcessSpan]);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeActivityTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeActivityTests.cs
@@ -50,6 +50,7 @@ public sealed class ConsumeActivityTests
         await Assert.That(activity!.Kind).IsEqualTo(ActivityKind.Consumer);
         await Assert.That(activity.GetTagItem("messaging.message.body.size")).IsEqualTo(512);
         await Assert.That(activity.GetTagItem("messaging.kafka.message.tombstone")).IsNull();
+        await Assert.That(activity.GetTagItem("messaging.kafka.cluster.id")).IsNull();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -323,6 +323,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
                 await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None))
             .Throws<BrokerVersionException>()
             .WithMessageContaining("Kafka 4.0");
+        await Assert.That(coordinator.CaptureGroupStatus().LastHeartbeatFailure)
+            .Contains("Kafka 4.0");
 
         await noHeartbeatManager.DisposeAsync();
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerGroupLivenessTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerGroupLivenessTests.cs
@@ -29,6 +29,18 @@ public sealed class ConsumerGroupLivenessTests
         await Assert.That(liveness.IsJoined).IsFalse();
     }
 
+    [Test]
+    public async Task TopicFilterSubscriptionWithConfiguredGroup_ReportsGroupParticipation()
+    {
+        await using var consumer = CreateConsumer();
+        consumer.Subscribe(static _ => true);
+
+        var liveness = ((IConsumerGroupLiveness)consumer).GroupLiveness;
+
+        await Assert.That(liveness.HasConsumerGroup).IsTrue();
+        await Assert.That(liveness.IsJoined).IsFalse();
+    }
+
     private static KafkaConsumer<string, string> CreateConsumer() => new(
         new ConsumerOptions
         {

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -398,23 +398,23 @@ public class MpscFetchBufferTests
     }
 
     [Test]
-    public async Task WaitToReadAsync_TimeoutDoesNotRunContinuationOnTimerThread()
+    public async Task WaitToReadAsync_TimeoutDoesNotRunContinuationInline()
     {
-        using var timeoutEntered = new ManualResetEventSlim();
+        var timeoutEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using var releaseTimeout = new ManualResetEventSlim();
-        using var continuationEntered = new ManualResetEventSlim();
+        var continuationEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using var releaseContinuation = new ManualResetEventSlim();
-        using var continuationFinished = new ManualResetEventSlim();
-        using var timeoutCallbackExited = new ManualResetEventSlim();
+        var continuationFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timeoutCallbackExited = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var buffer = new MpscFetchBuffer(
             capacity: 4,
             afterProducerWaiterCountIncrementedForTesting: null,
             beforeConsumerTimeoutForTesting: () =>
             {
-                timeoutEntered.Set();
+                timeoutEntered.TrySetResult();
                 releaseTimeout.Wait();
             },
-            afterConsumerTimeoutForTesting: timeoutCallbackExited.Set);
+            afterConsumerTimeoutForTesting: () => timeoutCallbackExited.TrySetResult());
         var result = true;
         Exception? continuationException = null;
 
@@ -423,7 +423,7 @@ public class MpscFetchBufferTests
             var awaiter = buffer.WaitToReadAsync(1, CancellationToken.None).GetAwaiter();
             awaiter.UnsafeOnCompleted(() =>
             {
-                continuationEntered.Set();
+                continuationEntered.TrySetResult();
                 releaseContinuation.Wait();
                 try
                 {
@@ -435,17 +435,17 @@ public class MpscFetchBufferTests
                 }
                 finally
                 {
-                    continuationFinished.Set();
+                    continuationFinished.TrySetResult();
                 }
             });
 
-            await Assert.That(timeoutEntered.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await timeoutEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
             releaseTimeout.Set();
-            await Assert.That(continuationEntered.Wait(TimeSpan.FromSeconds(5))).IsTrue();
-            await Assert.That(timeoutCallbackExited.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await continuationEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await timeoutCallbackExited.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
             releaseContinuation.Set();
-            await Assert.That(continuationFinished.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await continuationFinished.Task.WaitAsync(TimeSpan.FromSeconds(5));
             await Assert.That(continuationException).IsNull();
             await Assert.That(result).IsFalse();
         }

--- a/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
@@ -120,10 +120,10 @@ public sealed class KafkaClientStatusTests
             {
                 for (var i = 0; i < 1_000; i++)
                 {
-                    foreach (var identity in identities)
+                    foreach (var identity in identities.Where(static identity => identity.ClusterId != "cluster-status"))
                     {
-                        if (identity.ClusterId != "cluster-status")
-                            throw new InvalidOperationException("Observed an unpublished cluster identity.");
+                        throw new InvalidOperationException(
+                            $"Observed unpublished cluster identity '{identity.ClusterId ?? "<null>"}'.");
                     }
                 }
             }));

--- a/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
@@ -74,6 +74,25 @@ public sealed class KafkaClientStatusTests
     }
 
     [Test]
+    public async Task ConsumerStatus_TopicFilterReportsGroupParticipation()
+    {
+        await using var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = "status-consumer",
+                GroupId = "filter-group"
+            },
+            Serializers.String,
+            Serializers.String);
+        consumer.Subscribe(static topic => topic.StartsWith("orders-", StringComparison.Ordinal));
+
+        var group = consumer.GetStatus().ConsumerGroup!;
+
+        await Assert.That(group.HasConsumerGroup).IsTrue();
+    }
+
+    [Test]
     public async Task SharedClients_ReportCachedClusterIdentityDuringConcurrentRefreshes()
     {
         await using var client = Kafka.Connect("localhost:9092");

--- a/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
@@ -126,7 +126,8 @@ public sealed class KafkaClientStatusTests
                             $"Observed unpublished cluster identity '{identity.ClusterId ?? "<null>"}'.");
                     }
                 }
-            }));
+            }))
+            .ToArray();
         var writer = Task.Run(() =>
         {
             for (var i = 0; i < 1_000; i++)

--- a/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
@@ -1,0 +1,247 @@
+using System.Diagnostics;
+using System.Reflection;
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Diagnostics;
+using Dekaf.Metadata;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Unit.Diagnostics;
+
+[NotInParallel("ActivityListener")]
+public sealed class KafkaClientStatusTests
+{
+    [Test]
+    public async Task BuiltInClients_ExposeOptionalStatusCapabilityBeforeInitialization()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+        await using var shareConsumer = Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("status-share-group")
+            .Build();
+        await using var admin = new AdminClient(new AdminClientOptions
+        {
+            BootstrapServers = ["localhost:9092"]
+        });
+
+        var producerStatus = ((IKafkaClientStatusProvider)producer).GetStatus();
+        var consumerStatus = ((IKafkaClientStatusProvider)consumer).GetStatus();
+        var shareStatus = ((IKafkaClientStatusProvider)shareConsumer).GetStatus();
+        var adminStatus = ((IKafkaClientStatusProvider)admin).GetStatus();
+
+        await Assert.That(producerStatus.Role).IsEqualTo(KafkaClientRole.Producer);
+        await Assert.That(producerStatus.ClusterId).IsNull();
+        await Assert.That(producerStatus.Producer).IsNotNull();
+        await Assert.That(producerStatus.Producer!.Value.BufferedBytes).IsEqualTo(0);
+        await Assert.That(producerStatus.Producer.Value.BufferCapacityBytes).IsGreaterThan(0UL);
+        await Assert.That(consumerStatus.Role).IsEqualTo(KafkaClientRole.Consumer);
+        await Assert.That(consumerStatus.ConsumerGroup).IsNotNull();
+        await Assert.That(consumerStatus.ConsumerGroup!.HasConsumerGroup).IsFalse();
+        await Assert.That(shareStatus.Role).IsEqualTo(KafkaClientRole.ShareConsumer);
+        await Assert.That(shareStatus.ConsumerGroup!.HasConsumerGroup).IsTrue();
+        await Assert.That(adminStatus.Role).IsEqualTo(KafkaClientRole.Admin);
+        await Assert.That(adminStatus.ClusterId).IsNull();
+    }
+
+    [Test]
+    public async Task ConsumerStatus_ManualAssignmentDoesNotReportGroupParticipation()
+    {
+        await using var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = "status-consumer",
+                GroupId = "configured-but-unused-group"
+            },
+            Serializers.String,
+            Serializers.String);
+        consumer.Assign(new TopicPartition("orders", 0));
+
+        var group = consumer.GetStatus().ConsumerGroup!;
+
+        await Assert.That(group.HasConsumerGroup).IsFalse();
+        await Assert.That(group.Assignment).IsEquivalentTo([new TopicPartition("orders", 0)]);
+    }
+
+    [Test]
+    public async Task SharedClients_ReportCachedClusterIdentityDuringConcurrentRefreshes()
+    {
+        await using var client = Kafka.Connect("localhost:9092");
+        await using var producer = client.CreateProducer<string, string>().Build();
+        await using var consumer = client.CreateConsumer<string, string>("status-group").Build();
+        await using var shareConsumer = client.CreateShareConsumer<string, string>("status-share-group").Build();
+        await using var admin = client.CreateAdminClient().Build();
+
+        var metadataManager = GetField<MetadataManager>(producer, "_metadataManager");
+        metadataManager.Metadata.Update(CreateMetadata("cluster-status"));
+        SetTrustedClusterId(metadataManager, "cluster-status");
+
+        var identities = new IKafkaClientIdentity[]
+        {
+            (IKafkaClientIdentity)producer,
+            (IKafkaClientIdentity)consumer,
+            (IKafkaClientIdentity)shareConsumer,
+            (IKafkaClientIdentity)admin
+        };
+        foreach (var identity in identities)
+            await Assert.That(identity.ClusterId).IsEqualTo("cluster-status");
+
+        var readers = Enumerable.Range(0, Environment.ProcessorCount)
+            .Select(_ => Task.Run(() =>
+            {
+                for (var i = 0; i < 1_000; i++)
+                {
+                    foreach (var identity in identities)
+                    {
+                        if (identity.ClusterId != "cluster-status")
+                            throw new InvalidOperationException("Observed an unpublished cluster identity.");
+                    }
+                }
+            }));
+        var writer = Task.Run(() =>
+        {
+            for (var i = 0; i < 1_000; i++)
+                metadataManager.Metadata.Update(CreateMetadata("cluster-status"));
+        });
+
+        await Task.WhenAll(readers.Append(writer));
+    }
+
+    [Test]
+    public async Task RejectedMetadataClusterIdentity_IsNeverPublished()
+    {
+        await using var producer = new KafkaProducer<string, string>(
+            new ProducerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = "status-producer"
+            },
+            Serializers.String,
+            Serializers.String);
+        var metadataManager = GetField<MetadataManager>(producer, "_metadataManager");
+        metadataManager.Metadata.Update(CreateMetadata("cluster-a"));
+        SetTrustedClusterId(metadataManager, "cluster-a");
+
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            ErrorCode = ErrorCode.RebootstrapRequired,
+            ClusterId = "rejected-cluster",
+            Brokers = [],
+            Topics = []
+        });
+
+        await Assert.That(metadataManager.Metadata.ClusterId).IsEqualTo("rejected-cluster");
+        await Assert.That(producer.ClusterId).IsEqualTo("cluster-a");
+        await Assert.That(producer.GetStatus().ClusterId).IsEqualTo("cluster-a");
+    }
+
+    [Test]
+    public async Task ProducerAndConsumerActivities_IncludeKnownClusterIdentity()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == DekafDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await using var client = Kafka.Connect("localhost:9092");
+        await using var producer = (KafkaProducer<string, string>)client.CreateProducer<string, string>().Build();
+        await using var consumer = (KafkaConsumer<string, string>)client.CreateConsumer<string, string>("status-group").Build();
+        var metadataManager = GetField<MetadataManager>(producer, "_metadataManager");
+        metadataManager.Metadata.Update(CreateMetadata("cluster-status"));
+        SetTrustedClusterId(metadataManager, "cluster-status");
+
+        using var producerActivity = StartProducerActivity(producer);
+        using var pending = PendingFetchData.Create("orders", 0, Array.Empty<RecordBatch>());
+        using var consumerActivity = StartConsumerActivity(consumer, pending);
+
+        await Assert.That(producerActivity).IsNotNull();
+        await Assert.That(producerActivity!.GetTagItem("messaging.kafka.cluster.id"))
+            .IsEqualTo("cluster-status");
+        await Assert.That(consumerActivity).IsNotNull();
+        await Assert.That(consumerActivity!.GetTagItem("messaging.kafka.cluster.id"))
+            .IsEqualTo("cluster-status");
+    }
+
+    [Test]
+    public async Task ProducerActivity_OmitsUnknownClusterIdentity()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == DekafDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+        await using var producer = new KafkaProducer<string, string>(
+            new ProducerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = "status-producer"
+            },
+            Serializers.String,
+            Serializers.String);
+
+        using var activity = StartProducerActivity(producer);
+
+        await Assert.That(activity).IsNotNull();
+        await Assert.That(activity!.GetTagItem("messaging.kafka.cluster.id")).IsNull();
+    }
+
+    private static MetadataResponse CreateMetadata(string clusterId) => new()
+    {
+        ClusterId = clusterId,
+        Brokers =
+        [
+            new BrokerMetadata { NodeId = 0, Host = "localhost", Port = 9092 }
+        ],
+        Topics = Array.Empty<TopicMetadata>()
+    };
+
+    private static Activity? StartProducerActivity(KafkaProducer<string, string> producer)
+    {
+        var method = typeof(KafkaProducer<string, string>).GetMethod(
+            "StartPublishActivity",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        object?[] arguments =
+        [
+            new ProducerMessage<string, string> { Topic = "orders", Key = "key", Value = "value" }
+        ];
+        return (Activity?)method.Invoke(producer, arguments);
+    }
+
+    private static Activity? StartConsumerActivity(
+        KafkaConsumer<string, string> consumer,
+        PendingFetchData pending)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "StartConsumeActivity",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (Activity?)method.Invoke(consumer, [pending, null, 42L, 10, false, false]);
+    }
+
+    private static T GetField<T>(object instance, string name) =>
+        (T)instance.GetType()
+            .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(instance)!;
+
+    private static void SetTrustedClusterId(MetadataManager metadataManager, string clusterId) =>
+        typeof(MetadataManager)
+            .GetMethod(
+                "UpdateMetadataClusterId",
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                binder: null,
+                [typeof(string)],
+                modifiers: null)!
+            .Invoke(metadataManager, [clusterId]);
+}

--- a/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
@@ -247,7 +247,7 @@ public sealed class KafkaClientStatusTests
         var method = typeof(KafkaConsumer<string, string>).GetMethod(
             "StartConsumeActivity",
             BindingFlags.NonPublic | BindingFlags.Instance)!;
-        return (Activity?)method.Invoke(consumer, [pending, null, 42L, 10, false, false]);
+        return (Activity?)method.Invoke(consumer, [pending, null, 42L, false, false]);
     }
 
     private static T GetField<T>(object instance, string name) =>

--- a/tests/Dekaf.Tests.Unit/Diagnostics/TraceContextPropagatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/TraceContextPropagatorTests.cs
@@ -40,7 +40,8 @@ public sealed class TraceContextPropagatorTests
 
         var traceparent = result!.GetFirstAsString("traceparent");
         await Assert.That(traceparent).IsNotNull();
-        await Assert.That(traceparent!).StartsWith("00-");
+        await Assert.That(traceparent).IsEqualTo(
+            $"00-{activity!.TraceId}-{activity.SpanId}-{(activity.Recorded ? "01" : "00")}");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Diagnostics/TraceContextPropagatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/TraceContextPropagatorTests.cs
@@ -1,5 +1,8 @@
+using System.Buffers;
 using System.Diagnostics;
+using System.Text;
 using Dekaf.Diagnostics;
+using Dekaf.Protocol;
 using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Unit.Diagnostics;
@@ -42,6 +45,26 @@ public sealed class TraceContextPropagatorTests
         await Assert.That(traceparent).IsNotNull();
         await Assert.That(traceparent).IsEqualTo(
             $"00-{activity!.TraceId}-{activity.SpanId}-{(activity.Recorded ? "01" : "00")}");
+    }
+
+    [Test]
+    public async Task InjectTraceContext_DeferredHeaderWritesExpectedWireValue()
+    {
+        using var activity = new Activity("trace-wire")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+        var headers = TraceContextPropagator.InjectTraceContext(new Headers(1), activity)!;
+        var header = headers[0];
+        var output = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(output);
+
+        header.Write(ref writer);
+
+        await Assert.That(output.WrittenSpan[0]).IsEqualTo((byte)22);
+        await Assert.That(Encoding.UTF8.GetString(output.WrittenSpan.Slice(1, 11))).IsEqualTo("traceparent");
+        await Assert.That(output.WrittenSpan[12]).IsEqualTo((byte)110);
+        await Assert.That(Encoding.UTF8.GetString(output.WrittenSpan[13..])).IsEqualTo(
+            $"00-{activity.TraceId}-{activity.SpanId}-{(activity.Recorded ? "01" : "00")}");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Diagnostics/TraceContextPropagatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/TraceContextPropagatorTests.cs
@@ -87,6 +87,23 @@ public sealed class TraceContextPropagatorTests
     }
 
     [Test]
+    public async Task RemoveDeferredTraceContext_RestoresCallerOwnedHeaders()
+    {
+        using var firstActivity = new Activity("first-trace")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+        firstActivity.TraceStateString = "vendor=value";
+        var headers = new Headers(3).Add("existing", "value");
+
+        TraceContextPropagator.InjectTraceContext(headers, firstActivity);
+        headers.RemoveDeferredTraceContext();
+
+        await Assert.That(headers.Count).IsEqualTo(1);
+        await Assert.That(headers[0].Key).IsEqualTo("existing");
+        await Assert.That(headers[0].GetValueAsString()).IsEqualTo("value");
+    }
+
+    [Test]
     public async Task InjectTraceContext_WithTracestate_AddsBothHeaders()
     {
         using var listener = new ActivityListener

--- a/tests/Dekaf.Tests.Unit/Diagnostics/TraceContextPropagatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/TraceContextPropagatorTests.cs
@@ -69,6 +69,21 @@ public sealed class TraceContextPropagatorTests
     }
 
     [Test]
+    public async Task DeferredHeader_WithValue_UsesReplacementValue()
+    {
+        using var activity = new Activity("trace-replacement")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+        var deferred = Header.CreateDeferredTraceparent("traceparent", activity);
+        var replacement = "replacement"u8.ToArray();
+
+        var replaced = deferred with { Value = replacement };
+
+        await Assert.That(replaced.Value.Span.SequenceEqual(replacement)).IsTrue();
+        await Assert.That(replaced.GetValueAsString()).IsEqualTo("replacement");
+    }
+
+    [Test]
     public async Task InjectTraceContext_DeferredTracestateWritesExpectedWireValue()
     {
         using var activity = new Activity("tracestate-wire")

--- a/tests/Dekaf.Tests.Unit/Diagnostics/TraceContextPropagatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/TraceContextPropagatorTests.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Text;
 using Dekaf.Diagnostics;
+using Dekaf.Producer;
 using Dekaf.Protocol;
 using Dekaf.Serialization;
 
@@ -65,6 +66,24 @@ public sealed class TraceContextPropagatorTests
         await Assert.That(output.WrittenSpan[12]).IsEqualTo((byte)110);
         await Assert.That(Encoding.UTF8.GetString(output.WrittenSpan[13..])).IsEqualTo(
             $"00-{activity.TraceId}-{activity.SpanId}-{(activity.Recorded ? "01" : "00")}");
+    }
+
+    [Test]
+    public async Task ReturnPooledHeaders_ClearsDeferredActivityReference()
+    {
+        using var activity = new Activity("trace-retention")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+        activity.TraceStateString = "vendor=value";
+        var headers = TraceContextPropagator.InjectTraceContext(new Headers(2), activity)!;
+        var pooledHeaders = ProducerContainerPools.Headers.Rent(headers.Count);
+        for (var i = 0; i < headers.Count; i++)
+            pooledHeaders[i] = headers[i];
+
+        RecordAccumulator.ReturnPooledHeaders(pooledHeaders, headers.Count);
+
+        await Assert.That(pooledHeaders[0].HasDeferredTraceparent).IsFalse();
+        await Assert.That(pooledHeaders[0]).IsEqualTo(default(Header));
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Diagnostics/TraceContextPropagatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/TraceContextPropagatorTests.cs
@@ -69,6 +69,31 @@ public sealed class TraceContextPropagatorTests
     }
 
     [Test]
+    public async Task InjectTraceContext_DeferredTracestateWritesExpectedWireValue()
+    {
+        using var activity = new Activity("tracestate-wire")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+        activity.TraceStateString = "vendor=välue";
+        var header = TraceContextPropagator.InjectTraceContext(new Headers(2), activity)![1];
+        var output = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(output);
+
+        header.Write(ref writer);
+        var encoded = new byte[header.CalculateSize()];
+        var offset = 0;
+        header.Encode(encoded, ref offset);
+        var encodedMatchesWriter = encoded.AsSpan().SequenceEqual(output.WrittenSpan);
+
+        await Assert.That(output.WrittenSpan[0]).IsEqualTo((byte)20);
+        await Assert.That(Encoding.UTF8.GetString(output.WrittenSpan.Slice(1, 10))).IsEqualTo("tracestate");
+        await Assert.That(output.WrittenSpan[11]).IsEqualTo((byte)26);
+        await Assert.That(Encoding.UTF8.GetString(output.WrittenSpan[12..])).IsEqualTo("vendor=välue");
+        await Assert.That(offset).IsEqualTo(encoded.Length);
+        await Assert.That(encodedMatchesWriter).IsTrue();
+    }
+
+    [Test]
     public async Task ReturnPooledHeaders_ClearsDeferredActivityReference()
     {
         using var activity = new Activity("trace-retention")
@@ -84,6 +109,29 @@ public sealed class TraceContextPropagatorTests
 
         await Assert.That(pooledHeaders[0].HasDeferredTraceparent).IsFalse();
         await Assert.That(pooledHeaders[0]).IsEqualTo(default(Header));
+    }
+
+    [Test]
+    public async Task ReturnPooledHeaders_ClearsTrackedActivityBeforeAppendedHeaders()
+    {
+        using var activity = new Activity("trace-retention-with-appended-header")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+        activity.TraceStateString = "vendor=value";
+        var headers = new Headers(4).Add("existing", "value");
+        TraceContextPropagator.InjectTraceContext(headers, activity);
+        headers.Add("serializer", "appended");
+
+        KafkaProducer<string, string>.RentAndFillHeaders(
+            headers,
+            out var pooledHeaders,
+            out var headerCount);
+        RecordAccumulator.ReturnPooledHeaders(pooledHeaders, headerCount);
+
+        await Assert.That(pooledHeaders[0].Key).IsEqualTo("existing");
+        await Assert.That(pooledHeaders[1].Key).IsEqualTo("serializer");
+        await Assert.That(pooledHeaders[2]).IsEqualTo(default(Header));
+        await Assert.That(pooledHeaders[3].Key).IsEqualTo("tracestate");
     }
 
     [Test]
@@ -120,6 +168,42 @@ public sealed class TraceContextPropagatorTests
         await Assert.That(headers[0].Key).IsEqualTo("existing");
         await Assert.That(headers[1].Key).IsEqualTo("serializer");
         await Assert.That(headers[1].GetValueAsString()).IsEqualTo("appended");
+    }
+
+    [Test]
+    public async Task RemoveDeferredTraceContext_TracksHeadersRemovedBeforeInjectionSlot()
+    {
+        using var activity = new Activity("trace-with-removed-leading-header")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+        activity.TraceStateString = "vendor=value";
+        var headers = new Headers(5)
+            .Add("remove", "value")
+            .Add("existing", "value");
+
+        TraceContextPropagator.InjectTraceContext(headers, activity);
+        headers.Remove("remove");
+        headers.Add("serializer", "appended");
+        headers.RemoveDeferredTraceContext();
+
+        await Assert.That(headers.Count).IsEqualTo(2);
+        await Assert.That(headers[0].Key).IsEqualTo("existing");
+        await Assert.That(headers[1].Key).IsEqualTo("serializer");
+    }
+
+    [Test]
+    public async Task RemoveDeferredTraceContext_RemovesTracestateAfterTraceparentRemoval()
+    {
+        using var activity = new Activity("trace-with-removed-traceparent")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+        activity.TraceStateString = "vendor=value";
+        var headers = TraceContextPropagator.InjectTraceContext(new Headers(2), activity)!;
+
+        headers.Remove("traceparent");
+        headers.RemoveDeferredTraceContext();
+
+        await Assert.That(headers.Count).IsEqualTo(0);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -449,6 +449,68 @@ public class MetadataManagerTests
     }
 
     [Test]
+    public async Task RefreshMetadataAsync_RebootstrapRequired_PreservesTrustedBrokerStatus()
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.IsConnected.Returns(true);
+        connection.BrokerId.Returns(-1);
+        connection.Host.Returns("bootstrap");
+        connection.Port.Returns(9092);
+        await using var pool = new ConnectionPool(
+            "metadata-status-test",
+            new ConnectionOptions(),
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => ValueTask.FromResult(connection));
+        connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                Arg.Any<ApiVersionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys =
+                [
+                    new ApiVersion(
+                        ApiKey.Metadata,
+                        MetadataRequest.LowestSupportedVersion,
+                        MetadataRequest.HighestSupportedVersion)
+                ]
+            });
+        var rejected = new MetadataResponse
+        {
+            ErrorCode = ErrorCode.RebootstrapRequired,
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 99, Host = "untrusted", Port = 9199 }
+            ],
+            Topics = Array.Empty<TopicMetadata>()
+        };
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(
+                CreateMetadataResponse((1, "trusted", 9092)),
+                rejected);
+        await using var manager = new MetadataManager(
+            pool,
+            ["bootstrap:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                MetadataRecoveryStrategy = MetadataRecoveryStrategy.None
+            });
+
+        await manager.InitializeAsync();
+        var trustedStatus = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus();
+        await manager.RefreshMetadataAsync();
+        var rejectedStatus = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus();
+
+        await Assert.That(trustedStatus.Select(static broker => broker.BrokerId)).IsEquivalentTo([1]);
+        await Assert.That(rejectedStatus.Select(static broker => broker.BrokerId)).IsEquivalentTo([1]);
+    }
+
+    [Test]
     public async Task InitializeAsync_VersionlessConnection_UsesCompatibleApiVersionsV3()
     {
         var pool = Substitute.For<IConnectionPool>();

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -400,6 +400,55 @@ public class MetadataManagerTests
     }
 
     [Test]
+    public async Task InitializeAsync_PublishesAuthoritativeBrokerStatusSnapshot()
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.IsConnected.Returns(true);
+        connection.BrokerId.Returns(-1);
+        connection.Host.Returns("localhost");
+        connection.Port.Returns(9092);
+        connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                Arg.Any<ApiVersionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys =
+                [
+                    new ApiVersion(
+                        ApiKey.Metadata,
+                        MetadataRequest.LowestSupportedVersion,
+                        MetadataRequest.HighestSupportedVersion)
+                ]
+            });
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(
+                CreateMetadataResponse((1, "broker-1", 9092), (3, "broker-3", 9094)),
+                CreateMetadataResponse((3, "broker-3", 9094)));
+        await using var pool = new ConnectionPool(
+            "metadata-status-test",
+            new ConnectionOptions(),
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => ValueTask.FromResult(connection));
+        await using var manager = new MetadataManager(
+            pool,
+            ["localhost:9092"],
+            new MetadataOptions { EnableBackgroundRefresh = false });
+
+        await manager.InitializeAsync();
+        var initial = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus();
+        await manager.RefreshMetadataAsync();
+        var refreshed = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus();
+
+        await Assert.That(initial.Select(static broker => broker.BrokerId)).IsEquivalentTo([1, 3]);
+        await Assert.That(refreshed.Select(static broker => broker.BrokerId)).IsEquivalentTo([3]);
+    }
+
+    [Test]
     public async Task InitializeAsync_VersionlessConnection_UsesCompatibleApiVersionsV3()
     {
         var pool = Substitute.For<IConnectionPool>();

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -449,7 +449,7 @@ public class MetadataManagerTests
     }
 
     [Test]
-    public async Task RefreshMetadataAsync_RebootstrapRequired_PreservesTrustedBrokerStatus()
+    public async Task RefreshMetadataAsync_RebootstrapRequired_PreservesStatusAndRegistersFallbackRouting()
     {
         var connection = Substitute.For<IKafkaConnection>();
         connection.IsConnected.Returns(true);
@@ -505,9 +505,11 @@ public class MetadataManagerTests
         var trustedStatus = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus();
         await manager.RefreshMetadataAsync();
         var rejectedStatus = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus();
+        var fallbackConnection = await pool.GetConnectionAsync(99);
 
         await Assert.That(trustedStatus.Select(static broker => broker.BrokerId)).IsEquivalentTo([1]);
         await Assert.That(rejectedStatus.Select(static broker => broker.BrokerId)).IsEquivalentTo([1]);
+        await Assert.That(fallbackConnection).IsSameReferenceAs(connection);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -192,6 +192,33 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task StatusSnapshot_AggregatesControllerEndpointAliases()
+    {
+        await using var pool = new ConnectionPool(
+            clientId: "status-test",
+            connectionOptions: new ConnectionOptions(),
+            connectionsPerBroker: 1,
+            connectionFactory: (_, host, port, _, _) =>
+                ValueTask.FromResult<IKafkaConnection>(new TestIdleConnection(-1, host, port)));
+        _ = await pool.GetConnectionAsync("controller-alias-a", 29093);
+        _ = await pool.GetConnectionAsync("controller-alias-b", 39093);
+
+        var status = ((IConnectionPoolStatusSource)pool).GetEndpointConnectionStatus(
+            [new ConnectionStatusEndpoint(
+                2,
+                "controller-a",
+                19093,
+                [
+                    new ConnectionStatusEndpointAlias("controller-alias-a", 29093),
+                    new ConnectionStatusEndpointAlias("controller-alias-b", 39093),
+                    new ConnectionStatusEndpointAlias("controller-alias-a", 29093)
+                ])]).Single();
+
+        await Assert.That(status.ConnectionCount).IsEqualTo(2);
+        await Assert.That(status.ConnectedConnectionCount).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task StatusSnapshot_PreservesControllerDisconnectTimeWhenReplacementFails()
     {
         long statusTimestamp = 100;
@@ -335,8 +362,7 @@ public sealed class ConnectionPoolTests
                 2,
                 "controller-a",
                 19093,
-                "controller-alias",
-                29093)]).Single();
+                [new ConnectionStatusEndpointAlias("controller-alias", 29093)])]).Single();
 
         await Assert.That(status.LastConnectionStateChangeAtUtc).IsNull();
         await Assert.That(status.LastError).IsEqualTo("controller-alias refused");
@@ -365,8 +391,7 @@ public sealed class ConnectionPoolTests
                 2,
                 "controller-a",
                 19093,
-                "CONTROLLER-A",
-                19093)]).Single();
+                [new ConnectionStatusEndpointAlias("CONTROLLER-A", 19093)])]).Single();
 
         await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Disconnected);
         await Assert.That(status.LastError).IsEqualTo("CONTROLLER-A refused");

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -158,6 +158,28 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task StatusSnapshot_RecordsOnlyRepresentedBrokerClosures()
+    {
+        long statusTimestamp = 100;
+        var connection = new TestIdleConnection(7, "broker-a", 9092);
+        await using var pool = new ConnectionPool(
+            clientId: "status-test",
+            connectionOptions: new ConnectionOptions(),
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => ValueTask.FromResult<IKafkaConnection>(connection),
+            statusTimestampProvider: () => Volatile.Read(ref statusTimestamp));
+        pool.RegisterBroker(7, "broker-a", 9092);
+        pool.RegisterBroker(8, "broker-b", 9093);
+        _ = await pool.GetConnectionAsync(7);
+        Volatile.Write(ref statusTimestamp, 101);
+
+        await pool.CloseAllAsync();
+
+        await Assert.That(GetBrokerStateChangeTimestamp(pool, 7)).IsEqualTo(101);
+        await Assert.That(GetBrokerStateChangeTimestamp(pool, 8)).IsEqualTo(100);
+    }
+
+    [Test]
     public async Task StatusSnapshot_ReportsControllerEndpointConnectionFailure()
     {
         await using var pool = new ConnectionPool(

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -149,6 +149,29 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task StatusSnapshot_PreservesRequestFreshnessWhenBrokerEndpointChanges()
+    {
+        var connection = new TestIdleConnection(7, "broker-a", 9092)
+        {
+            LastSuccessfulRequestTimestampMs = 99
+        };
+        await using var pool = new ConnectionPool(
+            clientId: "status-test",
+            connectionOptions: new ConnectionOptions(),
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => ValueTask.FromResult<IKafkaConnection>(connection));
+        pool.RegisterBroker(7, "broker-a", 9092);
+        _ = await pool.GetConnectionAsync(7);
+
+        pool.RegisterBroker(7, "broker-b", 9093);
+
+        var status = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus().Single();
+        await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Disconnected);
+        await Assert.That(status.LastSuccessfulRequestAtUtc).IsNotNull();
+        await Assert.That(GetBrokerSuccessfulRequestTimestamp(pool, 7)).IsEqualTo(99);
+    }
+
+    [Test]
     public async Task StatusSnapshot_ReportsControllerEndpointConnection()
     {
         var connection = new TestIdleConnection(-1, "controller-a", 19093);

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -118,7 +118,10 @@ public sealed class ConnectionPoolTests
     {
         long statusTimestamp = 100;
         var creationAttempt = 0;
-        var connection = new TestIdleConnection(7, "broker-a", 9092);
+        var connection = new TestIdleConnection(7, "broker-a", 9092)
+        {
+            LastSuccessfulRequestTimestampMs = 99
+        };
         await using var pool = new ConnectionPool(
             clientId: "status-test",
             connectionOptions: new ConnectionOptions
@@ -140,7 +143,9 @@ public sealed class ConnectionPoolTests
 
         var status = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus().Single();
         await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Disconnected);
+        await Assert.That(status.LastSuccessfulRequestAtUtc).IsNotNull();
         await Assert.That(GetBrokerStateChangeTimestamp(pool, 7)).IsEqualTo(101);
+        await Assert.That(GetBrokerSuccessfulRequestTimestamp(pool, 7)).IsEqualTo(99);
     }
 
     [Test]
@@ -168,7 +173,10 @@ public sealed class ConnectionPoolTests
     {
         long statusTimestamp = 100;
         var creationAttempt = 0;
-        var connection = new TestIdleConnection(-1, "controller-a", 19093);
+        var connection = new TestIdleConnection(-1, "controller-a", 19093)
+        {
+            LastSuccessfulRequestTimestampMs = 99
+        };
         await using var pool = new ConnectionPool(
             clientId: "status-test",
             connectionOptions: new ConnectionOptions
@@ -191,7 +199,9 @@ public sealed class ConnectionPoolTests
         var status = ((IConnectionPoolStatusSource)pool).GetEndpointConnectionStatus(
             [new ConnectionStatusEndpoint(2, "controller-a", 19093)]).Single();
         await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Disconnected);
+        await Assert.That(status.LastSuccessfulRequestAtUtc).IsNotNull();
         await Assert.That(GetEndpointStateChangeTimestamp(pool, "controller-a", 19093)).IsEqualTo(101);
+        await Assert.That(GetEndpointSuccessfulRequestTimestamp(pool, "controller-a", 19093)).IsEqualTo(99);
     }
 
     [Test]
@@ -626,6 +636,24 @@ public sealed class ConnectionPoolTests
 
         // Removing a non-existent broker should be a no-op
         await pool.RemoveConnectionAsync(999);
+    }
+
+    [Test]
+    public async Task RemoveConnectionAsync_RegisteredBrokerWithoutConnection_DoesNotRecordStateChange()
+    {
+        long statusTimestamp = 100;
+        await using var pool = new ConnectionPool(
+            clientId: "status-test",
+            connectionOptions: new ConnectionOptions(),
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => throw new InvalidOperationException("Connection not expected"),
+            statusTimestampProvider: () => Volatile.Read(ref statusTimestamp));
+        pool.RegisterBroker(7, "broker-a", 9092);
+        Volatile.Write(ref statusTimestamp, 101);
+
+        await pool.RemoveConnectionAsync(7);
+
+        await Assert.That(GetBrokerStateChangeTimestamp(pool, 7)).IsEqualTo(100);
     }
 
     [Test]
@@ -2476,6 +2504,15 @@ public sealed class ConnectionPoolTests
     };
 
     private static long GetBrokerStateChangeTimestamp(ConnectionPool pool, int brokerId)
+        => GetBrokerRuntimeTimestamp(pool, brokerId, "LastStateChangeTimestampMs");
+
+    private static long GetBrokerSuccessfulRequestTimestamp(ConnectionPool pool, int brokerId)
+        => GetBrokerRuntimeTimestamp(pool, brokerId, "LastSuccessfulRequestTimestampMs");
+
+    private static long GetBrokerRuntimeTimestamp(
+        ConnectionPool pool,
+        int brokerId,
+        string propertyName)
     {
         var statesField = typeof(ConnectionPool).GetField(
             "_brokerConnectionRuntimeStates",
@@ -2487,13 +2524,23 @@ public sealed class ConnectionPoolTests
             ?? throw new InvalidOperationException("Connection runtime-state indexer was not found.");
         var state = indexer.GetValue(states, [brokerId])
             ?? throw new InvalidOperationException($"Connection runtime state for broker {brokerId} was not found.");
-        var timestampProperty = state.GetType().GetProperty("LastStateChangeTimestampMs")
-            ?? throw new InvalidOperationException("Connection state-change timestamp property was not found.");
+        var timestampProperty = state.GetType().GetProperty(propertyName)
+            ?? throw new InvalidOperationException($"Connection runtime-state property {propertyName} was not found.");
         return (long)(timestampProperty.GetValue(state)
             ?? throw new InvalidOperationException("Connection state-change timestamp was null."));
     }
 
     private static long GetEndpointStateChangeTimestamp(ConnectionPool pool, string host, int port)
+        => GetEndpointRuntimeTimestamp(pool, host, port, "LastStateChangeTimestampMs");
+
+    private static long GetEndpointSuccessfulRequestTimestamp(ConnectionPool pool, string host, int port)
+        => GetEndpointRuntimeTimestamp(pool, host, port, "LastSuccessfulRequestTimestampMs");
+
+    private static long GetEndpointRuntimeTimestamp(
+        ConnectionPool pool,
+        string host,
+        int port,
+        string propertyName)
     {
         var statesField = typeof(ConnectionPool).GetField(
             "_endpointConnectionRuntimeStates",
@@ -2508,8 +2555,8 @@ public sealed class ConnectionPoolTests
             ?? throw new InvalidOperationException("Endpoint runtime-state indexer was not found.");
         var state = indexer.GetValue(states, [key])
             ?? throw new InvalidOperationException($"Connection runtime state for endpoint {host}:{port} was not found.");
-        var timestampProperty = state.GetType().GetProperty("LastStateChangeTimestampMs")
-            ?? throw new InvalidOperationException("Connection state-change timestamp property was not found.");
+        var timestampProperty = state.GetType().GetProperty(propertyName)
+            ?? throw new InvalidOperationException($"Connection runtime-state property {propertyName} was not found.");
         return (long)(timestampProperty.GetValue(state)
             ?? throw new InvalidOperationException("Connection state-change timestamp was null."));
     }

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1056,6 +1056,40 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task ReapIdleConnectionsAsync_ControllerEndpoint_RecordsStateChange()
+    {
+        long statusTimestamp = 100;
+        var connection = new TestIdleConnection(-1, "controller-a", 19093)
+        {
+            LastSuccessfulRequestTimestampMs = 99
+        };
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions { ConnectionsMaxIdleMs = IdleThresholdMs },
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => new ValueTask<IKafkaConnection>(connection),
+            statusTimestampProvider: () => Volatile.Read(ref statusTimestamp));
+
+        await using (pool)
+        {
+            _ = await pool.GetConnectionAsync("controller-a", 19093);
+            connection.LastUsedTimestampMs = StaleIdleTimestamp();
+            Volatile.Write(ref statusTimestamp, 101);
+
+            var reaped = await pool.ReapIdleConnectionsAsync();
+            var status = ((IConnectionPoolStatusSource)pool).GetEndpointConnectionStatus(
+                [new ConnectionStatusEndpoint(2, "controller-a", 19093)]).Single();
+
+            await Assert.That(reaped).IsEqualTo(1);
+            await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Disconnected);
+            await Assert.That(status.ConnectionCount).IsEqualTo(0);
+            await Assert.That(GetEndpointStateChangeTimestamp(pool, "controller-a", 19093))
+                .IsGreaterThanOrEqualTo(101);
+            await Assert.That(GetEndpointSuccessfulRequestTimestamp(pool, "controller-a", 19093)).IsEqualTo(99);
+        }
+    }
+
+    [Test]
     public async Task ReapIdleConnectionsAsync_ActiveLease_DrainsBeforeDisposal()
     {
         var connection = new TestIdleConnection(1, "localhost", 9092);

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -99,13 +99,7 @@ public sealed class ConnectionPoolTests
                 ValueTask.FromException<IKafkaConnection>(new IOException("connection refused")));
         pool.RegisterBroker(7, "broker-a", 9092);
 
-        try
-        {
-            _ = await pool.GetConnectionAsync(7);
-        }
-        catch (IOException)
-        {
-        }
+        await Assert.ThrowsAsync<IOException>(async () => await pool.GetConnectionAsync(7));
 
         var status = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus().Single();
         await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Disconnected);

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -114,6 +114,36 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task StatusSnapshot_PreservesBrokerDisconnectTimeWhenReplacementFails()
+    {
+        long statusTimestamp = 100;
+        var creationAttempt = 0;
+        var connection = new TestIdleConnection(7, "broker-a", 9092);
+        await using var pool = new ConnectionPool(
+            clientId: "status-test",
+            connectionOptions: new ConnectionOptions
+            {
+                ReconnectBackoff = TimeSpan.FromMilliseconds(1),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(1)
+            },
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => Interlocked.Increment(ref creationAttempt) == 1
+                ? ValueTask.FromResult<IKafkaConnection>(connection)
+                : ValueTask.FromException<IKafkaConnection>(new IOException("replacement refused")),
+            statusTimestampProvider: () => Volatile.Read(ref statusTimestamp));
+        pool.RegisterBroker(7, "broker-a", 9092);
+        _ = await pool.GetConnectionAsync(7);
+        connection.DisconnectAt(101);
+        Volatile.Write(ref statusTimestamp, 102);
+
+        await Assert.ThrowsAsync<IOException>(async () => await pool.GetConnectionAsync(7));
+
+        var status = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus().Single();
+        await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Disconnected);
+        await Assert.That(GetBrokerStateChangeTimestamp(pool, 7)).IsEqualTo(101);
+    }
+
+    [Test]
     public async Task StatusSnapshot_ReportsControllerEndpointConnection()
     {
         var connection = new TestIdleConnection(-1, "controller-a", 19093);
@@ -131,6 +161,37 @@ public sealed class ConnectionPoolTests
         await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Connected);
         await Assert.That(status.ConnectionCount).IsEqualTo(1);
         await Assert.That(status.ConnectedConnectionCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task StatusSnapshot_PreservesControllerDisconnectTimeWhenReplacementFails()
+    {
+        long statusTimestamp = 100;
+        var creationAttempt = 0;
+        var connection = new TestIdleConnection(-1, "controller-a", 19093);
+        await using var pool = new ConnectionPool(
+            clientId: "status-test",
+            connectionOptions: new ConnectionOptions
+            {
+                ReconnectBackoff = TimeSpan.FromMilliseconds(1),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(1)
+            },
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => Interlocked.Increment(ref creationAttempt) == 1
+                ? ValueTask.FromResult<IKafkaConnection>(connection)
+                : ValueTask.FromException<IKafkaConnection>(new IOException("replacement refused")),
+            statusTimestampProvider: () => Volatile.Read(ref statusTimestamp));
+        _ = await pool.GetConnectionAsync("controller-a", 19093);
+        connection.DisconnectAt(101);
+        Volatile.Write(ref statusTimestamp, 102);
+
+        await Assert.ThrowsAsync<IOException>(async () =>
+            await pool.GetConnectionAsync("controller-a", 19093));
+
+        var status = ((IConnectionPoolStatusSource)pool).GetEndpointConnectionStatus(
+            [new ConnectionStatusEndpoint(2, "controller-a", 19093)]).Single();
+        await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Disconnected);
+        await Assert.That(GetEndpointStateChangeTimestamp(pool, "controller-a", 19093)).IsEqualTo(101);
     }
 
     [Test]
@@ -2628,6 +2689,12 @@ public sealed class ConnectionPoolTests
             Volatile.Write(ref _lastConnectionStateChangeTimestampMs, MonotonicClock.GetMilliseconds());
             Volatile.Write(ref _connected, 0);
             return ValueTask.CompletedTask;
+        }
+
+        public void DisconnectAt(long timestampMs)
+        {
+            Volatile.Write(ref _lastConnectionStateChangeTimestampMs, timestampMs);
+            Volatile.Write(ref _connected, 0);
         }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -108,6 +108,20 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task StatusSnapshot_ExcludesBrokersRemovedByMetadata()
+    {
+        await using var pool = new ConnectionPool("status-test");
+        pool.RegisterBroker(1, "removed-broker", 9092);
+        pool.RegisterBroker(2, "current-broker", 9093);
+        var statusSource = (IConnectionPoolStatusSource)pool;
+
+        statusSource.UpdateBrokerStatusSnapshot([2]);
+        var status = statusSource.GetBrokerConnectionStatus();
+
+        await Assert.That(status.Select(static broker => broker.BrokerId)).IsEquivalentTo([2]);
+    }
+
+    [Test]
     public async Task GetConnectionAsync_DisposedPool_ThrowsObjectDisposedException()
     {
         var pool = new ConnectionPool("test-client");

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -88,6 +88,7 @@ public sealed class ConnectionPoolTests
     [Test]
     public async Task StatusSnapshot_ReportsConnectionAttemptFailure()
     {
+        long statusTimestamp = 100;
         await using var pool = new ConnectionPool(
             clientId: "status-test",
             connectionOptions: new ConnectionOptions
@@ -97,12 +98,11 @@ public sealed class ConnectionPoolTests
             },
             connectionsPerBroker: 1,
             connectionFactory: (_, _, _, _, _) =>
-                ValueTask.FromException<IKafkaConnection>(new IOException("connection refused")));
+                ValueTask.FromException<IKafkaConnection>(new IOException("connection refused")),
+            statusTimestampProvider: () => Volatile.Read(ref statusTimestamp));
         pool.RegisterBroker(7, "broker-a", 9092);
         var stateChangeTimestamp = GetBrokerStateChangeTimestamp(pool, 7);
-        await Assert.That(SpinWait.SpinUntil(
-            () => MonotonicClock.GetMilliseconds() > stateChangeTimestamp,
-            TimeSpan.FromSeconds(1))).IsTrue();
+        Volatile.Write(ref statusTimestamp, 101);
 
         await Assert.ThrowsAsync<IOException>(async () => await pool.GetConnectionAsync(7));
 
@@ -131,6 +131,32 @@ public sealed class ConnectionPoolTests
         await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Connected);
         await Assert.That(status.ConnectionCount).IsEqualTo(1);
         await Assert.That(status.ConnectedConnectionCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task StatusSnapshot_ReportsControllerEndpointConnectionFailure()
+    {
+        await using var pool = new ConnectionPool(
+            clientId: "status-test",
+            connectionOptions: new ConnectionOptions
+            {
+                ReconnectBackoff = TimeSpan.FromMilliseconds(1),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(1)
+            },
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) =>
+                ValueTask.FromException<IKafkaConnection>(new IOException("controller refused")));
+
+        await Assert.ThrowsAsync<IOException>(async () =>
+            await pool.GetConnectionAsync("controller-a", 19093));
+
+        var status = ((IConnectionPoolStatusSource)pool).GetEndpointConnectionStatus(
+            [new ConnectionStatusEndpoint(2, "controller-a", 19093)]).Single();
+
+        await Assert.That(status.BrokerId).IsEqualTo(2);
+        await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Disconnected);
+        await Assert.That(status.LastError).IsEqualTo("controller refused");
+        await Assert.That(status.LastErrorAtUtc).IsNotNull();
     }
 
     [Test]
@@ -691,6 +717,30 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task ShrinkConnectionGroupAsync_RecordsExactStatusTransition()
+    {
+        long statusTimestamp = 100;
+        await using var pool = new ConnectionPool(
+            clientId: "status-test",
+            connectionOptions: new ConnectionOptions(),
+            connectionsPerBroker: 3,
+            connectionFactory: (brokerId, host, port, _, _) =>
+                ValueTask.FromResult<IKafkaConnection>(new TestIdleConnection(brokerId, host, port)),
+            statusTimestampProvider: () => Volatile.Read(ref statusTimestamp));
+        pool.RegisterBroker(1, "localhost", 9092);
+        _ = await pool.GetConnectionAsync(1);
+        var stateChangeBeforeShrink = GetBrokerStateChangeTimestamp(pool, 1);
+        Volatile.Write(ref statusTimestamp, 101);
+
+        var removed = await pool.ShrinkConnectionGroupAsync(1, 2);
+
+        await Assert.That(removed).IsNotNull();
+        await Assert.That(GetBrokerStateChangeTimestamp(pool, 1)).IsEqualTo(101);
+        await Assert.That(GetBrokerStateChangeTimestamp(pool, 1)).IsGreaterThan(stateChangeBeforeShrink);
+        await removed!.DisposeAsync();
+    }
+
+    [Test]
     public async Task ConnectionOptions_ConnectionsMaxIdleMs_DefaultsToNineMinutes()
     {
         var options = new ConnectionOptions();
@@ -740,6 +790,7 @@ public sealed class ConnectionPoolTests
     [Test]
     public async Task ReapIdleConnectionsAsync_IdleSingleConnection_DisposesAndRecreates()
     {
+        long statusTimestamp = 100;
         var created = new List<TestIdleConnection>();
         var pool = new ConnectionPool(
             clientId: "test-client",
@@ -750,7 +801,8 @@ public sealed class ConnectionPoolTests
                 var connection = new TestIdleConnection(brokerId, host, port);
                 created.Add(connection);
                 return new ValueTask<IKafkaConnection>(connection);
-            });
+            },
+            statusTimestampProvider: () => Volatile.Read(ref statusTimestamp));
 
         await using (pool)
         {
@@ -758,9 +810,7 @@ public sealed class ConnectionPoolTests
 
             var first = await pool.GetConnectionAsync(1);
             var stateChangeBeforeReap = GetBrokerStateChangeTimestamp(pool, 1);
-            await Assert.That(SpinWait.SpinUntil(
-                () => MonotonicClock.GetMilliseconds() > stateChangeBeforeReap,
-                TimeSpan.FromSeconds(1))).IsTrue();
+            Volatile.Write(ref statusTimestamp, 101);
             created[0].LastUsedTimestampMs = StaleIdleTimestamp();
             var reaped = await pool.ReapIdleConnectionsAsync();
             var stateChangeAfterReap = GetBrokerStateChangeTimestamp(pool, 1);

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -110,7 +110,7 @@ public sealed class ConnectionPoolTests
         var status = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus().Single();
         await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Disconnected);
         await Assert.That(status.LastErrorAtUtc).IsNotNull();
-        await Assert.That(status.LastError).IsEqualTo("Connection attempt failed.");
+        await Assert.That(status.LastError).IsEqualTo("connection refused");
     }
 
     [Test]
@@ -1032,6 +1032,10 @@ public sealed class ConnectionPoolTests
             await Assert.That(connection1).IsSameReferenceAs(scaledConnections[1]);
             await Assert.That(connection2).IsSameReferenceAs(scaledConnections[2]);
             await Assert.That(connection0).IsNotSameReferenceAs(originalSingleConnection);
+
+            var status = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus().Single();
+            await Assert.That(status.ConnectionCount).IsEqualTo(scaledCount + 1);
+            await Assert.That(status.ConnectedConnectionCount).IsEqualTo(scaledCount + 1);
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
+using Dekaf.Diagnostics;
 using Dekaf.Errors;
 using Dekaf.Networking;
 using Dekaf.Protocol;
@@ -17,6 +18,100 @@ namespace Dekaf.Tests.Unit.Networking;
 public sealed class ConnectionPoolTests
 {
     private const int IdleThresholdMs = 60000;
+
+    [Test]
+    public async Task StatusSnapshot_ReportsPerBrokerConnectionStateAndRequestFreshness()
+    {
+        var connection = new TestIdleConnection(7, "broker-a", 9092)
+        {
+            PendingRequestCount = 3,
+            LastSuccessfulRequestTimestampMs = MonotonicClock.GetMilliseconds() - 25
+        };
+        await using var pool = new ConnectionPool(
+            clientId: "status-test",
+            connectionOptions: new ConnectionOptions(),
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => ValueTask.FromResult<IKafkaConnection>(connection));
+        pool.RegisterBroker(7, "broker-a", 9092);
+
+        var disconnected = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus().Single();
+        await Assert.That(disconnected.State).IsEqualTo(BrokerConnectionState.Disconnected);
+        await Assert.That(disconnected.ConnectionCount).IsEqualTo(0);
+
+        _ = await pool.GetConnectionAsync(7);
+        var connected = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus().Single();
+
+        await Assert.That(connected.State).IsEqualTo(BrokerConnectionState.Connected);
+        await Assert.That(connected.ConnectionCount).IsEqualTo(1);
+        await Assert.That(connected.ConnectedConnectionCount).IsEqualTo(1);
+        await Assert.That(connected.PendingRequestCount).IsEqualTo(3);
+        await Assert.That(connected.LastSuccessfulRequestAtUtc).IsNotNull();
+        await Assert.That(connected.LastConnectionStateChangeAtUtc).IsNotNull();
+    }
+
+    [Test]
+    public async Task StatusSnapshot_ConcurrentReadsRemainSafeDuringConnectionStateChanges()
+    {
+        var connection = new TestIdleConnection(7, "broker-a", 9092);
+        await using var pool = new ConnectionPool(
+            clientId: "status-test",
+            connectionOptions: new ConnectionOptions(),
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => ValueTask.FromResult<IKafkaConnection>(connection));
+        pool.RegisterBroker(7, "broker-a", 9092);
+        _ = await pool.GetConnectionAsync(7);
+
+        var readers = Enumerable.Range(0, Environment.ProcessorCount)
+            .Select(_ => Task.Run(() =>
+            {
+                for (var i = 0; i < 1_000; i++)
+                {
+                    var status = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus();
+                    if (status.Count != 1 || status[0].BrokerId != 7)
+                        throw new InvalidOperationException("Broker status snapshot was inconsistent.");
+                }
+            }));
+        var writer = Task.Run(() =>
+        {
+            for (var i = 0; i < 1_000; i++)
+            {
+                connection.PendingRequestCount = i & 7;
+                connection.LastSuccessfulRequestTimestampMs = MonotonicClock.GetMilliseconds();
+                pool.RegisterBroker(7, "broker-a", 9092);
+            }
+        });
+
+        await Task.WhenAll(readers.Append(writer));
+    }
+
+    [Test]
+    public async Task StatusSnapshot_ReportsConnectionAttemptFailure()
+    {
+        await using var pool = new ConnectionPool(
+            clientId: "status-test",
+            connectionOptions: new ConnectionOptions
+            {
+                ReconnectBackoff = TimeSpan.FromMilliseconds(1),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(1)
+            },
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) =>
+                ValueTask.FromException<IKafkaConnection>(new IOException("connection refused")));
+        pool.RegisterBroker(7, "broker-a", 9092);
+
+        try
+        {
+            _ = await pool.GetConnectionAsync(7);
+        }
+        catch (IOException)
+        {
+        }
+
+        var status = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus().Single();
+        await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Disconnected);
+        await Assert.That(status.LastErrorAtUtc).IsNotNull();
+        await Assert.That(status.LastError).IsEqualTo("Connection attempt failed.");
+    }
 
     [Test]
     public async Task GetConnectionAsync_DisposedPool_ThrowsObjectDisposedException()
@@ -2162,6 +2257,7 @@ public sealed class ConnectionPoolTests
     internal sealed class TestIdleConnection(int brokerId, string host, int port) :
         IKafkaConnection,
         IIdleTrackedKafkaConnection,
+        IKafkaConnectionStatusSource,
         IRetirableKafkaConnection
     {
         private int _connected = 1;
@@ -2170,6 +2266,8 @@ public sealed class ConnectionPoolTests
         private int _disposeCount;
         private int _leaseCount;
         private int _retirementState;
+        private long _lastSuccessfulRequestTimestampMs;
+        private long _lastConnectionStateChangeTimestampMs = MonotonicClock.GetMilliseconds();
 
         public int BrokerId { get; } = brokerId;
         public string Host { get; } = host;
@@ -2192,12 +2290,24 @@ public sealed class ConnectionPoolTests
 
         public Func<int>? PendingRequestCountProvider { get; set; }
 
+        public long LastSuccessfulRequestTimestampMs
+        {
+            get => Volatile.Read(ref _lastSuccessfulRequestTimestampMs);
+            set => Volatile.Write(ref _lastSuccessfulRequestTimestampMs, value);
+        }
+
         long IIdleTrackedKafkaConnection.LastUsedTimestampMs => LastUsedTimestampMs;
 
         int IIdleTrackedKafkaConnection.PendingRequestCount =>
             PendingRequestCountProvider?.Invoke() ?? PendingRequestCount;
 
         void IIdleTrackedKafkaConnection.Touch() => LastUsedTimestampMs = Environment.TickCount64;
+
+        long IKafkaConnectionStatusSource.LastSuccessfulRequestTimestampMs =>
+            LastSuccessfulRequestTimestampMs;
+
+        long IKafkaConnectionStatusSource.LastConnectionStateChangeTimestampMs =>
+            Volatile.Read(ref _lastConnectionStateChangeTimestampMs);
 
         int IRetirableKafkaConnection.LeaseCount => Volatile.Read(ref _leaseCount);
 
@@ -2267,6 +2377,7 @@ public sealed class ConnectionPoolTests
         public ValueTask DisposeAsync()
         {
             Interlocked.Increment(ref _disposeCount);
+            Volatile.Write(ref _lastConnectionStateChangeTimestampMs, MonotonicClock.GetMilliseconds());
             Volatile.Write(ref _connected, 0);
             return ValueTask.CompletedTask;
         }

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1059,15 +1059,21 @@ public sealed class ConnectionPoolTests
     public async Task ShrinkConnectionGroupAsync_RecordsExactStatusTransition()
     {
         long statusTimestamp = 100;
+        var created = new List<TestIdleConnection>();
         await using var pool = new ConnectionPool(
             clientId: "status-test",
             connectionOptions: new ConnectionOptions(),
             connectionsPerBroker: 3,
             connectionFactory: (brokerId, host, port, _, _) =>
-                ValueTask.FromResult<IKafkaConnection>(new TestIdleConnection(brokerId, host, port)),
+            {
+                var connection = new TestIdleConnection(brokerId, host, port);
+                created.Add(connection);
+                return ValueTask.FromResult<IKafkaConnection>(connection);
+            },
             statusTimestampProvider: () => Volatile.Read(ref statusTimestamp));
         pool.RegisterBroker(1, "localhost", 9092);
         _ = await pool.GetConnectionAsync(1);
+        created[^1].LastSuccessfulRequestTimestampMs = 99;
         var stateChangeBeforeShrink = GetBrokerStateChangeTimestamp(pool, 1);
         Volatile.Write(ref statusTimestamp, 101);
 
@@ -1076,6 +1082,7 @@ public sealed class ConnectionPoolTests
         await Assert.That(removed).IsNotNull();
         await Assert.That(GetBrokerStateChangeTimestamp(pool, 1)).IsEqualTo(101);
         await Assert.That(GetBrokerStateChangeTimestamp(pool, 1)).IsGreaterThan(stateChangeBeforeShrink);
+        await Assert.That(GetBrokerSuccessfulRequestTimestamp(pool, 1)).IsEqualTo(99);
         await removed!.DisposeAsync();
     }
 
@@ -1148,6 +1155,7 @@ public sealed class ConnectionPoolTests
             pool.RegisterBroker(1, "localhost", 9092);
 
             var first = await pool.GetConnectionAsync(1);
+            created[0].LastSuccessfulRequestTimestampMs = 99;
             var stateChangeBeforeReap = GetBrokerStateChangeTimestamp(pool, 1);
             Volatile.Write(ref statusTimestamp, 101);
             created[0].LastUsedTimestampMs = StaleIdleTimestamp();
@@ -1160,6 +1168,7 @@ public sealed class ConnectionPoolTests
             await Assert.That(created[0].DisposeCount).IsEqualTo(1);
             await Assert.That(first).IsNotSameReferenceAs(second);
             await Assert.That(stateChangeAfterReap).IsGreaterThan(stateChangeBeforeReap);
+            await Assert.That(GetBrokerSuccessfulRequestTimestamp(pool, 1)).IsEqualTo(99);
 
             var diagnostic = pool.GetConnectionReapDiagnosticsSnapshot().Single();
             await Assert.That(diagnostic.BrokerId).IsEqualTo(1);

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -134,6 +134,30 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task StatusSnapshot_RecordsControllerEndpointClosure()
+    {
+        long statusTimestamp = 100;
+        var connection = new TestIdleConnection(-1, "controller-a", 19093);
+        await using var pool = new ConnectionPool(
+            clientId: "status-test",
+            connectionOptions: new ConnectionOptions(),
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => ValueTask.FromResult<IKafkaConnection>(connection),
+            statusTimestampProvider: () => Volatile.Read(ref statusTimestamp));
+        _ = await pool.GetConnectionAsync("controller-a", 19093);
+        Volatile.Write(ref statusTimestamp, 101);
+
+        await pool.CloseAllAsync();
+
+        var status = ((IConnectionPoolStatusSource)pool).GetEndpointConnectionStatus(
+            [new ConnectionStatusEndpoint(2, "controller-a", 19093)]).Single();
+        await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Disconnected);
+        await Assert.That(status.ConnectionCount).IsEqualTo(0);
+        await Assert.That(status.LastConnectionStateChangeAtUtc).IsNotNull();
+        await Assert.That(GetEndpointStateChangeTimestamp(pool, "controller-a", 19093)).IsEqualTo(101);
+    }
+
+    [Test]
     public async Task StatusSnapshot_ReportsControllerEndpointConnectionFailure()
     {
         await using var pool = new ConnectionPool(
@@ -2314,6 +2338,27 @@ public sealed class ConnectionPoolTests
             ?? throw new InvalidOperationException("Connection runtime-state indexer was not found.");
         var state = indexer.GetValue(states, [brokerId])
             ?? throw new InvalidOperationException($"Connection runtime state for broker {brokerId} was not found.");
+        var timestampProperty = state.GetType().GetProperty("LastStateChangeTimestampMs")
+            ?? throw new InvalidOperationException("Connection state-change timestamp property was not found.");
+        return (long)(timestampProperty.GetValue(state)
+            ?? throw new InvalidOperationException("Connection state-change timestamp was null."));
+    }
+
+    private static long GetEndpointStateChangeTimestamp(ConnectionPool pool, string host, int port)
+    {
+        var statesField = typeof(ConnectionPool).GetField(
+            "_endpointConnectionRuntimeStates",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Endpoint runtime-state field was not found.");
+        var states = statesField.GetValue(pool)
+            ?? throw new InvalidOperationException("Endpoint runtime-state dictionary was null.");
+        var keyType = states.GetType().GetGenericArguments()[0];
+        var key = Activator.CreateInstance(keyType, host, port)
+            ?? throw new InvalidOperationException("Endpoint runtime-state key was not created.");
+        var indexer = states.GetType().GetProperty("Item")
+            ?? throw new InvalidOperationException("Endpoint runtime-state indexer was not found.");
+        var state = indexer.GetValue(states, [key])
+            ?? throw new InvalidOperationException($"Connection runtime state for endpoint {host}:{port} was not found.");
         var timestampProperty = state.GetType().GetProperty("LastStateChangeTimestampMs")
             ?? throw new InvalidOperationException("Connection state-change timestamp property was not found.");
         return (long)(timestampProperty.GetValue(state)

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -201,7 +201,44 @@ public sealed class ConnectionPoolTests
 
         await Assert.That(status.BrokerId).IsEqualTo(2);
         await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Disconnected);
+        await Assert.That(status.LastConnectionStateChangeAtUtc).IsNull();
         await Assert.That(status.LastError).IsEqualTo("controller refused");
+        await Assert.That(status.LastErrorAtUtc).IsNotNull();
+    }
+
+    [Test]
+    public async Task StatusSnapshot_ReportsLatestFailureAcrossControllerEndpointAlias()
+    {
+        long statusTimestamp = 100;
+        await using var pool = new ConnectionPool(
+            clientId: "status-test",
+            connectionOptions: new ConnectionOptions
+            {
+                ReconnectBackoff = TimeSpan.FromMilliseconds(1),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(1)
+            },
+            connectionsPerBroker: 1,
+            connectionFactory: (_, host, _, _, _) =>
+                ValueTask.FromException<IKafkaConnection>(new IOException($"{host} refused")),
+            statusTimestampProvider: () => Volatile.Read(ref statusTimestamp));
+
+        Volatile.Write(ref statusTimestamp, 101);
+        await Assert.ThrowsAsync<IOException>(async () =>
+            await pool.GetConnectionAsync("controller-a", 19093));
+        Volatile.Write(ref statusTimestamp, 102);
+        await Assert.ThrowsAsync<IOException>(async () =>
+            await pool.GetConnectionAsync("controller-alias", 29093));
+
+        var status = ((IConnectionPoolStatusSource)pool).GetEndpointConnectionStatus(
+            [new ConnectionStatusEndpoint(
+                2,
+                "controller-a",
+                19093,
+                "controller-alias",
+                29093)]).Single();
+
+        await Assert.That(status.LastConnectionStateChangeAtUtc).IsNull();
+        await Assert.That(status.LastError).IsEqualTo("controller-alias refused");
         await Assert.That(status.LastErrorAtUtc).IsNotNull();
     }
 

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -370,6 +370,51 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task RuntimeState_ConcurrentFailuresPublishCoherentLatestTuple()
+    {
+        var stateType = typeof(ConnectionPool).GetNestedType(
+            "BrokerConnectionRuntimeState",
+            BindingFlags.NonPublic)!;
+        using var timestamp = new ThreadLocal<long>();
+        Func<long> timestampProvider = () => timestamp.Value;
+        var state = Activator.CreateInstance(
+            stateType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: [timestampProvider, false],
+            culture: null)!;
+        var recordFailure = stateType.GetMethod("RecordFailure")!;
+        var lastFailure = stateType.GetProperty("LastFailure")!;
+        var failureType = typeof(ConnectionPool).GetNestedType("FailureInfo", BindingFlags.NonPublic)!;
+        var sequenceProperty = failureType.GetProperty("Sequence")!;
+        var timestampProperty = failureType.GetProperty("TimestampMs")!;
+        var errorProperty = failureType.GetProperty("Error")!;
+        var mismatches = new ConcurrentQueue<string>();
+
+        Parallel.For(1, 1_001, sequence =>
+        {
+            timestamp.Value = sequence;
+            recordFailure.Invoke(state, [$"failure-{sequence}", (long)sequence]);
+
+            var failure = lastFailure.GetValue(state)!;
+            var publishedSequence = (long)sequenceProperty.GetValue(failure)!;
+            var publishedTimestamp = (long)timestampProperty.GetValue(failure)!;
+            var publishedError = (string)errorProperty.GetValue(failure)!;
+            if (publishedTimestamp != publishedSequence ||
+                publishedError != $"failure-{publishedSequence}")
+            {
+                mismatches.Enqueue(
+                    $"{publishedError}/{publishedTimestamp}/{publishedSequence}");
+            }
+        });
+
+        var finalFailure = lastFailure.GetValue(state)!;
+        var finalSequence = (long)sequenceProperty.GetValue(finalFailure)!;
+        await Assert.That(mismatches).IsEmpty();
+        await Assert.That(finalSequence).IsEqualTo(1_000);
+    }
+
+    [Test]
     public async Task StatusSnapshot_ResolvesControllerEndpointAliasWithDifferentHostnameCasing()
     {
         await using var pool = new ConnectionPool(

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -70,7 +70,8 @@ public sealed class ConnectionPoolTests
                     if (status.Count != 1 || status[0].BrokerId != 7)
                         throw new InvalidOperationException("Broker status snapshot was inconsistent.");
                 }
-            }));
+            }))
+            .ToArray();
         var writer = Task.Run(() =>
         {
             for (var i = 0; i < 1_000; i++)
@@ -1000,6 +1001,9 @@ public sealed class ConnectionPoolTests
             await Assert.That(reaped).IsEqualTo(1);
             await Assert.That(created[0].DisposeCount).IsEqualTo(0);
             await Assert.That(created[1].DisposeCount).IsEqualTo(1);
+            var status = ((IConnectionPoolStatusSource)pool).GetBrokerConnectionStatus().Single();
+            await Assert.That(status.ConnectionCount).IsEqualTo(1);
+            await Assert.That(status.ConnectedConnectionCount).IsEqualTo(1);
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -99,6 +99,10 @@ public sealed class ConnectionPoolTests
             connectionFactory: (_, _, _, _, _) =>
                 ValueTask.FromException<IKafkaConnection>(new IOException("connection refused")));
         pool.RegisterBroker(7, "broker-a", 9092);
+        var stateChangeTimestamp = GetBrokerStateChangeTimestamp(pool, 7);
+        await Assert.That(SpinWait.SpinUntil(
+            () => MonotonicClock.GetMilliseconds() > stateChangeTimestamp,
+            TimeSpan.FromSeconds(1))).IsTrue();
 
         await Assert.ThrowsAsync<IOException>(async () => await pool.GetConnectionAsync(7));
 
@@ -106,6 +110,27 @@ public sealed class ConnectionPoolTests
         await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Disconnected);
         await Assert.That(status.LastErrorAtUtc).IsNotNull();
         await Assert.That(status.LastError).IsEqualTo("connection refused");
+        await Assert.That(GetBrokerStateChangeTimestamp(pool, 7)).IsEqualTo(stateChangeTimestamp);
+    }
+
+    [Test]
+    public async Task StatusSnapshot_ReportsControllerEndpointConnection()
+    {
+        var connection = new TestIdleConnection(-1, "controller-a", 19093);
+        await using var pool = new ConnectionPool(
+            clientId: "status-test",
+            connectionOptions: new ConnectionOptions(),
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => ValueTask.FromResult<IKafkaConnection>(connection));
+        _ = await pool.GetConnectionAsync("controller-a", 19093);
+
+        var status = ((IConnectionPoolStatusSource)pool).GetEndpointConnectionStatus(
+            [new ConnectionStatusEndpoint(2, "controller-a", 19093)]).Single();
+
+        await Assert.That(status.BrokerId).IsEqualTo(2);
+        await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Connected);
+        await Assert.That(status.ConnectionCount).IsEqualTo(1);
+        await Assert.That(status.ConnectedConnectionCount).IsEqualTo(1);
     }
 
     [Test]
@@ -732,14 +757,20 @@ public sealed class ConnectionPoolTests
             pool.RegisterBroker(1, "localhost", 9092);
 
             var first = await pool.GetConnectionAsync(1);
+            var stateChangeBeforeReap = GetBrokerStateChangeTimestamp(pool, 1);
+            await Assert.That(SpinWait.SpinUntil(
+                () => MonotonicClock.GetMilliseconds() > stateChangeBeforeReap,
+                TimeSpan.FromSeconds(1))).IsTrue();
             created[0].LastUsedTimestampMs = StaleIdleTimestamp();
             var reaped = await pool.ReapIdleConnectionsAsync();
+            var stateChangeAfterReap = GetBrokerStateChangeTimestamp(pool, 1);
             var second = await pool.GetConnectionAsync(1);
 
             await Assert.That(reaped).IsEqualTo(1);
             await Assert.That(created.Count).IsEqualTo(2);
             await Assert.That(created[0].DisposeCount).IsEqualTo(1);
             await Assert.That(first).IsNotSameReferenceAs(second);
+            await Assert.That(stateChangeAfterReap).IsGreaterThan(stateChangeBeforeReap);
 
             var diagnostic = pool.GetConnectionReapDiagnosticsSnapshot().Single();
             await Assert.That(diagnostic.BrokerId).IsEqualTo(1);
@@ -2220,6 +2251,24 @@ public sealed class ConnectionPoolTests
         PrincipalName = "principal",
         Expiration = DateTimeOffset.UtcNow.AddHours(1)
     };
+
+    private static long GetBrokerStateChangeTimestamp(ConnectionPool pool, int brokerId)
+    {
+        var statesField = typeof(ConnectionPool).GetField(
+            "_brokerConnectionRuntimeStates",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Connection runtime-state field was not found.");
+        var states = statesField.GetValue(pool)
+            ?? throw new InvalidOperationException("Connection runtime-state dictionary was null.");
+        var indexer = states.GetType().GetProperty("Item")
+            ?? throw new InvalidOperationException("Connection runtime-state indexer was not found.");
+        var state = indexer.GetValue(states, [brokerId])
+            ?? throw new InvalidOperationException($"Connection runtime state for broker {brokerId} was not found.");
+        var timestampProperty = state.GetType().GetProperty("LastStateChangeTimestampMs")
+            ?? throw new InvalidOperationException("Connection state-change timestamp property was not found.");
+        return (long)(timestampProperty.GetValue(state)
+            ?? throw new InvalidOperationException("Connection state-change timestamp was null."));
+    }
 
     private static MemoryPool<byte> GetSharedPipeMemoryPool(ConnectionPool pool)
     {

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -225,7 +225,6 @@ public sealed class ConnectionPoolTests
         Volatile.Write(ref statusTimestamp, 101);
         await Assert.ThrowsAsync<IOException>(async () =>
             await pool.GetConnectionAsync("controller-a", 19093));
-        Volatile.Write(ref statusTimestamp, 102);
         await Assert.ThrowsAsync<IOException>(async () =>
             await pool.GetConnectionAsync("controller-alias", 29093));
 
@@ -239,6 +238,36 @@ public sealed class ConnectionPoolTests
 
         await Assert.That(status.LastConnectionStateChangeAtUtc).IsNull();
         await Assert.That(status.LastError).IsEqualTo("controller-alias refused");
+        await Assert.That(status.LastErrorAtUtc).IsNotNull();
+    }
+
+    [Test]
+    public async Task StatusSnapshot_ResolvesControllerEndpointAliasWithDifferentHostnameCasing()
+    {
+        await using var pool = new ConnectionPool(
+            clientId: "status-test",
+            connectionOptions: new ConnectionOptions
+            {
+                ReconnectBackoff = TimeSpan.FromMilliseconds(1),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(1)
+            },
+            connectionsPerBroker: 1,
+            connectionFactory: (_, host, _, _, _) =>
+                ValueTask.FromException<IKafkaConnection>(new IOException($"{host} refused")));
+
+        await Assert.ThrowsAsync<IOException>(async () =>
+            await pool.GetConnectionAsync("CONTROLLER-A", 19093));
+
+        var status = ((IConnectionPoolStatusSource)pool).GetEndpointConnectionStatus(
+            [new ConnectionStatusEndpoint(
+                2,
+                "controller-a",
+                19093,
+                "CONTROLLER-A",
+                19093)]).Single();
+
+        await Assert.That(status.State).IsEqualTo(BrokerConnectionState.Disconnected);
+        await Assert.That(status.LastError).IsEqualTo("CONTROLLER-A refused");
         await Assert.That(status.LastErrorAtUtc).IsNotNull();
     }
 

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -2148,7 +2148,7 @@ public sealed class ConnectionPoolTests
     public async Task ConnectionSetupTimeout_CallerCancellationDoesNotAdvanceFailures()
     {
         var attempts = 0;
-        var factoryEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellation = new CancellationTokenSource();
         var observedTimeouts = new List<TimeSpan>();
         await using var pool = CreateConnectionSetupTimeoutPool(
             randomValue: 0.5,
@@ -2157,7 +2157,8 @@ public sealed class ConnectionPoolTests
                 var attempt = Interlocked.Increment(ref attempts);
                 if (attempt == 1)
                 {
-                    factoryEntered.SetResult();
+                    // Cancel while the factory owns execution so the setup timeout cannot win on a stalled runner.
+                    cancellation.Cancel();
                     await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
                 }
                 if (attempt == 2)
@@ -2167,10 +2168,7 @@ public sealed class ConnectionPoolTests
             timeoutObserver: observedTimeouts.Add);
         pool.RegisterBroker(1, "broker-a", 9092);
 
-        using var cancellation = new CancellationTokenSource();
         var canceledAttempt = pool.GetConnectionAsync(1, cancellation.Token).AsTask();
-        await factoryEntered.Task;
-        cancellation.Cancel();
         await Assert.That(async () => await canceledAttempt).Throws<OperationCanceledException>();
         Func<Task> failedAttempt = () => pool.GetConnectionAsync(1).AsTask();
         await Assert.That(failedAttempt).Throws<InvalidOperationException>();

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1512,7 +1512,7 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         // The original defect (#2529) was counters wired onto a path production traffic never
         // took, so this drives the real send loop end to end rather than calling CompleteSend
         // directly: enqueue -> serialize -> scripted ack -> per-batch counter emission.
-        const string topic = "sent-counter-test-topic";
+        const string topic = "sent-counter-real-path-topic";
         // Resolve instrument names before the listener starts (static-initializer re-entry
         // landmine — see FireAndForgetDeliveryErrorMetricTests).
         var messagesSentName = DekafMetrics.MessagesSent.Name;
@@ -1547,7 +1547,7 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         {
             sender.Enqueue(CreateTestBatch(valueTaskSourcePool, topic, partition: 0, messageCount: 3));
 
-            await WaitUntilAsync(() => Volatile.Read(ref messagesSent) == 3, cancellationToken);
+            await WaitUntilAsync(() => Volatile.Read(ref messagesSent) >= 3, cancellationToken);
 
             // Bytes are the batch's encoded wire size, stamped during serialization.
             await Assert.That(Volatile.Read(ref bytesSent)).IsGreaterThan(0);

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Text;
+using Dekaf.Diagnostics;
 using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Producer;
@@ -10,6 +12,7 @@ using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Unit.Producer;
 
+[NotInParallel("ActivityListener")]
 public class KafkaProducerFastPathTests
 {
     private const string Topic = "test-topic";
@@ -109,6 +112,54 @@ public class KafkaProducerFastPathTests
         await Assert.That(metadata.Topic).IsEqualTo(Topic);
         await Assert.That(metadata.Partition).IsEqualTo(0);
         await Assert.That(metadata.Offset).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task ProduceAsync_Tracing_RestoresCallerOwnedHeadersAfterAppend()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == DekafDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 4096,
+            LingerMs = 10,
+            RequestTimeoutMs = 500,
+            DeliveryTimeoutMs = 1000,
+            CloseTimeoutMs = 1000
+        };
+
+        await using var producer = new KafkaProducer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+        await StopProducerBackgroundLoopsAsync(producer);
+        SeedProducerMetadata(producer);
+        SetInstanceField(producer, "_initialized", true);
+        var headers = new Headers(3).Add("existing", "value");
+
+        var produceTask = producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Key = "key",
+            Value = "value",
+            Headers = headers
+        });
+
+        await Assert.That(headers.Count).IsEqualTo(1);
+        await Assert.That(headers[0].Key).IsEqualTo("existing");
+
+        var readyBatch = CompleteCurrentBatch(producer.RecordAccumulator, new TopicPartition(Topic, 0));
+        readyBatch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow);
+        _ = await produceTask;
+
+        await Assert.That(headers.Count).IsEqualTo(1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
@@ -42,6 +42,41 @@ public sealed class ShareConsumerConnectionOwnershipTests
     }
 
     [Test]
+    public async Task HeartbeatVersionNegotiationFailure_IsReportedByStatus()
+    {
+        var options = CreateOptions();
+        var connection = new LeaseTrackingConnection(
+            new ApiVersion(
+                ApiKey.ShareGroupHeartbeat,
+                (short)(ShareGroupHeartbeatRequest.HighestSupportedVersion + 1),
+                (short)(ShareGroupHeartbeatRequest.HighestSupportedVersion + 1)));
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionByIndexAsync(1, 1, Arg.Any<CancellationToken>())
+            .Returns(connection);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        await using var coordinator = new ShareConsumerCoordinator(
+            options,
+            pool,
+            metadataManager,
+            getConnectionCount: () => 2);
+        typeof(ShareConsumerCoordinator).GetField(
+            "_coordinatorId",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(coordinator, 1);
+        var method = typeof(ShareConsumerCoordinator).GetMethod(
+            "SendShareGroupHeartbeatAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var heartbeat = (ValueTask<bool>)method.Invoke(
+            coordinator,
+            [false, CancellationToken.None])!;
+
+        await Assert.ThrowsAsync<BrokerVersionException>(async () => await heartbeat);
+
+        await Assert.That(coordinator.CaptureGroupStatus().LastHeartbeatFailure)
+            .Contains("Broker does not support ShareGroupHeartbeat");
+        await Assert.That(connection.LeaseCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task LeaveGroupAsync_HoldsConnectionLeaseThroughRequest()
     {
         var options = CreateOptions();

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
@@ -13,6 +13,35 @@ namespace Dekaf.Tests.Unit.ShareConsumer;
 public sealed class ShareConsumerConnectionOwnershipTests
 {
     [Test]
+    public async Task HeartbeatLeaseFailure_IsReportedByStatus()
+    {
+        var options = CreateOptions();
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionByIndexAsync(1, 1, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<IKafkaConnection>(new IOException("coordinator unavailable")));
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        await using var coordinator = new ShareConsumerCoordinator(
+            options,
+            pool,
+            metadataManager,
+            getConnectionCount: () => 2);
+        typeof(ShareConsumerCoordinator).GetField(
+            "_coordinatorId",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(coordinator, 1);
+        var method = typeof(ShareConsumerCoordinator).GetMethod(
+            "SendShareGroupHeartbeatAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var heartbeat = (ValueTask<bool>)method.Invoke(
+            coordinator,
+            [false, CancellationToken.None])!;
+
+        await Assert.ThrowsAsync<IOException>(async () => await heartbeat);
+
+        await Assert.That(coordinator.CaptureGroupStatus().LastHeartbeatFailure)
+            .IsEqualTo("coordinator unavailable");
+    }
+
+    [Test]
     public async Task LeaveGroupAsync_HoldsConnectionLeaseThroughRequest()
     {
         var options = CreateOptions();

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerActivityHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerActivityHotPathBenchmarks.cs
@@ -10,7 +10,9 @@ using Dekaf.Serialization;
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
 /// <summary>
-/// Broker-free allocation gate for the sampled, no-producer-context consumer activity path.
+/// Broker-free cost benchmark for the sampled, no-producer-context consumer activity path.
+/// Activity sampling intentionally creates a diagnostic span; the zero-listener consume path
+/// remains the zero-allocation hot-path gate.
 /// </summary>
 [MemoryDiagnoser]
 [SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerActivityHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerActivityHotPathBenchmarks.cs
@@ -1,0 +1,96 @@
+using System.Diagnostics;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Consumer;
+using Dekaf.Metadata;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Broker-free allocation gate for the sampled, no-producer-context consumer activity path.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class ConsumerActivityHotPathBenchmarks
+{
+    private KafkaConsumer<string, string> _consumer = null!;
+    private PendingFetchData _pending = null!;
+    private ActivityListener _listener = null!;
+    private StartConsumeActivity _startActivity = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = static source =>
+                source.Name == Diagnostics.DekafDiagnostics.ActivitySourceName,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(_listener);
+
+        _consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = "consumer-activity-hot-path",
+                GroupId = "consumer-activity-hot-path"
+            },
+            Serializers.String,
+            Serializers.String);
+        _pending = PendingFetchData.Create("orders", 0, Array.Empty<RecordBatch>());
+
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "StartConsumeActivity",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        _startActivity = method.CreateDelegate<StartConsumeActivity>();
+
+        var metadataManager = GetInstanceField<MetadataManager>(_consumer, "_metadataManager");
+        typeof(MetadataManager)
+            .GetMethod(
+                "UpdateMetadataClusterId",
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                binder: null,
+                [typeof(string)],
+                modifiers: null)?
+            .Invoke(metadataManager, ["consumer-activity-hot-path"]);
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        _pending.Dispose();
+        _listener.Dispose();
+        await _consumer.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public void StartAndStop()
+    {
+        using var activity = _startActivity(
+            _consumer,
+            _pending,
+            headers: null,
+            offset: 42,
+            isTombstone: false,
+            isProcessSpan: false);
+    }
+
+    private static T GetInstanceField<T>(object target, string name)
+    {
+        const BindingFlags Flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        return (T)target.GetType().GetField(name, Flags)!.GetValue(target)!;
+    }
+
+    private delegate Activity? StartConsumeActivity(
+        KafkaConsumer<string, string> consumer,
+        PendingFetchData pending,
+        IReadOnlyList<Header>? headers,
+        long offset,
+        bool isTombstone,
+        bool isProcessSpan);
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaConnectionStatusTrackingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaConnectionStatusTrackingBenchmarks.cs
@@ -1,0 +1,32 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Isolates the per-request cost of publishing the successful-request timestamp added by
+/// client-status snapshots. Both cases share one monotonic clock read; the candidate adds
+/// exactly one volatile store and no allocation.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class KafkaConnectionStatusTrackingBenchmarks
+{
+    private long _lastUsedTimestampMs;
+    private long _lastSuccessfulRequestTimestampMs;
+
+    [Benchmark(Baseline = true)]
+    public void IdleTrackingOnly()
+    {
+        var timestampMs = MonotonicClock.GetMilliseconds();
+        Volatile.Write(ref _lastUsedTimestampMs, timestampMs);
+    }
+
+    [Benchmark]
+    public void IdleAndSuccessfulRequestTracking()
+    {
+        var timestampMs = MonotonicClock.GetMilliseconds();
+        Volatile.Write(ref _lastUsedTimestampMs, timestampMs);
+        Volatile.Write(ref _lastSuccessfulRequestTimestampMs, timestampMs);
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PooledHeaderReturnBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PooledHeaderReturnBenchmarks.cs
@@ -13,8 +13,11 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
 public class PooledHeaderReturnBenchmarks
 {
+    private readonly Headers _headers = new(4);
+    private readonly Header _existingHeader = new("existing", "value"u8.ToArray());
     private Header _traceparent;
     private Header _tracestate;
+    private readonly Header _serializerHeader = new("serializer", "appended"u8.ToArray());
     private Activity _activity = null!;
 
     [GlobalSetup]
@@ -41,5 +44,46 @@ public class PooledHeaderReturnBenchmarks
         headers[0] = _traceparent;
         headers[1] = _tracestate;
         RecordAccumulator.ReturnPooledHeaders(headers, 2);
+    }
+
+    [Benchmark]
+    public void ReturnTracedHeadersAfterAppend()
+    {
+        var headers = ProducerContainerPools.Headers.Rent(4);
+        headers[0] = _serializerHeader;
+        headers[1] = _traceparent;
+        headers[2] = _tracestate;
+        RecordAccumulator.ReturnPooledHeaders(headers, 3);
+    }
+
+    [Benchmark]
+    public int RentFillAndReturnAfterAppend()
+    {
+        _headers.Clear();
+        _headers.Add(_existingHeader);
+        _headers.AddDeferredTraceContext(_activity, "vendor=value");
+        _headers.Add(_serializerHeader);
+
+        KafkaProducer<string, string>.RentAndFillHeaders(
+            _headers,
+            out var headers,
+            out var headerCount);
+        RecordAccumulator.ReturnPooledHeaders(headers, headerCount);
+        return headerCount;
+    }
+
+    [Benchmark]
+    public int RentFillAndReturnNormalHeaders()
+    {
+        _headers.Clear();
+        _headers.Add(_existingHeader);
+        _headers.Add(_serializerHeader);
+
+        KafkaProducer<string, string>.RentAndFillHeaders(
+            _headers,
+            out var headers,
+            out var headerCount);
+        RecordAccumulator.ReturnPooledHeaders(headers, headerCount);
+        return headerCount;
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PooledHeaderReturnBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PooledHeaderReturnBenchmarks.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Allocation and latency gate for returning traced producer-header arrays.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class PooledHeaderReturnBenchmarks
+{
+    private Header _traceparent;
+    private Header _tracestate;
+    private Activity _activity = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _activity = new Activity("pooled-header-return")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+        _activity.TraceStateString = "vendor=value";
+        var headers = Diagnostics.TraceContextPropagator.InjectTraceContext(
+            new Headers(2),
+            _activity)!;
+        _traceparent = headers[0];
+        _tracestate = headers[1];
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _activity.Dispose();
+
+    [Benchmark]
+    public void ReturnTracedHeaders()
+    {
+        var headers = ProducerContainerPools.Headers.Rent(2);
+        headers[0] = _traceparent;
+        headers[1] = _tracestate;
+        RecordAccumulator.ReturnPooledHeaders(headers, 2);
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerActivityDisabledBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerActivityDisabledBenchmarks.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Isolates the tracing-disabled producer activity branch. Cluster identity is read only
+/// after an activity has been created, so this path must remain allocation-free.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class ProducerActivityDisabledBenchmarks
+{
+    private KafkaProducer<string, string> _producer = null!;
+    private ProducerMessage<string, string> _message = null!;
+    private StartPublishActivityDelegate _startPublishActivity = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _producer = new KafkaProducer<string, string>(
+            new ProducerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = "activity-disabled-benchmark"
+            },
+            Serializers.String,
+            Serializers.String);
+        _message = new ProducerMessage<string, string>
+        {
+            Topic = "benchmark-topic",
+            Key = "key",
+            Value = "value"
+        };
+        _startPublishActivity = typeof(KafkaProducer<string, string>)
+            .GetMethod("StartPublishActivity", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .CreateDelegate<StartPublishActivityDelegate>(_producer);
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup() => await _producer.DisposeAsync().ConfigureAwait(false);
+
+    [Benchmark]
+    public Activity? StartPublishActivityWithoutListeners() => _startPublishActivity(ref _message);
+
+    private delegate Activity? StartPublishActivityDelegate(ref ProducerMessage<string, string> message);
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reflection;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
@@ -27,6 +28,8 @@ public class ProducerFireHotPathBenchmarks
     private CancellationTokenSource _drainerCts = null!;
     private Thread _drainerThread = null!;
     private string _value = null!;
+    private ProducerMessage<string, string>[] _messages = null!;
+    private ActivityListener? _activityListener;
 
     [Params(1000)]
     public int MessageSize { get; set; }
@@ -36,6 +39,9 @@ public class ProducerFireHotPathBenchmarks
 
     [Params(1, 12)]
     public int PartitionCount { get; set; }
+
+    [Params(false, true)]
+    public bool TracingEnabled { get; set; }
 
     [GlobalSetup]
     public async Task Setup()
@@ -59,6 +65,16 @@ public class ProducerFireHotPathBenchmarks
             Serializers.String,
             Serializers.String);
 
+        if (TracingEnabled)
+        {
+            _activityListener = new ActivityListener
+            {
+                ShouldListenTo = static source => source.Name == Diagnostics.DekafDiagnostics.ActivitySourceName,
+                Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+            };
+            ActivitySource.AddActivityListener(_activityListener);
+        }
+
         await StopBackgroundLoopsAsync(_producer).ConfigureAwait(false);
         SeedMetadata(_producer, PartitionCount);
         SetInstanceField(_producer, "_initialized", true);
@@ -73,6 +89,16 @@ public class ProducerFireHotPathBenchmarks
         }
 
         _value = new string('x', MessageSize);
+        _messages = new ProducerMessage<string, string>[100];
+        for (var i = 0; i < _messages.Length; i++)
+        {
+            _messages[i] = new ProducerMessage<string, string>
+            {
+                Topic = Topic,
+                Key = Keys[i],
+                Value = _value
+            };
+        }
         _drainerCts = new CancellationTokenSource();
         _drainerThread = new Thread(() => DrainLoop(_drainerCts.Token))
         {
@@ -91,6 +117,7 @@ public class ProducerFireHotPathBenchmarks
         _drainerCts.Cancel();
         _drainerThread.Join();
         _drainerCts.Dispose();
+        _activityListener?.Dispose();
 
         await _producer.DisposeAsync().ConfigureAwait(false);
     }
@@ -100,7 +127,7 @@ public class ProducerFireHotPathBenchmarks
     {
         for (var i = 0; i < 100; i++)
         {
-            var result = _producer.FireAsync(Topic, Keys[i], _value);
+            var result = _producer.FireAsync(_messages[i]);
             if (!result.IsCompletedSuccessfully)
             {
                 throw new InvalidOperationException(
@@ -163,6 +190,14 @@ public class ProducerFireHotPathBenchmarks
                 },
             ],
         });
+        typeof(MetadataManager)
+            .GetMethod(
+                "UpdateMetadataClusterId",
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                binder: null,
+                [typeof(string)],
+                modifiers: null)!
+            .Invoke(metadataManager, ["producer-fire-hot-path"]);
     }
 
     private static ValueTask StopBackgroundLoopsAsync(KafkaProducer<string, string> producer)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TraceContextInjectionBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TraceContextInjectionBenchmarks.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Allocation gate for injecting an already-created W3C activity into reusable headers.
+/// Activity creation and export are measured separately by the producer tracing benchmark.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class TraceContextInjectionBenchmarks
+{
+    private readonly Headers _headers = new(1);
+    private readonly byte[] _destination = new byte[80];
+    private Activity _activity = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _activity = new Activity("trace-context-injection")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _activity.Dispose();
+
+    [Benchmark]
+    public int Inject()
+    {
+        _headers.Clear();
+        return Diagnostics.TraceContextPropagator.InjectTraceContext(_headers, _activity)!.Count;
+    }
+
+    [Benchmark]
+    public int InjectAndEncode()
+    {
+        _headers.Clear();
+        Diagnostics.TraceContextPropagator.InjectTraceContext(_headers, _activity);
+        var offset = 0;
+        _headers[0].Encode(_destination, ref offset);
+        return offset;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TraceContextInjectionBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TraceContextInjectionBenchmarks.cs
@@ -14,9 +14,13 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 public class TraceContextInjectionBenchmarks
 {
     private readonly Headers _headers = new(1);
+    private readonly Headers _tracestateHeaders = new(2);
+    private readonly Header _leadingHeader = new("leading", "removed"u8.ToArray());
     private readonly Header _serializerHeader = new("serializer", "appended"u8.ToArray());
     private readonly byte[] _destination = new byte[80];
+    private readonly byte[] _tracestateDestination = new byte[128];
     private Activity _activity = null!;
+    private Activity _tracestateActivity = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -24,10 +28,18 @@ public class TraceContextInjectionBenchmarks
         _activity = new Activity("trace-context-injection")
             .SetIdFormat(ActivityIdFormat.W3C)
             .Start();
+        _tracestateActivity = new Activity("tracestate-context-injection")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+        _tracestateActivity.TraceStateString = "vendor=value";
     }
 
     [GlobalCleanup]
-    public void Cleanup() => _activity.Dispose();
+    public void Cleanup()
+    {
+        _activity.Dispose();
+        _tracestateActivity.Dispose();
+    }
 
     [Benchmark]
     public int Inject()
@@ -63,5 +75,29 @@ public class TraceContextInjectionBenchmarks
         _headers.Add(_serializerHeader);
         _headers.RemoveDeferredTraceContext();
         return _headers.Count;
+    }
+
+    [Benchmark]
+    public int InjectRemoveLeadingAndRemove()
+    {
+        _headers.Clear();
+        _headers.Add(_leadingHeader);
+        Diagnostics.TraceContextPropagator.InjectTraceContext(_headers, _activity);
+        _headers.Remove("leading");
+        _headers.RemoveDeferredTraceContext();
+        return _headers.Count;
+    }
+
+    [Benchmark]
+    public int InjectTracestateAndEncode()
+    {
+        _tracestateHeaders.Clear();
+        Diagnostics.TraceContextPropagator.InjectTraceContext(
+            _tracestateHeaders,
+            _tracestateActivity);
+        var offset = 0;
+        _tracestateHeaders[0].Encode(_tracestateDestination, ref offset);
+        _tracestateHeaders[1].Encode(_tracestateDestination, ref offset);
+        return offset;
     }
 }


### PR DESCRIPTION
## Summary

- add optional `IKafkaClientIdentity` and `IKafkaClientStatusProvider` capabilities to built-in producer, consumer, share-consumer, and admin clients
- expose immutable low-frequency snapshots for per-broker connections, producer backlog/capacity, and consumer-group heartbeat/assignment state
- publish only `MetadataManager`'s trusted cluster identity, preventing `RebootstrapRequired` or misrouted metadata from leaking as current identity
- add `messaging.kafka.cluster.id` to producer/consumer activities only after an activity exists
- add unit, Docker integration, public-API, allocation, and BenchmarkDotNet coverage

## Performance evidence

Exact predecessor: `5b4b3ea8`  
Candidate: `8bdf32f8`  
Runtime: .NET 10.0.11, i7-12700K, BenchmarkDotNet 0.15.8.

| Sampled hot path | Baseline | Candidate | Result |
|---|---:|---:|---:|
| producer activity allocation | 1136 B/message | 1040 B/message | -96 B/message |
| consumer activity allocation | 888 B/message | 864 B/message | -24 B/message |
| consumer activity CPU | 300.078 ns | 299.062 ns | overlapping 99.9% CIs |

`ProducerFireHotPathBenchmarks` covered the exact preallocated-message harness across linger 0/10 ms and 1/12 partitions. Every sampled candidate case allocated 1040 B/message with the cluster tag present. Tracing-disabled cases remained 0 B/message except the documented stochastic drainer-behind row (4 B/message cold-path noise).

`ConsumerActivityHotPathBenchmarks` used an exact predecessor/candidate pair with 10 measured iterations. Baseline CPU was 300.078 ns (99.9% CI 291.868–308.288); candidate CPU was 299.062 ns (99.9% CI 292.991–305.133). Allocation improved from 888 B to 864 B/message.

The performance fix writes the 55-byte W3C `traceparent` directly as UTF-8, eliminating the temporary formatted string while preserving exact bytes. The consumer omits `messaging.message.body.size`, which OpenTelemetry defines as Opt-In and Dekaf does not expose an opt-in for; this avoids a tag node and boxed per-record integer. Required/recommended activity tags, including `messaging.kafka.cluster.id`, remain.

The connection change adds one volatile timestamp store per successful Kafka request/batch, not per message. Snapshot collection is low-frequency and bounded by represented brokers/connections/partitions.

No paid stress lane was dispatched: the changed work is status collection plus isolated per-request/listener instrumentation, and exact local hot-path benchmarks provide causal allocation and CPU evidence.

## Validation
- `pwsh scripts/Test-PublicApiGate.ps1`
- `dotnet build --configuration Release` — 0 warnings/errors
- full unit suite — 6,817 net10.0 + 6,681 net8.0 passed
- focused Docker integration suite — 4 passed (shared identity, backlog drain, group heartbeat/assignment, broker disconnect/reconnect)
- hot-path allocation unit suite — 5 passed
- BenchmarkDotNet exact predecessor/candidate runs described above

Closes #2557
## Review and CI follow-up

- controller-bootstrapped admin identity/status now use the controller snapshot
- topic-filter subscriptions now report consumer-group participation
- mixed adaptive groups and retained singleton connections are counted with reference deduplication
- connection status retains the real failure message
- package validation now suppresses the two expected runtime-provided enum ISpanFormattable differences across netstandard2.0/net10.0
- public API gate and package compatibility validation pass
- heartbeat version negotiation failures are captured without hiding caller cancellation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added diagnostics APIs for Kafka cluster identity and operational status.
  - Admin, producer, consumer, and shared consumer clients now expose cluster IDs and status snapshots.
  - Status includes broker connectivity, connection errors, producer backlog, consumer-group activity, assignments, heartbeat details, and disposal state.
  - Tracing activities now include the Kafka cluster ID when available.

- **Tests**
  - Added coverage for status reporting, cluster identity, broker reconnects, consumer assignments, and producer backlog behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->