### PR TITLE
feat(consumer): add bounded snapshot consumption

### DIFF
--- a/docs/docs/consumer/offset-management.md
+++ b/docs/docs/consumer/offset-management.md
@@ -223,6 +223,46 @@ consumer.Positions.SeekToBeginning(new TopicPartition("my-topic", 0));
 consumer.Positions.SeekToEnd(new TopicPartition("my-topic", 0));
 ```
 
+### Tail and Finite Snapshots
+
+`SeekToTailAsync` resolves an isolation-aware watermark and seeks to the final number of Kafka
+**offsets**. The count is deliberately not a visible-record count: compacted records, aborted
+transactions, and control batches occupy offsets but are not returned.
+
+```csharp
+var partition = new TopicPartition("my-topic", 0);
+
+// Resolves max(low watermark, high watermark - 100) and applies the seek.
+TopicPartitionOffset start = await consumer.SeekToTailAsync(partition, 100, ct);
+
+// Captures the assigned partitions' ends once, then terminates at those bounds.
+await foreach (var record in consumer.ConsumeSnapshotAsync(ct))
+{
+    await ProcessAsync(record, ct);
+}
+```
+
+`ConsumeSnapshotAsync` starts at the consumer's current positions. It captures the current
+assignment and each partition's isolation-aware end offset when enumeration begins. Records
+appended afterward remain available to a later normal consume loop. Empty partitions finish
+immediately; control batches, aborted transactions, compaction holes, and retention gaps advance
+progress without being returned, so the snapshot cannot wait forever for a user-visible record
+after its bound.
+
+With `ReadCommitted`, the captured end is the last stable offset. Open transactions beyond it do
+not delay completion, and aborted records plus transaction markers advance progress without being
+returned.
+
+Snapshot ordering is the normal consumer ordering: offsets increase within each partition, while
+cross-partition order follows fetch arrival. Topic partitions added after capture are excluded. A
+rebalance, manual assignment change, or pause-state change invalidates the snapshot and throws
+`InvalidOperationException`; restart it after the consumer state stabilizes. Resume paused assigned
+partitions before starting a snapshot. Cancellation bounds the wait; there is no implicit timeout.
+
+The methods are exposed as extensions on `IKafkaConsumer<TKey, TValue>`. Dekaf's broker-backed and
+in-memory consumers implement `IBoundedKafkaConsumer<TKey, TValue>`; custom consumer wrappers can
+implement that capability to participate without breaking existing `IKafkaConsumer` implementations.
+
 Seek and pause/resume operations mutate current consumer state and return `void`. Keep them as separate statements:
 
 ```csharp

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Dekaf.Consumer;
@@ -395,6 +396,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     {
         SnapshotPartitionBound[] partitions;
         int consumerStateVersion;
+        int consumerGroupGeneration;
         lock (_gate)
         {
             ThrowIfDisposed();
@@ -407,9 +409,10 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             _snapshotActive = true;
             try
             {
-                partitions = new SnapshotPartitionBound[_assignment.Count];
+                var assignment = GetCurrentAssignmentUnderLock(out consumerGroupGeneration);
+                partitions = new SnapshotPartitionBound[assignment.Count];
                 var partitionIndex = 0;
-                foreach (var partition in _assignment)
+                foreach (var partition in assignment)
                 {
                     if (_paused.Contains(partition))
                     {
@@ -453,11 +456,10 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 bool complete;
                 lock (_gate)
                 {
-                    if (_consumerStateVersion != consumerStateVersion)
-                    {
-                        throw new InvalidOperationException(
-                            "The consumer assignment or pause state changed while a snapshot enumeration was active.");
-                    }
+                    ThrowIfSnapshotStateChangedUnderLock(
+                        consumerStateVersion,
+                        partitions,
+                        ref consumerGroupGeneration);
 
                     ProveInDoubtRecordUnderLock();
                     if (!TrySelectSnapshotRecordUnderLock(
@@ -1006,6 +1008,40 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         }
     }
 
+    private void ThrowIfSnapshotStateChangedUnderLock(
+        int consumerStateVersion,
+        SnapshotPartitionBound[] partitions,
+        ref int consumerGroupGeneration)
+    {
+        if (_consumerStateVersion != consumerStateVersion)
+            ThrowSnapshotStateChanged();
+
+        if (consumerGroupGeneration < 0
+            || _groupId is null
+            || _memberId is null
+            || _cluster.GetConsumerGroupGeneration(_groupId) == consumerGroupGeneration)
+        {
+            return;
+        }
+
+        var assignment = GetCurrentAssignmentUnderLock(out var currentGeneration);
+        if (assignment.Count != partitions.Length)
+            ThrowSnapshotStateChanged();
+
+        for (var i = 0; i < partitions.Length; i++)
+        {
+            if (!assignment.Contains(partitions[i].Partition))
+                ThrowSnapshotStateChanged();
+        }
+
+        consumerGroupGeneration = currentGeneration;
+    }
+
+    [DoesNotReturn]
+    private static void ThrowSnapshotStateChanged() =>
+        throw new InvalidOperationException(
+            "The consumer assignment or pause state changed while a snapshot enumeration was active.");
+
     /// <summary>
     /// Consume path used when at least one component has an <see cref="IAsyncDeserializer{T}"/>.
     /// Deliberate mirror of <see cref="TryConsumeOne"/>: both drive the same selection and
@@ -1322,12 +1358,21 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             partition.Partition,
             offset);
 
-    private IReadOnlySet<TopicPartition> GetCurrentAssignmentUnderLock()
+    private IReadOnlySet<TopicPartition> GetCurrentAssignmentUnderLock() =>
+        GetCurrentAssignmentUnderLock(out _);
+
+    private IReadOnlySet<TopicPartition> GetCurrentAssignmentUnderLock(out int consumerGroupGeneration)
     {
         if (_groupId is null || _memberId is null)
+        {
+            consumerGroupGeneration = -1;
             return _assignment;
+        }
 
-        var owned = _cluster.GetConsumerGroupAssignment(_groupId, _memberId);
+        var owned = _cluster.GetConsumerGroupAssignment(
+            _groupId,
+            _memberId,
+            out consumerGroupGeneration);
         return owned.Where(_assignment.Contains).ToHashSet();
     }
 

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -717,6 +717,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             // The in-memory cluster has no broker session timer. Always unregister on close so
             // RemainInGroup cannot create an immortal member that permanently owns partitions.
             UnregisterConsumerGroupMemberUnderLock();
+            _consumerStateVersion++;
             _disposed = true;
         }
 
@@ -1016,6 +1017,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         int consumerStateVersion,
         int consumerGroupGeneration)
     {
+        ThrowIfDisposed();
+
         if (_consumerStateVersion != consumerStateVersion)
             ThrowSnapshotStateChanged();
 

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -458,8 +458,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 {
                     ThrowIfSnapshotStateChangedUnderLock(
                         consumerStateVersion,
-                        partitions,
-                        ref consumerGroupGeneration);
+                        consumerGroupGeneration);
 
                     ProveInDoubtRecordUnderLock();
                     if (!TrySelectSnapshotRecordUnderLock(
@@ -491,8 +490,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                         record,
                         position,
                         consumerStateVersion,
-                        partitions,
-                        ref consumerGroupGeneration))
+                        consumerGroupGeneration))
                     continue;
 
                 yield return result;
@@ -1016,8 +1014,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     private void ThrowIfSnapshotStateChangedUnderLock(
         int consumerStateVersion,
-        SnapshotPartitionBound[] partitions,
-        ref int consumerGroupGeneration)
+        int consumerGroupGeneration)
     {
         if (_consumerStateVersion != consumerStateVersion)
             ThrowSnapshotStateChanged();
@@ -1030,17 +1027,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             return;
         }
 
-        var assignment = GetCurrentAssignmentUnderLock(out var currentGeneration);
-        if (assignment.Count != partitions.Length)
-            ThrowSnapshotStateChanged();
-
-        for (var i = 0; i < partitions.Length; i++)
-        {
-            if (!assignment.Contains(partitions[i].Partition))
-                ThrowSnapshotStateChanged();
-        }
-
-        consumerGroupGeneration = currentGeneration;
+        ThrowSnapshotStateChanged();
     }
 
     [DoesNotReturn]
@@ -1145,15 +1132,13 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         InMemoryRecord record,
         long expectedPosition,
         int consumerStateVersion,
-        SnapshotPartitionBound[] partitions,
-        ref int consumerGroupGeneration)
+        int consumerGroupGeneration)
     {
         lock (_gate)
         {
             ThrowIfSnapshotStateChangedUnderLock(
                 consumerStateVersion,
-                partitions,
-                ref consumerGroupGeneration);
+                consumerGroupGeneration);
             if (!_positions.TryGetValue(partition, out var currentPosition) || currentPosition != expectedPosition)
                 return false;
 

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -45,6 +45,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private TopicPartition _inDoubtPartition;
     private long _inDoubtNextOffset = -1;
     private int _consumerStateVersion;
+    private bool _snapshotActive;
     private readonly string? _groupId;
     private readonly string? _memberId;
     private string? _subscriptionPattern;
@@ -397,79 +398,102 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         lock (_gate)
         {
             ThrowIfDisposed();
-            partitions = new SnapshotPartitionBound[_assignment.Count];
-            var partitionIndex = 0;
-            foreach (var partition in _assignment)
+            if (_snapshotActive)
             {
-                if (_paused.Contains(partition))
-                {
-                    throw new InvalidOperationException(
-                        $"Cannot start a snapshot while assigned partition {partition} is paused.");
-                }
-
-                partitions[partitionIndex++] = new SnapshotPartitionBound(
-                    partition,
-                    _cluster.GetWatermarks(partition).High);
+                throw new InvalidOperationException(
+                    "Only one snapshot enumeration can be active on a consumer.");
             }
 
-            Array.Sort(partitions, static (left, right) =>
+            _snapshotActive = true;
+            try
             {
-                var topicComparison = StringComparer.Ordinal.Compare(
-                    left.Partition.Topic,
-                    right.Partition.Topic);
-                return topicComparison != 0
-                    ? topicComparison
-                    : left.Partition.Partition.CompareTo(right.Partition.Partition);
-            });
-            consumerStateVersion = _consumerStateVersion;
+                partitions = new SnapshotPartitionBound[_assignment.Count];
+                var partitionIndex = 0;
+                foreach (var partition in _assignment)
+                {
+                    if (_paused.Contains(partition))
+                    {
+                        throw new InvalidOperationException(
+                            $"Cannot start a snapshot while assigned partition {partition} is paused.");
+                    }
+
+                    partitions[partitionIndex++] = new SnapshotPartitionBound(
+                        partition,
+                        _cluster.GetWatermarks(partition).High);
+                }
+
+                Array.Sort(partitions, static (left, right) =>
+                {
+                    var topicComparison = StringComparer.Ordinal.Compare(
+                        left.Partition.Topic,
+                        right.Partition.Topic);
+                    return topicComparison != 0
+                        ? topicComparison
+                        : left.Partition.Partition.CompareTo(right.Partition.Partition);
+                });
+                consumerStateVersion = _consumerStateVersion;
+            }
+            catch
+            {
+                _snapshotActive = false;
+                throw;
+            }
         }
 
-        var activePartitionIndex = 0;
-        while (true)
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            TopicPartition partition;
-            InMemoryRecord record;
-            long position;
-            bool complete;
-            lock (_gate)
+            var activePartitionIndex = 0;
+            while (true)
             {
-                if (_consumerStateVersion != consumerStateVersion)
+                cancellationToken.ThrowIfCancellationRequested();
+
+                TopicPartition partition;
+                InMemoryRecord record;
+                long position;
+                bool complete;
+                lock (_gate)
                 {
-                    throw new InvalidOperationException(
-                        "The consumer assignment or pause state changed while a snapshot enumeration was active.");
+                    if (_consumerStateVersion != consumerStateVersion)
+                    {
+                        throw new InvalidOperationException(
+                            "The consumer assignment or pause state changed while a snapshot enumeration was active.");
+                    }
+
+                    ProveInDoubtRecordUnderLock();
+                    if (!TrySelectSnapshotRecordUnderLock(
+                            partitions,
+                            ref activePartitionIndex,
+                            out partition,
+                            out record,
+                            out position))
+                    {
+                        if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
+                            CommitStoredOffsets();
+                        complete = true;
+                    }
+                    else
+                    {
+                        complete = false;
+                    }
                 }
 
-                ProveInDoubtRecordUnderLock();
-                if (!TrySelectSnapshotRecordUnderLock(
-                        partitions,
-                        ref activePartitionIndex,
-                        out partition,
-                        out record,
-                        out position))
-                {
-                    if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
-                        CommitStoredOffsets();
-                    complete = true;
-                }
-                else
-                {
-                    complete = false;
-                }
+                if (complete)
+                    yield break;
+
+                var result = _hasAsyncDeserializers
+                    ? await ToConsumeResultAsync(partition, record, cancellationToken).ConfigureAwait(false)
+                    : ToConsumeResult(partition, record);
+
+                if (!TryAdvancePosition(partition, record, position))
+                    continue;
+
+                yield return result;
             }
-
-            if (complete)
-                yield break;
-
-            var result = _hasAsyncDeserializers
-                ? await ToConsumeResultAsync(partition, record, cancellationToken).ConfigureAwait(false)
-                : ToConsumeResult(partition, record);
-
-            if (!TryAdvancePosition(partition, record, position))
-                continue;
-
-            yield return result;
+        }
+        finally
+        {
+            lock (_gate)
+                _snapshotActive = false;
         }
     }
 
@@ -726,6 +750,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            ThrowIfSnapshotActiveUnderLock();
             var partition = new TopicPartition(offset.Topic, offset.Partition);
             DiscardInDoubtRecordUnderLock(partition);
             _positions[partition] = offset.Offset;
@@ -741,6 +766,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            ThrowIfSnapshotActiveUnderLock();
             foreach (var partition in SelectTargetPartitions(partitions))
             {
                 var position = _cluster.GetWatermarks(partition).Low;
@@ -759,6 +785,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            ThrowIfSnapshotActiveUnderLock();
             foreach (var partition in SelectTargetPartitions(partitions))
             {
                 var position = _cluster.GetWatermarks(partition).High;
@@ -954,9 +981,13 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 return true;
             }
 
-            _positions[bound.Partition] = bound.EndOffset;
-            if (_options.EnableAutoOffsetStore)
-                StoreOffsetUnderLock(bound.Partition, bound.EndOffset);
+            if (!_positions.TryGetValue(bound.Partition, out position)
+                || position < bound.EndOffset)
+            {
+                _positions[bound.Partition] = bound.EndOffset;
+                if (_options.EnableAutoOffsetStore)
+                    StoreOffsetUnderLock(bound.Partition, bound.EndOffset);
+            }
             activePartitionIndex++;
         }
 
@@ -964,6 +995,15 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         selectedRecord = null!;
         selectedPosition = -1;
         return false;
+    }
+
+    private void ThrowIfSnapshotActiveUnderLock()
+    {
+        if (_snapshotActive)
+        {
+            throw new InvalidOperationException(
+                "Cannot change consumer position while a snapshot enumeration is active.");
+        }
     }
 
     /// <summary>

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -12,12 +12,17 @@ namespace Dekaf.Testing;
 /// </summary>
 public sealed class InMemoryConsumer<TKey, TValue> :
     IKafkaConsumer<TKey, TValue>,
+    IBoundedKafkaConsumer<TKey, TValue>,
     IConsumerPositions,
     IConsumerPartitions,
     IConsumerOffsets,
     IConsumerBatchOffsetStore,
     IConsumerCommitConfiguration
 {
+    private readonly record struct SnapshotPartitionBound(
+        TopicPartition Partition,
+        long EndOffset);
+
     private readonly object _gate = new();
     private readonly InMemoryKafkaCluster _cluster;
     private readonly IDeserializer<TKey> _keyDeserializer;
@@ -39,6 +44,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     // proves it; an unwind (or close) leaves it unstaged so it is redelivered.
     private TopicPartition _inDoubtPartition;
     private long _inDoubtNextOffset = -1;
+    private int _consumerStateVersion;
     private readonly string? _groupId;
     private readonly string? _memberId;
     private string? _subscriptionPattern;
@@ -358,6 +364,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             _positions.Clear();
             _storedOffsets.Clear();
             _inDoubtNextOffset = -1;
+            _consumerStateVersion++;
             UnregisterConsumerGroupMemberUnderLock();
         }
     }
@@ -380,6 +387,109 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 }
             }
         }
+    }
+
+    public async IAsyncEnumerable<ConsumeResult<TKey, TValue>> ConsumeSnapshotAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        SnapshotPartitionBound[] partitions;
+        int consumerStateVersion;
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            partitions = new SnapshotPartitionBound[_assignment.Count];
+            var partitionIndex = 0;
+            foreach (var partition in _assignment)
+            {
+                if (_paused.Contains(partition))
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot start a snapshot while assigned partition {partition} is paused.");
+                }
+
+                partitions[partitionIndex++] = new SnapshotPartitionBound(
+                    partition,
+                    _cluster.GetWatermarks(partition).High);
+            }
+
+            Array.Sort(partitions, static (left, right) =>
+            {
+                var topicComparison = StringComparer.Ordinal.Compare(
+                    left.Partition.Topic,
+                    right.Partition.Topic);
+                return topicComparison != 0
+                    ? topicComparison
+                    : left.Partition.Partition.CompareTo(right.Partition.Partition);
+            });
+            consumerStateVersion = _consumerStateVersion;
+        }
+
+        var activePartitionIndex = 0;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            TopicPartition partition;
+            InMemoryRecord record;
+            long position;
+            bool complete;
+            lock (_gate)
+            {
+                if (_consumerStateVersion != consumerStateVersion)
+                {
+                    throw new InvalidOperationException(
+                        "The consumer assignment or pause state changed while a snapshot enumeration was active.");
+                }
+
+                ProveInDoubtRecordUnderLock();
+                if (!TrySelectSnapshotRecordUnderLock(
+                        partitions,
+                        ref activePartitionIndex,
+                        out partition,
+                        out record,
+                        out position))
+                {
+                    if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
+                        CommitStoredOffsets();
+                    complete = true;
+                }
+                else
+                {
+                    complete = false;
+                }
+            }
+
+            if (complete)
+                yield break;
+
+            var result = _hasAsyncDeserializers
+                ? await ToConsumeResultAsync(partition, record, cancellationToken).ConfigureAwait(false)
+                : ToConsumeResult(partition, record);
+
+            if (!TryAdvancePosition(partition, record, position))
+                continue;
+
+            yield return result;
+        }
+    }
+
+    public ValueTask<TopicPartitionOffset> SeekToTailAsync(
+        TopicPartition partition,
+        int offsetCount,
+        CancellationToken cancellationToken = default)
+    {
+        if (offsetCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(offsetCount), "Offset count cannot be negative.");
+
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        var watermarks = _cluster.GetWatermarks(partition);
+        var resolved = new TopicPartitionOffset(
+            partition.Topic,
+            partition.Partition,
+            Math.Max(watermarks.Low, watermarks.High - offsetCount));
+        Seek(resolved);
+        return ValueTask.FromResult(resolved);
     }
 
     public async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneAsync(
@@ -685,6 +795,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             _positions.Clear();
             _storedOffsets.Clear();
             _inDoubtNextOffset = -1;
+            _consumerStateVersion++;
             UnregisterConsumerGroupMemberUnderLock();
         }
     }
