### PR TITLE
fix(admin): retry pending controller election

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -100,7 +100,7 @@ public sealed class AdminClient : IAdminClient
                 _connectionPool,
                 _metadataManager,
                 options.BootstrapControllers,
-                metadataOptions.MetadataRefreshInterval);
+                metadataOptions);
         }
 
         _telemetryManager = new ClientTelemetryManager(
@@ -133,11 +133,16 @@ public sealed class AdminClient : IAdminClient
                     "Controller bootstrap endpoints require an independently owned AdminClient connection pool.");
             }
 
+            metadataOptions ??= new MetadataOptions
+            {
+                RetryBackoffMs = options.RetryBackoffMs,
+                RetryBackoffMaxMs = options.RetryBackoffMaxMs
+            };
             _controllerMetadataManager = new ControllerMetadataManager(
                 _connectionPool,
                 _metadataManager,
                 options.BootstrapControllers,
-                metadataOptions?.MetadataRefreshInterval ?? TimeSpan.FromMinutes(15));
+                metadataOptions);
         }
         _telemetryMetricCollector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Admin);
         _telemetryMetricCollector.RegisterMetricsForSubscription(options.ApplicationMetrics);

--- a/src/Dekaf/Admin/ControllerMetadataManager.cs
+++ b/src/Dekaf/Admin/ControllerMetadataManager.cs
@@ -66,113 +66,132 @@ internal sealed class ControllerMetadataManager : IDisposable
             var electionStartedAt = Stopwatch.GetTimestamp();
             var electionFailureCount = 0;
             var electionPending = false;
