### PR TITLE
test(producer): synchronize metadata refresh wave

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -162,6 +162,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly Action? _onPipelinedResponseAcquired;
     private readonly Action? _onWaveCoalesceStarted;
     private readonly Action? _onIdleWaitStarted;
+    private readonly Action? _onBulkFirstBatchPublished;
     private readonly Func<long> _getTimestamp;
     private readonly Func<int, CancellationToken, ValueTask> _delayForThrottle;
     private readonly TimeSpan _disposalDrainTimeout;
@@ -935,7 +936,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         Func<bool>? usesTransactionV2 = null,
         Action? onPipelinedResponseAcquired = null,
         Action? onWaveCoalesceStarted = null,
-        Action? onIdleWaitStarted = null)
+        Action? onIdleWaitStarted = null,
+        Action? onBulkFirstBatchPublished = null)
     {
         _unackedBudget = unackedBudget;
         _brokerId = brokerId;
@@ -962,6 +964,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _onPipelinedResponseAcquired = onPipelinedResponseAcquired;
         _onWaveCoalesceStarted = onWaveCoalesceStarted;
         _onIdleWaitStarted = onIdleWaitStarted;
+        _onBulkFirstBatchPublished = onBulkFirstBatchPublished;
         _disposalDrainTimeout = disposalDrainTimeout ?? DisposalDrainTimeout;
 
         _eventChannel = Channel.CreateUnbounded<SendLoopEvent>(new UnboundedChannelOptions
@@ -1154,13 +1157,25 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             }
             else
             {
-                for (var i = 0; i < batches.Count; i++)
+                if (batches.Count > 0)
                 {
-                    _enqueuedPartitions.Add(batches[i].TopicPartition);
-                    if (!writer.TryWrite(SendLoopEvent.NewBatch(batches[i])))
+                    _enqueuedPartitions.Add(batches[0].TopicPartition);
+                    if (!writer.TryWrite(SendLoopEvent.NewBatch(batches[0])))
                     {
-                        rejectedIndex = i;
-                        break;
+                        rejectedIndex = 0;
+                    }
+                    else
+                    {
+                        _onBulkFirstBatchPublished?.Invoke();
+                        for (var i = 1; i < batches.Count; i++)
+                        {
+                            _enqueuedPartitions.Add(batches[i].TopicPartition);
+                            if (!writer.TryWrite(SendLoopEvent.NewBatch(batches[i])))
+                            {
+                                rejectedIndex = i;
+                                break;
+                            }
+                        }
                     }
                 }
             }

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1131,15 +1131,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     }
 
     /// <summary>
-    /// Bulk enqueue for the sender loop: writes all batches to the event channel before the
-    /// send loop can wake and read them, ensuring all batches are available for coalescing
-    /// into a single ProduceRequest. This reduces per-request overhead in multi-broker setups
-    /// where each broker receives only a few partitions per drain cycle.
+    /// Bulk enqueue for the sender loop. Each batch is a separate channel event, so the send
+    /// loop may observe a prefix if this producer thread is preempted between writes. The
+    /// sender's request-wave coalescing window joins siblings that arrive in time.
     /// </summary>
     /// <remarks>
     /// Channel.TryWrite on unbounded channels always succeeds unless the channel is completed.
-    /// Writing all events in a tight loop (no yields) maximizes the chance they are all present
-    /// when the send loop reads from the channel.
+    /// Writes are deliberately not treated as one atomic publication.
     /// </remarks>
     public void EnqueueBulk(List<ReadyBatch> batches)
     {
@@ -4281,6 +4279,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     }
                     else
                     {
+                        // Deduplication is scoped to this send-loop request wave. A later failed
+                        // wave must be allowed to refresh again because broker leadership may
+                        // have changed since the preceding recovery attempt.
                         metadataRefreshTopics ??= new HashSet<string>(StringComparer.Ordinal);
                         PrepareDeferredNetworkRetry(batch, metadataRefreshTopics);
                         _sendFailedRetries.Enqueue((batch, generations[i]));

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -162,7 +162,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly Action? _onPipelinedResponseAcquired;
     private readonly Action? _onWaveCoalesceStarted;
     private readonly Action? _onIdleWaitStarted;
-    private readonly Action? _onBulkFirstBatchPublished;
     private readonly Func<long> _getTimestamp;
     private readonly Func<int, CancellationToken, ValueTask> _delayForThrottle;
     private readonly TimeSpan _disposalDrainTimeout;
@@ -355,7 +354,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         public bool TryClaim() => Interlocked.Exchange(ref _claimed, 1) == 0;
     }
 