@@ -696,14 +807,19 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            var changed = false;
             foreach (var offset in partitions)
             {
+                changed = true;
                 var partition = new TopicPartition(offset.Topic, offset.Partition);
                 var position = offset.Offset >= 0 ? offset.Offset : GetStartOffset(partition);
                 DiscardInDoubtRecordUnderLock(partition);
                 _assignment.Add(partition);
                 _positions[partition] = position;
             }
+
+            if (changed)
+                _consumerStateVersion++;
 
             RegisterConsumerGroupMemberUnderLock();
         }
@@ -716,14 +832,19 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            var changed = false;
             foreach (var partition in partitions)
             {
+                changed = true;
                 _assignment.Remove(partition);
                 _paused.Remove(partition);
                 _positions.Remove(partition);
                 _storedOffsets.Remove(partition);
                 DiscardInDoubtRecordUnderLock(partition);
             }
+
+            if (changed)
+                _consumerStateVersion++;
 
             RegisterConsumerGroupMemberUnderLock();
         }
@@ -736,8 +857,11 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            var changed = false;
             foreach (var partition in partitions)
-                _paused.Add(partition);
+                changed |= _paused.Add(partition);
+            if (changed)
+                _consumerStateVersion++;
         }
     }
 
@@ -748,8 +872,11 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            var changed = false;
             foreach (var partition in partitions)
-                _paused.Remove(partition);
+                changed |= _paused.Remove(partition);
+            if (changed)
+                _consumerStateVersion++;
         }
     }
 
@@ -804,6 +931,39 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             result = selectedResult;
             return true;
         }
+    }
+
+    private bool TrySelectSnapshotRecordUnderLock(
+        SnapshotPartitionBound[] partitions,
+        ref int activePartitionIndex,
+        out TopicPartition selectedPartition,
+        out InMemoryRecord selectedRecord,
+        out long selectedPosition)
+    {
+        while (activePartitionIndex < partitions.Length)
+        {
+            var bound = partitions[activePartitionIndex];
+            if (_positions.TryGetValue(bound.Partition, out var position)
+                && position < bound.EndOffset
+                && _cluster.TryRead(bound.Partition, position, out var record)
+                && record.Offset < bound.EndOffset)
+            {
+                selectedPartition = bound.Partition;
+                selectedRecord = record;
+                selectedPosition = position;
+                return true;
+            }
+
+            _positions[bound.Partition] = bound.EndOffset;
+            if (_options.EnableAutoOffsetStore)
+                StoreOffsetUnderLock(bound.Partition, bound.EndOffset);
+            activePartitionIndex++;
+        }
+
+        selectedPartition = default;
+        selectedRecord = null!;
+        selectedPosition = -1;
+        return false;
     }
 
     /// <summary>
@@ -1057,6 +1217,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             _assignment.Add(partition);
             _positions[partition] = position;
         }
+
+        _consumerStateVersion++;
     }
 
     private long GetStartOffset(TopicPartition partition)

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -486,7 +486,13 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                     ? await ToConsumeResultAsync(partition, record, cancellationToken).ConfigureAwait(false)
                     : ToConsumeResult(partition, record);
 
-                if (!TryAdvancePosition(partition, record, position))
+                if (!TryAdvanceSnapshotPosition(
+                        partition,
+                        record,
+                        position,
+                        consumerStateVersion,
+                        partitions,
+                        ref consumerGroupGeneration))
                     continue;
 
                 yield return result;
@@ -1113,6 +1119,41 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     {
         lock (_gate)
         {
+            if (!_positions.TryGetValue(partition, out var currentPosition) || currentPosition != expectedPosition)
+                return false;
+
+            _positions[partition] = record.Offset + 1;
+            if (_options.OffsetStoreTiming == OffsetStoreTiming.OnDelivery)
+            {
+                if (_options.EnableAutoOffsetStore)
+                    StoreOffsetUnderLock(partition, record.Offset + 1);
+                if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
+                    CommitStoredOffsets();
+            }
+            else
+            {
+                _inDoubtPartition = partition;
+                _inDoubtNextOffset = record.Offset + 1;
+            }
+
+            return true;
+        }
+    }
+
+    private bool TryAdvanceSnapshotPosition(
+        TopicPartition partition,
+        InMemoryRecord record,
+        long expectedPosition,
+        int consumerStateVersion,
+        SnapshotPartitionBound[] partitions,
+        ref int consumerGroupGeneration)
+    {
+        lock (_gate)
+        {
+            ThrowIfSnapshotStateChangedUnderLock(
+                consumerStateVersion,
+                partitions,
+                ref consumerGroupGeneration);
             if (!_positions.TryGetValue(partition, out var currentPosition) || currentPosition != expectedPosition)
                 return false;
 

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -15,6 +15,7 @@ public sealed class InMemoryKafkaCluster
     private readonly Dictionary<string, TopicState> _topics = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, TopicPartitionOffset>> _consumerGroupOffsets = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<string, HashSet<TopicPartition>>> _consumerGroupMembers = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, int> _consumerGroupGenerations = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, ShareLeaseState>>> _shareLeases = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, int>>> _shareDeliveryCounts = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Exception> _produceFailures = new(StringComparer.Ordinal);
@@ -124,6 +125,7 @@ public sealed class InMemoryKafkaCluster
             }
 
             members[memberId] = partitions;
+            _consumerGroupGenerations[groupId] = _consumerGroupGenerations.GetValueOrDefault(groupId) + 1;
         }
     }
 
@@ -137,24 +139,42 @@ public sealed class InMemoryKafkaCluster
             if (!_consumerGroupMembers.TryGetValue(groupId, out var members))
                 return;
 
-            members.Remove(memberId);
+            if (!members.Remove(memberId))
+                return;
+
+            _consumerGroupGenerations[groupId] = _consumerGroupGenerations.GetValueOrDefault(groupId) + 1;
             if (members.Count == 0)
+            {
                 _consumerGroupMembers.Remove(groupId);
+                _consumerGroupGenerations.Remove(groupId);
+            }
         }
     }
 
-    internal IReadOnlySet<TopicPartition> GetConsumerGroupAssignment(string groupId, string memberId)
+    internal IReadOnlySet<TopicPartition> GetConsumerGroupAssignment(
+        string groupId,
+        string memberId,
+        out int generation)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
         ArgumentException.ThrowIfNullOrWhiteSpace(memberId);
 
         lock (_gate)
         {
+            generation = _consumerGroupGenerations.GetValueOrDefault(groupId);
             var assignments = BuildConsumerGroupAssignments(groupId);
             return assignments.TryGetValue(memberId, out var partitions)
                 ? partitions.ToHashSet()
                 : new HashSet<TopicPartition>();
         }
+    }
+
+    internal int GetConsumerGroupGeneration(string groupId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+
+        lock (_gate)
+            return _consumerGroupGenerations.GetValueOrDefault(groupId);
     }
 
     public IReadOnlyList<InMemoryRecord> ReadRecords(string topic, int partition = 0)

