### PR TITLE
feat(schema-registry): add Vault Transit KMS provider

### DIFF
--- a/Dekaf.sln
+++ b/Dekaf.sln
@@ -73,6 +73,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.Serialization.Routing
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.SchemaRegistry.Kms.Gcp", "src\Dekaf.SchemaRegistry.Kms.Gcp\Dekaf.SchemaRegistry.Kms.Gcp.csproj", "{52043965-88BE-40BE-B801-70A13249AAE8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.SchemaRegistry.Kms.Vault", "src\Dekaf.SchemaRegistry.Kms.Vault\Dekaf.SchemaRegistry.Kms.Vault.csproj", "{170E0071-44E4-4D9B-AB44-4B324DE007F1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -455,6 +457,18 @@ Global
 		{52043965-88BE-40BE-B801-70A13249AAE8}.Release|x64.Build.0 = Release|Any CPU
 		{52043965-88BE-40BE-B801-70A13249AAE8}.Release|x86.ActiveCfg = Release|Any CPU
 		{52043965-88BE-40BE-B801-70A13249AAE8}.Release|x86.Build.0 = Release|Any CPU
+		{170E0071-44E4-4D9B-AB44-4B324DE007F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{170E0071-44E4-4D9B-AB44-4B324DE007F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{170E0071-44E4-4D9B-AB44-4B324DE007F1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{170E0071-44E4-4D9B-AB44-4B324DE007F1}.Debug|x64.Build.0 = Debug|Any CPU
+		{170E0071-44E4-4D9B-AB44-4B324DE007F1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{170E0071-44E4-4D9B-AB44-4B324DE007F1}.Debug|x86.Build.0 = Debug|Any CPU
+		{170E0071-44E4-4D9B-AB44-4B324DE007F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{170E0071-44E4-4D9B-AB44-4B324DE007F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{170E0071-44E4-4D9B-AB44-4B324DE007F1}.Release|x64.ActiveCfg = Release|Any CPU
+		{170E0071-44E4-4D9B-AB44-4B324DE007F1}.Release|x64.Build.0 = Release|Any CPU
+		{170E0071-44E4-4D9B-AB44-4B324DE007F1}.Release|x86.ActiveCfg = Release|Any CPU
+		{170E0071-44E4-4D9B-AB44-4B324DE007F1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -491,5 +505,6 @@ Global
 		{50CD7D4E-24BC-4CA1-A183-1257129A66DE} = {B2C3D4E5-F6A7-8901-BCDE-F12345678901}
 		{9AF82E67-E0BD-42A2-9539-AA72FB845FEE} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{52043965-88BE-40BE-B801-70A13249AAE8} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{170E0071-44E4-4D9B-AB44-4B324DE007F1} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 	EndGlobalSection
 EndGlobal

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -350,7 +350,8 @@ Use KMS type `hcvault` and a Confluent-compatible key identifier in
 and `orders-kek` as the key name. For nested mounts, use a path such as
 `https://vault.example:8200/team/transit/keys/orders-kek`. The key identifier's scheme, host, and
 port must exactly match the locally configured `vaultAddress`; this prevents a Schema Registry KEK
-from redirecting Vault credentials to another server. The namespace is sent as `X-Vault-Namespace`.
+from redirecting Vault credentials to another server. Configure `vaultAddress` as a root authority
+without a path prefix. The namespace is sent as `X-Vault-Namespace`.
 
 Grant `update` capability on `<mount>/encrypt/<key>` and `<mount>/decrypt/<key>`. The supplied
 `HttpClient` is caller-owned; `VaultTransitHttpClient`, `VaultKmsProvider`, and both token providers

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -328,7 +328,7 @@ var tokenProvider = new VaultStaticTokenProvider(
 var transitClient = new VaultTransitHttpClient(httpClient, tokenProvider);
 var vaultKms = new VaultKmsProvider(
     transitClient,
-    mountPoint: "transit",
+    vaultAddress: new Uri("https://vault.example:8200"),
     vaultNamespace: Environment.GetEnvironmentVariable("VAULT_NAMESPACE"));
 var csfle = new SchemaRegistryCsfleRuleHandler(schemaRegistry, [vaultKms]);
 ```
@@ -344,17 +344,21 @@ var tokenProvider = new VaultAppRoleTokenProvider(
     authMountPoint: "approle");
 ```
 
-Use KMS type `hcvault` and a Confluent-compatible key identifier containing the Vault address and
-Transit key name, for example `hcvault://https://vault.example:8200/orders-kek`. The URL must contain
-exactly one path segment: the address is `https://vault.example:8200`, while `orders-kek` is the key.
-Configure a non-default Transit mount on `VaultKmsProvider`; the namespace is sent as
-`X-Vault-Namespace`.
+Use KMS type `hcvault` and a Confluent-compatible key identifier in
+`https://<vault-address>/<mount>/keys/<key-name>` format, for example
+`https://vault.example:8200/transit/keys/orders-kek`. The provider extracts `transit` as the mount
+and `orders-kek` as the key name. For nested mounts, use a path such as
+`https://vault.example:8200/team/transit/keys/orders-kek`. The key identifier's scheme, host, and
+port must exactly match the locally configured `vaultAddress`; this prevents a Schema Registry KEK
+from redirecting Vault credentials to another server. The namespace is sent as `X-Vault-Namespace`.
 
 Grant `update` capability on `<mount>/encrypt/<key>` and `<mount>/decrypt/<key>`. The supplied
 `HttpClient` is caller-owned; `VaultTransitHttpClient`, `VaultKmsProvider`, and both token providers
 are safe for concurrent use. Cancellation reaches AppRole login and Transit HTTP requests. Errors
 omit Vault response bodies, key material, ciphertext, role IDs, secret IDs, and tokens. Serialized
-request/response buffers are zeroed before release.
+request/response buffers are zeroed before release. Credential and returned-token strings remain
+managed .NET strings and cannot be zeroed; source them from a secret-delivery mechanism and limit
+their lifetime accordingly.
 
 ## Consumer
 

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -306,6 +306,56 @@ Grant the runtime identity `cloudkms.cryptoKeyVersions.useToEncrypt` and
 Decrypter role. Cancellation is forwarded to the gRPC call. Provider errors omit service response
 text and key material, and temporary SDK plaintext buffers are cleared after copy-out.
 
+## HashiCorp Vault Transit KMS
+
+Install the opt-in Vault provider when Schema Registry client-side field-level encryption (CSFLE)
+uses a Transit secrets-engine key:
+
+```bash
+dotnet add package Dekaf.SchemaRegistry.Kms.Vault
+```
+
+For token authentication, create one shared `HttpClient` and read the token from your secret-delivery
+mechanism, such as `VAULT_TOKEN` or a Vault Agent sink:
+
+```csharp
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Kms.Vault;
+
+var httpClient = new HttpClient();
+var tokenProvider = new VaultStaticTokenProvider(
+    Environment.GetEnvironmentVariable("VAULT_TOKEN")!);
+var transitClient = new VaultTransitHttpClient(httpClient, tokenProvider);
+var vaultKms = new VaultKmsProvider(
+    transitClient,
+    mountPoint: "transit",
+    vaultNamespace: Environment.GetEnvironmentVariable("VAULT_NAMESPACE"));
+var csfle = new SchemaRegistryCsfleRuleHandler(schemaRegistry, [vaultKms]);
+```
+
+For AppRole, replace the token provider. The provider logs in through the configured auth mount and
+caches each address/namespace token until shortly before its lease expires:
+
+```csharp
+var tokenProvider = new VaultAppRoleTokenProvider(
+    httpClient,
+    roleId: Environment.GetEnvironmentVariable("VAULT_APPROLE_ROLE_ID")!,
+    secretId: Environment.GetEnvironmentVariable("VAULT_APPROLE_SECRET_ID")!,
+    authMountPoint: "approle");
+```
+
+Use KMS type `hcvault` and a Confluent-compatible key identifier containing the Vault address and
+Transit key name, for example `hcvault://https://vault.example:8200/orders-kek`. The URL must contain
+exactly one path segment: the address is `https://vault.example:8200`, while `orders-kek` is the key.
+Configure a non-default Transit mount on `VaultKmsProvider`; the namespace is sent as
+`X-Vault-Namespace`.
+
+Grant `update` capability on `<mount>/encrypt/<key>` and `<mount>/decrypt/<key>`. The supplied
+`HttpClient` is caller-owned; `VaultTransitHttpClient`, `VaultKmsProvider`, and both token providers
+are safe for concurrent use. Cancellation reaches AppRole login and Transit HTTP requests. Errors
+omit Vault response bodies, key material, ciphertext, role IDs, secret IDs, and tokens. Serialized
+request/response buffers are zeroed before release.
+
 ## Consumer
 
 ```csharp

--- a/src/Dekaf.SchemaRegistry.Kms.Vault/Dekaf.SchemaRegistry.Kms.Vault.csproj
+++ b/src/Dekaf.SchemaRegistry.Kms.Vault/Dekaf.SchemaRegistry.Kms.Vault.csproj
@@ -11,4 +11,8 @@
     <ProjectReference Include="..\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Dekaf.Tests.Unit" />
+  </ItemGroup>
+
 </Project>

--- a/src/Dekaf.SchemaRegistry.Kms.Vault/Dekaf.SchemaRegistry.Kms.Vault.csproj
+++ b/src/Dekaf.SchemaRegistry.Kms.Vault/Dekaf.SchemaRegistry.Kms.Vault.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Dekaf.SchemaRegistry.Kms.Vault</PackageId>
+    <Description>HashiCorp Vault Transit provider for Dekaf Schema Registry client-side field-level encryption</Description>
+    <PackageTags>kafka;schema-registry;encryption;hashicorp;vault;transit</PackageTags>
+    <PackageValidationBaselineVersion></PackageValidationBaselineVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Dekaf.SchemaRegistry.Kms.Vault/PublicAPI.Shipped.txt
+++ b/src/Dekaf.SchemaRegistry.Kms.Vault/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Dekaf.SchemaRegistry.Kms.Vault/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry.Kms.Vault/PublicAPI.Unshipped.txt
@@ -10,7 +10,7 @@ Dekaf.SchemaRegistry.Kms.Vault.VaultAppRoleTokenProvider.VaultAppRoleTokenProvid
 Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider
 Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider.Type.get -> string!
 Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider.UnwrapKeyAsync(System.ReadOnlyMemory<byte> encryptedKeyMaterial, Dekaf.SchemaRegistry.SchemaRegistryKmsKeyReference! keyReference, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
-Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider.VaultKmsProvider(Dekaf.SchemaRegistry.Kms.Vault.IVaultTransitClient! client, string! mountPoint = "transit", string? vaultNamespace = null, string! type = "hcvault") -> void
+Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider.VaultKmsProvider(Dekaf.SchemaRegistry.Kms.Vault.IVaultTransitClient! client, System.Uri! vaultAddress, string? vaultNamespace = null, string! type = "hcvault") -> void
 Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider.WrapKeyAsync(System.ReadOnlyMemory<byte> keyMaterial, Dekaf.SchemaRegistry.SchemaRegistryKmsKeyReference! keyReference, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
 Dekaf.SchemaRegistry.Kms.Vault.VaultStaticTokenProvider
 Dekaf.SchemaRegistry.Kms.Vault.VaultStaticTokenProvider.GetTokenAsync(System.Uri! vaultAddress, string? vaultNamespace, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<string!>
@@ -19,6 +19,4 @@ Dekaf.SchemaRegistry.Kms.Vault.VaultTransitHttpClient
 Dekaf.SchemaRegistry.Kms.Vault.VaultTransitHttpClient.DecryptAsync(System.Uri! vaultAddress, string! mountPoint, string! keyName, string? vaultNamespace, System.ReadOnlyMemory<byte> ciphertext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
 Dekaf.SchemaRegistry.Kms.Vault.VaultTransitHttpClient.EncryptAsync(System.Uri! vaultAddress, string! mountPoint, string! keyName, string? vaultNamespace, System.ReadOnlyMemory<byte> plaintext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
 Dekaf.SchemaRegistry.Kms.Vault.VaultTransitHttpClient.VaultTransitHttpClient(System.Net.Http.HttpClient! httpClient, Dekaf.SchemaRegistry.Kms.Vault.IVaultTokenProvider! tokenProvider) -> void
-const Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider.DefaultMountPoint = "transit" -> string!
 const Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider.DefaultType = "hcvault" -> string!
-const Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider.KeyUriPrefix = "hcvault://" -> string!

--- a/src/Dekaf.SchemaRegistry.Kms.Vault/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry.Kms.Vault/PublicAPI.Unshipped.txt
@@ -1,0 +1,24 @@
+#nullable enable
+Dekaf.SchemaRegistry.Kms.Vault.IVaultTokenProvider
+Dekaf.SchemaRegistry.Kms.Vault.IVaultTokenProvider.GetTokenAsync(System.Uri! vaultAddress, string? vaultNamespace, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<string!>
+Dekaf.SchemaRegistry.Kms.Vault.IVaultTransitClient
+Dekaf.SchemaRegistry.Kms.Vault.IVaultTransitClient.DecryptAsync(System.Uri! vaultAddress, string! mountPoint, string! keyName, string? vaultNamespace, System.ReadOnlyMemory<byte> ciphertext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
+Dekaf.SchemaRegistry.Kms.Vault.IVaultTransitClient.EncryptAsync(System.Uri! vaultAddress, string! mountPoint, string! keyName, string? vaultNamespace, System.ReadOnlyMemory<byte> plaintext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
+Dekaf.SchemaRegistry.Kms.Vault.VaultAppRoleTokenProvider
+Dekaf.SchemaRegistry.Kms.Vault.VaultAppRoleTokenProvider.GetTokenAsync(System.Uri! vaultAddress, string? vaultNamespace, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<string!>
+Dekaf.SchemaRegistry.Kms.Vault.VaultAppRoleTokenProvider.VaultAppRoleTokenProvider(System.Net.Http.HttpClient! httpClient, string! roleId, string! secretId, string! authMountPoint = "approle") -> void
+Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider
+Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider.Type.get -> string!
+Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider.UnwrapKeyAsync(System.ReadOnlyMemory<byte> encryptedKeyMaterial, Dekaf.SchemaRegistry.SchemaRegistryKmsKeyReference! keyReference, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
+Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider.VaultKmsProvider(Dekaf.SchemaRegistry.Kms.Vault.IVaultTransitClient! client, string! mountPoint = "transit", string? vaultNamespace = null, string! type = "hcvault") -> void
+Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider.WrapKeyAsync(System.ReadOnlyMemory<byte> keyMaterial, Dekaf.SchemaRegistry.SchemaRegistryKmsKeyReference! keyReference, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
+Dekaf.SchemaRegistry.Kms.Vault.VaultStaticTokenProvider
+Dekaf.SchemaRegistry.Kms.Vault.VaultStaticTokenProvider.GetTokenAsync(System.Uri! vaultAddress, string? vaultNamespace, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<string!>
+Dekaf.SchemaRegistry.Kms.Vault.VaultStaticTokenProvider.VaultStaticTokenProvider(string! token) -> void
+Dekaf.SchemaRegistry.Kms.Vault.VaultTransitHttpClient
+Dekaf.SchemaRegistry.Kms.Vault.VaultTransitHttpClient.DecryptAsync(System.Uri! vaultAddress, string! mountPoint, string! keyName, string? vaultNamespace, System.ReadOnlyMemory<byte> ciphertext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
+Dekaf.SchemaRegistry.Kms.Vault.VaultTransitHttpClient.EncryptAsync(System.Uri! vaultAddress, string! mountPoint, string! keyName, string? vaultNamespace, System.ReadOnlyMemory<byte> plaintext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<byte[]!>
+Dekaf.SchemaRegistry.Kms.Vault.VaultTransitHttpClient.VaultTransitHttpClient(System.Net.Http.HttpClient! httpClient, Dekaf.SchemaRegistry.Kms.Vault.IVaultTokenProvider! tokenProvider) -> void
+const Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider.DefaultMountPoint = "transit" -> string!
+const Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider.DefaultType = "hcvault" -> string!
+const Dekaf.SchemaRegistry.Kms.Vault.VaultKmsProvider.KeyUriPrefix = "hcvault://" -> string!

--- a/src/Dekaf.SchemaRegistry.Kms.Vault/VaultKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Vault/VaultKmsProvider.cs
@@ -48,7 +48,7 @@ public sealed class VaultKmsProvider : ISchemaRegistryKmsProvider
     /// Creates a provider using an injected Vault Transit client.
     /// </summary>
     /// <param name="client">Thread-safe Vault Transit client.</param>
-    /// <param name="vaultAddress">Allowed Vault server address.</param>
+    /// <param name="vaultAddress">Allowed root Vault server address without a path.</param>
     /// <param name="vaultNamespace">Optional Vault Enterprise namespace.</param>
     /// <param name="type">Schema Registry KMS provider type.</param>
     public VaultKmsProvider(
@@ -167,7 +167,7 @@ public sealed class VaultKmsProvider : ISchemaRegistryKmsProvider
                 "Vault key identifier must be an absolute HTTP or HTTPS Vault key URL.");
         }
 
-        var keyAddress = VaultTransitHttpClient.NormalizeAddress(keyUri);
+        var keyAddress = new Uri(keyUri.GetLeftPart(UriPartial.Authority) + "/", UriKind.Absolute);
         if (keyAddress != _vaultAddress)
         {
             throw new SchemaRegistryKmsException(

--- a/src/Dekaf.SchemaRegistry.Kms.Vault/VaultKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Vault/VaultKmsProvider.cs
@@ -1,0 +1,223 @@
+using System.Text.Json;
+
+namespace Dekaf.SchemaRegistry.Kms.Vault;
+
+/// <summary>
+/// Encrypts and decrypts data encryption keys through a Vault Transit client.
+/// </summary>
+public interface IVaultTransitClient
+{
+    /// <summary>
+    /// Encrypts plaintext with a Vault Transit key.
+    /// </summary>
+    ValueTask<byte[]> EncryptAsync(
+        Uri vaultAddress,
+        string mountPoint,
+        string keyName,
+        string? vaultNamespace,
+        ReadOnlyMemory<byte> plaintext,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Decrypts Vault Transit ciphertext.
+    /// </summary>
+    ValueTask<byte[]> DecryptAsync(
+        Uri vaultAddress,
+        string mountPoint,
+        string keyName,
+        string? vaultNamespace,
+        ReadOnlyMemory<byte> ciphertext,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Wraps and unwraps Schema Registry data encryption keys with HashiCorp Vault Transit.
+/// </summary>
+public sealed class VaultKmsProvider : ISchemaRegistryKmsProvider
+{
+    /// <summary>
+    /// Schema Registry KMS provider type.
+    /// </summary>
+    public const string DefaultType = "hcvault";
+
+    /// <summary>
+    /// URI prefix for Vault key references.
+    /// </summary>
+    public const string KeyUriPrefix = "hcvault://";
+
+    /// <summary>
+    /// Default Vault Transit secrets-engine mount point.
+    /// </summary>
+    public const string DefaultMountPoint = "transit";
+
+    private readonly IVaultTransitClient _client;
+    private readonly string _mountPoint;
+    private readonly string? _vaultNamespace;
+
+    /// <summary>
+    /// Creates a provider using an injected Vault Transit client.
+    /// </summary>
+    /// <param name="client">Thread-safe Vault Transit client.</param>
+    /// <param name="mountPoint">Transit secrets-engine mount point.</param>
+    /// <param name="vaultNamespace">Optional Vault Enterprise namespace.</param>
+    /// <param name="type">Schema Registry KMS provider type.</param>
+    public VaultKmsProvider(
+        IVaultTransitClient client,
+        string mountPoint = DefaultMountPoint,
+        string? vaultNamespace = null,
+        string type = DefaultType)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        if (string.IsNullOrWhiteSpace(type))
+            throw new ArgumentException("KMS provider type cannot be null or whitespace.", nameof(type));
+
+        _client = client;
+        _mountPoint = VaultTransitHttpClient.NormalizeMountPoint(mountPoint);
+        _vaultNamespace = VaultTransitHttpClient.NormalizeNamespace(vaultNamespace);
+        Type = type;
+    }
+
+    /// <inheritdoc />
+    public string Type { get; }
+
+    /// <inheritdoc />
+    public async ValueTask<byte[]> WrapKeyAsync(
+        ReadOnlyMemory<byte> keyMaterial,
+        SchemaRegistryKmsKeyReference keyReference,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (keyMaterial.IsEmpty)
+            throw new SchemaRegistryKmsException("Vault Transit wrap failed. Key material cannot be empty.");
+
+        var key = ResolveKey(keyReference);
+        try
+        {
+            var ciphertext = await _client.EncryptAsync(
+                    key.VaultAddress,
+                    _mountPoint,
+                    key.KeyName,
+                    _vaultNamespace,
+                    keyMaterial,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return RequireMaterial(ciphertext, "wrap");
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (SchemaRegistryKmsException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (IsVaultFailure(ex))
+        {
+            throw new SchemaRegistryKmsException("Vault Transit wrap failed.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<byte[]> UnwrapKeyAsync(
+        ReadOnlyMemory<byte> encryptedKeyMaterial,
+        SchemaRegistryKmsKeyReference keyReference,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (encryptedKeyMaterial.IsEmpty)
+        {
+            throw new SchemaRegistryKmsException(
+                "Vault Transit unwrap failed. Encrypted key material cannot be empty.");
+        }
+
+        var key = ResolveKey(keyReference);
+        try
+        {
+            var plaintext = await _client.DecryptAsync(
+                    key.VaultAddress,
+                    _mountPoint,
+                    key.KeyName,
+                    _vaultNamespace,
+                    encryptedKeyMaterial,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return RequireMaterial(plaintext, "unwrap");
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (SchemaRegistryKmsException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (IsVaultFailure(ex))
+        {
+            throw new SchemaRegistryKmsException("Vault Transit unwrap failed.", ex);
+        }
+    }
+
+    private VaultKeyReference ResolveKey(SchemaRegistryKmsKeyReference keyReference)
+    {
+        ArgumentNullException.ThrowIfNull(keyReference);
+        if (!string.Equals(Type, keyReference.KmsType, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new SchemaRegistryKmsException(
+                $"Vault KMS provider '{Type}' cannot resolve KMS type '{keyReference.KmsType}'.");
+        }
+
+        var keyId = keyReference.KmsKeyId;
+        if (string.IsNullOrWhiteSpace(keyId)
+            || !keyId.StartsWith(KeyUriPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new SchemaRegistryKmsException(
+                $"Vault key identifier must start with '{KeyUriPrefix}'.");
+        }
+
+        var absoluteKeyUrl = keyId[KeyUriPrefix.Length..];
+        if (!Uri.TryCreate(absoluteKeyUrl, UriKind.Absolute, out var keyUri)
+            || keyUri.Scheme is not ("http" or "https")
+            || keyUri.UserInfo.Length != 0
+            || keyUri.Query.Length != 0
+            || keyUri.Fragment.Length != 0)
+        {
+            throw new SchemaRegistryKmsException(
+                "Vault key identifier must contain an absolute HTTP or HTTPS Vault key URL.");
+        }
+
+        var segments = keyUri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length != 1)
+        {
+            throw new SchemaRegistryKmsException(
+                "Vault key URL must contain exactly one path segment naming the Transit key.");
+        }
+
+        var keyName = Uri.UnescapeDataString(segments[0]);
+        if (string.IsNullOrWhiteSpace(keyName) || keyName.Contains('/'))
+            throw new SchemaRegistryKmsException("Vault Transit key name is invalid.");
+
+        var vaultAddress = new Uri(keyUri.GetLeftPart(UriPartial.Authority) + "/", UriKind.Absolute);
+        return new VaultKeyReference(vaultAddress, keyName);
+    }
+
+    private static byte[] RequireMaterial(byte[]? material, string operation)
+    {
+        if (material is null || material.Length == 0)
+        {
+            throw new SchemaRegistryKmsException(
+                $"Vault Transit {operation} failed. The service returned no key material.");
+        }
+
+        return material;
+    }
+
+    private static bool IsVaultFailure(Exception exception) => exception is
+        HttpRequestException
+        or JsonException
+        or FormatException
+        or InvalidOperationException
+        or ArgumentException
+        or OperationCanceledException;
+
+    private readonly record struct VaultKeyReference(Uri VaultAddress, string KeyName);
+}

--- a/src/Dekaf.SchemaRegistry.Kms.Vault/VaultKmsProvider.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Vault/VaultKmsProvider.cs
@@ -40,30 +40,20 @@ public sealed class VaultKmsProvider : ISchemaRegistryKmsProvider
     /// </summary>
     public const string DefaultType = "hcvault";
 
-    /// <summary>
-    /// URI prefix for Vault key references.
-    /// </summary>
-    public const string KeyUriPrefix = "hcvault://";
-
-    /// <summary>
-    /// Default Vault Transit secrets-engine mount point.
-    /// </summary>
-    public const string DefaultMountPoint = "transit";
-
     private readonly IVaultTransitClient _client;
-    private readonly string _mountPoint;
+    private readonly Uri _vaultAddress;
     private readonly string? _vaultNamespace;
 
     /// <summary>
     /// Creates a provider using an injected Vault Transit client.
     /// </summary>
     /// <param name="client">Thread-safe Vault Transit client.</param>
-    /// <param name="mountPoint">Transit secrets-engine mount point.</param>
+    /// <param name="vaultAddress">Allowed Vault server address.</param>
     /// <param name="vaultNamespace">Optional Vault Enterprise namespace.</param>
     /// <param name="type">Schema Registry KMS provider type.</param>
     public VaultKmsProvider(
         IVaultTransitClient client,
-        string mountPoint = DefaultMountPoint,
+        Uri vaultAddress,
         string? vaultNamespace = null,
         string type = DefaultType)
     {
@@ -72,7 +62,7 @@ public sealed class VaultKmsProvider : ISchemaRegistryKmsProvider
             throw new ArgumentException("KMS provider type cannot be null or whitespace.", nameof(type));
 
         _client = client;
-        _mountPoint = VaultTransitHttpClient.NormalizeMountPoint(mountPoint);
+        _vaultAddress = VaultTransitHttpClient.NormalizeAddress(vaultAddress);
         _vaultNamespace = VaultTransitHttpClient.NormalizeNamespace(vaultNamespace);
         Type = type;
     }
@@ -94,8 +84,8 @@ public sealed class VaultKmsProvider : ISchemaRegistryKmsProvider
         try
         {
             var ciphertext = await _client.EncryptAsync(
-                    key.VaultAddress,
-                    _mountPoint,
+                    _vaultAddress,
+                    key.MountPoint,
                     key.KeyName,
                     _vaultNamespace,
                     keyMaterial,
@@ -134,8 +124,8 @@ public sealed class VaultKmsProvider : ISchemaRegistryKmsProvider
         try
         {
             var plaintext = await _client.DecryptAsync(
-                    key.VaultAddress,
-                    _mountPoint,
+                    _vaultAddress,
+                    key.MountPoint,
                     key.KeyName,
                     _vaultNamespace,
                     encryptedKeyMaterial,
@@ -166,38 +156,68 @@ public sealed class VaultKmsProvider : ISchemaRegistryKmsProvider
                 $"Vault KMS provider '{Type}' cannot resolve KMS type '{keyReference.KmsType}'.");
         }
 
-        var keyId = keyReference.KmsKeyId;
-        if (string.IsNullOrWhiteSpace(keyId)
-            || !keyId.StartsWith(KeyUriPrefix, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new SchemaRegistryKmsException(
-                $"Vault key identifier must start with '{KeyUriPrefix}'.");
-        }
-
-        var absoluteKeyUrl = keyId[KeyUriPrefix.Length..];
-        if (!Uri.TryCreate(absoluteKeyUrl, UriKind.Absolute, out var keyUri)
+        if (string.IsNullOrWhiteSpace(keyReference.KmsKeyId)
+            || !Uri.TryCreate(keyReference.KmsKeyId, UriKind.Absolute, out var keyUri)
             || keyUri.Scheme is not ("http" or "https")
             || keyUri.UserInfo.Length != 0
             || keyUri.Query.Length != 0
             || keyUri.Fragment.Length != 0)
         {
             throw new SchemaRegistryKmsException(
-                "Vault key identifier must contain an absolute HTTP or HTTPS Vault key URL.");
+                "Vault key identifier must be an absolute HTTP or HTTPS Vault key URL.");
         }
 
-        var segments = keyUri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        if (segments.Length != 1)
+        var keyAddress = VaultTransitHttpClient.NormalizeAddress(keyUri);
+        if (keyAddress != _vaultAddress)
         {
             throw new SchemaRegistryKmsException(
-                "Vault key URL must contain exactly one path segment naming the Transit key.");
+                "Vault key identifier authority does not match the configured Vault address.");
         }
 
-        var keyName = Uri.UnescapeDataString(segments[0]);
+        var escapedSegments = keyUri.AbsolutePath.Split('/');
+        if (escapedSegments.Length < 4
+            || escapedSegments[0].Length != 0
+            || escapedSegments.AsSpan(1).Contains(string.Empty))
+        {
+            throw new SchemaRegistryKmsException(
+                "Vault key identifier path must use '<mount>/keys/<key-name>'.");
+        }
+
+        var keyName = DecodePathSegment(escapedSegments[^1]);
         if (string.IsNullOrWhiteSpace(keyName) || keyName.Contains('/'))
             throw new SchemaRegistryKmsException("Vault Transit key name is invalid.");
 
-        var vaultAddress = new Uri(keyUri.GetLeftPart(UriPartial.Authority) + "/", UriKind.Absolute);
-        return new VaultKeyReference(vaultAddress, keyName);
+        if (!string.Equals(DecodePathSegment(escapedSegments[^2]), "keys", StringComparison.Ordinal))
+        {
+            throw new SchemaRegistryKmsException(
+                "Vault key identifier path must use '<mount>/keys/<key-name>'.");
+        }
+
+        var mountSegmentCount = escapedSegments.Length - 3;
+        var mountSegments = new string[mountSegmentCount];
+        for (var index = 0; index < mountSegments.Length; index++)
+            mountSegments[index] = DecodePathSegment(escapedSegments[index + 1]);
+
+        var mountPoint = string.Join('/', mountSegments);
+        try
+        {
+            mountPoint = VaultTransitHttpClient.NormalizeMountPoint(mountPoint);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new SchemaRegistryKmsException("Vault Transit mount point is invalid.", ex);
+        }
+
+        return new VaultKeyReference(mountPoint, keyName);
+    }
+
+    private static string DecodePathSegment(string segment)
+    {
+        var decoded = Uri.UnescapeDataString(segment);
+        if (decoded.Contains('/'))
+            throw new SchemaRegistryKmsException("Vault key identifier contains an invalid path segment.");
+
+        return decoded;
     }
 
     private static byte[] RequireMaterial(byte[]? material, string operation)
@@ -219,5 +239,5 @@ public sealed class VaultKmsProvider : ISchemaRegistryKmsProvider
         or ArgumentException
         or OperationCanceledException;
 
-    private readonly record struct VaultKeyReference(Uri VaultAddress, string KeyName);
+    private readonly record struct VaultKeyReference(string MountPoint, string KeyName);
 }

--- a/src/Dekaf.SchemaRegistry.Kms.Vault/VaultTransitHttpClient.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Vault/VaultTransitHttpClient.cs
@@ -366,10 +366,11 @@ public sealed class VaultTransitHttpClient : IVaultTransitClient
             || vaultAddress.Scheme is not ("http" or "https")
             || vaultAddress.UserInfo.Length != 0
             || vaultAddress.Query.Length != 0
-            || vaultAddress.Fragment.Length != 0)
+            || vaultAddress.Fragment.Length != 0
+            || vaultAddress.AbsolutePath is not ("" or "/"))
         {
             throw new ArgumentException(
-                "Vault address must be an absolute HTTP or HTTPS URI without credentials, query, or fragment.",
+                "Vault address must be an absolute HTTP or HTTPS URI without a path, credentials, query, or fragment.",
                 nameof(vaultAddress));
         }
 
@@ -419,7 +420,8 @@ public sealed class VaultTransitHttpClient : IVaultTransitClient
         if (content.Headers.ContentLength is > MaximumResponseBytes)
             throw new InvalidOperationException("Vault response exceeded the maximum allowed size.");
 
-        await using var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        await using var configuredStream = stream.ConfigureAwait(false);
         var readBuffer = ArrayPool<byte>.Shared.Rent(4096);
         var responseBuffer = new ArrayBufferWriter<byte>();
         try
@@ -466,7 +468,9 @@ public sealed class VaultTransitHttpClient : IVaultTransitClient
         vaultAddress = NormalizeAddress(vaultAddress);
         var normalizedMountPoint = NormalizeMountPoint(mountPoint);
         vaultNamespace = NormalizeNamespace(vaultNamespace);
-        if (string.IsNullOrWhiteSpace(keyName) || keyName.Contains('/'))
+        if (string.IsNullOrWhiteSpace(keyName)
+            || keyName.Contains('/')
+            || keyName is "." or "..")
             throw new ArgumentException("Vault Transit key name is invalid.", nameof(keyName));
 
         var token = await _tokenProvider

--- a/src/Dekaf.SchemaRegistry.Kms.Vault/VaultTransitHttpClient.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Vault/VaultTransitHttpClient.cs
@@ -67,6 +67,7 @@ public sealed class VaultAppRoleTokenProvider : IVaultTokenProvider
     private readonly string _roleId;
     private readonly string _secretId;
     private readonly string _authMountPoint;
+    private readonly TimeProvider _timeProvider;
     private readonly ConcurrentDictionary<AuthScope, TokenState> _tokens = [];
 
     /// <summary>
@@ -81,8 +82,19 @@ public sealed class VaultAppRoleTokenProvider : IVaultTokenProvider
         string roleId,
         string secretId,
         string authMountPoint = "approle")
+        : this(httpClient, roleId, secretId, authMountPoint, TimeProvider.System)
+    {
+    }
+
+    internal VaultAppRoleTokenProvider(
+        HttpClient httpClient,
+        string roleId,
+        string secretId,
+        string authMountPoint,
+        TimeProvider timeProvider)
     {
         ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(timeProvider);
         if (string.IsNullOrWhiteSpace(roleId))
             throw new ArgumentException("Vault AppRole role ID cannot be null or whitespace.", nameof(roleId));
         if (string.IsNullOrWhiteSpace(secretId))
@@ -92,6 +104,7 @@ public sealed class VaultAppRoleTokenProvider : IVaultTokenProvider
         _roleId = roleId;
         _secretId = secretId;
         _authMountPoint = VaultTransitHttpClient.NormalizeMountPoint(authMountPoint);
+        _timeProvider = timeProvider;
     }
 
     /// <inheritdoc />
@@ -107,7 +120,7 @@ public sealed class VaultAppRoleTokenProvider : IVaultTokenProvider
             VaultTransitHttpClient.NormalizeAddress(vaultAddress),
             VaultTransitHttpClient.NormalizeNamespace(vaultNamespace));
         var state = _tokens.GetOrAdd(scope, static _ => new TokenState());
-        return state.TryGetToken(DateTimeOffset.UtcNow, out var token)
+        return state.TryGetToken(_timeProvider.GetUtcNow(), out var token)
             ? new ValueTask<string>(token)
             : RefreshTokenAsync(scope, state, cancellationToken);
     }
@@ -120,7 +133,7 @@ public sealed class VaultAppRoleTokenProvider : IVaultTokenProvider
         await state.RefreshGate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            if (state.TryGetToken(DateTimeOffset.UtcNow, out var cachedToken))
+            if (state.TryGetToken(_timeProvider.GetUtcNow(), out var cachedToken))
                 return cachedToken;
 
             var requestBytes = JsonSerializer.SerializeToUtf8Bytes(
@@ -137,6 +150,7 @@ public sealed class VaultAppRoleTokenProvider : IVaultTokenProvider
                 request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
                 VaultTransitHttpClient.AddNamespaceHeader(request, scope.VaultNamespace);
 
+                var loginStartedAt = _timeProvider.GetUtcNow();
                 using var response = await _httpClient
                     .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                     .ConfigureAwait(false);
@@ -150,7 +164,7 @@ public sealed class VaultAppRoleTokenProvider : IVaultTokenProvider
                     var refreshAfterSeconds = leaseDurationSeconds > 60
                         ? leaseDurationSeconds - 30
                         : Math.Max(1, leaseDurationSeconds / 2);
-                    state.SetToken(token, DateTimeOffset.UtcNow.AddSeconds(refreshAfterSeconds));
+                    state.SetToken(token, loginStartedAt.AddSeconds(refreshAfterSeconds));
                     return token;
                 }
                 finally

--- a/src/Dekaf.SchemaRegistry.Kms.Vault/VaultTransitHttpClient.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Vault/VaultTransitHttpClient.cs
@@ -3,7 +3,6 @@ using System.Buffers.Text;
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http.Headers;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -413,8 +412,14 @@ public sealed class VaultTransitHttpClient : IVaultTransitClient
         }
     }
 
+    internal static ValueTask<byte[]> ReadResponseBytesAsync(
+        HttpContent content,
+        CancellationToken cancellationToken) =>
+        ReadResponseBytesAsync(content, ArrayPool<byte>.Shared, cancellationToken);
+
     internal static async ValueTask<byte[]> ReadResponseBytesAsync(
         HttpContent content,
+        ArrayPool<byte> bufferPool,
         CancellationToken cancellationToken)
     {
         if (content.Headers.ContentLength is > MaximumResponseBytes)
@@ -422,33 +427,62 @@ public sealed class VaultTransitHttpClient : IVaultTransitClient
 
         var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         await using var configuredStream = stream.ConfigureAwait(false);
-        var readBuffer = ArrayPool<byte>.Shared.Rent(4096);
-        var responseBuffer = new ArrayBufferWriter<byte>();
+        var initialCapacity = content.Headers.ContentLength is > 0 and var contentLength
+            ? (int)contentLength
+            : 4096;
+        var responseBuffer = bufferPool.Rent(initialCapacity);
+        var written = 0;
         try
         {
             while (true)
             {
+                if (written == MaximumResponseBytes)
+                {
+                    var probeBuffer = bufferPool.Rent(1);
+                    try
+                    {
+                        if (await stream.ReadAsync(probeBuffer.AsMemory(0, 1), cancellationToken)
+                                .ConfigureAwait(false) != 0)
+                        {
+                            throw new InvalidOperationException("Vault response exceeded the maximum allowed size.");
+                        }
+                    }
+                    finally
+                    {
+                        ReturnSensitiveBuffer(bufferPool, probeBuffer);
+                    }
+
+                    return responseBuffer.AsSpan(0, written).ToArray();
+                }
+
+                if (written == responseBuffer.Length)
+                {
+                    var nextCapacity = Math.Min(MaximumResponseBytes, responseBuffer.Length * 2);
+                    var retiredBuffer = responseBuffer;
+                    responseBuffer = bufferPool.Rent(nextCapacity);
+                    try
+                    {
+                        retiredBuffer.AsSpan(0, written).CopyTo(responseBuffer);
+                    }
+                    finally
+                    {
+                        ReturnSensitiveBuffer(bufferPool, retiredBuffer);
+                    }
+                }
+
+                var available = Math.Min(responseBuffer.Length - written, MaximumResponseBytes - written);
                 var read = await stream
-                    .ReadAsync(readBuffer.AsMemory(), cancellationToken)
+                    .ReadAsync(responseBuffer.AsMemory(written, available), cancellationToken)
                     .ConfigureAwait(false);
                 if (read == 0)
-                    return responseBuffer.WrittenSpan.ToArray();
+                    return responseBuffer.AsSpan(0, written).ToArray();
 
-                if (responseBuffer.WrittenCount > MaximumResponseBytes - read)
-                    throw new InvalidOperationException("Vault response exceeded the maximum allowed size.");
-
-                responseBuffer.Write(readBuffer.AsSpan(0, read));
+                written += read;
             }
         }
         finally
         {
-            CryptographicOperations.ZeroMemory(readBuffer);
-            ArrayPool<byte>.Shared.Return(readBuffer);
-            if (MemoryMarshal.TryGetArray(responseBuffer.WrittenMemory, out var segment) &&
-                segment.Array is not null)
-            {
-                CryptographicOperations.ZeroMemory(segment.Array.AsSpan(segment.Offset, segment.Count));
-            }
+            ReturnSensitiveBuffer(bufferPool, responseBuffer);
         }
     }
 
@@ -550,9 +584,12 @@ public sealed class VaultTransitHttpClient : IVaultTransitClient
     }
 
     private static void ReturnSensitiveBuffer(byte[] buffer)
+        => ReturnSensitiveBuffer(ArrayPool<byte>.Shared, buffer);
+
+    private static void ReturnSensitiveBuffer(ArrayPool<byte> bufferPool, byte[] buffer)
     {
         CryptographicOperations.ZeroMemory(buffer);
-        ArrayPool<byte>.Shared.Return(buffer);
+        bufferPool.Return(buffer);
     }
 }
 

--- a/src/Dekaf.SchemaRegistry.Kms.Vault/VaultTransitHttpClient.cs
+++ b/src/Dekaf.SchemaRegistry.Kms.Vault/VaultTransitHttpClient.cs
@@ -1,0 +1,546 @@
+using System.Buffers;
+using System.Buffers.Text;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Dekaf.SchemaRegistry.Kms.Vault;
+
+/// <summary>
+/// Supplies Vault tokens for Transit requests.
+/// </summary>
+public interface IVaultTokenProvider
+{
+    /// <summary>
+    /// Gets a token for a Vault address and namespace.
+    /// </summary>
+    ValueTask<string> GetTokenAsync(
+        Uri vaultAddress,
+        string? vaultNamespace,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Supplies a fixed Vault token.
+/// </summary>
+public sealed class VaultStaticTokenProvider : IVaultTokenProvider
+{
+    private readonly string _token;
+
+    /// <summary>
+    /// Creates a fixed-token provider.
+    /// </summary>
+    /// <param name="token">Vault token.</param>
+    public VaultStaticTokenProvider(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token) || ContainsNewLine(token))
+            throw new ArgumentException("Vault token is invalid.", nameof(token));
+
+        _token = token;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<string> GetTokenAsync(
+        Uri vaultAddress,
+        string? vaultNamespace,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(vaultAddress);
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask<string>(_token);
+    }
+
+    private static bool ContainsNewLine(string value) => value.Contains('\r') || value.Contains('\n');
+}
+
+/// <summary>
+/// Logs in with Vault AppRole and caches tokens until shortly before their lease expires.
+/// </summary>
+public sealed class VaultAppRoleTokenProvider : IVaultTokenProvider
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _roleId;
+    private readonly string _secretId;
+    private readonly string _authMountPoint;
+    private readonly ConcurrentDictionary<AuthScope, TokenState> _tokens = [];
+
+    /// <summary>
+    /// Creates an AppRole token provider.
+    /// </summary>
+    /// <param name="httpClient">Caller-owned HTTP client.</param>
+    /// <param name="roleId">AppRole role ID.</param>
+    /// <param name="secretId">AppRole secret ID.</param>
+    /// <param name="authMountPoint">AppRole authentication mount point.</param>
+    public VaultAppRoleTokenProvider(
+        HttpClient httpClient,
+        string roleId,
+        string secretId,
+        string authMountPoint = "approle")
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        if (string.IsNullOrWhiteSpace(roleId))
+            throw new ArgumentException("Vault AppRole role ID cannot be null or whitespace.", nameof(roleId));
+        if (string.IsNullOrWhiteSpace(secretId))
+            throw new ArgumentException("Vault AppRole secret ID cannot be null or whitespace.", nameof(secretId));
+
+        _httpClient = httpClient;
+        _roleId = roleId;
+        _secretId = secretId;
+        _authMountPoint = VaultTransitHttpClient.NormalizeMountPoint(authMountPoint);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<string> GetTokenAsync(
+        Uri vaultAddress,
+        string? vaultNamespace,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(vaultAddress);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var scope = new AuthScope(
+            VaultTransitHttpClient.NormalizeAddress(vaultAddress),
+            VaultTransitHttpClient.NormalizeNamespace(vaultNamespace));
+        var state = _tokens.GetOrAdd(scope, static _ => new TokenState());
+        return state.TryGetToken(DateTimeOffset.UtcNow, out var token)
+            ? new ValueTask<string>(token)
+            : RefreshTokenAsync(scope, state, cancellationToken);
+    }
+
+    private async ValueTask<string> RefreshTokenAsync(
+        AuthScope scope,
+        TokenState state,
+        CancellationToken cancellationToken)
+    {
+        await state.RefreshGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (state.TryGetToken(DateTimeOffset.UtcNow, out var cachedToken))
+                return cachedToken;
+
+            var requestBytes = JsonSerializer.SerializeToUtf8Bytes(
+                new AppRoleLoginRequest(_roleId, _secretId),
+                VaultJsonContext.Default.AppRoleLoginRequest);
+            try
+            {
+                using var request = new HttpRequestMessage(
+                    HttpMethod.Post,
+                    VaultTransitHttpClient.BuildUri(
+                        scope.VaultAddress,
+                        $"v1/auth/{VaultTransitHttpClient.EncodeMountPoint(_authMountPoint)}/login"));
+                request.Content = new ByteArrayContent(requestBytes);
+                request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+                VaultTransitHttpClient.AddNamespaceHeader(request, scope.VaultNamespace);
+
+                using var response = await _httpClient
+                    .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                    .ConfigureAwait(false);
+                VaultTransitHttpClient.EnsureSuccess(response);
+                var responseBytes = await VaultTransitHttpClient
+                    .ReadResponseBytesAsync(response.Content, cancellationToken)
+                    .ConfigureAwait(false);
+                try
+                {
+                    var (token, leaseDurationSeconds) = ParseLoginResponse(responseBytes);
+                    var refreshAfterSeconds = leaseDurationSeconds > 60
+                        ? leaseDurationSeconds - 30
+                        : Math.Max(1, leaseDurationSeconds / 2);
+                    state.SetToken(token, DateTimeOffset.UtcNow.AddSeconds(refreshAfterSeconds));
+                    return token;
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(responseBytes);
+                }
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(requestBytes);
+            }
+        }
+        finally
+        {
+            state.RefreshGate.Release();
+        }
+    }
+
+    private static (string Token, int LeaseDurationSeconds) ParseLoginResponse(ReadOnlyMemory<byte> responseBytes)
+    {
+        using var document = JsonDocument.Parse(responseBytes);
+        if (!document.RootElement.TryGetProperty("auth", out var auth)
+            || !auth.TryGetProperty("client_token", out var tokenElement)
+            || tokenElement.GetString() is not { Length: > 0 } token
+            || token.Contains('\r')
+            || token.Contains('\n')
+            || !auth.TryGetProperty("lease_duration", out var leaseElement)
+            || !leaseElement.TryGetInt32(out var leaseDurationSeconds)
+            || leaseDurationSeconds <= 0)
+        {
+            throw new InvalidOperationException("Vault AppRole login returned invalid authentication data.");
+        }
+
+        return (token, leaseDurationSeconds);
+    }
+
+    private readonly record struct AuthScope(Uri VaultAddress, string? VaultNamespace);
+
+    private sealed class TokenState
+    {
+        private string? _token;
+        private long _expiresAtUtcTicks;
+
+        internal SemaphoreSlim RefreshGate { get; } = new(1, 1);
+
+        internal bool TryGetToken(DateTimeOffset now, out string token)
+        {
+            var expiresAtUtcTicks = Volatile.Read(ref _expiresAtUtcTicks);
+            var cachedToken = Volatile.Read(ref _token);
+            if (expiresAtUtcTicks > now.UtcTicks && cachedToken is { Length: > 0 })
+            {
+                token = cachedToken;
+                return true;
+            }
+
+            token = string.Empty;
+            return false;
+        }
+
+        internal void SetToken(string token, DateTimeOffset expiresAt)
+        {
+            Volatile.Write(ref _token, token);
+            Volatile.Write(ref _expiresAtUtcTicks, expiresAt.UtcTicks);
+        }
+    }
+}
+
+/// <summary>
+/// Calls the HashiCorp Vault Transit HTTP API.
+/// </summary>
+public sealed class VaultTransitHttpClient : IVaultTransitClient
+{
+    private const int MaximumResponseBytes = 1024 * 1024;
+
+    private static ReadOnlySpan<byte> PlaintextPrefix => "{\"plaintext\":\""u8;
+    private static ReadOnlySpan<byte> CiphertextPrefix => "{\"ciphertext\":\""u8;
+    private static ReadOnlySpan<byte> JsonStringSuffix => "\"}"u8;
+
+    private readonly HttpClient _httpClient;
+    private readonly IVaultTokenProvider _tokenProvider;
+
+    /// <summary>
+    /// Creates a Vault Transit HTTP client.
+    /// </summary>
+    /// <param name="httpClient">Caller-owned HTTP client.</param>
+    /// <param name="tokenProvider">Vault token provider.</param>
+    public VaultTransitHttpClient(HttpClient httpClient, IVaultTokenProvider tokenProvider)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(tokenProvider);
+        _httpClient = httpClient;
+        _tokenProvider = tokenProvider;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<byte[]> EncryptAsync(
+        Uri vaultAddress,
+        string mountPoint,
+        string keyName,
+        string? vaultNamespace,
+        ReadOnlyMemory<byte> plaintext,
+        CancellationToken cancellationToken = default)
+    {
+        if (plaintext.IsEmpty)
+            throw new ArgumentException("Vault plaintext cannot be empty.", nameof(plaintext));
+
+        var payload = RentBase64Payload(plaintext.Span, out var payloadLength);
+        try
+        {
+            return await SendTransitRequestAsync(
+                    vaultAddress,
+                    mountPoint,
+                    keyName,
+                    vaultNamespace,
+                    "encrypt",
+                    payload,
+                    payloadLength,
+                    "ciphertext",
+                    responseIsBase64: false,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            ReturnSensitiveBuffer(payload);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<byte[]> DecryptAsync(
+        Uri vaultAddress,
+        string mountPoint,
+        string keyName,
+        string? vaultNamespace,
+        ReadOnlyMemory<byte> ciphertext,
+        CancellationToken cancellationToken = default)
+    {
+        if (ciphertext.IsEmpty)
+            throw new ArgumentException("Vault ciphertext cannot be empty.", nameof(ciphertext));
+
+        var payload = RentCiphertextPayload(ciphertext.Span, out var payloadLength);
+        try
+        {
+            return await SendTransitRequestAsync(
+                    vaultAddress,
+                    mountPoint,
+                    keyName,
+                    vaultNamespace,
+                    "decrypt",
+                    payload,
+                    payloadLength,
+                    "plaintext",
+                    responseIsBase64: true,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            ReturnSensitiveBuffer(payload);
+        }
+    }
+
+    internal static string NormalizeMountPoint(string mountPoint)
+    {
+        if (string.IsNullOrWhiteSpace(mountPoint))
+            throw new ArgumentException("Vault mount point cannot be null or whitespace.", nameof(mountPoint));
+
+        var normalized = mountPoint.Trim('/');
+        var segments = normalized.Split('/');
+        foreach (var segment in segments)
+        {
+            if (segment.Length == 0 || segment is "." or "..")
+                throw new ArgumentException("Vault mount point is invalid.", nameof(mountPoint));
+        }
+
+        return normalized;
+    }
+
+    internal static string? NormalizeNamespace(string? vaultNamespace)
+    {
+        if (vaultNamespace is null)
+            return null;
+
+        var normalized = vaultNamespace.Trim('/');
+        if (normalized.Length == 0
+            || normalized.Contains('\r')
+            || normalized.Contains('\n'))
+        {
+            throw new ArgumentException("Vault namespace is invalid.", nameof(vaultNamespace));
+        }
+
+        return normalized;
+    }
+
+    internal static Uri NormalizeAddress(Uri vaultAddress)
+    {
+        ArgumentNullException.ThrowIfNull(vaultAddress);
+        if (!vaultAddress.IsAbsoluteUri
+            || vaultAddress.Scheme is not ("http" or "https")
+            || vaultAddress.UserInfo.Length != 0
+            || vaultAddress.Query.Length != 0
+            || vaultAddress.Fragment.Length != 0)
+        {
+            throw new ArgumentException(
+                "Vault address must be an absolute HTTP or HTTPS URI without credentials, query, or fragment.",
+                nameof(vaultAddress));
+        }
+
+        return new Uri(vaultAddress.GetLeftPart(UriPartial.Authority) + "/", UriKind.Absolute);
+    }
+
+    internal static string EncodeMountPoint(string mountPoint)
+    {
+        var segments = mountPoint.Split('/');
+        var builder = new StringBuilder(mountPoint.Length);
+        for (var index = 0; index < segments.Length; index++)
+        {
+            if (index != 0)
+                builder.Append('/');
+            builder.Append(Uri.EscapeDataString(segments[index]));
+        }
+
+        return builder.ToString();
+    }
+
+    internal static Uri BuildUri(Uri vaultAddress, string relativePath)
+    {
+        return new Uri(NormalizeAddress(vaultAddress), relativePath);
+    }
+
+    internal static void AddNamespaceHeader(HttpRequestMessage request, string? vaultNamespace)
+    {
+        if (NormalizeNamespace(vaultNamespace) is { } normalizedNamespace)
+            request.Headers.TryAddWithoutValidation("X-Vault-Namespace", normalizedNamespace);
+    }
+
+    internal static void EnsureSuccess(HttpResponseMessage response)
+    {
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException(
+                $"Vault request failed with HTTP status {(int)response.StatusCode}.",
+                null,
+                response.StatusCode);
+        }
+    }
+
+    internal static async ValueTask<byte[]> ReadResponseBytesAsync(
+        HttpContent content,
+        CancellationToken cancellationToken)
+    {
+        if (content.Headers.ContentLength is > MaximumResponseBytes)
+            throw new InvalidOperationException("Vault response exceeded the maximum allowed size.");
+
+        await using var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var readBuffer = ArrayPool<byte>.Shared.Rent(4096);
+        var responseBuffer = new ArrayBufferWriter<byte>();
+        try
+        {
+            while (true)
+            {
+                var read = await stream
+                    .ReadAsync(readBuffer.AsMemory(), cancellationToken)
+                    .ConfigureAwait(false);
+                if (read == 0)
+                    return responseBuffer.WrittenSpan.ToArray();
+
+                if (responseBuffer.WrittenCount > MaximumResponseBytes - read)
+                    throw new InvalidOperationException("Vault response exceeded the maximum allowed size.");
+
+                responseBuffer.Write(readBuffer.AsSpan(0, read));
+            }
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(readBuffer);
+            ArrayPool<byte>.Shared.Return(readBuffer);
+            if (MemoryMarshal.TryGetArray(responseBuffer.WrittenMemory, out var segment) &&
+                segment.Array is not null)
+            {
+                CryptographicOperations.ZeroMemory(segment.Array.AsSpan(segment.Offset, segment.Count));
+            }
+        }
+    }
+
+    private async ValueTask<byte[]> SendTransitRequestAsync(
+        Uri vaultAddress,
+        string mountPoint,
+        string keyName,
+        string? vaultNamespace,
+        string operation,
+        byte[] payload,
+        int payloadLength,
+        string responseProperty,
+        bool responseIsBase64,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        vaultAddress = NormalizeAddress(vaultAddress);
+        var normalizedMountPoint = NormalizeMountPoint(mountPoint);
+        vaultNamespace = NormalizeNamespace(vaultNamespace);
+        if (string.IsNullOrWhiteSpace(keyName) || keyName.Contains('/'))
+            throw new ArgumentException("Vault Transit key name is invalid.", nameof(keyName));
+
+        var token = await _tokenProvider
+            .GetTokenAsync(vaultAddress, vaultNamespace, cancellationToken)
+            .ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(token) || token.Contains('\r') || token.Contains('\n'))
+            throw new InvalidOperationException("Vault token provider returned an invalid token.");
+
+        var path = $"v1/{EncodeMountPoint(normalizedMountPoint)}/{operation}/{Uri.EscapeDataString(keyName)}";
+        using var request = new HttpRequestMessage(HttpMethod.Post, BuildUri(vaultAddress, path));
+        request.Headers.TryAddWithoutValidation("X-Vault-Token", token);
+        AddNamespaceHeader(request, vaultNamespace);
+        request.Content = new ByteArrayContent(payload, 0, payloadLength);
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+        using var response = await _httpClient
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+        EnsureSuccess(response);
+        var responseBytes = await ReadResponseBytesAsync(response.Content, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            using var document = JsonDocument.Parse(responseBytes);
+            if (!document.RootElement.TryGetProperty("data", out var data)
+                || !data.TryGetProperty(responseProperty, out var material))
+            {
+                throw new InvalidOperationException("Vault Transit response did not contain key material.");
+            }
+
+            if (responseIsBase64)
+                return material.GetBytesFromBase64();
+
+            return material.GetString() is { Length: > 0 } ciphertext
+                ? Encoding.UTF8.GetBytes(ciphertext)
+                : throw new InvalidOperationException("Vault Transit response did not contain key material.");
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(responseBytes);
+        }
+    }
+
+    private static byte[] RentBase64Payload(ReadOnlySpan<byte> plaintext, out int payloadLength)
+    {
+        var maximumEncodedLength = Base64.GetMaxEncodedToUtf8Length(plaintext.Length);
+        var buffer = ArrayPool<byte>.Shared.Rent(
+            checked(PlaintextPrefix.Length + maximumEncodedLength + JsonStringSuffix.Length));
+        PlaintextPrefix.CopyTo(buffer);
+        var destination = buffer.AsSpan(PlaintextPrefix.Length, maximumEncodedLength);
+        var status = Base64.EncodeToUtf8(plaintext, destination, out var consumed, out var written);
+        if (status != OperationStatus.Done || consumed != plaintext.Length)
+        {
+            ReturnSensitiveBuffer(buffer);
+            throw new InvalidOperationException("Vault plaintext could not be encoded.");
+        }
+
+        JsonStringSuffix.CopyTo(buffer.AsSpan(PlaintextPrefix.Length + written));
+        payloadLength = PlaintextPrefix.Length + written + JsonStringSuffix.Length;
+        return buffer;
+    }
+
+    private static byte[] RentCiphertextPayload(ReadOnlySpan<byte> ciphertext, out int payloadLength)
+    {
+        foreach (var value in ciphertext)
+        {
+            if (value is < 0x20 or > 0x7e or (byte)'"' or (byte)'\\')
+                throw new FormatException("Vault ciphertext is not valid ASCII Transit ciphertext.");
+        }
+
+        var buffer = ArrayPool<byte>.Shared.Rent(
+            checked(CiphertextPrefix.Length + ciphertext.Length + JsonStringSuffix.Length));
+        CiphertextPrefix.CopyTo(buffer);
+        ciphertext.CopyTo(buffer.AsSpan(CiphertextPrefix.Length));
+        JsonStringSuffix.CopyTo(buffer.AsSpan(CiphertextPrefix.Length + ciphertext.Length));
+        payloadLength = CiphertextPrefix.Length + ciphertext.Length + JsonStringSuffix.Length;
+        return buffer;
+    }
+
+    private static void ReturnSensitiveBuffer(byte[] buffer)
+    {
+        CryptographicOperations.ZeroMemory(buffer);
+        ArrayPool<byte>.Shared.Return(buffer);
+    }
+}
+
+internal sealed record AppRoleLoginRequest(
+    [property: JsonPropertyName("role_id")] string RoleId,
+    [property: JsonPropertyName("secret_id")] string SecretId);
+
+[JsonSerializable(typeof(AppRoleLoginRequest))]
+internal sealed partial class VaultJsonContext : JsonSerializerContext;

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\..\src\Dekaf.Compression.Snappy\Dekaf.Compression.Snappy.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Gcp\Dekaf.SchemaRegistry.Kms.Gcp.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Vault\Dekaf.SchemaRegistry.Kms.Vault.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Json\Dekaf.SchemaRegistry.Json.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Lz4\Dekaf.Compression.Lz4.csproj" />

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/VaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/VaultKmsProviderTests.cs
@@ -8,7 +8,9 @@ namespace Dekaf.Tests.Unit.SchemaRegistry;
 
 public class VaultKmsProviderTests
 {
-    private const string KeyReference = "hcvault://https://vault.example:8200/orders-kek";
+    private const string KeyReference = "https://vault.example:8200/transit/keys/orders-kek";
+    private const string NestedMountKeyReference =
+        "https://vault.example:8200/team/transit/keys/orders-kek";
     private static readonly Uri VaultAddress = new("https://vault.example:8200/");
     private static readonly string[] ExpectedTokenHeader = ["token"];
     private static readonly string[] ExpectedNamespaceHeader = ["finance"];
@@ -33,11 +35,12 @@ public class VaultKmsProviderTests
                 Arg.Any<ReadOnlyMemory<byte>>(),
                 Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult(new byte[] { 1, 2, 3 }));
-        var provider = new VaultKmsProvider(client, "team/transit", "finance");
+        var provider = new VaultKmsProvider(client, VaultAddress, "finance");
         var plaintext = new byte[] { 1, 2, 3 };
 
-        var encrypted = await provider.WrapKeyAsync(plaintext, CreateKeyReference());
-        var decrypted = await provider.UnwrapKeyAsync(encrypted, CreateKeyReference());
+        var keyReference = CreateKeyReference(NestedMountKeyReference);
+        var encrypted = await provider.WrapKeyAsync(plaintext, keyReference);
+        var decrypted = await provider.UnwrapKeyAsync(encrypted, keyReference);
 
         await Assert.That(encrypted).IsEquivalentTo(Encoding.UTF8.GetBytes("vault:v1:wrapped"));
         await Assert.That(decrypted).IsEquivalentTo(plaintext);
@@ -73,7 +76,7 @@ public class VaultKmsProviderTests
                 Arg.Any<ReadOnlyMemory<byte>>(),
                 Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromException<byte[]>(failure));
-        var provider = new VaultKmsProvider(client);
+        var provider = new VaultKmsProvider(client, VaultAddress);
 
         var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
             () => provider.UnwrapKeyAsync(Encoding.UTF8.GetBytes("vault:v1:bad"), CreateKeyReference()).AsTask());
@@ -96,7 +99,7 @@ public class VaultKmsProviderTests
                 Arg.Any<ReadOnlyMemory<byte>>(),
                 Arg.Any<CancellationToken>())
             .Returns(call => new ValueTask<byte[]>(WaitForCancellationAsync(call.Arg<CancellationToken>())));
-        var provider = new VaultKmsProvider(client);
+        var provider = new VaultKmsProvider(client, VaultAddress);
         using var cancellation = new CancellationTokenSource();
         var operation = provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference(), cancellation.Token).AsTask();
 
@@ -105,7 +108,7 @@ public class VaultKmsProviderTests
         await Assert.That(async () => await operation).Throws<OperationCanceledException>();
         await client.Received(1).EncryptAsync(
             VaultAddress,
-            VaultKmsProvider.DefaultMountPoint,
+            "transit",
             "orders-kek",
             null,
             Arg.Any<ReadOnlyMemory<byte>>(),
@@ -124,7 +127,7 @@ public class VaultKmsProviderTests
                 Arg.Any<ReadOnlyMemory<byte>>(),
                 Arg.Any<CancellationToken>())
             .Returns(call => new ValueTask<byte[]>(EchoAfterYieldAsync(call.Arg<ReadOnlyMemory<byte>>())));
-        var provider = new VaultKmsProvider(client);
+        var provider = new VaultKmsProvider(client, VaultAddress);
 
         var operations = Enumerable.Range(1, 32)
             .Select(value => provider.WrapKeyAsync(new byte[] { (byte)value }, CreateKeyReference()).AsTask())
@@ -135,7 +138,7 @@ public class VaultKmsProviderTests
             await Assert.That(results[index]).IsEquivalentTo(new byte[] { (byte)(index + 1) });
         await client.Received(32).EncryptAsync(
             VaultAddress,
-            VaultKmsProvider.DefaultMountPoint,
+            "transit",
             "orders-kek",
             null,
             Arg.Any<ReadOnlyMemory<byte>>(),
@@ -143,14 +146,29 @@ public class VaultKmsProviderTests
     }
 
     [Test]
-    [Arguments("https://vault.example:8200/orders-kek")]
-    [Arguments("hcvault://ftp://vault.example/orders-kek")]
-    [Arguments("hcvault://https://vault.example/transit/orders-kek")]
-    [Arguments("hcvault://https://user@vault.example/orders-kek")]
+    public async Task ServerProvidedAuthority_IsRejectedBeforeVaultCall()
+    {
+        var client = Substitute.For<IVaultTransitClient>();
+        var provider = new VaultKmsProvider(client, VaultAddress);
+
+        await Assert.That(async () => await provider.WrapKeyAsync(
+                new byte[] { 1 },
+                CreateKeyReference("https://attacker.example:8200/transit/keys/orders-kek")))
+            .Throws<SchemaRegistryKmsException>();
+        await client.DidNotReceiveWithAnyArgs().EncryptAsync(
+            default!, default!, default!, default, default, default);
+    }
+
+    [Test]
+    [Arguments("hcvault://https://vault.example:8200/transit/keys/orders-kek")]
+    [Arguments("ftp://vault.example/transit/keys/orders-kek")]
+    [Arguments("https://vault.example/transit/orders-kek")]
+    [Arguments("https://user@vault.example/transit/keys/orders-kek")]
+    [Arguments("https://vault.example:8200/transit/keys/orders-kek/")]
     public async Task InvalidKeyReference_IsRejectedBeforeVaultCall(string keyId)
     {
         var client = Substitute.For<IVaultTransitClient>();
-        var provider = new VaultKmsProvider(client);
+        var provider = new VaultKmsProvider(client, VaultAddress);
 
         await Assert.That(async () => await provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference(keyId)))
             .Throws<SchemaRegistryKmsException>();
@@ -245,6 +263,32 @@ public class VaultKmsProviderTests
         await Assert.That(loginCount).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task AppRoleProvider_BasesExpiryOnLoginStartTime()
+    {
+        var loginCount = 0;
+        var timeProvider = new TestTimeProvider(new DateTimeOffset(2026, 8, 17, 0, 0, 0, TimeSpan.Zero));
+        var handler = new RecordingHandler((_, _) =>
+        {
+            Interlocked.Increment(ref loginCount);
+            timeProvider.Advance(TimeSpan.FromSeconds(31));
+            return Task.FromResult(JsonResponse(
+                "{\"auth\":{\"client_token\":\"app-token\",\"lease_duration\":60}}"));
+        });
+        using var httpClient = new HttpClient(handler);
+        var provider = new VaultAppRoleTokenProvider(
+            httpClient,
+            "role",
+            "secret",
+            "approle",
+            timeProvider);
+
+        _ = await provider.GetTokenAsync(VaultAddress, null);
+        _ = await provider.GetTokenAsync(VaultAddress, null);
+
+        await Assert.That(loginCount).IsEqualTo(2);
+    }
+
     private static SchemaRegistryKmsKeyReference CreateKeyReference(string keyId = KeyReference) => new()
     {
         KmsType = VaultKmsProvider.DefaultType,
@@ -277,5 +321,14 @@ public class VaultKmsProviderTests
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken) => send(request, cancellationToken);
+    }
+
+    private sealed class TestTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        internal void Advance(TimeSpan duration) => _utcNow += duration;
     }
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/VaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/VaultKmsProviderTests.cs
@@ -234,6 +234,69 @@ public class VaultKmsProviderTests
     }
 
     [Test]
+    public async Task Provider_RejectsBaseAddressPath()
+    {
+        var client = Substitute.For<IVaultTransitClient>();
+        var action = () => new VaultKmsProvider(
+            client,
+            new Uri("https://vault.example:8200/prefix/"));
+
+        await Assert.That(action).Throws<ArgumentException>();
+    }
+
+    [Test]
+    [Arguments(".")]
+    [Arguments("..")]
+    public async Task HttpClient_RejectsDotSegmentKeyName(string keyName)
+    {
+        var handler = new RecordingHandler(static (_, _) =>
+            throw new InvalidOperationException("HTTP request was not expected."));
+        using var httpClient = new HttpClient(handler);
+        var client = new VaultTransitHttpClient(httpClient, new VaultStaticTokenProvider("token"));
+
+        await Assert.That(async () => await client.EncryptAsync(
+                VaultAddress,
+                "transit",
+                keyName,
+                null,
+                new byte[] { 1 }))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task ResponseStream_AsyncDisposalDoesNotCaptureCallerContext()
+    {
+        var synchronizationContext = new QueueingSynchronizationContext();
+        var operation = Task.Run(() =>
+        {
+            var previousContext = SynchronizationContext.Current;
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+                using var content = new StreamContent(new AsynchronousDisposeStream());
+                return VaultTransitHttpClient
+                    .ReadResponseBytesAsync(content, CancellationToken.None)
+                    .AsTask()
+                    .GetAwaiter()
+                    .GetResult();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(previousContext);
+            }
+        });
+
+        try
+        {
+            await Assert.That(await operation.WaitAsync(TimeSpan.FromSeconds(1))).IsEmpty();
+        }
+        finally
+        {
+            synchronizationContext.Drain();
+        }
+    }
+
+    [Test]
     public async Task AppRoleProvider_LogsInOnceForConcurrentCallers()
     {
         var loginCount = 0;
@@ -321,6 +384,41 @@ public class VaultKmsProviderTests
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken) => send(request, cancellationToken);
+    }
+
+    private sealed class AsynchronousDisposeStream : MemoryStream
+    {
+        public override async ValueTask DisposeAsync()
+        {
+            await Task.Delay(10).ConfigureAwait(false);
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private sealed class QueueingSynchronizationContext : SynchronizationContext
+    {
+        private readonly Queue<(SendOrPostCallback Callback, object? State)> _callbacks = new();
+
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            lock (_callbacks)
+                _callbacks.Enqueue((d, state));
+        }
+
+        internal void Drain()
+        {
+            while (true)
+            {
+                (SendOrPostCallback Callback, object? State) callback;
+                lock (_callbacks)
+                {
+                    if (!_callbacks.TryDequeue(out callback))
+                        return;
+                }
+
+                callback.Callback(callback.State);
+            }
+        }
     }
 
     private sealed class TestTimeProvider(DateTimeOffset utcNow) : TimeProvider

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/VaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/VaultKmsProviderTests.cs
@@ -1,0 +1,281 @@
+using System.Net;
+using System.Text;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Kms.Vault;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public class VaultKmsProviderTests
+{
+    private const string KeyReference = "hcvault://https://vault.example:8200/orders-kek";
+    private static readonly Uri VaultAddress = new("https://vault.example:8200/");
+    private static readonly string[] ExpectedTokenHeader = ["token"];
+    private static readonly string[] ExpectedNamespaceHeader = ["finance"];
+
+    [Test]
+    public async Task WrapAndUnwrap_ResolveAddressMountKeyAndNamespace()
+    {
+        var client = Substitute.For<IVaultTransitClient>();
+        client.EncryptAsync(
+                Arg.Any<Uri>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(Encoding.UTF8.GetBytes("vault:v1:wrapped")));
+        client.DecryptAsync(
+                Arg.Any<Uri>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new byte[] { 1, 2, 3 }));
+        var provider = new VaultKmsProvider(client, "team/transit", "finance");
+        var plaintext = new byte[] { 1, 2, 3 };
+
+        var encrypted = await provider.WrapKeyAsync(plaintext, CreateKeyReference());
+        var decrypted = await provider.UnwrapKeyAsync(encrypted, CreateKeyReference());
+
+        await Assert.That(encrypted).IsEquivalentTo(Encoding.UTF8.GetBytes("vault:v1:wrapped"));
+        await Assert.That(decrypted).IsEquivalentTo(plaintext);
+        await client.Received(1).EncryptAsync(
+            VaultAddress,
+            "team/transit",
+            "orders-kek",
+            "finance",
+            Arg.Is<ReadOnlyMemory<byte>>(value => MemoryEquals(value, plaintext)),
+            Arg.Any<CancellationToken>());
+        await client.Received(1).DecryptAsync(
+            VaultAddress,
+            "team/transit",
+            "orders-kek",
+            "finance",
+            Arg.Is<ReadOnlyMemory<byte>>(value => MemoryEquals(value, encrypted)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    [Arguments(HttpStatusCode.NotFound, "wrong key")]
+    [Arguments(HttpStatusCode.Forbidden, "authorization: sensitive")]
+    [Arguments(HttpStatusCode.BadRequest, "ciphertext: sensitive")]
+    public async Task VaultFailure_IsReportedWithoutProviderResponse(HttpStatusCode statusCode, string detail)
+    {
+        var client = Substitute.For<IVaultTransitClient>();
+        var failure = new HttpRequestException(detail, null, statusCode);
+        client.DecryptAsync(
+                Arg.Any<Uri>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<byte[]>(failure));
+        var provider = new VaultKmsProvider(client);
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            () => provider.UnwrapKeyAsync(Encoding.UTF8.GetBytes("vault:v1:bad"), CreateKeyReference()).AsTask());
+
+        await Assert.That(exception!.Message).IsEqualTo("Vault Transit unwrap failed.");
+        await Assert.That(exception.Message).DoesNotContain("sensitive");
+        await Assert.That(exception.Message).DoesNotContain("wrong key");
+        await Assert.That(exception.InnerException).IsSameReferenceAs(failure);
+    }
+
+    [Test]
+    public async Task Cancellation_IsPropagatedToInFlightTransitCall()
+    {
+        var client = Substitute.For<IVaultTransitClient>();
+        client.EncryptAsync(
+                Arg.Any<Uri>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => new ValueTask<byte[]>(WaitForCancellationAsync(call.Arg<CancellationToken>())));
+        var provider = new VaultKmsProvider(client);
+        using var cancellation = new CancellationTokenSource();
+        var operation = provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference(), cancellation.Token).AsTask();
+
+        cancellation.Cancel();
+
+        await Assert.That(async () => await operation).Throws<OperationCanceledException>();
+        await client.Received(1).EncryptAsync(
+            VaultAddress,
+            VaultKmsProvider.DefaultMountPoint,
+            "orders-kek",
+            null,
+            Arg.Any<ReadOnlyMemory<byte>>(),
+            cancellation.Token);
+    }
+
+    [Test]
+    public async Task SharedProvider_UsesClientConcurrently()
+    {
+        var client = Substitute.For<IVaultTransitClient>();
+        client.EncryptAsync(
+                Arg.Any<Uri>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => new ValueTask<byte[]>(EchoAfterYieldAsync(call.Arg<ReadOnlyMemory<byte>>())));
+        var provider = new VaultKmsProvider(client);
+
+        var operations = Enumerable.Range(1, 32)
+            .Select(value => provider.WrapKeyAsync(new byte[] { (byte)value }, CreateKeyReference()).AsTask())
+            .ToArray();
+        var results = await Task.WhenAll(operations);
+
+        for (var index = 0; index < results.Length; index++)
+            await Assert.That(results[index]).IsEquivalentTo(new byte[] { (byte)(index + 1) });
+        await client.Received(32).EncryptAsync(
+            VaultAddress,
+            VaultKmsProvider.DefaultMountPoint,
+            "orders-kek",
+            null,
+            Arg.Any<ReadOnlyMemory<byte>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    [Arguments("https://vault.example:8200/orders-kek")]
+    [Arguments("hcvault://ftp://vault.example/orders-kek")]
+    [Arguments("hcvault://https://vault.example/transit/orders-kek")]
+    [Arguments("hcvault://https://user@vault.example/orders-kek")]
+    public async Task InvalidKeyReference_IsRejectedBeforeVaultCall(string keyId)
+    {
+        var client = Substitute.For<IVaultTransitClient>();
+        var provider = new VaultKmsProvider(client);
+
+        await Assert.That(async () => await provider.WrapKeyAsync(new byte[] { 1 }, CreateKeyReference(keyId)))
+            .Throws<SchemaRegistryKmsException>();
+        await client.DidNotReceiveWithAnyArgs().EncryptAsync(
+            default!, default!, default!, default, default, default);
+    }
+
+    [Test]
+    public async Task HttpClient_UsesTransitApiHeadersAndPayloads()
+    {
+        var requestNumber = 0;
+        var handler = new RecordingHandler(async (request, cancellationToken) =>
+        {
+            var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+            await Assert.That(request.Headers.GetValues("X-Vault-Token")).IsEquivalentTo(ExpectedTokenHeader);
+            await Assert.That(request.Headers.GetValues("X-Vault-Namespace"))
+                .IsEquivalentTo(ExpectedNamespaceHeader);
+
+            requestNumber++;
+            if (requestNumber == 1)
+            {
+                await Assert.That(request.RequestUri!.AbsolutePath)
+                    .IsEqualTo("/v1/team/transit/encrypt/orders-kek");
+                await Assert.That(body).IsEqualTo("{\"plaintext\":\"AQID\"}");
+                return JsonResponse("{\"data\":{\"ciphertext\":\"vault:v1:wrapped\"}}");
+            }
+
+            await Assert.That(request.RequestUri!.AbsolutePath)
+                .IsEqualTo("/v1/team/transit/decrypt/orders-kek");
+            await Assert.That(body).IsEqualTo("{\"ciphertext\":\"vault:v1:wrapped\"}");
+            return JsonResponse("{\"data\":{\"plaintext\":\"AQID\"}}");
+        });
+        using var httpClient = new HttpClient(handler);
+        var client = new VaultTransitHttpClient(httpClient, new VaultStaticTokenProvider("token"));
+
+        var encrypted = await client.EncryptAsync(
+            VaultAddress, "team/transit", "orders-kek", "finance", new byte[] { 1, 2, 3 });
+        var decrypted = await client.DecryptAsync(
+            VaultAddress, "team/transit", "orders-kek", "finance", encrypted);
+
+        await Assert.That(encrypted).IsEquivalentTo(Encoding.UTF8.GetBytes("vault:v1:wrapped"));
+        await Assert.That(decrypted).IsEquivalentTo(new byte[] { 1, 2, 3 });
+        await Assert.That(requestNumber).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task HttpClient_ForwardsCancellationToTransport()
+    {
+        var handler = new RecordingHandler(async (_, cancellationToken) =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("Cancellation was not observed.");
+        });
+        using var httpClient = new HttpClient(handler);
+        var client = new VaultTransitHttpClient(httpClient, new VaultStaticTokenProvider("token"));
+        using var cancellation = new CancellationTokenSource();
+        var operation = client.EncryptAsync(
+            VaultAddress, "transit", "orders-kek", null, new byte[] { 1 }, cancellation.Token).AsTask();
+
+        cancellation.Cancel();
+
+        await Assert.That(async () => await operation).Throws<OperationCanceledException>();
+    }
+
+    [Test]
+    public async Task AppRoleProvider_LogsInOnceForConcurrentCallers()
+    {
+        var loginCount = 0;
+        var handler = new RecordingHandler(async (request, cancellationToken) =>
+        {
+            Interlocked.Increment(ref loginCount);
+            var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+            await Assert.That(request.RequestUri!.AbsolutePath).IsEqualTo("/v1/auth/team-approle/login");
+            await Assert.That(request.Headers.GetValues("X-Vault-Namespace"))
+                .IsEquivalentTo(ExpectedNamespaceHeader);
+            await Assert.That(body).Contains("\"role_id\":\"role\"");
+            await Assert.That(body).Contains("\"secret_id\":\"secret\"");
+            await Task.Yield();
+            return JsonResponse(
+                "{\"auth\":{\"client_token\":\"app-token\",\"lease_duration\":3600}}");
+        });
+        using var httpClient = new HttpClient(handler);
+        var provider = new VaultAppRoleTokenProvider(httpClient, "role", "secret", "team-approle");
+
+        var operations = Enumerable.Range(0, 32)
+            .Select(_ => provider.GetTokenAsync(VaultAddress, "finance").AsTask())
+            .ToArray();
+        var tokens = await Task.WhenAll(operations);
+
+        foreach (var token in tokens)
+            await Assert.That(token).IsEqualTo("app-token");
+        await Assert.That(loginCount).IsEqualTo(1);
+    }
+
+    private static SchemaRegistryKmsKeyReference CreateKeyReference(string keyId = KeyReference) => new()
+    {
+        KmsType = VaultKmsProvider.DefaultType,
+        KmsKeyId = keyId
+    };
+
+    private static bool MemoryEquals(ReadOnlyMemory<byte> actual, byte[] expected) =>
+        actual.Span.SequenceEqual(expected);
+
+    private static async Task<byte[]> WaitForCancellationAsync(CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        throw new InvalidOperationException("Cancellation was not observed.");
+    }
+
+    private static async Task<byte[]> EchoAfterYieldAsync(ReadOnlyMemory<byte> plaintext)
+    {
+        await Task.Yield();
+        return plaintext.ToArray();
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(json, Encoding.UTF8, "application/json")
+    };
+
+    private sealed class RecordingHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> send) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => send(request, cancellationToken);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/VaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/VaultKmsProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Net;
 using System.Text;
 using Dekaf.SchemaRegistry;
@@ -297,6 +298,27 @@ public class VaultKmsProviderTests
     }
 
     [Test]
+    public async Task ResponseStream_GrowthZeroesEveryReturnedBuffer()
+    {
+        var expected = Enumerable.Range(0, 9000)
+            .Select(static value => (byte)((value % 251) + 1))
+            .ToArray();
+        using var content = new StreamContent(new MemoryStream(expected, writable: false));
+        content.Headers.ContentLength = null;
+        var bufferPool = new TrackingArrayPool();
+
+        var actual = await VaultTransitHttpClient.ReadResponseBytesAsync(
+            content,
+            bufferPool,
+            CancellationToken.None);
+
+        await Assert.That(actual.SequenceEqual(expected)).IsTrue();
+        await Assert.That(bufferPool.ReturnedBuffers.Count).IsGreaterThan(1);
+        foreach (var buffer in bufferPool.ReturnedBuffers)
+            await Assert.That(buffer.All(static value => value == 0)).IsTrue();
+    }
+
+    [Test]
     public async Task AppRoleProvider_LogsInOnceForConcurrentCallers()
     {
         var loginCount = 0;
@@ -419,6 +441,15 @@ public class VaultKmsProviderTests
                 callback.Callback(callback.State);
             }
         }
+    }
+
+    private sealed class TrackingArrayPool : ArrayPool<byte>
+    {
+        internal List<byte[]> ReturnedBuffers { get; } = [];
+
+        public override byte[] Rent(int minimumLength) => new byte[minimumLength];
+
+        public override void Return(byte[] array, bool clearArray = false) => ReturnedBuffers.Add(array);
     }
 
     private sealed class TestTimeProvider(DateTimeOffset utcNow) : TimeProvider

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/VaultKmsProviderBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/VaultKmsProviderBenchmarks.cs
@@ -1,0 +1,75 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Kms.Vault;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+public class VaultKmsProviderBenchmarks
+{
+    private static readonly Uri VaultAddress = new("https://vault.example:8200/");
+    private readonly byte[] _ciphertext = "vault:v1:benchmark"u8.ToArray();
+    private readonly byte[] _plaintext = new byte[32];
+    private readonly SchemaRegistryKmsKeyReference _keyReference = new()
+    {
+        KmsType = VaultKmsProvider.DefaultType,
+        KmsKeyId = "https://vault.example:8200/transit/keys/benchmark-kek"
+    };
+    private SynchronousTransitClient _client = null!;
+    private VaultKmsProvider _provider = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _client = new SynchronousTransitClient(_ciphertext, _plaintext);
+        _provider = new VaultKmsProvider(_client, VaultAddress, "benchmarks");
+    }
+
+    [Benchmark(Baseline = true)]
+    public ValueTask<byte[]> DirectWrapAsync() =>
+        _client.EncryptAsync(
+            VaultAddress,
+            "transit",
+            "benchmark-kek",
+            "benchmarks",
+            _plaintext);
+
+    [Benchmark]
+    public ValueTask<byte[]> ProviderWrapAsync() =>
+        _provider.WrapKeyAsync(_plaintext, _keyReference);
+
+    [Benchmark]
+    public ValueTask<byte[]> DirectUnwrapAsync() =>
+        _client.DecryptAsync(
+            VaultAddress,
+            "transit",
+            "benchmark-kek",
+            "benchmarks",
+            _ciphertext);
+
+    [Benchmark]
+    public ValueTask<byte[]> ProviderUnwrapAsync() =>
+        _provider.UnwrapKeyAsync(_ciphertext, _keyReference);
+
+    private sealed class SynchronousTransitClient(byte[] ciphertext, byte[] plaintext)
+        : IVaultTransitClient
+    {
+        public ValueTask<byte[]> EncryptAsync(
+            Uri vaultAddress,
+            string mountPoint,
+            string keyName,
+            string? vaultNamespace,
+            ReadOnlyMemory<byte> value,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(ciphertext);
+
+        public ValueTask<byte[]> DecryptAsync(
+            Uri vaultAddress,
+            string mountPoint,
+            string keyName,
+            string? vaultNamespace,
+            ReadOnlyMemory<byte> value,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(plaintext);
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/VaultKmsProviderBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/VaultKmsProviderBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using BenchmarkDotNet.Attributes;
 using Dekaf.SchemaRegistry;
 using Dekaf.SchemaRegistry.Kms.Vault;
@@ -71,5 +72,42 @@ public class VaultKmsProviderBenchmarks
             ReadOnlyMemory<byte> value,
             CancellationToken cancellationToken = default) =>
             ValueTask.FromResult(plaintext);
+    }
+}
+
+[MemoryDiagnoser]
+public class VaultTransitHttpClientBenchmarks
+{
+    private static readonly Uri VaultAddress = new("https://vault.example:8200/");
+    private static readonly byte[] Plaintext = new byte[32];
+    private HttpClient _httpClient = null!;
+    private VaultTransitHttpClient _client = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _httpClient = new HttpClient(new VaultResponseHandler());
+        _client = new VaultTransitHttpClient(_httpClient, new VaultStaticTokenProvider("token"));
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _httpClient.Dispose();
+
+    [Benchmark]
+    public ValueTask<byte[]> EncryptAsync() =>
+        _client.EncryptAsync(VaultAddress, "transit", "benchmark-kek", null, Plaintext);
+
+    private sealed class VaultResponseHandler : HttpMessageHandler
+    {
+        private static readonly byte[] Response =
+            "{\"data\":{\"ciphertext\":\"vault:v1:benchmark\"}}"u8.ToArray();
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(Response)
+            });
     }
 }

--- a/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
+++ b/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Avro\Dekaf.SchemaRegistry.Avro.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Json\Dekaf.SchemaRegistry.Json.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Vault\Dekaf.SchemaRegistry.Kms.Vault.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- add opt-in `Dekaf.SchemaRegistry.Kms.Vault` provider for Confluent-compatible `hcvault://` key references
- add cancellable Vault Transit HTTP client with static-token and AppRole authentication
- cache AppRole lease tokens per canonical Vault address/namespace and serialize refreshes
- validate address, namespace, mount, key, token, and response shape; sanitize HTTP errors
- clear temporary plaintext, ciphertext, login, and response byte buffers
- document address, key, mount, namespace, static-token/AppRole setup, policy, cancellation, ownership, and security

Closes #2704

## Validation

- `dotnet restore Dekaf.sln`
- `dotnet build Dekaf.sln --configuration Release --no-restore` — 0 warnings, 0 errors
- `dotnet pack src/Dekaf.SchemaRegistry.Kms.Vault/Dekaf.SchemaRegistry.Kms.Vault.csproj --configuration Release --no-build --no-restore`
- focused Vault tests: net10.0 13/13, net8.0 13/13
- full net10.0 unit suite: 6,886/6,886
- full net8.0 unit suite: 6,749/6,750; unrelated pre-existing scheduler-dependent MPSC test exposed and tracked in #2709

## Performance

This is an opt-in package with no references from existing runtime projects and no producer, consumer, serialization, protocol, or networking hot-path changes. Remote KMS operations are key-wrap boundaries, not per-message paths. Sensitive request construction uses pooled byte buffers; AppRole authentication is lease-cached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added HashiCorp Vault Transit KMS integration for Schema Registry client-side field-level encryption.
  - Supports static-token and AppRole authentication.
  - Supports key wrapping and unwrapping with Vault addresses, namespaces, mounts, and key references.
  - Includes cancellation handling, concurrent usage, token caching, and sanitized error reporting.

- **Documentation**
  - Added setup and configuration guidance, including authentication, permissions, key formats, ownership, concurrency, and sensitive-data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->