-            while (true)
+            Exception? lastException = null;
+            using var initializationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            if (_options.InitTimeoutMs <= 0)
+                initializationCts.Cancel();
+            else
+                initializationCts.CancelAfter(_options.InitTimeoutMs);
+            var initializationToken = initializationCts.Token;
+            try
             {
-                Exception? lastException = null;
-                foreach (var endpoint in endpoints)
+                while (true)
                 {
-                    try
+                    lastException = null;
+                    foreach (var endpoint in endpoints)
                     {
-                        using var lease = await _connectionPool.LeaseConnectionAsync(
-                            endpoint.Host,
-                            endpoint.Port,
-                            cancellationToken).ConfigureAwait(false);
-                        var connection = lease.Connection;
-                        var version = _versionManager.GetNegotiatedApiVersion(
-                            connection,
-                            ApiKey.DescribeCluster,
-                            1,
-                            DescribeClusterRequest.HighestSupportedVersion);
-                        var response = await connection.SendAsync<DescribeClusterRequest, DescribeClusterResponse>(
-                            new DescribeClusterRequest { EndpointType = DescribeClusterEndpointType.Controller },
-                            version,
-                            cancellationToken).ConfigureAwait(false);
-
-                        if (response.ErrorCode != ErrorCode.None)
+                        try
                         {
-                            throw KafkaException.FromErrorCode(
-                                response.ErrorCode,
-                                response.ErrorMessage ?? $"Controller discovery failed: {response.ErrorCode}");
-                        }
+                            initializationToken.ThrowIfCancellationRequested();
+                            using var lease = await _connectionPool.LeaseConnectionAsync(
+                                endpoint.Host,
+                                endpoint.Port,
+                                initializationToken).ConfigureAwait(false);
+                            initializationToken.ThrowIfCancellationRequested();
+                            var connection = lease.Connection;
+                            var version = _versionManager.GetNegotiatedApiVersion(
+                                connection,
+                                ApiKey.DescribeCluster,
+                                1,
+                                DescribeClusterRequest.HighestSupportedVersion);
+                            var response = await connection.SendAsync<DescribeClusterRequest, DescribeClusterResponse>(
+                                new DescribeClusterRequest { EndpointType = DescribeClusterEndpointType.Controller },
+                                version,
+                                initializationToken).ConfigureAwait(false);
+                            initializationToken.ThrowIfCancellationRequested();
 
-                        if (response.EndpointType != DescribeClusterEndpointType.Controller)
+                            if (response.ErrorCode != ErrorCode.None)
+                            {
+                                throw KafkaException.FromErrorCode(
+                                    response.ErrorCode,
+                                    response.ErrorMessage ?? $"Controller discovery failed: {response.ErrorCode}");
+                            }
+
+                            if (response.EndpointType != DescribeClusterEndpointType.Controller)
+                            {
+                                throw new KafkaException(
+                                    ErrorCode.MismatchedEndpointType,
+                                    $"Controller bootstrap endpoint {endpoint.Host}:{endpoint.Port} returned endpoint type {response.EndpointType}.");
+                            }
+
+                            if (response.ControllerId < 0)
+                            {
+                                electionPending = true;
+                                lastException = new KafkaException(
+                                    ErrorCode.UnknownControllerId,
+                                    "Controller discovery did not return an active controller ID.");
+                                continue;
+                            }
+
+                            var controllers = new Dictionary<int, ControllerEndpoint>(response.Nodes.Count);
+                            foreach (var node in response.Nodes)
+                                controllers[node.NodeId] = new ControllerEndpoint(node.NodeId, node.Host, node.Port, node.Rack);
+
+                            if (!controllers.ContainsKey(response.ControllerId))
+                            {
+                                throw new KafkaException(
+                                    ErrorCode.UnknownControllerId,
+                                    $"Controller discovery omitted active controller {response.ControllerId}.");
+                            }
+
+                            Volatile.Write(
+                                ref _snapshot,
+                                new ControllerMetadataSnapshot(
+                                    response.ClusterId,
+                                    response.ControllerId,
+                                    controllers,
+                                    DateTimeOffset.UtcNow));
+                            return;
+                        }
+                        catch (OperationCanceledException) when (initializationToken.IsCancellationRequested)
                         {
-                            throw new KafkaException(
-                                ErrorCode.MismatchedEndpointType,
-                                $"Controller bootstrap endpoint {endpoint.Host}:{endpoint.Port} returned endpoint type {response.EndpointType}.");
+                            throw;
                         }
-
-                        if (response.ControllerId < 0)
+                        catch (KafkaException ex) when (!ex.IsRetriable)
                         {
-                            electionPending = true;
-                            lastException = new KafkaException(
-                                ErrorCode.UnknownControllerId,
-                                "Controller discovery did not return an active controller ID.");
-                            continue;
+                            throw;
                         }
-
-                        var controllers = new Dictionary<int, ControllerEndpoint>(response.Nodes.Count);
-                        foreach (var node in response.Nodes)
-                            controllers[node.NodeId] = new ControllerEndpoint(node.NodeId, node.Host, node.Port, node.Rack);
-
-                        if (!controllers.ContainsKey(response.ControllerId))
+                        catch (Exception ex)
                         {
-                            throw new KafkaException(
-                                ErrorCode.UnknownControllerId,
-                                $"Controller discovery omitted active controller {response.ControllerId}.");
+                            lastException = ex;
                         }
-
-                        Volatile.Write(
-                            ref _snapshot,
-                            new ControllerMetadataSnapshot(
-                                response.ClusterId,
-                                response.ControllerId,
-                                controllers,
-                                DateTimeOffset.UtcNow));
-                        return;
                     }
-                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+
+                    initializationToken.ThrowIfCancellationRequested();
+
+                    if (!electionPending)
                     {
-                        throw;
+                        if (lastException is not null)
+                            ExceptionDispatchInfo.Capture(lastException).Throw();
+
+                        throw new InvalidOperationException("Unable to discover an active KRaft controller.");
                     }
-                    catch (KafkaException ex) when (!ex.IsRetriable)
-                    {
-                        throw;
-                    }
-                    catch (Exception ex)
-                    {
-                        lastException = ex;
-                    }
+
+                    if (electionFailureCount >= _options.MaxInitRetries)
+                        ExceptionDispatchInfo.Capture(lastException!).Throw();
+
+                    var elapsed = Stopwatch.GetElapsedTime(electionStartedAt);
+                    var remainingMs = _options.InitTimeoutMs - elapsed.TotalMilliseconds;
+                    if (remainingMs <= 0)
+                        throw CreateInitializationTimeout(electionStartedAt, lastException!);
+
+                    var backoffMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                        _options.RetryBackoffMs,
+                        _options.RetryBackoffMaxMs,
+                        ++electionFailureCount);
+                    await Task.Delay(
+                            (int)Math.Min(backoffMs, remainingMs),
+                            initializationToken)
+                        .ConfigureAwait(false);
                 }
-
-                if (!electionPending)
-                {
-                    if (lastException is not null)
-                        ExceptionDispatchInfo.Capture(lastException).Throw();
-
-                    throw new InvalidOperationException("Unable to discover an active KRaft controller.");
-                }
-
-                if (electionFailureCount >= _options.MaxInitRetries)
-                    ExceptionDispatchInfo.Capture(lastException!).Throw();
-
-                var elapsed = Stopwatch.GetElapsedTime(electionStartedAt);
-                var remainingMs = _options.InitTimeoutMs - elapsed.TotalMilliseconds;
-                if (remainingMs <= 0)
-                {
-                    throw new KafkaTimeoutException(
-                        TimeoutKind.Metadata,
-                        elapsed,
-                        TimeSpan.FromMilliseconds(_options.InitTimeoutMs),
-                        $"Controller discovery did not return an active controller within {_options.InitTimeoutMs}ms.",
-                        lastException!);
-                }
-
-                var backoffMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
-                    _options.RetryBackoffMs,
-                    _options.RetryBackoffMaxMs,
-                    ++electionFailureCount);
-                await Task.Delay((int)Math.Min(backoffMs, remainingMs), cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (OperationCanceledException ex) when (initializationCts.IsCancellationRequested)
+            {
+                throw CreateInitializationTimeout(electionStartedAt, lastException ?? ex);
             }
         }
         finally