--- a/src/Dekaf.Testing/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.Testing/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
+Dekaf.Testing.InMemoryConsumer<TKey, TValue>.ConsumeSnapshotAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Dekaf.Consumer.ConsumeResult<TKey, TValue>>!
+Dekaf.Testing.InMemoryConsumer<TKey, TValue>.SeekToTailAsync(Dekaf.TopicPartition partition, int offsetCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.TopicPartitionOffset>
 Dekaf.Testing.InMemoryConsumer<TKey, TValue>.StoreOffsets(System.ReadOnlySpan<Dekaf.TopicPartitionOffset> offsets) -> void
 Dekaf.Testing.InMemoryConsumer<TKey, TValue>.StoreOffsets<TOffsets>(TOffsets offsets) -> void

--- a/src/Dekaf/Consumer/BoundedConsumerExtensions.cs
+++ b/src/Dekaf/Consumer/BoundedConsumerExtensions.cs
@@ -1,0 +1,83 @@
+namespace Dekaf.Consumer;
+
+/// <summary>
+/// Optional capability for finite snapshot consumption and offset-count tail seeks.
+/// </summary>
+/// <remarks>
+/// Dekaf's built-in consumers implement this interface. The separate capability keeps existing
+/// <see cref="IKafkaConsumer{TKey,TValue}"/> implementations binary compatible while
+/// <see cref="BoundedConsumerExtensions"/> exposes the APIs on every consumer.
+/// </remarks>
+public interface IBoundedKafkaConsumer<TKey, TValue>
+{
+    /// <summary>
+    /// Consumes records between the current positions and a fixed snapshot of the assigned
+    /// partitions' end offsets.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The assignment and isolation-aware end offset of each assigned partition are captured once
+    /// when enumeration starts. Records appended later are not returned. Ordering across partitions
+    /// follows normal fetch order; ordering within each partition remains by offset.
+    /// </para>
+    /// <para>
+    /// Empty partitions complete immediately. Control batches, aborted transactions, compacted
+    /// offsets, and retention gaps advance progress without being returned. Paused partitions are
+    /// rejected. Changing the assignment or pause state terminates enumeration with an
+    /// <see cref="InvalidOperationException"/>; newly added topic partitions are not included.
+    /// </para>
+    /// <para>
+    /// This method is finite but has no implicit timeout. Cancellation stops the operation. With
+    /// <see cref="Protocol.Messages.IsolationLevel.ReadCommitted"/>, an open transaction beyond the
+    /// captured last stable offset does not delay completion.
+    /// </para>
+    /// </remarks>
+    IAsyncEnumerable<ConsumeResult<TKey, TValue>> ConsumeSnapshotAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Seeks a partition to the start of its final <paramref name="offsetCount"/> Kafka offsets.
+    /// </summary>
+    /// <remarks>
+    /// The count is explicitly an offset count, not a visible-record count. Compaction, control
+    /// batches, aborted transactions, or retention can therefore make fewer records visible. The
+    /// resolved offset is <c>max(low watermark, high watermark - offsetCount)</c>; zero seeks to the
+    /// captured high watermark. The partition must be assigned before records can be consumed.
+    /// </remarks>
+    ValueTask<TopicPartitionOffset> SeekToTailAsync(
+        TopicPartition partition,
+        int offsetCount,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Finite snapshot and tail operations for Kafka consumers.
+/// </summary>
+public static class BoundedConsumerExtensions
+{
+    /// <inheritdoc cref="IBoundedKafkaConsumer{TKey,TValue}.ConsumeSnapshotAsync"/>
+    public static IAsyncEnumerable<ConsumeResult<TKey, TValue>> ConsumeSnapshotAsync<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        return GetCapability(consumer).ConsumeSnapshotAsync(cancellationToken);
+    }
+
+    /// <inheritdoc cref="IBoundedKafkaConsumer{TKey,TValue}.SeekToTailAsync"/>
+    public static ValueTask<TopicPartitionOffset> SeekToTailAsync<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        TopicPartition partition,
+        int offsetCount,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        return GetCapability(consumer).SeekToTailAsync(partition, offsetCount, cancellationToken);
+    }
+
+    private static IBoundedKafkaConsumer<TKey, TValue> GetCapability<TKey, TValue>(
+        IKafkaConsumer<TKey, TValue> consumer) =>
+        consumer as IBoundedKafkaConsumer<TKey, TValue>
+        ?? throw new NotSupportedException(
+            $"Consumer type {consumer.GetType().FullName} does not support bounded consumption.");
+}

--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -33,7 +33,21 @@ namespace Dekaf.Consumer
         {
             Monitor.Enter(_publicationLock);
             Volatile.Write(ref ConsumeOneDeliveryChangesPending, 1);
-            Interlocked.Increment(ref Version);
+            // Snapshot delivery can reserve the odd epoch without entering this monitor.
+            // Wait until that tiny position-publication section completes, then claim the
+            // epoch with CAS so publication cannot overlap it.
+            var spin = new SpinWait();
+            while (true)
+            {
+                var version = Volatile.Read(ref Version);
+                if ((version & 1) == 0
+                    && Interlocked.CompareExchange(ref Version, version + 1, version) == version)
+                {
+                    return;
+                }
+
+                spin.SpinOnce();
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -41,6 +55,22 @@ namespace Dekaf.Consumer
         {
             Interlocked.Increment(ref Version);
             Monitor.Exit(_publicationLock);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryBeginSnapshotDelivery(int expectedVersion) =>
+            (expectedVersion & 1) == 0
+            && Interlocked.CompareExchange(
+                ref Version,
+                expectedVersion + 1,
+                expectedVersion) == expectedVersion;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int EndSnapshotDelivery(int deliveryVersion)
+        {
+            var stableVersion = deliveryVersion + 2;
+            Volatile.Write(ref Version, stableVersion);
+            return stableVersion;
         }
 
         public int CaptureStableVersion()

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -257,7 +257,11 @@ internal sealed class PendingFetchData : IDisposable
             instance.FetchEndOffsetExclusive = stopAtOffsetExclusive >= 0
                 ? Math.Min(actualEndOffset, stopAtOffsetExclusive)
                 : actualEndOffset;
-            instance.FetchEndLeaderEpoch = lastBatch.PartitionLeaderEpoch;
+            instance.FetchEndLeaderEpoch = FindFetchEndLeaderEpoch(
+                batches,
+                instance.FetchEndOffsetExclusive,
+                lastBatch,
+                actualEndOffset);
         }
 
         for (var i = 0; i < batches.Count; i++)
@@ -279,6 +283,38 @@ internal sealed class PendingFetchData : IDisposable
         }
 
         return instance;
+    }
+
+    private static int FindFetchEndLeaderEpoch(
+        IReadOnlyList<RecordBatch> batches,
+        long fetchEndOffsetExclusive,
+        RecordBatch lastBatch,
+        long actualEndOffset)
+    {
+        if (fetchEndOffsetExclusive == actualEndOffset)
+            return lastBatch.PartitionLeaderEpoch;
+
+        // Find the last batch beginning before the exclusive boundary. Fetch responses are
+        // offset-ordered; binary search avoids adding a second O(n) pass to fetch processing.
+        var low = 0;
+        var high = batches.Count - 1;
+        var leaderEpoch = -1;
+        while (low <= high)
+        {
+            var middle = low + ((high - low) >> 1);
+            var batch = batches[middle];
+            if (batch.BaseOffset < fetchEndOffsetExclusive)
+            {
+                leaderEpoch = batch.PartitionLeaderEpoch;
+                low = middle + 1;
+            }
+            else
+            {
+                high = middle - 1;
+            }
+        }
+
+        return leaderEpoch;
     }
 
     public static PendingFetchData CreateSnapshotEnd(
@@ -899,7 +935,7 @@ internal sealed class SnapshotConsumeState
     private readonly HashSet<TopicPartition> _completed = [];
     private readonly HashSet<TopicPartition> _queuedEndMarkers = [];
     private int _remaining;
-    private int _assignmentInvalidated;
+    private int _consumerStateInvalidated;
 
     public SnapshotConsumeState(
         Dictionary<TopicPartition, long> endOffsets,
@@ -957,14 +993,14 @@ internal sealed class SnapshotConsumeState
             _queuedEndMarkers.Remove(partition);
     }
 
-    public void InvalidateAssignment() => Volatile.Write(ref _assignmentInvalidated, 1);
+    public void InvalidateConsumerState() => Volatile.Write(ref _consumerStateInvalidated, 1);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void ThrowIfConsumerStateChanged(
         TopicPartitionSet assignment,
         TopicPartitionSet paused)
     {
-        if (Volatile.Read(ref _assignmentInvalidated) != 0
+        if (Volatile.Read(ref _consumerStateInvalidated) != 0
             || !ReferenceEquals(_assignment, assignment)
             || !ReferenceEquals(_paused, paused))
         {
@@ -2821,10 +2857,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                             if (activeSnapshot is not null)
                             {
-                                lock (_snapshotStateGate)
+                                iterationStatus = TrackSnapshotConsumedPosition(
+                                    activeSnapshot,
+                                    pending,
+                                    offset,
+                                    messageBytes,
+                                    ref recordIterationVersion);
+                                if (iterationStatus != RecordIterationStatus.Continue)
                                 {
-                                    ThrowIfSnapshotStateChanged(activeSnapshot);
-                                    TrackConsumedPosition(pending, offset, messageBytes);
+                                    pausedDuringDelivery = iterationStatus == RecordIterationStatus.Paused;
+                                    HandleStoppedRecordIteration(topicPartition, pausedDuringDelivery);
+                                    if (pausedDuringDelivery)
+                                        pending.BufferCurrentForRedelivery();
+                                    break;
                                 }
                             }
                             else
@@ -4292,6 +4337,36 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (_options.EnableAutoOffsetStore && EagerOffsetStore)
         {
             StoreOffsetCore(pending.TopicPartition, offset + 1, pending.LastYieldedLeaderEpoch);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private RecordIterationStatus TrackSnapshotConsumedPosition(
+        SnapshotConsumeState snapshot,
+        PendingFetchData pending,
+        long offset,
+        int messageBytes,
+        ref int recordIterationVersion)
+    {
+        while (true)
+        {
+            if (_batchIterationEpoch.TryBeginSnapshotDelivery(recordIterationVersion))
+            {
+                try
+                {
+                    ThrowIfSnapshotStateChanged(snapshot);
+                    TrackConsumedPosition(pending, offset, messageBytes);
+                    return RecordIterationStatus.Continue;
+                }
+                finally
+                {
+                    recordIterationVersion = _batchIterationEpoch.EndSnapshotDelivery(recordIterationVersion);
+                }
+            }
+
+            var status = GetRecordIterationStatus(pending.TopicPartition, ref recordIterationVersion);
+            if (status != RecordIterationStatus.Continue)
+                return status;
         }
     }
 
@@ -6437,7 +6512,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void QueueCoordinatorRevokedPartitionsForFetchClear(IReadOnlyList<TopicPartition> partitions)
     {
-        Volatile.Read(ref _activeSnapshot)?.InvalidateAssignment();
+        Volatile.Read(ref _activeSnapshot)?.InvalidateConsumerState();
 
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
@@ -6500,6 +6575,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         _batchIterationEpoch.BeginPublication();
         try
         {
+            Volatile.Read(ref _activeSnapshot)?.InvalidateConsumerState();
             Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
         }
         finally

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2303,7 +2303,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             InvalidatePartitionCache();
             await foreach (var result in ConsumeAsync(cancellationToken).ConfigureAwait(false))
             {
-                snapshot.ThrowIfConsumerStateChanged(_assignmentSnapshot, _pausedSnapshot);
+                ThrowIfSnapshotStateChanged(snapshot);
                 var partition = new TopicPartition(result.Topic, result.Partition);
                 if (!snapshot.TryGetEndOffset(partition, out var endOffset))
                 {
@@ -2423,7 +2423,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         var snapshot = new SnapshotConsumeState(endOffsets, assignment, paused, startOffsets);
-        snapshot.ThrowIfConsumerStateChanged(_assignmentSnapshot, _pausedSnapshot);
+        ThrowIfSnapshotStateChanged(snapshot);
 
         for (var i = 0; i < partitions.Length; i++)
         {
@@ -2498,7 +2498,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         lock (_snapshotStateGate)
         {
-            snapshot.ThrowIfConsumerStateChanged(_assignmentSnapshot, _pausedSnapshot);
+            ThrowIfSnapshotStateChanged(snapshot);
             if (!snapshot.Complete(partition))
                 return;
 
@@ -2513,6 +2513,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
         }
         InvalidatePartitionCache();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ThrowIfSnapshotStateChanged(SnapshotConsumeState snapshot)
+    {
+        snapshot.ThrowIfConsumerStateChanged(_assignmentSnapshot, _pausedSnapshot);
+
+        var coordinator = _coordinator;
+        if (coordinator is not null &&
+            coordinator.AssignmentVersion != Volatile.Read(ref _lastCoordinatorAssignmentVersion))
+        {
+            throw new SnapshotStateChangedException();
+        }
     }
 
     public async IAsyncEnumerable<ConsumeResult<TKey, TValue>> ConsumeAsync(
@@ -2552,7 +2565,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             var activeSnapshot = Volatile.Read(ref _activeSnapshot);
             if (activeSnapshot is not null)
-                activeSnapshot.ThrowIfConsumerStateChanged(_assignmentSnapshot, _pausedSnapshot);
+                ThrowIfSnapshotStateChanged(activeSnapshot);
 
             if (_assignmentSnapshot.Count == 0)
             {
@@ -2808,9 +2821,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             {
                                 lock (_snapshotStateGate)
                                 {
-                                    activeSnapshot.ThrowIfConsumerStateChanged(
-                                        _assignmentSnapshot,
-                                        _pausedSnapshot);
+                                    ThrowIfSnapshotStateChanged(activeSnapshot);
                                     TrackConsumedPosition(pending, offset, messageBytes);
                                 }
                             }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1368,6 +1368,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly object _pausedDirectFetchCancellationSourceLock = new();
     // Cold capability state stays at the tail so normal consume field layout remains stable.
     private SnapshotConsumeState? _activeSnapshot;
+    private int _snapshotOperationActive;
 
     private static readonly long s_preferredReadReplicaMaxAgeTimestampDelta =
         (long)(TimeSpan.FromMinutes(5).TotalSeconds * Stopwatch.Frequency);
@@ -2239,20 +2240,25 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             throw new ObjectDisposedException(nameof(KafkaConsumer<TKey, TValue>));
 
         ThrowIfNotInitialized();
-        await RecordPollAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureAssignmentForPollAsync(cancellationToken).ConfigureAwait(false);
-        var snapshot = await CaptureSnapshotStateAsync(cancellationToken).ConfigureAwait(false);
-        if (snapshot.IsComplete)
-            yield break;
-
-        if (Interlocked.CompareExchange(ref _activeSnapshot, snapshot, null) is not null)
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            throw new InvalidOperationException(
-                "Only one snapshot enumeration can be active on a consumer.");
+            if (Interlocked.Exchange(ref _snapshotOperationActive, 1) != 0)
+            {
+                throw new InvalidOperationException(
+                    "Only one snapshot enumeration can be active on a consumer.");
+            }
         }
 
+        SnapshotConsumeState? snapshot = null;
         try
         {
+            await RecordPollAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureAssignmentForPollAsync(cancellationToken).ConfigureAwait(false);
+            snapshot = await CaptureSnapshotStateAsync(cancellationToken).ConfigureAwait(false);
+            if (snapshot.IsComplete)
+                yield break;
+
+            Volatile.Write(ref _activeSnapshot, snapshot);
             ResetFetchBufferForSnapshot(snapshot);
             InvalidatePartitionCache();
             await foreach (var result in ConsumeAsync(cancellationToken).ConfigureAwait(false))
@@ -2309,11 +2315,22 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
         finally
         {
-            if (ReferenceEquals(
-                    Interlocked.CompareExchange(ref _activeSnapshot, null, snapshot),
-                    snapshot))
+            try
             {
-                InvalidatePartitionCache();
+                if (snapshot is not null
+                    && ReferenceEquals(
+                        Interlocked.CompareExchange(ref _activeSnapshot, null, snapshot),
+                        snapshot))
+                {
+                    if (!snapshot.IsComplete)
+                        ResetFetchBufferAfterAbortedSnapshot(snapshot);
+
+                    InvalidatePartitionCache();
+                }
+            }
+            finally
+            {
+                Volatile.Write(ref _snapshotOperationActive, 0);
             }
         }
     }
@@ -2372,8 +2389,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             var partition = partitions[i];
             var endOffset = endOffsets[partition];
+            var startOffset = startOffsets[partition];
             if (endOffset == 0
-                || (_fetchPositions.TryGetValue(partition, out var position) && position >= endOffset))
+                || startOffset >= endOffset)
             {
                 snapshot.Complete(partition);
             }
@@ -2389,8 +2407,29 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // excluded records never reach deserializers.
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            ClearFetchBufferForPartitions(snapshot.Assignment);
+            ClearFetchBufferForPartitions(snapshot.Assignment, stagePendingClear: true);
             foreach (var (partition, offset) in snapshot.StartOffsets)
+            {
+                _fetchPositions[partition] = offset;
+                _eofEmitted.TryRemove(partition, out _);
+            }
+        }
+    }
+
+    private void ResetFetchBufferAfterAbortedSnapshot(SnapshotConsumeState snapshot)
+    {
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            // Assignment changes own their buffer reset and position initialization.
+            if (!ReferenceEquals(snapshot.Assignment, _assignmentSnapshot))
+                return;
+
+            var resumeOffsets = new Dictionary<TopicPartition, long>(snapshot.StartOffsets.Count);
+            foreach (var (partition, startOffset) in snapshot.StartOffsets)
+                resumeOffsets[partition] = GetPosition(partition) ?? startOffset;
+
+            ClearFetchBufferForPartitions(snapshot.Assignment, stagePendingClear: true);
+            foreach (var (partition, offset) in resumeOffsets)
             {
                 _fetchPositions[partition] = offset;
                 _eofEmitted.TryRemove(partition, out _);
@@ -2407,11 +2446,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (!snapshot.Complete(partition))
             return;
 
-        Seek(new TopicPartitionOffset(
-            partition.Topic,
-            partition.Partition,
-            endOffset,
-            leaderEpoch));
+        LogSeek(partition.Topic, partition.Partition, endOffset);
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            SeekLocked(new TopicPartitionOffset(
+                partition.Topic,
+                partition.Partition,
+                endOffset,
+                leaderEpoch));
+        }
         InvalidatePartitionCache();
     }
 
@@ -4095,7 +4138,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
-    private bool TryGetActiveConsumedPosition(TopicPartition partition, out long position, out int leaderEpoch)
+    private bool TryGetActiveConsumedPosition(
+        TopicPartition partition,
+        out long position,
+        out int leaderEpoch,
+        bool includeFilteredProgress = true)
     {
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
         {
@@ -4118,7 +4165,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         var pending = _pendingFetches.Peek();
-        if (!TryGetConsumedPosition(pending, out var tp, out position, out leaderEpoch) || !tp.Equals(partition))
+        if (!TryGetConsumedPosition(
+                pending,
+                out var tp,
+                out position,
+                out leaderEpoch,
+                includeFilteredProgress)
+            || !tp.Equals(partition))
         {
             position = 0;
             leaderEpoch = -1;
@@ -5782,19 +5835,34 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     public void Seek(TopicPartitionOffset offset)
     {
         LogSeek(offset.Topic, offset.Partition, offset.Offset);
-        var tp = new TopicPartition(offset.Topic, offset.Partition);
         // Keep invalidation, buffer drain, and position replacement atomic with prefetch publication.
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            ClearFetchBufferForPartitions([tp], stagePendingClear: true);
+            ThrowIfSnapshotOperationActive();
+            SeekLocked(offset);
+        }
+    }
 
-            if (offset.LeaderEpoch >= 0)
-                SetLastConsumedLeaderEpoch(tp, offset.LeaderEpoch);
-            else
-                ClearLastConsumedLeaderEpoch(tp);
-            SetPosition(tp, offset.Offset, dirty: true);
-            _fetchPositions[tp] = offset.Offset;
-            _eofEmitted.TryRemove(tp, out _);
+    private void SeekLocked(TopicPartitionOffset offset)
+    {
+        var partition = new TopicPartition(offset.Topic, offset.Partition);
+        ClearFetchBufferForPartitions([partition], stagePendingClear: true);
+
+        if (offset.LeaderEpoch >= 0)
+            SetLastConsumedLeaderEpoch(partition, offset.LeaderEpoch);
+        else
+            ClearLastConsumedLeaderEpoch(partition);
+        SetPosition(partition, offset.Offset, dirty: true);
+        _fetchPositions[partition] = offset.Offset;
+        _eofEmitted.TryRemove(partition, out _);
+    }
+
+    private void ThrowIfSnapshotOperationActive()
+    {
+        if (Volatile.Read(ref _snapshotOperationActive) != 0)
+        {
+            throw new InvalidOperationException(
+                "Cannot change consumer position while a snapshot enumeration is active.");
         }
     }
 
@@ -5802,6 +5870,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
+            ThrowIfSnapshotOperationActive();
             ClearFetchBufferForPartitions(partitions, stagePendingClear: true);
 
             foreach (var partition in partitions)
@@ -5818,6 +5887,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
+            ThrowIfSnapshotOperationActive();
             ClearFetchBufferForPartitions(partitions, stagePendingClear: true);
 
             foreach (var partition in partitions)
@@ -6447,7 +6517,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 GetLastConsumedLeaderEpoch(partition),
                 reset);
 
-            if (TryGetActiveConsumedPosition(partition, out var activePosition, out var activeLeaderEpoch))
+            if (TryGetActiveConsumedPosition(
+                    partition,
+                    out var activePosition,
+                    out var activeLeaderEpoch,
+                    includeFilteredProgress: false))
             {
                 resumeOffset = Math.Max(
                     resumeOffset,

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -899,6 +899,7 @@ internal sealed class SnapshotConsumeState
     private readonly HashSet<TopicPartition> _completed = [];
     private readonly HashSet<TopicPartition> _queuedEndMarkers = [];
     private int _remaining;
+    private int _assignmentInvalidated;
 
     public SnapshotConsumeState(
         Dictionary<TopicPartition, long> endOffsets,
@@ -956,18 +957,25 @@ internal sealed class SnapshotConsumeState
             _queuedEndMarkers.Remove(partition);
     }
 
+    public void InvalidateAssignment() => Volatile.Write(ref _assignmentInvalidated, 1);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void ThrowIfConsumerStateChanged(
         TopicPartitionSet assignment,
         TopicPartitionSet paused)
     {
-        if (!ReferenceEquals(_assignment, assignment) || !ReferenceEquals(_paused, paused))
+        if (Volatile.Read(ref _assignmentInvalidated) != 0
+            || !ReferenceEquals(_assignment, assignment)
+            || !ReferenceEquals(_paused, paused))
         {
-            throw new InvalidOperationException(
-                "The consumer assignment or pause state changed while a snapshot enumeration was active.");
+            throw new SnapshotStateChangedException();
         }
     }
 }
+
+internal sealed class SnapshotStateChangedException()
+    : InvalidOperationException(
+        "The consumer assignment or pause state changed while a snapshot enumeration was active.");
 
 internal static class ConsumerFetchPools
 {
@@ -2542,7 +2550,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 recordIterationEpochSeed |= 1;
             _recordIterationEpochSeed = recordIterationEpochSeed;
 
-            if (Volatile.Read(ref _activeSnapshot) is { } activeSnapshot)
+            var activeSnapshot = Volatile.Read(ref _activeSnapshot);
+            if (activeSnapshot is not null)
                 activeSnapshot.ThrowIfConsumerStateChanged(_assignmentSnapshot, _pausedSnapshot);
 
             if (_assignmentSnapshot.Count == 0)
@@ -2795,12 +2804,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 }
                             }
 
-                            if (hasAsyncDeserializers &&
-                                Volatile.Read(ref _activeSnapshot) is { } deserializedSnapshot)
+                            if (activeSnapshot is not null)
                             {
                                 lock (_snapshotStateGate)
                                 {
-                                    deserializedSnapshot.ThrowIfConsumerStateChanged(
+                                    activeSnapshot.ThrowIfConsumerStateChanged(
                                         _assignmentSnapshot,
                                         _pausedSnapshot);
                                     TrackConsumedPosition(pending, offset, messageBytes);
@@ -2834,6 +2842,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             previousActivity = null;
                             LogRecordParsingError(ex, pending.Topic, pending.PartitionIndex);
                             break;
+                        }
+                        catch (SnapshotStateChangedException)
+                        {
+                            throw;
                         }
                         catch (Exception ex) when (!readingProtocolData)
                         {
@@ -6412,6 +6424,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void QueueCoordinatorRevokedPartitionsForFetchClear(IReadOnlyList<TopicPartition> partitions)
     {
+        Volatile.Read(ref _activeSnapshot)?.InvalidateAssignment();
+
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
             foreach (var partition in partitions)
@@ -7966,13 +7980,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// </summary>
     private void PublishPausedSnapshot()
     {
-        var pausedSnapshot = _paused.Keys.ToHashSet();
         lock (_snapshotStateGate)
         {
             _batchIterationEpoch.BeginPublication();
             try
             {
-                _pausedSnapshot = pausedSnapshot;
+                _pausedSnapshot = _paused.Keys.ToHashSet();
                 Interlocked.Increment(ref _pausedSnapshotVersion);
             }
             finally

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2303,7 +2303,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             InvalidatePartitionCache();
             await foreach (var result in ConsumeAsync(cancellationToken).ConfigureAwait(false))
             {
-                ThrowIfSnapshotStateChanged(snapshot);
+                // ConsumeAsync validates snapshot state and advances the delivered position
+                // atomically. Its yield is the delivery linearization point; revalidating here
+                // could reject a record whose position has already advanced.
                 var partition = new TopicPartition(result.Topic, result.Partition);
                 if (!snapshot.TryGetEndOffset(partition, out var endOffset))
                 {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -297,11 +297,11 @@ internal sealed class PendingFetchData : IDisposable
         return instance;
     }
 
-    private void AttachParsedRecordSlab(IReadOnlyList<RecordBatch> batches)
+    private void AttachParsedRecordSlab(IReadOnlyList<RecordBatch> batches, int batchCount)
     {
         var totalRecordCount = 0;
 
-        for (var i = 0; i < batches.Count; i++)
+        for (var i = 0; i < batchCount; i++)
         {
             var recordCount = batches[i].UnparsedLazyRecordCount;
             if (recordCount < 0 || recordCount > RecordBatch.MaxReasonableLazyRecordCount - totalRecordCount)
@@ -318,7 +318,7 @@ internal sealed class PendingFetchData : IDisposable
         _parsedRecordSlabOwner = slabPool;
         slab.AsSpan(0, totalRecordCount).Clear();
         var offset = 0;
-        for (var i = 0; i < batches.Count; i++)
+        for (var i = 0; i < batchCount; i++)
         {
             var batch = batches[i];
             var recordCount = batch.UnparsedLazyRecordCount;
@@ -468,7 +468,8 @@ internal sealed class PendingFetchData : IDisposable
     public IReadOnlyList<RecordBatch> GetBatches() => _batches;
 
     /// <summary>
-    /// Eagerly parses all records in all batches at once.
+    /// Eagerly parses all records in consumable batches at once. Snapshot batches wholly at
+    /// or beyond the captured end remain unparsed because they can never produce a record.
     /// Call before sequential consumption to avoid per-record lazy parse overhead
     /// (disposed check + bounds check + EnsureParsedUpTo call per indexer access).
     /// This is a per-batch cost amortized over all records in the batch.
@@ -484,11 +485,24 @@ internal sealed class PendingFetchData : IDisposable
         if (Interlocked.Exchange(ref _error, null) is { } error)
             throw error;
 
-        AttachParsedRecordSlab(_batches);
+        var batchCount = _batches.Count;
+        if (_stopAtOffsetExclusive >= 0)
+        {
+            for (var i = 0; i < batchCount; i++)
+            {
+                if (_batches[i].BaseOffset < _stopAtOffsetExclusive)
+                    continue;
+
+                batchCount = i;
+                break;
+            }
+        }
+
+        AttachParsedRecordSlab(_batches, batchCount);
 
         try
         {
-            for (var i = 0; i < _batches.Count; i++)
+            for (var i = 0; i < batchCount; i++)
             {
                 var batch = _batches[i];
                 batch.EnsureAllRecordsParsed();
@@ -1385,6 +1399,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     // Cold capability state stays at the tail so normal consume field layout remains stable.
     private SnapshotConsumeState? _activeSnapshot;
     private int _snapshotOperationActive;
+    private readonly object _snapshotStateGate = new();
 
     private static readonly long s_preferredReadReplicaMaxAgeTimestampDelta =
         (long)(TimeSpan.FromMinutes(5).TotalSeconds * Stopwatch.Frequency);
@@ -2270,6 +2285,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             await RecordPollAsync(cancellationToken).ConfigureAwait(false);
             await EnsureAssignmentForPollAsync(cancellationToken).ConfigureAwait(false);
+            ProvePriorDeliveryForSnapshot();
             snapshot = await CaptureSnapshotStateAsync(cancellationToken).ConfigureAwait(false);
             if (snapshot.IsComplete)
                 yield break;
@@ -2432,6 +2448,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
+    private void ProvePriorDeliveryForSnapshot()
+    {
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            if (_pendingFetches.Count == 0)
+                return;
+
+            var priorPending = _pendingFetches.Peek();
+            priorPending.MarkYieldedProcessed();
+            FlushConsumedPositions(priorPending);
+        }
+    }
+
     private void ResetFetchBufferAfterAbortedSnapshot(SnapshotConsumeState snapshot)
     {
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
@@ -2459,17 +2488,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         long endOffset,
         int leaderEpoch)
     {
-        if (!snapshot.Complete(partition))
-            return;
-
-        LogSeek(partition.Topic, partition.Partition, endOffset);
-        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        lock (_snapshotStateGate)
         {
-            SeekLocked(new TopicPartitionOffset(
-                partition.Topic,
-                partition.Partition,
-                endOffset,
-                leaderEpoch));
+            snapshot.ThrowIfConsumerStateChanged(_assignmentSnapshot, _pausedSnapshot);
+            if (!snapshot.Complete(partition))
+                return;
+
+            LogSeek(partition.Topic, partition.Partition, endOffset);
+            lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+            {
+                SeekLocked(new TopicPartitionOffset(
+                    partition.Topic,
+                    partition.Partition,
+                    endOffset,
+                    leaderEpoch));
+            }
         }
         InvalidatePartitionCache();
     }
@@ -2762,7 +2795,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 }
                             }
 
-                            TrackConsumedPosition(pending, offset, messageBytes);
+                            if (hasAsyncDeserializers &&
+                                Volatile.Read(ref _activeSnapshot) is { } deserializedSnapshot)
+                            {
+                                lock (_snapshotStateGate)
+                                {
+                                    deserializedSnapshot.ThrowIfConsumerStateChanged(
+                                        _assignmentSnapshot,
+                                        _pausedSnapshot);
+                                    TrackConsumedPosition(pending, offset, messageBytes);
+                                }
+                            }
+                            else
+                            {
+                                TrackConsumedPosition(pending, offset, messageBytes);
+                            }
                             // Committable state advances only at fetch-boundary flushes; see
                             // AutoCommitLoopAsync for the offset-safety contract this preserves.
 
@@ -7887,14 +7934,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private void PublishAssignmentSnapshot()
     {
         var assignmentSnapshot = new HashSet<TopicPartition>(_assignment);
-        _batchIterationEpoch.BeginPublication();
-        try
+        lock (_snapshotStateGate)
         {
-            _assignmentSnapshot = assignmentSnapshot;
-        }
-        finally
-        {
-            _batchIterationEpoch.EndPublication();
+            _batchIterationEpoch.BeginPublication();
+            try
+            {
+                _assignmentSnapshot = assignmentSnapshot;
+            }
+            finally
+            {
+                _batchIterationEpoch.EndPublication();
+            }
         }
         Interlocked.Increment(ref _assignmentEnsureVersion);
         Volatile.Write(ref _lastCoordinatorAssignmentVersion, -1);
@@ -7916,15 +7966,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// </summary>
     private void PublishPausedSnapshot()
     {
-        _batchIterationEpoch.BeginPublication();
-        try
+        var pausedSnapshot = _paused.Keys.ToHashSet();
+        lock (_snapshotStateGate)
         {
-            _pausedSnapshot = _paused.Keys.ToHashSet();
-            Interlocked.Increment(ref _pausedSnapshotVersion);
-        }
-        finally
-        {
-            _batchIterationEpoch.EndPublication();
+            _batchIterationEpoch.BeginPublication();
+            try
+            {
+                _pausedSnapshot = pausedSnapshot;
+                Interlocked.Increment(ref _pausedSnapshotVersion);
+            }
+            finally
+            {
+                _batchIterationEpoch.EndPublication();
+            }
         }
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -525,19 +525,10 @@ internal sealed class PendingFetchData : IDisposable
         _currentRecordsArrayOffset = batch.GetParsedRecordsOffset();
 
         CurrentBaseOffset = batch.BaseOffset;
-        if (_stopAtOffsetExclusive >= 0)
+        if (_stopAtOffsetExclusive >= 0
+            && CurrentBaseOffset + batch.LastOffsetDelta >= _stopAtOffsetExclusive)
         {
-            while (_currentRecordsCount > 0)
-            {
-                var lastRecordIndex = _currentRecordsCount - 1;
-                var lastRecord = _currentRecordsArray is { } recordsArray
-                    ? recordsArray[_currentRecordsArrayOffset + lastRecordIndex]
-                    : records[lastRecordIndex];
-                if (CurrentBaseOffset + lastRecord.OffsetDelta < _stopAtOffsetExclusive)
-                    break;
-
-                _currentRecordsCount--;
-            }
+            _currentRecordsCount = FindSnapshotRecordCount(records);
         }
 
         CurrentPartitionLeaderEpoch = batch.PartitionLeaderEpoch;
@@ -546,6 +537,31 @@ internal sealed class PendingFetchData : IDisposable
         CurrentTimestampType = (attrs & RecordBatchAttributes.TimestampTypeLogAppendTime) != 0
             ? TimestampType.LogAppendTime
             : TimestampType.CreateTime;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private int FindSnapshotRecordCount(IReadOnlyList<Record> records)
+    {
+        if (CurrentBaseOffset >= _stopAtOffsetExclusive)
+            return 0;
+
+        var low = 0;
+        var high = _currentRecordsCount;
+        // Offset deltas are monotonic within a Kafka record batch, so a lower-bound
+        // search avoids walking every record in the excluded suffix.
+        while (low < high)
+        {
+            var middle = low + ((high - low) >> 1);
+            var offsetDelta = _currentRecordsArray is { } recordsArray
+                ? recordsArray[_currentRecordsArrayOffset + middle].OffsetDelta
+                : records[middle].OffsetDelta;
+            if (CurrentBaseOffset + offsetDelta < _stopAtOffsetExclusive)
+                low = middle + 1;
+            else
+                high = middle;
+        }
+
+        return low;
     }
 
     /// <summary>

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -192,6 +192,27 @@ internal sealed class PendingFetchData : IDisposable
     /// </summary>
     public long MessageCount { get; private set; }
     internal bool IsExhausted { get; private set; }
+    internal long FetchEndOffsetExclusive
+    {
+        get => _fetchEndOffsetExclusive;
+        private set => _fetchEndOffsetExclusive = value;
+    }
+    internal int FetchEndLeaderEpoch
+    {
+        get => _fetchEndLeaderEpoch;
+        private set => _fetchEndLeaderEpoch = value;
+    }
+    internal bool ReachedSnapshotEnd
+    {
+        get => _reachedSnapshotEnd;
+        private set => _reachedSnapshotEnd = value;
+    }
+    internal long SnapshotEndOffset
+    {
+        get => _snapshotEndOffset;
+        private set => _snapshotEndOffset = value;
+    }
+    internal bool IsSnapshotEnd => SnapshotEndOffset >= 0;
 
     private long _emittedMessageCount;
     private long _emittedBytesConsumed;
@@ -214,7 +235,8 @@ internal sealed class PendingFetchData : IDisposable
         IReadOnlyList<AbortedTransaction>? abortedTransactions = null,
         IPooledMemory? memoryOwner = null,
         string? activityName = null,
-        long skipRecordsBelowOffset = -1)
+        long skipRecordsBelowOffset = -1,
+        long stopAtOffsetExclusive = -1)
     {
         var instance = Rent();
         instance.Topic = topic;
@@ -224,6 +246,19 @@ internal sealed class PendingFetchData : IDisposable
         instance._batches = batches;
         instance._memoryOwner = memoryOwner;
         instance._skipRecordsBelowOffset = skipRecordsBelowOffset;
+        instance._stopAtOffsetExclusive = stopAtOffsetExclusive;
+
+        if (batches.Count > 0)
+        {
+            var lastBatch = batches[^1];
+            var actualEndOffset = lastBatch.BaseOffset + lastBatch.LastOffsetDelta + 1;
+            instance.ReachedSnapshotEnd = stopAtOffsetExclusive >= 0
+                                          && actualEndOffset >= stopAtOffsetExclusive;
+            instance.FetchEndOffsetExclusive = stopAtOffsetExclusive >= 0
+                ? Math.Min(actualEndOffset, stopAtOffsetExclusive)
+                : actualEndOffset;
+            instance.FetchEndLeaderEpoch = lastBatch.PartitionLeaderEpoch;
+        }
 
         for (var i = 0; i < batches.Count; i++)
             batches[i].AttachConsumerPoolOwner(instance, instance.HeaderGeneration);
@@ -243,6 +278,22 @@ internal sealed class PendingFetchData : IDisposable
             }
         }
 
+        return instance;
+    }
+
+    public static PendingFetchData CreateSnapshotEnd(
+        string topic,
+        int partitionIndex,
+        long endOffset,
+        SnapshotConsumeState? snapshot = null)
+    {
+        var instance = Rent();
+        instance.Topic = topic;
+        instance.PartitionIndex = partitionIndex;
+        instance.TopicPartition = new TopicPartition(topic, partitionIndex);
+        instance._batches = Array.Empty<RecordBatch>();
+        instance.SnapshotEndOffset = endOffset;
+        instance._snapshotMarkerState = snapshot;
         return instance;
     }
 
@@ -474,6 +525,21 @@ internal sealed class PendingFetchData : IDisposable
         _currentRecordsArrayOffset = batch.GetParsedRecordsOffset();
 
         CurrentBaseOffset = batch.BaseOffset;
+        if (_stopAtOffsetExclusive >= 0)
+        {
+            while (_currentRecordsCount > 0)
+            {
+                var lastRecordIndex = _currentRecordsCount - 1;
+                var lastRecord = _currentRecordsArray is { } recordsArray
+                    ? recordsArray[_currentRecordsArrayOffset + lastRecordIndex]
+                    : records[lastRecordIndex];
+                if (CurrentBaseOffset + lastRecord.OffsetDelta < _stopAtOffsetExclusive)
+                    break;
+
+                _currentRecordsCount--;
+            }
+        }
+
         CurrentPartitionLeaderEpoch = batch.PartitionLeaderEpoch;
         CurrentBaseTimestamp = batch.BaseTimestamp;
         var attrs = batch.Attributes;
@@ -700,6 +766,8 @@ internal sealed class PendingFetchData : IDisposable
         _memoryOwner?.Dispose();
 
         // Reset state for reuse
+        _snapshotMarkerState?.ReleaseEndMarker(TopicPartition);
+        _snapshotMarkerState = null;
         _batches = null!;
         _memoryOwner = null;
         _batchIndex = -1;
@@ -729,9 +797,14 @@ internal sealed class PendingFetchData : IDisposable
         TotalBytesConsumed = 0;
         MessageCount = 0;
         IsExhausted = false;
+        FetchEndOffsetExclusive = -1;
+        FetchEndLeaderEpoch = -1;
+        ReachedSnapshotEnd = false;
+        SnapshotEndOffset = -1;
         _emittedMessageCount = 0;
         _emittedBytesConsumed = 0;
         _skipRecordsBelowOffset = -1;
+        _stopAtOffsetExclusive = -1;
         PartitionIndex = 0;
         TopicPartition = default;
         Topic = null!;
@@ -749,6 +822,15 @@ internal sealed class PendingFetchData : IDisposable
             capacity);
         return state;
     }
+
+    // Snapshot and filtered-fetch state stays at the cold tail so adding bounded-consume
+    // support does not move the cache-hot record iteration fields in this pooled object.
+    private long _fetchEndOffsetExclusive = -1;
+    private long _snapshotEndOffset = -1;
+    private long _stopAtOffsetExclusive = -1;
+    private int _fetchEndLeaderEpoch = -1;
+    private bool _reachedSnapshotEnd;
+    private SnapshotConsumeState? _snapshotMarkerState;
 
     private sealed class PendingFetchDataPoolState
     {
@@ -773,6 +855,86 @@ internal sealed class PendingFetchData : IDisposable
                 target = next;
 
             target.Pool.Return(item);
+        }
+    }
+}
+
+internal sealed class SnapshotConsumeState
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<TopicPartition, long> _endOffsets;
+    private readonly Dictionary<TopicPartition, long> _startOffsets;
+    private readonly TopicPartitionSet _assignment;
+    private readonly TopicPartitionSet _paused;
+    private readonly HashSet<TopicPartition> _completed = [];
+    private readonly HashSet<TopicPartition> _queuedEndMarkers = [];
+    private int _remaining;
+
+    public SnapshotConsumeState(
+        Dictionary<TopicPartition, long> endOffsets,
+        TopicPartitionSet? assignment = null,
+        TopicPartitionSet? paused = null,
+        Dictionary<TopicPartition, long>? startOffsets = null)
+    {
+        _endOffsets = endOffsets;
+        _startOffsets = startOffsets ?? [];
+        _assignment = assignment ?? new HashSet<TopicPartition>(endOffsets.Keys);
+        _paused = paused ?? new HashSet<TopicPartition>();
+        _remaining = endOffsets.Count;
+    }
+
+    public bool IsComplete => Volatile.Read(ref _remaining) == 0;
+    public TopicPartitionSet Assignment => _assignment;
+    public Dictionary<TopicPartition, long> StartOffsets => _startOffsets;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetEndOffset(TopicPartition partition, out long endOffset) =>
+        _endOffsets.TryGetValue(partition, out endOffset);
+
+    public bool IsPartitionComplete(TopicPartition partition)
+    {
+        lock (_gate)
+            return _completed.Contains(partition);
+    }
+
+    public bool Complete(TopicPartition partition)
+    {
+        lock (_gate)
+        {
+            if (!_endOffsets.ContainsKey(partition) || !_completed.Add(partition))
+                return false;
+
+            Volatile.Write(ref _remaining, _remaining - 1);
+            return true;
+        }
+    }
+
+    public bool TryQueueEndMarker(TopicPartition partition, long visibleEndOffset, out long endOffset)
+    {
+        if (!_endOffsets.TryGetValue(partition, out endOffset) || visibleEndOffset < endOffset)
+            return false;
+
+        lock (_gate)
+        {
+            return !_completed.Contains(partition) && _queuedEndMarkers.Add(partition);
+        }
+    }
+
+    public void ReleaseEndMarker(TopicPartition partition)
+    {
+        lock (_gate)
+            _queuedEndMarkers.Remove(partition);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void ThrowIfConsumerStateChanged(
+        TopicPartitionSet assignment,
+        TopicPartitionSet paused)
+    {
+        if (!ReferenceEquals(_assignment, assignment) || !ReferenceEquals(_paused, paused))
+        {
+            throw new InvalidOperationException(
+                "The consumer assignment or pause state changed while a snapshot enumeration was active.");
         }
     }
 }
@@ -872,6 +1034,7 @@ internal static class ConsumerFetchPools
 /// <typeparam name="TValue">Value type.</typeparam>
 public sealed partial class KafkaConsumer<TKey, TValue> :
     IKafkaConsumer<TKey, TValue>,
+    IBoundedKafkaConsumer<TKey, TValue>,
     IConsumerGroupLiveness,
     IConsumerPositions,
     IConsumerPartitions,
@@ -1203,6 +1366,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private TopicPartitionSet _deliveryPausedSnapshot = new HashSet<TopicPartition>();
     // Prevent Resume from cancelling a pooled CTS after it has been returned and re-rented.
     private readonly object _pausedDirectFetchCancellationSourceLock = new();
+    // Cold capability state stays at the tail so normal consume field layout remains stable.
+    private SnapshotConsumeState? _activeSnapshot;
 
     private static readonly long s_preferredReadReplicaMaxAgeTimestampDelta =
         (long)(TimeSpan.FromMinutes(5).TotalSeconds * Stopwatch.Frequency);
@@ -2067,6 +2232,189 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         InvalidateFetchRequestCache();
     }
 
+    public async IAsyncEnumerable<ConsumeResult<TKey, TValue>> ConsumeSnapshotAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (Volatile.Read(ref _consumerDisposed) != 0)
+            throw new ObjectDisposedException(nameof(KafkaConsumer<TKey, TValue>));
+
+        ThrowIfNotInitialized();
+        await RecordPollAsync(cancellationToken).ConfigureAwait(false);
+        await EnsureAssignmentForPollAsync(cancellationToken).ConfigureAwait(false);
+        var snapshot = await CaptureSnapshotStateAsync(cancellationToken).ConfigureAwait(false);
+        if (snapshot.IsComplete)
+            yield break;
+
+        if (Interlocked.CompareExchange(ref _activeSnapshot, snapshot, null) is not null)
+        {
+            throw new InvalidOperationException(
+                "Only one snapshot enumeration can be active on a consumer.");
+        }
+
+        try
+        {
+            ResetFetchBufferForSnapshot(snapshot);
+            InvalidatePartitionCache();
+            await foreach (var result in ConsumeAsync(cancellationToken).ConfigureAwait(false))
+            {
+                snapshot.ThrowIfConsumerStateChanged(_assignmentSnapshot, _pausedSnapshot);
+                var partition = new TopicPartition(result.Topic, result.Partition);
+                if (!snapshot.TryGetEndOffset(partition, out var endOffset))
+                {
+                    throw new InvalidOperationException(
+                        "The consumer assignment changed while a snapshot enumeration was active.");
+                }
+
+                if (result.IsPartitionEof)
+                {
+                    if (result.Offset >= endOffset)
+                    {
+                        CompleteSnapshotPartition(
+                            snapshot,
+                            partition,
+                            endOffset,
+                            leaderEpoch: -1);
+                    }
+
+                    if (snapshot.IsComplete)
+                        yield break;
+                    continue;
+                }
+
+                if (result.Offset >= endOffset)
+                {
+                    CompleteSnapshotPartition(
+                        snapshot,
+                        partition,
+                        endOffset,
+                        result.LeaderEpoch ?? -1);
+                    if (snapshot.IsComplete)
+                        yield break;
+                    continue;
+                }
+
+                yield return result;
+
+                if (result.Offset + 1 >= endOffset)
+                {
+                    CompleteSnapshotPartition(
+                        snapshot,
+                        partition,
+                        endOffset,
+                        result.LeaderEpoch ?? -1);
+                    if (snapshot.IsComplete)
+                        yield break;
+                }
+            }
+        }
+        finally
+        {
+            if (ReferenceEquals(
+                    Interlocked.CompareExchange(ref _activeSnapshot, null, snapshot),
+                    snapshot))
+            {
+                InvalidatePartitionCache();
+            }
+        }
+    }
+
+    public async ValueTask<TopicPartitionOffset> SeekToTailAsync(
+        TopicPartition partition,
+        int offsetCount,
+        CancellationToken cancellationToken = default)
+    {
+        if (offsetCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(offsetCount), "Offset count cannot be negative.");
+
+        var watermarks = await QueryWatermarkOffsetsAsync(partition, cancellationToken).ConfigureAwait(false);
+        var offset = Math.Max(watermarks.Low, watermarks.High - offsetCount);
+        var resolved = new TopicPartitionOffset(partition.Topic, partition.Partition, offset);
+        Seek(resolved);
+        return resolved;
+    }
+
+    private async ValueTask<SnapshotConsumeState> CaptureSnapshotStateAsync(
+        CancellationToken cancellationToken)
+    {
+        var assignment = _assignmentSnapshot;
+        var paused = _pausedSnapshot;
+        var partitions = new TopicPartition[assignment.Count];
+        var index = 0;
+        foreach (var partition in assignment)
+        {
+            if (paused.Contains(partition))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot start a snapshot while assigned partition {partition} is paused.");
+            }
+
+            partitions[index++] = partition;
+        }
+
+        var endOffsets = new Dictionary<TopicPartition, long>(partitions.Length);
+        var startOffsets = new Dictionary<TopicPartition, long>(partitions.Length);
+        for (var i = 0; i < partitions.Length; i++)
+        {
+            var partition = partitions[i];
+            var watermarks = await QueryWatermarkOffsetsAsync(partition, cancellationToken)
+                .ConfigureAwait(false);
+            endOffsets.Add(partition, watermarks.High);
+            startOffsets.Add(
+                partition,
+                GetPosition(partition)
+                ?? _fetchPositions.GetValueOrDefault(partition, watermarks.Low));
+        }
+
+        var snapshot = new SnapshotConsumeState(endOffsets, assignment, paused, startOffsets);
+        snapshot.ThrowIfConsumerStateChanged(_assignmentSnapshot, _pausedSnapshot);
+
+        for (var i = 0; i < partitions.Length; i++)
+        {
+            var partition = partitions[i];
+            var endOffset = endOffsets[partition];
+            if (endOffset == 0
+                || (_fetchPositions.TryGetValue(partition, out var position) && position >= endOffset))
+            {
+                snapshot.Complete(partition);
+            }
+        }
+
+        return snapshot;
+    }
+
+    private void ResetFetchBufferForSnapshot(SnapshotConsumeState snapshot)
+    {
+        // Capture may overlap an unbounded prefetch that includes records beyond a partition's
+        // fixed end. Invalidate those responses and restart from the user-visible positions so
+        // excluded records never reach deserializers.
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            ClearFetchBufferForPartitions(snapshot.Assignment);
+            foreach (var (partition, offset) in snapshot.StartOffsets)
+            {
+                _fetchPositions[partition] = offset;
+                _eofEmitted.TryRemove(partition, out _);
+            }
+        }
+    }
+
+    private void CompleteSnapshotPartition(
+        SnapshotConsumeState snapshot,
+        TopicPartition partition,
+        long endOffset,
+        int leaderEpoch)
+    {
+        if (!snapshot.Complete(partition))
+            return;
+
+        Seek(new TopicPartitionOffset(
+            partition.Topic,
+            partition.Partition,
+            endOffset,
+            leaderEpoch));
+        InvalidatePartitionCache();
+    }
+
     public async IAsyncEnumerable<ConsumeResult<TKey, TValue>> ConsumeAsync(
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
@@ -2101,6 +2449,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0)
                 recordIterationEpochSeed |= 1;
             _recordIterationEpochSeed = recordIterationEpochSeed;
+
+            if (Volatile.Read(ref _activeSnapshot) is { } activeSnapshot)
+                activeSnapshot.ThrowIfConsumerStateChanged(_assignmentSnapshot, _pausedSnapshot);
 
             if (_assignmentSnapshot.Count == 0)
             {
@@ -2198,6 +2549,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     var pausedDuringDelivery = false;
                     long? batchProcessingStarted = _adaptiveFetchSizer is not null
                         ? Stopwatch.GetTimestamp() : null;
+
+                    if (pending.IsSnapshotEnd)
+                    {
+                        _pendingEofEvents.Enqueue((pending.TopicPartition, pending.SnapshotEndOffset));
+                        DequeuePendingFetch().Dispose();
+                        continue;
+                    }
 
                     // Eagerly parse all records in this fetch's batches upfront.
                     // This converts per-record lazy parse overhead (disposed check +
@@ -2413,6 +2771,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Batch-level position flush. _positions and _fetchPositions are updated
                     // once per partition-fetch (in prefetch mode it is managed by UpdateFetchPositionsFromPrefetch).
                     FlushConsumedPositions(pending);
+
+                    if (pending.ReachedSnapshotEnd)
+                    {
+                        _pendingEofEvents.Enqueue((
+                            pending.TopicPartition,
+                            pending.FetchEndOffsetExclusive));
+                    }
 
                     // Record consumer metrics per-fetch instead of per-message.
                     // PendingFetchData already tracks MessageCount and TotalBytesConsumed,
@@ -3526,7 +3891,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 records,
                                 partitionResponse.AbortedTransactions,
                                 activityName: activityName,
-                                skipRecordsBelowOffset: _fetchPositions.GetValueOrDefault(tp, -1));
+                                skipRecordsBelowOffset: _fetchPositions.GetValueOrDefault(tp, -1),
+                                stopAtOffsetExclusive: GetSnapshotEndOffset(tp));
 
                             // Collect for later - we'll assign memory owner to the last one
                             pendingItems.Add(pending);
@@ -3539,6 +3905,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 DisposePendingFetches(pendingItems);
                                 throw stuckError;
                             }
+
+                            if (TryCreateSnapshotEndMarker(tp, partitionResponse) is { } marker)
+                                pendingItems.Add(marker);
                         }
                     }
                 }
@@ -3595,7 +3964,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// </summary>
     private bool FlushConsumedPositions(PendingFetchData pending)
     {
-        if (!TryGetConsumedPosition(pending, out var tp, out var nextOffset, out var leaderEpoch))
+        // A staged reset/revocation invalidates unread protocol progress from this fetch.
+        // Preserve only records already delivered; filtered/control offsets from the stale
+        // response must not overwrite the replacement position.
+        var includeFilteredProgress = !HasPendingFetchClear(pending.TopicPartition);
+        if (!TryGetConsumedPosition(
+                pending,
+                out var tp,
+                out var nextOffset,
+                out var leaderEpoch,
+                includeFilteredProgress))
             return false;
 
         // Positions always advance past everything yielded (delivery semantics), but the
@@ -3608,10 +3986,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         _positions[tp] = nextOffset;
         SetLastConsumedLeaderEpoch(tp, leaderEpoch);
 
-        var stagedFullYieldedRange = true;
+        var fullyTraversed = pending.IsExhausted && pending.FetchEndOffsetExclusive >= 0;
+        var allYieldedRecordsProven = pending.ProvenOffset == pending.LastYieldedOffset;
+        var stagedFullRange = true;
         if (_options.EnableAutoOffsetStore)
         {
-            if (EagerOffsetStore)
+            if (EagerOffsetStore || (fullyTraversed && allYieldedRecordsProven))
             {
                 StoreOffsetCore(tp, nextOffset, leaderEpoch);
             }
@@ -3619,7 +3999,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 if (pending.ProvenOffset >= 0)
                     StoreOffsetCore(tp, pending.ProvenOffset + 1, pending.ProvenLeaderEpoch);
-                stagedFullYieldedRange = pending.ProvenOffset + 1 >= nextOffset;
+                stagedFullRange = pending.ProvenOffset + 1 >= nextOffset;
             }
         }
 
@@ -3628,10 +4008,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             _fetchPositions[tp] = nextOffset;
         }
 
-        // Keep the active snapshot alive while an in-doubt record remains unstaged so a
+        // Keep the active consumed position alive while an in-doubt record remains unstaged so a
         // later explicit CommitAsync can still vouch for it (break → CommitAsync → close).
-        if (stagedFullYieldedRange)
-            ClearActiveConsumedPosition(tp, nextOffset);
+        if (stagedFullRange)
+            ClearActiveConsumedPosition(tp);
 
         return true;
     }
@@ -3928,9 +4308,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         PendingFetchData pending,
         out TopicPartition partition,
         out long nextOffset,
-        out int leaderEpoch)
+        out int leaderEpoch,
+        bool includeFilteredProgress = true)
     {
-        if (pending.LastYieldedOffset < 0)
+        var fullyTraversed = includeFilteredProgress
+                             && pending.IsExhausted
+                             && pending.FetchEndOffsetExclusive >= 0;
+        if (pending.LastYieldedOffset < 0 && !fullyTraversed)
         {
             partition = default;
             nextOffset = 0;
@@ -3939,8 +4323,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         partition = pending.TopicPartition;
-        nextOffset = pending.LastYieldedOffset + 1;
-        leaderEpoch = pending.LastYieldedLeaderEpoch;
+        if (fullyTraversed && pending.FetchEndOffsetExclusive > pending.LastYieldedOffset + 1)
+        {
+            nextOffset = pending.FetchEndOffsetExclusive;
+            leaderEpoch = pending.FetchEndLeaderEpoch;
+        }
+        else
+        {
+            nextOffset = pending.LastYieldedOffset + 1;
+            leaderEpoch = pending.LastYieldedLeaderEpoch;
+        }
         return true;
     }
 
@@ -4005,13 +4397,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void UpdateFetchPositionsFromPrefetch(PendingFetchData pending, int fetchBufferEpoch)
     {
-        // Calculate the last offset in the prefetched data
-        // We need to update fetch positions so next prefetch gets new data
-        var batches = pending.GetBatches();
-        if (batches.Count == 0) return;
+        var nextOffset = pending.FetchEndOffsetExclusive;
+        if (nextOffset < 0)
+            return;
 
-        var lastBatch = batches[^1];
-        var lastOffset = lastBatch.BaseOffset + lastBatch.LastOffsetDelta;
         var tp = pending.TopicPartition;
 
         // Thread-safe update using ConcurrentDictionary — must use AddOrUpdate (not TryGetValue
@@ -4019,7 +4408,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // concurrently, and AddOrUpdate's CAS loop prevents TOCTOU races from overwriting a
         // concurrent seek-forward with a stale prefetch offset.
         // Uses the factoryArgument overload with static lambdas to avoid closure allocation.
-        var nextOffset = lastOffset + 1;
         var update = (Consumer: this, FetchBufferEpoch: fetchBufferEpoch, NextOffset: nextOffset);
         _fetchPositions.AddOrUpdate(
             tp,
@@ -4060,6 +4448,35 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         return null;
+    }
+
+    private PendingFetchData? TryCreateSnapshotEndMarker(
+        TopicPartition partition,
+        FetchResponsePartition response)
+    {
+        var snapshot = Volatile.Read(ref _activeSnapshot);
+        if (snapshot is null)
+            return null;
+
+        var visibleEndOffset = _options.IsolationLevel == IsolationLevel.ReadCommitted
+                               && response.LastStableOffset >= 0
+            ? response.LastStableOffset
+            : response.HighWatermark;
+        return snapshot.TryQueueEndMarker(partition, visibleEndOffset, out var endOffset)
+            ? PendingFetchData.CreateSnapshotEnd(
+                partition.Topic,
+                partition.Partition,
+                endOffset,
+                snapshot)
+            : null;
+    }
+
+    private long GetSnapshotEndOffset(TopicPartition partition)
+    {
+        var snapshot = Volatile.Read(ref _activeSnapshot);
+        return snapshot is not null && snapshot.TryGetEndOffset(partition, out var endOffset)
+            ? endOffset
+            : -1;
     }
 
     /// <summary>
@@ -6039,11 +6456,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             foreach (var pending in _pendingFetches)
             {
+                // The reset invalidates the fetch epoch. Preserve only delivered records;
+                // filtered/control progress from that stale fetch cannot override the broker's
+                // divergence boundary.
                 if (TryGetConsumedPosition(
                         pending,
                         out var pendingPartition,
                         out var nextOffset,
-                        out var pendingLeaderEpoch)
+                        out var pendingLeaderEpoch,
+                        includeFilteredProgress: false)
                     && pendingPartition.Equals(partition))
                 {
                     resumeOffset = Math.Max(
@@ -7562,10 +7983,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             var maxPartitions = snapshot.Count;
             assignmentArray = ArrayPool<TopicPartition>.Shared.Rent(maxPartitions);
             assignmentCount = 0;
+            var activeSnapshot = Volatile.Read(ref _activeSnapshot);
 
             foreach (var partition in snapshot)
             {
-                if (!_paused.ContainsKey(partition))
+                if (!_paused.ContainsKey(partition)
+                    && (activeSnapshot is null || !activeSnapshot.IsPartitionComplete(partition)))
                 {
                     assignmentArray[assignmentCount++] = partition;
                 }
@@ -8157,7 +8580,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             records,
                             partitionResponse.AbortedTransactions,
                             activityName: activityName,
-                            skipRecordsBelowOffset: _fetchPositions.GetValueOrDefault(tp, -1)));
+                            skipRecordsBelowOffset: _fetchPositions.GetValueOrDefault(tp, -1),
+                            stopAtOffsetExclusive: GetSnapshotEndOffset(tp)));
                     }
                     else
                     {
@@ -8172,6 +8596,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             }
 
                             throw stuckError;
