### PR TITLE
feat(schema-registry): add GCP KMS provider

### DIFF
--- a/Dekaf.sln
+++ b/Dekaf.sln
@@ -71,6 +71,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.Tests.Mutation.Protoc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.Serialization.Routing", "src\Dekaf.Serialization.Routing\Dekaf.Serialization.Routing.csproj", "{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.SchemaRegistry.Kms.Gcp", "src\Dekaf.SchemaRegistry.Kms.Gcp\Dekaf.SchemaRegistry.Kms.Gcp.csproj", "{52043965-88BE-40BE-B801-70A13249AAE8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -441,6 +443,18 @@ Global
 		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}.Release|x64.Build.0 = Release|Any CPU
 		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}.Release|x86.ActiveCfg = Release|Any CPU
 		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE}.Release|x86.Build.0 = Release|Any CPU
+		{52043965-88BE-40BE-B801-70A13249AAE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52043965-88BE-40BE-B801-70A13249AAE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52043965-88BE-40BE-B801-70A13249AAE8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{52043965-88BE-40BE-B801-70A13249AAE8}.Debug|x64.Build.0 = Debug|Any CPU
+		{52043965-88BE-40BE-B801-70A13249AAE8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{52043965-88BE-40BE-B801-70A13249AAE8}.Debug|x86.Build.0 = Debug|Any CPU
+		{52043965-88BE-40BE-B801-70A13249AAE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52043965-88BE-40BE-B801-70A13249AAE8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52043965-88BE-40BE-B801-70A13249AAE8}.Release|x64.ActiveCfg = Release|Any CPU
+		{52043965-88BE-40BE-B801-70A13249AAE8}.Release|x64.Build.0 = Release|Any CPU
+		{52043965-88BE-40BE-B801-70A13249AAE8}.Release|x86.ActiveCfg = Release|Any CPU
+		{52043965-88BE-40BE-B801-70A13249AAE8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -476,5 +490,6 @@ Global
 		{DF2BABFD-6483-43F3-8AC1-B6A1C36CB777} = {B2C3D4E5-F6A7-8901-BCDE-F12345678901}
 		{50CD7D4E-24BC-4CA1-A183-1257129A66DE} = {B2C3D4E5-F6A7-8901-BCDE-F12345678901}
 		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{52043965-88BE-40BE-B801-70A13249AAE8} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,9 @@
     <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.15.0" />
     <PackageVersion Include="Dekaf" Version="$(DekafPackageVersion)" />
     <PackageVersion Include="GitVersion.MsBuild" Version="6.8.2" />
+    <PackageVersion Include="Google.Cloud.Kms.V1" Version="3.26.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
+    <PackageVersion Include="Grpc.Core.Api" Version="2.83.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.83.0" />
     <PackageVersion Include="K4os.Compression.LZ4.Streams" Version="1.3.8" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -264,6 +264,48 @@ owns validation when set; otherwise `ValidateServerCertificate`,
 `ValidateServerCertificateHostName`, custom roots, revocation, and protocol settings are enforced by
 the default pipeline.
 
+## Google Cloud KMS
+
+Install the opt-in Google Cloud provider when Schema Registry client-side field-level encryption
+(CSFLE) uses a Cloud KMS key:
+
+```bash
+dotnet add package Dekaf.SchemaRegistry.Kms.Gcp
+```
+
+```csharp
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Kms.Gcp;
+
+var gcpKms = new GcpKmsProvider();
+var csfle = new SchemaRegistryCsfleRuleHandler(schemaRegistry, [gcpKms]);
+```
+
+The default constructor uses Google Application Default Credentials and the default Cloud KMS
+endpoint. Build and inject a client to select a regional endpoint, explicit credentials, emulator,
+or custom channel configuration:
+
+```csharp
+using Google.Cloud.Kms.V1;
+
+var kmsClient = new KeyManagementServiceClientBuilder
+{
+    Endpoint = "europe-west2-kms.googleapis.com"
+}.Build();
+var gcpKms = new GcpKmsProvider(kmsClient);
+```
+
+The supplied `KeyManagementServiceClient` is caller-owned and safe to share. Use the full CryptoKey
+resource name
+`projects/<project>/locations/<location>/keyRings/<key-ring>/cryptoKeys/<key>`. An optional
+`gcp-kms://` prefix is accepted. Cloud KMS embeds the primary key version in its ciphertext, so the
+CryptoKey resource—not a CryptoKeyVersion—is used for both encryption and decryption.
+
+Grant the runtime identity `cloudkms.cryptoKeyVersions.useToEncrypt` and
+`cloudkms.cryptoKeyVersions.useToDecrypt`, for example with the Cloud KMS CryptoKey Encrypter/
+Decrypter role. Cancellation is forwarded to the gRPC call. Provider errors omit service response
+text and key material, and temporary SDK plaintext buffers are cleared after copy-out.
+
 ## Consumer
 
 ```csharp

--- a/src/Dekaf.SchemaRegistry.Kms.Gcp/Dekaf.SchemaRegistry.Kms.Gcp.csproj
+++ b/src/Dekaf.SchemaRegistry.Kms.Gcp/Dekaf.SchemaRegistry.Kms.Gcp.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Dekaf.SchemaRegistry.Kms.Gcp</PackageId>
+    <Description>Google Cloud KMS provider for Dekaf Schema Registry client-side field-level encryption</Description>
+    <PackageTags>kafka;schema-registry;encryption;gcp;cloud-kms</PackageTags>
+    <PackageValidationBaselineVersion></PackageValidationBaselineVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Kms.V1" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Core.Api" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Dekaf.SchemaRegistry.Kms.Gcp/GcpKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Gcp/GcpKmsProvider.cs
@@ -64,10 +64,33 @@ public sealed class GcpKmsProvider : ISchemaRegistryKmsProvider
         var keyName = ResolveKeyName(keyReference);
         try
         {
+            var request = new EncryptRequest
+            {
+                Name = keyName.ToString(),
+                Plaintext = UnsafeByteOperations.UnsafeWrap(keyMaterial),
+                PlaintextCrc32C = GcpCrc32C.Compute(keyMaterial.Span)
+            };
             var response = await _client
-                .EncryptAsync(keyName, UnsafeByteOperations.UnsafeWrap(keyMaterial), cancellationToken)
+                .EncryptAsync(request, cancellationToken)
                 .ConfigureAwait(false);
-            return CopyAndClearMaterial(response.Ciphertext, "wrap");
+            if (!response.VerifiedPlaintextCrc32C)
+            {
+                ClearMaterial(response.Ciphertext);
+                throw new SchemaRegistryKmsException(
+                    "Google Cloud KMS wrap failed. The service could not verify request integrity.");
+            }
+
+            if (!IsVersionOfKey(response.Name, request.Name))
+            {
+                ClearMaterial(response.Ciphertext);
+                throw new SchemaRegistryKmsException(
+                    "Google Cloud KMS wrap failed. The service used an unexpected key version.");
+            }
+
+            return CopyVerifyAndClearMaterial(
+                response.Ciphertext,
+                response.CiphertextCrc32C,
+                "wrap");
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -76,11 +99,11 @@ public sealed class GcpKmsProvider : ISchemaRegistryKmsProvider
         catch (RpcException ex) when (
             cancellationToken.IsCancellationRequested && ex.StatusCode == StatusCode.Cancelled)
         {
-            throw new OperationCanceledException("Google Cloud KMS wrap was canceled.", ex, cancellationToken);
+            throw new OperationCanceledException("Google Cloud KMS wrap was canceled.", cancellationToken);
         }
-        catch (RpcException ex)
+        catch (RpcException)
         {
-            throw new SchemaRegistryKmsException("Google Cloud KMS wrap failed.", ex);
+            throw new SchemaRegistryKmsException("Google Cloud KMS wrap failed.");
         }
     }
 
@@ -100,10 +123,19 @@ public sealed class GcpKmsProvider : ISchemaRegistryKmsProvider
         var keyName = ResolveKeyName(keyReference);
         try
         {
+            var request = new DecryptRequest
+            {
+                Name = keyName.ToString(),
+                Ciphertext = UnsafeByteOperations.UnsafeWrap(encryptedKeyMaterial),
+                CiphertextCrc32C = GcpCrc32C.Compute(encryptedKeyMaterial.Span)
+            };
             var response = await _client
-                .DecryptAsync(keyName, UnsafeByteOperations.UnsafeWrap(encryptedKeyMaterial), cancellationToken)
+                .DecryptAsync(request, cancellationToken)
                 .ConfigureAwait(false);
-            return CopyAndClearMaterial(response.Plaintext, "unwrap");
+            return CopyVerifyAndClearMaterial(
+                response.Plaintext,
+                response.PlaintextCrc32C,
+                "unwrap");
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -112,11 +144,11 @@ public sealed class GcpKmsProvider : ISchemaRegistryKmsProvider
         catch (RpcException ex) when (
             cancellationToken.IsCancellationRequested && ex.StatusCode == StatusCode.Cancelled)
         {
-            throw new OperationCanceledException("Google Cloud KMS unwrap was canceled.", ex, cancellationToken);
+            throw new OperationCanceledException("Google Cloud KMS unwrap was canceled.", cancellationToken);
         }
-        catch (RpcException ex)
+        catch (RpcException)
         {
-            throw new SchemaRegistryKmsException("Google Cloud KMS unwrap failed.", ex);
+            throw new SchemaRegistryKmsException("Google Cloud KMS unwrap failed.");
         }
     }
 
@@ -146,25 +178,81 @@ public sealed class GcpKmsProvider : ISchemaRegistryKmsProvider
         return keyName;
     }
 
-    private static byte[] CopyAndClearMaterial(ByteString material, string operation)
+    private static byte[] CopyVerifyAndClearMaterial(
+        ByteString material,
+        long? expectedCrc32C,
+        string operation)
     {
-        if (material.IsEmpty)
-        {
-            throw new SchemaRegistryKmsException(
-                $"Google Cloud KMS {operation} failed. The service returned no key material.");
-        }
-
         try
         {
+            if (material.IsEmpty)
+            {
+                throw new SchemaRegistryKmsException(
+                    $"Google Cloud KMS {operation} failed. The service returned no key material.");
+            }
+
+            if (expectedCrc32C is null || GcpCrc32C.Compute(material.Span) != expectedCrc32C)
+            {
+                throw new SchemaRegistryKmsException(
+                    $"Google Cloud KMS {operation} failed. Response integrity validation failed.");
+            }
+
             return material.ToByteArray();
         }
         finally
         {
-            if (MemoryMarshal.TryGetArray(material.Memory, out var segment)
-                && segment.Array is not null)
+            ClearMaterial(material);
+        }
+    }
+
+    private static bool IsVersionOfKey(string versionName, string keyName)
+    {
+        var prefixLength = keyName.Length + "/cryptoKeyVersions/".Length;
+        return versionName.Length > prefixLength
+            && versionName.StartsWith(keyName, StringComparison.Ordinal)
+            && versionName.AsSpan(keyName.Length).StartsWith("/cryptoKeyVersions/", StringComparison.Ordinal);
+    }
+
+    private static void ClearMaterial(ByteString material)
+    {
+        if (MemoryMarshal.TryGetArray(material.Memory, out var segment)
+            && segment.Array is not null)
+        {
+            CryptographicOperations.ZeroMemory(segment.Array.AsSpan(segment.Offset, segment.Count));
+        }
+    }
+
+    private static class GcpCrc32C
+    {
+        private const uint ReversedCastagnoliPolynomial = 0x82F63B78;
+        private static readonly uint[] Table = CreateTable();
+
+        internal static long Compute(ReadOnlySpan<byte> data)
+        {
+            var crc = uint.MaxValue;
+            foreach (var value in data)
+                crc = Table[(crc ^ value) & 0xff] ^ (crc >> 8);
+
+            return crc ^ uint.MaxValue;
+        }
+
+        private static uint[] CreateTable()
+        {
+            var table = new uint[256];
+            for (var index = 0; index < table.Length; index++)
             {
-                CryptographicOperations.ZeroMemory(segment.Array.AsSpan(segment.Offset, segment.Count));
+                var crc = (uint)index;
+                for (var bit = 0; bit < 8; bit++)
+                {
+                    crc = (crc & 1) == 0
+                        ? crc >> 1
+                        : (crc >> 1) ^ ReversedCastagnoliPolynomial;
+                }
+
+                table[index] = crc;
             }
+
+            return table;
         }
     }
 }

--- a/src/Dekaf.SchemaRegistry.Kms.Gcp/GcpKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Gcp/GcpKmsProvider.cs
@@ -1,0 +1,170 @@
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using Google.Cloud.Kms.V1;
+using Google.Protobuf;
+using Grpc.Core;
+
+namespace Dekaf.SchemaRegistry.Kms.Gcp;
+
+/// <summary>
+/// Wraps and unwraps Schema Registry data encryption keys with Google Cloud KMS.
+/// </summary>
+public sealed class GcpKmsProvider : ISchemaRegistryKmsProvider
+{
+    /// <summary>
+    /// Schema Registry KMS provider type.
+    /// </summary>
+    public const string DefaultType = "gcp-kms";
+
+    /// <summary>
+    /// Optional URI prefix for Google Cloud KMS key resource names.
+    /// </summary>
+    public const string KeyUriPrefix = "gcp-kms://";
+
+    private readonly KeyManagementServiceClient _client;
+
+    /// <summary>
+    /// Creates a provider using Google Application Default Credentials and the default endpoint.
+    /// </summary>
+    public GcpKmsProvider()
+        : this(KeyManagementServiceClient.Create())
+    {
+    }
+
+    /// <summary>
+    /// Creates a provider using a caller-supplied Google Cloud KMS client.
+    /// </summary>
+    /// <param name="client">Shared Google Cloud KMS client.</param>
+    /// <param name="type">Schema Registry KMS provider type.</param>
+    public GcpKmsProvider(
+        KeyManagementServiceClient client,
+        string type = DefaultType)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        if (string.IsNullOrWhiteSpace(type))
+            throw new ArgumentException("KMS provider type cannot be null or whitespace.", nameof(type));
+
+        _client = client;
+        Type = type;
+    }
+
+    /// <inheritdoc />
+    public string Type { get; }
+
+    /// <inheritdoc />
+    public async ValueTask<byte[]> WrapKeyAsync(
+        ReadOnlyMemory<byte> keyMaterial,
+        SchemaRegistryKmsKeyReference keyReference,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (keyMaterial.IsEmpty)
+            throw new SchemaRegistryKmsException("Google Cloud KMS wrap failed. Key material cannot be empty.");
+
+        var keyName = ResolveKeyName(keyReference);
+        try
+        {
+            var response = await _client
+                .EncryptAsync(keyName, UnsafeByteOperations.UnsafeWrap(keyMaterial), cancellationToken)
+                .ConfigureAwait(false);
+            return CopyAndClearMaterial(response.Ciphertext, "wrap");
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (RpcException ex) when (
+            cancellationToken.IsCancellationRequested && ex.StatusCode == StatusCode.Cancelled)
+        {
+            throw new OperationCanceledException("Google Cloud KMS wrap was canceled.", ex, cancellationToken);
+        }
+        catch (RpcException ex)
+        {
+            throw new SchemaRegistryKmsException("Google Cloud KMS wrap failed.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<byte[]> UnwrapKeyAsync(
+        ReadOnlyMemory<byte> encryptedKeyMaterial,
+        SchemaRegistryKmsKeyReference keyReference,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (encryptedKeyMaterial.IsEmpty)
+        {
+            throw new SchemaRegistryKmsException(
+                "Google Cloud KMS unwrap failed. Encrypted key material cannot be empty.");
+        }
+
+        var keyName = ResolveKeyName(keyReference);
+        try
+        {
+            var response = await _client
+                .DecryptAsync(keyName, UnsafeByteOperations.UnsafeWrap(encryptedKeyMaterial), cancellationToken)
+                .ConfigureAwait(false);
+            return CopyAndClearMaterial(response.Plaintext, "unwrap");
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (RpcException ex) when (
+            cancellationToken.IsCancellationRequested && ex.StatusCode == StatusCode.Cancelled)
+        {
+            throw new OperationCanceledException("Google Cloud KMS unwrap was canceled.", ex, cancellationToken);
+        }
+        catch (RpcException ex)
+        {
+            throw new SchemaRegistryKmsException("Google Cloud KMS unwrap failed.", ex);
+        }
+    }
+
+    private CryptoKeyName ResolveKeyName(SchemaRegistryKmsKeyReference keyReference)
+    {
+        ArgumentNullException.ThrowIfNull(keyReference);
+        if (!string.Equals(Type, keyReference.KmsType, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new SchemaRegistryKmsException(
+                $"Google Cloud KMS provider '{Type}' cannot resolve KMS type '{keyReference.KmsType}'.");
+        }
+
+        var keyId = keyReference.KmsKeyId;
+        if (string.IsNullOrWhiteSpace(keyId))
+            throw new SchemaRegistryKmsException("Google Cloud KMS key identifier cannot be null or whitespace.");
+
+        if (keyId.StartsWith(KeyUriPrefix, StringComparison.OrdinalIgnoreCase))
+            keyId = keyId[KeyUriPrefix.Length..];
+
+        if (!CryptoKeyName.TryParse(keyId, out var keyName))
+        {
+            throw new SchemaRegistryKmsException(
+                "Google Cloud KMS key identifier must use "
+                + "'projects/<project>/locations/<location>/keyRings/<key-ring>/cryptoKeys/<key>'.");
+        }
+
+        return keyName;
+    }
+
+    private static byte[] CopyAndClearMaterial(ByteString material, string operation)
+    {
+        if (material.IsEmpty)
+        {
+            throw new SchemaRegistryKmsException(
+                $"Google Cloud KMS {operation} failed. The service returned no key material.");
+        }
+
+        try
+        {
+            return material.ToByteArray();
+        }
+        finally
+        {
+            if (MemoryMarshal.TryGetArray(material.Memory, out var segment)
+                && segment.Array is not null)
+            {
+                CryptographicOperations.ZeroMemory(segment.Array.AsSpan(segment.Offset, segment.Count));
+            }
+        }
+    }
+}

--- a/src/Dekaf.SchemaRegistry.Kms.Gcp/PublicAPI.Shipped.txt
+++ b/src/Dekaf.SchemaRegistry.Kms.Gcp/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Dekaf.SchemaRegistry.Kms.Gcp/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry.Kms.Gcp/PublicAPI.Unshipped.txt
@@ -1,0 +1,9 @@
+#nullable enable
+Dekaf.SchemaRegistry.Kms.Gcp.GcpKmsProvider
+Dekaf.SchemaRegistry.Kms.Gcp.GcpKmsProvider.GcpKmsProvider() -> void
+Dekaf.SchemaRegistry.Kms.Gcp.GcpKmsProvider.GcpKmsProvider(Google.Cloud.Kms.V1.KeyManagementServiceClient! client, string! type = "gcp-kms") -> void
+Dekaf.SchemaRegistry.Kms.Gcp.GcpKmsProvider.Type.get -> string!
+Dekaf.SchemaRegistry.Kms.Gcp.GcpKmsProvider.UnwrapKeyAsync(System.ReadOnlyMemory<byte> encryptedKeyMaterial, Dekaf.SchemaRegistry.SchemaRegistryKmsKeyReference! keyReference, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
+Dekaf.SchemaRegistry.Kms.Gcp.GcpKmsProvider.WrapKeyAsync(System.ReadOnlyMemory<byte> keyMaterial, Dekaf.SchemaRegistry.SchemaRegistryKmsKeyReference! keyReference, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
+const Dekaf.SchemaRegistry.Kms.Gcp.GcpKmsProvider.DefaultType = "gcp-kms" -> string!
+const Dekaf.SchemaRegistry.Kms.Gcp.GcpKmsProvider.KeyUriPrefix = "gcp-kms://" -> string!

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\..\src\Dekaf\Dekaf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Snappy\Dekaf.Compression.Snappy.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Gcp\Dekaf.SchemaRegistry.Kms.Gcp.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Json\Dekaf.SchemaRegistry.Json.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Lz4\Dekaf.Compression.Lz4.csproj" />

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/GcpKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/GcpKmsProviderTests.cs
@@ -1,6 +1,7 @@
 using Google.Cloud.Kms.V1;
 using Google.Protobuf;
 using Grpc.Core;
+using Dekaf.Protocol.Records;
 using Dekaf.SchemaRegistry;
 using Dekaf.SchemaRegistry.Kms.Gcp;
 using NSubstitute;
@@ -11,30 +12,33 @@ public class GcpKmsProviderTests
 {
     private const string KeyResourceName =
         "projects/payments/locations/europe-west2/keyRings/orders/cryptoKeys/kek";
+    private const string KeyVersionResourceName = KeyResourceName + "/cryptoKeyVersions/1";
 
     [Test]
     public async Task WrapAndUnwrap_UseConfiguredCryptoKey()
     {
         var client = Substitute.For<KeyManagementServiceClient>();
-        ByteString? plaintext = null;
-        ByteString? ciphertext = null;
+        EncryptRequest? encryptRequest = null;
+        DecryptRequest? decryptRequest = null;
         var ciphertextResponseBuffer = new byte[] { 4, 5, 6 };
         var plaintextResponseBuffer = new byte[] { 1, 2, 3 };
         client.EncryptAsync(
-                Arg.Any<CryptoKeyName>(),
-                Arg.Do<ByteString>(value => plaintext = value),
+                Arg.Do<EncryptRequest>(value => encryptRequest = value),
                 Arg.Any<CancellationToken>())
             .Returns(new EncryptResponse
             {
-                Ciphertext = UnsafeByteOperations.UnsafeWrap(ciphertextResponseBuffer)
+                Name = KeyVersionResourceName,
+                Ciphertext = UnsafeByteOperations.UnsafeWrap(ciphertextResponseBuffer),
+                CiphertextCrc32C = Crc32C.Compute(ciphertextResponseBuffer),
+                VerifiedPlaintextCrc32C = true
             });
         client.DecryptAsync(
-                Arg.Any<CryptoKeyName>(),
-                Arg.Do<ByteString>(value => ciphertext = value),
+                Arg.Do<DecryptRequest>(value => decryptRequest = value),
                 Arg.Any<CancellationToken>())
             .Returns(new DecryptResponse
             {
-                Plaintext = UnsafeByteOperations.UnsafeWrap(plaintextResponseBuffer)
+                Plaintext = UnsafeByteOperations.UnsafeWrap(plaintextResponseBuffer),
+                PlaintextCrc32C = Crc32C.Compute(plaintextResponseBuffer)
             });
         var provider = new GcpKmsProvider(client);
 
@@ -43,17 +47,19 @@ public class GcpKmsProviderTests
 
         await Assert.That(encrypted).IsEquivalentTo(new byte[] { 4, 5, 6 });
         await Assert.That(decrypted).IsEquivalentTo(new byte[] { 1, 2, 3 });
-        await Assert.That(plaintext!.ToByteArray()).IsEquivalentTo(new byte[] { 1, 2, 3 });
-        await Assert.That(ciphertext!.ToByteArray()).IsEquivalentTo(new byte[] { 4, 5, 6 });
+        await Assert.That(encryptRequest!.Name).IsEqualTo(KeyResourceName);
+        await Assert.That(encryptRequest.Plaintext.ToByteArray()).IsEquivalentTo(new byte[] { 1, 2, 3 });
+        await Assert.That(encryptRequest.PlaintextCrc32C).IsEqualTo(Crc32C.Compute([1, 2, 3]));
+        await Assert.That(decryptRequest!.Name).IsEqualTo(KeyResourceName);
+        await Assert.That(decryptRequest.Ciphertext.ToByteArray()).IsEquivalentTo(new byte[] { 4, 5, 6 });
+        await Assert.That(decryptRequest.CiphertextCrc32C).IsEqualTo(Crc32C.Compute([4, 5, 6]));
         await Assert.That(ciphertextResponseBuffer).IsEquivalentTo(new byte[] { 0, 0, 0 });
         await Assert.That(plaintextResponseBuffer).IsEquivalentTo(new byte[] { 0, 0, 0 });
         await client.Received(1).EncryptAsync(
-            CryptoKeyName.Parse(KeyResourceName),
-            Arg.Any<ByteString>(),
+            Arg.Any<EncryptRequest>(),
             Arg.Any<CancellationToken>());
         await client.Received(1).DecryptAsync(
-            CryptoKeyName.Parse(KeyResourceName),
-            Arg.Any<ByteString>(),
+            Arg.Any<DecryptRequest>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -63,23 +69,116 @@ public class GcpKmsProviderTests
     public async Task KeyReference_AcceptsRawResourceOrProviderUri(string keyId)
     {
         var client = Substitute.For<KeyManagementServiceClient>();
-        client.EncryptAsync(Arg.Any<CryptoKeyName>(), Arg.Any<ByteString>(), Arg.Any<CancellationToken>())
-            .Returns(new EncryptResponse { Ciphertext = ByteString.CopyFrom([9]) });
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new EncryptResponse
+            {
+                Name = KeyVersionResourceName,
+                Ciphertext = ByteString.CopyFrom([9]),
+                CiphertextCrc32C = Crc32C.Compute([9]),
+                VerifiedPlaintextCrc32C = true
+            });
         var provider = new GcpKmsProvider(client);
 
         await provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference(keyId));
 
         await client.Received(1).EncryptAsync(
-            CryptoKeyName.Parse(KeyResourceName),
-            Arg.Any<ByteString>(),
+            Arg.Is<EncryptRequest>(request => request.Name == KeyResourceName),
             Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Wrap_UnverifiedRequestIntegrity_IsRejectedAndResponseIsCleared()
+    {
+        var client = Substitute.For<KeyManagementServiceClient>();
+        var responseBuffer = new byte[] { 4, 5, 6 };
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new EncryptResponse
+            {
+                Name = KeyVersionResourceName,
+                Ciphertext = UnsafeByteOperations.UnsafeWrap(responseBuffer),
+                CiphertextCrc32C = Crc32C.Compute(responseBuffer),
+                VerifiedPlaintextCrc32C = false
+            });
+        var provider = new GcpKmsProvider(client);
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            () => provider.WrapKeyAsync(new byte[] { 1, 2, 3 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).Contains("request integrity");
+        await Assert.That(responseBuffer).IsEquivalentTo(new byte[] { 0, 0, 0 });
+    }
+
+    [Test]
+    [Arguments(null)]
+    [Arguments(0L)]
+    public async Task Wrap_InvalidResponseChecksum_IsRejectedAndResponseIsCleared(long? responseCrc32C)
+    {
+        var client = Substitute.For<KeyManagementServiceClient>();
+        var responseBuffer = new byte[] { 4, 5, 6 };
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new EncryptResponse
+            {
+                Name = KeyVersionResourceName,
+                Ciphertext = UnsafeByteOperations.UnsafeWrap(responseBuffer),
+                CiphertextCrc32C = responseCrc32C,
+                VerifiedPlaintextCrc32C = true
+            });
+        var provider = new GcpKmsProvider(client);
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            () => provider.WrapKeyAsync(new byte[] { 1, 2, 3 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).Contains("Response integrity");
+        await Assert.That(responseBuffer).IsEquivalentTo(new byte[] { 0, 0, 0 });
+    }
+
+    [Test]
+    public async Task Wrap_UnexpectedKeyVersion_IsRejectedAndResponseIsCleared()
+    {
+        var client = Substitute.For<KeyManagementServiceClient>();
+        var responseBuffer = new byte[] { 4, 5, 6 };
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new EncryptResponse
+            {
+                Name = "projects/other/locations/europe-west2/keyRings/orders/cryptoKeys/kek/cryptoKeyVersions/1",
+                Ciphertext = UnsafeByteOperations.UnsafeWrap(responseBuffer),
+                CiphertextCrc32C = Crc32C.Compute(responseBuffer),
+                VerifiedPlaintextCrc32C = true
+            });
+        var provider = new GcpKmsProvider(client);
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            () => provider.WrapKeyAsync(new byte[] { 1, 2, 3 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).Contains("unexpected key version");
+        await Assert.That(responseBuffer).IsEquivalentTo(new byte[] { 0, 0, 0 });
+    }
+
+    [Test]
+    public async Task Unwrap_CorruptResponse_IsRejectedAndResponseIsCleared()
+    {
+        var client = Substitute.For<KeyManagementServiceClient>();
+        var responseBuffer = new byte[] { 1, 2, 3 };
+        client.DecryptAsync(Arg.Any<DecryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new DecryptResponse
+            {
+                Plaintext = UnsafeByteOperations.UnsafeWrap(responseBuffer),
+                PlaintextCrc32C = 0
+            });
+        var provider = new GcpKmsProvider(client);
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            () => provider.UnwrapKeyAsync(new byte[] { 4, 5, 6 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).Contains("Response integrity");
+        await Assert.That(responseBuffer).IsEquivalentTo(new byte[] { 0, 0, 0 });
     }
 
     [Test]
     public async Task WrongKey_IsReportedWithoutProviderResponse()
     {
         var client = Substitute.For<KeyManagementServiceClient>();
-        client.DecryptAsync(Arg.Any<CryptoKeyName>(), Arg.Any<ByteString>(), Arg.Any<CancellationToken>())
+        client.DecryptAsync(Arg.Any<DecryptRequest>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<DecryptResponse>(CreateRpcException(StatusCode.NotFound, "wrong key")));
         var provider = new GcpKmsProvider(client);
 
@@ -95,7 +194,7 @@ public class GcpKmsProviderTests
     {
         var client = Substitute.For<KeyManagementServiceClient>();
         var denied = CreateRpcException(StatusCode.PermissionDenied, "authorization: sensitive");
-        client.EncryptAsync(Arg.Any<CryptoKeyName>(), Arg.Any<ByteString>(), Arg.Any<CancellationToken>())
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<EncryptResponse>(denied));
         var provider = new GcpKmsProvider(client);
 
@@ -104,14 +203,15 @@ public class GcpKmsProviderTests
 
         await Assert.That(exception!.Message).IsEqualTo("Google Cloud KMS wrap failed.");
         await Assert.That(exception.Message).DoesNotContain("sensitive");
-        await Assert.That(exception.InnerException).IsSameReferenceAs(denied);
+        await Assert.That(exception.InnerException).IsNull();
+        await Assert.That(exception.ToString()).DoesNotContain("sensitive");
     }
 
     [Test]
     public async Task MalformedCiphertext_IsReportedWithoutProviderResponse()
     {
         var client = Substitute.For<KeyManagementServiceClient>();
-        client.DecryptAsync(Arg.Any<CryptoKeyName>(), Arg.Any<ByteString>(), Arg.Any<CancellationToken>())
+        client.DecryptAsync(Arg.Any<DecryptRequest>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<DecryptResponse>(
                 CreateRpcException(StatusCode.InvalidArgument, "ciphertext: sensitive")));
         var provider = new GcpKmsProvider(client);
@@ -127,7 +227,7 @@ public class GcpKmsProviderTests
     public async Task Cancellation_IsPropagatedToInFlightGcpCall()
     {
         var client = Substitute.For<KeyManagementServiceClient>();
-        client.EncryptAsync(Arg.Any<CryptoKeyName>(), Arg.Any<ByteString>(), Arg.Any<CancellationToken>())
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
             .Returns(call => WaitForCancellationAsync(call.Arg<CancellationToken>()));
         var provider = new GcpKmsProvider(client);
         using var cancellation = new CancellationTokenSource();
@@ -137,8 +237,7 @@ public class GcpKmsProviderTests
 
         await Assert.That(async () => await operation).Throws<OperationCanceledException>();
         await client.Received(1).EncryptAsync(
-            CryptoKeyName.Parse(KeyResourceName),
-            Arg.Any<ByteString>(),
+            Arg.Any<EncryptRequest>(),
             cancellation.Token);
     }
 
@@ -147,7 +246,7 @@ public class GcpKmsProviderTests
     {
         var completion = new TaskCompletionSource<EncryptResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
         var client = Substitute.For<KeyManagementServiceClient>();
-        client.EncryptAsync(Arg.Any<CryptoKeyName>(), Arg.Any<ByteString>(), Arg.Any<CancellationToken>())
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
             .Returns(completion.Task);
         var provider = new GcpKmsProvider(client);
         using var cancellation = new CancellationTokenSource();
@@ -164,8 +263,8 @@ public class GcpKmsProviderTests
     public async Task SharedProvider_UsesClientConcurrently()
     {
         var client = Substitute.For<KeyManagementServiceClient>();
-        client.EncryptAsync(Arg.Any<CryptoKeyName>(), Arg.Any<ByteString>(), Arg.Any<CancellationToken>())
-            .Returns(call => EchoAfterYieldAsync(call.Arg<ByteString>()));
+        client.EncryptAsync(Arg.Any<EncryptRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => EchoAfterYieldAsync(call.Arg<EncryptRequest>()));
         var provider = new GcpKmsProvider(client);
 
         var operations = Enumerable.Range(1, 32)
@@ -176,8 +275,7 @@ public class GcpKmsProviderTests
         for (var index = 0; index < results.Length; index++)
             await Assert.That(results[index]).IsEquivalentTo(new byte[] { (byte)(index + 1) });
         await client.Received(32).EncryptAsync(
-            CryptoKeyName.Parse(KeyResourceName),
-            Arg.Any<ByteString>(),
+            Arg.Any<EncryptRequest>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -192,8 +290,7 @@ public class GcpKmsProviderTests
             .Throws<SchemaRegistryKmsException>();
         await client.DidNotReceive()
             .EncryptAsync(
-                Arg.Any<CryptoKeyName>(),
-                Arg.Any<ByteString>(),
+                Arg.Any<EncryptRequest>(),
                 Arg.Any<CancellationToken>());
     }
 
@@ -212,9 +309,15 @@ public class GcpKmsProviderTests
         throw new InvalidOperationException("Cancellation was not observed.");
     }
 
-    private static async Task<EncryptResponse> EchoAfterYieldAsync(ByteString plaintext)
+    private static async Task<EncryptResponse> EchoAfterYieldAsync(EncryptRequest request)
     {
         await Task.Yield();
-        return new EncryptResponse { Ciphertext = ByteString.CopyFrom(plaintext.Span) };
+        return new EncryptResponse
+        {
+            Name = KeyVersionResourceName,
+            Ciphertext = ByteString.CopyFrom(request.Plaintext.Span),
+            CiphertextCrc32C = request.PlaintextCrc32C,
+            VerifiedPlaintextCrc32C = true
+        };
     }
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/GcpKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/GcpKmsProviderTests.cs
@@ -1,0 +1,220 @@
+using Google.Cloud.Kms.V1;
+using Google.Protobuf;
+using Grpc.Core;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Kms.Gcp;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public class GcpKmsProviderTests
+{
+    private const string KeyResourceName =
+        "projects/payments/locations/europe-west2/keyRings/orders/cryptoKeys/kek";
+
+    [Test]
+    public async Task WrapAndUnwrap_UseConfiguredCryptoKey()
+    {
+        var client = Substitute.For<KeyManagementServiceClient>();
+        ByteString? plaintext = null;
+        ByteString? ciphertext = null;
+        var ciphertextResponseBuffer = new byte[] { 4, 5, 6 };
+        var plaintextResponseBuffer = new byte[] { 1, 2, 3 };
+        client.EncryptAsync(
+                Arg.Any<CryptoKeyName>(),
+                Arg.Do<ByteString>(value => plaintext = value),
+                Arg.Any<CancellationToken>())
+            .Returns(new EncryptResponse
+            {
+                Ciphertext = UnsafeByteOperations.UnsafeWrap(ciphertextResponseBuffer)
+            });
+        client.DecryptAsync(
+                Arg.Any<CryptoKeyName>(),
+                Arg.Do<ByteString>(value => ciphertext = value),
+                Arg.Any<CancellationToken>())
+            .Returns(new DecryptResponse
+            {
+                Plaintext = UnsafeByteOperations.UnsafeWrap(plaintextResponseBuffer)
+            });
+        var provider = new GcpKmsProvider(client);
+
+        var encrypted = await provider.WrapKeyAsync(new byte[] { 1, 2, 3 }, CreateKeyReference());
+        var decrypted = await provider.UnwrapKeyAsync(encrypted, CreateKeyReference());
+
+        await Assert.That(encrypted).IsEquivalentTo(new byte[] { 4, 5, 6 });
+        await Assert.That(decrypted).IsEquivalentTo(new byte[] { 1, 2, 3 });
+        await Assert.That(plaintext!.ToByteArray()).IsEquivalentTo(new byte[] { 1, 2, 3 });
+        await Assert.That(ciphertext!.ToByteArray()).IsEquivalentTo(new byte[] { 4, 5, 6 });
+        await Assert.That(ciphertextResponseBuffer).IsEquivalentTo(new byte[] { 0, 0, 0 });
+        await Assert.That(plaintextResponseBuffer).IsEquivalentTo(new byte[] { 0, 0, 0 });
+        await client.Received(1).EncryptAsync(
+            CryptoKeyName.Parse(KeyResourceName),
+            Arg.Any<ByteString>(),
+            Arg.Any<CancellationToken>());
+        await client.Received(1).DecryptAsync(
+            CryptoKeyName.Parse(KeyResourceName),
+            Arg.Any<ByteString>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    [Arguments(KeyResourceName)]
+    [Arguments(GcpKmsProvider.KeyUriPrefix + KeyResourceName)]
+    public async Task KeyReference_AcceptsRawResourceOrProviderUri(string keyId)
+    {
+        var client = Substitute.For<KeyManagementServiceClient>();
+        client.EncryptAsync(Arg.Any<CryptoKeyName>(), Arg.Any<ByteString>(), Arg.Any<CancellationToken>())
+            .Returns(new EncryptResponse { Ciphertext = ByteString.CopyFrom([9]) });
+        var provider = new GcpKmsProvider(client);
+
+        await provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference(keyId));
+
+        await client.Received(1).EncryptAsync(
+            CryptoKeyName.Parse(KeyResourceName),
+            Arg.Any<ByteString>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task WrongKey_IsReportedWithoutProviderResponse()
+    {
+        var client = Substitute.For<KeyManagementServiceClient>();
+        client.DecryptAsync(Arg.Any<CryptoKeyName>(), Arg.Any<ByteString>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<DecryptResponse>(CreateRpcException(StatusCode.NotFound, "wrong key")));
+        var provider = new GcpKmsProvider(client);
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            () => provider.UnwrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).IsEqualTo("Google Cloud KMS unwrap failed.");
+        await Assert.That(exception.Message).DoesNotContain("wrong key");
+    }
+
+    [Test]
+    public async Task AuthorizationFailure_IsReportedWithoutProviderResponse()
+    {
+        var client = Substitute.For<KeyManagementServiceClient>();
+        var denied = CreateRpcException(StatusCode.PermissionDenied, "authorization: sensitive");
+        client.EncryptAsync(Arg.Any<CryptoKeyName>(), Arg.Any<ByteString>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<EncryptResponse>(denied));
+        var provider = new GcpKmsProvider(client);
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            () => provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).IsEqualTo("Google Cloud KMS wrap failed.");
+        await Assert.That(exception.Message).DoesNotContain("sensitive");
+        await Assert.That(exception.InnerException).IsSameReferenceAs(denied);
+    }
+
+    [Test]
+    public async Task MalformedCiphertext_IsReportedWithoutProviderResponse()
+    {
+        var client = Substitute.For<KeyManagementServiceClient>();
+        client.DecryptAsync(Arg.Any<CryptoKeyName>(), Arg.Any<ByteString>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<DecryptResponse>(
+                CreateRpcException(StatusCode.InvalidArgument, "ciphertext: sensitive")));
+        var provider = new GcpKmsProvider(client);
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            () => provider.UnwrapKeyAsync(new byte[] { 1 }, CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).IsEqualTo("Google Cloud KMS unwrap failed.");
+        await Assert.That(exception.Message).DoesNotContain("sensitive");
+    }
+
+    [Test]
+    public async Task Cancellation_IsPropagatedToInFlightGcpCall()
+    {
+        var client = Substitute.For<KeyManagementServiceClient>();
+        client.EncryptAsync(Arg.Any<CryptoKeyName>(), Arg.Any<ByteString>(), Arg.Any<CancellationToken>())
+            .Returns(call => WaitForCancellationAsync(call.Arg<CancellationToken>()));
+        var provider = new GcpKmsProvider(client);
+        using var cancellation = new CancellationTokenSource();
+        var operation = provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference(), cancellation.Token).AsTask();
+
+        cancellation.Cancel();
+
+        await Assert.That(async () => await operation).Throws<OperationCanceledException>();
+        await client.Received(1).EncryptAsync(
+            CryptoKeyName.Parse(KeyResourceName),
+            Arg.Any<ByteString>(),
+            cancellation.Token);
+    }
+
+    [Test]
+    public async Task RpcCancellation_IsTranslatedWhenCallerTokenIsCanceled()
+    {
+        var completion = new TaskCompletionSource<EncryptResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = Substitute.For<KeyManagementServiceClient>();
+        client.EncryptAsync(Arg.Any<CryptoKeyName>(), Arg.Any<ByteString>(), Arg.Any<CancellationToken>())
+            .Returns(completion.Task);
+        var provider = new GcpKmsProvider(client);
+        using var cancellation = new CancellationTokenSource();
+        var operation = provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference(), cancellation.Token).AsTask();
+
+        cancellation.Cancel();
+        completion.SetException(CreateRpcException(StatusCode.Cancelled, "canceled"));
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(() => operation);
+        await Assert.That(exception!.CancellationToken).IsEqualTo(cancellation.Token);
+    }
+
+    [Test]
+    public async Task SharedProvider_UsesClientConcurrently()
+    {
+        var client = Substitute.For<KeyManagementServiceClient>();
+        client.EncryptAsync(Arg.Any<CryptoKeyName>(), Arg.Any<ByteString>(), Arg.Any<CancellationToken>())
+            .Returns(call => EchoAfterYieldAsync(call.Arg<ByteString>()));
+        var provider = new GcpKmsProvider(client);
+
+        var operations = Enumerable.Range(1, 32)
+            .Select(value => provider.WrapKeyAsync(new byte[] { (byte)value }, CreateKeyReference()).AsTask())
+            .ToArray();
+        var results = await Task.WhenAll(operations);
+
+        for (var index = 0; index < results.Length; index++)
+            await Assert.That(results[index]).IsEquivalentTo(new byte[] { (byte)(index + 1) });
+        await client.Received(32).EncryptAsync(
+            CryptoKeyName.Parse(KeyResourceName),
+            Arg.Any<ByteString>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task InvalidResourceName_IsRejectedBeforeGcpCall()
+    {
+        var client = Substitute.For<KeyManagementServiceClient>();
+        var provider = new GcpKmsProvider(client);
+        var reference = CreateKeyReference("projects/payments/locations/europe-west2/keyRings/orders");
+
+        await Assert.That(async () => await provider.WrapKeyAsync(new byte[] { 1 }, reference))
+            .Throws<SchemaRegistryKmsException>();
+        await client.DidNotReceive()
+            .EncryptAsync(
+                Arg.Any<CryptoKeyName>(),
+                Arg.Any<ByteString>(),
+                Arg.Any<CancellationToken>());
+    }
+
+    private static SchemaRegistryKmsKeyReference CreateKeyReference(string keyId = KeyResourceName) => new()
+    {
+        KmsType = GcpKmsProvider.DefaultType,
+        KmsKeyId = keyId
+    };
+
+    private static RpcException CreateRpcException(StatusCode statusCode, string detail) =>
+        new(new Status(statusCode, detail));
+
+    private static async Task<EncryptResponse> WaitForCancellationAsync(CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        throw new InvalidOperationException("Cancellation was not observed.");
+    }
+
+    private static async Task<EncryptResponse> EchoAfterYieldAsync(ByteString plaintext)
+    {
+        await Task.Yield();
+        return new EncryptResponse { Ciphertext = ByteString.CopyFrom(plaintext.Span) };
+    }
+}


### PR DESCRIPTION
Closes #2703

## Summary
- add opt-in `Dekaf.SchemaRegistry.Kms.Gcp` package using Google Cloud KMS
- support `gcp-kms` resource references, Application Default Credentials, and injected `KeyManagementServiceClient` instances for endpoints/credentials/testing
- validate CryptoKey resource names, sanitize gRPC failures, forward and translate cancellation, and safely share one immutable client
- avoid plaintext input copies and zero SDK response buffers after copy-out
- document setup, resource names, regional endpoints, ADC, IAM, cancellation, and concurrency

## Validation
- `dotnet build Dekaf.sln --configuration Release --no-restore` (0 warnings, 0 errors)
- `dotnet pack src/Dekaf.SchemaRegistry.Kms.Gcp/Dekaf.SchemaRegistry.Kms.Gcp.csproj --configuration Release --no-build`
- unit tests net10.0: 6,883 passed
- unit tests net8.0: 6,747 passed
- focused GCP provider tests: 10 passed per framework

## Performance
No existing runtime or hot path changes. Google SDK dependencies are isolated in the opt-in package; wrap/unwrap occurs at remote DEK operations. No benchmark lane is applicable.