### PR TITLE
feat(serialization): add allocation-free routing serdes

### DIFF
--- a/Dekaf.sln
+++ b/Dekaf.sln
@@ -67,6 +67,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.Tests.Mutation.Produc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.Tests.Mutation.Protocol", "tests\Dekaf.Tests.Mutation.Protocol\Dekaf.Tests.Mutation.Protocol.csproj", "{50CD7D4E-24BC-4CA1-A183-1257129A66DE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.Serialization.Routing", "src\Dekaf.Serialization.Routing\Dekaf.Serialization.Routing.csproj", "{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -413,6 +415,18 @@ Global
 		{50CD7D4E-24BC-4CA1-A183-1257129A66DE}.Release|x64.Build.0 = Release|Any CPU
 		{50CD7D4E-24BC-4CA1-A183-1257129A66DE}.Release|x86.ActiveCfg = Release|Any CPU
 		{50CD7D4E-24BC-4CA1-A183-1257129A66DE}.Release|x86.Build.0 = Release|Any CPU
+		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}.Debug|x64.Build.0 = Debug|Any CPU
+		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}.Debug|x86.Build.0 = Debug|Any CPU
+		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}.Release|x64.ActiveCfg = Release|Any CPU
+		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}.Release|x64.Build.0 = Release|Any CPU
+		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}.Release|x86.ActiveCfg = Release|Any CPU
+		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -446,5 +460,6 @@ Global
 		{8F730686-3362-4BF0-9BAB-962D8C872A6C} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{DF2BABFD-6483-43F3-8AC1-B6A1C36CB777} = {B2C3D4E5-F6A7-8901-BCDE-F12345678901}
 		{50CD7D4E-24BC-4CA1-A183-1257129A66DE} = {B2C3D4E5-F6A7-8901-BCDE-F12345678901}
