### PR TITLE
feat(schema-registry): add Azure KMS provider

### DIFF
--- a/Dekaf.sln
+++ b/Dekaf.sln
@@ -77,6 +77,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.SchemaRegistry.Kms.Va
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.SchemaRegistry.Kms.Aws", "src\Dekaf.SchemaRegistry.Kms.Aws\Dekaf.SchemaRegistry.Kms.Aws.csproj", "{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.SchemaRegistry.Kms.Azure", "src\Dekaf.SchemaRegistry.Kms.Azure\Dekaf.SchemaRegistry.Kms.Azure.csproj", "{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -483,6 +485,18 @@ Global
 		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}.Release|x64.Build.0 = Release|Any CPU
 		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}.Release|x86.ActiveCfg = Release|Any CPU
 		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD}.Release|x86.Build.0 = Release|Any CPU
+		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}.Debug|x64.Build.0 = Debug|Any CPU
+		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}.Debug|x86.Build.0 = Debug|Any CPU
+		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}.Release|x64.ActiveCfg = Release|Any CPU
+		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}.Release|x64.Build.0 = Release|Any CPU
+		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}.Release|x86.ActiveCfg = Release|Any CPU
+		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -521,5 +535,6 @@ Global
 		{52043965-88BE-40BE-B801-70A13249AAE8} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{170E0071-44E4-4D9B-AB44-4B324DE007F1} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,8 @@
   <ItemGroup>
     <PackageVersion Include="Apache.Avro" Version="1.12.1" />
     <PackageVersion Include="AWSSDK.KeyManagementService" Version="4.0.100.8" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.10.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
     <PackageVersion Include="Confluent.Kafka" Version="2.15.0" />

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -448,9 +448,12 @@ existing data keeps decrypting after rotation. For a versionless key, set the KE
 material.
 
 For RBAC-enabled vaults, grant the identity the Key Vault Crypto User role. For vaults using legacy
-access policies, grant the `keys/wrapKey` and `keys/unwrapKey` permissions. One provider instance is
-safe for concurrent use and caches one `CryptographyClient` per configured key identifier. Clients
-for key versions read from ciphertext use a bounded cache.
+access policies, grant the `keys/wrapKey` and `keys/unwrapKey` permissions. Managed HSM uses its own
+local RBAC system: grant the identity the
+[Managed HSM Crypto User role](https://learn.microsoft.com/azure/key-vault/managed-hsm/role-management)
+at the `/keys` scope or the specific key's scope. One provider instance is safe for concurrent use
+and caches one `CryptographyClient` per configured key identifier. Clients for key versions read
+from ciphertext use a bounded cache.
 Cancellation is forwarded to Azure; provider error messages do not include service response text
 or key material.
 

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -406,6 +406,44 @@ using var usKms = new AwsKmsProvider(RegionEndpoint.USEast1, type: "aws-kms-us-e
 var multiRegionCsfle = new SchemaRegistryCsfleRuleHandler(schemaRegistry, [euKms, usKms]);
 ```
 
+## Azure Key Vault KMS
+
+Install the opt-in Azure provider when Schema Registry client-side field-level encryption (CSFLE)
+uses an Azure Key Vault key:
+
+```bash
+dotnet add package Dekaf.SchemaRegistry.Kms.Azure
+```
+
+```csharp
+using Azure.Identity;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Kms.Azure;
+
+var credential = new DefaultAzureCredential();
+var azureKms = new AzureKeyVaultKmsProvider(credential);
+var csfle = new SchemaRegistryCsfleRuleHandler(schemaRegistry, [azureKms]);
+```
+
+`DefaultAzureCredential` uses the standard Azure credential chain. Production applications can
+instead pass a specific credential such as `ManagedIdentityCredential` or
+`ClientSecretCredential`. The credential and any supplied `CryptographyClientOptions` are
+caller-owned. For complete client-construction control, implement
+`IAzureKeyVaultCryptographyClientFactory`.
+
+Use an absolute key identifier with `/keys/<name>` or `/keys/<name>/<version>`, for example
+`https://payments.vault.azure.net/keys/orders-kek`. The provider accepts KMS types `azure-kv` and
+Confluent-compatible `azure-kms`; matching `azure-kv://` and `azure-kms://` prefixes on the key
+identifier are optional. It uses RSA-OAEP-256. Prefer a versioned key identifier so existing data
+keeps decrypting after rotation. For a versionless key, set the KEK property
+`encrypt.azure.key.version.save=true` to embed the exact Azure key version in newly wrapped key
+material.
+
+Grant the identity `keys/encrypt` and `keys/decrypt` permissions, for example through the Key Vault
+Crypto Service Encryption User RBAC role. One provider instance is safe for concurrent use and
+caches one `CryptographyClient` per resolved key identifier. Cancellation is forwarded to Azure;
+provider error messages do not include service response text or key material.
+
 ## Consumer
 
 ```csharp

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -437,7 +437,9 @@ caller-owned. For complete client-construction control, implement
 `IAzureKeyVaultCryptographyClientFactory`.
 
 Use an absolute HTTPS key identifier with `/keys/<name>` or `/keys/<name>/<version>`, for example
-`https://payments.vault.azure.net/keys/orders-kek`. Each provider instance registers one KMS type;
+`https://payments.vault.azure.net/keys/orders-kek`. Azure public, US Government, and China Key Vault
+DNS authorities are accepted; other authorities are rejected before credential use. Each
+provider instance registers one KMS type;
 register the default instance for `azure-kv`, the `ConfluentType` instance for Confluent-compatible
 `azure-kms`, or both as shown above. Matching `azure-kv://` and `azure-kms://` prefixes on the key
 identifier are optional. The provider uses RSA-OAEP-256. Prefer a versioned key identifier so
@@ -447,7 +449,8 @@ material.
 
 For RBAC-enabled vaults, grant the identity the Key Vault Crypto User role. For vaults using legacy
 access policies, grant the `keys/encrypt` and `keys/decrypt` permissions. One provider instance is
-safe for concurrent use and caches one `CryptographyClient` per resolved key identifier.
+safe for concurrent use and caches one `CryptographyClient` per configured key identifier. Clients
+for key versions read from ciphertext use a bounded cache.
 Cancellation is forwarded to Azure; provider error messages do not include service response text
 or key material.
 

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -451,9 +451,9 @@ For RBAC-enabled vaults, grant the identity the Key Vault Crypto User role. For 
 access policies, grant the `keys/wrapKey` and `keys/unwrapKey` permissions. Managed HSM uses its own
 local RBAC system: grant the identity the
 [Managed HSM Crypto User role](https://learn.microsoft.com/azure/key-vault/managed-hsm/role-management)
-at the `/keys` scope or the specific key's scope. One provider instance is safe for concurrent use
-and caches one `CryptographyClient` per configured key identifier. Clients for key versions read
-from ciphertext use a bounded cache.
+at the `/keys` scope or the specific key's scope. One provider instance is safe for concurrent use.
+It bounds both its configured-key client cache and its ciphertext key-version client cache to 64
+entries.
 Cancellation is forwarded to Azure; provider error messages do not include service response text
 or key material.
 

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -448,7 +448,7 @@ existing data keeps decrypting after rotation. For a versionless key, set the KE
 material.
 
 For RBAC-enabled vaults, grant the identity the Key Vault Crypto User role. For vaults using legacy
-access policies, grant the `keys/encrypt` and `keys/decrypt` permissions. One provider instance is
+access policies, grant the `keys/wrapKey` and `keys/unwrapKey` permissions. One provider instance is
 safe for concurrent use and caches one `CryptographyClient` per configured key identifier. Clients
 for key versions read from ciphertext use a bounded cache.
 Cancellation is forwarded to Azure; provider error messages do not include service response text

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -438,8 +438,8 @@ caller-owned. For complete client-construction control, implement
 
 Use an absolute HTTPS key identifier with `/keys/<name>` or `/keys/<name>/<version>`, for example
 `https://payments.vault.azure.net/keys/orders-kek`. Azure public, US Government, and China Key Vault
-DNS authorities are accepted; other authorities are rejected before credential use. Each
-provider instance registers one KMS type;
+and Managed HSM DNS authorities are accepted; other authorities are rejected before credential use.
+Each provider instance registers one KMS type;
 register the default instance for `azure-kv`, the `ConfluentType` instance for Confluent-compatible
 `azure-kms`, or both as shown above. Matching `azure-kv://` and `azure-kms://` prefixes on the key
 identifier are optional. The provider uses RSA-OAEP-256. Prefer a versioned key identifier so

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -422,7 +422,12 @@ using Dekaf.SchemaRegistry.Kms.Azure;
 
 var credential = new DefaultAzureCredential();
 var azureKms = new AzureKeyVaultKmsProvider(credential);
-var csfle = new SchemaRegistryCsfleRuleHandler(schemaRegistry, [azureKms]);
+var confluentAzureKms = new AzureKeyVaultKmsProvider(
+    credential,
+    type: AzureKeyVaultKmsProvider.ConfluentType);
+var csfle = new SchemaRegistryCsfleRuleHandler(
+    schemaRegistry,
+    [azureKms, confluentAzureKms]);
 ```
 
 `DefaultAzureCredential` uses the standard Azure credential chain. Production applications can
@@ -431,11 +436,12 @@ instead pass a specific credential such as `ManagedIdentityCredential` or
 caller-owned. For complete client-construction control, implement
 `IAzureKeyVaultCryptographyClientFactory`.
 
-Use an absolute key identifier with `/keys/<name>` or `/keys/<name>/<version>`, for example
-`https://payments.vault.azure.net/keys/orders-kek`. The provider accepts KMS types `azure-kv` and
-Confluent-compatible `azure-kms`; matching `azure-kv://` and `azure-kms://` prefixes on the key
-identifier are optional. It uses RSA-OAEP-256. Prefer a versioned key identifier so existing data
-keeps decrypting after rotation. For a versionless key, set the KEK property
+Use an absolute HTTPS key identifier with `/keys/<name>` or `/keys/<name>/<version>`, for example
+`https://payments.vault.azure.net/keys/orders-kek`. Each provider instance registers one KMS type;
+register the default instance for `azure-kv`, the `ConfluentType` instance for Confluent-compatible
+`azure-kms`, or both as shown above. Matching `azure-kv://` and `azure-kms://` prefixes on the key
+identifier are optional. The provider uses RSA-OAEP-256. Prefer a versioned key identifier so
+existing data keeps decrypting after rotation. For a versionless key, set the KEK property
 `encrypt.azure.key.version.save=true` to embed the exact Azure key version in newly wrapped key
 material.
 

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -445,10 +445,11 @@ existing data keeps decrypting after rotation. For a versionless key, set the KE
 `encrypt.azure.key.version.save=true` to embed the exact Azure key version in newly wrapped key
 material.
 
-Grant the identity `keys/encrypt` and `keys/decrypt` permissions, for example through the Key Vault
-Crypto Service Encryption User RBAC role. One provider instance is safe for concurrent use and
-caches one `CryptographyClient` per resolved key identifier. Cancellation is forwarded to Azure;
-provider error messages do not include service response text or key material.
+For RBAC-enabled vaults, grant the identity the Key Vault Crypto User role. For vaults using legacy
+access policies, grant the `keys/encrypt` and `keys/decrypt` permissions. One provider instance is
+safe for concurrent use and caches one `CryptographyClient` per resolved key identifier.
+Cancellation is forwarded to Azure; provider error messages do not include service response text
+or key material.
 
 ## Consumer
 

--- a/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
@@ -51,19 +51,14 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
     public const string SaveVersionProperty = "encrypt.azure.key.version.save";
 
     private const int AzureKeyVersionLength = 32;
-    internal const int EmbeddedVersionClientCapacity = 64;
-    private const int EmbeddedVersionClientAssociativity = 4;
-    private const int EmbeddedVersionClientSetCount =
-        EmbeddedVersionClientCapacity / EmbeddedVersionClientAssociativity;
+    internal const int ClientCacheCapacity = 64;
+    internal const int EmbeddedVersionClientCapacity = ClientCacheCapacity;
     private const byte HeaderSeparator = (byte)':';
 
     private static ReadOnlySpan<byte> VersionHeaderPrefix => "azure:v1:"u8;
 
-    private readonly IAzureKeyVaultCryptographyClientFactory _clientFactory;
-    private readonly ConcurrentDictionary<Uri, Lazy<CryptographyClient>> _clients = [];
-    private readonly ConcurrentDictionary<Uri, Lazy<CryptographyClient>> _embeddedVersionClients = [];
-    private readonly VersionClientEntry?[] _embeddedVersionClientSlots =
-        new VersionClientEntry[EmbeddedVersionClientCapacity];
+    private readonly BoundedClientCache _clients;
+    private readonly BoundedClientCache _embeddedVersionClients;
 
     /// <summary>
     /// Creates a provider using <see cref="DefaultAzureCredential" />.
@@ -100,7 +95,8 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         if (string.IsNullOrWhiteSpace(type))
             throw new ArgumentException("KMS provider type cannot be null or whitespace.", nameof(type));
 
-        _clientFactory = clientFactory;
+        _clients = new BoundedClientCache(clientFactory, ClientCacheCapacity);
+        _embeddedVersionClients = new BoundedClientCache(clientFactory, EmbeddedVersionClientCapacity);
         Type = type;
     }
 
@@ -119,7 +115,7 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
 
         var key = ResolveKey(keyReference);
         var plaintext = GetInputArray(keyMaterial, out var temporaryPlaintext);
-        var client = GetClientEntry(key.KeyId);
+        var client = _clients.GetOrAdd(key.KeyId);
         try
         {
             var result = await client.Value
@@ -141,7 +137,7 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         }
         catch (Exception ex) when (!client.IsValueCreated)
         {
-            _clients.TryRemove(KeyValuePair.Create(key.KeyId, client));
+            _clients.Remove(key.KeyId, client);
             if (ex is OperationCanceledException && cancellationToken.IsCancellationRequested)
                 throw;
 
@@ -186,9 +182,8 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         }
 
         var ciphertext = GetInputArray(wrappedMaterial, out var temporaryCiphertext);
-        var client = hasEmbeddedVersion
-            ? GetEmbeddedVersionClientEntry(key.KeyId, version)
-            : GetClientEntry(key.KeyId);
+        var clientCache = hasEmbeddedVersion ? _embeddedVersionClients : _clients;
+        var client = clientCache.GetOrAdd(key.KeyId);
         var evictClient = false;
         try
         {
@@ -200,10 +195,7 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         }
         catch (Exception ex) when (!client.IsValueCreated)
         {
-            if (hasEmbeddedVersion)
-                RemoveEmbeddedVersionClient(key.KeyId, version, client);
-            else
-                _clients.TryRemove(KeyValuePair.Create(key.KeyId, client));
+            clientCache.Remove(key.KeyId, client);
 
             if (ex is OperationCanceledException && cancellationToken.IsCancellationRequested)
                 throw;
@@ -226,112 +218,14 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         {
             ClearTemporaryBuffer(temporaryCiphertext);
             if (hasEmbeddedVersion && evictClient)
-                RemoveEmbeddedVersionClient(key.KeyId, version, client);
+                clientCache.Remove(key.KeyId, client);
         }
     }
 
     private static int VersionHeaderLength => VersionHeaderPrefix.Length + AzureKeyVersionLength + 1;
 
-    private Lazy<CryptographyClient> GetClientEntry(Uri keyId) => _clients.GetOrAdd(
-        keyId,
-        static (uri, factory) => new Lazy<CryptographyClient>(
-            () => factory.CreateClient(uri),
-            LazyThreadSafetyMode.ExecutionAndPublication),
-        _clientFactory);
-
-    private Lazy<CryptographyClient> GetEmbeddedVersionClientEntry(Uri keyId, string version)
-    {
-        var client = _embeddedVersionClients.GetOrAdd(
-            keyId,
-            static (uri, factory) => new Lazy<CryptographyClient>(
-                () => factory.CreateClient(uri),
-                LazyThreadSafetyMode.ExecutionAndPublication),
-            _clientFactory);
-        TrackEmbeddedVersionClient(keyId, version, client);
-        return client;
-    }
-
-    private void TrackEmbeddedVersionClient(
-        Uri keyId,
-        string version,
-        Lazy<CryptographyClient> client)
-    {
-        var hash = GetEmbeddedVersionClientHash(keyId, version);
-        var setStart = GetEmbeddedVersionClientSetStart(hash);
-        VersionClientEntry? candidate = null;
-        while (true)
-        {
-            var emptySlot = -1;
-            for (var offset = 0; offset < EmbeddedVersionClientAssociativity; offset++)
-            {
-                var slot = setStart + offset;
-                var current = Volatile.Read(ref _embeddedVersionClientSlots[slot]);
-                if (current is not null && ReferenceEquals(current.Client, client))
-                    return;
-
-                if (current is null && emptySlot < 0)
-                    emptySlot = slot;
-            }
-
-            candidate ??= new VersionClientEntry(keyId, client);
-            if (emptySlot >= 0)
-            {
-                var occupied = Interlocked.CompareExchange(
-                    ref _embeddedVersionClientSlots[emptySlot],
-                    candidate,
-                    null);
-                if (occupied is null)
-                    return;
-
-                continue;
-            }
-
-            var evictionSlot = setStart
-                + (int)(((uint)hash >> 16) & (EmbeddedVersionClientAssociativity - 1));
-            var evicted = Volatile.Read(ref _embeddedVersionClientSlots[evictionSlot]);
-            if (evicted is not null && ReferenceEquals(evicted.Client, client))
-                return;
-
-            var published = Interlocked.CompareExchange(
-                ref _embeddedVersionClientSlots[evictionSlot],
-                candidate,
-                evicted);
-            if (ReferenceEquals(published, evicted))
-            {
-                if (evicted is not null)
-                {
-                    _embeddedVersionClients.TryRemove(
-                        KeyValuePair.Create(evicted.KeyId, evicted.Client));
-                }
-
-                return;
-            }
-        }
-    }
-
-    private void RemoveEmbeddedVersionClient(
-        Uri keyId,
-        string version,
-        Lazy<CryptographyClient> client)
-    {
-        _embeddedVersionClients.TryRemove(KeyValuePair.Create(keyId, client));
-        var setStart = GetEmbeddedVersionClientSetStart(GetEmbeddedVersionClientHash(keyId, version));
-        for (var offset = 0; offset < EmbeddedVersionClientAssociativity; offset++)
-        {
-            var slot = setStart + offset;
-            var current = Volatile.Read(ref _embeddedVersionClientSlots[slot]);
-            if (current is not null && ReferenceEquals(current.Client, client))
-                Interlocked.CompareExchange(ref _embeddedVersionClientSlots[slot], null, current);
-        }
-    }
-
-    private static int GetEmbeddedVersionClientHash(Uri keyId, string version) =>
-        HashCode.Combine(keyId, StringComparer.Ordinal.GetHashCode(version));
-
-    private static int GetEmbeddedVersionClientSetStart(int hash) =>
-        (int)((uint)hash & (EmbeddedVersionClientSetCount - 1)) * EmbeddedVersionClientAssociativity;
-
     internal int EmbeddedVersionClientCount => _embeddedVersionClients.Count;
+    internal int ClientCount => _clients.Count;
 
     private KeyReference ResolveKey(SchemaRegistryKmsKeyReference keyReference)
     {
@@ -381,6 +275,7 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
     private static bool HasTrustedVaultAuthority(string? value)
     {
         const string httpsPrefix = "https://";
+        const string defaultPort = ":443";
         if (value is null || !value.StartsWith(httpsPrefix, StringComparison.OrdinalIgnoreCase))
             return false;
 
@@ -389,7 +284,11 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         if (pathStart <= 0)
             return false;
 
-        return IsTrustedVaultHost(remainder[..pathStart]);
+        var authority = remainder[..pathStart];
+        if (authority.EndsWith(defaultPort, StringComparison.Ordinal))
+            authority = authority[..^defaultPort.Length];
+
+        return IsTrustedVaultHost(authority);
     }
 
     private static bool IsTrustedVaultHost(ReadOnlySpan<char> host) =>
@@ -553,7 +452,105 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
             version);
     }
 
-    private sealed record VersionClientEntry(Uri KeyId, Lazy<CryptographyClient> Client);
+    private sealed class BoundedClientCache(
+        IAzureKeyVaultCryptographyClientFactory clientFactory,
+        int capacity)
+    {
+        private const int Associativity = 4;
+
+        private readonly ConcurrentDictionary<Uri, Lazy<CryptographyClient>> _entries = [];
+        private readonly ClientCacheEntry?[] _slots = new ClientCacheEntry[capacity];
+
+        internal int Count => _entries.Count;
+
+        internal Lazy<CryptographyClient> GetOrAdd(Uri keyId)
+        {
+            if (_entries.TryGetValue(keyId, out var client))
+                return client;
+
+            var candidate = CreateClientEntry(keyId, clientFactory);
+            client = _entries.GetOrAdd(keyId, candidate);
+            Track(keyId, client);
+            return client;
+        }
+
+        private static Lazy<CryptographyClient> CreateClientEntry(
+            Uri keyId,
+            IAzureKeyVaultCryptographyClientFactory factory) => new(
+                () => factory.CreateClient(keyId),
+                LazyThreadSafetyMode.ExecutionAndPublication);
+
+        internal void Remove(Uri keyId, Lazy<CryptographyClient> client)
+        {
+            _entries.TryRemove(KeyValuePair.Create(keyId, client));
+            var setStart = GetSetStart(keyId);
+            for (var offset = 0; offset < Associativity; offset++)
+            {
+                var slot = setStart + offset;
+                var current = Volatile.Read(ref _slots[slot]);
+                if (current is not null && ReferenceEquals(current.Client, client))
+                    Interlocked.CompareExchange(ref _slots[slot], null, current);
+            }
+        }
+
+        private void Track(Uri keyId, Lazy<CryptographyClient> client)
+        {
+            var hash = keyId.GetHashCode();
+            var setStart = GetSetStart(hash);
+            ClientCacheEntry? candidate = null;
+            while (true)
+            {
+                var emptySlot = -1;
+                for (var offset = 0; offset < Associativity; offset++)
+                {
+                    var slot = setStart + offset;
+                    var current = Volatile.Read(ref _slots[slot]);
+                    if (current is not null && ReferenceEquals(current.Client, client))
+                        return;
+
+                    if (current is null && emptySlot < 0)
+                        emptySlot = slot;
+                }
+
+                candidate ??= new ClientCacheEntry(keyId, client);
+                if (emptySlot >= 0)
+                {
+                    var occupied = Interlocked.CompareExchange(
+                        ref _slots[emptySlot],
+                        candidate,
+                        null);
+                    if (occupied is null)
+                        return;
+
+                    continue;
+                }
+
+                var evictionSlot = setStart + (int)(((uint)hash >> 16) & (Associativity - 1));
+                var evicted = Volatile.Read(ref _slots[evictionSlot]);
+                if (evicted is not null && ReferenceEquals(evicted.Client, client))
+                    return;
+
+                var published = Interlocked.CompareExchange(
+                    ref _slots[evictionSlot],
+                    candidate,
+                    evicted);
+                if (!ReferenceEquals(published, evicted))
+                    continue;
+
+                if (evicted is not null)
+                    _entries.TryRemove(KeyValuePair.Create(evicted.KeyId, evicted.Client));
+
+                return;
+            }
+        }
+
+        private int GetSetStart(Uri keyId) => GetSetStart(keyId.GetHashCode());
+
+        private int GetSetStart(int hash) =>
+            (int)((uint)hash & ((capacity / Associativity) - 1)) * Associativity;
+
+        private sealed record ClientCacheEntry(Uri KeyId, Lazy<CryptographyClient> Client);
+    }
 
     private sealed class TokenCredentialClientFactory(
         TokenCredential credential,

--- a/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
@@ -116,9 +116,10 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
 
         var key = ResolveKey(keyReference);
         var plaintext = GetInputArray(keyMaterial, out var temporaryPlaintext);
+        var client = GetClientEntry(key.KeyId);
         try
         {
-            var result = await GetClient(key.KeyId)
+            var result = await client.Value
                 .WrapKeyAsync(KeyWrapAlgorithm.RsaOaep256, plaintext, cancellationToken)
                 .ConfigureAwait(false);
             var ciphertext = RequireMaterial(result.EncryptedKey, "wrap");
@@ -134,6 +135,14 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
             }
 
             return AddVersionHeader(ciphertext, resolvedKey.Version!);
+        }
+        catch (Exception ex) when (!client.IsValueCreated)
+        {
+            _clients.TryRemove(KeyValuePair.Create(key.KeyId, client));
+            if (IsAzureFailure(ex))
+                throw new SchemaRegistryKmsException("Azure Key Vault wrap failed.");
+
+            throw;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -183,6 +192,18 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
             var plaintext = RequireMaterial(result.Key, "unwrap");
             return plaintext;
         }
+        catch (Exception ex) when (!client.IsValueCreated)
+        {
+            if (hasEmbeddedVersion)
+                RemoveEmbeddedVersionClient(key.KeyId, version, client);
+            else
+                _clients.TryRemove(KeyValuePair.Create(key.KeyId, client));
+
+            if (IsAzureFailure(ex))
+                throw new SchemaRegistryKmsException("Azure Key Vault unwrap failed.");
+
+            throw;
+        }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
@@ -201,8 +222,6 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
     }
 
     private static int VersionHeaderLength => VersionHeaderPrefix.Length + AzureKeyVersionLength + 1;