-    private enum SendLoopEventType : byte
+    internal enum SendLoopEventType : byte
     {
         NewBatch,
         ResponseReady, // Lightweight signal: a response task completed, poll _pendingResponsesByConnection
@@ -379,7 +378,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     }
 
     [StructLayout(LayoutKind.Auto)]
-    private readonly struct SendLoopEvent
+    internal readonly struct SendLoopEvent
     {
         public readonly SendLoopEventType Type;
         public readonly ReadyBatch? Batch;
@@ -937,7 +936,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         Action? onPipelinedResponseAcquired = null,
         Action? onWaveCoalesceStarted = null,
         Action? onIdleWaitStarted = null,
-        Action? onBulkFirstBatchPublished = null)
+        Channel<SendLoopEvent>? eventChannel = null)
     {
         _unackedBudget = unackedBudget;
         _brokerId = brokerId;
@@ -964,14 +963,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _onPipelinedResponseAcquired = onPipelinedResponseAcquired;
         _onWaveCoalesceStarted = onWaveCoalesceStarted;
         _onIdleWaitStarted = onIdleWaitStarted;
-        _onBulkFirstBatchPublished = onBulkFirstBatchPublished;
         _disposalDrainTimeout = disposalDrainTimeout ?? DisposalDrainTimeout;
 
-        _eventChannel = Channel.CreateUnbounded<SendLoopEvent>(new UnboundedChannelOptions
-        {
-            SingleReader = true,
-            SingleWriter = false
-        });
+        _eventChannel = eventChannel ??
+            Channel.CreateUnbounded<SendLoopEvent>(new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = false
+            });
         _transactionEnrollmentCompleted = error =>
             _eventChannel.Writer.TryWrite(SendLoopEvent.TransactionEnrollmentReady(error));
 
@@ -1157,25 +1156,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             }
             else
             {
-                if (batches.Count > 0)
+                for (var i = 0; i < batches.Count; i++)
                 {
-                    _enqueuedPartitions.Add(batches[0].TopicPartition);
-                    if (!writer.TryWrite(SendLoopEvent.NewBatch(batches[0])))
+                    _enqueuedPartitions.Add(batches[i].TopicPartition);
+                    if (!writer.TryWrite(SendLoopEvent.NewBatch(batches[i])))
                     {
-                        rejectedIndex = 0;
-                    }
-                    else
-                    {
-                        _onBulkFirstBatchPublished?.Invoke();
-                        for (var i = 1; i < batches.Count; i++)
-                        {
-                            _enqueuedPartitions.Add(batches[i].TopicPartition);
-                            if (!writer.TryWrite(SendLoopEvent.NewBatch(batches[i])))
-                            {
-                                rejectedIndex = i;
-                                break;
-                            }
-                        }
+                        rejectedIndex = i;
+                        break;
                     }
                 }
             }

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1511,7 +1511,7 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         // The original defect (#2529) was counters wired onto a path production traffic never
         // took, so this drives the real send loop end to end rather than calling CompleteSend
         // directly: enqueue -> serialize -> scripted ack -> per-batch counter emission.
-        const string topic = "test-topic";
+        const string topic = "sent-counter-test-topic";
         // Resolve instrument names before the listener starts (static-initializer re-entry
         // landmine — see FireAndForgetDeliveryErrorMetricTests).
         var messagesSentName = DekafMetrics.MessagesSent.Name;
@@ -2988,9 +2988,9 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         var reroutedCount = 0;
         var firstBatch = CreateTestBatch(valueTaskSourcePool, topic, partition: 0);
         var secondBatch = CreateTestBatch(valueTaskSourcePool, topic, partition: 1);
-        var injectPreemptedSibling = 1;
-        BrokerSender? sender = null;
-        sender = CreateSender(
+        using var waveCoalesceStarted = new ManualResetEventSlim();
+        using var bulkPublishCompleted = new ManualResetEventSlim();
+        var sender = CreateSender(
             pool,
             options,
             accumulator,
@@ -3003,9 +3003,10 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             },
             onWaveCoalesceStarted: () =>
             {
-                if (Interlocked.Exchange(ref injectPreemptedSibling, 0) != 0)
-                    sender!.Enqueue(secondBatch);
-            });
+                waveCoalesceStarted.Set();
+                bulkPublishCompleted.Wait(cancellationToken);
+            },
+            onBulkFirstBatchPublished: () => waveCoalesceStarted.Wait(cancellationToken));
 
         // Model producer-thread preemption after publishing the first of two bulk events.
         // Pre-seeding the known wave width makes the sender enter its coalescing hook; the