+                        }
+
+                        if (TryCreateSnapshotEndMarker(tp, partitionResponse) is { } marker)
+                        {
+                            pendingItems ??= ConsumerFetchPools.RentPendingFetchDataList();
+                            pendingItems.Add(marker);
                         }
                     }
                 }

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -1,4 +1,12 @@
 #nullable enable
+Dekaf.Consumer.BoundedConsumerExtensions
+Dekaf.Consumer.IBoundedKafkaConsumer<TKey, TValue>
+Dekaf.Consumer.IBoundedKafkaConsumer<TKey, TValue>.ConsumeSnapshotAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Dekaf.Consumer.ConsumeResult<TKey, TValue>>!
+Dekaf.Consumer.IBoundedKafkaConsumer<TKey, TValue>.SeekToTailAsync(Dekaf.TopicPartition partition, int offsetCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.TopicPartitionOffset>
+Dekaf.Consumer.KafkaConsumer<TKey, TValue>.ConsumeSnapshotAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Dekaf.Consumer.ConsumeResult<TKey, TValue>>!
+Dekaf.Consumer.KafkaConsumer<TKey, TValue>.SeekToTailAsync(Dekaf.TopicPartition partition, int offsetCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.TopicPartitionOffset>
+static Dekaf.Consumer.BoundedConsumerExtensions.ConsumeSnapshotAsync<TKey, TValue>(this Dekaf.Consumer.IKafkaConsumer<TKey, TValue>! consumer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Dekaf.Consumer.ConsumeResult<TKey, TValue>>!
+static Dekaf.Consumer.BoundedConsumerExtensions.SeekToTailAsync<TKey, TValue>(this Dekaf.Consumer.IKafkaConsumer<TKey, TValue>! consumer, Dekaf.TopicPartition partition, int offsetCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.TopicPartitionOffset>
 Dekaf.Serialization.SerializationContext.IsKeyNull.get -> bool
 Dekaf.Serialization.SerializationContext.KeyData.get -> System.ReadOnlyMemory<byte>
 Dekaf.Serialization.SerializationContext.KeyData.set -> void

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -1,4 +1,12 @@
 #nullable enable
+Dekaf.Consumer.BoundedConsumerExtensions
+Dekaf.Consumer.IBoundedKafkaConsumer<TKey, TValue>
+Dekaf.Consumer.IBoundedKafkaConsumer<TKey, TValue>.ConsumeSnapshotAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Dekaf.Consumer.ConsumeResult<TKey, TValue>>!
+Dekaf.Consumer.IBoundedKafkaConsumer<TKey, TValue>.SeekToTailAsync(Dekaf.TopicPartition partition, int offsetCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.TopicPartitionOffset>
+Dekaf.Consumer.KafkaConsumer<TKey, TValue>.ConsumeSnapshotAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Dekaf.Consumer.ConsumeResult<TKey, TValue>>!
+Dekaf.Consumer.KafkaConsumer<TKey, TValue>.SeekToTailAsync(Dekaf.TopicPartition partition, int offsetCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.TopicPartitionOffset>
+static Dekaf.Consumer.BoundedConsumerExtensions.ConsumeSnapshotAsync<TKey, TValue>(this Dekaf.Consumer.IKafkaConsumer<TKey, TValue>! consumer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Dekaf.Consumer.ConsumeResult<TKey, TValue>>!
+static Dekaf.Consumer.BoundedConsumerExtensions.SeekToTailAsync<TKey, TValue>(this Dekaf.Consumer.IKafkaConsumer<TKey, TValue>! consumer, Dekaf.TopicPartition partition, int offsetCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.TopicPartitionOffset>
 Dekaf.Serialization.SerializationContext.IsKeyNull.get -> bool
 Dekaf.Serialization.SerializationContext.KeyData.get -> System.ReadOnlyMemory<byte>
 Dekaf.Serialization.SerializationContext.KeyData.set -> void

--- a/tests/Dekaf.Tests.Integration/ConsumerSnapshotIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerSnapshotIntegrationTests.cs
@@ -169,13 +169,16 @@ public sealed class ConsumerSnapshotIntegrationTests(KafkaTestContainer kafka)
         var partition = new TopicPartition(topic, 0);
         consumer.Partitions.Assign(partition);
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var capturedWatermarks = await WaitForConditionAsync(
+            async () => await consumer.Offsets.QueryWatermarkOffsetsAsync(partition, timeout.Token)
+                .ConfigureAwait(false),
+            static watermarks => watermarks.High >= 4,
+            description: "aborted transaction watermark visibility").ConfigureAwait(false);
 
         var records = await CollectAsync(consumer.ConsumeSnapshotAsync(timeout.Token)).ConfigureAwait(false);
-        var watermarks = await consumer.Offsets.QueryWatermarkOffsetsAsync(partition, timeout.Token)
-            .ConfigureAwait(false);
 
         await Assert.That(records).IsEmpty();
-        await Assert.That(consumer.Positions.GetPosition(partition)).IsEqualTo(watermarks.High);
+        await Assert.That(consumer.Positions.GetPosition(partition)).IsEqualTo(capturedWatermarks.High);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Integration/ConsumerSnapshotIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerSnapshotIntegrationTests.cs
@@ -222,11 +222,13 @@ public sealed class ConsumerSnapshotIntegrationTests(KafkaTestContainer kafka)
         await ProduceRangeAsync(topic, partition: 0, count: 3).ConfigureAwait(false);
         await ProduceRangeAsync(topic, partition: 1, count: 3).ConfigureAwait(false);
         var groupId = $"snapshot-rebalance-{Guid.NewGuid():N}";
+        var rebalanceListener = new RevocationListener();
         await using var firstConsumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithGroupId(groupId)
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
             .WithQueuedMinMessages(1)
+            .WithRebalanceListener(rebalanceListener)
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync().ConfigureAwait(false);
         firstConsumer.Subscribe(topic);
@@ -245,21 +247,10 @@ public sealed class ConsumerSnapshotIntegrationTests(KafkaTestContainer kafka)
         var secondResult = await secondConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), timeout.Token)
             .ConfigureAwait(false);
         await Assert.That(secondResult).IsNotNull();
+        await rebalanceListener.WaitForRevocationAsync(timeout.Token).ConfigureAwait(false);
 
-        var assignmentInvalidated = false;
-        try
-        {
-            while (await snapshot.MoveNextAsync())
-            {
-                // Drain until the rebalance invalidates the captured assignment.
-            }
-        }
-        catch (InvalidOperationException)
-        {
-            assignmentInvalidated = true;
-        }
-
-        await Assert.That(assignmentInvalidated).IsTrue();
+        await Assert.That(async () => await snapshot.MoveNextAsync().AsTask())
+            .Throws<InvalidOperationException>();
     }
 
     private async ValueTask<IKafkaConsumer<string, string>> CreateConsumerAsync(
@@ -311,5 +302,30 @@ public sealed class ConsumerSnapshotIntegrationTests(KafkaTestContainer kafka)
         await foreach (var record in source.ConfigureAwait(false))
             records.Add(record);
         return records;
+    }
+
+    private sealed class RevocationListener : IRebalanceListener
+    {
+        private readonly TaskCompletionSource _revoked = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ValueTask OnPartitionsAssignedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+        public ValueTask OnPartitionsRevokedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            _revoked.TrySetResult();
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnPartitionsLostAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+        public Task WaitForRevocationAsync(CancellationToken cancellationToken) =>
+            _revoked.Task.WaitAsync(cancellationToken);
     }
 }

--- a/tests/Dekaf.Tests.Integration/ConsumerSnapshotIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerSnapshotIntegrationTests.cs
@@ -167,6 +167,30 @@ public sealed class ConsumerSnapshotIntegrationTests(KafkaTestContainer kafka)
     }
 
     [Test]
+    public async Task ConsumeSnapshotAsync_PauseDuringSynchronousDeserializationDoesNotAdvance()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        await ProduceRangeAsync(topic, partition: 0, count: 1).ConfigureAwait(false);
+        var deserializer = new CallbackDeserializer();
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithQueuedMinMessages(1)
+            .WithValueDeserializer(deserializer)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync().ConfigureAwait(false);
+        var partition = new TopicPartition(topic, 0);
+        consumer.Partitions.Assign(partition);
+        deserializer.SetCallback(() => consumer.Partitions.Pause(partition));
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await using var snapshot = consumer.ConsumeSnapshotAsync(timeout.Token).GetAsyncEnumerator();
+
+        await Assert.That(async () => await snapshot.MoveNextAsync().AsTask().ConfigureAwait(false))
+            .Throws<InvalidOperationException>();
+        await Assert.That(consumer.Positions.GetPosition(partition)).IsEqualTo(0L);
+    }
+
+    [Test]
     public async Task ConsumeSnapshotAsync_StateChangeAfterFinalYieldThrows()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
@@ -441,5 +465,18 @@ public sealed class ConsumerSnapshotIntegrationTests(KafkaTestContainer kafka)
             _blocked.Task.WaitAsync(cancellationToken);
 
         public void Release() => _release.TrySetResult();
+    }
+
+    private sealed class CallbackDeserializer : IDeserializer<string>
+    {
+        private Action? _callback;
+
+        internal void SetCallback(Action callback) => _callback = callback;
+
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            Interlocked.Exchange(ref _callback, null)?.Invoke();
+            return Encoding.UTF8.GetString(data.Span);
+        }
     }
 }

