### PR TITLE
feat(schema-registry): add AWS KMS provider

### DIFF
--- a/Dekaf.sln
+++ b/Dekaf.sln
@@ -75,6 +75,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.SchemaRegistry.Kms.Gc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.SchemaRegistry.Kms.Vault", "src\Dekaf.SchemaRegistry.Kms.Vault\Dekaf.SchemaRegistry.Kms.Vault.csproj", "{170E0071-44E4-4D9B-AB44-4B324DE007F1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.SchemaRegistry.Kms.Aws", "src\Dekaf.SchemaRegistry.Kms.Aws\Dekaf.SchemaRegistry.Kms.Aws.csproj", "{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -469,6 +471,18 @@ Global
 		{170E0071-44E4-4D9B-AB44-4B324DE007F1}.Release|x64.Build.0 = Release|Any CPU
 		{170E0071-44E4-4D9B-AB44-4B324DE007F1}.Release|x86.ActiveCfg = Release|Any CPU
 		{170E0071-44E4-4D9B-AB44-4B324DE007F1}.Release|x86.Build.0 = Release|Any CPU
+		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}.Debug|x64.Build.0 = Debug|Any CPU
+		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}.Debug|x86.Build.0 = Debug|Any CPU
+		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}.Release|x64.ActiveCfg = Release|Any CPU
+		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}.Release|x64.Build.0 = Release|Any CPU
+		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}.Release|x86.ActiveCfg = Release|Any CPU
+		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -506,5 +520,6 @@ Global
 		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{52043965-88BE-40BE-B801-70A13249AAE8} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{170E0071-44E4-4D9B-AB44-4B324DE007F1} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageVersion Include="Apache.Avro" Version="1.12.1" />
+    <PackageVersion Include="AWSSDK.KeyManagementService" Version="4.0.100.8" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
     <PackageVersion Include="Confluent.Kafka" Version="2.15.0" />

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -393,6 +393,15 @@ Schema Registry key references may contain a raw key ARN/alias or a Confluent-co
 cancellation to the AWS SDK, is safe for concurrent use, never logs key material or ciphertext, and
 clears temporary plaintext buffers where the runtime exposes them.
 