@@ -3018,9 +3019,22 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
 
         try
         {
-            sender.Enqueue(firstBatch);
+            var bulkPublish = Task.Run(
+                () =>
+                {
+                    try
+                    {
+                        sender.EnqueueBulk([firstBatch, secondBatch]);
+                    }
+                    finally
+                    {
+                        bulkPublishCompleted.Set();
+                    }
+                },
+                CancellationToken.None);
 
             await rerouted.Task.WaitAsync(cancellationToken);
+            await bulkPublish.WaitAsync(cancellationToken);
 
             await Assert.That(staleConnection.SendPipelinedAfterWriteCalls).IsEqualTo(1);
             await Assert.That(Volatile.Read(ref metadataRequests)).IsEqualTo(1);
@@ -3029,6 +3043,8 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         }
         finally
         {
+            waveCoalesceStarted.Set();
+            bulkPublishCompleted.Set();
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await valueTaskSourcePool.DisposeAsync();

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -2936,7 +2936,7 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
 
     [Test]
     [Timeout(30_000)]
-    public async Task SendLoop_CoalescedSendFailure_RefreshesMetadataOncePerTopic(
+    public async Task SendLoop_SingleRequestWaveFailure_RefreshesMetadataOncePerTopic(
         CancellationToken cancellationToken)
     {
         const string topic = "test-topic";
@@ -2986,7 +2986,11 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
         var rerouted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var reroutedCount = 0;
-        var sender = CreateSender(
+        var firstBatch = CreateTestBatch(valueTaskSourcePool, topic, partition: 0);
+        var secondBatch = CreateTestBatch(valueTaskSourcePool, topic, partition: 1);
+        var injectPreemptedSibling = 1;
+        BrokerSender? sender = null;
+        sender = CreateSender(
             pool,
             options,
             accumulator,
@@ -2996,20 +3000,29 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             {
                 if (Interlocked.Increment(ref reroutedCount) == 2)
                     rerouted.TrySetResult();
+            },
+            onWaveCoalesceStarted: () =>
+            {
+                if (Interlocked.Exchange(ref injectPreemptedSibling, 0) != 0)
+                    sender!.Enqueue(secondBatch);
             });
+
+        // Model producer-thread preemption after publishing the first of two bulk events.
+        // Pre-seeding the known wave width makes the sender enter its coalescing hook; the
+        // hook then deterministically publishes the sibling before the request is sealed.
+        var knownPartitions = (HashSet<TopicPartition>)typeof(BrokerSender).GetField(
+            "_knownPartitions",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
+        knownPartitions.Add(new TopicPartition(topic, 0));
+        knownPartitions.Add(new TopicPartition(topic, 1));
 
         try
         {
-            var firstBatch = CreateTestBatch(valueTaskSourcePool, topic, partition: 0);
-            var secondBatch = CreateTestBatch(valueTaskSourcePool, topic, partition: 1);
-            sender.EnqueueBulk(
-            [
-                firstBatch,
-                secondBatch
-            ]);
+            sender.Enqueue(firstBatch);
 
             await rerouted.Task.WaitAsync(cancellationToken);
 
+            await Assert.That(staleConnection.SendPipelinedAfterWriteCalls).IsEqualTo(1);
             await Assert.That(Volatile.Read(ref metadataRequests)).IsEqualTo(1);
             await Assert.That(accumulator.IsMuted(firstBatch.TopicPartition)).IsFalse();
             await Assert.That(accumulator.IsMuted(secondBatch.TopicPartition)).IsFalse();

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Reflection;
+using System.Threading.Channels;
 using System.Threading.Tasks.Sources;
 using Dekaf.Compression;
 using Dekaf.Diagnostics;
@@ -2990,6 +2991,8 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         var secondBatch = CreateTestBatch(valueTaskSourcePool, topic, partition: 1);
         using var waveCoalesceStarted = new ManualResetEventSlim();
         using var bulkPublishCompleted = new ManualResetEventSlim();
+        var eventChannel = new FirstWriteBlockingChannel<BrokerSender.SendLoopEvent>(
+            () => waveCoalesceStarted.Wait(cancellationToken));
         var sender = CreateSender(
             pool,
             options,
@@ -3006,7 +3009,7 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
                 waveCoalesceStarted.Set();
                 bulkPublishCompleted.Wait(cancellationToken);
             },
-            onBulkFirstBatchPublished: () => waveCoalesceStarted.Wait(cancellationToken));
+            eventChannel: eventChannel);
 
         // Model producer-thread preemption after publishing the first of two bulk events.
         // Pre-seeding the known wave width makes the sender enter its coalescing hook; the
@@ -3048,6 +3051,41 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    private sealed class FirstWriteBlockingChannel<T> : Channel<T>
+    {
+        internal FirstWriteBlockingChannel(Action afterFirstWrite)
+        {
+            var inner = Channel.CreateUnbounded<T>(new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = false
+            });
+            Reader = inner.Reader;
+            Writer = new FirstWriteBlockingWriter(inner.Writer, afterFirstWrite);
+        }
+
+        private sealed class FirstWriteBlockingWriter(
+            ChannelWriter<T> inner,
+            Action afterFirstWrite) : ChannelWriter<T>
+        {
+            private Action? _afterFirstWrite = afterFirstWrite;
+
+            public override bool TryComplete(Exception? error = null) => inner.TryComplete(error);
+
+            public override bool TryWrite(T item)
+            {
+                var written = inner.TryWrite(item);
+                if (written)
+                    Interlocked.Exchange(ref _afterFirstWrite, null)?.Invoke();
+
+                return written;
+            }
+
+            public override ValueTask<bool> WaitToWriteAsync(CancellationToken cancellationToken = default) =>
+                inner.WaitToWriteAsync(cancellationToken);
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/ScriptedProduceResponses.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ScriptedProduceResponses.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Reflection;
+using System.Threading.Channels;
 using Dekaf.Compression;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -263,7 +264,7 @@ public abstract class ScriptedProduceResponseFixture
         Action? onPipelinedResponseAcquired = null,
         Action? onWaveCoalesceStarted = null,
         Action? onIdleWaitStarted = null,
-        Action? onBulkFirstBatchPublished = null,
+        Channel<BrokerSender.SendLoopEvent>? eventChannel = null,
         BrokerUnackedByteBudget? unackedBudget = null,
         int produceApiVersion = 9,
         bool isTransactional = false,
@@ -295,5 +296,5 @@ public abstract class ScriptedProduceResponseFixture
             onPipelinedResponseAcquired: onPipelinedResponseAcquired,
             onWaveCoalesceStarted: onWaveCoalesceStarted,
             onIdleWaitStarted: onIdleWaitStarted,
-            onBulkFirstBatchPublished: onBulkFirstBatchPublished);
+            eventChannel: eventChannel);
 }

--- a/tests/Dekaf.Tests.Unit/Producer/ScriptedProduceResponses.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ScriptedProduceResponses.cs
@@ -263,6 +263,7 @@ public abstract class ScriptedProduceResponseFixture
         Action? onPipelinedResponseAcquired = null,
         Action? onWaveCoalesceStarted = null,
         Action? onIdleWaitStarted = null,
+        Action? onBulkFirstBatchPublished = null,
         BrokerUnackedByteBudget? unackedBudget = null,
         int produceApiVersion = 9,
         bool isTransactional = false,
@@ -293,5 +294,6 @@ public abstract class ScriptedProduceResponseFixture
             usesTransactionV2: () => usesTransactionV2,
             onPipelinedResponseAcquired: onPipelinedResponseAcquired,
             onWaveCoalesceStarted: onWaveCoalesceStarted,
-            onIdleWaitStarted: onIdleWaitStarted);
+            onIdleWaitStarted: onIdleWaitStarted,
+            onBulkFirstBatchPublished: onBulkFirstBatchPublished);
 }


### PR DESCRIPTION
Closes #2694

## Summary
- model producer preemption after the first channel publication at a deterministic request-wave hook
- assert both partitions fail in one ProduceRequest and trigger one metadata refresh
- document that `EnqueueBulk` publishes separate, non-atomic channel events
- define metadata-refresh deduplication as request-wave scoped; adjacent failed waves may refresh independently

## Validation
- focused test: 25/25 passes on net10.0 and 25/25 on net8.0
- full unit suite: 6,843 net10.0 + 6,707 net8.0 passed
- Release build: 0 warnings/errors
- no arbitrary delays, retries, or blocking synchronization
- no product IL change; `src/` changes are comments only, so benchmark/stress gates are not applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk message publishing so the first batch is confirmed before subsequent batches are sent.
  * Improved handling of send failures and metadata refreshes during concurrent publication requests.

* **Tests**
  * Added coverage for bulk publication timing and single-request failure handling.
  * Improved test reliability and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->