--- a/tests/Dekaf.Tests.Integration/ConsumerSnapshotIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerSnapshotIntegrationTests.cs
@@ -1,0 +1,244 @@
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Consumer")]
+public sealed class ConsumerSnapshotIntegrationTests(KafkaTestContainer kafka)
+    : TransactionalKafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task ConsumeSnapshotAsync_EmptyPartitionCompletesWithoutWaiting()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        await using var consumer = await CreateConsumerAsync(queuedMinMessages: 10).ConfigureAwait(false);
+        consumer.Partitions.Assign(new TopicPartition(topic, 0));
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        var records = await CollectAsync(consumer.ConsumeSnapshotAsync(timeout.Token)).ConfigureAwait(false);
+
+        await Assert.That(records).IsEmpty();
+    }
+
+    [Test]
+    public async Task SeekToTailAndSnapshot_MultiplePartitionsReturnFinalOffsetsWithPrefetch()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2).ConfigureAwait(false);
+        await ProduceRangeAsync(topic, partition: 0, count: 5).ConfigureAwait(false);
+        await ProduceRangeAsync(topic, partition: 1, count: 5).ConfigureAwait(false);
+        await using var consumer = await CreateConsumerAsync(queuedMinMessages: 10).ConfigureAwait(false);
+        var partition0 = new TopicPartition(topic, 0);
+        var partition1 = new TopicPartition(topic, 1);
+        consumer.Partitions.Assign(partition0, partition1);
+        await consumer.SeekToTailAsync(partition0, 2).ConfigureAwait(false);
+        await consumer.SeekToTailAsync(partition1, 2).ConfigureAwait(false);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var records = await CollectAsync(consumer.ConsumeSnapshotAsync(timeout.Token)).ConfigureAwait(false);
+
+        await Assert.That(records).Count().IsEqualTo(4);
+        await Assert.That(records.Where(record => record.Partition == 0).Select(record => record.Offset))
+            .IsEquivalentTo([3L, 4L]);
+        await Assert.That(records.Where(record => record.Partition == 1).Select(record => record.Offset))
+            .IsEquivalentTo([3L, 4L]);
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_RecordAppendedAfterCaptureIsLeftForNormalConsumption()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        await ProduceRangeAsync(topic, partition: 0, count: 2).ConfigureAwait(false);
+        await using var consumer = await CreateConsumerAsync(queuedMinMessages: 10).ConfigureAwait(false);
+        consumer.Partitions.Assign(new TopicPartition(topic, 0));
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await using var snapshot = consumer.ConsumeSnapshotAsync(timeout.Token).GetAsyncEnumerator();
+
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+        var first = snapshot.Current;
+        await ProduceRangeAsync(topic, partition: 0, start: 2, count: 1).ConfigureAwait(false);
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+        var second = snapshot.Current;
+        await Assert.That(await snapshot.MoveNextAsync()).IsFalse();
+        var appended = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(15), timeout.Token)
+            .ConfigureAwait(false);
+
+        await Assert.That(new[] { first.Offset, second.Offset }).IsEquivalentTo([0L, 1L]);
+        await Assert.That(appended).IsNotNull();
+        await Assert.That(appended!.Value.Offset).IsEqualTo(2L);
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_ReadCommittedAbortedOnlyLogCompletesWithoutRecords()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithTransactionalId($"snapshot-abort-{Guid.NewGuid():N}")
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync().ConfigureAwait(false);
+        await producer.InitTransactionsAsync().ConfigureAwait(false);
+        await using (var transaction = producer.BeginTransaction())
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                await transaction.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic,
+                    Partition = 0,
+                    Key = $"aborted-{i}",
+                    Value = $"aborted-{i}"
+                }, CancellationToken.None).ConfigureAwait(false);
+            }
+
+            await transaction.AbortAsync().ConfigureAwait(false);
+        }
+
+        await using var consumer = await CreateConsumerAsync(
+            queuedMinMessages: 1,
+            isolationLevel: IsolationLevel.ReadCommitted).ConfigureAwait(false);
+        var partition = new TopicPartition(topic, 0);
+        consumer.Partitions.Assign(partition);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var records = await CollectAsync(consumer.ConsumeSnapshotAsync(timeout.Token)).ConfigureAwait(false);
+        var watermarks = await consumer.Offsets.QueryWatermarkOffsetsAsync(partition, timeout.Token)
+            .ConfigureAwait(false);
+
+        await Assert.That(records).IsEmpty();
+        await Assert.That(consumer.Positions.GetPosition(partition)).IsEqualTo(watermarks.High);
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_RetentionGapResetsAndCompletesAtCapturedEnd()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        await ProduceRangeAsync(topic, partition: 0, count: 10, valueSize: 8 * 1024).ConfigureAwait(false);
+        var partition = new TopicPartition(topic, 0);
+        await using var consumer = await CreateConsumerAsync(
+            queuedMinMessages: 1,
+            maxPartitionFetchBytes: 9 * 1024).ConfigureAwait(false);
+        consumer.Partitions.Assign(partition);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await using var snapshot = consumer.ConsumeSnapshotAsync(timeout.Token).GetAsyncEnumerator();
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+        var offsets = new List<long> { snapshot.Current.Offset };
+
+        await using (var admin = new AdminClientBuilder()
+                         .WithBootstrapServers(KafkaContainer.BootstrapServers)
+                         .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+                         .Build())
+        {
+            var deleted = await admin.DeleteRecordsAsync(new Dictionary<TopicPartition, long>
+            {
+                [partition] = 5
+            }).ConfigureAwait(false);
+            await Assert.That(deleted[partition]).IsGreaterThanOrEqualTo(5L);
+        }
+
+        while (await snapshot.MoveNextAsync())
+            offsets.Add(snapshot.Current.Offset);
+
+        await Assert.That(offsets).IsEquivalentTo([0L, 5L, 6L, 7L, 8L, 9L]);
+        await Assert.That(consumer.Positions.GetPosition(partition)).IsEqualTo(10L);
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_GroupRebalanceInvalidatesCapturedAssignment()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2).ConfigureAwait(false);
+        await ProduceRangeAsync(topic, partition: 0, count: 3).ConfigureAwait(false);
+        await ProduceRangeAsync(topic, partition: 1, count: 3).ConfigureAwait(false);
+        var groupId = $"snapshot-rebalance-{Guid.NewGuid():N}";
+        await using var firstConsumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithQueuedMinMessages(1)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync().ConfigureAwait(false);
+        firstConsumer.Subscribe(topic);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(45));
+        await using var snapshot = firstConsumer.ConsumeSnapshotAsync(timeout.Token).GetAsyncEnumerator();
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+
+        await using var secondConsumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithQueuedMinMessages(1)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync().ConfigureAwait(false);
+        secondConsumer.Subscribe(topic);
+        var secondResult = await secondConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), timeout.Token)
+            .ConfigureAwait(false);
+        await Assert.That(secondResult).IsNotNull();
+
+        var assignmentInvalidated = false;
+        try
+        {
+            while (await snapshot.MoveNextAsync())
+            {
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            assignmentInvalidated = true;
+        }
+
+        await Assert.That(assignmentInvalidated).IsTrue();
+    }
+
+    private async ValueTask<IKafkaConsumer<string, string>> CreateConsumerAsync(
+        int queuedMinMessages,
+        IsolationLevel isolationLevel = IsolationLevel.ReadUncommitted,
+        int? maxPartitionFetchBytes = null)
+    {
+        var builder = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithQueuedMinMessages(queuedMinMessages)
+            .WithIsolationLevel(isolationLevel)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory());
+        if (maxPartitionFetchBytes.HasValue)
+            builder.WithMaxPartitionFetchBytes(maxPartitionFetchBytes.Value);
+
+        return await builder.BuildAsync().ConfigureAwait(false);
+    }
+
+    private async Task ProduceRangeAsync(
+        string topic,
+        int partition,
+        int count,
+        int start = 0,
+        int valueSize = 0)
+    {
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync().ConfigureAwait(false);
+
+        for (var i = start; i < start + count; i++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = partition,
+                Key = $"key-{i}",
+                Value = valueSize > 0 ? new string((char)('a' + i % 26), valueSize) : $"value-{i}"
+            }, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<List<ConsumeResult<string, string>>> CollectAsync(
+        IAsyncEnumerable<ConsumeResult<string, string>> source)
+    {
+        var records = new List<ConsumeResult<string, string>>();
+        await foreach (var record in source.ConfigureAwait(false))
+            records.Add(record);
+        return records;
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ConsumerSnapshotIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerSnapshotIntegrationTests.cs
@@ -1,7 +1,9 @@
+using System.Text;
 using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Integration;
 
@@ -134,6 +136,90 @@ public sealed class ConsumerSnapshotIntegrationTests(KafkaTestContainer kafka)
             .Throws<InvalidOperationException>();
         await Assert.That(() => consumer.SeekToEnd(partition))
             .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_PauseDuringAsyncDeserializationDoesNotAdvance()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        await ProduceRangeAsync(topic, partition: 0, count: 1).ConfigureAwait(false);
+        var deserializer = new BlockingAsyncDeserializer(blockOnCall: 1);
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithQueuedMinMessages(1)
+            .WithValueDeserializer(deserializer)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync().ConfigureAwait(false);
+        var partition = new TopicPartition(topic, 0);
+        consumer.Partitions.Assign(partition);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await using var snapshot = consumer.ConsumeSnapshotAsync(timeout.Token).GetAsyncEnumerator();
+        var moveNext = snapshot.MoveNextAsync().AsTask();
+        await deserializer.WaitUntilBlockedAsync(timeout.Token).ConfigureAwait(false);
+
+        consumer.Partitions.Pause(partition);
+        deserializer.Release();
+
+        await Assert.That(async () => await moveNext.ConfigureAwait(false))
+            .Throws<InvalidOperationException>();
+        await Assert.That(consumer.Positions.GetPosition(partition)).IsEqualTo(0L);
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_StateChangeAfterFinalYieldThrows()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        await ProduceRangeAsync(topic, partition: 0, count: 1).ConfigureAwait(false);
+        await using var consumer = await CreateConsumerAsync(queuedMinMessages: 1).ConfigureAwait(false);
+        var partition = new TopicPartition(topic, 0);
+        consumer.Partitions.Assign(partition);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await using var snapshot = consumer.ConsumeSnapshotAsync(timeout.Token).GetAsyncEnumerator();
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+
+        consumer.Partitions.Pause(partition);
+
+        await Assert.That(async () => await snapshot.MoveNextAsync().AsTask())
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_CanceledStartProvesPriorDelivery()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        await ProduceRangeAsync(topic, partition: 0, count: 2).ConfigureAwait(false);
+        var groupId = $"snapshot-prior-delivery-{Guid.NewGuid():N}";
+        var deserializer = new BlockingAsyncDeserializer(blockOnCall: 2);
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithQueuedMinMessages(1)
+            .WithValueDeserializer(deserializer)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync().ConfigureAwait(false);
+        var partition = new TopicPartition(topic, 0);
+        consumer.Subscribe(topic);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(45));
+        await using (var normal = consumer.ConsumeAsync(timeout.Token).GetAsyncEnumerator())
+        {
+            await Assert.That(await normal.MoveNextAsync()).IsTrue();
+            await Assert.That(normal.Current.Offset).IsEqualTo(0L);
+        }
+
+        using var snapshotCancellation = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token);
+        await using var snapshot = consumer.ConsumeSnapshotAsync(snapshotCancellation.Token).GetAsyncEnumerator();
+        var moveNext = snapshot.MoveNextAsync().AsTask();
+        await deserializer.WaitUntilBlockedAsync(timeout.Token).ConfigureAwait(false);
+        snapshotCancellation.Cancel();
+        deserializer.Release();
+        await Assert.That(async () => await moveNext.ConfigureAwait(false))
+            .Throws<OperationCanceledException>();
+
+        await consumer.CommitAsync(timeout.Token).ConfigureAwait(false);
+        var committed = await consumer.GetCommittedOffsetAsync(partition, timeout.Token).ConfigureAwait(false);
+        await Assert.That(committed).IsEqualTo(1L);
     }
 
     [Test]