+		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -276,6 +276,9 @@ var producer = await Kafka.CreateProducer<string, Order>()
 await producer.ProduceAsync("orders", order.Id, order);
 ```
 
+For heterogeneous event streams, `Dekaf.Serialization.Routing` provides frozen, allocation-free
+topic and schema-ID deserializers plus topic and runtime-type serializers.
+
 ## Security
 
 ### TLS

--- a/docs/docs/serialization/routing.md
+++ b/docs/docs/serialization/routing.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 4
+---
+
+# Routing Serdes
+
+`Dekaf.Serialization.Routing` routes heterogeneous records without allocating during steady-state
+dispatch. Registration is a cold-start operation; call `Freeze()` before passing a router to a
+producer or consumer. Frozen routers are safe for concurrent use.
+
+```bash
+dotnet add package Dekaf.Serialization.Routing
+```
+
+## Route consumed values by topic
+
+```csharp
+using Dekaf.Serialization.Routing;
+
+var deserializer = new TopicRoutingDeserializer<IEvent>()
+    .Register("orders", orderDeserializer)
+    .Register("payments", paymentDeserializer)
+    .Freeze();
+
+await using var consumer = await Kafka.CreateConsumer<string, IEvent>()
+    .WithBootstrapServers("localhost:9092")
+    .WithGroupId("event-router")
+    .WithValueDeserializer(deserializer)
+    .BuildAsync();
+```
+
+Each registered `IDeserializer<TDerived>` remains strongly typed. No cast delegate or closure is
+created while consuming.
+
+## Route Schema Registry payloads by schema ID
+
+`SchemaIdRoutingDeserializer<TBase>` reads the schema ID from the standard Confluent framing:
+magic byte `0`, followed by a four-byte big-endian schema ID. The selected deserializer receives
+the complete framed payload, so existing Schema Registry deserializers continue to work.
+
+```csharp
+using Dekaf.Serialization.Routing;
+
+var deserializer = new SchemaIdRoutingDeserializer<IEvent>()
+    .Register(17, customerV1Deserializer)
+    .Register(23, customerV2Deserializer)
+    .Freeze();
+```
+
+Malformed framing throws `SerializationException`. An unknown topic or schema ID also throws
+unless a fallback was registered with `SetFallback(...)` before `Freeze()`.
+
+## Route produced values
+
+Use `TopicRoutingSerializer<TBase>` when the destination topic determines the format. Use
+`TypeRoutingSerializer<TBase>` when the value's exact runtime type determines it.
+
+```csharp
+using Dekaf.Serialization.Routing;
+
+var serializer = new TypeRoutingSerializer<IEvent>()
+    .Register(orderSerializer)
+    .Register(paymentSerializer)
+    .Freeze();
+```
+
+Topic routes validate that the value matches the registered derived serializer type. Runtime-type
+routes use exact type matching; derived subclasses need their own registration or a fallback.
+
+## Inspect the raw record key
+
+During value deserialization, `SerializationContext.KeyData` exposes the raw key bytes without a
+copy. `SerializationContext.IsKeyNull` distinguishes a Kafka null key from a non-null empty key.
+
+The memory can reference a pooled receive buffer. Read it only during the current deserializer
+call; never store it, return it, or use it after deserialization completes. `KeyData` is not
+meaningful during serialization or key deserialization.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -52,6 +52,7 @@ const sidebars = {
         'serialization/built-in',
         'serialization/json',
         'serialization/schema-registry',
+        'serialization/routing',
         'serialization/custom',
       ],
     },

--- a/src/Dekaf.Serialization.Routing/Dekaf.Serialization.Routing.csproj
+++ b/src/Dekaf.Serialization.Routing/Dekaf.Serialization.Routing.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Dekaf.Serialization.Routing</PackageId>
+    <Description>Allocation-free routing serializers and deserializers for Dekaf</Description>
+    <PackageTags>kafka;serialization;routing</PackageTags>
+    <!-- New package: no previously published baseline exists yet. -->
+    <PackageValidationBaselineVersion></PackageValidationBaselineVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dekaf\Dekaf.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Dekaf.Serialization.Routing/FrozenRouteTable.cs
+++ b/src/Dekaf.Serialization.Routing/FrozenRouteTable.cs
@@ -1,0 +1,60 @@
+using System.Collections.Frozen;
+
+namespace Dekaf.Serialization.Routing;
+
+internal sealed class FrozenRouteTable<TKey, TRoute>(IEqualityComparer<TKey>? comparer = null)
+    where TKey : notnull
+    where TRoute : class
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<TKey, TRoute> _registrations = new(comparer);
+    private FrozenDictionary<TKey, TRoute>? _routes;
+    private TRoute? _fallback;
+
+    internal bool IsFrozen => Volatile.Read(ref _routes) is not null;
+
+    internal void Register(TKey key, TRoute route)
+    {
+        lock (_gate)
+        {
+            if (_routes is not null)
+                throw new InvalidOperationException("Routes cannot be changed after Freeze().");
+            if (!_registrations.TryAdd(key, route))
+                throw new InvalidOperationException("A route is already registered for the supplied key.");
+        }
+    }
+
+    internal void SetFallback(TRoute route)
+    {
+        lock (_gate)
+        {
+            if (_routes is not null)
+                throw new InvalidOperationException("Routes cannot be changed after Freeze().");
+            _fallback = route;
+        }
+    }
+
+    internal void Freeze()
+    {
+        lock (_gate)
+        {
+            if (_routes is null)
+            {
+                Volatile.Write(
+                    ref _routes,
+                    _registrations.ToFrozenDictionary(comparer: _registrations.Comparer));
+            }
+        }
+    }
+
+    internal bool TryGetRoute(TKey key, out TRoute route)
+    {
+        var routes = Volatile.Read(ref _routes)
+            ?? throw new InvalidOperationException("Freeze() must be called before routing data.");
+        if (routes.TryGetValue(key, out route!))
+            return true;
+
+        route = _fallback!;
+        return route is not null;
+    }
+}

--- a/src/Dekaf.Serialization.Routing/PublicAPI.Shipped.txt
+++ b/src/Dekaf.Serialization.Routing/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Dekaf.Serialization.Routing/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.Serialization.Routing/PublicAPI.Unshipped.txt
@@ -1,0 +1,29 @@
+#nullable enable
+Dekaf.Serialization.Routing.SchemaIdRoutingDeserializer<TBase>
+Dekaf.Serialization.Routing.SchemaIdRoutingDeserializer<TBase>.Deserialize(System.ReadOnlyMemory<byte> data, Dekaf.Serialization.SerializationContext context) -> TBase!
+Dekaf.Serialization.Routing.SchemaIdRoutingDeserializer<TBase>.Freeze() -> Dekaf.Serialization.Routing.SchemaIdRoutingDeserializer<TBase!>!
+Dekaf.Serialization.Routing.SchemaIdRoutingDeserializer<TBase>.IsFrozen.get -> bool
+Dekaf.Serialization.Routing.SchemaIdRoutingDeserializer<TBase>.Register<TDerived>(int schemaId, Dekaf.Serialization.IDeserializer<TDerived!>! deserializer) -> Dekaf.Serialization.Routing.SchemaIdRoutingDeserializer<TBase!>!
+Dekaf.Serialization.Routing.SchemaIdRoutingDeserializer<TBase>.SchemaIdRoutingDeserializer() -> void
+Dekaf.Serialization.Routing.SchemaIdRoutingDeserializer<TBase>.SetFallback(Dekaf.Serialization.IDeserializer<TBase!>! deserializer) -> Dekaf.Serialization.Routing.SchemaIdRoutingDeserializer<TBase!>!
+Dekaf.Serialization.Routing.TopicRoutingDeserializer<TBase>
+Dekaf.Serialization.Routing.TopicRoutingDeserializer<TBase>.Deserialize(System.ReadOnlyMemory<byte> data, Dekaf.Serialization.SerializationContext context) -> TBase!
+Dekaf.Serialization.Routing.TopicRoutingDeserializer<TBase>.Freeze() -> Dekaf.Serialization.Routing.TopicRoutingDeserializer<TBase!>!
+Dekaf.Serialization.Routing.TopicRoutingDeserializer<TBase>.IsFrozen.get -> bool
+Dekaf.Serialization.Routing.TopicRoutingDeserializer<TBase>.Register<TDerived>(string! topic, Dekaf.Serialization.IDeserializer<TDerived!>! deserializer) -> Dekaf.Serialization.Routing.TopicRoutingDeserializer<TBase!>!
+Dekaf.Serialization.Routing.TopicRoutingDeserializer<TBase>.SetFallback(Dekaf.Serialization.IDeserializer<TBase!>! deserializer) -> Dekaf.Serialization.Routing.TopicRoutingDeserializer<TBase!>!
+Dekaf.Serialization.Routing.TopicRoutingDeserializer<TBase>.TopicRoutingDeserializer() -> void
+Dekaf.Serialization.Routing.TopicRoutingSerializer<TBase>
+Dekaf.Serialization.Routing.TopicRoutingSerializer<TBase>.Freeze() -> Dekaf.Serialization.Routing.TopicRoutingSerializer<TBase!>!
+Dekaf.Serialization.Routing.TopicRoutingSerializer<TBase>.IsFrozen.get -> bool
+Dekaf.Serialization.Routing.TopicRoutingSerializer<TBase>.Register<TDerived>(string! topic, Dekaf.Serialization.ISerializer<TDerived!>! serializer) -> Dekaf.Serialization.Routing.TopicRoutingSerializer<TBase!>!
+Dekaf.Serialization.Routing.TopicRoutingSerializer<TBase>.Serialize<TWriter>(TBase! value, ref TWriter destination, Dekaf.Serialization.SerializationContext context) -> void
+Dekaf.Serialization.Routing.TopicRoutingSerializer<TBase>.SetFallback(Dekaf.Serialization.ISerializer<TBase!>! serializer) -> Dekaf.Serialization.Routing.TopicRoutingSerializer<TBase!>!
+Dekaf.Serialization.Routing.TopicRoutingSerializer<TBase>.TopicRoutingSerializer() -> void
+Dekaf.Serialization.Routing.TypeRoutingSerializer<TBase>
+Dekaf.Serialization.Routing.TypeRoutingSerializer<TBase>.Freeze() -> Dekaf.Serialization.Routing.TypeRoutingSerializer<TBase!>!
+Dekaf.Serialization.Routing.TypeRoutingSerializer<TBase>.IsFrozen.get -> bool
+Dekaf.Serialization.Routing.TypeRoutingSerializer<TBase>.Register<TDerived>(Dekaf.Serialization.ISerializer<TDerived!>! serializer) -> Dekaf.Serialization.Routing.TypeRoutingSerializer<TBase!>!
+Dekaf.Serialization.Routing.TypeRoutingSerializer<TBase>.Serialize<TWriter>(TBase! value, ref TWriter destination, Dekaf.Serialization.SerializationContext context) -> void
+Dekaf.Serialization.Routing.TypeRoutingSerializer<TBase>.SetFallback(Dekaf.Serialization.ISerializer<TBase!>! serializer) -> Dekaf.Serialization.Routing.TypeRoutingSerializer<TBase!>!
+Dekaf.Serialization.Routing.TypeRoutingSerializer<TBase>.TypeRoutingSerializer() -> void

--- a/src/Dekaf.Serialization.Routing/RoutingDeserializers.cs
+++ b/src/Dekaf.Serialization.Routing/RoutingDeserializers.cs
@@ -1,0 +1,131 @@
+using System.Buffers.Binary;
+using Dekaf.Errors;
+
+namespace Dekaf.Serialization.Routing;
+
+/// <summary>
+/// Routes deserialization by the record topic.
+/// </summary>
+/// <typeparam name="TBase">The common reference type returned by every route.</typeparam>
+public sealed class TopicRoutingDeserializer<TBase> : IDeserializer<TBase>
+    where TBase : class
+{
+    private readonly FrozenRouteTable<string, IDeserializer<TBase>> _routes = new(StringComparer.Ordinal);
+
+    /// <summary>Whether registration has been frozen for routing.</summary>
+    public bool IsFrozen => _routes.IsFrozen;
+
+    /// <summary>Registers one topic route.</summary>
+    public TopicRoutingDeserializer<TBase> Register<TDerived>(
+        string topic,
+        IDeserializer<TDerived> deserializer)
+        where TDerived : class, TBase
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+        ArgumentNullException.ThrowIfNull(deserializer);
+        _routes.Register(topic, deserializer);
+        return this;
+    }
+
+    /// <summary>Sets the route used when no topic registration matches.</summary>
+    public TopicRoutingDeserializer<TBase> SetFallback(IDeserializer<TBase> deserializer)
+    {
+        ArgumentNullException.ThrowIfNull(deserializer);
+        _routes.SetFallback(deserializer);
+        return this;
+    }
+
+    /// <summary>Freezes registration and enables concurrent routing.</summary>
+    public TopicRoutingDeserializer<TBase> Freeze()
+    {
+        _routes.Freeze();
+        return this;
+    }
+
+    /// <inheritdoc />
+    public TBase Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+    {
+        if (_routes.TryGetRoute(context.Topic, out var route))
+            return route.Deserialize(data, context);
+
+        throw MissingRoute("topic", context.Topic, context);
+    }
+
+    private static SerializationException MissingRoute(
+        string routeKind,
+        string routeValue,
+        SerializationContext context) =>
+        new($"No {routeKind} deserializer route is registered for '{routeValue}'.")
+        {
+            Topic = context.Topic,
+            Component = context.Component
+        };
+}
+
+/// <summary>
+/// Routes Confluent-framed Schema Registry payloads by schema ID.
+/// </summary>
+/// <remarks>
+/// The selected deserializer receives the complete framed input. Registration is mutable only
+/// before <see cref="Freeze"/>; after freezing, routing is thread-safe and allocation-free.
+/// </remarks>
+/// <typeparam name="TBase">The common reference type returned by every route.</typeparam>
+public sealed class SchemaIdRoutingDeserializer<TBase> : IDeserializer<TBase>
+    where TBase : class
+{
+    private const int HeaderSize = 5;
+    private readonly FrozenRouteTable<int, IDeserializer<TBase>> _routes = new();
+
+    /// <summary>Whether registration has been frozen for routing.</summary>
+    public bool IsFrozen => _routes.IsFrozen;
+
+    /// <summary>Registers one schema-ID route.</summary>
+    public SchemaIdRoutingDeserializer<TBase> Register<TDerived>(
+        int schemaId,
+        IDeserializer<TDerived> deserializer)
+        where TDerived : class, TBase
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(schemaId);
+        ArgumentNullException.ThrowIfNull(deserializer);
+        _routes.Register(schemaId, deserializer);
+        return this;
+    }
+
+    /// <summary>Sets the route used when no schema-ID registration matches.</summary>
+    public SchemaIdRoutingDeserializer<TBase> SetFallback(IDeserializer<TBase> deserializer)
+    {
+        ArgumentNullException.ThrowIfNull(deserializer);
+        _routes.SetFallback(deserializer);
+        return this;
+    }
+
+    /// <summary>Freezes registration and enables concurrent routing.</summary>
+    public SchemaIdRoutingDeserializer<TBase> Freeze()
+    {
+        _routes.Freeze();
+        return this;
+    }
+
+    /// <inheritdoc />
+    public TBase Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+    {
+        if (data.Length < HeaderSize || data.Span[0] != 0)
+        {
+            throw new SerializationException("Schema-ID routing requires Confluent framing.")
+            {
+                Topic = context.Topic,
+                Component = context.Component
+            };
+        }
+
+        var schemaId = BinaryPrimitives.ReadInt32BigEndian(data.Span.Slice(1, sizeof(int)));
+        if (_routes.TryGetRoute(schemaId, out var route))
+            return route.Deserialize(data, context);
+
+        throw new SerializationException($"No schema-ID deserializer route is registered for '{schemaId}'.")
+        {
+            Topic = context.Topic,
+            Component = context.Component
+        };
+    }
+}

--- a/src/Dekaf.Serialization.Routing/RoutingSerializers.cs
+++ b/src/Dekaf.Serialization.Routing/RoutingSerializers.cs
@@ -1,0 +1,176 @@
+using System.Buffers;
+using Dekaf.Errors;
+
+namespace Dekaf.Serialization.Routing;
+
+/// <summary>
+/// Routes serialization by the destination topic.
+/// </summary>
+/// <typeparam name="TBase">The common reference type accepted by every route.</typeparam>
+public sealed class TopicRoutingSerializer<TBase> : ISerializer<TBase>
+    where TBase : class
+{
+    private readonly FrozenRouteTable<string, SerializerRoute<TBase>> _routes = new(StringComparer.Ordinal);
+
+    /// <summary>Whether registration has been frozen for routing.</summary>
+    public bool IsFrozen => _routes.IsFrozen;
+
+    /// <summary>Registers one topic route.</summary>
+    public TopicRoutingSerializer<TBase> Register<TDerived>(string topic, ISerializer<TDerived> serializer)
+        where TDerived : class, TBase
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+        ArgumentNullException.ThrowIfNull(serializer);
+        _routes.Register(topic, new SerializerRoute<TBase, TDerived>(serializer));
+        return this;
+    }
+
+    /// <summary>Sets the route used when no topic registration matches.</summary>
+    public TopicRoutingSerializer<TBase> SetFallback(ISerializer<TBase> serializer)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        _routes.SetFallback(new SerializerRoute<TBase, TBase>(serializer));
+        return this;
+    }
+
+    /// <summary>Freezes registration and enables concurrent routing.</summary>
+    public TopicRoutingSerializer<TBase> Freeze()
+    {
+        _routes.Freeze();
+        return this;
+    }
+
+    /// <inheritdoc />
+    public void Serialize<TWriter>(TBase value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#if NET10_0_OR_GREATER
+        , allows ref struct
+#endif
+    {
+        if (value is null)
+            throw MissingRoute("runtime type", "null", context);
+
+        if (_routes.TryGetRoute(context.Topic, out var route))
+        {
+            route.Serialize(value, ref destination, context);
+            return;
+        }
+
+        throw MissingRoute("topic", context.Topic, context);
+    }
+
+    private static SerializationException MissingRoute(
+        string routeKind,
+        string routeValue,
+        SerializationContext context) =>
+        new($"No {routeKind} serializer route is registered for '{routeValue}'.")
+        {
+            Topic = context.Topic,
+            Component = context.Component
+        };
+}
+
+/// <summary>
+/// Routes serialization by the value's exact runtime type.
+/// </summary>
+/// <typeparam name="TBase">The common reference type accepted by every route.</typeparam>
+public sealed class TypeRoutingSerializer<TBase> : ISerializer<TBase>
+    where TBase : class
+{
+    private readonly FrozenRouteTable<Type, SerializerRoute<TBase>> _routes = new();
+
+    /// <summary>Whether registration has been frozen for routing.</summary>
+    public bool IsFrozen => _routes.IsFrozen;
+
+    /// <summary>Registers one exact runtime-type route.</summary>
+    public TypeRoutingSerializer<TBase> Register<TDerived>(ISerializer<TDerived> serializer)
+        where TDerived : class, TBase
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        _routes.Register(typeof(TDerived), new SerializerRoute<TBase, TDerived>(serializer));
+        return this;
+    }
+
+    /// <summary>Sets the route used when no exact runtime-type registration matches.</summary>
+    public TypeRoutingSerializer<TBase> SetFallback(ISerializer<TBase> serializer)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        _routes.SetFallback(new SerializerRoute<TBase, TBase>(serializer));
+        return this;
+    }
+
+    /// <summary>Freezes registration and enables concurrent routing.</summary>
+    public TypeRoutingSerializer<TBase> Freeze()
+    {
+        _routes.Freeze();
+        return this;
+    }
+
+    /// <inheritdoc />
+    public void Serialize<TWriter>(TBase value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#if NET10_0_OR_GREATER
+        , allows ref struct
+#endif
+    {
+        if (value is null)
+        {
+            throw new SerializationException("No runtime-type serializer route is registered for 'null'.")
+            {
+                Topic = context.Topic,
+                Component = context.Component
+            };
+        }
+
+        if (_routes.TryGetRoute(value.GetType(), out var route))
+        {
+            route.Serialize(value, ref destination, context);
+            return;
+        }
+
+        var routeValue = value.GetType().FullName;
+        throw new SerializationException($"No runtime-type serializer route is registered for '{routeValue}'.")
+        {
+            Topic = context.Topic,
+            Component = context.Component
+        };
+    }
+}
+
+internal abstract class SerializerRoute<TBase>
+    where TBase : class
+{
+    internal abstract void Serialize<TWriter>(
+        TBase value,
+        ref TWriter destination,
+        SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#if NET10_0_OR_GREATER
+        , allows ref struct
+#endif
+        ;
+}
+
+internal sealed class SerializerRoute<TBase, TDerived>(ISerializer<TDerived> serializer)
+    : SerializerRoute<TBase>
+    where TBase : class
+    where TDerived : class, TBase
+{
+    internal override void Serialize<TWriter>(
+        TBase value,
+        ref TWriter destination,
+        SerializationContext context)
+    {
+        if (value is not TDerived typedValue)
+        {
+            throw new SerializationException(
+                $"The route requires '{typeof(TDerived).FullName}', but received '{value?.GetType().FullName ?? "null"}'.")
+            {
+                Topic = context.Topic,
+                Component = context.Component
+            };
+        }
+
+        serializer.Serialize(typedValue, ref destination, context);
+    }
+}

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -970,6 +970,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             {
                 Topic = topicPartition.Topic,
                 Component = SerializationComponent.Key,
+                KeyData = ReadOnlyMemory<byte>.Empty,
                 IsNull = false
             };
 
@@ -989,6 +990,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         {
             Topic = topicPartition.Topic,
             Component = SerializationComponent.Value,
+            KeyData = SerializationContext.NormalizeKeyData(record.Key, record.IsKeyNull),
             IsNull = record.IsValueNull
         };
         var valueData = record.IsValueNull ? ReadOnlyMemory<byte>.Empty : record.Value;

--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -450,7 +450,13 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             _asyncValueDeserializer,
             _valueDeserializer,
             record.IsValueNull ? ReadOnlyMemory<byte>.Empty : record.Value,
-            Context(record.Topic, SerializationComponent.Value, record.Headers, isNull: record.IsValueNull),
+            Context(
+                record.Topic,
+                SerializationComponent.Value,
+                record.Headers,
+                isNull: record.IsValueNull,
+                keyData: record.Key,
+                isKeyNull: record.IsKeyNull),
             cancellationToken).ConfigureAwait(false);
 
         return new ShareConsumeResult<TKey, TValue>
@@ -487,10 +493,22 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
         var value = record.IsValueNull
             ? _valueDeserializer.Deserialize(
                 ReadOnlyMemory<byte>.Empty,
-                Context(record.Topic, SerializationComponent.Value, record.Headers, isNull: true))
+                Context(
+                    record.Topic,
+                    SerializationComponent.Value,
+                    record.Headers,
+                    isNull: true,
+                    keyData: record.Key,
+                    isKeyNull: record.IsKeyNull))
             : _valueDeserializer.Deserialize(
                 record.Value,
-                Context(record.Topic, SerializationComponent.Value, record.Headers, isNull: false));
+                Context(
+                    record.Topic,
+                    SerializationComponent.Value,
+                    record.Headers,
+                    isNull: false,
+                    keyData: record.Key,
+                    isKeyNull: record.IsKeyNull));
 
         return new ShareConsumeResult<TKey, TValue>
         {
@@ -577,12 +595,15 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
         string topic,
         SerializationComponent component,
         IReadOnlyList<Header>? headers,
-        bool isNull) =>
+        bool isNull,
+        ReadOnlyMemory<byte> keyData = default,
+        bool isKeyNull = false) =>
         new()
         {
             Topic = topic,
             Component = component,
             Headers = headers is null ? null : new Headers(headers),
+            KeyData = SerializationContext.NormalizeKeyData(keyData, isKeyNull),
             IsNull = isNull
         };
 

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -632,6 +632,7 @@ public readonly struct ConsumeResult<TKey, TValue>
             serializationContext.Topic = topic;
             serializationContext.Component = SerializationComponent.Key;
             serializationContext.Headers = null;
+            serializationContext.KeyData = ReadOnlyMemory<byte>.Empty;
             serializationContext.IsNull = false;
 
             Key = keyDeserializer.Deserialize(keyData, serializationContext);
@@ -646,6 +647,7 @@ public readonly struct ConsumeResult<TKey, TValue>
             serializationContext.Topic = topic;
             serializationContext.Component = SerializationComponent.Value;
             serializationContext.Headers = null;
+            serializationContext.KeyData = SerializationContext.NormalizeKeyData(keyData, isKeyNull);
             serializationContext.IsNull = isValueNull;
 
             Value = isValueNull

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4799,6 +4799,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 Topic = topic,
                 Component = SerializationComponent.Key,
+                KeyData = ReadOnlyMemory<byte>.Empty,
                 IsNull = false
             };
             try
@@ -4829,6 +4830,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             Topic = topic,
             Component = SerializationComponent.Value,
+            KeyData = SerializationContext.NormalizeKeyData(keyData, isKeyNull),
             IsNull = isValueNull
         };
         var valueBytes = isValueNull ? ReadOnlyMemory<byte>.Empty : valueData;

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -1,4 +1,7 @@
 #nullable enable
+Dekaf.Serialization.SerializationContext.IsKeyNull.get -> bool
+Dekaf.Serialization.SerializationContext.KeyData.get -> System.ReadOnlyMemory<byte>
+Dekaf.Serialization.SerializationContext.KeyData.set -> void
 Dekaf.Consumer.ConsumerOffsetStoreExtensions
 Dekaf.Consumer.IConsumerBatchOffsetStore
 Dekaf.Consumer.IConsumerBatchOffsetStore.StoreOffsets(System.ReadOnlySpan<Dekaf.TopicPartitionOffset> offsets) -> void

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -1,4 +1,7 @@
 #nullable enable
+Dekaf.Serialization.SerializationContext.IsKeyNull.get -> bool
+Dekaf.Serialization.SerializationContext.KeyData.get -> System.ReadOnlyMemory<byte>
+Dekaf.Serialization.SerializationContext.KeyData.set -> void
 Dekaf.Consumer.ConsumerOffsetStoreExtensions
 Dekaf.Consumer.IConsumerBatchOffsetStore
 Dekaf.Consumer.IConsumerBatchOffsetStore.StoreOffsets(System.ReadOnlySpan<Dekaf.TopicPartitionOffset> offsets) -> void

--- a/src/Dekaf/Serialization/ISerializer.cs
+++ b/src/Dekaf/Serialization/ISerializer.cs
@@ -99,6 +99,24 @@ public struct SerializationContext
     public Headers? Headers { get; set; }
 
     /// <summary>
+    /// Raw record-key bytes available while deserializing a consumed value.
+    /// </summary>
+    /// <remarks>
+    /// The memory may reference a pooled receive buffer and is valid only for the duration of the
+    /// current <see cref="IDeserializer{T}.Deserialize"/> or async deserializer call. Deserializers
+    /// must not retain it. This property is empty for key deserialization and serialization.
+    /// </remarks>
+    public ReadOnlyMemory<byte> KeyData { get; set; }
+
+    /// <summary>
+    /// Whether <see cref="KeyData"/> represents a null consumed record key.
+    /// </summary>
+    public readonly bool IsKeyNull => KeyData.Equals(default(ReadOnlyMemory<byte>));
+
+    internal static ReadOnlyMemory<byte> NormalizeKeyData(ReadOnlyMemory<byte> keyData, bool isKeyNull) =>
+        isKeyNull ? default : keyData.IsEmpty ? Array.Empty<byte>() : keyData;
+
+    /// <summary>
     /// Whether the original data was null (as opposed to empty).
     /// This allows deserializers to distinguish between null values and empty byte arrays.
     /// </summary>

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -1083,11 +1083,17 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
                     t_serializationContext.Topic = topicInfo.Name;
                     t_serializationContext.Component = SerializationComponent.Key;
+                    t_serializationContext.KeyData = ReadOnlyMemory<byte>.Empty;
+                    t_serializationContext.IsNull = record.IsKeyNull;
                     var key = record.IsKeyNull
                         ? default
                         : _keyDeserializer.Deserialize(record.Key, t_serializationContext);
 
                     t_serializationContext.Component = SerializationComponent.Value;
+                    t_serializationContext.KeyData = SerializationContext.NormalizeKeyData(
+                        record.Key,
+                        record.IsKeyNull);
+                    t_serializationContext.IsNull = record.IsValueNull;
                     var value = record.IsValueNull
                         ? default!
                         : _valueDeserializer.Deserialize(record.Value, t_serializationContext);

--- a/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
+++ b/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dekaf\Dekaf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Serialization.Json\Dekaf.Serialization.Json.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Serialization.Routing\Dekaf.Serialization.Routing.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Avro\Dekaf.SchemaRegistry.Avro.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
@@ -31,6 +32,7 @@
   <ItemGroup Condition="'$(PublishAot)' == 'true'">
     <Compile Remove="OutboxRelayIntegrationTests.cs" />
     <Compile Remove="SchemaRegistrySubjectCompatibilityTests.cs" />
+    <Compile Remove="RoutingSerdeIntegrationTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Dekaf.Tests.Integration/RoutingSerdeIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/RoutingSerdeIntegrationTests.cs
@@ -1,0 +1,159 @@
+using System.Buffers;
+using Avro.Generic;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Producer;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Avro;
+using Dekaf.Serialization;
+using Dekaf.Serialization.Routing;
+using AvroSchema = Avro.Schema;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Serialization")]
+[ClassDataSource<KafkaWithSchemaRegistryContainer>(Shared = SharedType.PerTestSession)]
+public sealed class RoutingSerdeIntegrationTests(KafkaWithSchemaRegistryContainer testInfra)
+{
+    private const string EventV1Schema = """
+        {
+            "type": "record",
+            "name": "RoutedEvent",
+            "namespace": "dekaf.tests",
+            "fields": [
+                { "name": "id", "type": "long" },
+                { "name": "name", "type": "string" }
+            ]
+        }
+        """;
+
+    private const string EventV2Schema = """
+        {
+            "type": "record",
+            "name": "RoutedEvent",
+            "namespace": "dekaf.tests",
+            "fields": [
+                { "name": "id", "type": "long" },
+                { "name": "name", "type": "string" },
+                { "name": "category", "type": "string", "default": "general" }
+            ]
+        }
+        """;
+
+    [Test]
+    public async Task SchemaIdRouter_ConsumesMultipleVersionsAndProvidesRawKey()
+    {
+        var topic = await testInfra.CreateTestTopicAsync();
+        using var registry = new SchemaRegistryClient(new SchemaRegistryConfig { Url = testInfra.RegistryUrl });
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(registry);
+        await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(registry);
+
+        var v1Record = CreateRecord(EventV1Schema, 1, "one");
+        var v2Record = CreateRecord(EventV2Schema, 2, "two", "priority");
+        var v1SchemaId = await serializer.WarmupAsync(topic, v1Record);
+        var v2SchemaId = await serializer.WarmupAsync(topic, v2Record);
+        await deserializer.WarmupAsync(v1SchemaId);
+        await deserializer.WarmupAsync(v2SchemaId);
+        var v1Bytes = Serialize(serializer, topic, v1Record);
+        var v2Bytes = Serialize(serializer, topic, v2Record);
+
+        var v1Route = new AvroRouteDeserializer<V1Event>(deserializer, static (record, key) =>
+            new V1Event((long)record["id"]!, key));
+        var v2Route = new AvroRouteDeserializer<V2Event>(deserializer, static (record, key) =>
+            new V2Event((long)record["id"]!, (string)record["category"]!, key));
+        var incompleteRouter = new SchemaIdRoutingDeserializer<RoutedEvent>()
+            .Register(v1SchemaId, v1Route)
+            .Freeze();
+        var router = new SchemaIdRoutingDeserializer<RoutedEvent>()
+            .Register(v1SchemaId, v1Route)
+            .Register(v2SchemaId, v2Route)
+            .Freeze();
+
+        await Assert.That(() => incompleteRouter.Deserialize(v2Bytes, ValueContext(topic)))
+            .Throws<SerializationException>();
+
+        await using (var producer = await Kafka.CreateProducer<string, byte[]>()
+            .WithBootstrapServers(testInfra.BootstrapServers)
+            .WithClientId("routing-serde-producer")
+            .BuildAsync())
+        {
+            await producer.ProduceAsync(topic, "key-v1", v1Bytes);
+            await producer.ProduceAsync(topic, "key-v2", v2Bytes);
+            await producer.FlushWithTimeoutAsync();
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string, RoutedEvent>()
+            .WithBootstrapServers(testInfra.BootstrapServers)
+            .WithClientId("routing-serde-consumer")
+            .WithGroupId($"routing-serde-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithValueDeserializer(router)
+            .BuildAsync();
+        consumer.Subscribe(topic);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var events = new List<RoutedEvent>(2);
+        await foreach (var message in consumer.ConsumeAsync(timeout.Token))
+        {
+            events.Add(message.Value);
+            if (events.Count == 2)
+                break;
+        }
+
+        await Assert.That(v1SchemaId).IsNotEqualTo(v2SchemaId);
+        await Assert.That(events[0]).IsTypeOf<V1Event>();
+        await Assert.That(events[1]).IsTypeOf<V2Event>();
+        await Assert.That(events[0].Key).IsEqualTo("key-v1");
+        await Assert.That(events[1].Key).IsEqualTo("key-v2");
+        await Assert.That(((V2Event)events[1]).Category).IsEqualTo("priority");
+    }
+
+    private static GenericRecord CreateRecord(
+        string schemaJson,
+        long id,
+        string name,
+        string? category = null)
+    {
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(schemaJson);
+        var record = new GenericRecord(schema);
+        record.Add("id", id);
+        record.Add("name", name);
+        if (category is not null)
+            record.Add("category", category);
+        return record;
+    }
+
+    private static byte[] Serialize(
+        AvroSchemaRegistrySerializer<GenericRecord> serializer,
+        string topic,
+        GenericRecord record)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var context = ValueContext(topic);
+        serializer.Serialize(record, ref buffer, context);
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    private static SerializationContext ValueContext(string topic) => new()
+    {
+        Topic = topic,
+        Component = SerializationComponent.Value
+    };
+
+    private abstract record RoutedEvent(long Id, string Key);
+    private sealed record V1Event(long Id, string Key) : RoutedEvent(Id, Key);
+    private sealed record V2Event(long Id, string Category, string Key) : RoutedEvent(Id, Key);
+
+    private sealed class AvroRouteDeserializer<TEvent>(
+        AvroSchemaRegistryDeserializer<GenericRecord> inner,
+        Func<GenericRecord, string, TEvent> create) : IDeserializer<TEvent>
+        where TEvent : RoutedEvent
+    {
+        public TEvent Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            var record = inner.Deserialize(data, context);
+            var key = Serializers.String.Deserialize(context.KeyData, context);
+            return create(record, key);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\src\Dekaf.Compression.Brotli\Dekaf.Compression.Brotli.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Avro\Dekaf.SchemaRegistry.Avro.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Serialization.Json\Dekaf.Serialization.Json.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Serialization.Routing\Dekaf.Serialization.Routing.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Testing\Dekaf.Testing.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Extensions.DependencyInjection\Dekaf.Extensions.DependencyInjection.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Extensions.Hosting\Dekaf.Extensions.Hosting.csproj" />

--- a/tests/Dekaf.Tests.Unit/Serialization/RoutingSerdeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/RoutingSerdeTests.cs
@@ -1,0 +1,271 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Serialization;
+using Dekaf.Serialization.Routing;
+
+namespace Dekaf.Tests.Unit.Serialization;
+
+public sealed class RoutingSerdeTests
+{
+    private static readonly AlphaEvent Alpha = new();
+    private static readonly BetaEvent Beta = new();
+    private static readonly EventDeserializer<AlphaEvent> AlphaDeserializer = new(Alpha);
+    private static readonly EventDeserializer<BetaEvent> BetaDeserializer = new(Beta);
+
+    [Test]
+    public async Task TopicDeserializer_RoutesDerivedTypesAndFallback()
+    {
+        var fallback = new EventDeserializer<EventBase>(Beta);
+        var router = new TopicRoutingDeserializer<EventBase>()
+            .Register("alpha", AlphaDeserializer)
+            .Register("beta", BetaDeserializer)
+            .SetFallback(fallback)
+            .Freeze();
+
+        await Assert.That(router.IsFrozen).IsTrue();
+        await Assert.That(router.Deserialize(ReadOnlyMemory<byte>.Empty, Context("alpha"))).IsSameReferenceAs(Alpha);
+        await Assert.That(router.Deserialize(ReadOnlyMemory<byte>.Empty, Context("beta"))).IsSameReferenceAs(Beta);
+        await Assert.That(router.Deserialize(ReadOnlyMemory<byte>.Empty, Context("other"))).IsSameReferenceAs(Beta);
+    }
+
+    [Test]
+    public async Task SchemaIdDeserializer_RoutesFullConfluentFrame()
+    {
+        var capturing = new CapturingDeserializer(Alpha);
+        var router = new SchemaIdRoutingDeserializer<EventBase>()
+            .Register(42, capturing)
+            .Freeze();
+        var frame = Frame(42, 1, 2, 3);
+
+        var result = router.Deserialize(frame, Context());
+
+        await Assert.That(result).IsSameReferenceAs(Alpha);
+        await Assert.That(capturing.Data.Span.SequenceEqual(frame)).IsTrue();
+    }
+
+    [Test]
+    public async Task SchemaIdDeserializer_RoutesMultipleSchemaVersions()
+    {
+        var router = new SchemaIdRoutingDeserializer<EventBase>()
+            .Register(10, AlphaDeserializer)
+            .Register(11, BetaDeserializer)
+            .Freeze();
+
+        await Assert.That(router.Deserialize(Frame(10), Context())).IsSameReferenceAs(Alpha);
+        await Assert.That(router.Deserialize(Frame(11), Context())).IsSameReferenceAs(Beta);
+    }
+
+    [Test]
+    public async Task Routers_RejectUnknownAndMalformedRoutes()
+    {
+        var topicRouter = new TopicRoutingDeserializer<EventBase>().Freeze();
+        var schemaRouter = new SchemaIdRoutingDeserializer<EventBase>().Freeze();
+
+        await Assert.That(() => topicRouter.Deserialize(ReadOnlyMemory<byte>.Empty, Context("unknown")))
+            .Throws<SerializationException>();
+        await Assert.That(() => schemaRouter.Deserialize(new byte[] { 1, 0, 0, 0, 1 }, Context()))
+            .Throws<SerializationException>();
+        await Assert.That(() => schemaRouter.Deserialize(Frame(99), Context()))
+            .Throws<SerializationException>();
+    }
+
+    [Test]
+    public async Task Routers_RequireFreezeAndRejectLaterMutation()
+    {
+        var router = new TopicRoutingDeserializer<EventBase>()
+            .Register("alpha", AlphaDeserializer);
+
+        await Assert.That(() => router.Deserialize(ReadOnlyMemory<byte>.Empty, Context("alpha")))
+            .Throws<InvalidOperationException>();
+
+        router.Freeze();
+
+        await Assert.That(() => router.Register("beta", BetaDeserializer))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => router.SetFallback(new EventDeserializer<EventBase>(Beta)))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task TopicSerializer_RoutesDerivedTypeWithoutDelegateAllocation()
+    {
+        var router = new TopicRoutingSerializer<EventBase>()
+            .Register("alpha", new EventSerializer<AlphaEvent>(0xA1))
+            .Register("beta", new EventSerializer<BetaEvent>(0xB2))
+            .Freeze();
+        var alphaBuffer = new ArrayBufferWriter<byte>();
+        var betaBuffer = new ArrayBufferWriter<byte>();
+
+        router.Serialize(Alpha, ref alphaBuffer, Context("alpha"));
+        router.Serialize(Beta, ref betaBuffer, Context("beta"));
+
+        await Assert.That(alphaBuffer.WrittenSpan[0]).IsEqualTo((byte)0xA1);
+        await Assert.That(betaBuffer.WrittenSpan[0]).IsEqualTo((byte)0xB2);
+    }
+
+    [Test]
+    public async Task TopicSerializer_RejectsValueOfWrongDerivedType()
+    {
+        var router = new TopicRoutingSerializer<EventBase>()
+            .Register("alpha", new EventSerializer<AlphaEvent>(0xA1))
+            .Freeze();
+        var buffer = new ArrayBufferWriter<byte>();
+
+        void SerializeWrongType() => router.Serialize(Beta, ref buffer, Context("alpha"));
+
+        await Assert.That(SerializeWrongType).Throws<SerializationException>();
+    }
+
+    [Test]
+    public async Task TypeSerializer_RoutesExactRuntimeTypeAndFallback()
+    {
+        var router = new TypeRoutingSerializer<EventBase>()
+            .Register(new EventSerializer<AlphaEvent>(0xA1))
+            .SetFallback(new EventSerializer<EventBase>(0xFF))
+            .Freeze();
+        var alphaBuffer = new ArrayBufferWriter<byte>();
+        var betaBuffer = new ArrayBufferWriter<byte>();
+
+        router.Serialize(Alpha, ref alphaBuffer, Context());
+        router.Serialize(Beta, ref betaBuffer, Context());
+
+        await Assert.That(alphaBuffer.WrittenSpan[0]).IsEqualTo((byte)0xA1);
+        await Assert.That(betaBuffer.WrittenSpan[0]).IsEqualTo((byte)0xFF);
+    }
+
+    [Test]
+    public async Task FrozenRouter_SupportsConcurrentReads()
+    {
+        var router = new TopicRoutingDeserializer<EventBase>()
+            .Register("alpha", AlphaDeserializer)
+            .Freeze();
+        var failures = 0;
+
+        Parallel.For(0, 10_000, _ =>
+        {
+            if (!ReferenceEquals(router.Deserialize(ReadOnlyMemory<byte>.Empty, Context("alpha")), Alpha))
+                Interlocked.Increment(ref failures);
+        });
+
+        await Assert.That(failures).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Registration_IsThreadSafeBeforeFreeze()
+    {
+        const int routeCount = 64;
+        var router = new TopicRoutingDeserializer<EventBase>();
+
+        Parallel.For(0, routeCount, index =>
+            router.Register($"topic-{index}", AlphaDeserializer));
+        router.Freeze();
+
+        var failures = 0;
+        Parallel.For(0, routeCount, index =>
+        {
+            if (!ReferenceEquals(
+                    router.Deserialize(ReadOnlyMemory<byte>.Empty, Context($"topic-{index}")),
+                    Alpha))
+            {
+                Interlocked.Increment(ref failures);
+            }
+        });
+
+        await Assert.That(failures).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ConsumeResult_ProvidesRawKeyOnlyToValueDeserializer()
+    {
+        var key = new byte[] { 1, 2, 3 };
+        var keyDeserializer = new ContextCapturingDeserializer<string>("key");
+        var valueDeserializer = new ContextCapturingDeserializer<string>("value");
+
+        _ = new ConsumeResult<string, string>(
+            "events", 0, 0, key, false, new byte[] { 4 }, false, null, 0,
+            TimestampType.NotAvailable, null, keyDeserializer, valueDeserializer);
+
+        await Assert.That(keyDeserializer.Context.KeyData.IsEmpty).IsTrue();
+        await Assert.That(keyDeserializer.Context.IsKeyNull).IsTrue();
+        await Assert.That(valueDeserializer.Context.KeyData.Span.SequenceEqual(key)).IsTrue();
+        await Assert.That(valueDeserializer.Context.IsKeyNull).IsFalse();
+    }
+
+    [Test]
+    public async Task ConsumeResult_DistinguishesNullKeyFromEmptyKey()
+    {
+        var nullKey = new ContextCapturingDeserializer<string>("value");
+        var emptyKey = new ContextCapturingDeserializer<string>("value");
+
+        _ = new ConsumeResult<string, string>(
+            "events", 0, 0, ReadOnlyMemory<byte>.Empty, true, new byte[] { 1 }, false, null, 0,
+            TimestampType.NotAvailable, null, null, nullKey);
+        _ = new ConsumeResult<string, string>(
+            "events", 0, 0, ReadOnlyMemory<byte>.Empty, false, new byte[] { 1 }, false, null, 0,
+            TimestampType.NotAvailable, null, null, emptyKey);
+
+        await Assert.That(nullKey.Context.IsKeyNull).IsTrue();
+        await Assert.That(emptyKey.Context.IsKeyNull).IsFalse();
+        await Assert.That(emptyKey.Context.KeyData.IsEmpty).IsTrue();
+    }
+
+    private static SerializationContext Context(string topic = "events") => new()
+    {
+        Topic = topic,
+        Component = SerializationComponent.Value
+    };
+
+    private static byte[] Frame(int schemaId, params byte[] payload)
+    {
+        var frame = new byte[sizeof(byte) + sizeof(int) + payload.Length];
+        BinaryPrimitives.WriteInt32BigEndian(frame.AsSpan(1), schemaId);
+        payload.CopyTo(frame, 5);
+        return frame;
+    }
+
+    private abstract class EventBase;
+    private sealed class AlphaEvent : EventBase;
+    private sealed class BetaEvent : EventBase;
+
+    private sealed class EventDeserializer<T>(T value) : IDeserializer<T>
+    {
+        public T Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) => value;
+    }
+
+    private sealed class CapturingDeserializer(EventBase value) : IDeserializer<EventBase>
+    {
+        public ReadOnlyMemory<byte> Data { get; private set; }
+
+        public EventBase Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            Data = data;
+            return value;
+        }
+    }
+
+    private sealed class ContextCapturingDeserializer<T>(T value) : IDeserializer<T>
+    {
+        public SerializationContext Context { get; private set; }
+
+        public T Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            Context = context;
+            return value;
+        }
+    }
+
+    private sealed class EventSerializer<T>(byte marker) : ISerializer<T>
+    {
+        public void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
+            where TWriter : IBufferWriter<byte>
+#if NET10_0_OR_GREATER
+            , allows ref struct
+#endif
+        {
+            destination.GetSpan(1)[0] = marker;
+            destination.Advance(1);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryAsyncSerdeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryAsyncSerdeTests.cs
@@ -301,7 +301,31 @@ public sealed class InMemoryAsyncSerdeTests
 
         await Assert.That(record.Key).IsEqualTo("k");
         await Assert.That(record.Value).IsEqualTo("v");
+        await Assert.That(Encoding.UTF8.GetString(serde.LastDeserializeContext.KeyData.Span)).IsEqualTo("v:k");
+        await Assert.That(serde.LastDeserializeContext.IsKeyNull).IsFalse();
         await Assert.That(offsets[new TopicPartition("shared", 0)]).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ShareConsumer_SyncValueDeserializer_ReceivesRawKeyContext()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var valueDeserializer = new CapturingStringDeserializer();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var shareConsumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            Serializers.String,
+            valueDeserializer,
+            new InMemoryShareConsumerOptions { GroupId = "sync-key-context" });
+
+        await producer.ProduceAsync("shared", "key", "value");
+        shareConsumer.Subscribe("shared");
+
+        var record = await shareConsumer.PollAsync().FirstAsync();
+
+        await Assert.That(record.Value).IsEqualTo("value");
+        await Assert.That(Encoding.UTF8.GetString(valueDeserializer.Context.KeyData.Span)).IsEqualTo("key");
+        await Assert.That(valueDeserializer.Context.IsKeyNull).IsFalse();
     }
 
     [Test]
@@ -409,6 +433,17 @@ public sealed class InMemoryAsyncSerdeTests
     {
         public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) =>
             throw new InvalidOperationException("Deserialization failed.");
+    }
+
+    private sealed class CapturingStringDeserializer : IDeserializer<string>
+    {
+        public SerializationContext Context { get; private set; }
+
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            Context = context;
+            return Encoding.UTF8.GetString(data.Span);
+        }
     }
 
     /// <summary>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/RoutingSerdeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/RoutingSerdeBenchmarks.cs
@@ -1,0 +1,137 @@
+using System.Buffers;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using Dekaf.Serialization;
+using Dekaf.Serialization.Routing;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Measures frozen routing overhead and verifies zero steady-state allocation.</summary>
+[MemoryDiagnoser]
+[ShortRunJob(RuntimeMoniker.Net10_0)]
+[Config(typeof(RoutingConfig))]
+public class RoutingSerdeBenchmarks
+{
+    private static readonly Event Payload = new();
+    private static readonly ReadOnlyMemory<byte> Data = new byte[] { 1, 2, 3 };
+    private static readonly ReadOnlyMemory<byte> FramedData = new byte[] { 0, 0, 0, 0, 42, 1, 2, 3 };
+    private readonly EventDeserializer _deserializer = new();
+    private readonly EventSerializer _serializer = new();
+    private ArrayBufferWriter<byte> _buffer = new(16);
+    private TopicRoutingDeserializer<Event> _topicDeserializer = null!;
+    private SchemaIdRoutingDeserializer<Event> _schemaIdDeserializer = null!;
+    private TopicRoutingSerializer<Event> _topicSerializer = null!;
+    private TypeRoutingSerializer<Event> _typeSerializer = null!;
+    private SerializationContext _context;
+
+    private sealed class RoutingConfig : ManualConfig
+    {
+        public RoutingConfig() => AddColumn(
+            StatisticColumn.OperationsPerSecond,
+            StatisticColumn.P50,
+            P99Column.Instance,
+            StatisticColumn.Max);
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _context = new SerializationContext
+        {
+            Topic = "events",
+            Component = SerializationComponent.Value
+        };
+        _topicDeserializer = new TopicRoutingDeserializer<Event>()
+            .Register("events", _deserializer)
+            .Freeze();
+        _schemaIdDeserializer = new SchemaIdRoutingDeserializer<Event>()
+            .Register(42, _deserializer)
+            .Freeze();
+        _topicSerializer = new TopicRoutingSerializer<Event>()
+            .Register("events", _serializer)
+            .Freeze();
+        _typeSerializer = new TypeRoutingSerializer<Event>()
+            .Register(_serializer)
+            .Freeze();
+
+        SerializeDirect();
+    }
+
+    [Benchmark(Baseline = true)]
+    public Event DeserializeDirect() => _deserializer.Deserialize(Data, _context);
+
+    [Benchmark]
+    public Event DeserializeByTopic() => _topicDeserializer.Deserialize(Data, _context);
+
+    [Benchmark]
+    public Event DeserializeBySchemaId() => _schemaIdDeserializer.Deserialize(FramedData, _context);
+
+    [Benchmark]
+    public int SerializeDirect()
+    {
+        _buffer.Clear();
+        _serializer.Serialize(Payload, ref _buffer, _context);
+        return _buffer.WrittenCount;
+    }
+
+    [Benchmark]
+    public int SerializeByTopic()
+    {
+        _buffer.Clear();
+        _topicSerializer.Serialize(Payload, ref _buffer, _context);
+        return _buffer.WrittenCount;
+    }
+
+    [Benchmark]
+    public int SerializeByRuntimeType()
+    {
+        _buffer.Clear();
+        _typeSerializer.Serialize(Payload, ref _buffer, _context);
+        return _buffer.WrittenCount;
+    }
+
+    public sealed class Event;
+
+    private sealed class EventDeserializer : IDeserializer<Event>
+    {
+        public Event Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) => Payload;
+    }
+
+    private sealed class EventSerializer : ISerializer<Event>
+    {
+        public void Serialize<TWriter>(Event value, ref TWriter destination, SerializationContext context)
+            where TWriter : IBufferWriter<byte>, allows ref struct
+        {
+            destination.GetSpan(1)[0] = 1;
+            destination.Advance(1);
+        }
+    }
+
+    private sealed class P99Column : IColumn
+    {
+        internal static readonly P99Column Instance = new();
+
+        public string Id => nameof(P99Column);
+        public string ColumnName => "P99 (ns)";
+        public string Legend => "99th percentile of iteration time per operation in nanoseconds";
+        public UnitType UnitType => UnitType.Time;
+        public bool IsNumeric => true;
+        public ColumnCategory Category => ColumnCategory.Statistics;
+        public int PriorityInCategory => 0;
+        public bool AlwaysShow => true;
+
+        public string GetValue(Summary summary, BenchmarkCase benchmarkCase) =>
+            GetValue(summary, benchmarkCase, summary.Style);
+
+        public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style) =>
+            summary[benchmarkCase]?.ResultStatistics?.Percentiles.Percentile(99)
+                .ToString("N3", style.CultureInfo) ?? "NA";
+
+        public bool IsAvailable(Summary summary) => true;
+        public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
+++ b/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\src\Dekaf.Compression.Lz4\Dekaf.Compression.Lz4.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Zstd\Dekaf.Compression.Zstd.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Serialization.Json\Dekaf.Serialization.Json.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Serialization.Routing\Dekaf.Serialization.Routing.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Avro\Dekaf.SchemaRegistry.Avro.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

- add `Dekaf.Serialization.Routing` with frozen topic/schema-ID deserializers and topic/runtime-type serializers
- expose zero-copy raw key memory to value deserializers, including null-vs-empty semantics and pooled-memory lifetime documentation
- add unit, Kafka + Schema Registry integration, package, docs, and `MemoryDiagnoser` coverage

Closes #2558

## Design

Registration is cold and lock-protected. `Freeze()` creates an immutable `FrozenDictionary` and publishes it with release semantics; steady-state lookup is O(1), lock-free, and allocation-free. Derived serializers use cold-created generic adapters—no per-message reflection, delegate creation, boxing, enumeration, or object arrays.

Unknown routes throw `SerializationException` unless `SetFallback(...)` was configured before freeze. Schema-ID routing validates Confluent framing and passes the complete frame to the selected deserializer.

`SerializationContext.KeyData` points directly at the consumed record key. `IsKeyNull` distinguishes null from non-null empty keys without another context field. The memory must not escape the current deserializer call.

## Performance evidence

Environment: Windows 11, i7-12700K, .NET 10.0.11, BenchmarkDotNet 0.15.8.

### Frozen routing (`RoutingSerdeBenchmarks`, ShortRun)

| Operation | CPU time/message (mean) | p50 | p99 | max | Throughput | Allocated |
|---|---:|---:|---:|---:|---:|---:|
| Direct deserialize | 0.947 ns | 0.955 ns | 0.966 ns | 0.967 ns | 1,056.0 M/s | 0 B |
| Topic deserialize | 2.675 ns | 2.651 ns | 2.769 ns | 2.771 ns | 373.8 M/s | 0 B |
| Schema-ID deserialize | 2.229 ns | 2.338 ns | 2.438 ns | 2.440 ns | 448.6 M/s | 0 B |
| Direct serialize | 2.215 ns | 2.221 ns | 2.246 ns | 2.247 ns | 451.4 M/s | 0 B |
| Topic serialize | 13.743 ns | 13.661 ns | 14.066 ns | 14.074 ns | 72.8 M/s | 0 B |
| Runtime-type serialize | 14.559 ns | 14.562 ns | 14.590 ns | 14.590 ns | 68.7 M/s | 0 B |

### Existing consumer construction gate

Exact predecessor: `6eeb4a6a6fbf88ee6fac52b36256d1e76f872e0d`.

| Metric | Baseline | Candidate | Delta |
|---|---:|---:|---:|
| Mean / CPU time per message | 46.365 ns | 41.236 ns | -11.1% |
| p50 | 45.973 ns | 40.916 ns | -11.0% |
| max | 53.670 ns | 43.079 ns | -19.7% |
| Allocated | 112 B | 112 B | unchanged |

The 112 B is the benchmark's existing string decode allocation; raw-key context adds 0 B. No protected metric regressed. No paid network stress lane was dispatched because routing is a local serde/context path; the exact microbenchmarks isolate the affected work.

## Validation

- `dotnet build Dekaf.sln -c Release --no-restore`: clean, 0 warnings/errors
- unit net10: 6,815 passed
- unit net8: 6,679 passed
- focused routing unit tests: 12 passed on each TFM
- full integration net10: 938 total, 936 passed, 2 skipped, 0 failed/timed out
- focused Schema Registry integration: 1 passed (known, unknown, and evolved schema IDs + raw key)
- public API gate: 17 shipping projects covered
- routing `MemoryDiagnoser`: every case 0 B
- NuGet pack: net8/net10 DLLs + symbols produced
- Docusaurus production build: passed

During full validation, concurrent net8/net10 test processes exposed an unrelated scheduler-dependent producer test assumption. Root cause and deterministic-fix criteria are tracked in #2694; both suites pass sequentially.