### PR TITLE
perf(avro): eliminate SpecificRecord allocations

### DIFF
--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -253,6 +253,12 @@ These formats match Confluent serializers. Avro `GenericRecord` subjects use the
 record's runtime schema, JSON Schema subjects use the schema `title` when present, and Protobuf
 subjects use the message descriptor's full name.
 
+Avro generated `ISpecificRecord` types serialize without per-message allocations when their record
+fields are scalar `null`, `boolean`, `int`, `long`, `float`, `double`, `string`, or `bytes` fields
+exposed by matching public properties. Unsupported SpecificRecord shapes fail when the serializer is
+created instead of silently falling back to Apache Avro's allocating `Get(int): object` path. Use
+`GenericRecord` for collection, union, enum, fixed, logical, or nested record fields.
+
 When using the generic `SchemaRegistrySerializer` with a record-based strategy, prefer its
 subject-independent `Func<Schema>` schema factory overload. The subject-aware `Func<string, Schema>`
 overload may be called again with the schema-derived subject until the callback and schema name agree.

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeSpecificRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeSpecificRecordWriter.cs
@@ -1,0 +1,159 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Dekaf.SchemaRegistry.Avro;
+
+internal sealed unsafe class AllocationFreeSpecificRecordWriter<
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
+{
+    private readonly FieldPlan[] _fields;
+
+    private AllocationFreeSpecificRecordWriter(FieldPlan[] fields) => _fields = fields;
+
+    internal static AllocationFreeSpecificRecordWriter<T> Create(global::Avro.Schema schema)
+    {
+        if (typeof(T).IsValueType)
+        {
+            throw new NotSupportedException(
+                $"SpecificRecord type {typeof(T)} must be a reference type for allocation-free serialization.");
+        }
+
+        if (schema is not global::Avro.RecordSchema recordSchema)
+        {
+            throw new NotSupportedException(
+                $"SpecificRecord type {typeof(T)} must expose an Avro record schema.");
+        }
+
+        var fields = new FieldPlan[recordSchema.Fields.Count];
+        for (var i = 0; i < fields.Length; i++)
+            fields[i] = CreateFieldPlan(recordSchema.Fields[i]);
+
+        return new AllocationFreeSpecificRecordWriter<T>(fields);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void Write(T value, AllocationFreeBinaryEncoder encoder)
+    {
+        var fields = _fields;
+        for (var i = 0; i < fields.Length; i++)
+        {
+            ref readonly var field = ref fields[i];
+            switch (field.Kind)
+            {
+                case FieldKind.Null:
+                    encoder.WriteNull();
+                    break;
+                case FieldKind.Boolean:
+                    encoder.WriteBoolean(((delegate* managed<T, bool>)field.Getter)(value));
+                    break;
+                case FieldKind.Int:
+                    encoder.WriteInt(((delegate* managed<T, int>)field.Getter)(value));
+                    break;
+                case FieldKind.Long:
+                    encoder.WriteLong(((delegate* managed<T, long>)field.Getter)(value));
+                    break;
+                case FieldKind.Float:
+                    encoder.WriteFloat(((delegate* managed<T, float>)field.Getter)(value));
+                    break;
+                case FieldKind.Double:
+                    encoder.WriteDouble(((delegate* managed<T, double>)field.Getter)(value));
+                    break;
+                case FieldKind.String:
+                    encoder.WriteString(((delegate* managed<T, string>)field.Getter)(value));
+                    break;
+                case FieldKind.Bytes:
+                    encoder.WriteBytes(((delegate* managed<T, byte[]>)field.Getter)(value));
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unknown SpecificRecord field kind {field.Kind}.");
+            }
+        }
+    }
+
+    private static FieldPlan CreateFieldPlan(global::Avro.Field field)
+    {
+        var kind = GetFieldKind(field);
+        if (kind == FieldKind.Null)
+            return new FieldPlan(kind, 0);
+
+        var property = FindProperty(field.Name);
+        if (property?.GetMethod is not { IsStatic: false, IsAbstract: false } getter ||
+            property.GetIndexParameters().Length != 0)
+        {
+            throw UnsupportedField(
+                field,
+                $"a readable public property named '{field.Name}' was not found");
+        }
+
+        var expectedType = GetExpectedType(kind);
+        if (property.PropertyType != expectedType)
+        {
+            throw UnsupportedField(
+                field,
+                $"property '{property.Name}' has type {property.PropertyType}, expected {expectedType}");
+        }
+
+        return new FieldPlan(kind, getter.MethodHandle.GetFunctionPointer());
+    }
+
+    private static PropertyInfo? FindProperty(string name)
+    {
+        var property = typeof(T).GetProperty(name);
+        if (property is not null)
+            return property;
+
+        var properties = typeof(T).GetProperties();
+        for (var i = 0; i < properties.Length; i++)
+        {
+            if (string.Equals(properties[i].Name, name, StringComparison.OrdinalIgnoreCase))
+                return properties[i];
+        }
+
+        return null;
+    }
+
+    private static FieldKind GetFieldKind(global::Avro.Field field) => field.Schema.Tag switch
+    {
+        global::Avro.Schema.Type.Null => FieldKind.Null,
+        global::Avro.Schema.Type.Boolean => FieldKind.Boolean,
+        global::Avro.Schema.Type.Int => FieldKind.Int,
+        global::Avro.Schema.Type.Long => FieldKind.Long,
+        global::Avro.Schema.Type.Float => FieldKind.Float,
+        global::Avro.Schema.Type.Double => FieldKind.Double,
+        global::Avro.Schema.Type.String => FieldKind.String,
+        global::Avro.Schema.Type.Bytes => FieldKind.Bytes,
+        _ => throw UnsupportedField(field, $"schema type {field.Schema.Tag} is not supported")
+    };
+
+    private static Type GetExpectedType(FieldKind kind) => kind switch
+    {
+        FieldKind.Boolean => typeof(bool),
+        FieldKind.Int => typeof(int),
+        FieldKind.Long => typeof(long),
+        FieldKind.Float => typeof(float),
+        FieldKind.Double => typeof(double),
+        FieldKind.String => typeof(string),
+        FieldKind.Bytes => typeof(byte[]),
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
+    };
+
+    private static NotSupportedException UnsupportedField(global::Avro.Field field, string reason) =>
+        new(
+            $"SpecificRecord field '{field.Name}' on {typeof(T)} cannot use allocation-free serialization: " +
+            $"{reason}. Use GenericRecord or a supported scalar SpecificRecord shape.");
+
+    private readonly record struct FieldPlan(FieldKind Kind, nint Getter);
+
+    private enum FieldKind : byte
+    {
+        Null,
+        Boolean,
+        Int,
+        Long,
+        Float,
+        Double,
+        String,
+        Bytes
+    }
+}

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeSpecificRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeSpecificRecordWriter.cs
@@ -12,12 +12,19 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
     private AllocationFreeSpecificRecordWriter(FieldPlan[] fields) => _fields = fields;
 
     internal static AllocationFreeSpecificRecordWriter<T> Create(global::Avro.Schema schema) =>
-        Create(schema, typeof(T));
+        Create(schema, typeof(T), rejectOverridableGetters: true);
 
     internal static AllocationFreeSpecificRecordWriter<T> Create(
         global::Avro.Schema schema,
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
-        Type recordType)
+        Type recordType) =>
+        Create(schema, recordType, rejectOverridableGetters: false);
+
+    private static AllocationFreeSpecificRecordWriter<T> Create(
+        global::Avro.Schema schema,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+        Type recordType,
+        bool rejectOverridableGetters)
     {
         if (recordType.IsValueType || !typeof(T).IsAssignableFrom(recordType))
         {
@@ -32,8 +39,17 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
         }
 
         var fields = new FieldPlan[recordSchema.Fields.Count];
+        var properties = recordType.GetProperties();
+        var claimedProperties = new HashSet<PropertyInfo>();
         for (var i = 0; i < fields.Length; i++)
-            fields[i] = CreateFieldPlan(recordSchema.Fields[i], recordType);
+        {
+            fields[i] = CreateFieldPlan(
+                recordSchema.Fields[i],
+                recordType,
+                properties,
+                claimedProperties,
+                rejectOverridableGetters);
+        }
 
         return new AllocationFreeSpecificRecordWriter<T>(fields);
     }