+Each provider instance registers one KMS type. Applications using keys in multiple regions can give
+each regional provider a distinct type and use that type on the matching KEK:
+
+```csharp
+using var euKms = new AwsKmsProvider(RegionEndpoint.EUWest2, type: "aws-kms-eu-west-2");
+using var usKms = new AwsKmsProvider(RegionEndpoint.USEast1, type: "aws-kms-us-east-1");
+var multiRegionCsfle = new SchemaRegistryCsfleRuleHandler(schemaRegistry, [euKms, usKms]);
+```
+
 ## Consumer
 
 ```csharp

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -361,6 +361,38 @@ request/response buffers are zeroed before release. Credential and returned-toke
 managed .NET strings and cannot be zeroed; source them from a secret-delivery mechanism and limit
 their lifetime accordingly.
 
+## AWS KMS for client-side field-level encryption
+
+Install `Dekaf.SchemaRegistry.Kms.Aws` only in applications that use AWS KMS. The AWS SDK dependency
+stays out of `Dekaf.SchemaRegistry` and other serializer packages.
+
+```csharp
+using Amazon;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Kms.Aws;
+
+using var awsKms = new AwsKmsProvider(RegionEndpoint.EUWest2);
+var csfle = new SchemaRegistryCsfleRuleHandler(schemaRegistry, [awsKms]);
+var rules = new SchemaRegistryRuleExecutor([csfle]);
+```
+
+`AwsKmsProvider()` uses the AWS SDK default credential and region provider chains. The region
+constructor fixes the KMS endpoint while retaining the default credential chain. For custom
+endpoints, retry settings, or other SDK options, pass an `AmazonKeyManagementServiceConfig`. For
+explicit credentials or application-managed client lifetimes, construct an
+`AmazonKeyManagementServiceClient` and pass it as `IAmazonKeyManagementService`; injected clients
+remain caller-owned unless `ownsClient: true` is specified.
+
+The AWS SDK default credential chain checks explicitly configured client credentials first, then
+environment credentials, web-identity/container credentials, shared AWS profiles, and instance
+metadata as applicable to the host. Prefer short-lived workload credentials over long-lived access
+keys. The principal needs `kms:Encrypt` and `kms:Decrypt` for each configured key.
+
+Schema Registry key references may contain a raw key ARN/alias or a Confluent-compatible
+`aws-kms://` URI. Configure the provider's region or endpoint to match the key. The provider forwards
+cancellation to the AWS SDK, is safe for concurrent use, never logs key material or ciphertext, and
+clears temporary plaintext buffers where the runtime exposes them.
+
 ## Consumer
 
 ```csharp

--- a/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
@@ -105,7 +105,7 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
         {
             throw;
         }
-        catch (AmazonServiceException ex)
+        catch (Exception ex) when (ex is AmazonServiceException or AmazonClientException)
         {
             throw new SchemaRegistryKmsException("AWS KMS wrap failed.", ex);
         }
@@ -142,7 +142,7 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
         {
             throw;
         }
-        catch (AmazonServiceException ex)
+        catch (Exception ex) when (ex is AmazonServiceException or AmazonClientException)
         {
             throw new SchemaRegistryKmsException("AWS KMS unwrap failed.", ex);
         }

--- a/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
@@ -29,14 +30,17 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
     public const string KeyUriPrefix = "aws-kms://";
 
     private const int MaximumPlaintextLength = 4096;
+    private const int DisposeDrainTimeoutMilliseconds = 100;
     private const int DisposedMask = int.MinValue;
     private const int ActiveOperationMask = int.MaxValue;
 
     private readonly IAmazonKeyManagementService _client;
     private readonly bool _ownsClient;
-    private readonly ManualResetEventSlim _operationsCompleted = new(initialState: false);
+    private readonly CancellationTokenSource _disposeCancellation = new();
     private int _operationState;
-    private int _completionSignalFinished;
+    private int _cancellationFinished;
+    private int _clientDisposed;
+    private int _cancellationDisposed;
 
     /// <summary>
     /// Creates a provider using the AWS SDK default credential and region provider chains.
@@ -102,6 +106,8 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
         CancellationToken cancellationToken = default)
     {
         using var operation = EnterOperation();
+        using var linkedCancellation = CreateLinkedCancellation(cancellationToken);
+        var operationToken = linkedCancellation?.Token ?? _disposeCancellation.Token;
         cancellationToken.ThrowIfCancellationRequested();
         if (keyMaterial.IsEmpty)
             throw new SchemaRegistryKmsException("AWS KMS wrap failed. Key material cannot be empty.");
@@ -120,11 +126,11 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
             {
                 KeyId = keyId,
                 Plaintext = plaintext
-            }, cancellationToken).ConfigureAwait(false);
+            }, operationToken).ConfigureAwait(false);
 
             return CopyResponse(response.CiphertextBlob, "wrap", clearSource: false);
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (operationToken.IsCancellationRequested)
         {
             throw;
         }
@@ -145,6 +151,8 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
         CancellationToken cancellationToken = default)
     {
         using var operation = EnterOperation();
+        using var linkedCancellation = CreateLinkedCancellation(cancellationToken);
+        var operationToken = linkedCancellation?.Token ?? _disposeCancellation.Token;
         cancellationToken.ThrowIfCancellationRequested();
         if (encryptedKeyMaterial.IsEmpty)
             throw new SchemaRegistryKmsException("AWS KMS unwrap failed. Encrypted key material cannot be empty.");
@@ -157,11 +165,11 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
             {
                 KeyId = keyId,
                 CiphertextBlob = ciphertext
-            }, cancellationToken).ConfigureAwait(false);
+            }, operationToken).ConfigureAwait(false);
 
             return CopyResponse(response.Plaintext, "unwrap", clearSource: true);
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (operationToken.IsCancellationRequested)
         {
             throw;
         }
@@ -184,20 +192,22 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
 
         try
         {
-            if ((previousState & ActiveOperationMask) != 0)
-            {
-                _operationsCompleted.Wait();
-                var spinner = new SpinWait();
-                while (Volatile.Read(ref _completionSignalFinished) == 0)
-                    spinner.SpinOnce();
-            }
-
-            if (_ownsClient)
-                _client.Dispose();
+            _disposeCancellation.Cancel();
         }
         finally
         {
-            _operationsCompleted.Dispose();
+            Volatile.Write(ref _cancellationFinished, 1);
+            try
+            {
+                if ((previousState & ActiveOperationMask) != 0)
+                    WaitForOperationsToDrain();
+
+                DisposeOwnedClient();
+            }
+            finally
+            {
+                TryDisposeCancellation();
+            }
         }
     }
 
@@ -220,10 +230,41 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
     private void ExitOperation()
     {
         if (Interlocked.Decrement(ref _operationState) == DisposedMask)
+            TryDisposeCancellation();
+    }
+
+    private CancellationTokenSource? CreateLinkedCancellation(CancellationToken cancellationToken) =>
+        cancellationToken.CanBeCanceled
+            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposeCancellation.Token)
+            : null;
+
+    private void WaitForOperationsToDrain()
+    {
+        var startedAt = Stopwatch.GetTimestamp();
+        var spinner = new SpinWait();
+        while ((Volatile.Read(ref _operationState) & ActiveOperationMask) != 0 &&
+               Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds < DisposeDrainTimeoutMilliseconds)
         {
-            _operationsCompleted.Set();
-            Volatile.Write(ref _completionSignalFinished, 1);
+            spinner.SpinOnce();
         }
+    }
+
+    private void DisposeOwnedClient()
+    {
+        if (_ownsClient && Interlocked.Exchange(ref _clientDisposed, 1) == 0)
+            _client.Dispose();
+    }
+
+    private void TryDisposeCancellation()
+    {
+        if ((Volatile.Read(ref _operationState) & ActiveOperationMask) != 0 ||
+            Volatile.Read(ref _cancellationFinished) == 0 ||
+            Interlocked.Exchange(ref _cancellationDisposed, 1) != 0)
+        {
+            return;
+        }
+
+        _disposeCancellation.Dispose();
     }
 
     private string ResolveKeyId(SchemaRegistryKmsKeyReference keyReference)

--- a/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
@@ -190,25 +190,12 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
         if ((previousState & DisposedMask) != 0)
             return;
 
-        try
-        {
-            _disposeCancellation.Cancel();
-        }
-        finally
-        {
-            Volatile.Write(ref _cancellationFinished, 1);
-            try
-            {
-                if ((previousState & ActiveOperationMask) != 0)
-                    WaitForOperationsToDrain();
+        _ = CancelOperationsAsync();
 
-                DisposeOwnedClient();
-            }
-            finally
-            {
-                TryDisposeCancellation();
-            }
-        }
+        if ((previousState & ActiveOperationMask) != 0)
+            WaitForOperationsToDrain();
+
+        DisposeOwnedClient();
     }
 
     private OperationLease EnterOperation()
@@ -237,6 +224,23 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
         cancellationToken.CanBeCanceled
             ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposeCancellation.Token)
             : null;
+
+    private async Task CancelOperationsAsync()
+    {
+        try
+        {
+            await _disposeCancellation.CancelAsync().ConfigureAwait(false);
+        }
+        catch (AggregateException)
+        {
+            // Client cancellation callbacks are external; disposal remains best-effort and bounded.
+        }
+        finally
+        {
+            Volatile.Write(ref _cancellationFinished, 1);
+            TryDisposeCancellation();
+        }
+    }
 
     private void WaitForOperationsToDrain()
     {

--- a/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
@@ -29,10 +29,14 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
     public const string KeyUriPrefix = "aws-kms://";
 
     private const int MaximumPlaintextLength = 4096;
+    private const int DisposedMask = int.MinValue;
+    private const int ActiveOperationMask = int.MaxValue;
 
     private readonly IAmazonKeyManagementService _client;
     private readonly bool _ownsClient;
-    private int _disposed;
+    private readonly ManualResetEventSlim _operationsCompleted = new(initialState: false);
+    private int _operationState;
+    private int _completionSignalFinished;
 
     /// <summary>
     /// Creates a provider using the AWS SDK default credential and region provider chains.
@@ -97,7 +101,7 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
         SchemaRegistryKmsKeyReference keyReference,
         CancellationToken cancellationToken = default)
     {
-        ThrowIfDisposed();
+        using var operation = EnterOperation();
         cancellationToken.ThrowIfCancellationRequested();
         if (keyMaterial.IsEmpty)
             throw new SchemaRegistryKmsException("AWS KMS wrap failed. Key material cannot be empty.");
@@ -140,7 +144,7 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
         SchemaRegistryKmsKeyReference keyReference,
         CancellationToken cancellationToken = default)
     {
-        ThrowIfDisposed();
+        using var operation = EnterOperation();
         cancellationToken.ThrowIfCancellationRequested();
         if (encryptedKeyMaterial.IsEmpty)
             throw new SchemaRegistryKmsException("AWS KMS unwrap failed. Encrypted key material cannot be empty.");
@@ -174,10 +178,52 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
     /// <inheritdoc />
     public void Dispose()
     {
-        if (Interlocked.Exchange(ref _disposed, 1) != 0 || !_ownsClient)
+        var previousState = Interlocked.Or(ref _operationState, DisposedMask);
+        if ((previousState & DisposedMask) != 0)
             return;
 
-        _client.Dispose();
+        try
+        {
+            if ((previousState & ActiveOperationMask) != 0)
+            {
+                _operationsCompleted.Wait();
+                var spinner = new SpinWait();
+                while (Volatile.Read(ref _completionSignalFinished) == 0)
+                    spinner.SpinOnce();
+            }
+
+            if (_ownsClient)
+                _client.Dispose();
+        }
+        finally
+        {
+            _operationsCompleted.Dispose();
+        }
+    }
+
+    private OperationLease EnterOperation()
+    {
+        while (true)
+        {
+            var state = Volatile.Read(ref _operationState);
+            if ((state & DisposedMask) != 0)
+                throw new ObjectDisposedException(nameof(AwsKmsProvider));
+
+            if ((state & ActiveOperationMask) == ActiveOperationMask)
+                throw new InvalidOperationException("AWS KMS provider has too many active operations.");
+
+            if (Interlocked.CompareExchange(ref _operationState, state + 1, state) == state)
+                return new OperationLease(this);
+        }
+    }
+
+    private void ExitOperation()
+    {
+        if (Interlocked.Decrement(ref _operationState) == DisposedMask)
+        {
+            _operationsCompleted.Set();
+            Volatile.Write(ref _completionSignalFinished, 1);
+        }
     }
 
     private string ResolveKeyId(SchemaRegistryKmsKeyReference keyReference)
@@ -306,5 +352,8 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
             throw new ArgumentException("KMS provider type cannot be null or whitespace.", nameof(type));
     }
 
-    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed != 0, this);
+    private readonly struct OperationLease(AwsKmsProvider owner) : IDisposable
+    {
+        public void Dispose() => owner.ExitOperation();
+    }
 }

--- a/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
@@ -363,6 +363,7 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
         or SocketException
         or TimeoutException
         or AuthenticationException
+        or ObjectDisposedException
         or OperationCanceledException;
 
     private static AmazonKeyManagementServiceClient CreateOwnedClient(string type)

--- a/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
@@ -1,4 +1,7 @@
+using System.Net;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Security.Authentication;
 using System.Security.Cryptography;
 using Amazon;
 using Amazon.KeyManagementService;
@@ -34,8 +37,9 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
     /// <summary>
     /// Creates a provider using the AWS SDK default credential and region provider chains.
     /// </summary>
-    public AwsKmsProvider()
-        : this(new AmazonKeyManagementServiceClient(), ownsClient: true)
+    /// <param name="type">Schema Registry KMS provider type.</param>
+    public AwsKmsProvider(string type = DefaultType)
+        : this(CreateOwnedClient(type), ownsClient: true, type: type)
     {
     }
 
@@ -43,8 +47,12 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
     /// Creates a provider using the AWS SDK default credential provider chain in <paramref name="region" />.
     /// </summary>
     /// <param name="region">AWS region containing the KMS key.</param>
-    public AwsKmsProvider(RegionEndpoint region)
-        : this(new AmazonKeyManagementServiceClient(region ?? throw new ArgumentNullException(nameof(region))), ownsClient: true)
+    /// <param name="type">Schema Registry KMS provider type.</param>
+    public AwsKmsProvider(RegionEndpoint region, string type = DefaultType)
+        : this(
+            CreateOwnedClient(region, type),
+            ownsClient: true,
+            type: type)
     {
     }
 
@@ -52,8 +60,12 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
     /// Creates a provider using the AWS SDK default credential provider chain and client configuration.
     /// </summary>
     /// <param name="config">AWS KMS client configuration, including region or custom service endpoint.</param>
-    public AwsKmsProvider(AmazonKeyManagementServiceConfig config)
-        : this(new AmazonKeyManagementServiceClient(config ?? throw new ArgumentNullException(nameof(config))), ownsClient: true)
+    /// <param name="type">Schema Registry KMS provider type.</param>
+    public AwsKmsProvider(AmazonKeyManagementServiceConfig config, string type = DefaultType)
+        : this(
+            CreateOwnedClient(config, type),
+            ownsClient: true,
+            type: type)
     {
     }
 
@@ -62,15 +74,22 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
     /// </summary>
     /// <param name="client">Thread-safe AWS KMS client.</param>
     /// <param name="ownsClient">Whether disposing this provider also disposes <paramref name="client" />.</param>
-    public AwsKmsProvider(IAmazonKeyManagementService client, bool ownsClient = false)
+    /// <param name="type">Schema Registry KMS provider type.</param>
+    public AwsKmsProvider(
+        IAmazonKeyManagementService client,
+        bool ownsClient = false,
+        string type = DefaultType)
     {
         ArgumentNullException.ThrowIfNull(client);
+        ValidateType(type);
+
         _client = client;
         _ownsClient = ownsClient;
+        Type = type;
     }
 
     /// <inheritdoc />
-    public string Type => DefaultType;
+    public string Type { get; }
 
     /// <inheritdoc />
     public async ValueTask<byte[]> WrapKeyAsync(
@@ -105,9 +124,9 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
         {
             throw;
         }
-        catch (Exception ex) when (ex is AmazonServiceException or AmazonClientException)
+        catch (Exception ex) when (IsAwsFailure(ex))
         {
-            throw new SchemaRegistryKmsException("AWS KMS wrap failed.", ex);
+            throw new SchemaRegistryKmsException("AWS KMS wrap failed.");
         }
         finally
         {
@@ -142,9 +161,9 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
         {
             throw;
         }
-        catch (Exception ex) when (ex is AmazonServiceException or AmazonClientException)
+        catch (Exception ex) when (IsAwsFailure(ex))
         {
-            throw new SchemaRegistryKmsException("AWS KMS unwrap failed.", ex);
+            throw new SchemaRegistryKmsException("AWS KMS unwrap failed.");
         }
         finally
         {
@@ -161,13 +180,13 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
         _client.Dispose();
     }
 
-    private static string ResolveKeyId(SchemaRegistryKmsKeyReference keyReference)
+    private string ResolveKeyId(SchemaRegistryKmsKeyReference keyReference)
     {
         ArgumentNullException.ThrowIfNull(keyReference);
-        if (!string.Equals(keyReference.KmsType, DefaultType, StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(keyReference.KmsType, Type, StringComparison.OrdinalIgnoreCase))
         {
             throw new SchemaRegistryKmsException(
-                $"AWS KMS provider cannot resolve KMS type '{keyReference.KmsType}'.");
+                $"AWS KMS provider '{Type}' cannot resolve KMS type '{keyReference.KmsType}'.");
         }
 
         var keyId = keyReference.KmsKeyId;
@@ -224,6 +243,45 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
     {
         if (temporaryBuffer is not null)
             CryptographicOperations.ZeroMemory(temporaryBuffer);
+    }
+
+    private static bool IsAwsFailure(Exception exception) => exception is
+        AmazonServiceException
+        or AmazonClientException
+        or HttpRequestException
+        or IOException
+        or WebException
+        or SocketException
+        or TimeoutException
+        or AuthenticationException
+        or OperationCanceledException;
+
+    private static AmazonKeyManagementServiceClient CreateOwnedClient(string type)
+    {
+        ValidateType(type);
+        return new AmazonKeyManagementServiceClient();
+    }
+
+    private static AmazonKeyManagementServiceClient CreateOwnedClient(RegionEndpoint region, string type)
+    {
+        ArgumentNullException.ThrowIfNull(region);
+        ValidateType(type);
+        return new AmazonKeyManagementServiceClient(region);
+    }
+
+    private static AmazonKeyManagementServiceClient CreateOwnedClient(
+        AmazonKeyManagementServiceConfig config,
+        string type)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ValidateType(type);
+        return new AmazonKeyManagementServiceClient(config);
+    }
+
+    private static void ValidateType(string type)
+    {
+        if (string.IsNullOrWhiteSpace(type))
+            throw new ArgumentException("KMS provider type cannot be null or whitespace.", nameof(type));
     }
 
     private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed != 0, this);

--- a/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
@@ -233,9 +233,31 @@ public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
             }
             finally
             {
-                if (clearSource && stream.TryGetBuffer(out var buffer))
-                    CryptographicOperations.ZeroMemory(buffer.AsSpan());
+                if (clearSource)
+                    ClearResponseStream(stream);
             }
+        }
+    }
+
+    private static void ClearResponseStream(MemoryStream stream)
+    {
+        if (stream.TryGetBuffer(out var buffer))
+        {
+            CryptographicOperations.ZeroMemory(buffer.AsSpan());
+            return;
+        }
+
+        if (!stream.CanWrite)
+            return;
+
+        stream.Position = 0;
+        Span<byte> zeros = stackalloc byte[256];
+        zeros.Clear();
+        for (var remaining = stream.Length; remaining > 0;)
+        {
+            var count = (int)Math.Min(remaining, zeros.Length);
+            stream.Write(zeros[..count]);
+            remaining -= count;
         }
     }
 

--- a/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Aws/AwsKmsProvider.cs
@@ -1,0 +1,230 @@
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using Amazon;
+using Amazon.KeyManagementService;
+using Amazon.KeyManagementService.Model;
+using Amazon.Runtime;
+
+namespace Dekaf.SchemaRegistry.Kms.Aws;
+
+/// <summary>
+/// Wraps and unwraps Schema Registry data encryption keys with AWS Key Management Service.
+/// </summary>
+/// <remarks>
+/// AWS SDK clients are thread-safe. Reuse one provider for all operations that share a client configuration.
+/// </remarks>
+public sealed class AwsKmsProvider : ISchemaRegistryKmsProvider, IDisposable
+{
+    /// <summary>
+    /// Schema Registry KMS provider type.
+    /// </summary>
+    public const string DefaultType = "aws-kms";
+
+    /// <summary>
+    /// Confluent-compatible AWS KMS key URI prefix.
+    /// </summary>
+    public const string KeyUriPrefix = "aws-kms://";
+
+    private const int MaximumPlaintextLength = 4096;
+
+    private readonly IAmazonKeyManagementService _client;
+    private readonly bool _ownsClient;
+    private int _disposed;
+
+    /// <summary>
+    /// Creates a provider using the AWS SDK default credential and region provider chains.
+    /// </summary>
+    public AwsKmsProvider()
+        : this(new AmazonKeyManagementServiceClient(), ownsClient: true)
+    {
+    }
+
+    /// <summary>
+    /// Creates a provider using the AWS SDK default credential provider chain in <paramref name="region" />.
+    /// </summary>
+    /// <param name="region">AWS region containing the KMS key.</param>
+    public AwsKmsProvider(RegionEndpoint region)
+        : this(new AmazonKeyManagementServiceClient(region ?? throw new ArgumentNullException(nameof(region))), ownsClient: true)
+    {
+    }
+
+    /// <summary>
+    /// Creates a provider using the AWS SDK default credential provider chain and client configuration.
+    /// </summary>
+    /// <param name="config">AWS KMS client configuration, including region or custom service endpoint.</param>
+    public AwsKmsProvider(AmazonKeyManagementServiceConfig config)
+        : this(new AmazonKeyManagementServiceClient(config ?? throw new ArgumentNullException(nameof(config))), ownsClient: true)
+    {
+    }
+
+    /// <summary>
+    /// Creates a provider using an existing AWS KMS client.
+    /// </summary>
+    /// <param name="client">Thread-safe AWS KMS client.</param>
+    /// <param name="ownsClient">Whether disposing this provider also disposes <paramref name="client" />.</param>
+    public AwsKmsProvider(IAmazonKeyManagementService client, bool ownsClient = false)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        _client = client;
+        _ownsClient = ownsClient;
+    }
+
+    /// <inheritdoc />
+    public string Type => DefaultType;
+
+    /// <inheritdoc />
+    public async ValueTask<byte[]> WrapKeyAsync(
+        ReadOnlyMemory<byte> keyMaterial,
+        SchemaRegistryKmsKeyReference keyReference,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
+        if (keyMaterial.IsEmpty)
+            throw new SchemaRegistryKmsException("AWS KMS wrap failed. Key material cannot be empty.");
+
+        if (keyMaterial.Length > MaximumPlaintextLength)
+        {
+            throw new SchemaRegistryKmsException(
+                $"AWS KMS wrap failed. Key material cannot exceed {MaximumPlaintextLength} bytes.");
+        }
+
+        var keyId = ResolveKeyId(keyReference);
+        using var plaintext = CreateInputStream(keyMaterial, out var temporaryBuffer);
+        try
+        {
+            var response = await _client.EncryptAsync(new EncryptRequest
+            {
+                KeyId = keyId,
+                Plaintext = plaintext
+            }, cancellationToken).ConfigureAwait(false);
+
+            return CopyResponse(response.CiphertextBlob, "wrap", clearSource: false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (AmazonServiceException ex)
+        {
+            throw new SchemaRegistryKmsException("AWS KMS wrap failed.", ex);
+        }
+        finally
+        {
+            ClearTemporaryBuffer(temporaryBuffer);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<byte[]> UnwrapKeyAsync(
+        ReadOnlyMemory<byte> encryptedKeyMaterial,
+        SchemaRegistryKmsKeyReference keyReference,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
+        if (encryptedKeyMaterial.IsEmpty)
+            throw new SchemaRegistryKmsException("AWS KMS unwrap failed. Encrypted key material cannot be empty.");
+
+        var keyId = ResolveKeyId(keyReference);
+        using var ciphertext = CreateInputStream(encryptedKeyMaterial, out var temporaryBuffer);
+        try
+        {
+            var response = await _client.DecryptAsync(new DecryptRequest
+            {
+                KeyId = keyId,
+                CiphertextBlob = ciphertext
+            }, cancellationToken).ConfigureAwait(false);
+
+            return CopyResponse(response.Plaintext, "unwrap", clearSource: true);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (AmazonServiceException ex)
+        {
+            throw new SchemaRegistryKmsException("AWS KMS unwrap failed.", ex);
+        }
+        finally
+        {
+            ClearTemporaryBuffer(temporaryBuffer);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0 || !_ownsClient)
+            return;
+
+        _client.Dispose();
+    }
+
+    private static string ResolveKeyId(SchemaRegistryKmsKeyReference keyReference)
+    {
+        ArgumentNullException.ThrowIfNull(keyReference);
+        if (!string.Equals(keyReference.KmsType, DefaultType, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new SchemaRegistryKmsException(
+                $"AWS KMS provider cannot resolve KMS type '{keyReference.KmsType}'.");
+        }
+
+        var keyId = keyReference.KmsKeyId;
+        if (string.IsNullOrWhiteSpace(keyId))
+            throw new SchemaRegistryKmsException("AWS KMS key identifier cannot be null or whitespace.");
+
+        if (keyId.StartsWith(KeyUriPrefix, StringComparison.OrdinalIgnoreCase))
+            keyId = keyId[KeyUriPrefix.Length..];
+
+        if (string.IsNullOrWhiteSpace(keyId))
+            throw new SchemaRegistryKmsException("AWS KMS key identifier cannot be null or whitespace.");
+
+        return keyId;
+    }
+
+    private static MemoryStream CreateInputStream(ReadOnlyMemory<byte> source, out byte[]? temporaryBuffer)
+    {
+        if (MemoryMarshal.TryGetArray(source, out var segment) && segment.Array is not null)
+        {
+            temporaryBuffer = null;
+            return new MemoryStream(segment.Array, segment.Offset, segment.Count, writable: false, publiclyVisible: false);
+        }
+
+        temporaryBuffer = source.ToArray();
+        return new MemoryStream(temporaryBuffer, writable: false);
+    }
+
+    private static byte[] CopyResponse(MemoryStream? stream, string operation, bool clearSource)
+    {
+        if (stream is null)
+            throw new SchemaRegistryKmsException($"AWS KMS {operation} failed. The service returned no key material.");
+
+        using (stream)
+        {
+            try
+            {
+                if (stream.Length == 0)
+                {
+                    throw new SchemaRegistryKmsException(
+                        $"AWS KMS {operation} failed. The service returned empty key material.");
+                }
+
+                return stream.ToArray();
+            }
+            finally
+            {
+                if (clearSource && stream.TryGetBuffer(out var buffer))
+                    CryptographicOperations.ZeroMemory(buffer.AsSpan());
+            }
+        }
+    }
+
+    private static void ClearTemporaryBuffer(byte[]? temporaryBuffer)
+    {
+        if (temporaryBuffer is not null)
+            CryptographicOperations.ZeroMemory(temporaryBuffer);
+    }
+
+    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed != 0, this);
+}

--- a/src/Dekaf.SchemaRegistry.Kms.Aws/Dekaf.SchemaRegistry.Kms.Aws.csproj
+++ b/src/Dekaf.SchemaRegistry.Kms.Aws/Dekaf.SchemaRegistry.Kms.Aws.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Dekaf.SchemaRegistry.Kms.Aws</PackageId>
+    <Description>AWS KMS provider for Dekaf Schema Registry client-side field-level encryption</Description>
+    <PackageTags>kafka;schema-registry;encryption;aws;kms</PackageTags>
+    <PackageValidationBaselineVersion></PackageValidationBaselineVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.KeyManagementService" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Dekaf.SchemaRegistry.Kms.Aws/PublicAPI.Shipped.txt
+++ b/src/Dekaf.SchemaRegistry.Kms.Aws/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Dekaf.SchemaRegistry.Kms.Aws/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry.Kms.Aws/PublicAPI.Unshipped.txt
@@ -1,0 +1,12 @@
+#nullable enable
+Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider
+Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.AwsKmsProvider() -> void
+Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.AwsKmsProvider(Amazon.KeyManagementService.AmazonKeyManagementServiceConfig! config) -> void
+Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.AwsKmsProvider(Amazon.KeyManagementService.IAmazonKeyManagementService! client, bool ownsClient = false) -> void
+Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.AwsKmsProvider(Amazon.RegionEndpoint! region) -> void
+Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.Dispose() -> void
+Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.Type.get -> string!
+Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.UnwrapKeyAsync(System.ReadOnlyMemory<byte> encryptedKeyMaterial, Dekaf.SchemaRegistry.SchemaRegistryKmsKeyReference! keyReference, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
+Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.WrapKeyAsync(System.ReadOnlyMemory<byte> keyMaterial, Dekaf.SchemaRegistry.SchemaRegistryKmsKeyReference! keyReference, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
+const Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.DefaultType = "aws-kms" -> string!
+const Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.KeyUriPrefix = "aws-kms://" -> string!

--- a/src/Dekaf.SchemaRegistry.Kms.Aws/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry.Kms.Aws/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider
-Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.AwsKmsProvider() -> void
-Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.AwsKmsProvider(Amazon.KeyManagementService.AmazonKeyManagementServiceConfig! config) -> void
-Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.AwsKmsProvider(Amazon.KeyManagementService.IAmazonKeyManagementService! client, bool ownsClient = false) -> void
-Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.AwsKmsProvider(Amazon.RegionEndpoint! region) -> void
+Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.AwsKmsProvider(Amazon.KeyManagementService.AmazonKeyManagementServiceConfig! config, string! type = "aws-kms") -> void
+Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.AwsKmsProvider(Amazon.KeyManagementService.IAmazonKeyManagementService! client, bool ownsClient = false, string! type = "aws-kms") -> void
+Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.AwsKmsProvider(Amazon.RegionEndpoint! region, string! type = "aws-kms") -> void
+Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.AwsKmsProvider(string! type = "aws-kms") -> void
 Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.Dispose() -> void
 Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.Type.get -> string!
 Dekaf.SchemaRegistry.Kms.Aws.AwsKmsProvider.UnwrapKeyAsync(System.ReadOnlyMemory<byte> encryptedKeyMaterial, Dekaf.SchemaRegistry.SchemaRegistryKmsKeyReference! keyReference, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Gcp\Dekaf.SchemaRegistry.Kms.Gcp.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Vault\Dekaf.SchemaRegistry.Kms.Vault.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Aws\Dekaf.SchemaRegistry.Kms.Aws.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Json\Dekaf.SchemaRegistry.Json.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Lz4\Dekaf.Compression.Lz4.csproj" />

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
@@ -1,0 +1,223 @@
+using Amazon.KeyManagementService;
+using Amazon.KeyManagementService.Model;
+using Amazon.Runtime;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Kms.Aws;
+using NSubstitute;
+using System.Net;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public class AwsKmsProviderTests
+{
+    private const string KeyArn = "arn:aws:kms:eu-west-2:123456789012:key/1234";
+
+    [Test]
+    public async Task WrapAndUnwrap_UseAwsKmsEnvelopeOperations()
+    {
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        EncryptRequest? encryptRequest = null;
+        DecryptRequest? decryptRequest = null;
+        client.EncryptAsync(Arg.Do<EncryptRequest>(request => encryptRequest = request), Arg.Any<CancellationToken>())
+            .Returns(new EncryptResponse { CiphertextBlob = new MemoryStream([4, 5, 6]) });
+        client.DecryptAsync(Arg.Do<DecryptRequest>(request => decryptRequest = request), Arg.Any<CancellationToken>())
+            .Returns(new DecryptResponse { Plaintext = new MemoryStream([1, 2, 3]) });
+        using var provider = new AwsKmsProvider(client);
+        var keyReference = CreateKeyReference();
+
+        var encrypted = await provider.WrapKeyAsync(new byte[] { 1, 2, 3 }, keyReference);
+        var decrypted = await provider.UnwrapKeyAsync(encrypted, keyReference);
+
+        await Assert.That(encrypted).IsEquivalentTo(new byte[] { 4, 5, 6 });
+        await Assert.That(decrypted).IsEquivalentTo(new byte[] { 1, 2, 3 });
+        await Assert.That(encryptRequest!.KeyId).IsEqualTo(KeyArn);
+        await Assert.That(ReadAll(encryptRequest.Plaintext)).IsEquivalentTo(new byte[] { 1, 2, 3 });
+        await Assert.That(decryptRequest!.KeyId).IsEqualTo(KeyArn);
+        await Assert.That(ReadAll(decryptRequest.CiphertextBlob)).IsEquivalentTo(new byte[] { 4, 5, 6 });
+    }
+
+    [Test]
+    public async Task ConfluentKeyUri_StripsProviderPrefix()
+    {
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        EncryptRequest? captured = null;
+        client.EncryptAsync(Arg.Do<EncryptRequest>(request => captured = request), Arg.Any<CancellationToken>())
+            .Returns(new EncryptResponse { CiphertextBlob = new MemoryStream([9]) });
+        using var provider = new AwsKmsProvider(client);
+
+        await provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference(AwsKmsProvider.KeyUriPrefix + KeyArn));
+
+        await Assert.That(captured!.KeyId).IsEqualTo(KeyArn);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task AwsFailure_IsSanitizedAndPreservesCause(bool wrap)
+    {
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        var failure = new AmazonKeyManagementServiceException("secret provider response");
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>()).Returns(Task.FromException<EncryptResponse>(failure));
+        client.DecryptAsync(Arg.Any<DecryptRequest>(), Arg.Any<CancellationToken>()).Returns(Task.FromException<DecryptResponse>(failure));
+        using var provider = new AwsKmsProvider(client);
+
+        var exception = wrap
+            ? await Assert.ThrowsAsync<SchemaRegistryKmsException>(() => provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask())
+            : await Assert.ThrowsAsync<SchemaRegistryKmsException>(() => provider.UnwrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).IsEqualTo(wrap ? "AWS KMS wrap failed." : "AWS KMS unwrap failed.");
+        await Assert.That(exception.InnerException).IsSameReferenceAs(failure);
+    }
+
+    [Test]
+    public async Task MalformedCiphertext_IsReportedWithoutMaterial()
+    {
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        client.DecryptAsync(Arg.Any<DecryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<DecryptResponse>(new InvalidCiphertextException("ciphertext: sensitive")));
+        using var provider = new AwsKmsProvider(client);
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            () => provider.UnwrapKeyAsync(new byte[] { 1, 2, 3 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).IsEqualTo("AWS KMS unwrap failed.");
+        await Assert.That(exception.Message).DoesNotContain("sensitive");
+    }
+
+    [Test]
+    public async Task WrongKey_IsReportedWithoutKeyMaterial()
+    {
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        client.DecryptAsync(Arg.Any<DecryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<DecryptResponse>(new IncorrectKeyException("wrong key: sensitive")));
+        using var provider = new AwsKmsProvider(client);
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            () => provider.UnwrapKeyAsync(new byte[] { 1, 2, 3 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).IsEqualTo("AWS KMS unwrap failed.");
+        await Assert.That(exception.Message).DoesNotContain("sensitive");
+    }
+
+    [Test]
+    public async Task AuthorizationFailure_IsReportedWithoutProviderResponse()
+    {
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        var denied = new AmazonKeyManagementServiceException(
+            "access response: sensitive",
+            ErrorType.Sender,
+            "AccessDeniedException",
+            "request-id",
+            HttpStatusCode.Forbidden);
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<EncryptResponse>(denied));
+        using var provider = new AwsKmsProvider(client);
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            () => provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).IsEqualTo("AWS KMS wrap failed.");
+        await Assert.That(exception.Message).DoesNotContain("sensitive");
+        await Assert.That(exception.InnerException).IsSameReferenceAs(denied);
+    }
+
+    [Test]
+    public async Task Cancellation_IsPropagatedToInFlightAwsCall()
+    {
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        using var cancellation = new CancellationTokenSource();
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => WaitForCancellationAsync(call.Arg<CancellationToken>()));
+        using var provider = new AwsKmsProvider(client);
+        var operation = provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference(), cancellation.Token).AsTask();
+
+        cancellation.Cancel();
+
+        await Assert.That(async () => await operation)
+            .Throws<OperationCanceledException>();
+        await client.Received(1).EncryptAsync(Arg.Any<EncryptRequest>(), cancellation.Token);
+    }
+
+    [Test]
+    public async Task SharedProvider_IsThreadSafe()
+    {
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => EchoAfterYieldAsync(call.Arg<EncryptRequest>()));
+        using var provider = new AwsKmsProvider(client);
+
+        var operations = Enumerable.Range(1, 32)
+            .Select(value => provider.WrapKeyAsync(new byte[] { (byte)value }, CreateKeyReference()).AsTask())
+            .ToArray();
+        var results = await Task.WhenAll(operations);
+
+        for (var index = 0; index < results.Length; index++)
+            await Assert.That(results[index]).IsEquivalentTo(new byte[] { (byte)(index + 1) });
+    }
+
+    [Test]
+    public async Task OwnedClient_IsDisposedWithProvider()
+    {
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        var provider = new AwsKmsProvider(client, ownsClient: true);
+
+        provider.Dispose();
+        provider.Dispose();
+
+        client.Received(1).Dispose();
+        await Assert.That(async () => await provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference()))
+            .Throws<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task InvalidReference_IsRejectedBeforeAwsCall()
+    {
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        using var provider = new AwsKmsProvider(client);
+        var reference = new SchemaRegistryKmsKeyReference
+        {
+            KmsType = "gcp-kms",
+            KmsKeyId = KeyArn
+        };
+
+        await Assert.That(async () => await provider.WrapKeyAsync(new byte[] { 1 }, reference))
+            .Throws<SchemaRegistryKmsException>();
+        await client.DidNotReceiveWithAnyArgs().EncryptAsync(default!, default);
+    }
+
+    [Test]
+    public async Task EmptyKeyIdentifier_IsRejectedBeforeAwsCall()
+    {
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        using var provider = new AwsKmsProvider(client);
+        var reference = new SchemaRegistryKmsKeyReference
+        {
+            KmsType = AwsKmsProvider.DefaultType,
+            KmsKeyId = null!
+        };
+
+        await Assert.That(async () => await provider.WrapKeyAsync(new byte[] { 1 }, reference))
+            .Throws<SchemaRegistryKmsException>();
+        await client.DidNotReceiveWithAnyArgs().EncryptAsync(default!, default);
+    }
+
+    private static SchemaRegistryKmsKeyReference CreateKeyReference(string keyId = KeyArn) => new()
+    {
+        KmsType = AwsKmsProvider.DefaultType,
+        KmsKeyId = keyId
+    };
+
+    private static byte[] ReadAll(MemoryStream stream) => stream.ToArray();
+
+    private static async Task<EncryptResponse> WaitForCancellationAsync(CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        throw new InvalidOperationException("Cancellation was not observed.");
+    }
+
+    private static async Task<EncryptResponse> EchoAfterYieldAsync(EncryptRequest request)
+    {
+        await Task.Yield();
+        return new EncryptResponse { CiphertextBlob = new MemoryStream(ReadAll(request.Plaintext)) };
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
@@ -5,6 +5,7 @@ using Dekaf.SchemaRegistry;
 using Dekaf.SchemaRegistry.Kms.Aws;
 using NSubstitute;
 using System.Net;
+using System.Reflection;
 
 namespace Dekaf.Tests.Unit.SchemaRegistry;
 
@@ -242,6 +243,58 @@ public class AwsKmsProviderTests
     }
 
     [Test]
+    public async Task Dispose_WaitsForActiveOperationBeforeDisposingOwnedClient()
+    {
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var operationCompletion = new TaskCompletionSource<EncryptResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var disposeStarted = new ManualResetEventSlim(initialState: false);
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                operationStarted.SetResult();
+                return operationCompletion.Task;
+            });
+        var provider = new AwsKmsProvider(client, ownsClient: true);
+
+        var wrapTask = provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask();
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var disposeTask = Task.Run(() =>
+        {
+            disposeStarted.Set();
+            provider.Dispose();
+        });
+
+        try
+        {
+            await Assert.That(disposeStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(SpinWait.SpinUntil(
+                () => GetOperationState(provider) < 0,
+                TimeSpan.FromSeconds(5))).IsTrue();
+            client.DidNotReceive().Dispose();
+
+            operationCompletion.SetResult(CreateEncryptResponse());
+
+            await Assert.That(await wrapTask.WaitAsync(TimeSpan.FromSeconds(5)))
+                .IsEquivalentTo(new byte[] { 4, 5, 6 });
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+            client.Received(1).Dispose();
+        }
+        finally
+        {
+            operationCompletion.TrySetResult(CreateEncryptResponse());
+            try
+            {
+                await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            finally
+            {
+                provider.Dispose();
+            }
+        }
+    }
+
+    [Test]
     public async Task InvalidReference_IsRejectedBeforeAwsCall()
     {
         var client = Substitute.For<IAmazonKeyManagementService>();
@@ -311,6 +364,14 @@ public class AwsKmsProviderTests
     };
 
     private static byte[] ReadAll(MemoryStream stream) => stream.ToArray();
+
+    private static EncryptResponse CreateEncryptResponse() =>
+        new() { CiphertextBlob = new MemoryStream([4, 5, 6]) };
+
+    private static int GetOperationState(AwsKmsProvider provider) =>
+        (int)typeof(AwsKmsProvider)
+            .GetField("_operationState", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(provider)!;
 
     private static async Task<EncryptResponse> WaitForCancellationAsync(CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
@@ -334,6 +334,45 @@ public class AwsKmsProviderTests
     }
 
     [Test]
+    public async Task Dispose_ReturnsPromptlyWhenCancellationCallbackBlocks()
+    {
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callbackEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var callbackRelease = new ManualResetEventSlim();
+        var operationCompletion = new TaskCompletionSource<EncryptResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                _ = call.Arg<CancellationToken>().Register(() =>
+                {
+                    callbackEntered.SetResult();
+                    callbackRelease.Wait();
+                });
+                operationStarted.SetResult();
+                return operationCompletion.Task;
+            });
+        using var provider = new AwsKmsProvider(client, ownsClient: true);
+        var wrapTask = provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask();
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var disposeTask = Task.Run(provider.Dispose);
+
+        try
+        {
+            await callbackEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(2));
+            client.Received(1).Dispose();
+        }
+        finally
+        {
+            callbackRelease.Set();
+            operationCompletion.TrySetResult(CreateEncryptResponse());
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+            await wrapTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Test]
     public async Task InvalidReference_IsRejectedBeforeAwsCall()
     {
         var client = Substitute.For<IAmazonKeyManagementService>();

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
@@ -70,6 +70,31 @@ public class AwsKmsProviderTests
     }
 
     [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task AwsClientFailure_IsSanitizedAndPreservesCause(bool wrap)
+    {
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        var failure = new AmazonClientException("credential provider response: sensitive");
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<EncryptResponse>(failure));
+        client.DecryptAsync(Arg.Any<DecryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<DecryptResponse>(failure));
+        using var provider = new AwsKmsProvider(client);
+
+        var exception = wrap
+            ? await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+                () => provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask())
+            : await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+                () => provider.UnwrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message)
+            .IsEqualTo(wrap ? "AWS KMS wrap failed." : "AWS KMS unwrap failed.");
+        await Assert.That(exception.Message).DoesNotContain("sensitive");
+        await Assert.That(exception.InnerException).IsSameReferenceAs(failure);
+    }
+
+    [Test]
     public async Task MalformedCiphertext_IsReportedWithoutMaterial()
     {
         var client = Substitute.For<IAmazonKeyManagementService>();
@@ -159,7 +184,7 @@ public class AwsKmsProviderTests
     public async Task OwnedClient_IsDisposedWithProvider()
     {
         var client = Substitute.For<IAmazonKeyManagementService>();
-        var provider = new AwsKmsProvider(client, ownsClient: true);
+        using var provider = new AwsKmsProvider(client, ownsClient: true);
 
         provider.Dispose();
         provider.Dispose();

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
@@ -139,6 +139,23 @@ public class AwsKmsProviderTests
     }
 
     [Test]
+    public async Task Unwrap_ZeroesNonExposablePlaintextStream()
+    {
+        var plaintext = new byte[] { 1, 2, 3 };
+        var stream = new MemoryStream(plaintext);
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        client.DecryptAsync(Arg.Any<DecryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new DecryptResponse { Plaintext = stream });
+        using var provider = new AwsKmsProvider(client);
+
+        var unwrapped = await provider.UnwrapKeyAsync(new byte[] { 4, 5, 6 }, CreateKeyReference());
+
+        await Assert.That(stream.TryGetBuffer(out _)).IsFalse();
+        await Assert.That(unwrapped).IsEquivalentTo(new byte[] { 1, 2, 3 });
+        await Assert.That(plaintext).IsEquivalentTo(new byte[] { 0, 0, 0 });
+    }
+
+    [Test]
     public async Task WrongKey_IsReportedWithoutKeyMaterial()
     {
         var client = Substitute.For<IAmazonKeyManagementService>();

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
@@ -1,11 +1,11 @@
 using Amazon.KeyManagementService;
 using Amazon.KeyManagementService.Model;
 using Amazon.Runtime;
+using System.Diagnostics;
 using Dekaf.SchemaRegistry;
 using Dekaf.SchemaRegistry.Kms.Aws;
 using NSubstitute;
 using System.Net;
-using System.Reflection;
 
 namespace Dekaf.Tests.Unit.SchemaRegistry;
 
@@ -199,8 +199,13 @@ public class AwsKmsProviderTests
     {
         var client = Substitute.For<IAmazonKeyManagementService>();
         using var cancellation = new CancellationTokenSource();
+        CancellationToken operationToken = default;
         client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
-            .Returns(call => WaitForCancellationAsync(call.Arg<CancellationToken>()));
+            .Returns(call =>
+            {
+                operationToken = call.Arg<CancellationToken>();
+                return WaitForCancellationAsync(operationToken);
+            });
         using var provider = new AwsKmsProvider(client);
         var operation = provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference(), cancellation.Token).AsTask();
 
@@ -208,7 +213,8 @@ public class AwsKmsProviderTests
 
         await Assert.That(async () => await operation)
             .Throws<OperationCanceledException>();
-        await client.Received(1).EncryptAsync(Arg.Any<EncryptRequest>(), cancellation.Token);
+        await Assert.That(operationToken.IsCancellationRequested).IsTrue();
+        await client.Received(1).EncryptAsync(Arg.Any<EncryptRequest>(), operationToken);
     }
 
     [Test]
@@ -243,11 +249,35 @@ public class AwsKmsProviderTests
     }
 
     [Test]
-    public async Task Dispose_WaitsForActiveOperationBeforeDisposingOwnedClient()
+    public async Task Dispose_CancelsActiveOperationBeforeDisposingOwnedClient()
+    {
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                operationStarted.SetResult();
+                return WaitForCancellationAsync(call.Arg<CancellationToken>());
+            });
+        using var provider = new AwsKmsProvider(client, ownsClient: true);
+
+        var wrapTask = provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask();
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var elapsed = Stopwatch.StartNew();
+
+        provider.Dispose();
+
+        elapsed.Stop();
+        await Assert.That(elapsed.Elapsed).IsLessThan(TimeSpan.FromSeconds(2));
+        await Assert.That(async () => await wrapTask).Throws<OperationCanceledException>();
+        client.Received(1).Dispose();
+    }
+
+    [Test]
+    public async Task Dispose_ReturnsPromptlyWhenActiveOperationIgnoresCancellation()
     {
         var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var operationCompletion = new TaskCompletionSource<EncryptResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var disposeStarted = new ManualResetEventSlim(initialState: false);
         var client = Substitute.For<IAmazonKeyManagementService>();
         client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
             .Returns(_ =>
@@ -255,42 +285,26 @@ public class AwsKmsProviderTests
                 operationStarted.SetResult();
                 return operationCompletion.Task;
             });
-        var provider = new AwsKmsProvider(client, ownsClient: true);
-
+        using var provider = new AwsKmsProvider(client, ownsClient: true);
         var wrapTask = provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask();
         await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        var disposeTask = Task.Run(() =>
-        {
-            disposeStarted.Set();
-            provider.Dispose();
-        });
 
         try
         {
-            await Assert.That(disposeStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
-            await Assert.That(SpinWait.SpinUntil(
-                () => GetOperationState(provider) < 0,
-                TimeSpan.FromSeconds(5))).IsTrue();
-            client.DidNotReceive().Dispose();
+            var elapsed = Stopwatch.StartNew();
+            provider.Dispose();
+            elapsed.Stop();
 
+            await Assert.That(elapsed.Elapsed).IsLessThan(TimeSpan.FromSeconds(2));
+            client.Received(1).Dispose();
             operationCompletion.SetResult(CreateEncryptResponse());
-
             await Assert.That(await wrapTask.WaitAsync(TimeSpan.FromSeconds(5)))
                 .IsEquivalentTo(new byte[] { 4, 5, 6 });
-            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
-            client.Received(1).Dispose();
         }
         finally
         {
             operationCompletion.TrySetResult(CreateEncryptResponse());
-            try
-            {
-                await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
-            }
-            finally
-            {
-                provider.Dispose();
-            }
+            await wrapTask.WaitAsync(TimeSpan.FromSeconds(5));
         }
     }
 
@@ -367,11 +381,6 @@ public class AwsKmsProviderTests
 
     private static EncryptResponse CreateEncryptResponse() =>
         new() { CiphertextBlob = new MemoryStream([4, 5, 6]) };
-
-    private static int GetOperationState(AwsKmsProvider provider) =>
-        (int)typeof(AwsKmsProvider)
-            .GetField("_operationState", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .GetValue(provider)!;
 
     private static async Task<EncryptResponse> WaitForCancellationAsync(CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
@@ -53,7 +53,7 @@ public class AwsKmsProviderTests
     [Test]
     [Arguments(true)]
     [Arguments(false)]
-    public async Task AwsFailure_IsSanitizedAndPreservesCause(bool wrap)
+    public async Task AwsFailure_IsSanitizedWithoutSensitiveCause(bool wrap)
     {
         var client = Substitute.For<IAmazonKeyManagementService>();
         var failure = new AmazonKeyManagementServiceException("secret provider response");
@@ -66,13 +66,14 @@ public class AwsKmsProviderTests
             : await Assert.ThrowsAsync<SchemaRegistryKmsException>(() => provider.UnwrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask());
 
         await Assert.That(exception!.Message).IsEqualTo(wrap ? "AWS KMS wrap failed." : "AWS KMS unwrap failed.");
-        await Assert.That(exception.InnerException).IsSameReferenceAs(failure);
+        await Assert.That(exception.InnerException).IsNull();
+        await Assert.That(exception.ToString()).DoesNotContain("secret provider response");
     }
 
     [Test]
     [Arguments(true)]
     [Arguments(false)]
-    public async Task AwsClientFailure_IsSanitizedAndPreservesCause(bool wrap)
+    public async Task AwsClientFailure_IsSanitizedWithoutSensitiveCause(bool wrap)
     {
         var client = Substitute.For<IAmazonKeyManagementService>();
         var failure = new AmazonClientException("credential provider response: sensitive");
@@ -91,7 +92,35 @@ public class AwsKmsProviderTests
         await Assert.That(exception!.Message)
             .IsEqualTo(wrap ? "AWS KMS wrap failed." : "AWS KMS unwrap failed.");
         await Assert.That(exception.Message).DoesNotContain("sensitive");
-        await Assert.That(exception.InnerException).IsSameReferenceAs(failure);
+        await Assert.That(exception.InnerException).IsNull();
+        await Assert.That(exception.ToString()).DoesNotContain("sensitive");
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TransportFailure_IsSanitizedWithoutSensitiveCause(bool wrap)
+    {
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        Exception failure = wrap
+            ? new HttpRequestException("transport response: sensitive")
+            : new TimeoutException("timeout response: sensitive");
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<EncryptResponse>(failure));
+        client.DecryptAsync(Arg.Any<DecryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<DecryptResponse>(failure));
+        using var provider = new AwsKmsProvider(client);
+
+        var exception = wrap
+            ? await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+                () => provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask())
+            : await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+                () => provider.UnwrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message)
+            .IsEqualTo(wrap ? "AWS KMS wrap failed." : "AWS KMS unwrap failed.");
+        await Assert.That(exception.InnerException).IsNull();
+        await Assert.That(exception.ToString()).DoesNotContain("sensitive");
     }
 
     [Test]
@@ -143,7 +172,8 @@ public class AwsKmsProviderTests
 
         await Assert.That(exception!.Message).IsEqualTo("AWS KMS wrap failed.");
         await Assert.That(exception.Message).DoesNotContain("sensitive");
-        await Assert.That(exception.InnerException).IsSameReferenceAs(denied);
+        await Assert.That(exception.InnerException).IsNull();
+        await Assert.That(exception.ToString()).DoesNotContain("sensitive");
     }
 
     [Test]
@@ -211,6 +241,35 @@ public class AwsKmsProviderTests
     }
 
     [Test]
+    public async Task CustomType_ResolvesMatchingRegionalProvider()
+    {
+        const string regionalType = "aws-kms-eu-west-2";
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new EncryptResponse { CiphertextBlob = new MemoryStream([9]) });
+        using var provider = new AwsKmsProvider(client, type: regionalType);
+
+        var encrypted = await provider.WrapKeyAsync(
+            new byte[] { 1 },
+            CreateKeyReference(KeyArn, regionalType));
+
+        await Assert.That(provider.Type).IsEqualTo(regionalType);
+        await Assert.That(encrypted).IsEquivalentTo(new byte[] { 9 });
+        await client.Received(1).EncryptAsync(
+            Arg.Is<EncryptRequest>(request => request.KeyId == KeyArn),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task EmptyCustomType_IsRejected()
+    {
+        var client = Substitute.For<IAmazonKeyManagementService>();
+
+        await Assert.That(() => new AwsKmsProvider(client, type: " "))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
     public async Task EmptyKeyIdentifier_IsRejectedBeforeAwsCall()
     {
         var client = Substitute.For<IAmazonKeyManagementService>();
@@ -226,9 +285,11 @@ public class AwsKmsProviderTests
         await client.DidNotReceiveWithAnyArgs().EncryptAsync(default!, default);
     }
 
-    private static SchemaRegistryKmsKeyReference CreateKeyReference(string keyId = KeyArn) => new()
+    private static SchemaRegistryKmsKeyReference CreateKeyReference(
+        string keyId = KeyArn,
+        string type = AwsKmsProvider.DefaultType) => new()
     {
-        KmsType = AwsKmsProvider.DefaultType,
+        KmsType = type,
         KmsKeyId = keyId
     };
 

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AwsKmsProviderTests.cs
@@ -125,6 +125,31 @@ public class AwsKmsProviderTests
     }
 
     [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task DisposedTransportFailure_IsSanitizedWithoutSensitiveCause(bool wrap)
+    {
+        var client = Substitute.For<IAmazonKeyManagementService>();
+        var failure = new ObjectDisposedException("HttpClient", "disposed transport: sensitive");
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<EncryptResponse>(failure));
+        client.DecryptAsync(Arg.Any<DecryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<DecryptResponse>(failure));
+        using var provider = new AwsKmsProvider(client);
+
+        var exception = wrap
+            ? await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+                () => provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask())
+            : await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+                () => provider.UnwrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message)
+            .IsEqualTo(wrap ? "AWS KMS wrap failed." : "AWS KMS unwrap failed.");
+        await Assert.That(exception.InnerException).IsNull();
+        await Assert.That(exception.ToString()).DoesNotContain("sensitive");
+    }
+
+    [Test]
     public async Task MalformedCiphertext_IsReportedWithoutMaterial()
     {
         var client = Substitute.For<IAmazonKeyManagementService>();

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AwsKmsProviderBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AwsKmsProviderBenchmarks.cs
@@ -1,0 +1,42 @@
+using Amazon;
+using Amazon.KeyManagementService;
+using Amazon.KeyManagementService.Model;
+using Amazon.Runtime;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Kms.Aws;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 10)]
+public class AwsKmsProviderBenchmarks
+{
+    private readonly byte[] _encryptedKeyMaterial = [4, 5, 6];
+    private readonly SchemaRegistryKmsKeyReference _keyReference = new()
+    {
+        KmsType = AwsKmsProvider.DefaultType,
+        KmsKeyId = "arn:aws:kms:eu-west-2:123456789012:key/1234"
+    };
+    private readonly AwsKmsProvider _provider = new(new SuccessfulClient(), ownsClient: true);
+
+    [Benchmark]
+    public ValueTask<byte[]> UnwrapNonExposableResponse() =>
+        _provider.UnwrapKeyAsync(_encryptedKeyMaterial, _keyReference);
+
+    [GlobalCleanup]
+    public void Cleanup() => _provider.Dispose();
+
+    private sealed class SuccessfulClient()
+        : AmazonKeyManagementServiceClient(new AnonymousAWSCredentials(), RegionEndpoint.EUWest2)
+    {
+        public override Task<DecryptResponse> DecryptAsync(
+            DecryptRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var plaintext = new byte[] { 1, 2, 3 };
+            return Task.FromResult(new DecryptResponse { Plaintext = new MemoryStream(plaintext) });
+        }
+    }
+}

--- a/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
+++ b/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Json\Dekaf.SchemaRegistry.Json.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Vault\Dekaf.SchemaRegistry.Kms.Vault.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Aws\Dekaf.SchemaRegistry.Kms.Aws.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- add opt-in `Dekaf.SchemaRegistry.Kms.Aws` package using AWS SDK v4
- support raw AWS KMS key IDs/ARNs and Confluent-compatible `aws-kms://` URIs
- provide default credential/region chain, explicit region/config, and injected-client construction
- forward cancellation, sanitize provider failures, dispose owned clients, and clear temporary plaintext buffers
- document credentials, IAM permissions, configuration, endpoints, and CSFLE registration