@@ -280,6 +299,17 @@ internal sealed class ControllerMetadataManager : IDisposable
     private bool IsRefreshDue(ControllerMetadataSnapshot snapshot) =>
         snapshot.LastRefreshed == default
         || DateTimeOffset.UtcNow - snapshot.LastRefreshed >= _options.MetadataRefreshInterval;
+
+    private KafkaTimeoutException CreateInitializationTimeout(long startedAt, Exception innerException)
+    {
+        var elapsed = Stopwatch.GetElapsedTime(startedAt);
+        return new KafkaTimeoutException(
+            TimeoutKind.Metadata,
+            elapsed,
+            TimeSpan.FromMilliseconds(Math.Max(0, _options.InitTimeoutMs)),
+            $"Controller discovery did not return an active controller within {_options.InitTimeoutMs}ms.",
+            innerException);
+    }
 
     private static ArgumentException InvalidEndpoint(string? value) =>
         new($"Invalid controller bootstrap endpoint '{value}'. Expected host:port.");

--- a/src/Dekaf/Admin/ControllerMetadataManager.cs
+++ b/src/Dekaf/Admin/ControllerMetadataManager.cs
@@ -55,7 +55,26 @@ internal sealed class ControllerMetadataManager : IDisposable
     private async ValueTask RefreshAsync(bool force, CancellationToken cancellationToken)
     {
         ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
-        await _refreshLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var initializationStartedAt = Stopwatch.GetTimestamp();
+        using var initializationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (_options.InitTimeoutMs <= 0)
+            initializationCts.Cancel();
+        else
+            initializationCts.CancelAfter(_options.InitTimeoutMs);
+        var initializationToken = initializationCts.Token;
+        try
+        {
+            await _refreshLock.WaitAsync(initializationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException ex) when (initializationCts.IsCancellationRequested)
+        {
+            throw CreateInitializationTimeout(initializationStartedAt, ex);
+        }
+
         try
         {
             var snapshot = Snapshot;
@@ -63,16 +82,9 @@ internal sealed class ControllerMetadataManager : IDisposable
                 return;
 
             var endpoints = BuildRefreshEndpoints(snapshot, _bootstrapEndpoints);
-            var electionStartedAt = Stopwatch.GetTimestamp();
             var electionFailureCount = 0;
             var electionPending = false;
             Exception? lastException = null;
-            using var initializationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            if (_options.InitTimeoutMs <= 0)
-                initializationCts.Cancel();
-            else
-                initializationCts.CancelAfter(_options.InitTimeoutMs);
-            var initializationToken = initializationCts.Token;
             try
             {
                 while (true)
@@ -170,10 +182,10 @@ internal sealed class ControllerMetadataManager : IDisposable
                     if (electionFailureCount >= _options.MaxInitRetries)
                         ExceptionDispatchInfo.Capture(lastException!).Throw();
 
-                    var elapsed = Stopwatch.GetElapsedTime(electionStartedAt);
+                    var elapsed = Stopwatch.GetElapsedTime(initializationStartedAt);
                     var remainingMs = _options.InitTimeoutMs - elapsed.TotalMilliseconds;
                     if (remainingMs <= 0)
-                        throw CreateInitializationTimeout(electionStartedAt, lastException!);
+                        throw CreateInitializationTimeout(initializationStartedAt, lastException!);
 
                     var backoffMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
                         _options.RetryBackoffMs,
@@ -191,7 +203,7 @@ internal sealed class ControllerMetadataManager : IDisposable
             }
             catch (OperationCanceledException ex) when (initializationCts.IsCancellationRequested)
             {
-                throw CreateInitializationTimeout(electionStartedAt, lastException ?? ex);
+                throw CreateInitializationTimeout(initializationStartedAt, lastException ?? ex);
             }
         }
         finally

--- a/src/Dekaf/Admin/ControllerMetadataManager.cs
+++ b/src/Dekaf/Admin/ControllerMetadataManager.cs
@@ -1,8 +1,11 @@
+using System.Diagnostics;
 using System.Runtime.ExceptionServices;
+using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Dekaf.Retry;
 
 namespace Dekaf.Admin;
 
@@ -14,7 +17,7 @@ internal sealed class ControllerMetadataManager : IDisposable
     private readonly IConnectionPool _connectionPool;
     private readonly MetadataManager _versionManager;
     private readonly IReadOnlyList<ControllerEndpoint> _bootstrapEndpoints;
-    private readonly TimeSpan _refreshInterval;
+    private readonly MetadataOptions _options;
     private readonly SemaphoreSlim _refreshLock = new(1, 1);
     private ControllerMetadataSnapshot _snapshot = ControllerMetadataSnapshot.Empty;
     private int _disposed;
@@ -23,15 +26,18 @@ internal sealed class ControllerMetadataManager : IDisposable
         IConnectionPool connectionPool,
         MetadataManager versionManager,
         IReadOnlyList<string> bootstrapControllers,
-        TimeSpan refreshInterval)
+        MetadataOptions options)
     {
-        if (refreshInterval < TimeSpan.Zero)
-            throw new ArgumentOutOfRangeException(nameof(refreshInterval), "Controller metadata refresh interval must not be negative.");
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.MetadataRefreshInterval < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                "Controller metadata refresh interval must not be negative.");
 
         _connectionPool = connectionPool;
         _versionManager = versionManager;
         _bootstrapEndpoints = ParseEndpoints(bootstrapControllers);