@@ -79,13 +95,16 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
 
     private static FieldPlan CreateFieldPlan(
         global::Avro.Field field,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type recordType)
+        Type recordType,
+        PropertyInfo[] properties,
+        HashSet<PropertyInfo> claimedProperties,
+        bool rejectOverridableGetters)
     {
         var kind = GetFieldKind(field, recordType);
         if (kind == FieldKind.Null)
             return new FieldPlan(kind, 0);
 
-        var property = FindProperty(recordType, field.Name);
+        var property = FindProperty(recordType, field, properties);
         if (property?.GetMethod is not { IsStatic: false, IsAbstract: false } getter ||
             property.GetIndexParameters().Length != 0)
         {
@@ -93,6 +112,14 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
                 recordType,
                 field,
                 $"a readable public property named '{field.Name}' was not found");
+        }
+
+        if (rejectOverridableGetters && getter is { IsVirtual: true, IsFinal: false })
+        {
+            throw UnsupportedField(
+                recordType,
+                field,
+                $"property '{property.Name}' has an overridable getter");
         }
 
         var expectedType = GetExpectedType(kind);
@@ -104,25 +131,59 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
                 $"property '{property.Name}' has type {property.PropertyType}, expected {expectedType}");
         }
 
+        if (!claimedProperties.Add(property))
+        {
+            throw UnsupportedField(
+                recordType,
+                field,
+                $"property '{property.Name}' also matches another schema field");
+        }
+
         return new FieldPlan(kind, getter.MethodHandle.GetFunctionPointer());
     }
 
     private static PropertyInfo? FindProperty(
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type recordType,
-        string name)
+        Type recordType,
+        global::Avro.Field field,
+        PropertyInfo[] properties)
     {
-        var property = recordType.GetProperty(name);
-        if (property is not null)
-            return property;
-
-        var properties = recordType.GetProperties();
+        PropertyInfo? match = null;
         for (var i = 0; i < properties.Length; i++)
         {
-            if (string.Equals(properties[i].Name, name, StringComparison.OrdinalIgnoreCase))
-                return properties[i];
+            if (!string.Equals(properties[i].Name, field.Name, StringComparison.Ordinal))
+                continue;
+
+            if (match is not null)
+            {
+                throw UnsupportedField(
+                    recordType,
+                    field,
+                    $"multiple public properties named '{field.Name}' were found");
+            }
+
+            match = properties[i];
         }
 
-        return null;
+        if (match is not null)
+            return match;
+
+        for (var i = 0; i < properties.Length; i++)
+        {
+            if (!string.Equals(properties[i].Name, field.Name, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (match is not null)
+            {
+                throw UnsupportedField(
+                    recordType,
+                    field,
+                    $"multiple public properties match '{field.Name}' ignoring case");
+            }
+
+            match = properties[i];
+        }
+
+        return match;
     }
 
     private static FieldKind GetFieldKind(global::Avro.Field field, Type recordType) => field.Schema.Tag switch

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeSpecificRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeSpecificRecordWriter.cs
@@ -11,23 +11,29 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
 
     private AllocationFreeSpecificRecordWriter(FieldPlan[] fields) => _fields = fields;
 
-    internal static AllocationFreeSpecificRecordWriter<T> Create(global::Avro.Schema schema)
+    internal static AllocationFreeSpecificRecordWriter<T> Create(global::Avro.Schema schema) =>
+        Create(schema, typeof(T));
+
+    internal static AllocationFreeSpecificRecordWriter<T> Create(
+        global::Avro.Schema schema,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+        Type recordType)
     {
-        if (typeof(T).IsValueType)
+        if (recordType.IsValueType || !typeof(T).IsAssignableFrom(recordType))
         {
             throw new NotSupportedException(
-                $"SpecificRecord type {typeof(T)} must be a reference type for allocation-free serialization.");
+                $"SpecificRecord type {recordType} must be a reference type assignable to {typeof(T)} for allocation-free serialization.");
         }
 
         if (schema is not global::Avro.RecordSchema recordSchema)
         {
             throw new NotSupportedException(
-                $"SpecificRecord type {typeof(T)} must expose an Avro record schema.");
+                $"SpecificRecord type {recordType} must expose an Avro record schema.");
         }
 
         var fields = new FieldPlan[recordSchema.Fields.Count];
         for (var i = 0; i < fields.Length; i++)
-            fields[i] = CreateFieldPlan(recordSchema.Fields[i]);
+            fields[i] = CreateFieldPlan(recordSchema.Fields[i], recordType);
 
         return new AllocationFreeSpecificRecordWriter<T>(fields);
     }
@@ -71,17 +77,20 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
         }
     }
 
-    private static FieldPlan CreateFieldPlan(global::Avro.Field field)
+    private static FieldPlan CreateFieldPlan(
+        global::Avro.Field field,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type recordType)
     {
-        var kind = GetFieldKind(field);
+        var kind = GetFieldKind(field, recordType);
         if (kind == FieldKind.Null)
             return new FieldPlan(kind, 0);
 
-        var property = FindProperty(field.Name);
+        var property = FindProperty(recordType, field.Name);
         if (property?.GetMethod is not { IsStatic: false, IsAbstract: false } getter ||
             property.GetIndexParameters().Length != 0)
         {
             throw UnsupportedField(
+                recordType,
                 field,
                 $"a readable public property named '{field.Name}' was not found");
         }
@@ -90,6 +99,7 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
         if (property.PropertyType != expectedType)
         {
             throw UnsupportedField(
+                recordType,
                 field,
                 $"property '{property.Name}' has type {property.PropertyType}, expected {expectedType}");
         }
@@ -97,13 +107,15 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
         return new FieldPlan(kind, getter.MethodHandle.GetFunctionPointer());
     }
 
-    private static PropertyInfo? FindProperty(string name)
+    private static PropertyInfo? FindProperty(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type recordType,
+        string name)
     {
-        var property = typeof(T).GetProperty(name);
+        var property = recordType.GetProperty(name);
         if (property is not null)
             return property;
 
-        var properties = typeof(T).GetProperties();
+        var properties = recordType.GetProperties();
         for (var i = 0; i < properties.Length; i++)
         {
             if (string.Equals(properties[i].Name, name, StringComparison.OrdinalIgnoreCase))
@@ -113,7 +125,7 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
         return null;
     }
 
-    private static FieldKind GetFieldKind(global::Avro.Field field) => field.Schema.Tag switch
+    private static FieldKind GetFieldKind(global::Avro.Field field, Type recordType) => field.Schema.Tag switch
     {
         global::Avro.Schema.Type.Null => FieldKind.Null,
         global::Avro.Schema.Type.Boolean => FieldKind.Boolean,
@@ -123,7 +135,7 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
         global::Avro.Schema.Type.Double => FieldKind.Double,
         global::Avro.Schema.Type.String => FieldKind.String,
         global::Avro.Schema.Type.Bytes => FieldKind.Bytes,
-        _ => throw UnsupportedField(field, $"schema type {field.Schema.Tag} is not supported")
+        _ => throw UnsupportedField(recordType, field, $"schema type {field.Schema.Tag} is not supported")
     };
 
     private static Type GetExpectedType(FieldKind kind) => kind switch
@@ -138,9 +150,12 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
     };
 
-    private static NotSupportedException UnsupportedField(global::Avro.Field field, string reason) =>
+    private static NotSupportedException UnsupportedField(
+        Type recordType,
+        global::Avro.Field field,
+        string reason) =>
         new(
-            $"SpecificRecord field '{field.Name}' on {typeof(T)} cannot use allocation-free serialization: " +
+            $"SpecificRecord field '{field.Name}' on {recordType} cannot use allocation-free serialization: " +
             $"{reason}. Use GenericRecord or a supported scalar SpecificRecord shape.");
 
     private readonly record struct FieldPlan(FieldKind Kind, nint Getter);

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeSpecificRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeSpecificRecordWriter.cs
@@ -69,11 +69,21 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
                     encoder.WriteDouble(((delegate* managed<T, double>)field.Getter)(value));
                     break;
                 case FieldKind.String:
-                    encoder.WriteString(((delegate* managed<T, string>)field.Getter)(value));
+                {
+                    var fieldValue = ((delegate* managed<T, string>)field.Getter)(value);
+                    if (fieldValue is null)
+                        ThrowNullValue(field.Kind);
+                    encoder.WriteString(fieldValue);
                     break;
+                }
                 case FieldKind.Bytes:
-                    encoder.WriteBytes(((delegate* managed<T, byte[]>)field.Getter)(value));
+                {
+                    var fieldValue = ((delegate* managed<T, byte[]>)field.Getter)(value);
+                    if (fieldValue is null)
+                        ThrowNullValue(field.Kind);
+                    encoder.WriteBytes(fieldValue);
                     break;
+                }
                 default:
                     throw new InvalidOperationException($"Unknown SpecificRecord field kind {field.Kind}.");
             }
@@ -204,6 +214,12 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
         new(
             $"SpecificRecord field '{field.Name}' on {recordType} cannot use allocation-free serialization: " +
             $"{reason}. Use GenericRecord or a supported scalar SpecificRecord shape.");
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowNullValue(FieldKind kind) =>
+        throw new global::Avro.AvroTypeException(
+            $"SpecificRecord {kind} fields cannot be null when the Avro schema is non-nullable.");
 
     private readonly record struct FieldPlan(FieldKind Kind, nint Getter);
 

--- a/src/Dekaf.SchemaRegistry.Avro/AllocationFreeSpecificRecordWriter.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AllocationFreeSpecificRecordWriter.cs
@@ -11,25 +11,13 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
 
     private AllocationFreeSpecificRecordWriter(FieldPlan[] fields) => _fields = fields;
 
-    internal static AllocationFreeSpecificRecordWriter<T> Create(global::Avro.Schema schema) =>
-        Create(schema, typeof(T), rejectOverridableGetters: true);
-
-    internal static AllocationFreeSpecificRecordWriter<T> Create(
-        global::Avro.Schema schema,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
-        Type recordType) =>
-        Create(schema, recordType, rejectOverridableGetters: false);
-
-    private static AllocationFreeSpecificRecordWriter<T> Create(
-        global::Avro.Schema schema,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
-        Type recordType,
-        bool rejectOverridableGetters)
+    internal static AllocationFreeSpecificRecordWriter<T> Create(global::Avro.Schema schema)
     {
-        if (recordType.IsValueType || !typeof(T).IsAssignableFrom(recordType))
+        var recordType = typeof(T);
+        if (recordType.IsValueType)
         {
             throw new NotSupportedException(
-                $"SpecificRecord type {recordType} must be a reference type assignable to {typeof(T)} for allocation-free serialization.");
+                $"SpecificRecord type {recordType} must be a reference type for allocation-free serialization.");
         }
 
         if (schema is not global::Avro.RecordSchema recordSchema)
@@ -47,8 +35,7 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
                 recordSchema.Fields[i],
                 recordType,
                 properties,
-                claimedProperties,
-                rejectOverridableGetters);
+                claimedProperties);
         }
 
         return new AllocationFreeSpecificRecordWriter<T>(fields);
@@ -97,8 +84,7 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
         global::Avro.Field field,
         Type recordType,
         PropertyInfo[] properties,
-        HashSet<PropertyInfo> claimedProperties,
-        bool rejectOverridableGetters)
+        HashSet<PropertyInfo> claimedProperties)
     {
         var kind = GetFieldKind(field, recordType);
         if (kind == FieldKind.Null)
@@ -114,7 +100,7 @@ internal sealed unsafe class AllocationFreeSpecificRecordWriter<
                 $"a readable public property named '{field.Name}' was not found");
         }
 