@@ -327,5 +413,33 @@ public sealed class ConsumerSnapshotIntegrationTests(KafkaTestContainer kafka)
 
         public Task WaitForRevocationAsync(CancellationToken cancellationToken) =>
             _revoked.Task.WaitAsync(cancellationToken);
+    }
+
+    private sealed class BlockingAsyncDeserializer(int blockOnCall) : IAsyncDeserializer<string>
+    {
+        private readonly TaskCompletionSource _blocked = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _callCount;
+
+        public async ValueTask<string> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Increment(ref _callCount) == blockOnCall)
+            {
+                _blocked.TrySetResult();
+                await _release.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            return Encoding.UTF8.GetString(data.Span);
+        }
+
+        public Task WaitUntilBlockedAsync(CancellationToken cancellationToken) =>
+            _blocked.Task.WaitAsync(cancellationToken);
+
+        public void Release() => _release.TrySetResult();
     }
 }

--- a/tests/Dekaf.Tests.Integration/ConsumerSnapshotIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerSnapshotIntegrationTests.cs
@@ -70,6 +70,73 @@ public sealed class ConsumerSnapshotIntegrationTests(KafkaTestContainer kafka)
     }
 
     [Test]
+    public async Task ConsumeSnapshotAsync_PrefetchedCursorAheadUsesDeliveredPosition()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        await ProduceRangeAsync(topic, partition: 0, count: 5).ConfigureAwait(false);
+        await using var consumer = await CreateConsumerAsync(queuedMinMessages: 10).ConfigureAwait(false);
+        consumer.Partitions.Assign(new TopicPartition(topic, 0));
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var first = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(15), timeout.Token)
+            .ConfigureAwait(false);
+        var remaining = await CollectAsync(consumer.ConsumeSnapshotAsync(timeout.Token)).ConfigureAwait(false);
+
+        await Assert.That(first).IsNotNull();
+        await Assert.That(first!.Value.Offset).IsEqualTo(0L);
+        await Assert.That(remaining.Select(static record => record.Offset))
+            .IsEquivalentTo([1L, 2L, 3L, 4L]);
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_EarlyDisposeDoesNotLeakSnapshotEofToNormalConsume()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        await ProduceRangeAsync(topic, partition: 0, count: 5).ConfigureAwait(false);
+        await using var consumer = await CreateConsumerAsync(queuedMinMessages: 10).ConfigureAwait(false);
+        consumer.Partitions.Assign(new TopicPartition(topic, 0));
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var snapshot = consumer.ConsumeSnapshotAsync(timeout.Token).GetAsyncEnumerator();
+
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+        await Assert.That(snapshot.Current.Offset).IsEqualTo(0L);
+        await snapshot.DisposeAsync();
+        await ProduceRangeAsync(topic, partition: 0, start: 5, count: 1).ConfigureAwait(false);
+
+        var offsets = new List<long>();
+        for (var i = 0; i < 5; i++)
+        {
+            var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(15), timeout.Token)
+                .ConfigureAwait(false);
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!.Value.IsPartitionEof).IsFalse();
+            offsets.Add(result.Value.Offset);
+        }
+
+        await Assert.That(offsets).IsEquivalentTo([1L, 2L, 3L, 4L, 5L]);
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_SeekDuringEnumerationThrows()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        await ProduceRangeAsync(topic, partition: 0, count: 2).ConfigureAwait(false);
+        await using var consumer = await CreateConsumerAsync(queuedMinMessages: 1).ConfigureAwait(false);
+        var partition = new TopicPartition(topic, 0);
+        consumer.Partitions.Assign(partition);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await using var snapshot = consumer.ConsumeSnapshotAsync(timeout.Token).GetAsyncEnumerator();
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+
+        await Assert.That(() => consumer.Seek(new TopicPartitionOffset(topic, 0, 0)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => consumer.SeekToBeginning(partition))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => consumer.SeekToEnd(partition))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task ConsumeSnapshotAsync_ReadCommittedAbortedOnlyLogCompletesWithoutRecords()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
@@ -181,6 +248,7 @@ public sealed class ConsumerSnapshotIntegrationTests(KafkaTestContainer kafka)
         {
             while (await snapshot.MoveNextAsync())
             {
+                // Drain until the rebalance invalidates the captured assignment.
             }
         }
         catch (InvalidOperationException)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