-        _refreshInterval = refreshInterval;
+        _options = options;
     }
 
     internal ControllerMetadataSnapshot Snapshot => Volatile.Read(ref _snapshot);
@@ -56,86 +62,118 @@ internal sealed class ControllerMetadataManager : IDisposable
             if (!force && !IsRefreshDue(snapshot))
                 return;
 
-            Exception? lastException = null;
             var endpoints = BuildRefreshEndpoints(snapshot, _bootstrapEndpoints);
-            foreach (var endpoint in endpoints)
+            var electionStartedAt = Stopwatch.GetTimestamp();
+            var electionFailureCount = 0;
+            while (true)
             {
-                try
+                Exception? lastException = null;
+                var electionPending = false;
+                foreach (var endpoint in endpoints)
                 {
-                    using var lease = await _connectionPool.LeaseConnectionAsync(
-                        endpoint.Host,
-                        endpoint.Port,
-                        cancellationToken).ConfigureAwait(false);
-                    var connection = lease.Connection;
-                    var version = _versionManager.GetNegotiatedApiVersion(
-                        connection,
-                        ApiKey.DescribeCluster,
-                        1,
-                        DescribeClusterRequest.HighestSupportedVersion);
-                    var response = await connection.SendAsync<DescribeClusterRequest, DescribeClusterResponse>(
-                        new DescribeClusterRequest { EndpointType = DescribeClusterEndpointType.Controller },
-                        version,
-                        cancellationToken).ConfigureAwait(false);
-
-                    if (response.ErrorCode != ErrorCode.None)
+                    try
                     {
-                        throw KafkaException.FromErrorCode(
-                            response.ErrorCode,
-                            response.ErrorMessage ?? $"Controller discovery failed: {response.ErrorCode}");
-                    }
+                        using var lease = await _connectionPool.LeaseConnectionAsync(
+                            endpoint.Host,
+                            endpoint.Port,
+                            cancellationToken).ConfigureAwait(false);
+                        var connection = lease.Connection;
+                        var version = _versionManager.GetNegotiatedApiVersion(
+                            connection,
+                            ApiKey.DescribeCluster,
+                            1,
+                            DescribeClusterRequest.HighestSupportedVersion);
+                        var response = await connection.SendAsync<DescribeClusterRequest, DescribeClusterResponse>(
+                            new DescribeClusterRequest { EndpointType = DescribeClusterEndpointType.Controller },
+                            version,
+                            cancellationToken).ConfigureAwait(false);
 
-                    if (response.EndpointType != DescribeClusterEndpointType.Controller)
+                        if (response.ErrorCode != ErrorCode.None)
+                        {
+                            throw KafkaException.FromErrorCode(
+                                response.ErrorCode,
+                                response.ErrorMessage ?? $"Controller discovery failed: {response.ErrorCode}");
+                        }
+
+                        if (response.EndpointType != DescribeClusterEndpointType.Controller)
+                        {
+                            throw new KafkaException(
+                                ErrorCode.MismatchedEndpointType,
+                                $"Controller bootstrap endpoint {endpoint.Host}:{endpoint.Port} returned endpoint type {response.EndpointType}.");
+                        }
+
+                        if (response.ControllerId < 0)
+                        {
+                            electionPending = true;
+                            lastException = new KafkaException(
+                                ErrorCode.UnknownControllerId,
+                                "Controller discovery did not return an active controller ID.");
+                            continue;
+                        }
+
+                        var controllers = new Dictionary<int, ControllerEndpoint>(response.Nodes.Count);
+                        foreach (var node in response.Nodes)
+                            controllers[node.NodeId] = new ControllerEndpoint(node.NodeId, node.Host, node.Port, node.Rack);
+
+                        if (!controllers.ContainsKey(response.ControllerId))
+                        {
+                            throw new KafkaException(
+                                ErrorCode.UnknownControllerId,
+                                $"Controller discovery omitted active controller {response.ControllerId}.");
+                        }
+
+                        Volatile.Write(
+                            ref _snapshot,
+                            new ControllerMetadataSnapshot(
+                                response.ClusterId,
+                                response.ControllerId,
+                                controllers,
+                                DateTimeOffset.UtcNow));
+                        return;
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                     {
-                        throw new KafkaException(
-                            ErrorCode.MismatchedEndpointType,
-                            $"Controller bootstrap endpoint {endpoint.Host}:{endpoint.Port} returned endpoint type {response.EndpointType}.");
+                        throw;
                     }
-
-                    if (response.ControllerId < 0)
+                    catch (KafkaException ex) when (!ex.IsRetriable)
                     {
-                        throw new KafkaException(
-                            ErrorCode.UnknownControllerId,
-                            "Controller discovery did not return an active controller ID.");
+                        throw;
                     }
-
-                    var controllers = new Dictionary<int, ControllerEndpoint>(response.Nodes.Count);
-                    foreach (var node in response.Nodes)
-                        controllers[node.NodeId] = new ControllerEndpoint(node.NodeId, node.Host, node.Port, node.Rack);
-
-                    if (!controllers.ContainsKey(response.ControllerId))
+                    catch (Exception ex)
                     {
-                        throw new KafkaException(
-                            ErrorCode.UnknownControllerId,
-                            $"Controller discovery omitted active controller {response.ControllerId}.");
+                        lastException = ex;
                     }
-
-                    Volatile.Write(
-                        ref _snapshot,
-                        new ControllerMetadataSnapshot(
-                            response.ClusterId,
-                            response.ControllerId,
-                            controllers,
-                            DateTimeOffset.UtcNow));
-                    return;
                 }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+
+                if (!electionPending)
                 {
-                    throw;
+                    if (lastException is not null)
+                        ExceptionDispatchInfo.Capture(lastException).Throw();
+
+                    throw new InvalidOperationException("Unable to discover an active KRaft controller.");
                 }
-                catch (KafkaException ex) when (!ex.IsRetriable)
+
+                if (electionFailureCount >= _options.MaxInitRetries)
+                    ExceptionDispatchInfo.Capture(lastException!).Throw();
+
+                var elapsed = Stopwatch.GetElapsedTime(electionStartedAt);
+                var remainingMs = _options.InitTimeoutMs - elapsed.TotalMilliseconds;
+                if (remainingMs <= 0)
                 {
-                    throw;
+                    throw new KafkaTimeoutException(
+                        TimeoutKind.Metadata,
+                        elapsed,
+                        TimeSpan.FromMilliseconds(_options.InitTimeoutMs),
+                        $"Controller discovery did not return an active controller within {_options.InitTimeoutMs}ms.",
+                        lastException!);
                 }
-                catch (Exception ex)
-                {
-                    lastException = ex;
-                }
+
+                var backoffMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                    _options.RetryBackoffMs,
+                    _options.RetryBackoffMaxMs,
+                    ++electionFailureCount);
+                await Task.Delay((int)Math.Min(backoffMs, remainingMs), cancellationToken).ConfigureAwait(false);
             }
