### PR TITLE
test(consumer): remove paused resume timing race

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -499,19 +499,15 @@ public sealed class ConsumerPauseResumeCacheTests
         await using var consumer = CreatePrefetchedConsumer(CreatePendingFetch(partition, 10, 1));
         consumer.Pause(partition);
 
-        using var cancellationSource = new CancellationTokenSource();
-        var consume = consumer.ConsumeOneAsync(
-            Timeout.InfiniteTimeSpan,
-            cancellationSource.Token).AsTask();
+        var consume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
         var pausedDirectFetchCancellationSource = GetField("_pausedDirectFetchCancellationSource");
         await Assert.That(SpinWait.SpinUntil(
             () => pausedDirectFetchCancellationSource.GetValue(consumer) is not null,
             TimeSpan.FromSeconds(5))).IsTrue();
 
-        cancellationSource.CancelAfter(TimeSpan.FromMilliseconds(75));
         consumer.Resume(partition);
 
-        var resumed = await consume;
+        var resumed = await consume.WaitAsync(TimeSpan.FromSeconds(5));
         await Assert.That(resumed).IsNotNull();
         await Assert.That(resumed!.Value.Topic).IsEqualTo(partition.Topic);
         await Assert.That(resumed.Value.Partition).IsEqualTo(partition.Partition);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -499,7 +499,8 @@ public sealed class ConsumerPauseResumeCacheTests
         await using var consumer = CreatePrefetchedConsumer(CreatePendingFetch(partition, 10, 1));
         consumer.Pause(partition);
 
-        var consume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        using var cancellationSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var consume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan, cancellationSource.Token).AsTask();
         var pausedDirectFetchCancellationSource = GetField("_pausedDirectFetchCancellationSource");
         await Assert.That(SpinWait.SpinUntil(
             () => pausedDirectFetchCancellationSource.GetValue(consumer) is not null,
@@ -507,7 +508,7 @@ public sealed class ConsumerPauseResumeCacheTests
 
         consumer.Resume(partition);
 
-        var resumed = await consume.WaitAsync(TimeSpan.FromSeconds(5));
+        var resumed = await consume;
         await Assert.That(resumed).IsNotNull();
         await Assert.That(resumed!.Value.Topic).IsEqualTo(partition.Topic);
         await Assert.That(resumed.Value.Partition).IsEqualTo(partition.Partition);


### PR DESCRIPTION
Closes #2717.

## Change

- replace the fixed 75 ms caller-cancellation race with a generous 5-second caller bound;
- await the actual `ConsumeOneAsync` task directly, so regression cancellation/faults remain observed;
- keep deterministic synchronization that proves the paused direct-fetch wake source is armed before `Resume`;
- preserve retained-record delivery and wake-source cleanup assertions.

## Validation

- Release builds: net8.0 and net10.0, 0 warnings/errors.
- final focused fresh-process repetitions: 50/50 on net8.0 and 50/50 on net10.0.
- full unit net8.0: 6,871/6,871.
- full unit net10.0: 7,007/7,007.
- exact-head CI Passed; Claude and CodeRabbit clear.

Test-only change; no production hot path, benchmark, or stress lane applies.