-        if (rejectOverridableGetters && getter is { IsVirtual: true, IsFinal: false })
+        if (getter is { IsVirtual: true, IsFinal: false })
         {
             throw UnsupportedField(
                 recordType,

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryExtensions.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryExtensions.cs
@@ -20,7 +20,9 @@ public static class AvroSchemaRegistryExtensions
     /// <returns>The builder for chaining.</returns>
     public static ProducerBuilder<TKey, TValue> UseAvroSchemaRegistry<
         TKey,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TValue>(
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicFields |
+            DynamicallyAccessedMemberTypes.PublicProperties)] TValue>(
         this ProducerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,
         AvroSerializerConfig? config = null)
@@ -41,7 +43,9 @@ public static class AvroSchemaRegistryExtensions
     /// <param name="config">Optional Avro serializer configuration.</param>
     /// <returns>The builder for chaining.</returns>
     public static ProducerBuilder<TKey, TValue> UseAvroSchemaRegistryKey<
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TKey,
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicFields |
+            DynamicallyAccessedMemberTypes.PublicProperties)] TKey,
         TValue>(
         this ProducerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -3,7 +3,6 @@ using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using Avro.Generic;
-using Avro.IO;
 using Avro.Specific;
 using Dekaf.Serialization;
 using AvroSchema = Avro.Schema;
@@ -34,7 +33,9 @@ namespace Dekaf.SchemaRegistry.Avro;
 /// </remarks>
 /// <typeparam name="T">The type to serialize. Must be either an Avro ISpecificRecord or GenericRecord.</typeparam>
 public sealed class AvroSchemaRegistrySerializer<
-    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>
+    [DynamicallyAccessedMembers(
+        DynamicallyAccessedMemberTypes.PublicFields |
+        DynamicallyAccessedMemberTypes.PublicProperties)] T>
     : ISerializer<T>, IAsyncSerializerPreparer<T>, IAsyncDisposable
 {
     private const byte MagicByte = 0x00;
@@ -50,8 +51,7 @@ public sealed class AvroSchemaRegistrySerializer<
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
     private readonly ConcurrentDictionary<AvroSchema, DynamicSchemaCache> _dynamicSchemaCaches =
         new(AvroSchemaLogicalComparer.Instance);
-    private readonly ConcurrentDictionary<AvroSchema, SpecificDefaultWriter> _specificWriters =
-        new(AvroSchemaReferenceComparer.Instance);
+    private readonly AllocationFreeSpecificRecordWriter<T>? _specificWriter;
     private readonly AvroSchema? _writerSchema;
     private DynamicSchemaCache? _lastDynamicSchemaCache;
 
@@ -72,10 +72,12 @@ public sealed class AvroSchemaRegistrySerializer<
 
         // Try to get schema from type T if it's a specific record
         _writerSchema = GetSchemaFromType();
+        if (_writerSchema is not null)
+            _specificWriter = AllocationFreeSpecificRecordWriter<T>.Create(_writerSchema);
     }
 
     internal int CachedGenericWriterCount => _dynamicSchemaCaches.Count;
-    internal int CachedSpecificWriterCount => _specificWriters.Count;
+    internal int CachedSpecificWriterCount => _specificWriter is null ? 0 : 1;
     internal int CachedDynamicSubjectSchemaCount => _dynamicSchemaCaches.Count;
 
     /// <summary>
@@ -301,16 +303,15 @@ public sealed class AvroSchemaRegistrySerializer<
     {
         switch (value)
         {
-            case ISpecificRecord specificRecord:
-                var specificWriter = _specificWriters.GetOrAdd(
-                    specificRecord.Schema,
-                    static schema => new SpecificDefaultWriter(schema));
-                specificWriter.Write(specificRecord.Schema, specificRecord, encoder);
-                break;
-
             case GenericRecord genericRecord:
                 var genericWriter = GetGenericWriter(genericRecord.Schema);
                 genericWriter.Write(genericRecord, encoder);
+                break;
+
+            case ISpecificRecord:
+                var specificWriter = _specificWriter ?? throw new NotSupportedException(
+                    $"SpecificRecord type {typeof(T)} does not expose a supported static _SCHEMA field.");
+                specificWriter.Write(value, encoder);
                 break;
 
             default:

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -2,7 +2,6 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Avro.Generic;
 using Avro.Specific;
 using Dekaf.Serialization;
@@ -33,8 +32,8 @@ namespace Dekaf.SchemaRegistry.Avro;
 /// </para>
 /// </remarks>
 /// <typeparam name="T">
-/// The type to serialize. Must be either an Avro ISpecificRecord or GenericRecord. NativeAOT requires
-/// a concrete SpecificRecord type with a statically discoverable schema; runtime SpecificRecord discovery is unsupported.
+/// The type to serialize. Must be either a concrete Avro ISpecificRecord type with a statically
+/// discoverable schema or GenericRecord. Runtime SpecificRecord type discovery is unsupported.
 /// </typeparam>
 public sealed class AvroSchemaRegistrySerializer<
     [DynamicallyAccessedMembers(
@@ -55,12 +54,9 @@ public sealed class AvroSchemaRegistrySerializer<
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
     private readonly ConcurrentDictionary<AvroSchema, DynamicSchemaCache> _dynamicSchemaCaches =
         new(AvroSchemaLogicalComparer.Instance);
-    private readonly ConcurrentDictionary<RuntimeSpecificWriterKey, RuntimeSpecificWriterEntry> _runtimeSpecificWriters =
-        new(RuntimeSpecificWriterKeyComparer.Instance);
     private readonly AllocationFreeSpecificRecordWriter<T>? _specificWriter;
     private readonly AvroSchema? _writerSchema;
     private DynamicSchemaCache? _lastDynamicSchemaCache;
-    private RuntimeSpecificWriterEntry? _lastRuntimeSpecificWriter;
 
     /// <summary>
     /// Creates a new Avro Schema Registry serializer.
@@ -81,15 +77,15 @@ public sealed class AvroSchemaRegistrySerializer<
         _writerSchema = GetSchemaFromType();
         if (_writerSchema is not null)
             _specificWriter = AllocationFreeSpecificRecordWriter<T>.Create(_writerSchema);
-        else if (!RuntimeFeature.IsDynamicCodeSupported && typeof(ISpecificRecord).IsAssignableFrom(typeof(T)))
+        else if (typeof(ISpecificRecord).IsAssignableFrom(typeof(T)))
         {
-            throw new PlatformNotSupportedException(
-                $"NativeAOT serialization requires a concrete SpecificRecord type with a statically discoverable schema; {typeof(T)} requires runtime type discovery.");
+            throw new NotSupportedException(
+                $"Allocation-free SpecificRecord serialization requires a concrete type with a statically discoverable schema; {typeof(T)} requires trimming-unsafe runtime type discovery.");
         }
     }
 
     internal int CachedGenericWriterCount => _dynamicSchemaCaches.Count;
-    internal int CachedSpecificWriterCount => (_specificWriter is null ? 0 : 1) + _runtimeSpecificWriters.Count;
+    internal int CachedSpecificWriterCount => _specificWriter is null ? 0 : 1;
     internal int CachedDynamicSubjectSchemaCount => _dynamicSchemaCaches.Count;
 
     /// <summary>
@@ -320,9 +316,10 @@ public sealed class AvroSchemaRegistrySerializer<
                 genericWriter.Write(genericRecord, encoder);
                 break;
 
-            case ISpecificRecord specificRecord:
-                var specificWriter = GetSpecificWriter(value, specificRecord);
-                specificWriter.Write(value, encoder);
+            case ISpecificRecord:
+                (_specificWriter ?? throw new InvalidOperationException(
+                    $"SpecificRecord type {typeof(T)} does not have a prepared allocation-free writer."))
+                    .Write(value, encoder);
                 break;
 
             default:
@@ -461,31 +458,6 @@ public sealed class AvroSchemaRegistrySerializer<
     private AllocationFreeGenericRecordWriter GetGenericWriter(AvroSchema schema) =>
         GetDynamicSchemaCache(schema).Writer;
 
-    private AllocationFreeSpecificRecordWriter<T> GetSpecificWriter(T value, ISpecificRecord record)
-    {
-        if (_specificWriter is { } fixedWriter)
-            return fixedWriter;
-
-        var recordType = value!.GetType();
-        var schema = record.Schema;
-        var last = Volatile.Read(ref _lastRuntimeSpecificWriter);
-        if (last is not null &&
-            last.Key.RecordType == recordType &&
-            ReferenceEquals(last.Key.Schema, schema))
-        {
-            return last.Writer;
-        }
-
-        var key = new RuntimeSpecificWriterKey(recordType, schema);
-        var entry = _runtimeSpecificWriters.GetOrAdd(
-            key,
-            static value => new RuntimeSpecificWriterEntry(
-                value,
-                AllocationFreeSpecificRecordWriter<T>.Create(value.Schema, value.RecordType)));
-        Volatile.Write(ref _lastRuntimeSpecificWriter, entry);
-        return entry.Writer;
-    }
-
     private DynamicSchemaCache GetDynamicSchemaCache(AvroSchema schema)
     {
         var last = Volatile.Read(ref _lastDynamicSchemaCache);
@@ -515,27 +487,6 @@ public sealed class AvroSchemaRegistrySerializer<
         internal AvroSchema LastSeenSchema;
         internal SubjectSchemaIdCache SubjectSchemaIdCache { get; }
         internal AllocationFreeGenericRecordWriter Writer { get; }
-    }
-
-    private readonly record struct RuntimeSpecificWriterKey(
-        [property: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type RecordType,
-        AvroSchema Schema);
-
-    private sealed record RuntimeSpecificWriterEntry(
-        RuntimeSpecificWriterKey Key,
-        AllocationFreeSpecificRecordWriter<T> Writer);
-
-    private sealed class RuntimeSpecificWriterKeyComparer : IEqualityComparer<RuntimeSpecificWriterKey>
-    {
-        internal static readonly RuntimeSpecificWriterKeyComparer Instance = new();
-
-        private RuntimeSpecificWriterKeyComparer() { }
-
-        public bool Equals(RuntimeSpecificWriterKey x, RuntimeSpecificWriterKey y) =>
-            x.RecordType == y.RecordType && ReferenceEquals(x.Schema, y.Schema);
-
-        public int GetHashCode(RuntimeSpecificWriterKey value) =>
-            HashCode.Combine(value.RecordType, RuntimeHelpers.GetHashCode(value.Schema));
     }
 
     private static AvroSchema? GetSchemaFromType()

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Avro.Generic;
 using Avro.Specific;
 using Dekaf.Serialization;
@@ -51,9 +52,12 @@ public sealed class AvroSchemaRegistrySerializer<
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
     private readonly ConcurrentDictionary<AvroSchema, DynamicSchemaCache> _dynamicSchemaCaches =
         new(AvroSchemaLogicalComparer.Instance);
+    private readonly ConcurrentDictionary<RuntimeSpecificWriterKey, RuntimeSpecificWriterEntry> _runtimeSpecificWriters =
+        new(RuntimeSpecificWriterKeyComparer.Instance);
     private readonly AllocationFreeSpecificRecordWriter<T>? _specificWriter;
     private readonly AvroSchema? _writerSchema;
     private DynamicSchemaCache? _lastDynamicSchemaCache;
+    private RuntimeSpecificWriterEntry? _lastRuntimeSpecificWriter;
 
     /// <summary>
     /// Creates a new Avro Schema Registry serializer.
@@ -77,7 +81,7 @@ public sealed class AvroSchemaRegistrySerializer<
     }
 
     internal int CachedGenericWriterCount => _dynamicSchemaCaches.Count;
-    internal int CachedSpecificWriterCount => _specificWriter is null ? 0 : 1;
+    internal int CachedSpecificWriterCount => (_specificWriter is null ? 0 : 1) + _runtimeSpecificWriters.Count;
     internal int CachedDynamicSubjectSchemaCount => _dynamicSchemaCaches.Count;
 
     /// <summary>
@@ -308,9 +312,8 @@ public sealed class AvroSchemaRegistrySerializer<
                 genericWriter.Write(genericRecord, encoder);
                 break;
 
-            case ISpecificRecord:
-                var specificWriter = _specificWriter ?? throw new NotSupportedException(
-                    $"SpecificRecord type {typeof(T)} does not expose a supported static _SCHEMA field.");
+            case ISpecificRecord specificRecord:
+                var specificWriter = GetSpecificWriter(value, specificRecord);
                 specificWriter.Write(value, encoder);
                 break;
 
@@ -450,6 +453,31 @@ public sealed class AvroSchemaRegistrySerializer<
     private AllocationFreeGenericRecordWriter GetGenericWriter(AvroSchema schema) =>
         GetDynamicSchemaCache(schema).Writer;
 
+    private AllocationFreeSpecificRecordWriter<T> GetSpecificWriter(T value, ISpecificRecord record)
+    {
+        if (_specificWriter is { } fixedWriter)
+            return fixedWriter;
+
+        var recordType = value!.GetType();
+        var schema = record.Schema;
+        var last = Volatile.Read(ref _lastRuntimeSpecificWriter);
+        if (last is not null &&
+            last.Key.RecordType == recordType &&
+            ReferenceEquals(last.Key.Schema, schema))
+        {
+            return last.Writer;
+        }
+
+        var key = new RuntimeSpecificWriterKey(recordType, schema);
+        var entry = _runtimeSpecificWriters.GetOrAdd(
+            key,
+            static value => new RuntimeSpecificWriterEntry(
+                value,
+                AllocationFreeSpecificRecordWriter<T>.Create(value.Schema, value.RecordType)));
+        Volatile.Write(ref _lastRuntimeSpecificWriter, entry);
+        return entry.Writer;
+    }
+
     private DynamicSchemaCache GetDynamicSchemaCache(AvroSchema schema)
     {
         var last = Volatile.Read(ref _lastDynamicSchemaCache);
@@ -479,6 +507,27 @@ public sealed class AvroSchemaRegistrySerializer<
         internal AvroSchema LastSeenSchema;
         internal SubjectSchemaIdCache SubjectSchemaIdCache { get; }
         internal AllocationFreeGenericRecordWriter Writer { get; }
+    }
+
+    private readonly record struct RuntimeSpecificWriterKey(
+        [property: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type RecordType,
+        AvroSchema Schema);
+
+    private sealed record RuntimeSpecificWriterEntry(
+        RuntimeSpecificWriterKey Key,
+        AllocationFreeSpecificRecordWriter<T> Writer);
+
+    private sealed class RuntimeSpecificWriterKeyComparer : IEqualityComparer<RuntimeSpecificWriterKey>
+    {
+        internal static readonly RuntimeSpecificWriterKeyComparer Instance = new();
+
+        private RuntimeSpecificWriterKeyComparer() { }
+
+        public bool Equals(RuntimeSpecificWriterKey x, RuntimeSpecificWriterKey y) =>
+            x.RecordType == y.RecordType && ReferenceEquals(x.Schema, y.Schema);
+
+        public int GetHashCode(RuntimeSpecificWriterKey value) =>
+            HashCode.Combine(value.RecordType, RuntimeHelpers.GetHashCode(value.Schema));
     }
 
     private static AvroSchema? GetSchemaFromType()

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -32,7 +32,10 @@ namespace Dekaf.SchemaRegistry.Avro;
 /// blocks on Schema Registry calls.
 /// </para>
 /// </remarks>
-/// <typeparam name="T">The type to serialize. Must be either an Avro ISpecificRecord or GenericRecord.</typeparam>
+/// <typeparam name="T">
+/// The type to serialize. Must be either an Avro ISpecificRecord or GenericRecord. NativeAOT requires
+/// a concrete SpecificRecord type with a statically discoverable schema; runtime SpecificRecord discovery is unsupported.
+/// </typeparam>
 public sealed class AvroSchemaRegistrySerializer<
     [DynamicallyAccessedMembers(
         DynamicallyAccessedMemberTypes.PublicFields |
@@ -78,6 +81,11 @@ public sealed class AvroSchemaRegistrySerializer<
         _writerSchema = GetSchemaFromType();
         if (_writerSchema is not null)
             _specificWriter = AllocationFreeSpecificRecordWriter<T>.Create(_writerSchema);
+        else if (!RuntimeFeature.IsDynamicCodeSupported && typeof(ISpecificRecord).IsAssignableFrom(typeof(T)))
+        {
+            throw new PlatformNotSupportedException(
+                $"NativeAOT serialization requires a concrete SpecificRecord type with a statically discoverable schema; {typeof(T)} requires runtime type discovery.");
+        }
     }
 
     internal int CachedGenericWriterCount => _dynamicSchemaCaches.Count;

--- a/src/Dekaf.SchemaRegistry.Avro/Dekaf.SchemaRegistry.Avro.csproj
+++ b/src/Dekaf.SchemaRegistry.Avro/Dekaf.SchemaRegistry.Avro.csproj
@@ -4,6 +4,7 @@
     <PackageId>Dekaf.SchemaRegistry.Avro</PackageId>
     <Description>Apache Avro serialization with Schema Registry integration for Dekaf Kafka client</Description>
     <PackageTags>kafka;schema-registry;avro;serialization</PackageTags>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Dekaf.Tests.Aot/Program.cs
+++ b/tests/Dekaf.Tests.Aot/Program.cs
@@ -1,6 +1,5 @@
 using System.Buffers;
 using System.Net;
-using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -185,8 +184,7 @@ internal static class AotSmoke
 
     private static async Task RunAvroSchemaRegistryPackageSmokeAsync(InMemorySchemaRegistry registry)
     {
-        if (!RuntimeFeature.IsDynamicCodeSupported)
-            RequireInterfaceTypedAvroSerializerRejected(registry);
+        RequireInterfaceTypedAvroSerializerRejected(registry);
 
         await using var serializer = new AvroSchemaRegistrySerializer<AotAvroRecord>(registry);
         await using var deserializer = new AvroSchemaRegistryDeserializer<AotAvroRecord>(registry);
@@ -208,13 +206,13 @@ internal static class AotSmoke
         {
             _ = new AvroSchemaRegistrySerializer<ISpecificRecord>(registry);
         }
-        catch (PlatformNotSupportedException)
+        catch (NotSupportedException)
         {
             return;
         }
 
         throw new InvalidOperationException(
-            "Interface-typed Avro serialization must be rejected when runtime type discovery is unavailable.");
+            "Interface-typed Avro serialization must reject trimming-unsafe runtime type discovery.");
     }
 
     private static async Task RunProtobufSchemaRegistryPackageSmokeAsync(InMemorySchemaRegistry registry)

--- a/tests/Dekaf.Tests.Aot/Program.cs
+++ b/tests/Dekaf.Tests.Aot/Program.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -184,6 +185,9 @@ internal static class AotSmoke
 
     private static async Task RunAvroSchemaRegistryPackageSmokeAsync(InMemorySchemaRegistry registry)
     {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+            RequireInterfaceTypedAvroSerializerRejected(registry);
+
         await using var serializer = new AvroSchemaRegistrySerializer<AotAvroRecord>(registry);
         await using var deserializer = new AvroSchemaRegistryDeserializer<AotAvroRecord>(registry);
 
@@ -196,6 +200,21 @@ internal static class AotSmoke
         var roundTrip = deserializer.Deserialize(buffer.WrittenMemory, ValueContext);
         Require(roundTrip.Id == payload.Id, "Avro Schema Registry ID mismatch.");
         Require(roundTrip.Name == payload.Name, "Avro Schema Registry name mismatch.");
+    }
+
+    private static void RequireInterfaceTypedAvroSerializerRejected(InMemorySchemaRegistry registry)
+    {
+        try
+        {
+            _ = new AvroSchemaRegistrySerializer<ISpecificRecord>(registry);
+        }
+        catch (PlatformNotSupportedException)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "Interface-typed Avro serialization must be rejected when runtime type discovery is unavailable.");
     }
 
     private static async Task RunProtobufSchemaRegistryPackageSmokeAsync(InMemorySchemaRegistry registry)

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -5,6 +5,7 @@ using System.Numerics;
 using System.Text;
 using Avro.Generic;
 using Avro.IO;
+using Avro.Specific;
 using Dekaf.SchemaRegistry;
 using Dekaf.SchemaRegistry.Avro;
 using Dekaf.Serialization;
@@ -29,6 +30,35 @@ public sealed class AvroSerializerTests
             "fields": [
                 { "name": "id", "type": "int" },
                 { "name": "name", "type": "string" }
+            ]
+        }
+        """;
+
+    private const string SpecificScalarRecordSchema = """
+        {
+            "type": "record",
+            "name": "SpecificScalarRecord",
+            "namespace": "test",
+            "fields": [
+                { "name": "nothing", "type": "null" },
+                { "name": "enabled", "type": "boolean" },
+                { "name": "count", "type": "int" },
+                { "name": "sequence", "type": "long" },
+                { "name": "ratio", "type": "float" },
+                { "name": "total", "type": "double" },
+                { "name": "name", "type": "string" },
+                { "name": "payload", "type": "bytes" }
+            ]
+        }
+        """;
+
+    private const string SpecificArrayRecordSchema = """
+        {
+            "type": "record",
+            "name": "SpecificArrayRecord",
+            "namespace": "test",
+            "fields": [
+                { "name": "values", "type": { "type": "array", "items": "int" } }
             ]
         }
         """;
@@ -1300,6 +1330,41 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Serializer_SpecificRecord_ScalarFieldsMatchApacheAvroBytes()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<SpecificScalarRecord>(schemaRegistry);
+        var record = new SpecificScalarRecord
+        {
+            Enabled = true,
+            Count = -42,
+            Sequence = long.MaxValue,
+            Ratio = 1.25f,
+            Total = -123.5,
+            Name = "specific",
+            Payload = [0, 1, 127, 255]
+        };
+        var expected = SerializeSpecificAvroRecord(record);
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(record, ref buffer, CreateContext());
+
+        await Assert.That(buffer.WrittenSpan.Slice(5).SequenceEqual(expected)).IsTrue();
+        await Assert.That(serializer.CachedSpecificWriterCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Serializer_SpecificRecord_UnsupportedFieldFailsDuringPreparation()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => GC.KeepAlive(new AvroSchemaRegistrySerializer<SpecificArrayRecord>(schemaRegistry)));
+
+        await Assert.That(exception!.Message).Contains("schema type Array is not supported");
+    }
+
+    [Test]
     public async Task Serializer_UsesTopicNameStrategy_ByDefault()
     {
         // Arrange
@@ -1674,6 +1739,14 @@ public sealed class AvroSerializerTests
         await Assert.That(buffer.WrittenSpan.Slice(5).SequenceEqual(expected)).IsTrue();
     }
 
+    private static byte[] SerializeSpecificAvroRecord(ISpecificRecord record)
+    {
+        using var stream = new MemoryStream();
+        var writer = new SpecificDefaultWriter(record.Schema);
+        writer.Write(record.Schema, record, new BinaryEncoder(stream));
+        return stream.ToArray();
+    }
+
     private static async Task AssertSerializedPayloadMatches(
         AvroSchemaRegistrySerializer<GenericRecord> serializer,
         Avro.RecordSchema schema,
@@ -1801,5 +1874,48 @@ public sealed class AvroSerializerTests
 
         public override bool IsInstanceOfLogicalType(object logicalValue) =>
             logicalValue is string value && value.StartsWith("text-", StringComparison.Ordinal);
+    }
+
+    private sealed class SpecificScalarRecord : ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificScalarRecordSchema);
+
+        public bool Enabled { get; init; }
+        public int Count { get; init; }
+        public long Sequence { get; init; }
+        public float Ratio { get; init; }
+        public double Total { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public byte[] Payload { get; init; } = [];
+        public AvroSchema Schema => _SCHEMA;
+
+        public object? Get(int fieldPos) => fieldPos switch
+        {
+            0 => null,
+            1 => Enabled,
+            2 => Count,
+            3 => Sequence,
+            4 => Ratio,
+            5 => Total,
+            6 => Name,
+            7 => Payload,
+            _ => throw new ArgumentOutOfRangeException(nameof(fieldPos))
+        };
+
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
+    }
+
+    private sealed class SpecificArrayRecord : ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificArrayRecordSchema);
+
+        public int[] Values { get; init; } = [];
+        public AvroSchema Schema => _SCHEMA;
+
+        public object Get(int fieldPos) => fieldPos == 0
+            ? Values
+            : throw new ArgumentOutOfRangeException(nameof(fieldPos));
+
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
     }
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -63,6 +63,33 @@ public sealed class AvroSerializerTests
         }
         """;
 
+    private const string SpecificMissingPropertySchema = """
+        {
+            "type": "record",
+            "name": "SpecificMissingPropertyRecord",
+            "namespace": "test",
+            "fields": [{ "name": "missing", "type": "int" }]
+        }
+        """;
+
+    private const string SpecificMismatchedPropertySchema = """
+        {
+            "type": "record",
+            "name": "SpecificMismatchedPropertyRecord",
+            "namespace": "test",
+            "fields": [{ "name": "count", "type": "int" }]
+        }
+        """;
+
+    private const string SpecificCaseInsensitivePropertySchema = """
+        {
+            "type": "record",
+            "name": "SpecificCaseInsensitivePropertyRecord",
+            "namespace": "test",
+            "fields": [{ "name": "userId", "type": "int" }]
+        }
+        """;
+
     private const string AllFieldTypesSchema = """
         {
             "type": "record",
@@ -1354,6 +1381,30 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Serializer_InterfaceTypedSpecificRecord_MatchesApacheAvroBytes()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<ISpecificRecord>(schemaRegistry);
+        ISpecificRecord record = new SpecificScalarRecord
+        {
+            Enabled = true,
+            Count = -42,
+            Sequence = long.MaxValue,
+            Ratio = 1.25f,
+            Total = -123.5,
+            Name = "specific",
+            Payload = [0, 1, 127, 255]
+        };
+        var expected = SerializeSpecificAvroRecord(record);
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(record, ref buffer, CreateContext());
+
+        await Assert.That(buffer.WrittenSpan.Slice(5).SequenceEqual(expected)).IsTrue();
+        await Assert.That(serializer.CachedSpecificWriterCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Serializer_SpecificRecord_UnsupportedFieldFailsDuringPreparation()
     {
         using var schemaRegistry = new MockSchemaRegistryClient();
@@ -1362,6 +1413,42 @@ public sealed class AvroSerializerTests
             () => GC.KeepAlive(new AvroSchemaRegistrySerializer<SpecificArrayRecord>(schemaRegistry)));
 
         await Assert.That(exception!.Message).Contains("schema type Array is not supported");
+    }
+
+    [Test]
+    public async Task Serializer_SpecificRecord_MissingPropertyFailsDuringPreparation()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => GC.KeepAlive(new AvroSchemaRegistrySerializer<SpecificMissingPropertyRecord>(schemaRegistry)));
+
+        await Assert.That(exception!.Message).Contains("a readable public property named 'missing' was not found");
+    }
+
+    [Test]
+    public async Task Serializer_SpecificRecord_MismatchedPropertyTypeFailsDuringPreparation()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => GC.KeepAlive(new AvroSchemaRegistrySerializer<SpecificMismatchedPropertyRecord>(schemaRegistry)));
+
+        await Assert.That(exception!.Message).Contains("has type System.Int64, expected System.Int32");
+    }
+
+    [Test]
+    public async Task Serializer_SpecificRecord_CaseInsensitivePropertyMatchesSchemaField()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<SpecificCaseInsensitivePropertyRecord>(schemaRegistry);
+        var record = new SpecificCaseInsensitivePropertyRecord { UserId = 7 };
+        var expected = SerializeSpecificAvroRecord(record);
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(record, ref buffer, CreateContext());
+
+        await Assert.That(buffer.WrittenSpan.Slice(5).SequenceEqual(expected)).IsTrue();
     }
 
     [Test]
@@ -1916,6 +2003,39 @@ public sealed class AvroSerializerTests
             ? Values
             : throw new ArgumentOutOfRangeException(nameof(fieldPos));
 
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
+    }
+
+    private sealed class SpecificMissingPropertyRecord : ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificMissingPropertySchema);
+
+        public AvroSchema Schema => _SCHEMA;
+        public object Get(int fieldPos) => throw new ArgumentOutOfRangeException(nameof(fieldPos));
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
+    }
+
+    private sealed class SpecificMismatchedPropertyRecord : ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificMismatchedPropertySchema);
+
+        public long Count { get; init; }
+        public AvroSchema Schema => _SCHEMA;
+        public object Get(int fieldPos) => fieldPos == 0
+            ? Count
+            : throw new ArgumentOutOfRangeException(nameof(fieldPos));
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
+    }
+
+    private sealed class SpecificCaseInsensitivePropertyRecord : ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificCaseInsensitivePropertySchema);
+
+        public int UserId { get; init; }
+        public AvroSchema Schema => _SCHEMA;
+        public object Get(int fieldPos) => fieldPos == 0
+            ? UserId
+            : throw new ArgumentOutOfRangeException(nameof(fieldPos));
         public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
     }
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -1411,27 +1411,14 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
-    public async Task Serializer_InterfaceTypedSpecificRecord_MatchesApacheAvroBytes()
+    public async Task Serializer_InterfaceTypedSpecificRecord_FailsDuringPreparation()
     {
         using var schemaRegistry = new MockSchemaRegistryClient();
-        await using var serializer = new AvroSchemaRegistrySerializer<ISpecificRecord>(schemaRegistry);
-        ISpecificRecord record = new SpecificScalarRecord
-        {
-            Enabled = true,
-            Count = -42,
-            Sequence = long.MaxValue,
-            Ratio = 1.25f,
-            Total = -123.5,
-            Name = "specific",
-            Payload = [0, 1, 127, 255]
-        };
-        var expected = SerializeSpecificAvroRecord(record);
-        var buffer = new ArrayBufferWriter<byte>();
 
-        serializer.Serialize(record, ref buffer, CreateContext());
+        var exception = Assert.Throws<NotSupportedException>(
+            () => GC.KeepAlive(new AvroSchemaRegistrySerializer<ISpecificRecord>(schemaRegistry)));
 
-        await Assert.That(buffer.WrittenSpan.Slice(5).SequenceEqual(expected)).IsTrue();
-        await Assert.That(serializer.CachedSpecificWriterCount).IsEqualTo(1);
+        await Assert.That(exception!.Message).Contains("trimming-unsafe runtime type discovery");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -1411,6 +1411,28 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Serializer_SpecificRecord_NonNullableReferenceFieldRejectsNull(bool nullBytes)
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<SpecificScalarRecord>(schemaRegistry);
+        var record = new SpecificScalarRecord
+        {
+            Name = nullBytes ? "specific" : null!,
+            Payload = nullBytes ? null! : []
+        };
+
+        await Assert.That(Serialize).Throws<Avro.AvroTypeException>();
+
+        void Serialize()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(record, ref buffer, CreateContext());
+        }
+    }
+
+    [Test]
     public async Task Serializer_InterfaceTypedSpecificRecord_FailsDuringPreparation()
     {
         using var schemaRegistry = new MockSchemaRegistryClient();

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -90,6 +90,36 @@ public sealed class AvroSerializerTests
         }
         """;
 
+    private const string SpecificVirtualPropertySchema = """
+        {
+            "type": "record",
+            "name": "SpecificVirtualPropertyRecord",
+            "namespace": "test",
+            "fields": [{ "name": "count", "type": "int" }]
+        }
+        """;
+
+    private const string SpecificAmbiguousPropertySchema = """
+        {
+            "type": "record",
+            "name": "SpecificAmbiguousPropertyRecord",
+            "namespace": "test",
+            "fields": [{ "name": "count", "type": "int" }]
+        }
+        """;
+
+    private const string SpecificAliasedPropertySchema = """
+        {
+            "type": "record",
+            "name": "SpecificAliasedPropertyRecord",
+            "namespace": "test",
+            "fields": [
+                { "name": "Name", "type": "string" },
+                { "name": "name", "type": "string" }
+            ]
+        }
+        """;
+
     private const string AllFieldTypesSchema = """
         {
             "type": "record",
@@ -1452,6 +1482,40 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Serializer_SpecificRecord_OverridablePropertyFailsDuringPreparation()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        GC.KeepAlive(new SpecificVirtualPropertyDerivedRecord());
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => GC.KeepAlive(new AvroSchemaRegistrySerializer<SpecificVirtualPropertyRecord>(schemaRegistry)));
+
+        await Assert.That(exception!.Message).Contains("property 'Count' has an overridable getter");
+    }
+
+    [Test]
+    public async Task Serializer_SpecificRecord_AmbiguousPropertyFailsDuringPreparation()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => GC.KeepAlive(new AvroSchemaRegistrySerializer<SpecificAmbiguousPropertyRecord>(schemaRegistry)));
+
+        await Assert.That(exception!.Message).Contains("multiple public properties match 'count' ignoring case");
+    }
+
+    [Test]
+    public async Task Serializer_SpecificRecord_PropertyCannotMatchMultipleSchemaFields()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => GC.KeepAlive(new AvroSchemaRegistrySerializer<SpecificAliasedPropertyRecord>(schemaRegistry)));
+
+        await Assert.That(exception!.Message).Contains("property 'Name' also matches another schema field");
+    }
+
+    [Test]
     public async Task Serializer_UsesTopicNameStrategy_ByDefault()
     {
         // Arrange
@@ -2035,6 +2099,52 @@ public sealed class AvroSerializerTests
         public AvroSchema Schema => _SCHEMA;
         public object Get(int fieldPos) => fieldPos == 0
             ? UserId
+            : throw new ArgumentOutOfRangeException(nameof(fieldPos));
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
+    }
+
+    private class SpecificVirtualPropertyRecord : ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificVirtualPropertySchema);
+
+        public virtual int Count { get; init; }
+        public AvroSchema Schema => _SCHEMA;
+        public object Get(int fieldPos) => fieldPos == 0
+            ? Count
+            : throw new ArgumentOutOfRangeException(nameof(fieldPos));
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
+    }
+
+    private sealed class SpecificVirtualPropertyDerivedRecord : SpecificVirtualPropertyRecord
+    {
+        public override int Count { get; init; }
+    }
+
+    private class SpecificAmbiguousPropertyBase
+    {
+        public long Count { get; init; }
+    }
+
+    private sealed class SpecificAmbiguousPropertyRecord : SpecificAmbiguousPropertyBase, ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificAmbiguousPropertySchema);
+
+        public new int Count { get; init; }
+        public AvroSchema Schema => _SCHEMA;
+        public object Get(int fieldPos) => fieldPos == 0
+            ? Count
+            : throw new ArgumentOutOfRangeException(nameof(fieldPos));
+        public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
+    }
+
+    private sealed class SpecificAliasedPropertyRecord : ISpecificRecord
+    {
+        public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(SpecificAliasedPropertySchema);
+
+        public string Name { get; init; } = string.Empty;
+        public AvroSchema Schema => _SCHEMA;
+        public object Get(int fieldPos) => fieldPos is 0 or 1
+            ? Name
             : throw new ArgumentOutOfRangeException(nameof(fieldPos));
         public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
     }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -13,7 +13,7 @@ using RegistrySchema = Dekaf.SchemaRegistry.Schema;
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
 /// <summary>
-/// Measures the producer's generic Avro path and the unchanged Apache SpecificRecord control.
+/// Measures prepared GenericRecord and SpecificRecord serialization paths.
 /// </summary>
 [MemoryDiagnoser(displayGenColumns: false)]
 public class AvroSchemaRegistrySerializerBenchmarks
@@ -330,7 +330,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_nestedRecordListRecord, ref _serializeBuffer, _context);
     }
 
-    [Benchmark(Description = "Control: Apache writer prepared SpecificRecord")]
+    [Benchmark(Description = "Serialize prepared SpecificRecord (int + string)")]
     public void SerializeSpecificRecord()
     {
         _serializeBuffer.ResetWrittenCount();

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -154,6 +154,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
 
     private AvroSchemaRegistrySerializer<GenericRecord> _serializer = null!;
     private AvroSchemaRegistrySerializer<SpecificBenchmarkRecord> _specificSerializer = null!;
+    private AvroSchemaRegistrySerializer<ISpecificRecord> _interfaceSpecificSerializer = null!;
     private GenericRecord[] _equivalentRecords = null!;
     private GenericRecord _intRecord = null!;
     private GenericRecord _nullableIntArrayRecord = null!;
@@ -167,6 +168,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
     private GenericRecord _nestedRecordCollectionRecord = null!;
     private GenericRecord _nestedRecordListRecord = null!;
     private SpecificBenchmarkRecord _specificRecord = null!;
+    private ISpecificRecord _interfaceSpecificRecord = null!;
     private ArrayBufferWriter<byte> _serializeBuffer = null!;
     private GenericRecord _stableRecord = null!;
     private SerializationContext _context;
@@ -180,6 +182,8 @@ public class AvroSchemaRegistrySerializerBenchmarks
         Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkIntBytesLogicalType());
         _serializer = new AvroSchemaRegistrySerializer<GenericRecord>(new BenchmarkSchemaRegistryClient());
         _specificSerializer = new AvroSchemaRegistrySerializer<SpecificBenchmarkRecord>(
+            new BenchmarkSchemaRegistryClient());
+        _interfaceSpecificSerializer = new AvroSchemaRegistrySerializer<ISpecificRecord>(
             new BenchmarkSchemaRegistryClient());
         _context = new SerializationContext
         {
@@ -203,6 +207,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _conditionalValueLogicalStringArrayRecord = CreateConditionalValueLogicalStringArrayRecord();
         (_nestedRecordCollectionRecord, _nestedRecordListRecord) = CreateNestedRecordCollectionRecords();
         _specificRecord = new SpecificBenchmarkRecord { Id = 42, Name = "benchmark" };
+        _interfaceSpecificRecord = _specificRecord;
         _serializeBuffer = new ArrayBufferWriter<byte>();
         _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
@@ -227,6 +232,8 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializer.Serialize(_nestedRecordListRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _specificSerializer.Serialize(_specificRecord, ref _serializeBuffer, _context);
+        _serializeBuffer.ResetWrittenCount();
+        _interfaceSpecificSerializer.Serialize(_interfaceSpecificRecord, ref _serializeBuffer, _context);
     }
 
     [GlobalCleanup]
@@ -234,6 +241,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
     {
         await _serializer.DisposeAsync().ConfigureAwait(false);
         await _specificSerializer.DisposeAsync().ConfigureAwait(false);
+        await _interfaceSpecificSerializer.DisposeAsync().ConfigureAwait(false);
     }
 
     [Benchmark(Baseline = true, Description = "Prepare stable generic Avro schema")]
@@ -335,6 +343,13 @@ public class AvroSchemaRegistrySerializerBenchmarks
     {
         _serializeBuffer.ResetWrittenCount();
         _specificSerializer.Serialize(_specificRecord, ref _serializeBuffer, _context);
+    }
+
+    [Benchmark(Description = "Serialize interface-typed SpecificRecord (int + string)")]
+    public void SerializeInterfaceSpecificRecord()
+    {
+        _serializeBuffer.ResetWrittenCount();
+        _interfaceSpecificSerializer.Serialize(_interfaceSpecificRecord, ref _serializeBuffer, _context);
     }
 
     private static GenericRecord CreateRecord(int id)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -154,7 +154,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
 
     private AvroSchemaRegistrySerializer<GenericRecord> _serializer = null!;
     private AvroSchemaRegistrySerializer<SpecificBenchmarkRecord> _specificSerializer = null!;
-    private AvroSchemaRegistrySerializer<ISpecificRecord> _interfaceSpecificSerializer = null!;
     private GenericRecord[] _equivalentRecords = null!;
     private GenericRecord _intRecord = null!;
     private GenericRecord _nullableIntArrayRecord = null!;
@@ -168,7 +167,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
     private GenericRecord _nestedRecordCollectionRecord = null!;
     private GenericRecord _nestedRecordListRecord = null!;
     private SpecificBenchmarkRecord _specificRecord = null!;
-    private ISpecificRecord _interfaceSpecificRecord = null!;
     private ArrayBufferWriter<byte> _serializeBuffer = null!;
     private GenericRecord _stableRecord = null!;
     private SerializationContext _context;
@@ -182,8 +180,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
         Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkIntBytesLogicalType());
         _serializer = new AvroSchemaRegistrySerializer<GenericRecord>(new BenchmarkSchemaRegistryClient());
         _specificSerializer = new AvroSchemaRegistrySerializer<SpecificBenchmarkRecord>(
-            new BenchmarkSchemaRegistryClient());
-        _interfaceSpecificSerializer = new AvroSchemaRegistrySerializer<ISpecificRecord>(
             new BenchmarkSchemaRegistryClient());
         _context = new SerializationContext
         {
@@ -207,7 +203,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _conditionalValueLogicalStringArrayRecord = CreateConditionalValueLogicalStringArrayRecord();
         (_nestedRecordCollectionRecord, _nestedRecordListRecord) = CreateNestedRecordCollectionRecords();
         _specificRecord = new SpecificBenchmarkRecord { Id = 42, Name = "benchmark" };
-        _interfaceSpecificRecord = _specificRecord;
         _serializeBuffer = new ArrayBufferWriter<byte>();
         _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
@@ -233,7 +228,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _serializeBuffer.ResetWrittenCount();
         _specificSerializer.Serialize(_specificRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
-        _interfaceSpecificSerializer.Serialize(_interfaceSpecificRecord, ref _serializeBuffer, _context);
     }
 
     [GlobalCleanup]
@@ -241,7 +235,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
     {
         await _serializer.DisposeAsync().ConfigureAwait(false);
         await _specificSerializer.DisposeAsync().ConfigureAwait(false);
-        await _interfaceSpecificSerializer.DisposeAsync().ConfigureAwait(false);
     }
 
     [Benchmark(Baseline = true, Description = "Prepare stable generic Avro schema")]
@@ -343,13 +336,6 @@ public class AvroSchemaRegistrySerializerBenchmarks
     {
         _serializeBuffer.ResetWrittenCount();
         _specificSerializer.Serialize(_specificRecord, ref _serializeBuffer, _context);
-    }
-
-    [Benchmark(Description = "Serialize interface-typed SpecificRecord (int + string)")]
-    public void SerializeInterfaceSpecificRecord()
-    {
-        _serializeBuffer.ResetWrittenCount();
-        _interfaceSpecificSerializer.Serialize(_interfaceSpecificRecord, ref _serializeBuffer, _context);
     }
 
     private static GenericRecord CreateRecord(int id)


### PR DESCRIPTION
Closes #2697

## Summary
- prepare a scalar SpecificRecord field plan once from the generated public properties
- invoke typed managed function pointers on the hot path, bypassing `ISpecificRecord.Get(int): object`
- reject unsupported SpecificRecord shapes during serializer construction instead of silently allocating
- preserve GenericRecord fast paths, Apache Avro wire bytes, schema selection, and rules

## Performance
BenchmarkDotNet ShortRun, .NET 10.0.11, i7-12700K, exact parent `a5245f58` → candidate `37e5b120`:

| Benchmark | Parent | Candidate | Delta | Allocated |
|---|---:|---:|---:|---:|
| SpecificRecord (`int` + `string`) | 52.517 ns | 22.756 ns | -56.7% | 152 B → 0 B |
| Generic stable prepare control | 1.292 ns | 1.225 ns | -5.2% | 0 B → 0 B |
| Generic scalar-union control | 22.212 ns | 21.903 ns | -1.4% | 0 B → 0 B |

The full nine-benchmark Avro sweep also kept every candidate benchmark at 0 B; focused reruns resolved initial ShortRun noise on the two unchanged controls.

## Validation
- Release build: 0 warnings/errors, net8.0 + net10.0
- Unit: 6,692 net8.0 + 6,828 net10.0 passed
- exact Apache Avro byte parity across null/bool/int/long/float/double/string/bytes
- unsupported array shape fails during construction
- managed AOT smoke executable passed
- local NativeAOT publish attempted; Windows C++ linker prerequisite is unavailable on this machine, so CI NativeAOT jobs are the native-code gate

## Dependency
This is intentionally stacked on #2683 because it reuses that PR's allocation-free binary encoder. Rebase/base change to `main` after #2683 merges.