-
-            if (lastException is not null)
-                ExceptionDispatchInfo.Capture(lastException).Throw();
-
-            throw new InvalidOperationException("Unable to discover an active KRaft controller.");
         }
         finally
         {
@@ -241,7 +279,7 @@ internal sealed class ControllerMetadataManager : IDisposable
 
     private bool IsRefreshDue(ControllerMetadataSnapshot snapshot) =>
         snapshot.LastRefreshed == default
-        || DateTimeOffset.UtcNow - snapshot.LastRefreshed >= _refreshInterval;
+        || DateTimeOffset.UtcNow - snapshot.LastRefreshed >= _options.MetadataRefreshInterval;
 
     private static ArgumentException InvalidEndpoint(string? value) =>
         new($"Invalid controller bootstrap endpoint '{value}'. Expected host:port.");

--- a/src/Dekaf/Admin/ControllerMetadataManager.cs
+++ b/src/Dekaf/Admin/ControllerMetadataManager.cs
@@ -65,10 +65,10 @@ internal sealed class ControllerMetadataManager : IDisposable
             var endpoints = BuildRefreshEndpoints(snapshot, _bootstrapEndpoints);
             var electionStartedAt = Stopwatch.GetTimestamp();
             var electionFailureCount = 0;
+            var electionPending = false;
             while (true)
             {
                 Exception? lastException = null;
-                var electionPending = false;
                 foreach (var endpoint in endpoints)
                 {
                     try

--- a/tests/Dekaf.Tests.Integration/ProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerTests.cs
@@ -207,6 +207,23 @@ public class ProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
         // Arrange
         var topic = await KafkaContainer.CreateTestTopicAsync();
 
+        // Acks.None cannot observe or retry a request rejected while the new partition leader
+        // is still becoming ready. Prove readiness with an acknowledged write first.
+        await using (var warmupProducer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-producer-acks-none-warmup")
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync())
+        {
+            await warmupProducer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = "warmup",
+                Value = "warmup"
+            }, CancellationToken.None);
+        }
+
         await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithClientId("test-producer-acks-none")
@@ -241,6 +258,9 @@ public class ProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         await foreach (var msg in consumer.ConsumeAsync(cts.Token))
         {
+            if (msg.Key == "warmup")
+                continue;
+
             await Assert.That(msg.Key).IsEqualTo("key1");
             await Assert.That(msg.Value).IsEqualTo("value1");
             break;

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
@@ -42,6 +42,19 @@ public sealed class AdminClientControllerBootstrapTests
     }
 
     [Test]
+    public async Task DescribeClusterAsync_RetriesWhileControllerElectionIsPending()
+    {
+        await using var context = new ControllerAdminContext(
+            CreateDiscoveryResponse(activeControllerId: -1));
+        context.EnqueueDiscovery(CreateDiscoveryResponse(activeControllerId: 1));
+
+        var result = await context.Client.DescribeClusterAsync();
+
+        await Assert.That(result.ControllerId).IsEqualTo(1);
+        await Assert.That(context.DiscoveryRequests).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task DescribeMetadataQuorumAsync_RoutesToAdvertisedActiveController()
     {
         await using var context = new ControllerAdminContext();
@@ -111,7 +124,7 @@ public sealed class AdminClientControllerBootstrapTests
                 pool,
                 metadataManager,
                 ["controller-1:9093", "invalid"],
-                TimeSpan.FromMinutes(15)))
+                new MetadataOptions()))
             .Throws<ArgumentException>();
 
         await Assert.That(exception!.Message).Contains("invalid");