## Validation

- Release build: net8.0 + net10.0, 0 warnings
- focused `AwsKmsProviderTests`: 12/12 on net8.0 and net10.0
- full unit suite: 6,855/6,855 net10.0; 6,719/6,719 net8.0
- `dotnet pack`: package validation/API analyzers clean; nupkg + snupkg produced
- coverage includes wrap/unwrap success, Confluent URI compatibility, wrong key, authorization failure, malformed ciphertext, in-flight cancellation, concurrent shared use, ownership/disposal, and invalid configuration

No benchmark/stress lane: this is a new opt-in package with no reference from existing runtime packages. KMS operations wrap/unwrap DEKs through remote AWS APIs; no existing serialization/produce/consume hot path changes.

AWS SDK behavior follows the official [KMS client API](https://docs.aws.amazon.com/sdkfornet/v4/apidocs/items/KeyManagementService/TKeyManagementServiceClient.html) and [credential resolution documentation](https://docs.aws.amazon.com/sdk-for-net/v4/developer-guide/creds-assign.html).

Closes #2701
Part of #2692 and #2560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS KMS support for client-side schema registry field-level encryption.
  * Supports configurable regions, endpoints, credentials, and client instances for wrapping and unwrapping keys.
  * Added validation, cancellation support, secure buffer handling, concurrency safety, and clear error reporting.
* **Documentation**
  * Added setup and usage guidance, including permissions, key references, multi-region configurations, and operational considerations.
* **Tests**
  * Added coverage for AWS KMS operations, validation, cancellation, concurrency, disposal, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->