@@ -236,6 +236,42 @@ public class ConsumeBatchTests
         }
     }
 
+    [Test]
+    public async Task BatchIterationEpoch_DeliveryGateSerializesPublication()
+    {
+        var epoch = new BatchIterationEpoch();
+        var deliveryVersion = epoch.Version;
+        await Assert.That(epoch.TryBeginSnapshotDelivery(deliveryVersion)).IsTrue();
+        using var publicationEntered = new ManualResetEventSlim();
+        var publisher = new Thread(() =>
+        {
+            epoch.BeginPublication();
+            publicationEntered.Set();
+            epoch.EndPublication();
+        })
+        {
+            IsBackground = true
+        };
+
+        try
+        {
+            publisher.Start();
+            await Assert.That(SpinWait.SpinUntil(
+                    () => Volatile.Read(ref epoch.ConsumeOneDeliveryChangesPending) != 0,
+                    TimeSpan.FromSeconds(5)))
+                .IsTrue();
+            await Assert.That(publicationEntered.IsSet).IsFalse();
+        }
+        finally
+        {
+            epoch.EndSnapshotDelivery(deliveryVersion);
+        }
+
+        await Assert.That(publicationEntered.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+        await Assert.That(publisher.Join(TimeSpan.FromSeconds(5))).IsTrue();
+        await Assert.That(epoch.Version & 1).IsEqualTo(0);
+    }
+
     /// <summary>
     /// Creates a PendingFetchData with a single RecordBatch containing the specified number of records.
     /// </summary>

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -339,6 +339,30 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
+    public async Task ResetToDivergingEpoch_DoesNotPreserveFilteredNewEpochProgress()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        var partition = new TopicPartition(Topic, 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
+
+        var pending = CreatePendingFetchData(leaderEpoch: 9, baseOffset: 43);
+        while (pending.MoveNext())
+        {
+            // Exhaust the stale fetch without delivering any records.
+        }
+        GetPendingFetches(consumer).Enqueue(pending);
+
+        InvokeResetToDivergingEpoch(
+            consumer,
+            CreateDivergingEpochResponse(epoch: 7, endOffset: 42));
+
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.GetPosition(partition)).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ResetToDivergingEpoch_ClearsActiveAutoCommitSnapshot()
     {
         var pool = Substitute.For<IConnectionPool>();
@@ -871,7 +895,7 @@ public sealed class ConsumerLeaderDiscoveryTests
             }
         };
 
-    private static PendingFetchData CreatePendingFetchData(int leaderEpoch = -1)
+    private static PendingFetchData CreatePendingFetchData(int leaderEpoch = -1, long baseOffset = 0)
     {
         var records = new Record[3];
         for (var i = 0; i < records.Length; i++)
@@ -887,7 +911,7 @@ public sealed class ConsumerLeaderDiscoveryTests
         var pending = PendingFetchData.Create(
             Topic,
             partitionIndex: 0,
-            [new RecordBatch { BaseOffset = 0, PartitionLeaderEpoch = leaderEpoch, Records = records }]);
+            [new RecordBatch { BaseOffset = baseOffset, PartitionLeaderEpoch = leaderEpoch, Records = records }]);
         pending.EagerParseAll();
         return pending;
     }
@@ -1040,7 +1064,7 @@ public sealed class ConsumerLeaderDiscoveryTests
             .GetMethod("TryGetActiveConsumedPosition", BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("TryGetActiveConsumedPosition method not found");
 
-        object?[] arguments = [partition, 0L, -1];
+        object?[] arguments = [partition, 0L, -1, true];
         if (!(bool)method.Invoke(consumer, arguments)!)
             return null;
 

--- a/tests/Dekaf.Tests.Unit/Consumer/SnapshotConsumptionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/SnapshotConsumptionTests.cs
@@ -146,6 +146,28 @@ public sealed class SnapshotConsumptionTests
     }
 
     [Test]
+    public async Task SnapshotBound_DoesNotEagerlyParseWholePostBoundLazyBatch()
+    {
+        var records = LazyRecordList.Create(new byte[] { 0x02 }, count: 1024);
+        var batch = new RecordBatch
+        {
+            BaseOffset = 100,
+            LastOffsetDelta = records.Count - 1,
+            Records = records
+        };
+        using var pending = PendingFetchData.Create(
+            Partition0.Topic,
+            Partition0.Partition,
+            [batch],
+            stopAtOffsetExclusive: 50);
+
+        pending.EagerParseAll();
+
+        await Assert.That(pending.MoveNext()).IsFalse();
+        await Assert.That(pending.IsExhausted).IsTrue();
+    }
+
+    [Test]
     public async Task DiscardedSnapshotEndMarker_CanBeQueuedAgain()
     {
         var state = new SnapshotConsumeState(new Dictionary<TopicPartition, long>

--- a/tests/Dekaf.Tests.Unit/Consumer/SnapshotConsumptionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/SnapshotConsumptionTests.cs
@@ -125,6 +125,27 @@ public sealed class SnapshotConsumptionTests
     }
 
     [Test]
+    public async Task SnapshotBound_SkipsPostBoundBatchWithoutRecordScan()
+    {
+        var records = new ThrowOnAccessRecordList(count: 1024);
+        var batch = new RecordBatch
+        {
+            BaseOffset = 100,
+            LastOffsetDelta = records.Count - 1,
+            Records = records
+        };
+        using var pending = PendingFetchData.Create(
+            Partition0.Topic,
+            Partition0.Partition,
+            [batch],
+            stopAtOffsetExclusive: 50);
+        pending.EagerParseAll();
+
+        await Assert.That(pending.MoveNext()).IsFalse();
+        await Assert.That(pending.IsExhausted).IsTrue();
+    }
+
+    [Test]
     public async Task DiscardedSnapshotEndMarker_CanBeQueuedAgain()
     {
         var state = new SnapshotConsumeState(new Dictionary<TopicPartition, long>
@@ -152,5 +173,19 @@ public sealed class SnapshotConsumptionTests
             "FlushConsumedPositions",
             BindingFlags.Instance | BindingFlags.NonPublic)!;
         return (bool)method.Invoke(consumer, [pending])!;
+    }
+
+    private sealed class ThrowOnAccessRecordList(int count) : IReadOnlyList<Record>
+    {
+        public int Count { get; } = count;
+
+        public Record this[int index] =>
+            throw new InvalidOperationException($"Record {index} should not be inspected.");
+
+        public IEnumerator<Record> GetEnumerator() =>
+            throw new InvalidOperationException("Records should not be enumerated.");
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() =>
+            GetEnumerator();
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/SnapshotConsumptionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/SnapshotConsumptionTests.cs
@@ -64,6 +64,22 @@ public sealed class SnapshotConsumptionTests
     }
 
     [Test]
+    public async Task SnapshotState_ExplicitInvalidationThrows()
+    {
+        var assignment = new HashSet<TopicPartition> { Partition0 };
+        var paused = new HashSet<TopicPartition>();
+        var state = new SnapshotConsumeState(new Dictionary<TopicPartition, long>
+        {
+            [Partition0] = 10
+        }, assignment, paused);
+
+        state.InvalidateConsumerState();
+
+        await Assert.That(() => state.ThrowIfConsumerStateChanged(assignment, paused))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
     [Arguments(RecordBatchAttributes.IsControlBatch, false)]
     [Arguments(RecordBatchAttributes.IsTransactional, true)]
     public async Task ExhaustedFilteredBatch_AdvancesConsumerPosition(
@@ -165,6 +181,40 @@ public sealed class SnapshotConsumptionTests
 
         await Assert.That(pending.MoveNext()).IsFalse();
         await Assert.That(pending.IsExhausted).IsTrue();
+    }
+
+    [Test]
+    public async Task SnapshotBound_UsesLeaderEpochFromBoundaryBatch()
+    {
+        var beforeBoundary = new RecordBatch
+        {
+            BaseOffset = 0,
+            LastOffsetDelta = 9,
+            PartitionLeaderEpoch = 3,
+            Records = []
+        };
+        var boundaryBatch = new RecordBatch
+        {
+            BaseOffset = 10,
+            LastOffsetDelta = 9,
+            PartitionLeaderEpoch = 4,
+            Records = []
+        };
+        var trailingBatch = new RecordBatch
+        {
+            BaseOffset = 20,
+            LastOffsetDelta = 9,
+            PartitionLeaderEpoch = 5,
+            Records = []
+        };
+        using var pending = PendingFetchData.Create(
+            Partition0.Topic,
+            Partition0.Partition,
+            [beforeBoundary, boundaryBatch, trailingBatch],
+            stopAtOffsetExclusive: 15);
+
+        await Assert.That(pending.FetchEndOffsetExclusive).IsEqualTo(15L);
+        await Assert.That(pending.FetchEndLeaderEpoch).IsEqualTo(4);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/SnapshotConsumptionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/SnapshotConsumptionTests.cs
@@ -1,0 +1,156 @@
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class SnapshotConsumptionTests
+{
+    private static readonly TopicPartition Partition0 = new("orders", 0);
+    private static readonly TopicPartition Partition1 = new("orders", 1);
+
+    [Test]
+    public async Task SnapshotState_CompletesOnlyAfterEveryCapturedPartition()
+    {
+        var state = new SnapshotConsumeState(new Dictionary<TopicPartition, long>
+        {
+            [Partition0] = 10,
+            [Partition1] = 20
+        });
+
+        await Assert.That(state.IsComplete).IsFalse();
+        await Assert.That(state.Complete(Partition0)).IsTrue();
+        await Assert.That(state.Complete(Partition0)).IsFalse();
+        await Assert.That(state.IsComplete).IsFalse();
+        await Assert.That(state.Complete(Partition1)).IsTrue();
+        await Assert.That(state.IsComplete).IsTrue();
+    }
+
+    [Test]
+    public async Task SnapshotState_EndMarkerRequiresCapturedVisibleEndAndQueuesOnce()
+    {
+        var state = new SnapshotConsumeState(new Dictionary<TopicPartition, long>
+        {
+            [Partition0] = 42
+        });
+
+        var beforeBound = state.TryQueueEndMarker(Partition0, 41, out var beforeEnd);
+        var atBound = state.TryQueueEndMarker(Partition0, 42, out var end);
+        var duplicate = state.TryQueueEndMarker(Partition0, 100, out _);
+
+        await Assert.That(beforeBound).IsFalse();
+        await Assert.That(beforeEnd).IsEqualTo(42L);
+        await Assert.That(atBound).IsTrue();
+        await Assert.That(end).IsEqualTo(42L);
+        await Assert.That(duplicate).IsFalse();
+    }
+
+    [Test]
+    public async Task SnapshotState_AssignmentChangeThrows()
+    {
+        var assignment = new HashSet<TopicPartition> { Partition0 };
+        var paused = new HashSet<TopicPartition>();
+        var state = new SnapshotConsumeState(new Dictionary<TopicPartition, long>
+        {
+            [Partition0] = 10
+        }, assignment, paused);
+
+        await Assert.That(() => state.ThrowIfConsumerStateChanged(
+                new HashSet<TopicPartition> { Partition1 },
+                paused))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    [Arguments(RecordBatchAttributes.IsControlBatch, false)]
+    [Arguments(RecordBatchAttributes.IsTransactional, true)]
+    public async Task ExhaustedFilteredBatch_AdvancesConsumerPosition(
+        RecordBatchAttributes attributes,
+        bool includeAbortedTransaction)
+    {
+        const long baseOffset = 25;
+        const long producerId = 7;
+        var batch = new RecordBatch
+        {
+            BaseOffset = baseOffset,
+            LastOffsetDelta = 2,
+            ProducerId = producerId,
+            Attributes = attributes,
+            Records =
+            [
+                new Record { OffsetDelta = 0 },
+                new Record { OffsetDelta = 1 },
+                new Record { OffsetDelta = 2 }
+            ]
+        };
+        var abortedTransactions = includeAbortedTransaction
+            ? new[] { new AbortedTransaction { ProducerId = producerId, FirstOffset = baseOffset } }
+            : null;
+        using var pending = PendingFetchData.Create(
+            Partition0.Topic,
+            Partition0.Partition,
+            [batch],
+            abortedTransactions);
+        pending.EagerParseAll();
+
+        await Assert.That(pending.MoveNext()).IsFalse();
+        await Assert.That(pending.IsExhausted).IsTrue();
+
+        await using var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                QueuedMinMessages = 1
+            },
+            Serializers.String,
+            Serializers.String);
+        var flushed = InvokeFlushConsumedPositions(consumer, pending);
+
+        await Assert.That(flushed).IsTrue();
+        await Assert.That(consumer.GetPosition(Partition0)).IsEqualTo(baseOffset + 3);
+    }
+
+    [Test]
+    public async Task SnapshotEndMarker_CarriesExactCapturedBound()
+    {
+        using var marker = PendingFetchData.CreateSnapshotEnd("orders", 3, 123);
+
+        await Assert.That(marker.IsSnapshotEnd).IsTrue();
+        await Assert.That(marker.SnapshotEndOffset).IsEqualTo(123L);
+        await Assert.That(marker.TopicPartition).IsEqualTo(new TopicPartition("orders", 3));
+        await Assert.That(marker.MoveNext()).IsFalse();
+    }
+
+    [Test]
+    public async Task DiscardedSnapshotEndMarker_CanBeQueuedAgain()
+    {
+        var state = new SnapshotConsumeState(new Dictionary<TopicPartition, long>
+        {
+            [Partition0] = 42
+        });
+        await Assert.That(state.TryQueueEndMarker(Partition0, 42, out var endOffset)).IsTrue();
+
+        using (PendingFetchData.CreateSnapshotEnd(
+                   Partition0.Topic,
+                   Partition0.Partition,
+                   endOffset,
+                   state))
+        {
+        }
+
+        await Assert.That(state.TryQueueEndMarker(Partition0, 42, out _)).IsTrue();
+    }
+
+    private static bool InvokeFlushConsumedPositions(
+        KafkaConsumer<string, string> consumer,
+        PendingFetchData pending)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "FlushConsumedPositions",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (bool)method.Invoke(consumer, [pending])!;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
@@ -146,6 +146,27 @@ public sealed class InMemoryBoundedConsumerTests
     }
 
     [Test]
+    public async Task ConsumeSnapshotAsync_GroupAssignmentAbaChangeThrows()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events");
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await ProduceRangeAsync(producer, "events", partition: 0, count: 3);
+        await using var first = CreateGroupConsumer(cluster, "a");
+        first.Subscribe("events");
+        await using var snapshot = first.ConsumeSnapshotAsync().GetAsyncEnumerator();
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+
+        await using (var second = CreateGroupConsumer(cluster, "b"))
+        {
+            second.Subscribe("events");
+        }
+
+        await Assert.That(async () => await snapshot.MoveNextAsync().AsTask())
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task ConsumeSnapshotAsync_AssignmentChangeThrows()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
@@ -103,6 +103,47 @@ public sealed class InMemoryBoundedConsumerTests
     }
 
     [Test]
+    public async Task ConsumeSnapshotAsync_GroupMembersCaptureOnlyOwnedPartitions()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events", partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await ProduceRangeAsync(producer, "events", partition: 0, count: 1);
+        await ProduceRangeAsync(producer, "events", partition: 1, count: 1);
+        await using var first = CreateGroupConsumer(cluster, "a");
+        await using var second = CreateGroupConsumer(cluster, "b");
+        first.Subscribe("events");
+        second.Subscribe("events");
+
+        var firstRecords = await CollectAsync(first.ConsumeSnapshotAsync());
+        var secondRecords = await CollectAsync(second.ConsumeSnapshotAsync());
+
+        await Assert.That(firstRecords).Count().IsEqualTo(1);
+        await Assert.That(secondRecords).Count().IsEqualTo(1);
+        await Assert.That(firstRecords[0].Partition).IsNotEqualTo(secondRecords[0].Partition);
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_GroupOwnershipChangeThrows()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events", partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await ProduceRangeAsync(producer, "events", partition: 0, count: 2);
+        await ProduceRangeAsync(producer, "events", partition: 1, count: 2);
+        await using var first = CreateGroupConsumer(cluster, "a");
+        first.Subscribe("events");
+        await using var snapshot = first.ConsumeSnapshotAsync().GetAsyncEnumerator();
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+
+        await using var second = CreateGroupConsumer(cluster, "b");
+        second.Subscribe("events");
+
+        await Assert.That(async () => await snapshot.MoveNextAsync().AsTask())
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task ConsumeSnapshotAsync_AssignmentChangeThrows()
     {
         var cluster = new InMemoryKafkaCluster();
@@ -238,6 +279,27 @@ public sealed class InMemoryBoundedConsumerTests
                 Value = $"value-{i}"
             });
         }