@@ -135,6 +148,7 @@ public sealed class AdminClientControllerBootstrapTests
 
         await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.MismatchedEndpointType);
         await Assert.That(exception.Message).Contains("Expected broker endpoint");
+        await Assert.That(context.DiscoveryRequests).IsEqualTo(1);
     }
 
     [Test]
@@ -286,7 +300,9 @@ public sealed class AdminClientControllerBootstrapTests
                 ownsResources: true,
                 metadataOptions: new MetadataOptions
                 {
-                    MetadataRefreshInterval = refreshInterval ?? TimeSpan.FromMinutes(15)
+                    MetadataRefreshInterval = refreshInterval ?? TimeSpan.FromMinutes(15),
+                    RetryBackoffMs = 1,
+                    RetryBackoffMaxMs = 1
                 });
         }
 

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
@@ -106,6 +106,38 @@ public sealed class AdminClientControllerBootstrapTests
     }
 
     [Test]
+    public async Task RefreshAsync_InitializationDeadlineIncludesRefreshLockWait()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var versionManager = new MetadataManager(pool, []);
+        using var manager = new ControllerMetadataManager(
+            pool,
+            versionManager,
+            ["seed:9093"],
+            new MetadataOptions { InitTimeoutMs = 0 });
+        var refreshLock = (SemaphoreSlim)typeof(ControllerMetadataManager)
+            .GetField("_refreshLock", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(manager)!;
+        await refreshLock.WaitAsync();
+        var lockHeld = true;
+
+        try
+        {
+            var operation = manager.RefreshAsync(CancellationToken.None);
+
+            await Assert.That(operation.IsCompleted).IsTrue();
+            refreshLock.Release();
+            lockHeld = false;
+            await Assert.That(async () => await operation).Throws<KafkaTimeoutException>();
+        }
+        finally
+        {
+            if (lockHeld)
+                refreshLock.Release();
+        }
+    }
+
+    [Test]
     public async Task DescribeMetadataQuorumAsync_RoutesToAdvertisedActiveController()
     {
         await using var context = new ControllerAdminContext();

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
@@ -55,6 +55,20 @@ public sealed class AdminClientControllerBootstrapTests
     }
 
     [Test]
+    public async Task DescribeClusterAsync_RetainsPendingElectionAcrossRetriableFailure()
+    {
+        await using var context = new ControllerAdminContext(
+            CreateDiscoveryResponse(activeControllerId: -1));
+        context.EnqueueDiscovery(new KafkaException(ErrorCode.RequestTimedOut, "Controller unavailable"));
+        context.EnqueueDiscovery(CreateDiscoveryResponse(activeControllerId: 1));
+
+        var result = await context.Client.DescribeClusterAsync();
+
+        await Assert.That(result.ControllerId).IsEqualTo(1);
+        await Assert.That(context.DiscoveryRequests).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task DescribeMetadataQuorumAsync_RoutesToAdvertisedActiveController()
     {
         await using var context = new ControllerAdminContext();
@@ -256,7 +270,7 @@ public sealed class AdminClientControllerBootstrapTests
     private sealed class ControllerAdminContext : IAsyncDisposable
     {
         private readonly MetadataManager _metadataManager;
-        private readonly Queue<DescribeClusterResponse> _discoveryResponses = new();
+        private readonly Queue<object> _discoveryOutcomes = new();
 
         internal ControllerAdminContext(
             DescribeClusterResponse? discoveryResponse = null,
@@ -278,7 +292,7 @@ public sealed class AdminClientControllerBootstrapTests
                     });
                 });
 
-            _discoveryResponses.Enqueue(discoveryResponse ?? CreateDiscoveryResponse(activeControllerId: 2));
+            _discoveryOutcomes.Enqueue(discoveryResponse ?? CreateDiscoveryResponse(activeControllerId: 2));
             ConfigureDiscovery(BootstrapController);
             ConfigureDiscovery(ActiveController);
             ConfigureDiscovery(OtherController);
