### PR TITLE
test(producer): make crash sequencing deterministic

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -739,6 +739,8 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
         var injectedFailure = new InvalidOperationException("injected pending-response failure");
         var allRerouted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var coalesceStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseCoalesce = new ManualResetEventSlim();
         var reroutedSequences = new ConcurrentQueue<int>();
         var reroutedCount = 0;
         var crashEnabled = 0;
@@ -758,14 +760,24 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             {
                 if (Interlocked.Exchange(ref crashEnabled, 0) != 0)
                     throw injectedFailure;
+
+                coalesceStarted.TrySetResult();
+                releaseCoalesce.Wait(cancellationToken);
             });
 
         try
         {
             var pendingFirst = CreateTestBatchWithDelivery(valueTaskSourcePool, "test-topic", 0);
             var pendingSecond = CreateTestBatchWithDelivery(valueTaskSourcePool, "test-topic", 1);
-            sender.EnqueueBulk([pendingFirst.Batch, pendingSecond.Batch]);
+            SeedKnownPartitions(sender, pendingFirst.Batch.TopicPartition, pendingSecond.Batch.TopicPartition);
+            sender.Enqueue(pendingFirst.Batch);
+            await coalesceStarted.Task.WaitAsync(cancellationToken);
+
+            sender.Enqueue(pendingSecond.Batch);
+            releaseCoalesce.Set();
             await WaitUntilAsync(() => GetPendingResponseCount(sender) == 1, cancellationToken);
+            await Assert.That(pendingFirst.Batch.RecordBatch.BaseSequence).IsGreaterThanOrEqualTo(0);
+            await Assert.That(pendingSecond.Batch.RecordBatch.BaseSequence).IsGreaterThanOrEqualTo(0);
 
             var coalesced = CreateTestBatchWithDelivery(valueTaskSourcePool, "test-topic", 0);
             Volatile.Write(ref crashEnabled, 1);
@@ -787,6 +799,7 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         }
         finally
         {
+            releaseCoalesce.Set();
             pendingResponse.TrySetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 0));
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();


### PR DESCRIPTION
## Summary

- gate the sender at its existing wave-coalescing test hook
- enqueue both pending idempotent batches before releasing the first send
- assert both batches have assigned base sequences before injecting the unexpected exit
- release the test gate on every cleanup path

This removes the scheduling assumption that one pending response necessarily contained both bulk-enqueued batches.

## Test plan

- [x] focused test: 50/50 passes on net10.0
- [x] focused test: 50/50 passes on net8.0
- [x] full unit suite net10.0: 6,983 passed
- [x] full unit suite net8.0: 6,847 passed
- [x] Release builds: 0 warnings/errors
- [x] `/simplify`, self-review, and `git diff --check`

No `src/` change; no benchmark required.

Closes #2716