+    }
+
+    private static InMemoryConsumer<string, string> CreateGroupConsumer(
+        InMemoryKafkaCluster cluster,
+        string memberId) =>
+        new(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "snapshot-group",
+                MemberId = memberId,
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+
+    private static async Task<List<ConsumeResult<string, string>>> CollectAsync(
+        IAsyncEnumerable<ConsumeResult<string, string>> records)
+    {
+        var results = new List<ConsumeResult<string, string>>();
+        await foreach (var record in records)
+            results.Add(record);
+        return results;
     }
 
     private static async Task<List<string>> CollectValuesAsync(

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
@@ -1,5 +1,7 @@
+using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Producer;
+using Dekaf.Serialization;
 using Dekaf.Testing;
 
 namespace Dekaf.Tests.Unit.Testing;
@@ -185,6 +187,32 @@ public sealed class InMemoryBoundedConsumerTests
     }
 
     [Test]
+    public async Task ConsumeSnapshotAsync_PauseDuringAsyncDeserializationThrowsWithoutAdvancing()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events");
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await ProduceRangeAsync(producer, "events", partition: 0, count: 1);
+        var deserializer = new BlockingAsyncDeserializer();
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            Serializers.String,
+            deserializer,
+            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+        var partition = new TopicPartition("events", 0);
+        consumer.Assign(partition);
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+        var moveNext = snapshot.MoveNextAsync().AsTask();
+        await deserializer.WaitUntilEnteredAsync();
+
+        consumer.Pause(partition);
+        deserializer.Release();
+
+        await Assert.That(async () => await moveNext).Throws<InvalidOperationException>();
+        await Assert.That(consumer.GetPosition(partition)).IsEqualTo(0L);
+    }
+
+    [Test]
     public async Task ConsumeSnapshotAsync_SeekDuringEnumerationThrows()
     {
         var cluster = new InMemoryKafkaCluster();
@@ -309,5 +337,27 @@ public sealed class InMemoryBoundedConsumerTests
         await foreach (var record in records)
             values.Add(record.Value);
         return values;
+    }
+
+    private sealed class BlockingAsyncDeserializer : IAsyncDeserializer<string>
+    {
+        private readonly TaskCompletionSource _entered = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async ValueTask<string> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            _entered.TrySetResult();
+            await _release.Task.WaitAsync(cancellationToken);
+            return Encoding.UTF8.GetString(data.Span);
+        }
+
+        public Task WaitUntilEnteredAsync() => _entered.Task;
+
+        public void Release() => _release.TrySetResult();
     }
 }

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
@@ -1,0 +1,189 @@
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Testing;
+
+namespace Dekaf.Tests.Unit.Testing;
+
+public sealed class InMemoryBoundedConsumerTests
+{
+    [Test]
+    public async Task SeekToTailAsync_UsesOffsetCountAndClampsToLowWatermark()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events");
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await ProduceRangeAsync(producer, "events", partition: 0, count: 5);
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+        var partition = new TopicPartition("events", 0);
+        consumer.Assign(partition);
+
+        var tail = await consumer.SeekToTailAsync(partition, offsetCount: 2);
+        var values = await CollectValuesAsync(consumer.ConsumeSnapshotAsync());
+        var clamped = await consumer.SeekToTailAsync(partition, offsetCount: int.MaxValue);
+
+        await Assert.That(tail.Offset).IsEqualTo(3L);
+        await Assert.That(values).IsEquivalentTo(["value-3", "value-4"]);
+        await Assert.That(clamped.Offset).IsEqualTo(0L);
+    }
+
+    [Test]
+    public async Task SeekToTailAsync_ZeroSeeksToCapturedEnd()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events");
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await ProduceRangeAsync(producer, "events", partition: 0, count: 3);
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+        var partition = new TopicPartition("events", 0);
+        consumer.Assign(partition);
+
+        var tail = await consumer.SeekToTailAsync(partition, offsetCount: 0);
+        var values = await CollectValuesAsync(consumer.ConsumeSnapshotAsync());
+
+        await Assert.That(tail.Offset).IsEqualTo(3L);
+        await Assert.That(values).IsEmpty();
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_ExcludesRecordsAppendedAfterCapture()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events");
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await ProduceRangeAsync(producer, "events", partition: 0, count: 2);
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+        consumer.Assign(new TopicPartition("events", 0));
+
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+        var first = snapshot.Current.Value;
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = "events",
+            Partition = 0,
+            Key = "key-2",
+            Value = "value-2"
+        });
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+        var second = snapshot.Current.Value;
+        await Assert.That(await snapshot.MoveNextAsync()).IsFalse();
+
+        var appended = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+        await Assert.That(new[] { first, second }).IsEquivalentTo(["value-0", "value-1"]);
+        await Assert.That(appended!.Value.Value).IsEqualTo("value-2");
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_CapturesMultiplePartitionsAndCompletesEmptyOnes()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events", partitionCount: 3);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await ProduceRangeAsync(producer, "events", partition: 0, count: 2);
+        await ProduceRangeAsync(producer, "events", partition: 1, count: 2);
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+        consumer.Assign(
+            new TopicPartition("events", 0),
+            new TopicPartition("events", 1),
+            new TopicPartition("events", 2));
+
+        var values = await CollectValuesAsync(consumer.ConsumeSnapshotAsync());
+
+        await Assert.That(values).Count().IsEqualTo(4);
+        await Assert.That(values).Contains("value-0");
+        await Assert.That(values).Contains("value-1");
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_AssignmentChangeThrows()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events", partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await ProduceRangeAsync(producer, "events", partition: 0, count: 2);
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+        consumer.Assign(new TopicPartition("events", 0));
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+
+        consumer.IncrementalAssign([new TopicPartitionOffset("events", 1, 0)]);
+
+        await Assert.That(async () => await snapshot.MoveNextAsync().AsTask())
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_PauseAfterCaptureThrows()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events");
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await ProduceRangeAsync(producer, "events", partition: 0, count: 2);
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+        var partition = new TopicPartition("events", 0);
+        consumer.Assign(partition);
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+
+        consumer.Pause(partition);
+
+        await Assert.That(async () => await snapshot.MoveNextAsync().AsTask())
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task BoundedExtensions_ReachBuiltInCapabilityThroughInterface()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events");
+        IKafkaConsumer<string, string> consumer = new InMemoryConsumer<string, string>(cluster);
+        await using var disposable = consumer;
+        var partition = new TopicPartition("events", 0);
+        consumer.Partitions.Assign(partition);
+
+        var tail = await consumer.SeekToTailAsync(partition, 0);
+        var values = await CollectValuesAsync(consumer.ConsumeSnapshotAsync());
+
+        await Assert.That(tail.Offset).IsEqualTo(0L);
+        await Assert.That(values).IsEmpty();
+    }
+
+    private static async Task ProduceRangeAsync(
+        InMemoryProducer<string, string> producer,
+        string topic,
+        int partition,
+        int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = partition,
+                Key = $"key-{i}",
+                Value = $"value-{i}"
+            });
+        }
+    }
+
+    private static async Task<List<string>> CollectValuesAsync(
+        IAsyncEnumerable<ConsumeResult<string, string>> records)
+    {
+        var values = new List<string>();
+        await foreach (var record in records)
+            values.Add(record.Value);
+        return values;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
@@ -144,6 +144,68 @@ public sealed class InMemoryBoundedConsumerTests
     }
 
     [Test]
+    public async Task ConsumeSnapshotAsync_SeekDuringEnumerationThrows()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events");
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await ProduceRangeAsync(producer, "events", partition: 0, count: 2);
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+        var partition = new TopicPartition("events", 0);
+        consumer.Assign(partition);
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+
+        await Assert.That(() => consumer.Seek(new TopicPartitionOffset("events", 0, 0)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => consumer.SeekToBeginning(partition))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => consumer.SeekToEnd(partition))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_ConcurrentEnumerationThrows()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events");
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await ProduceRangeAsync(producer, "events", partition: 0, count: 2);
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+        consumer.Assign(new TopicPartition("events", 0));
+        await using var first = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+        await using var second = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+        await Assert.That(await first.MoveNextAsync()).IsTrue();
+
+        await Assert.That(async () => await second.MoveNextAsync().AsTask())
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_PositionBeyondBoundIsNotRewound()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events");
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await ProduceRangeAsync(producer, "events", partition: 0, count: 3);
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+        var partition = new TopicPartition("events", 0);
+        consumer.Assign(partition);
+        consumer.Seek(new TopicPartitionOffset("events", 0, 10));
+
+        var values = await CollectValuesAsync(consumer.ConsumeSnapshotAsync());
+
+        await Assert.That(values).IsEmpty();
+        await Assert.That(consumer.GetPosition(partition)).IsEqualTo(10L);
+    }
+
+    [Test]
     public async Task BoundedExtensions_ReachBuiltInCapabilityThroughInterface()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Producer;
@@ -234,6 +235,32 @@ public sealed class InMemoryBoundedConsumerTests
     }
 
     [Test]
+    public async Task ConsumeSnapshotAsync_CloseDuringAsyncDeserializationThrowsWithoutAdvancing()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events");
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await ProduceRangeAsync(producer, "events", partition: 0, count: 1);
+        var deserializer = new BlockingAsyncDeserializer();
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            Serializers.String,
+            deserializer,
+            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+        var partition = new TopicPartition("events", 0);
+        consumer.Assign(partition);
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+        var moveNext = snapshot.MoveNextAsync().AsTask();
+        await deserializer.WaitUntilEnteredAsync();
+
+        await consumer.CloseAsync();
+        deserializer.Release();
+
+        await Assert.That(async () => await moveNext).Throws<ObjectDisposedException>();
+        await Assert.That(GetPositionAfterClose(consumer, partition)).IsEqualTo(0L);
+    }
+
+    [Test]
     public async Task ConsumeSnapshotAsync_SeekDuringEnumerationThrows()
     {
         var cluster = new InMemoryKafkaCluster();
@@ -358,6 +385,16 @@ public sealed class InMemoryBoundedConsumerTests
         await foreach (var record in records)
             values.Add(record.Value);
         return values;
+    }
+
+    private static long GetPositionAfterClose(
+        InMemoryConsumer<string, string> consumer,
+        TopicPartition partition)
+    {
+        var field = typeof(InMemoryConsumer<string, string>).GetField(
+            "_positions",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return ((Dictionary<TopicPartition, long>)field.GetValue(consumer)!)[partition];
     }
 
     private sealed class BlockingAsyncDeserializer : IAsyncDeserializer<string>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncBufferedFastPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncBufferedFastPathBenchmarks.cs
@@ -93,16 +93,30 @@ public class ConsumeAsyncBufferedFastPathBenchmarks
         BufferedConsumerHarness.InitializeForBufferedFastPath(_consumer, Topic, Partition);
     }
 
-    [IterationSetup]
-    public void IterationSetup()
+    [IterationSetup(Target = nameof(ConsumeBufferedStream))]
+    public void UnboundedIterationSetup()
     {
         _iterationCancellation = new CancellationTokenSource();
         BufferedConsumerHarness.ReseedPendingFetches(
             _consumer, Topic, Partition, _batchRecords, BatchCount, RecordsPerBatch);
     }
 
+    [IterationSetup(Target = nameof(ConsumeSnapshotBufferedStream))]
+    public void SnapshotIterationSetup()
+    {
+        _iterationCancellation = new CancellationTokenSource();
+        BufferedConsumerHarness.ReseedPendingFetches(
+            _consumer, Topic, Partition, _batchRecords, BatchCount, RecordsPerBatch);
+        BufferedConsumerHarness.ActivateSnapshotForBufferedFastPath(
+            _consumer, Topic, Partition, MessageCount);
+    }
+
     [IterationCleanup]
-    public void IterationCleanup() => _iterationCancellation.Dispose();
+    public void IterationCleanup()
+    {
+        BufferedConsumerHarness.DeactivateSnapshotForBufferedFastPath(_consumer);
+        _iterationCancellation.Dispose();
+    }
 
     [Benchmark(OperationsPerInvoke = MessageCount)]
     public async Task<int> ConsumeBufferedStream()
@@ -120,6 +134,26 @@ public class ConsumeAsyncBufferedFastPathBenchmarks
         {
             // ConsumeAsync polls indefinitely once buffered data is drained. The token ends
             // the invocation only after the pending-fetch cleanup measured above completes.
+        }
+
+        return count;
+    }
+
+    [Benchmark(OperationsPerInvoke = MessageCount)]
+    public async Task<int> ConsumeSnapshotBufferedStream()
+    {
+        var count = 0;
+        try
+        {
+            await foreach (var _ in _consumer.ConsumeAsync(_iterationCancellation.Token).ConfigureAwait(false))
+            {
+                if (++count == MessageCount)
+                    _iterationCancellation.Cancel();
+            }
+        }
+        catch (OperationCanceledException) when (_iterationCancellation.IsCancellationRequested)
+        {
+            // End only after the final bounded record completed validation and position tracking.
         }
 
         return count;

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerHotPathBenchmarks.cs
@@ -236,10 +236,22 @@ public class ConsumerHotPathBenchmarks
         return chars;
     }
 
-    private PendingFetchData CreatePendingFetchData(Record[]? records = null)
+    [Benchmark(Description = "Snapshot bound skips post-bound batch")]
+    public bool SnapshotBound_SkipPostBoundBatch()
+    {
+        using var pending = CreatePendingFetchData(
+            baseOffset: MessageCount,
+            stopAtOffsetExclusive: 0);
+        return pending.MoveNext();
+    }
+
+    private PendingFetchData CreatePendingFetchData(
+        Record[]? records = null,
+        long baseOffset = 0,
+        long stopAtOffsetExclusive = -1)
     {
         var recordBatch = RecordBatch.RentFromPool();
-        recordBatch.BaseOffset = 0;
+        recordBatch.BaseOffset = baseOffset;
         recordBatch.BaseTimestamp = _timestampMs;
         recordBatch.MaxTimestamp = _timestampMs + MessageCount - 1;
         recordBatch.LastOffsetDelta = MessageCount - 1;
@@ -247,7 +259,11 @@ public class ConsumerHotPathBenchmarks
         recordBatch.Records = records ?? _records;
 
         _batchList.Batch = recordBatch;
-        var pending = PendingFetchData.Create(_topic, partitionIndex: 0, _batchList);
+        var pending = PendingFetchData.Create(
+            _topic,
+            partitionIndex: 0,
+            _batchList,
+            stopAtOffsetExclusive: stopAtOffsetExclusive);
         pending.EagerParseAll();
         return pending;
     }

--- a/tools/Dekaf.Benchmarks/Infrastructure/BufferedConsumerHarness.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/BufferedConsumerHarness.cs
@@ -83,6 +83,32 @@ internal static class BufferedConsumerHarness
             pendingFetches.Dequeue().Dispose();
     }
 
+    /// <summary>
+    /// Installs the immutable state captured by a bounded snapshot so the complete buffered
+    /// delivery loop, including its per-record snapshot validation and position publication,
+    /// can be measured without broker I/O.
+    /// </summary>
+    public static void ActivateSnapshotForBufferedFastPath<TKey, TValue>(
+        KafkaConsumer<TKey, TValue> consumer,
+        string topic,
+        int partition,
+        long endOffset)
+    {
+        var topicPartition = new TopicPartition(topic, partition);
+        var assignment = (IReadOnlySet<TopicPartition>)GetPrivateField(consumer, "_assignmentSnapshot")!;
+        var paused = (IReadOnlySet<TopicPartition>)GetPrivateField(consumer, "_pausedSnapshot")!;
+        var snapshot = new SnapshotConsumeState(
+            new Dictionary<TopicPartition, long> { [topicPartition] = endOffset },
+            assignment,
+            paused,
+            new Dictionary<TopicPartition, long> { [topicPartition] = 0 });
+        SetPrivateField(consumer, "_activeSnapshot", snapshot);
+    }
+
+    public static void DeactivateSnapshotForBufferedFastPath<TKey, TValue>(
+        KafkaConsumer<TKey, TValue> consumer) =>
+        SetPrivateField(consumer, "_activeSnapshot", null);
+
     private static Queue<PendingFetchData> GetPendingFetches<TKey, TValue>(
         KafkaConsumer<TKey, TValue> consumer)
         => (Queue<PendingFetchData>)GetPrivateField(consumer, "_pendingFetches")!;


### PR DESCRIPTION
Closes #2559

## Summary

- add optional `IBoundedKafkaConsumer<TKey, TValue>` capability plus `IKafkaConsumer` extensions for finite snapshots and offset-count tail seeks
- capture isolation-aware partition bounds once, exclude later appends before deserialization, and progress through control batches, aborted transactions, compaction holes, and retention gaps
- preserve normal consume hot-path layout and zero allocations; add equivalent in-memory consumer behavior
- document ordering, rebalance/pause invalidation, cancellation, and `ReadCommitted` semantics

## Validation

- `dotnet build --configuration Release` — clean, 0 warnings/errors
- full unit: net10 6818/6818; net8 6682/6682
- focused post-rebase unit: 14/14; focused core post-layout fix: 7/7
- focused Kafka integration post-rebase: 6/6
- full net8 Kafka integration: 941 passed, 2 Kafka-version skips, 0 failed
- full net10 Kafka integration: 940 passed, 2 skips, 1 unrelated existing controller-election race; exact-base isolated control passed and #2696 tracks the root cause
- `npm run build` in `docs/` — passed

## Performance

`ConsumeAsyncBufferedFastPathBenchmarks`, .NET 10.0.11, `[MemoryDiagnoser]`, exact base `634ec7ae` and candidate `df3bb652`, same machine/configuration.

| Message | Exact-base control | Candidate | Decision | Allocated |
|---|---:|---:|---|---:|
| 100 B | 67.45 ns stable | 67.12 ns stable | -0.50%; pass | 0 B |
| 1000 B | noisy 75.13 ns mean / 70.65 ns median; fast cluster 67.46-71.54 ns | 67.87 ns stable | inside/faster than control cluster; no regression | 0 B |

The first control run and alternate size samples showed machine-level bimodal noise. Per Rule 8, I stopped after the base → candidate → base controls and one exact candidate repeat. Every candidate/control run remained allocation-free; the stable per-size candidate samples show no protected-metric regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added finite snapshot consumption for assigned partitions, excluding records added after capture.
  - Added tail seeking by offset count, including low-watermark handling.
  - Added consumer APIs and extension methods for bounded consumption.
  - Snapshot processing handles empty partitions, filtered records, cancellation, pausing, and assignment changes safely.

- **Documentation**
  - Documented snapshot consumption and tail-seeking behavior, including ordering, visibility, pausing, and cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->