-
-    private CryptographyClient GetClient(Uri keyId) => GetClientEntry(keyId).Value;
 
     private Lazy<CryptographyClient> GetClientEntry(Uri keyId) => _clients.GetOrAdd(
         keyId,

--- a/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
@@ -51,12 +51,16 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
     public const string SaveVersionProperty = "encrypt.azure.key.version.save";
 
     private const int AzureKeyVersionLength = 32;
+    internal const int EmbeddedVersionClientCapacity = 64;
     private const byte HeaderSeparator = (byte)':';
 
     private static ReadOnlySpan<byte> VersionHeaderPrefix => "azure:v1:"u8;
 
     private readonly IAzureKeyVaultCryptographyClientFactory _clientFactory;
     private readonly ConcurrentDictionary<Uri, Lazy<CryptographyClient>> _clients = [];
+    private readonly ConcurrentDictionary<Uri, Lazy<CryptographyClient>> _embeddedVersionClients = [];
+    private readonly VersionClientEntry?[] _embeddedVersionClientSlots =
+        new VersionClientEntry[EmbeddedVersionClientCapacity];
 
     /// <summary>
     /// Creates a provider using <see cref="DefaultAzureCredential" />.
@@ -167,7 +171,9 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         }
 
         var ciphertext = GetInputArray(wrappedMaterial, out var temporaryCiphertext);
-        var client = GetClientEntry(key.KeyId);
+        var client = hasEmbeddedVersion
+            ? GetEmbeddedVersionClientEntry(key.KeyId, version)
+            : GetClientEntry(key.KeyId);
         var evictClient = false;
         try
         {
@@ -190,7 +196,7 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         {
             ClearTemporaryBuffer(temporaryCiphertext);
             if (hasEmbeddedVersion && evictClient)
-                _clients.TryRemove(KeyValuePair.Create(key.KeyId, client));
+                RemoveEmbeddedVersionClient(key.KeyId, version, client);
         }
     }
 
@@ -204,6 +210,66 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
             () => factory.CreateClient(uri),
             LazyThreadSafetyMode.ExecutionAndPublication),
         _clientFactory);