@@ -315,7 +329,9 @@ public sealed class AdminClientControllerBootstrapTests
         internal DescribeClusterRequest? LastDiscoveryRequest { get; private set; }
         internal short LastDiscoveryVersion { get; private set; }
 
-        internal void EnqueueDiscovery(DescribeClusterResponse response) => _discoveryResponses.Enqueue(response);
+        internal void EnqueueDiscovery(DescribeClusterResponse response) => _discoveryOutcomes.Enqueue(response);
+
+        internal void EnqueueDiscovery(Exception exception) => _discoveryOutcomes.Enqueue(exception);
 
         public async ValueTask DisposeAsync() => await Client.DisposeAsync().ConfigureAwait(false);
 
@@ -330,10 +346,15 @@ public sealed class AdminClientControllerBootstrapTests
                     DiscoveryRequests++;
                     LastDiscoveryRequest = callInfo.ArgAt<DescribeClusterRequest>(0);
                     LastDiscoveryVersion = callInfo.ArgAt<short>(1);
-                    var response = _discoveryResponses.Count > 1
-                        ? _discoveryResponses.Dequeue()
-                        : _discoveryResponses.Peek();
-                    return ValueTask.FromResult(response);
+                    var outcome = _discoveryOutcomes.Count > 1
+                        ? _discoveryOutcomes.Dequeue()
+                        : _discoveryOutcomes.Peek();
+                    return outcome switch
+                    {
+                        DescribeClusterResponse response => ValueTask.FromResult(response),
+                        Exception exception => ValueTask.FromException<DescribeClusterResponse>(exception),
+                        _ => throw new InvalidOperationException("Unknown controller discovery outcome.")
+                    };
                 });
         }
 

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
@@ -69,6 +69,43 @@ public sealed class AdminClientControllerBootstrapTests
     }
 
     [Test]
+    public async Task DescribeClusterAsync_DeadlineCancelsInFlightDiscovery()
+    {
+        await using var context = new ControllerAdminContext(
+            CreateDiscoveryResponse(activeControllerId: -1),
+            initTimeoutMs: 250);
+        context.EnqueueDiscovery(WaitForDiscoveryCancellationAsync);
+
+        var exception = await Assert.That(async () => await context.Client.DescribeClusterAsync())
+            .Throws<KafkaTimeoutException>();
+
+        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Metadata);
+        await Assert.That(context.DiscoveryRequests).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task DescribeClusterAsync_CallerCancellationWinsOverInitializationDeadline()
+    {
+        var discoveryStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var context = new ControllerAdminContext(
+            CreateDiscoveryResponse(activeControllerId: -1),
+            initTimeoutMs: 10_000);
+        context.EnqueueDiscovery(async cancellationToken =>
+        {
+            discoveryStarted.TrySetResult(true);
+            return await WaitForDiscoveryCancellationAsync(cancellationToken);
+        });
+        using var cancellation = new CancellationTokenSource();
+        var operation = context.Client.DescribeClusterAsync(cancellation.Token).AsTask();
+        await discoveryStarted.Task;
+
+        cancellation.Cancel();
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(() => operation);
+        await Assert.That(exception).IsNotTypeOf<KafkaTimeoutException>();
+    }
+
+    [Test]
     public async Task DescribeMetadataQuorumAsync_RoutesToAdvertisedActiveController()
     {
         await using var context = new ControllerAdminContext();
@@ -267,6 +304,13 @@ public sealed class AdminClientControllerBootstrapTests
         ]
     };
 
+    private static async ValueTask<DescribeClusterResponse> WaitForDiscoveryCancellationAsync(
+        CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        throw new InvalidOperationException("Controller discovery cancellation was not observed.");
+    }
+
     private sealed class ControllerAdminContext : IAsyncDisposable
     {
         private readonly MetadataManager _metadataManager;
@@ -274,7 +318,8 @@ public sealed class AdminClientControllerBootstrapTests
 
         internal ControllerAdminContext(
             DescribeClusterResponse? discoveryResponse = null,
-            TimeSpan? refreshInterval = null)
+            TimeSpan? refreshInterval = null,
+            int initTimeoutMs = 60_000)
         {
             BootstrapController = CreateConnection("seed", 9093);
             ActiveController = CreateConnection("controller-2", 19094);
@@ -316,7 +361,8 @@ public sealed class AdminClientControllerBootstrapTests
                 {
                     MetadataRefreshInterval = refreshInterval ?? TimeSpan.FromMinutes(15),
                     RetryBackoffMs = 1,
-                    RetryBackoffMaxMs = 1
+                    RetryBackoffMaxMs = 1,
+                    InitTimeoutMs = initTimeoutMs
                 });
         }
 
@@ -332,6 +378,10 @@ public sealed class AdminClientControllerBootstrapTests
         internal void EnqueueDiscovery(DescribeClusterResponse response) => _discoveryOutcomes.Enqueue(response);
 
         internal void EnqueueDiscovery(Exception exception) => _discoveryOutcomes.Enqueue(exception);
+
+        internal void EnqueueDiscovery(
+            Func<CancellationToken, ValueTask<DescribeClusterResponse>> operation) =>
+            _discoveryOutcomes.Enqueue(operation);
 
         public async ValueTask DisposeAsync() => await Client.DisposeAsync().ConfigureAwait(false);
 
@@ -353,6 +403,8 @@ public sealed class AdminClientControllerBootstrapTests
                     {
                         DescribeClusterResponse response => ValueTask.FromResult(response),
                         Exception exception => ValueTask.FromException<DescribeClusterResponse>(exception),
+                        Func<CancellationToken, ValueTask<DescribeClusterResponse>> operation =>
+                            operation(callInfo.ArgAt<CancellationToken>(2)),
                         _ => throw new InvalidOperationException("Unknown controller discovery outcome.")
                     };
                 });

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ControllerMetadataRefreshBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ControllerMetadataRefreshBenchmarks.cs
@@ -1,0 +1,136 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Admin;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 10)]
+public class ControllerMetadataRefreshBenchmarks
+{
+    private TestConnectionPool _pool = null!;
+    private MetadataManager _versionManager = null!;
+    private ControllerMetadataManager _manager = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _pool = new TestConnectionPool();
+        _versionManager = new MetadataManager(_pool, []);
+        _versionManager.SetApiVersion(ApiKey.DescribeCluster, 1, 2);
+        _manager = new ControllerMetadataManager(
+            _pool,
+            _versionManager,
+            ["seed:9093"],
+            new MetadataOptions { InitTimeoutMs = 60_000 });
+    }
+
+    [Benchmark]
+    public ValueTask Refresh() => _manager.RefreshAsync(CancellationToken.None);
+
+    [GlobalCleanup]
+    public async ValueTask Cleanup()
+    {
+        _manager.Dispose();
+        await _versionManager.DisposeAsync().ConfigureAwait(false);
+        await _pool.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private sealed class TestConnectionPool : IConnectionPool
+    {
+        private readonly IKafkaConnection _connection = new TestConnection();
+
+        public ValueTask<IKafkaConnection> GetConnectionAsync(
+            string host,
+            int port,
+            CancellationToken cancellationToken = default) => ValueTask.FromResult(_connection);
+
+        public ValueTask<IKafkaConnection> GetConnectionAsync(
+            int brokerId,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public ValueTask<IKafkaConnection> GetConnectionByIndexAsync(
+            int brokerId,
+            int index,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public void RegisterBroker(int brokerId, string host, int port) => throw new NotSupportedException();
+
+        public ValueTask<int> ScaleConnectionGroupAsync(
+            int brokerId,
+            int newCount,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public ValueTask<IKafkaConnection?> ShrinkConnectionGroupAsync(
+            int brokerId,
+            int newCount,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public ValueTask RemoveConnectionAsync(int brokerId) => throw new NotSupportedException();
+
+        public ValueTask CloseAllAsync() => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => _connection.DisposeAsync();
+    }
+
+    private sealed class TestConnection : IKafkaConnection
+    {
+        private static readonly DescribeClusterResponse Response = new()
+        {
+            ErrorCode = ErrorCode.None,
+            EndpointType = DescribeClusterEndpointType.Controller,
+            ClusterId = "cluster-a",
+            ControllerId = 1,
+            Nodes = [new DescribeClusterNode { NodeId = 1, Host = "controller-1", Port = 19093 }]
+        };
+
+        public int BrokerId => -1;
+        public string Host => "seed";
+        public int Port => 9093;
+        public bool IsConnected => true;
+
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            ValueTask.FromResult((TResponse)(IKafkaResponse)Response);
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ControllerMetadataRefreshBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ControllerMetadataRefreshBenchmarks.cs
@@ -98,8 +98,11 @@ public class ControllerMetadataRefreshBenchmarks
             short apiVersion,
             CancellationToken cancellationToken = default)
             where TRequest : IKafkaRequest<TResponse>
-            where TResponse : IKafkaResponse =>
-            ValueTask.FromResult((TResponse)(IKafkaResponse)Response);
+            where TResponse : IKafkaResponse
+        {
+            IKafkaResponse response = Response;
+            return ValueTask.FromResult((TResponse)response);
+        }
 
         public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
             TRequest request,


### PR DESCRIPTION
Closes #2696

## Summary
- treat `DescribeCluster.ControllerId < 0` as transient KRaft election state
- retry all controller bootstrap endpoints with configured metadata backoff and initialization deadline
- preserve immediate failure for non-retriable discovery errors
- carry metadata retry/deadline settings into controller discovery

## Validation
- regression fails on parent (`ControllerId == -1` throws) and passes with exactly two discovery requests for `-1 -> 1`
- `AdminClientControllerBootstrapTests`: 11/11 net10.0, 11/11 net8.0
- full unit: 6,844 net10.0; 6,708 net8.0
- controller-only Kafka integration: 1/1
- Release builds: 0 warnings/errors
- `/simplify` and final self-review completed
- no message/request hot-path changes; benchmark gate not applicable