+
+    private Lazy<CryptographyClient> GetEmbeddedVersionClientEntry(Uri keyId, string version)
+    {
+        var client = _embeddedVersionClients.GetOrAdd(
+            keyId,
+            static (uri, factory) => new Lazy<CryptographyClient>(
+                () => factory.CreateClient(uri),
+                LazyThreadSafetyMode.ExecutionAndPublication),
+            _clientFactory);
+        TrackEmbeddedVersionClient(keyId, version, client);
+        return client;
+    }
+
+    private void TrackEmbeddedVersionClient(
+        Uri keyId,
+        string version,
+        Lazy<CryptographyClient> client)
+    {
+        var slot = GetEmbeddedVersionClientSlot(version);
+        VersionClientEntry? candidate = null;
+        while (true)
+        {
+            var current = Volatile.Read(ref _embeddedVersionClientSlots[slot]);
+            if (current is not null && ReferenceEquals(current.Client, client))
+                return;
+
+            candidate ??= new VersionClientEntry(keyId, client);
+            var published = Interlocked.CompareExchange(
+                ref _embeddedVersionClientSlots[slot],
+                candidate,
+                current);
+            if (ReferenceEquals(published, current))
+            {
+                if (current is not null)
+                {
+                    _embeddedVersionClients.TryRemove(
+                        KeyValuePair.Create(current.KeyId, current.Client));
+                }
+
+                return;
+            }
+        }
+    }
+
+    private void RemoveEmbeddedVersionClient(
+        Uri keyId,
+        string version,
+        Lazy<CryptographyClient> client)
+    {
+        _embeddedVersionClients.TryRemove(KeyValuePair.Create(keyId, client));
+        var slot = GetEmbeddedVersionClientSlot(version);
+        var current = Volatile.Read(ref _embeddedVersionClientSlots[slot]);
+        if (current is not null && ReferenceEquals(current.Client, client))
+            Interlocked.CompareExchange(ref _embeddedVersionClientSlots[slot], null, current);
+    }
+
+    private static int GetEmbeddedVersionClientSlot(string version) =>
+        (int)((uint)StringComparer.Ordinal.GetHashCode(version) & (EmbeddedVersionClientCapacity - 1));
+
+    internal int EmbeddedVersionClientCount => _embeddedVersionClients.Count;
 
     private KeyReference ResolveKey(SchemaRegistryKmsKeyReference keyReference)
     {
@@ -228,7 +294,8 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
 
     private static KeyReference ParseKeyUri(string? value, string description)
     {
-        if (!Uri.TryCreate(value, UriKind.Absolute, out var keyId)
+        if (!HasTrustedVaultAuthority(value)
+            || !Uri.TryCreate(value, UriKind.Absolute, out var keyId)
             || !string.Equals(keyId.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal)
             || keyId.UserInfo.Length != 0
             || keyId.Query.Length != 0
@@ -247,6 +314,49 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         var vaultUri = new Uri(keyId.GetLeftPart(UriPartial.Authority), UriKind.Absolute);
         var versionlessKeyId = new Uri(vaultUri, $"keys/{segments[1]}");
         return new KeyReference(keyId, versionlessKeyId, segments.Length == 3 ? segments[2] : null);
+    }
+
+    private static bool HasTrustedVaultAuthority(string? value)
+    {
+        const string httpsPrefix = "https://";
+        if (value is null || !value.StartsWith(httpsPrefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var remainder = value.AsSpan(httpsPrefix.Length);
+        var pathStart = remainder.IndexOf('/');
+        if (pathStart <= 0)
+            return false;
+
+        return IsTrustedVaultHost(remainder[..pathStart]);
+    }
+
+    private static bool IsTrustedVaultHost(ReadOnlySpan<char> host) =>
+        HasVaultSuffix(host, ".vault.azure.net")
+        || HasVaultSuffix(host, ".vault.azure.cn")
+        || HasVaultSuffix(host, ".vault.usgovcloudapi.net");
+
+    private static bool HasVaultSuffix(ReadOnlySpan<char> host, ReadOnlySpan<char> suffix)
+    {
+        if (host.Length <= suffix.Length
+            || !host.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var vaultName = host[..^suffix.Length];
+        for (var index = 0; index < vaultName.Length; index++)
+        {
+            var value = vaultName[index];
+            if (value is not (>= 'a' and <= 'z')
+                and not (>= 'A' and <= 'Z')
+                and not (>= '0' and <= '9')
+                and not '-')
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static byte[] GetInputArray(ReadOnlyMemory<byte> source, out byte[]? temporaryBuffer)
@@ -376,6 +486,8 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
             VersionlessKeyId,
             version);
     }
+
+    private sealed record VersionClientEntry(Uri KeyId, Lazy<CryptographyClient> Client);
 
     private sealed class TokenCredentialClientFactory(
         TokenCredential credential,

--- a/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
@@ -52,6 +52,9 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
 
     private const int AzureKeyVersionLength = 32;
     internal const int EmbeddedVersionClientCapacity = 64;
+    private const int EmbeddedVersionClientAssociativity = 4;
+    private const int EmbeddedVersionClientSetCount =
+        EmbeddedVersionClientCapacity / EmbeddedVersionClientAssociativity;
     private const byte HeaderSeparator = (byte)':';
 
     private static ReadOnlySpan<byte> VersionHeaderPrefix => "azure:v1:"u8;
@@ -247,25 +250,52 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         string version,
         Lazy<CryptographyClient> client)
     {
-        var slot = GetEmbeddedVersionClientSlot(version);
+        var hash = GetEmbeddedVersionClientHash(keyId, version);
+        var setStart = GetEmbeddedVersionClientSetStart(hash);
         VersionClientEntry? candidate = null;
         while (true)
         {
-            var current = Volatile.Read(ref _embeddedVersionClientSlots[slot]);
-            if (current is not null && ReferenceEquals(current.Client, client))
-                return;
+            var emptySlot = -1;
+            for (var offset = 0; offset < EmbeddedVersionClientAssociativity; offset++)
+            {
+                var slot = setStart + offset;
+                var current = Volatile.Read(ref _embeddedVersionClientSlots[slot]);
+                if (current is not null && ReferenceEquals(current.Client, client))
+                    return;
+
+                if (current is null && emptySlot < 0)
+                    emptySlot = slot;
+            }
 
             candidate ??= new VersionClientEntry(keyId, client);
-            var published = Interlocked.CompareExchange(
-                ref _embeddedVersionClientSlots[slot],
-                candidate,
-                current);
-            if (ReferenceEquals(published, current))
+            if (emptySlot >= 0)
             {
-                if (current is not null)
+                var occupied = Interlocked.CompareExchange(
+                    ref _embeddedVersionClientSlots[emptySlot],
+                    candidate,
+                    null);
+                if (occupied is null)
+                    return;
+
+                continue;
+            }
+
+            var evictionSlot = setStart
+                + (int)(((uint)hash >> 16) & (EmbeddedVersionClientAssociativity - 1));
+            var evicted = Volatile.Read(ref _embeddedVersionClientSlots[evictionSlot]);
+            if (evicted is not null && ReferenceEquals(evicted.Client, client))
+                return;
+
+            var published = Interlocked.CompareExchange(
+                ref _embeddedVersionClientSlots[evictionSlot],
+                candidate,
+                evicted);
+            if (ReferenceEquals(published, evicted))
+            {
+                if (evicted is not null)
                 {
                     _embeddedVersionClients.TryRemove(
-                        KeyValuePair.Create(current.KeyId, current.Client));
+                        KeyValuePair.Create(evicted.KeyId, evicted.Client));
                 }
 
                 return;
@@ -279,14 +309,21 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         Lazy<CryptographyClient> client)
     {
         _embeddedVersionClients.TryRemove(KeyValuePair.Create(keyId, client));
-        var slot = GetEmbeddedVersionClientSlot(version);
-        var current = Volatile.Read(ref _embeddedVersionClientSlots[slot]);
-        if (current is not null && ReferenceEquals(current.Client, client))
-            Interlocked.CompareExchange(ref _embeddedVersionClientSlots[slot], null, current);
+        var setStart = GetEmbeddedVersionClientSetStart(GetEmbeddedVersionClientHash(keyId, version));
+        for (var offset = 0; offset < EmbeddedVersionClientAssociativity; offset++)
+        {
+            var slot = setStart + offset;
+            var current = Volatile.Read(ref _embeddedVersionClientSlots[slot]);
+            if (current is not null && ReferenceEquals(current.Client, client))
+                Interlocked.CompareExchange(ref _embeddedVersionClientSlots[slot], null, current);
+        }
     }
 
-    private static int GetEmbeddedVersionClientSlot(string version) =>
-        (int)((uint)StringComparer.Ordinal.GetHashCode(version) & (EmbeddedVersionClientCapacity - 1));
+    private static int GetEmbeddedVersionClientHash(Uri keyId, string version) =>
+        HashCode.Combine(keyId, StringComparer.Ordinal.GetHashCode(version));
+
+    private static int GetEmbeddedVersionClientSetStart(int hash) =>
+        (int)((uint)hash & (EmbeddedVersionClientSetCount - 1)) * EmbeddedVersionClientAssociativity;
 
     internal int EmbeddedVersionClientCount => _embeddedVersionClients.Count;
 
@@ -486,12 +523,13 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         or AuthenticationFailedException
         or CredentialUnavailableException
         or CryptographicException
-        or ArgumentException;
+        or ArgumentException
+        or OperationCanceledException;
 
     private static bool ShouldEvictFailedVersionClient(Exception exception) => exception switch
     {
         RequestFailedException { Status: 0 or 408 or 429 or >= 500 } => false,
-        AuthenticationFailedException or CredentialUnavailableException => false,
+        AuthenticationFailedException or CredentialUnavailableException or OperationCanceledException => false,
         _ => true
     };
 

--- a/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
@@ -119,9 +119,9 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         try
         {
             var result = await GetClient(key.KeyId)
-                .EncryptAsync(EncryptionAlgorithm.RsaOaep256, plaintext, cancellationToken)
+                .WrapKeyAsync(KeyWrapAlgorithm.RsaOaep256, plaintext, cancellationToken)
                 .ConfigureAwait(false);
-            var ciphertext = RequireMaterial(result.Ciphertext, "wrap");
+            var ciphertext = RequireMaterial(result.EncryptedKey, "wrap");
 
             if (!ShouldSaveVersion(keyReference.KmsProps))
                 return ciphertext;
@@ -178,9 +178,9 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         try
         {
             var result = await client.Value
-                .DecryptAsync(EncryptionAlgorithm.RsaOaep256, ciphertext, cancellationToken)
+                .UnwrapKeyAsync(KeyWrapAlgorithm.RsaOaep256, ciphertext, cancellationToken)
                 .ConfigureAwait(false);
-            var plaintext = RequireMaterial(result.Plaintext, "unwrap");
+            var plaintext = RequireMaterial(result.Key, "unwrap");
             return plaintext;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
@@ -352,7 +352,10 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
     private static bool IsTrustedVaultHost(ReadOnlySpan<char> host) =>
         HasVaultSuffix(host, ".vault.azure.net")
         || HasVaultSuffix(host, ".vault.azure.cn")
-        || HasVaultSuffix(host, ".vault.usgovcloudapi.net");
+        || HasVaultSuffix(host, ".vault.usgovcloudapi.net")
+        || HasVaultSuffix(host, ".managedhsm.azure.net")
+        || HasVaultSuffix(host, ".managedhsm.azure.cn")
+        || HasVaultSuffix(host, ".managedhsm.usgovcloudapi.net");
 
     private static bool HasVaultSuffix(ReadOnlySpan<char> host, ReadOnlySpan<char> suffix)
     {

--- a/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
@@ -142,6 +142,9 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         catch (Exception ex) when (!client.IsValueCreated)
         {
             _clients.TryRemove(KeyValuePair.Create(key.KeyId, client));
+            if (ex is OperationCanceledException && cancellationToken.IsCancellationRequested)
+                throw;
+
             if (IsAzureFailure(ex))
                 throw new SchemaRegistryKmsException("Azure Key Vault wrap failed.");
 
@@ -201,6 +204,9 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
                 RemoveEmbeddedVersionClient(key.KeyId, version, client);
             else
                 _clients.TryRemove(KeyValuePair.Create(key.KeyId, client));
+
+            if (ex is OperationCanceledException && cancellationToken.IsCancellationRequested)
+                throw;
 
             if (IsAzureFailure(ex))
                 throw new SchemaRegistryKmsException("Azure Key Vault unwrap failed.");

--- a/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
@@ -168,14 +168,13 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
 
         var ciphertext = GetInputArray(wrappedMaterial, out var temporaryCiphertext);
         var client = GetClientEntry(key.KeyId);
-        var retainClient = false;
+        var evictClient = false;
         try
         {
             var result = await client.Value
                 .DecryptAsync(EncryptionAlgorithm.RsaOaep256, ciphertext, cancellationToken)
                 .ConfigureAwait(false);
             var plaintext = RequireMaterial(result.Plaintext, "unwrap");
-            retainClient = true;
             return plaintext;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -184,12 +183,13 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         }
         catch (Exception ex) when (IsAzureFailure(ex))
         {
+            evictClient = ShouldEvictFailedVersionClient(ex);
             throw new SchemaRegistryKmsException("Azure Key Vault unwrap failed.");
         }
         finally
         {
             ClearTemporaryBuffer(temporaryCiphertext);
-            if (hasEmbeddedVersion && !retainClient)
+            if (hasEmbeddedVersion && evictClient)
                 _clients.TryRemove(KeyValuePair.Create(key.KeyId, client));
         }
     }
@@ -355,6 +355,13 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         or CredentialUnavailableException
         or CryptographicException
         or ArgumentException;
+
+    private static bool ShouldEvictFailedVersionClient(Exception exception) => exception switch
+    {
+        RequestFailedException { Status: 0 or 408 or 429 or >= 500 } => false,
+        AuthenticationFailedException or CredentialUnavailableException => false,
+        _ => true
+    };
 
     private static void ClearTemporaryBuffer(byte[]? temporaryBuffer)
     {

--- a/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
@@ -85,17 +85,28 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
     /// <summary>
     /// Creates a provider using a custom Azure Key Vault client factory.
     /// </summary>
-    /// <param name="clientFactory">Factory used once per distinct key identifier.</param>
+    /// <param name="clientFactory">Factory used to create clients for key identifiers.</param>
     /// <param name="type">Schema Registry KMS provider type.</param>
     public AzureKeyVaultKmsProvider(
         IAzureKeyVaultCryptographyClientFactory clientFactory,
         string type = DefaultType)
+        : this(clientFactory, type, clientCacheCountChangedForTesting: null)
+    {
+    }
+
+    internal AzureKeyVaultKmsProvider(
+        IAzureKeyVaultCryptographyClientFactory clientFactory,
+        string type,
+        Action<int>? clientCacheCountChangedForTesting)
     {
         ArgumentNullException.ThrowIfNull(clientFactory);
         if (string.IsNullOrWhiteSpace(type))
             throw new ArgumentException("KMS provider type cannot be null or whitespace.", nameof(type));
 
-        _clients = new BoundedClientCache(clientFactory, ClientCacheCapacity);
+        _clients = new BoundedClientCache(
+            clientFactory,
+            ClientCacheCapacity,
+            clientCacheCountChangedForTesting);
         _embeddedVersionClients = new BoundedClientCache(clientFactory, EmbeddedVersionClientCapacity);
         Type = type;
     }
@@ -454,12 +465,13 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
 
     private sealed class BoundedClientCache(
         IAzureKeyVaultCryptographyClientFactory clientFactory,
-        int capacity)
+        int capacity,
+        Action<int>? countChangedForTesting = null)
     {
-        private const int Associativity = 4;
-
         private readonly ConcurrentDictionary<Uri, Lazy<CryptographyClient>> _entries = [];
         private readonly ClientCacheEntry?[] _slots = new ClientCacheEntry[capacity];
+        private readonly object _missLock = new();
+        private int _nextSlot;
 
         internal int Count => _entries.Count;
 
@@ -468,10 +480,23 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
             if (_entries.TryGetValue(keyId, out var client))
                 return client;
 
-            var candidate = CreateClientEntry(keyId, clientFactory);
-            client = _entries.GetOrAdd(keyId, candidate);
-            Track(keyId, client);
-            return client;
+            lock (_missLock)
+            {
+                if (_entries.TryGetValue(keyId, out client))
+                    return client;
+
+                var slot = GetInsertionSlot();
+                var evicted = _slots[slot];
+                if (evicted is not null)
+                    _entries.TryRemove(KeyValuePair.Create(evicted.KeyId, evicted.Client));
+
+                client = CreateClientEntry(keyId, clientFactory);
+                _entries[keyId] = client;
+                _slots[slot] = new ClientCacheEntry(keyId, client);
+                _nextSlot = (slot + 1) % capacity;
+                countChangedForTesting?.Invoke(_entries.Count);
+                return client;
+            }
         }
 
         private static Lazy<CryptographyClient> CreateClientEntry(
@@ -482,72 +507,36 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
 
         internal void Remove(Uri keyId, Lazy<CryptographyClient> client)
         {
-            _entries.TryRemove(KeyValuePair.Create(keyId, client));
-            var setStart = GetSetStart(keyId);
-            for (var offset = 0; offset < Associativity; offset++)
+            lock (_missLock)
             {
-                var slot = setStart + offset;
-                var current = Volatile.Read(ref _slots[slot]);
-                if (current is not null && ReferenceEquals(current.Client, client))
-                    Interlocked.CompareExchange(ref _slots[slot], null, current);
-            }
-        }
-
-        private void Track(Uri keyId, Lazy<CryptographyClient> client)
-        {
-            var hash = keyId.GetHashCode();
-            var setStart = GetSetStart(hash);
-            ClientCacheEntry? candidate = null;
-            while (true)
-            {
-                var emptySlot = -1;
-                for (var offset = 0; offset < Associativity; offset++)
-                {
-                    var slot = setStart + offset;
-                    var current = Volatile.Read(ref _slots[slot]);
-                    if (current is not null && ReferenceEquals(current.Client, client))
-                        return;
-
-                    if (current is null && emptySlot < 0)
-                        emptySlot = slot;
-                }
-
-                candidate ??= new ClientCacheEntry(keyId, client);
-                if (emptySlot >= 0)
-                {
-                    var occupied = Interlocked.CompareExchange(
-                        ref _slots[emptySlot],
-                        candidate,
-                        null);
-                    if (occupied is null)
-                        return;
-
-                    continue;
-                }
-
-                var evictionSlot = setStart + (int)(((uint)hash >> 16) & (Associativity - 1));
-                var evicted = Volatile.Read(ref _slots[evictionSlot]);
-                if (evicted is not null && ReferenceEquals(evicted.Client, client))
+                if (!_entries.TryRemove(KeyValuePair.Create(keyId, client)))
                     return;
 
-                var published = Interlocked.CompareExchange(
-                    ref _slots[evictionSlot],
-                    candidate,
-                    evicted);
-                if (!ReferenceEquals(published, evicted))
-                    continue;
+                for (var slot = 0; slot < capacity; slot++)
+                {
+                    var current = _slots[slot];
+                    if (current is not null && ReferenceEquals(current.Client, client))
+                    {
+                        _slots[slot] = null;
+                        break;
+                    }
+                }
 
-                if (evicted is not null)
-                    _entries.TryRemove(KeyValuePair.Create(evicted.KeyId, evicted.Client));
-
-                return;
+                countChangedForTesting?.Invoke(_entries.Count);
             }
         }
 
-        private int GetSetStart(Uri keyId) => GetSetStart(keyId.GetHashCode());
+        private int GetInsertionSlot()
+        {
+            for (var offset = 0; offset < capacity; offset++)
+            {
+                var slot = (_nextSlot + offset) % capacity;
+                if (_slots[slot] is null)
+                    return slot;
+            }
 
-        private int GetSetStart(int hash) =>
-            (int)((uint)hash & ((capacity / Associativity) - 1)) * Associativity;
+            return _nextSlot;
+        }
 
         private sealed record ClientCacheEntry(Uri KeyId, Lazy<CryptographyClient> Client);
     }

--- a/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
@@ -157,7 +157,8 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
 
         var key = ResolveKey(keyReference);
         var wrappedMaterial = encryptedKeyMaterial;
-        if (TryReadVersionHeader(encryptedKeyMaterial.Span, out var version))
+        var hasEmbeddedVersion = TryReadVersionHeader(encryptedKeyMaterial.Span, out var version);
+        if (hasEmbeddedVersion)
         {
             key = key.WithVersion(version);
             wrappedMaterial = encryptedKeyMaterial[VersionHeaderLength..];
@@ -166,12 +167,16 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         }
 
         var ciphertext = GetInputArray(wrappedMaterial, out var temporaryCiphertext);
+        var client = GetClientEntry(key.KeyId);
+        var retainClient = false;
         try
         {
-            var result = await GetClient(key.KeyId)
+            var result = await client.Value
                 .DecryptAsync(EncryptionAlgorithm.RsaOaep256, ciphertext, cancellationToken)
                 .ConfigureAwait(false);
-            return RequireMaterial(result.Plaintext, "unwrap");
+            var plaintext = RequireMaterial(result.Plaintext, "unwrap");
+            retainClient = true;
+            return plaintext;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -184,17 +189,21 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         finally
         {
             ClearTemporaryBuffer(temporaryCiphertext);
+            if (hasEmbeddedVersion && !retainClient)
+                _clients.TryRemove(KeyValuePair.Create(key.KeyId, client));
         }
     }
 
     private static int VersionHeaderLength => VersionHeaderPrefix.Length + AzureKeyVersionLength + 1;
 
-    private CryptographyClient GetClient(Uri keyId) => _clients.GetOrAdd(
+    private CryptographyClient GetClient(Uri keyId) => GetClientEntry(keyId).Value;
+
+    private Lazy<CryptographyClient> GetClientEntry(Uri keyId) => _clients.GetOrAdd(
         keyId,
         static (uri, factory) => new Lazy<CryptographyClient>(
             () => factory.CreateClient(uri),
             LazyThreadSafetyMode.ExecutionAndPublication),
-        _clientFactory).Value;
+        _clientFactory);
 
     private KeyReference ResolveKey(SchemaRegistryKmsKeyReference keyReference)
     {

--- a/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
@@ -137,7 +137,7 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         }
         catch (Exception ex) when (IsAzureFailure(ex))
         {
-            throw new SchemaRegistryKmsException("Azure Key Vault wrap failed.", ex);
+            throw new SchemaRegistryKmsException("Azure Key Vault wrap failed.");
         }
         finally
         {
@@ -179,7 +179,7 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
         }
         catch (Exception ex) when (IsAzureFailure(ex))
         {
-            throw new SchemaRegistryKmsException("Azure Key Vault unwrap failed.", ex);
+            throw new SchemaRegistryKmsException("Azure Key Vault unwrap failed.");
         }
         finally
         {
@@ -220,7 +220,7 @@ public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
     private static KeyReference ParseKeyUri(string? value, string description)
     {
         if (!Uri.TryCreate(value, UriKind.Absolute, out var keyId)
-            || keyId.Scheme is not ("http" or "https")
+            || !string.Equals(keyId.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal)
             || keyId.UserInfo.Length != 0
             || keyId.Query.Length != 0
             || keyId.Fragment.Length != 0)

--- a/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Azure/AzureKeyVaultKmsProvider.cs
@@ -1,0 +1,374 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using Azure;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Security.KeyVault.Keys.Cryptography;
+
+namespace Dekaf.SchemaRegistry.Kms.Azure;
+
+/// <summary>
+/// Creates Azure Key Vault cryptography clients for KMS key identifiers.
+/// </summary>
+public interface IAzureKeyVaultCryptographyClientFactory
+{
+    /// <summary>
+    /// Creates a client for an Azure Key Vault key identifier, optionally including a key version.
+    /// </summary>
+    /// <param name="keyId">Absolute Azure Key Vault key identifier.</param>
+    CryptographyClient CreateClient(Uri keyId);
+}
+
+/// <summary>
+/// Wraps and unwraps Schema Registry data encryption keys with Azure Key Vault Keys.
+/// </summary>
+public sealed class AzureKeyVaultKmsProvider : ISchemaRegistryKmsProvider
+{
+    /// <summary>
+    /// Default Schema Registry KMS provider type.
+    /// </summary>
+    public const string DefaultType = "azure-kv";
+
+    /// <summary>
+    /// Confluent Schema Registry KMS provider type.
+    /// </summary>
+    public const string ConfluentType = "azure-kms";
+
+    /// <summary>
+    /// URI prefix accepted for the default provider type.
+    /// </summary>
+    public const string KeyUriPrefix = "azure-kv://";
+
+    /// <summary>
+    /// Confluent-compatible URI prefix.
+    /// </summary>
+    public const string ConfluentKeyUriPrefix = "azure-kms://";
+
+    /// <summary>
+    /// KEK property that embeds the exact Azure key version in wrapped key material.
+    /// </summary>
+    public const string SaveVersionProperty = "encrypt.azure.key.version.save";
+
+    private const int AzureKeyVersionLength = 32;
+    private const byte HeaderSeparator = (byte)':';
+
+    private static ReadOnlySpan<byte> VersionHeaderPrefix => "azure:v1:"u8;
+
+    private readonly IAzureKeyVaultCryptographyClientFactory _clientFactory;
+    private readonly ConcurrentDictionary<Uri, Lazy<CryptographyClient>> _clients = [];
+
+    /// <summary>
+    /// Creates a provider using <see cref="DefaultAzureCredential" />.
+    /// </summary>
+    public AzureKeyVaultKmsProvider()
+        : this(new DefaultAzureCredential())
+    {
+    }
+
+    /// <summary>
+    /// Creates a provider using an Azure token credential.
+    /// </summary>
+    /// <param name="credential">Credential used to authenticate with Azure Key Vault.</param>
+    /// <param name="clientOptions">Optional Azure Key Vault cryptography client options.</param>
+    /// <param name="type">Schema Registry KMS provider type.</param>
+    public AzureKeyVaultKmsProvider(
+        TokenCredential credential,
+        CryptographyClientOptions? clientOptions = null,
+        string type = DefaultType)
+        : this(new TokenCredentialClientFactory(credential, clientOptions), type)
+    {
+    }
+
+    /// <summary>
+    /// Creates a provider using a custom Azure Key Vault client factory.
+    /// </summary>
+    /// <param name="clientFactory">Factory used once per distinct key identifier.</param>
+    /// <param name="type">Schema Registry KMS provider type.</param>
+    public AzureKeyVaultKmsProvider(
+        IAzureKeyVaultCryptographyClientFactory clientFactory,
+        string type = DefaultType)
+    {
+        ArgumentNullException.ThrowIfNull(clientFactory);
+        if (string.IsNullOrWhiteSpace(type))
+            throw new ArgumentException("KMS provider type cannot be null or whitespace.", nameof(type));
+
+        _clientFactory = clientFactory;
+        Type = type;
+    }
+
+    /// <inheritdoc />
+    public string Type { get; }
+
+    /// <inheritdoc />
+    public async ValueTask<byte[]> WrapKeyAsync(
+        ReadOnlyMemory<byte> keyMaterial,
+        SchemaRegistryKmsKeyReference keyReference,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (keyMaterial.IsEmpty)
+            throw new SchemaRegistryKmsException("Azure Key Vault wrap failed. Key material cannot be empty.");
+
+        var key = ResolveKey(keyReference);
+        var plaintext = GetInputArray(keyMaterial, out var temporaryPlaintext);
+        try
+        {
+            var result = await GetClient(key.KeyId)
+                .EncryptAsync(EncryptionAlgorithm.RsaOaep256, plaintext, cancellationToken)
+                .ConfigureAwait(false);
+            var ciphertext = RequireMaterial(result.Ciphertext, "wrap");
+
+            if (!ShouldSaveVersion(keyReference.KmsProps))
+                return ciphertext;
+
+            var resolvedKey = ParseKeyUri(result.KeyId, "Azure Key Vault response key identifier");
+            if (!IsValidVersion(resolvedKey.Version))
+            {
+                throw new SchemaRegistryKmsException(
+                    "Azure Key Vault wrap failed. The service did not return a valid key version.");
+            }
+
+            return AddVersionHeader(ciphertext, resolvedKey.Version!);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (IsAzureFailure(ex))
+        {
+            throw new SchemaRegistryKmsException("Azure Key Vault wrap failed.", ex);
+        }
+        finally
+        {
+            ClearTemporaryBuffer(temporaryPlaintext);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<byte[]> UnwrapKeyAsync(
+        ReadOnlyMemory<byte> encryptedKeyMaterial,
+        SchemaRegistryKmsKeyReference keyReference,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (encryptedKeyMaterial.IsEmpty)
+            throw new SchemaRegistryKmsException("Azure Key Vault unwrap failed. Encrypted key material cannot be empty.");
+
+        var key = ResolveKey(keyReference);
+        var wrappedMaterial = encryptedKeyMaterial;
+        if (TryReadVersionHeader(encryptedKeyMaterial.Span, out var version))
+        {
+            key = key.WithVersion(version);
+            wrappedMaterial = encryptedKeyMaterial[VersionHeaderLength..];
+            if (wrappedMaterial.IsEmpty)
+                throw new SchemaRegistryKmsException("Azure Key Vault ciphertext contains no wrapped key material.");
+        }
+
+        var ciphertext = GetInputArray(wrappedMaterial, out var temporaryCiphertext);
+        try
+        {
+            var result = await GetClient(key.KeyId)
+                .DecryptAsync(EncryptionAlgorithm.RsaOaep256, ciphertext, cancellationToken)
+                .ConfigureAwait(false);
+            return RequireMaterial(result.Plaintext, "unwrap");
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (IsAzureFailure(ex))
+        {
+            throw new SchemaRegistryKmsException("Azure Key Vault unwrap failed.", ex);
+        }
+        finally
+        {
+            ClearTemporaryBuffer(temporaryCiphertext);
+        }
+    }
+
+    private static int VersionHeaderLength => VersionHeaderPrefix.Length + AzureKeyVersionLength + 1;
+
+    private CryptographyClient GetClient(Uri keyId) => _clients.GetOrAdd(
+        keyId,
+        static (uri, factory) => new Lazy<CryptographyClient>(
+            () => factory.CreateClient(uri),
+            LazyThreadSafetyMode.ExecutionAndPublication),
+        _clientFactory).Value;
+
+    private KeyReference ResolveKey(SchemaRegistryKmsKeyReference keyReference)
+    {
+        ArgumentNullException.ThrowIfNull(keyReference);
+        if (!string.Equals(Type, keyReference.KmsType, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new SchemaRegistryKmsException(
+                $"Azure Key Vault provider '{Type}' cannot resolve KMS type '{keyReference.KmsType}'.");
+        }
+
+        var keyId = keyReference.KmsKeyId;
+        if (string.IsNullOrWhiteSpace(keyId))
+            throw new SchemaRegistryKmsException("Azure Key Vault key identifier cannot be null or whitespace.");
+
+        if (keyId.StartsWith(KeyUriPrefix, StringComparison.OrdinalIgnoreCase))
+            keyId = keyId[KeyUriPrefix.Length..];
+        else if (keyId.StartsWith(ConfluentKeyUriPrefix, StringComparison.OrdinalIgnoreCase))
+            keyId = keyId[ConfluentKeyUriPrefix.Length..];
+
+        return ParseKeyUri(keyId, "Azure Key Vault key identifier");
+    }
+
+    private static KeyReference ParseKeyUri(string? value, string description)
+    {
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var keyId)
+            || keyId.Scheme is not ("http" or "https")
+            || keyId.UserInfo.Length != 0
+            || keyId.Query.Length != 0
+            || keyId.Fragment.Length != 0)
+        {
+            throw new SchemaRegistryKmsException($"{description} is not a valid absolute key URI.");
+        }
+
+        var segments = keyId.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length is < 2 or > 3 || !string.Equals(segments[0], "keys", StringComparison.Ordinal))
+        {
+            throw new SchemaRegistryKmsException(
+                $"{description} must use the path '/keys/<name>[/<version>]'.");
+        }
+
+        var vaultUri = new Uri(keyId.GetLeftPart(UriPartial.Authority), UriKind.Absolute);
+        var versionlessKeyId = new Uri(vaultUri, $"keys/{segments[1]}");
+        return new KeyReference(keyId, versionlessKeyId, segments.Length == 3 ? segments[2] : null);
+    }
+
+    private static byte[] GetInputArray(ReadOnlyMemory<byte> source, out byte[]? temporaryBuffer)
+    {
+        if (System.Runtime.InteropServices.MemoryMarshal.TryGetArray(source, out var segment)
+            && segment.Array is not null
+            && segment.Offset == 0
+            && segment.Count == segment.Array.Length)
+        {
+            temporaryBuffer = null;
+            return segment.Array;
+        }
+
+        temporaryBuffer = source.ToArray();
+        return temporaryBuffer;
+    }
+
+    private static byte[] RequireMaterial(byte[]? material, string operation)
+    {
+        if (material is null || material.Length == 0)
+        {
+            throw new SchemaRegistryKmsException(
+                $"Azure Key Vault {operation} failed. The service returned no key material.");
+        }
+
+        return material;
+    }
+
+    private static bool ShouldSaveVersion(IReadOnlyDictionary<string, string>? properties) =>
+        properties is not null
+        && properties.TryGetValue(SaveVersionProperty, out var value)
+        && bool.TryParse(value, out var enabled)
+        && enabled;
+
+    private static byte[] AddVersionHeader(byte[] ciphertext, string version)
+    {
+        var output = new byte[checked(VersionHeaderLength + ciphertext.Length)];
+        VersionHeaderPrefix.CopyTo(output);
+        Encoding.ASCII.GetBytes(version, output.AsSpan(VersionHeaderPrefix.Length, AzureKeyVersionLength));
+        output[VersionHeaderLength - 1] = HeaderSeparator;
+        ciphertext.CopyTo(output, VersionHeaderLength);
+        return output;
+    }
+
+    private static bool TryReadVersionHeader(ReadOnlySpan<byte> ciphertext, out string version)
+    {
+        if (!ciphertext.StartsWith(VersionHeaderPrefix))
+        {
+            version = string.Empty;
+            return false;
+        }
+
+        if (ciphertext.Length < VersionHeaderLength
+            || ciphertext[VersionHeaderLength - 1] != HeaderSeparator)
+        {
+            throw new SchemaRegistryKmsException("Azure Key Vault ciphertext contains an invalid version header.");
+        }
+
+        var versionBytes = ciphertext.Slice(VersionHeaderPrefix.Length, AzureKeyVersionLength);
+        if (!IsValidVersion(versionBytes))
+            throw new SchemaRegistryKmsException("Azure Key Vault ciphertext contains an invalid embedded key version.");
+
+        version = Encoding.ASCII.GetString(versionBytes);
+        return true;
+    }
+
+    private static bool IsValidVersion(string? version)
+    {
+        if (version is null || version.Length != AzureKeyVersionLength)
+            return false;
+
+        foreach (var value in version)
+        {
+            if (value is not (>= '0' and <= '9')
+                and not (>= 'a' and <= 'f')
+                and not (>= 'A' and <= 'F'))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsValidVersion(ReadOnlySpan<byte> version)
+    {
+        if (version.Length != AzureKeyVersionLength)
+            return false;
+
+        foreach (var value in version)
+        {
+            if (value is not (>= (byte)'0' and <= (byte)'9')
+                and not (>= (byte)'a' and <= (byte)'f')
+                and not (>= (byte)'A' and <= (byte)'F'))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsAzureFailure(Exception exception) => exception is
+        RequestFailedException
+        or AuthenticationFailedException
+        or CredentialUnavailableException
+        or CryptographicException
+        or ArgumentException;
+
+    private static void ClearTemporaryBuffer(byte[]? temporaryBuffer)
+    {
+        if (temporaryBuffer is not null)
+            CryptographicOperations.ZeroMemory(temporaryBuffer);
+    }
+
+    private readonly record struct KeyReference(Uri KeyId, Uri VersionlessKeyId, string? Version)
+    {
+        internal KeyReference WithVersion(string version) => new(
+            new Uri($"{VersionlessKeyId.AbsoluteUri.TrimEnd('/')}/{version}", UriKind.Absolute),
+            VersionlessKeyId,
+            version);
+    }
+
+    private sealed class TokenCredentialClientFactory(
+        TokenCredential credential,
+        CryptographyClientOptions? options) : IAzureKeyVaultCryptographyClientFactory
+    {
+        private readonly TokenCredential _credential = credential ?? throw new ArgumentNullException(nameof(credential));
+
+        public CryptographyClient CreateClient(Uri keyId) => options is null
+            ? new CryptographyClient(keyId, _credential)
+            : new CryptographyClient(keyId, _credential, options);
+    }
+}

--- a/src/Dekaf.SchemaRegistry.Kms.Azure/Dekaf.SchemaRegistry.Kms.Azure.csproj
+++ b/src/Dekaf.SchemaRegistry.Kms.Azure/Dekaf.SchemaRegistry.Kms.Azure.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Dekaf.SchemaRegistry.Kms.Azure</PackageId>
+    <Description>Azure Key Vault provider for Dekaf Schema Registry client-side field-level encryption</Description>
+    <PackageTags>kafka;schema-registry;encryption;azure;key-vault</PackageTags>
+    <PackageValidationBaselineVersion></PackageValidationBaselineVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Dekaf.Tests.Unit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Dekaf.SchemaRegistry.Kms.Azure/PublicAPI.Shipped.txt
+++ b/src/Dekaf.SchemaRegistry.Kms.Azure/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Dekaf.SchemaRegistry.Kms.Azure/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry.Kms.Azure/PublicAPI.Unshipped.txt
@@ -1,0 +1,15 @@
+#nullable enable
+Dekaf.SchemaRegistry.Kms.Azure.AzureKeyVaultKmsProvider
+Dekaf.SchemaRegistry.Kms.Azure.AzureKeyVaultKmsProvider.AzureKeyVaultKmsProvider() -> void
+Dekaf.SchemaRegistry.Kms.Azure.AzureKeyVaultKmsProvider.AzureKeyVaultKmsProvider(Azure.Core.TokenCredential! credential, Azure.Security.KeyVault.Keys.Cryptography.CryptographyClientOptions? clientOptions = null, string! type = "azure-kv") -> void
+Dekaf.SchemaRegistry.Kms.Azure.AzureKeyVaultKmsProvider.AzureKeyVaultKmsProvider(Dekaf.SchemaRegistry.Kms.Azure.IAzureKeyVaultCryptographyClientFactory! clientFactory, string! type = "azure-kv") -> void
+Dekaf.SchemaRegistry.Kms.Azure.AzureKeyVaultKmsProvider.Type.get -> string!
+Dekaf.SchemaRegistry.Kms.Azure.AzureKeyVaultKmsProvider.UnwrapKeyAsync(System.ReadOnlyMemory<byte> encryptedKeyMaterial, Dekaf.SchemaRegistry.SchemaRegistryKmsKeyReference! keyReference, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
+Dekaf.SchemaRegistry.Kms.Azure.AzureKeyVaultKmsProvider.WrapKeyAsync(System.ReadOnlyMemory<byte> keyMaterial, Dekaf.SchemaRegistry.SchemaRegistryKmsKeyReference! keyReference, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
+Dekaf.SchemaRegistry.Kms.Azure.IAzureKeyVaultCryptographyClientFactory
+Dekaf.SchemaRegistry.Kms.Azure.IAzureKeyVaultCryptographyClientFactory.CreateClient(System.Uri! keyId) -> Azure.Security.KeyVault.Keys.Cryptography.CryptographyClient!
+const Dekaf.SchemaRegistry.Kms.Azure.AzureKeyVaultKmsProvider.ConfluentKeyUriPrefix = "azure-kms://" -> string!
+const Dekaf.SchemaRegistry.Kms.Azure.AzureKeyVaultKmsProvider.ConfluentType = "azure-kms" -> string!
+const Dekaf.SchemaRegistry.Kms.Azure.AzureKeyVaultKmsProvider.DefaultType = "azure-kv" -> string!
+const Dekaf.SchemaRegistry.Kms.Azure.AzureKeyVaultKmsProvider.KeyUriPrefix = "azure-kv://" -> string!
+const Dekaf.SchemaRegistry.Kms.Azure.AzureKeyVaultKmsProvider.SaveVersionProperty = "encrypt.azure.key.version.save" -> string!

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Gcp\Dekaf.SchemaRegistry.Kms.Gcp.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Vault\Dekaf.SchemaRegistry.Kms.Vault.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Aws\Dekaf.SchemaRegistry.Kms.Aws.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Azure\Dekaf.SchemaRegistry.Kms.Azure.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Json\Dekaf.SchemaRegistry.Json.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Lz4\Dekaf.Compression.Lz4.csproj" />

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
@@ -437,15 +437,20 @@ public class AzureKeyVaultKmsProviderTests
                 key: [4, 5, 6],
                 algorithm: KeyWrapAlgorithm.RsaOaep256));
         var factory = new RecordingFactory(_ => client);
-        var provider = new AzureKeyVaultKmsProvider(factory);
+        var maximumClientCount = 0;
+        var provider = new AzureKeyVaultKmsProvider(
+            factory,
+            AzureKeyVaultKmsProvider.DefaultType,
+            count => maximumClientCount = Math.Max(maximumClientCount, count));
         var operations = Enumerable.Range(0, 256)
-            .Select(index => provider.WrapKeyAsync(
+            .Select(index => Task.Run(() => provider.WrapKeyAsync(
                 new byte[] { 1 },
-                CreateKeyReference($"https://vault{index}.vault.azure.net/keys/kek")).AsTask())
+                CreateKeyReference($"https://vault{index}.vault.azure.net/keys/kek")).AsTask()))
             .ToArray();
 
         await Task.WhenAll(operations);
 
+        await Assert.That(maximumClientCount).IsEqualTo(AzureKeyVaultKmsProvider.ClientCacheCapacity);
         await Assert.That(provider.ClientCount).IsEqualTo(AzureKeyVaultKmsProvider.ClientCacheCapacity);
         await Assert.That(factory.CreateCount).IsEqualTo(operations.Length);
     }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
@@ -178,6 +178,32 @@ public class AzureKeyVaultKmsProviderTests
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task FactoryCancellation_WithCallerCancellation_IsPropagated(bool unwrap)
+    {
+        using var cancellation = new CancellationTokenSource();
+        var factory = new RecordingFactory(_ =>
+        {
+            cancellation.Cancel();
+            throw new OperationCanceledException(cancellation.Token);
+        });
+        var provider = new AzureKeyVaultKmsProvider(factory);
+        var material = unwrap
+            ? Encoding.ASCII.GetBytes($"azure:v1:{KeyVersion}:wrapped")
+            : new byte[] { 1 };
+
+        var exception = unwrap
+            ? await Assert.ThrowsAsync<OperationCanceledException>(
+                () => provider.UnwrapKeyAsync(material, CreateKeyReference(), cancellation.Token).AsTask())
+            : await Assert.ThrowsAsync<OperationCanceledException>(
+                () => provider.WrapKeyAsync(material, CreateKeyReference(), cancellation.Token).AsTask());
+
+        await Assert.That(exception!.CancellationToken).IsEqualTo(cancellation.Token);
+        await Assert.That(factory.CreateCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task MalformedVersionHeader_IsRejectedBeforeAzureCall()
     {
         var client = CreateClient(KeyUri);

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
@@ -22,22 +22,22 @@ public class AzureKeyVaultKmsProviderTests
         var client = CreateClient(KeyUri);
         byte[]? plaintext = null;
         byte[]? ciphertext = null;
-        client.EncryptAsync(
-                EncryptionAlgorithm.RsaOaep256,
+        client.WrapKeyAsync(
+                KeyWrapAlgorithm.RsaOaep256,
                 Arg.Do<byte[]>(value => plaintext = value),
                 Arg.Any<CancellationToken>())
-            .Returns(CryptographyModelFactory.EncryptResult(
+            .Returns(CryptographyModelFactory.WrapResult(
                 keyId: VersionedKeyUri,
-                ciphertext: [4, 5, 6],
-                algorithm: EncryptionAlgorithm.RsaOaep256));
-        client.DecryptAsync(
-                EncryptionAlgorithm.RsaOaep256,
+                key: [4, 5, 6],
+                algorithm: KeyWrapAlgorithm.RsaOaep256));
+        client.UnwrapKeyAsync(
+                KeyWrapAlgorithm.RsaOaep256,
                 Arg.Do<byte[]>(value => ciphertext = value),
                 Arg.Any<CancellationToken>())
-            .Returns(CryptographyModelFactory.DecryptResult(
+            .Returns(CryptographyModelFactory.UnwrapResult(
                 keyId: VersionedKeyUri,
-                plaintext: [1, 2, 3],
-                algorithm: EncryptionAlgorithm.RsaOaep256));
+                key: [1, 2, 3],
+                algorithm: KeyWrapAlgorithm.RsaOaep256));
         var factory = new RecordingFactory(_ => client);
         var provider = new AzureKeyVaultKmsProvider(factory);
 
@@ -49,6 +49,16 @@ public class AzureKeyVaultKmsProviderTests
         await Assert.That(plaintext).IsEquivalentTo(new byte[] { 1, 2, 3 });
         await Assert.That(ciphertext).IsEquivalentTo(new byte[] { 4, 5, 6 });
         await Assert.That(factory.CreatedKeyIds).IsEquivalentTo(new[] { new Uri(KeyUri) });
+        await client.Received(1).WrapKeyAsync(
+            KeyWrapAlgorithm.RsaOaep256,
+            Arg.Any<byte[]>(),
+            Arg.Any<CancellationToken>());
+        await client.Received(1).UnwrapKeyAsync(
+            KeyWrapAlgorithm.RsaOaep256,
+            Arg.Any<byte[]>(),
+            Arg.Any<CancellationToken>());
+        await client.DidNotReceiveWithAnyArgs().EncryptAsync(default, default!, default);
+        await client.DidNotReceiveWithAnyArgs().DecryptAsync(default, default!, default);
     }
 
     [Test]
@@ -57,11 +67,11 @@ public class AzureKeyVaultKmsProviderTests
     public async Task ProviderKeyPrefix_IsStripped(string prefix, string type)
     {
         var client = CreateClient(KeyUri);
-        client.EncryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
-            .Returns(CryptographyModelFactory.EncryptResult(
+        client.WrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(CryptographyModelFactory.WrapResult(
                 keyId: VersionedKeyUri,
-                ciphertext: [9],
-                algorithm: EncryptionAlgorithm.RsaOaep256));
+                key: [9],
+                algorithm: KeyWrapAlgorithm.RsaOaep256));
         var factory = new RecordingFactory(_ => client);
         var provider = new AzureKeyVaultKmsProvider(factory, type);
 
@@ -74,17 +84,17 @@ public class AzureKeyVaultKmsProviderTests
     public async Task SaveVersion_EmbedsVersionAndTargetsItDuringUnwrap()
     {
         var versionlessClient = CreateClient(KeyUri);
-        versionlessClient.EncryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
-            .Returns(CryptographyModelFactory.EncryptResult(
+        versionlessClient.WrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(CryptographyModelFactory.WrapResult(
                 keyId: VersionedKeyUri,
-                ciphertext: [4, 5, 6],
-                algorithm: EncryptionAlgorithm.RsaOaep256));
+                key: [4, 5, 6],
+                algorithm: KeyWrapAlgorithm.RsaOaep256));
         var versionedClient = CreateClient(VersionedKeyUri);
-        versionedClient.DecryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
-            .Returns(CryptographyModelFactory.DecryptResult(
+        versionedClient.UnwrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(CryptographyModelFactory.UnwrapResult(
                 keyId: VersionedKeyUri,
-                plaintext: [1, 2, 3],
-                algorithm: EncryptionAlgorithm.RsaOaep256));
+                key: [1, 2, 3],
+                algorithm: KeyWrapAlgorithm.RsaOaep256));
         var factory = new RecordingFactory(uri =>
             uri.AbsoluteUri == new Uri(VersionedKeyUri).AbsoluteUri ? versionedClient : versionlessClient);
         var provider = new AzureKeyVaultKmsProvider(factory);
@@ -105,8 +115,8 @@ public class AzureKeyVaultKmsProviderTests
     public async Task WrongKey_IsReportedWithoutProviderResponse()
     {
         var client = CreateClient(KeyUri);
-        client.DecryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<DecryptResult>(new RequestFailedException(404, "wrong key: sensitive")));
+        client.UnwrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<UnwrapResult>(new RequestFailedException(404, "wrong key: sensitive")));
         var provider = new AzureKeyVaultKmsProvider(new RecordingFactory(_ => client));
 
         var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
@@ -121,8 +131,8 @@ public class AzureKeyVaultKmsProviderTests
     {
         var client = CreateClient(KeyUri);
         var denied = new RequestFailedException(403, "authorization: sensitive");
-        client.EncryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<EncryptResult>(denied));
+        client.WrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<WrapResult>(denied));
         var provider = new AzureKeyVaultKmsProvider(new RecordingFactory(_ => client));
 
         var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
@@ -147,15 +157,15 @@ public class AzureKeyVaultKmsProviderTests
 
         await Assert.That(exception!.Message).Contains("invalid version header");
         await client.DidNotReceiveWithAnyArgs()
-            .DecryptAsync(default, default!, default);
+            .UnwrapKeyAsync(default, default!, default);
     }
 
     [Test]
     public async Task MalformedCiphertext_IsReportedWithoutProviderResponse()
     {
         var client = CreateClient(KeyUri);
-        client.DecryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<DecryptResult>(new RequestFailedException(400, "ciphertext: sensitive")));
+        client.UnwrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<UnwrapResult>(new RequestFailedException(400, "ciphertext: sensitive")));
         var provider = new AzureKeyVaultKmsProvider(new RecordingFactory(_ => client));
 
         var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
@@ -169,8 +179,8 @@ public class AzureKeyVaultKmsProviderTests
     public async Task PermanentEmbeddedVersionFailures_AreNotRetained()
     {
         var client = CreateClient(KeyUri);
-        client.DecryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<DecryptResult>(new RequestFailedException(400, "invalid ciphertext")));
+        client.UnwrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<UnwrapResult>(new RequestFailedException(400, "invalid ciphertext")));
         var factory = new RecordingFactory(_ => client);
         var provider = new AzureKeyVaultKmsProvider(factory);
 
@@ -197,8 +207,8 @@ public class AzureKeyVaultKmsProviderTests
     public async Task TransientEmbeddedVersionFailures_RetainClient(int status)
     {
         var client = CreateClient(VersionedKeyUri);
-        client.DecryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<DecryptResult>(new RequestFailedException(status, "transient")));
+        client.UnwrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<UnwrapResult>(new RequestFailedException(status, "transient")));
         var factory = new RecordingFactory(_ => client);
         var provider = new AzureKeyVaultKmsProvider(factory);
         var ciphertext = Encoding.ASCII.GetBytes($"azure:v1:{KeyVersion}:wrapped");
@@ -216,8 +226,8 @@ public class AzureKeyVaultKmsProviderTests
     public async Task TransientEmbeddedVersionFailures_KeepClientCacheBounded()
     {
         var client = CreateClient(VersionedKeyUri);
-        client.DecryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<DecryptResult>(new RequestFailedException(503, "Unavailable")));
+        client.UnwrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<UnwrapResult>(new RequestFailedException(503, "Unavailable")));
         var factory = new RecordingFactory(_ => client);
         var provider = new AzureKeyVaultKmsProvider(factory);
 
@@ -237,8 +247,8 @@ public class AzureKeyVaultKmsProviderTests
     public async Task CancelledEmbeddedVersion_RetainsClient()
     {
         var client = CreateClient(VersionedKeyUri);
-        client.DecryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
-            .Returns(call => WaitForDecryptCancellationAsync(call.Arg<CancellationToken>()));
+        client.UnwrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(call => WaitForUnwrapCancellationAsync(call.Arg<CancellationToken>()));
         var factory = new RecordingFactory(_ => client);
         var provider = new AzureKeyVaultKmsProvider(factory);
         var ciphertext = Encoding.ASCII.GetBytes($"azure:v1:{KeyVersion}:wrapped");
@@ -260,7 +270,7 @@ public class AzureKeyVaultKmsProviderTests
     public async Task Cancellation_IsPropagatedToInFlightAzureCall()
     {
         var client = CreateClient(KeyUri);
-        client.EncryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+        client.WrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
             .Returns(call => WaitForCancellationAsync(call.Arg<CancellationToken>()));
         var provider = new AzureKeyVaultKmsProvider(new RecordingFactory(_ => client));
         using var cancellation = new CancellationTokenSource();
@@ -270,14 +280,14 @@ public class AzureKeyVaultKmsProviderTests
 
         await Assert.That(async () => await operation).Throws<OperationCanceledException>();
         await client.Received(1)
-            .EncryptAsync(EncryptionAlgorithm.RsaOaep256, Arg.Any<byte[]>(), cancellation.Token);
+            .WrapKeyAsync(KeyWrapAlgorithm.RsaOaep256, Arg.Any<byte[]>(), cancellation.Token);
     }
 
     [Test]
     public async Task SharedProvider_CreatesOneClientPerKey()
     {
         var client = CreateClient(KeyUri);
-        client.EncryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+        client.WrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
             .Returns(call => EchoAfterYieldAsync(call.Arg<byte[]>()));
         var factory = new RecordingFactory(_ => client);
         var provider = new AzureKeyVaultKmsProvider(factory);
@@ -315,11 +325,11 @@ public class AzureKeyVaultKmsProviderTests
     public async Task SupportedAzureVaultAuthority_IsAccepted(string keyUri)
     {
         var client = CreateClient(KeyUri);
-        client.EncryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
-            .Returns(CryptographyModelFactory.EncryptResult(
+        client.WrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(CryptographyModelFactory.WrapResult(
                 keyId: VersionedKeyUri,
-                ciphertext: [9],
-                algorithm: EncryptionAlgorithm.RsaOaep256));
+                key: [9],
+                algorithm: KeyWrapAlgorithm.RsaOaep256));
         var factory = new RecordingFactory(_ => client);
         var provider = new AzureKeyVaultKmsProvider(factory);
 
@@ -349,25 +359,25 @@ public class AzureKeyVaultKmsProviderTests
             : null
     };
 
-    private static async Task<EncryptResult> WaitForCancellationAsync(CancellationToken cancellationToken)
+    private static async Task<WrapResult> WaitForCancellationAsync(CancellationToken cancellationToken)
     {
         await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
         throw new InvalidOperationException("Cancellation was not observed.");
     }
 
-    private static async Task<DecryptResult> WaitForDecryptCancellationAsync(CancellationToken cancellationToken)
+    private static async Task<UnwrapResult> WaitForUnwrapCancellationAsync(CancellationToken cancellationToken)
     {
         await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
         throw new InvalidOperationException("Cancellation was not observed.");
     }
 
-    private static async Task<EncryptResult> EchoAfterYieldAsync(byte[] plaintext)
+    private static async Task<WrapResult> EchoAfterYieldAsync(byte[] plaintext)
     {
         await Task.Yield();
-        return CryptographyModelFactory.EncryptResult(
+        return CryptographyModelFactory.WrapResult(
             keyId: VersionedKeyUri,
-            ciphertext: plaintext.ToArray(),
-            algorithm: EncryptionAlgorithm.RsaOaep256);
+            key: plaintext.ToArray(),
+            algorithm: KeyWrapAlgorithm.RsaOaep256);
     }
 
     private sealed class RecordingFactory(Func<Uri, CryptographyClient> create) : IAzureKeyVaultCryptographyClientFactory

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
@@ -1,0 +1,266 @@
+using System.Collections.Concurrent;
+using System.Text;
+using Azure;
+using Azure.Core;
+using Azure.Security.KeyVault.Keys;
+using Azure.Security.KeyVault.Keys.Cryptography;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Kms.Azure;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public class AzureKeyVaultKmsProviderTests
+{
+    private const string KeyUri = "https://payments.vault.azure.net/keys/kek";
+    private const string KeyVersion = "0123456789abcdef0123456789abcdef";
+    private const string VersionedKeyUri = KeyUri + "/" + KeyVersion;
+
+    [Test]
+    public async Task WrapAndUnwrap_UseRsaOaep256()
+    {
+        var client = CreateClient(KeyUri);
+        byte[]? plaintext = null;
+        byte[]? ciphertext = null;
+        client.EncryptAsync(
+                EncryptionAlgorithm.RsaOaep256,
+                Arg.Do<byte[]>(value => plaintext = value),
+                Arg.Any<CancellationToken>())
+            .Returns(CryptographyModelFactory.EncryptResult(
+                keyId: VersionedKeyUri,
+                ciphertext: [4, 5, 6],
+                algorithm: EncryptionAlgorithm.RsaOaep256));
+        client.DecryptAsync(
+                EncryptionAlgorithm.RsaOaep256,
+                Arg.Do<byte[]>(value => ciphertext = value),
+                Arg.Any<CancellationToken>())
+            .Returns(CryptographyModelFactory.DecryptResult(
+                keyId: VersionedKeyUri,
+                plaintext: [1, 2, 3],
+                algorithm: EncryptionAlgorithm.RsaOaep256));
+        var factory = new RecordingFactory(_ => client);
+        var provider = new AzureKeyVaultKmsProvider(factory);
+
+        var encrypted = await provider.WrapKeyAsync(new byte[] { 1, 2, 3 }, CreateKeyReference());
+        var decrypted = await provider.UnwrapKeyAsync(encrypted, CreateKeyReference());
+
+        await Assert.That(encrypted).IsEquivalentTo(new byte[] { 4, 5, 6 });
+        await Assert.That(decrypted).IsEquivalentTo(new byte[] { 1, 2, 3 });
+        await Assert.That(plaintext).IsEquivalentTo(new byte[] { 1, 2, 3 });
+        await Assert.That(ciphertext).IsEquivalentTo(new byte[] { 4, 5, 6 });
+        await Assert.That(factory.CreatedKeyIds).IsEquivalentTo(new[] { new Uri(KeyUri) });
+    }
+
+    [Test]
+    [Arguments(AzureKeyVaultKmsProvider.KeyUriPrefix, AzureKeyVaultKmsProvider.DefaultType)]
+    [Arguments(AzureKeyVaultKmsProvider.ConfluentKeyUriPrefix, AzureKeyVaultKmsProvider.ConfluentType)]
+    public async Task ProviderKeyPrefix_IsStripped(string prefix, string type)
+    {
+        var client = CreateClient(KeyUri);
+        client.EncryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(CryptographyModelFactory.EncryptResult(
+                keyId: VersionedKeyUri,
+                ciphertext: [9],
+                algorithm: EncryptionAlgorithm.RsaOaep256));
+        var factory = new RecordingFactory(_ => client);
+        var provider = new AzureKeyVaultKmsProvider(factory, type);
+
+        await provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference(prefix + KeyUri, type));
+
+        await Assert.That(factory.CreatedKeyIds).IsEquivalentTo(new[] { new Uri(KeyUri) });
+    }
+
+    [Test]
+    public async Task SaveVersion_EmbedsVersionAndTargetsItDuringUnwrap()
+    {
+        var versionlessClient = CreateClient(KeyUri);
+        versionlessClient.EncryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(CryptographyModelFactory.EncryptResult(
+                keyId: VersionedKeyUri,
+                ciphertext: [4, 5, 6],
+                algorithm: EncryptionAlgorithm.RsaOaep256));
+        var versionedClient = CreateClient(VersionedKeyUri);
+        versionedClient.DecryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(CryptographyModelFactory.DecryptResult(
+                keyId: VersionedKeyUri,
+                plaintext: [1, 2, 3],
+                algorithm: EncryptionAlgorithm.RsaOaep256));
+        var factory = new RecordingFactory(uri =>
+            uri.AbsoluteUri == new Uri(VersionedKeyUri).AbsoluteUri ? versionedClient : versionlessClient);
+        var provider = new AzureKeyVaultKmsProvider(factory);
+        var keyReference = CreateKeyReference(saveVersion: true);
+
+        var encrypted = await provider.WrapKeyAsync(new byte[] { 1, 2, 3 }, keyReference);
+        var decrypted = await provider.UnwrapKeyAsync(encrypted, keyReference);
+
+        var expectedHeader = Encoding.ASCII.GetBytes($"azure:v1:{KeyVersion}:");
+        await Assert.That(encrypted.AsSpan(0, expectedHeader.Length).ToArray()).IsEquivalentTo(expectedHeader);
+        await Assert.That(encrypted.AsSpan(expectedHeader.Length).ToArray()).IsEquivalentTo(new byte[] { 4, 5, 6 });
+        await Assert.That(decrypted).IsEquivalentTo(new byte[] { 1, 2, 3 });
+        await Assert.That(factory.CreatedKeyIds).Contains(new Uri(KeyUri));
+        await Assert.That(factory.CreatedKeyIds).Contains(new Uri(VersionedKeyUri));
+    }
+
+    [Test]
+    public async Task WrongKey_IsReportedWithoutProviderResponse()
+    {
+        var client = CreateClient(KeyUri);
+        client.DecryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<DecryptResult>(new RequestFailedException(404, "wrong key: sensitive")));
+        var provider = new AzureKeyVaultKmsProvider(new RecordingFactory(_ => client));
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            () => provider.UnwrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).IsEqualTo("Azure Key Vault unwrap failed.");
+        await Assert.That(exception.Message).DoesNotContain("sensitive");
+    }
+
+    [Test]
+    public async Task AuthorizationFailure_IsReportedWithoutProviderResponse()
+    {
+        var client = CreateClient(KeyUri);
+        var denied = new RequestFailedException(403, "authorization: sensitive");
+        client.EncryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<EncryptResult>(denied));
+        var provider = new AzureKeyVaultKmsProvider(new RecordingFactory(_ => client));
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            () => provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).IsEqualTo("Azure Key Vault wrap failed.");
+        await Assert.That(exception.Message).DoesNotContain("sensitive");
+        await Assert.That(exception.InnerException).IsSameReferenceAs(denied);
+    }
+
+    [Test]
+    public async Task MalformedVersionHeader_IsRejectedBeforeAzureCall()
+    {
+        var client = CreateClient(KeyUri);
+        var factory = new RecordingFactory(_ => client);
+        var provider = new AzureKeyVaultKmsProvider(factory);
+        var malformed = Encoding.ASCII.GetBytes("azure:v1:short");
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            () => provider.UnwrapKeyAsync(malformed, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).Contains("invalid version header");
+        await client.DidNotReceiveWithAnyArgs()
+            .DecryptAsync(default, default!, default);
+    }
+
+    [Test]
+    public async Task MalformedCiphertext_IsReportedWithoutProviderResponse()
+    {
+        var client = CreateClient(KeyUri);
+        client.DecryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<DecryptResult>(new RequestFailedException(400, "ciphertext: sensitive")));
+        var provider = new AzureKeyVaultKmsProvider(new RecordingFactory(_ => client));
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            () => provider.UnwrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).IsEqualTo("Azure Key Vault unwrap failed.");
+        await Assert.That(exception.Message).DoesNotContain("sensitive");
+    }
+
+    [Test]
+    public async Task Cancellation_IsPropagatedToInFlightAzureCall()
+    {
+        var client = CreateClient(KeyUri);
+        client.EncryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(call => WaitForCancellationAsync(call.Arg<CancellationToken>()));
+        var provider = new AzureKeyVaultKmsProvider(new RecordingFactory(_ => client));
+        using var cancellation = new CancellationTokenSource();
+        var operation = provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference(), cancellation.Token).AsTask();
+
+        cancellation.Cancel();
+
+        await Assert.That(async () => await operation).Throws<OperationCanceledException>();
+        await client.Received(1)
+            .EncryptAsync(EncryptionAlgorithm.RsaOaep256, Arg.Any<byte[]>(), cancellation.Token);
+    }
+
+    [Test]
+    public async Task SharedProvider_CreatesOneClientPerKey()
+    {
+        var client = CreateClient(KeyUri);
+        client.EncryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(call => EchoAfterYieldAsync(call.Arg<byte[]>()));
+        var factory = new RecordingFactory(_ => client);
+        var provider = new AzureKeyVaultKmsProvider(factory);
+
+        var operations = Enumerable.Range(1, 32)
+            .Select(value => provider.WrapKeyAsync(new byte[] { (byte)value }, CreateKeyReference()).AsTask())
+            .ToArray();
+        var results = await Task.WhenAll(operations);
+
+        await Assert.That(factory.CreateCount).IsEqualTo(1);
+        for (var index = 0; index < results.Length; index++)
+            await Assert.That(results[index]).IsEquivalentTo(new byte[] { (byte)(index + 1) });
+    }
+
+    [Test]
+    public async Task InvalidKeyUri_IsRejectedBeforeClientCreation()
+    {
+        var factory = new RecordingFactory(_ => CreateClient(KeyUri));
+        var provider = new AzureKeyVaultKmsProvider(factory);
+        var reference = CreateKeyReference("https://payments.vault.azure.net/secrets/not-a-key");
+
+        await Assert.That(async () => await provider.WrapKeyAsync(new byte[] { 1 }, reference))
+            .Throws<SchemaRegistryKmsException>();
+        await Assert.That(factory.CreateCount).IsEqualTo(0);
+    }
+
+    private static CryptographyClient CreateClient(string keyUri)
+    {
+        var credential = Substitute.For<TokenCredential>();
+        return Substitute.For<CryptographyClient>(new Uri(keyUri), credential);
+    }
+
+    private static SchemaRegistryKmsKeyReference CreateKeyReference(
+        string keyId = KeyUri,
+        string type = AzureKeyVaultKmsProvider.DefaultType,
+        bool saveVersion = false) => new()
+    {
+        KmsType = type,
+        KmsKeyId = keyId,
+        KmsProps = saveVersion
+            ? new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [AzureKeyVaultKmsProvider.SaveVersionProperty] = bool.TrueString
+            }
+            : null
+    };
+
+    private static async Task<EncryptResult> WaitForCancellationAsync(CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        throw new InvalidOperationException("Cancellation was not observed.");
+    }
+
+    private static async Task<EncryptResult> EchoAfterYieldAsync(byte[] plaintext)
+    {
+        await Task.Yield();
+        return CryptographyModelFactory.EncryptResult(
+            keyId: VersionedKeyUri,
+            ciphertext: plaintext.ToArray(),
+            algorithm: EncryptionAlgorithm.RsaOaep256);
+    }
+
+    private sealed class RecordingFactory(Func<Uri, CryptographyClient> create) : IAzureKeyVaultCryptographyClientFactory
+    {
+        private int _createCount;
+
+        internal ConcurrentBag<Uri> CreatedKeyIds { get; } = [];
+
+        internal int CreateCount => Volatile.Read(ref _createCount);
+
+        public CryptographyClient CreateClient(Uri keyId)
+        {
+            Interlocked.Increment(ref _createCount);
+            CreatedKeyIds.Add(keyId);
+            return create(keyId);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
@@ -130,7 +130,8 @@ public class AzureKeyVaultKmsProviderTests
 
         await Assert.That(exception!.Message).IsEqualTo("Azure Key Vault wrap failed.");
         await Assert.That(exception.Message).DoesNotContain("sensitive");
-        await Assert.That(exception.InnerException).IsSameReferenceAs(denied);
+        await Assert.That(exception.InnerException).IsNull();
+        await Assert.That(exception.ToString()).DoesNotContain("sensitive");
     }
 
     [Test]
@@ -201,11 +202,13 @@ public class AzureKeyVaultKmsProviderTests
     }
 
     [Test]
-    public async Task InvalidKeyUri_IsRejectedBeforeClientCreation()
+    [Arguments("https://payments.vault.azure.net/secrets/not-a-key")]
+    [Arguments("http://payments.vault.azure.net/keys/kek")]
+    public async Task InvalidKeyUri_IsRejectedBeforeClientCreation(string keyUri)
     {
         var factory = new RecordingFactory(_ => CreateClient(KeyUri));
         var provider = new AzureKeyVaultKmsProvider(factory);
-        var reference = CreateKeyReference("https://payments.vault.azure.net/secrets/not-a-key");
+        var reference = CreateKeyReference(keyUri);
 
         await Assert.That(async () => await provider.WrapKeyAsync(new byte[] { 1 }, reference))
             .Throws<SchemaRegistryKmsException>();

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
@@ -489,6 +489,7 @@ public class AzureKeyVaultKmsProviderTests
         _ = await provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference(keyUri));
 
         await Assert.That(factory.CreateCount).IsEqualTo(1);
+        await Assert.That(factory.CreatedKeyIds).Contains(new Uri(keyUri));
     }
 
     private static CryptographyClient CreateClient(string keyUri)

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
@@ -166,6 +166,30 @@ public class AzureKeyVaultKmsProviderTests
     }
 
     [Test]
+    public async Task FailedEmbeddedVersions_AreNotRetained()
+    {
+        var client = CreateClient(KeyUri);
+        client.DecryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<DecryptResult>(new RequestFailedException(400, "invalid ciphertext")));
+        var factory = new RecordingFactory(_ => client);
+        var provider = new AzureKeyVaultKmsProvider(factory);
+
+        for (var pass = 0; pass < 2; pass++)
+        {
+            for (var index = 0; index < 32; index++)
+            {
+                var version = index.ToString("x32");
+                var ciphertext = Encoding.ASCII.GetBytes($"azure:v1:{version}:wrapped");
+
+                await Assert.That(async () => await provider.UnwrapKeyAsync(ciphertext, CreateKeyReference()))
+                    .Throws<SchemaRegistryKmsException>();
+            }
+        }
+
+        await Assert.That(factory.CreateCount).IsEqualTo(64);
+    }
+
+    [Test]
     public async Task Cancellation_IsPropagatedToInFlightAzureCall()
     {
         var client = CreateClient(KeyUri);

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
@@ -364,6 +364,9 @@ public class AzureKeyVaultKmsProviderTests
     [Arguments("https://payments.vault.azure.net/keys/kek")]
     [Arguments("https://payments.vault.azure.cn/keys/kek")]
     [Arguments("https://payments.vault.usgovcloudapi.net/keys/kek")]
+    [Arguments("https://payments.managedhsm.azure.net/keys/kek")]
+    [Arguments("https://payments.managedhsm.azure.cn/keys/kek")]
+    [Arguments("https://payments.managedhsm.usgovcloudapi.net/keys/kek")]
     public async Task SupportedAzureVaultAuthority_IsAccepted(string keyUri)
     {
         var client = CreateClient(KeyUri);

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
@@ -428,10 +428,34 @@ public class AzureKeyVaultKmsProviderTests
     }
 
     [Test]
+    public async Task SharedProvider_ConcurrentDistinctKeys_KeepsClientCacheBounded()
+    {
+        var client = CreateClient(KeyUri);
+        client.WrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(CryptographyModelFactory.WrapResult(
+                keyId: VersionedKeyUri,
+                key: [4, 5, 6],
+                algorithm: KeyWrapAlgorithm.RsaOaep256));
+        var factory = new RecordingFactory(_ => client);
+        var provider = new AzureKeyVaultKmsProvider(factory);
+        var operations = Enumerable.Range(0, 256)
+            .Select(index => provider.WrapKeyAsync(
+                new byte[] { 1 },
+                CreateKeyReference($"https://vault{index}.vault.azure.net/keys/kek")).AsTask())
+            .ToArray();
+
+        await Task.WhenAll(operations);
+
+        await Assert.That(provider.ClientCount).IsEqualTo(AzureKeyVaultKmsProvider.ClientCacheCapacity);
+        await Assert.That(factory.CreateCount).IsEqualTo(operations.Length);
+    }
+
+    [Test]
     [Arguments("https://payments.vault.azure.net/secrets/not-a-key")]
     [Arguments("http://payments.vault.azure.net/keys/kek")]
     [Arguments("https://attacker.example/keys/kek")]
     [Arguments("https://payments.vault.azure.net.attacker.example/keys/kek")]
+    [Arguments("https://payments.vault.azure.net:8443/keys/kek")]
     public async Task InvalidKeyUri_IsRejectedBeforeClientCreation(string keyUri)
     {
         var factory = new RecordingFactory(_ => CreateClient(KeyUri));
@@ -445,6 +469,7 @@ public class AzureKeyVaultKmsProviderTests
 
     [Test]
     [Arguments("https://payments.vault.azure.net/keys/kek")]
+    [Arguments("https://payments.vault.azure.net:443/keys/kek")]
     [Arguments("https://payments.vault.azure.cn/keys/kek")]
     [Arguments("https://payments.vault.usgovcloudapi.net/keys/kek")]
     [Arguments("https://payments.managedhsm.azure.net/keys/kek")]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
@@ -145,6 +145,39 @@ public class AzureKeyVaultKmsProviderTests
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task AzureSdkCancellation_WithoutCallerCancellation_IsSanitized(bool unwrap)
+    {
+        var client = CreateClient(KeyUri);
+        var cancellation = new OperationCanceledException("internal timeout: sensitive");
+        client.WrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<WrapResult>(cancellation));
+        client.UnwrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<UnwrapResult>(cancellation));
+        var factory = new RecordingFactory(_ => client);
+        var provider = new AzureKeyVaultKmsProvider(factory);
+        var material = unwrap
+            ? Encoding.ASCII.GetBytes($"azure:v1:{KeyVersion}:wrapped")
+            : new byte[] { 1 };
+        SchemaRegistryKmsException? exception = null;
+
+        for (var pass = 0; pass < 2; pass++)
+        {
+            exception = unwrap
+                ? await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+                    () => provider.UnwrapKeyAsync(material, CreateKeyReference()).AsTask())
+                : await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+                    () => provider.WrapKeyAsync(material, CreateKeyReference()).AsTask());
+        }
+
+        await Assert.That(exception!.Message)
+            .IsEqualTo(unwrap ? "Azure Key Vault unwrap failed." : "Azure Key Vault wrap failed.");
+        await Assert.That(exception.ToString()).DoesNotContain("sensitive");
+        await Assert.That(factory.CreateCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task MalformedVersionHeader_IsRejectedBeforeAzureCall()
     {
         var client = CreateClient(KeyUri);
@@ -241,6 +274,30 @@ public class AzureKeyVaultKmsProviderTests
 
         await Assert.That(provider.EmbeddedVersionClientCount)
             .IsLessThanOrEqualTo(AzureKeyVaultKmsProvider.EmbeddedVersionClientCapacity);
+    }
+
+    [Test]
+    public async Task SameVersionAcrossKeys_RetainsBothEmbeddedVersionClients()
+    {
+        const string otherKeyUri = "https://orders.vault.azure.net/keys/kek";
+        var client = CreateClient(VersionedKeyUri);
+        client.UnwrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<UnwrapResult>(new RequestFailedException(503, "Unavailable")));
+        var factory = new RecordingFactory(_ => client);
+        var provider = new AzureKeyVaultKmsProvider(factory);
+        var ciphertext = Encoding.ASCII.GetBytes($"azure:v1:{KeyVersion}:wrapped");
+
+        for (var pass = 0; pass < 2; pass++)
+        {
+            await Assert.That(async () => await provider.UnwrapKeyAsync(ciphertext, CreateKeyReference()))
+                .Throws<SchemaRegistryKmsException>();
+            await Assert.That(async () => await provider.UnwrapKeyAsync(
+                    ciphertext,
+                    CreateKeyReference(otherKeyUri)))
+                .Throws<SchemaRegistryKmsException>();
+        }
+
+        await Assert.That(factory.CreateCount).IsEqualTo(2);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
@@ -213,6 +213,27 @@ public class AzureKeyVaultKmsProviderTests
     }
 
     [Test]
+    public async Task TransientEmbeddedVersionFailures_KeepClientCacheBounded()
+    {
+        var client = CreateClient(VersionedKeyUri);
+        client.DecryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<DecryptResult>(new RequestFailedException(503, "Unavailable")));
+        var factory = new RecordingFactory(_ => client);
+        var provider = new AzureKeyVaultKmsProvider(factory);
+
+        for (var index = 0; index < 1_024; index++)
+        {
+            var version = index.ToString("x32");
+            var ciphertext = Encoding.ASCII.GetBytes($"azure:v1:{version}:wrapped");
+            await Assert.That(async () => await provider.UnwrapKeyAsync(ciphertext, CreateKeyReference()))
+                .Throws<SchemaRegistryKmsException>();
+        }
+
+        await Assert.That(provider.EmbeddedVersionClientCount)
+            .IsLessThanOrEqualTo(AzureKeyVaultKmsProvider.EmbeddedVersionClientCapacity);
+    }
+
+    [Test]
     public async Task CancelledEmbeddedVersion_RetainsClient()
     {
         var client = CreateClient(VersionedKeyUri);
@@ -274,6 +295,8 @@ public class AzureKeyVaultKmsProviderTests
     [Test]
     [Arguments("https://payments.vault.azure.net/secrets/not-a-key")]
     [Arguments("http://payments.vault.azure.net/keys/kek")]
+    [Arguments("https://attacker.example/keys/kek")]
+    [Arguments("https://payments.vault.azure.net.attacker.example/keys/kek")]
     public async Task InvalidKeyUri_IsRejectedBeforeClientCreation(string keyUri)
     {
         var factory = new RecordingFactory(_ => CreateClient(KeyUri));
@@ -283,6 +306,26 @@ public class AzureKeyVaultKmsProviderTests
         await Assert.That(async () => await provider.WrapKeyAsync(new byte[] { 1 }, reference))
             .Throws<SchemaRegistryKmsException>();
         await Assert.That(factory.CreateCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [Arguments("https://payments.vault.azure.net/keys/kek")]
+    [Arguments("https://payments.vault.azure.cn/keys/kek")]
+    [Arguments("https://payments.vault.usgovcloudapi.net/keys/kek")]
+    public async Task SupportedAzureVaultAuthority_IsAccepted(string keyUri)
+    {
+        var client = CreateClient(KeyUri);
+        client.EncryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(CryptographyModelFactory.EncryptResult(
+                keyId: VersionedKeyUri,
+                ciphertext: [9],
+                algorithm: EncryptionAlgorithm.RsaOaep256));
+        var factory = new RecordingFactory(_ => client);
+        var provider = new AzureKeyVaultKmsProvider(factory);
+
+        _ = await provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference(keyUri));
+
+        await Assert.That(factory.CreateCount).IsEqualTo(1);
     }
 
     private static CryptographyClient CreateClient(string keyUri)

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
@@ -166,7 +166,7 @@ public class AzureKeyVaultKmsProviderTests
     }
 
     [Test]
-    public async Task FailedEmbeddedVersions_AreNotRetained()
+    public async Task PermanentEmbeddedVersionFailures_AreNotRetained()
     {
         var client = CreateClient(KeyUri);
         client.DecryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
@@ -187,6 +187,52 @@ public class AzureKeyVaultKmsProviderTests
         }
 
         await Assert.That(factory.CreateCount).IsEqualTo(64);
+    }
+
+    [Test]
+    [Arguments(408)]
+    [Arguments(429)]
+    [Arguments(500)]
+    [Arguments(503)]
+    public async Task TransientEmbeddedVersionFailures_RetainClient(int status)
+    {
+        var client = CreateClient(VersionedKeyUri);
+        client.DecryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<DecryptResult>(new RequestFailedException(status, "transient")));
+        var factory = new RecordingFactory(_ => client);
+        var provider = new AzureKeyVaultKmsProvider(factory);
+        var ciphertext = Encoding.ASCII.GetBytes($"azure:v1:{KeyVersion}:wrapped");
+
+        for (var pass = 0; pass < 2; pass++)
+        {
+            await Assert.That(async () => await provider.UnwrapKeyAsync(ciphertext, CreateKeyReference()))
+                .Throws<SchemaRegistryKmsException>();
+        }
+
+        await Assert.That(factory.CreateCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task CancelledEmbeddedVersion_RetainsClient()
+    {
+        var client = CreateClient(VersionedKeyUri);
+        client.DecryptAsync(Arg.Any<EncryptionAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(call => WaitForDecryptCancellationAsync(call.Arg<CancellationToken>()));
+        var factory = new RecordingFactory(_ => client);
+        var provider = new AzureKeyVaultKmsProvider(factory);
+        var ciphertext = Encoding.ASCII.GetBytes($"azure:v1:{KeyVersion}:wrapped");
+
+        for (var pass = 0; pass < 2; pass++)
+        {
+            using var cancellation = new CancellationTokenSource();
+            var operation = provider.UnwrapKeyAsync(ciphertext, CreateKeyReference(), cancellation.Token).AsTask();
+
+            cancellation.Cancel();
+
+            await Assert.That(async () => await operation).Throws<OperationCanceledException>();
+        }
+
+        await Assert.That(factory.CreateCount).IsEqualTo(1);
     }
 
     [Test]
@@ -261,6 +307,12 @@ public class AzureKeyVaultKmsProviderTests
     };
 
     private static async Task<EncryptResult> WaitForCancellationAsync(CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        throw new InvalidOperationException("Cancellation was not observed.");
+    }
+
+    private static async Task<DecryptResult> WaitForDecryptCancellationAsync(CancellationToken cancellationToken)
     {
         await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
         throw new InvalidOperationException("Cancellation was not observed.");

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AzureKeyVaultKmsProviderTests.cs
@@ -284,6 +284,48 @@ public class AzureKeyVaultKmsProviderTests
     }
 
     [Test]
+    public async Task WrapKey_FactoryFailure_IsRetried()
+    {
+        var client = CreateClient(KeyUri);
+        client.WrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(CryptographyModelFactory.WrapResult(
+                keyId: VersionedKeyUri,
+                key: [4, 5, 6],
+                algorithm: KeyWrapAlgorithm.RsaOaep256));
+        var factory = new RecordingFactory(_ => client);
+        factory.FailNextCreation(new InvalidOperationException("transient factory failure"));
+        var provider = new AzureKeyVaultKmsProvider(factory);
+
+        await Assert.That(async () => await provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference()))
+            .Throws<InvalidOperationException>();
+        var encrypted = await provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference());
+
+        await Assert.That(encrypted).IsEquivalentTo(new byte[] { 4, 5, 6 });
+        await Assert.That(factory.CreateCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task VersionlessUnwrap_FactoryFailure_IsRetried()
+    {
+        var client = CreateClient(KeyUri);
+        client.UnwrapKeyAsync(Arg.Any<KeyWrapAlgorithm>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(CryptographyModelFactory.UnwrapResult(
+                keyId: VersionedKeyUri,
+                key: [1, 2, 3],
+                algorithm: KeyWrapAlgorithm.RsaOaep256));
+        var factory = new RecordingFactory(_ => client);
+        factory.FailNextCreation(new RequestFailedException(503, "Unavailable"));
+        var provider = new AzureKeyVaultKmsProvider(factory);
+
+        await Assert.That(async () => await provider.UnwrapKeyAsync(new byte[] { 4, 5, 6 }, CreateKeyReference()))
+            .Throws<SchemaRegistryKmsException>();
+        var plaintext = await provider.UnwrapKeyAsync(new byte[] { 4, 5, 6 }, CreateKeyReference());
+
+        await Assert.That(plaintext).IsEquivalentTo(new byte[] { 1, 2, 3 });
+        await Assert.That(factory.CreateCount).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task SharedProvider_CreatesOneClientPerKey()
     {
         var client = CreateClient(KeyUri);
@@ -383,15 +425,22 @@ public class AzureKeyVaultKmsProviderTests
     private sealed class RecordingFactory(Func<Uri, CryptographyClient> create) : IAzureKeyVaultCryptographyClientFactory
     {
         private int _createCount;
+        private Exception? _nextCreationException;
 
         internal ConcurrentBag<Uri> CreatedKeyIds { get; } = [];
 
         internal int CreateCount => Volatile.Read(ref _createCount);
 
+        internal void FailNextCreation(Exception exception) =>
+            Interlocked.Exchange(ref _nextCreationException, exception);
+
         public CryptographyClient CreateClient(Uri keyId)
         {
             Interlocked.Increment(ref _createCount);
             CreatedKeyIds.Add(keyId);
+            if (Interlocked.Exchange(ref _nextCreationException, null) is { } exception)
+                throw exception;
+
             return create(keyId);
         }
     }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AzureKeyVaultKmsProviderBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AzureKeyVaultKmsProviderBenchmarks.cs
@@ -15,17 +15,40 @@ public class AzureKeyVaultKmsProviderBenchmarks
     private const string KeyUri = "https://payments.vault.azure.net/keys/kek";
     private const string KeyVersion = "0123456789abcdef0123456789abcdef";
 
-    private readonly byte[] _encryptedKeyMaterial = Encoding.ASCII.GetBytes($"azure:v1:{KeyVersion}:wrapped");
+    private readonly byte[] _keyMaterial = [1, 2, 3];
+    private readonly byte[] _versionlessEncryptedKeyMaterial = Encoding.ASCII.GetBytes("wrapped");
+    private readonly byte[] _versionedEncryptedKeyMaterial = Encoding.ASCII.GetBytes($"azure:v1:{KeyVersion}:wrapped");
     private readonly SchemaRegistryKmsKeyReference _keyReference = new()
     {
         KmsType = AzureKeyVaultKmsProvider.DefaultType,
         KmsKeyId = KeyUri
     };
+    private readonly SchemaRegistryKmsKeyReference _versionedKeyReference = new()
+    {
+        KmsType = AzureKeyVaultKmsProvider.DefaultType,
+        KmsKeyId = KeyUri,
+        KmsProps = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [AzureKeyVaultKmsProvider.SaveVersionProperty] = bool.TrueString
+        }
+    };
     private readonly AzureKeyVaultKmsProvider _provider = new(new ClientFactory());
 
     [Benchmark]
+    public ValueTask<byte[]> WrapVersionlessKey() =>
+        _provider.WrapKeyAsync(_keyMaterial, _keyReference);
+
+    [Benchmark]
+    public ValueTask<byte[]> WrapVersionedKey() =>
+        _provider.WrapKeyAsync(_keyMaterial, _versionedKeyReference);
+
+    [Benchmark]
+    public ValueTask<byte[]> UnwrapVersionlessKey() =>
+        _provider.UnwrapKeyAsync(_versionlessEncryptedKeyMaterial, _keyReference);
+
+    [Benchmark]
     public ValueTask<byte[]> UnwrapVersionedKey() =>
-        _provider.UnwrapKeyAsync(_encryptedKeyMaterial, _keyReference);
+        _provider.UnwrapKeyAsync(_versionedEncryptedKeyMaterial, _keyReference);
 
     private sealed class ClientFactory : IAzureKeyVaultCryptographyClientFactory
     {
@@ -36,14 +59,23 @@ public class AzureKeyVaultKmsProviderBenchmarks
 
     private sealed class SuccessfulClient : CryptographyClient
     {
-        private readonly Task<UnwrapResult> _result = Task.FromResult(CryptographyModelFactory.UnwrapResult(
+        private readonly Task<WrapResult> _wrapResult = Task.FromResult(CryptographyModelFactory.WrapResult(
+            keyId: $"{KeyUri}/{KeyVersion}",
+            key: [4, 5, 6],
+            algorithm: KeyWrapAlgorithm.RsaOaep256));
+        private readonly Task<UnwrapResult> _unwrapResult = Task.FromResult(CryptographyModelFactory.UnwrapResult(
             keyId: $"{KeyUri}/{KeyVersion}",
             key: [1, 2, 3],
             algorithm: KeyWrapAlgorithm.RsaOaep256));
 
+        public override Task<WrapResult> WrapKeyAsync(
+            KeyWrapAlgorithm algorithm,
+            byte[] key,
+            CancellationToken cancellationToken = default) => _wrapResult;
+
         public override Task<UnwrapResult> UnwrapKeyAsync(
             KeyWrapAlgorithm algorithm,
             byte[] ciphertext,
-            CancellationToken cancellationToken = default) => _result;
+            CancellationToken cancellationToken = default) => _unwrapResult;
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AzureKeyVaultKmsProviderBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AzureKeyVaultKmsProviderBenchmarks.cs
@@ -1,0 +1,49 @@
+using System.Text;
+using Azure.Security.KeyVault.Keys;
+using Azure.Security.KeyVault.Keys.Cryptography;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Kms.Azure;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 10)]
+public class AzureKeyVaultKmsProviderBenchmarks
+{
+    private const string KeyUri = "https://payments.vault.azure.net/keys/kek";
+    private const string KeyVersion = "0123456789abcdef0123456789abcdef";
+
+    private readonly byte[] _encryptedKeyMaterial = Encoding.ASCII.GetBytes($"azure:v1:{KeyVersion}:wrapped");
+    private readonly SchemaRegistryKmsKeyReference _keyReference = new()
+    {
+        KmsType = AzureKeyVaultKmsProvider.DefaultType,
+        KmsKeyId = KeyUri
+    };
+    private readonly AzureKeyVaultKmsProvider _provider = new(new ClientFactory());
+
+    [Benchmark]
+    public ValueTask<byte[]> UnwrapVersionedKey() =>
+        _provider.UnwrapKeyAsync(_encryptedKeyMaterial, _keyReference);
+
+    private sealed class ClientFactory : IAzureKeyVaultCryptographyClientFactory
+    {
+        private readonly CryptographyClient _client = new SuccessfulClient();
+
+        public CryptographyClient CreateClient(Uri keyId) => _client;
+    }
+
+    private sealed class SuccessfulClient : CryptographyClient
+    {
+        private readonly Task<DecryptResult> _result = Task.FromResult(CryptographyModelFactory.DecryptResult(
+            keyId: $"{KeyUri}/{KeyVersion}",
+            plaintext: [1, 2, 3],
+            algorithm: EncryptionAlgorithm.RsaOaep256));
+
+        public override Task<DecryptResult> DecryptAsync(
+            EncryptionAlgorithm algorithm,
+            byte[] ciphertext,
+            CancellationToken cancellationToken = default) => _result;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AzureKeyVaultKmsProviderBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AzureKeyVaultKmsProviderBenchmarks.cs
@@ -36,13 +36,13 @@ public class AzureKeyVaultKmsProviderBenchmarks
 
     private sealed class SuccessfulClient : CryptographyClient
     {
-        private readonly Task<DecryptResult> _result = Task.FromResult(CryptographyModelFactory.DecryptResult(
+        private readonly Task<UnwrapResult> _result = Task.FromResult(CryptographyModelFactory.UnwrapResult(
             keyId: $"{KeyUri}/{KeyVersion}",
-            plaintext: [1, 2, 3],
-            algorithm: EncryptionAlgorithm.RsaOaep256));
+            key: [1, 2, 3],
+            algorithm: KeyWrapAlgorithm.RsaOaep256));
 
-        public override Task<DecryptResult> DecryptAsync(
-            EncryptionAlgorithm algorithm,
+        public override Task<UnwrapResult> UnwrapKeyAsync(
+            KeyWrapAlgorithm algorithm,
             byte[] ciphertext,
             CancellationToken cancellationToken = default) => _result;
     }

--- a/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
+++ b/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Vault\Dekaf.SchemaRegistry.Kms.Vault.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Aws\Dekaf.SchemaRegistry.Kms.Aws.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Azure\Dekaf.SchemaRegistry.Kms.Azure.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #2702

## Summary
- add opt-in `Dekaf.SchemaRegistry.Kms.Azure` package using Azure Key Vault Keys
- support `azure-kv`, Confluent-compatible `azure-kms`, `DefaultAzureCredential`, injected credentials/options, and custom client factories
- preserve exact Azure key versions across rotation, sanitize failures, forward cancellation, cache clients thread-safely, and clear temporary buffers
- document setup, key identifiers, versioning, credentials, permissions, cancellation, and concurrency

## Validation
- `dotnet build Dekaf.sln --configuration Release --no-restore` (0 warnings, 0 errors)
- `dotnet pack src/Dekaf.SchemaRegistry.Kms.Azure/Dekaf.SchemaRegistry.Kms.Azure.csproj --configuration Release --no-build`
- unit tests net10.0: 6,884 passed
- unit tests net8.0: 6,748 passed
- focused Azure provider tests: 11 passed per framework

## Performance
No existing runtime or hot path changes. Azure SDK dependencies are isolated in the opt-in package; wrap/unwrap occurs at remote DEK operations. No benchmark lane is applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Azure Key Vault support for Schema Registry key management using RSA-OAEP-256 encryption.
  - Supports key versioning, rotation, cancellation, credential options, and standard or Confluent Azure KMS identifiers.
  - Added client caching, validation, and sanitized error handling.

- **Documentation**
  - Added setup, permissions, configuration, rotation, caching, and usage guidance.

- **Tests**
  - Added comprehensive coverage for encryption, versioning, validation, cancellation, concurrency, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->