### PR TITLE
test(consumer): stabilize MPSC timeout tests

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Protocol.Records;
@@ -320,32 +321,51 @@ public class MpscFetchBufferTests
     [Test]
     public async Task WaitToReadAsync_StaleTimeoutCannotCompleteNextWait()
     {
-        using var timeoutEntered = new ManualResetEventSlim();
-        using var releaseTimeout = new ManualResetEventSlim();
-        using var timeoutExited = new ManualResetEventSlim();
+        var timeoutEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseTimeout = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timeoutExited = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timeoutThreadFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var buffer = new MpscFetchBuffer(
             capacity: 4,
             afterProducerWaiterCountIncrementedForTesting: null,
             beforeConsumerTimeoutForTesting: () =>
             {
-                timeoutEntered.Set();
-                releaseTimeout.Wait();
+                timeoutEntered.TrySetResult();
+                releaseTimeout.Task.GetAwaiter().GetResult();
             },
-            afterConsumerTimeoutForTesting: timeoutExited.Set);
+            afterConsumerTimeoutForTesting: timeoutExited.SetResult);
         var item = CreateDummy();
+        Thread? timeoutThread = null;
 
         try
         {
-            var firstWait = buffer.WaitToReadAsync(1, CancellationToken.None).AsTask();
-            await Assert.That(timeoutEntered.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            // Keep the real timer dormant and run its callback on a dedicated thread so
+            // the stale-timeout gate cannot occupy or starve a ThreadPool worker.
+            var firstWait = buffer.WaitToReadAsync(30_000, CancellationToken.None).AsTask();
+            timeoutThread = new Thread(() =>
+            {
+                try
+                {
+                    TriggerConsumerTimeout(buffer);
+                    timeoutThreadFinished.TrySetResult();
+                }
+                catch (Exception exception)
+                {
+                    timeoutThreadFinished.TrySetException(exception);
+                }
+            }) { IsBackground = true };
+            timeoutThread.Start();
+
+            await timeoutEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
             await Assert.That(buffer.TryWrite(item)).IsTrue();
             await Assert.That(await firstWait).IsTrue();
             await Assert.That(buffer.TryRead(out var read)).IsTrue();
             await Assert.That(read).IsSameReferenceAs(item);
 
             var nextWait = buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None).AsTask();
-            releaseTimeout.Set();
-            await Assert.That(timeoutExited.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            releaseTimeout.TrySetResult();
+            await timeoutExited.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await timeoutThreadFinished.Task.WaitAsync(TimeSpan.FromSeconds(5));
             await Assert.That(nextWait.IsCompleted).IsFalse();
 
             buffer.Complete();
@@ -353,9 +373,17 @@ public class MpscFetchBufferTests
         }
         finally
         {
-            releaseTimeout.Set();
-            item.Dispose();
-            buffer.Dispose();
+            releaseTimeout.TrySetResult();
+            try
+            {
+                if (timeoutThread is not null)
+                    await timeoutThreadFinished.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            finally
+            {
+                item.Dispose();
+                buffer.Dispose();
+            }
         }
     }
 
@@ -398,61 +426,50 @@ public class MpscFetchBufferTests
     }
 
     [Test]
-    public async Task WaitToReadAsync_TimeoutDoesNotRunContinuationInline()
+    public async Task WaitToReadAsync_TimeoutDoesNotRunContinuationOnTimerThread()
     {
-        var timeoutEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var releaseTimeout = new ManualResetEventSlim();
         var continuationEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var releaseContinuation = new ManualResetEventSlim();
-        var continuationFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continuationFinished = new TaskCompletionSource<(int ThreadId, bool Result)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         var timeoutCallbackExited = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timeoutThreadId = 0;
         var buffer = new MpscFetchBuffer(
             capacity: 4,
             afterProducerWaiterCountIncrementedForTesting: null,
             beforeConsumerTimeoutForTesting: () =>
+                Volatile.Write(ref timeoutThreadId, Environment.CurrentManagedThreadId),
+            afterConsumerTimeoutForTesting: () =>
             {
-                timeoutEntered.TrySetResult();
-                releaseTimeout.Wait();
-            },
-            afterConsumerTimeoutForTesting: () => timeoutCallbackExited.TrySetResult());
-        var result = true;
-        Exception? continuationException = null;
+                continuationEntered.Task.GetAwaiter().GetResult();
+                timeoutCallbackExited.TrySetResult();
+            });
 
         try
         {
             var awaiter = buffer.WaitToReadAsync(1, CancellationToken.None).GetAwaiter();
             awaiter.UnsafeOnCompleted(() =>
             {
+                var continuationThreadId = Environment.CurrentManagedThreadId;
                 continuationEntered.TrySetResult();
-                releaseContinuation.Wait();
                 try
                 {
-                    result = awaiter.GetResult();
+                    continuationFinished.TrySetResult((continuationThreadId, awaiter.GetResult()));
                 }
                 catch (Exception exception)
                 {
-                    continuationException = exception;
-                }
-                finally
-                {
-                    continuationFinished.TrySetResult();
+                    continuationFinished.TrySetException(exception);
                 }
             });
 
-            await timeoutEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
-            releaseTimeout.Set();
-            await continuationEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var completion = await continuationFinished.Task.WaitAsync(TimeSpan.FromSeconds(5));
             await timeoutCallbackExited.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-            releaseContinuation.Set();
-            await continuationFinished.Task.WaitAsync(TimeSpan.FromSeconds(5));
-            await Assert.That(continuationException).IsNull();
-            await Assert.That(result).IsFalse();
+            await Assert.That(completion.ThreadId).IsNotEqualTo(Volatile.Read(ref timeoutThreadId));
+            await Assert.That(completion.Result).IsFalse();
         }
         finally
         {
-            releaseTimeout.Set();
-            releaseContinuation.Set();
+            continuationEntered.TrySetResult();
             buffer.Dispose();
         }
     }
@@ -931,5 +948,22 @@ public class MpscFetchBufferTests
             "_readWaiterActive",
             BindingFlags.NonPublic | BindingFlags.Instance)!;
         return (bool)field.GetValue(buffer)!;
+    }
+
+    private static void TriggerConsumerTimeout(MpscFetchBuffer buffer)
+    {
+        var readWaiterField = typeof(MpscFetchBuffer).GetField(
+            "_readWaiter",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var readWaiter = readWaiterField.GetValue(buffer)!;
+        var timeoutDeadlineField = readWaiter.GetType().GetField(
+            "_timeoutDeadline",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var onTimeout = readWaiter.GetType().GetMethod(
+            "OnTimeout",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        timeoutDeadlineField.SetValue(readWaiter, Stopwatch.GetTimestamp() - Stopwatch.Frequency);
+        onTimeout.Invoke(readWaiter, null);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -426,21 +426,24 @@ public class MpscFetchBufferTests
     }
 
     [Test]
-    public async Task WaitToReadAsync_TimeoutDoesNotRunContinuationOnTimerThread()
+    public async Task WaitToReadAsync_TimeoutDoesNotRunContinuationInline()
     {
-        var continuationEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var continuationFinished = new TaskCompletionSource<(int ThreadId, bool Result)>(
+        var continuationFinished = new TaskCompletionSource<(bool RanInline, bool Result)>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var timeoutCallbackExited = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var timeoutThreadId = 0;
+        var timeoutCallbackActive = 0;
         var buffer = new MpscFetchBuffer(
             capacity: 4,
             afterProducerWaiterCountIncrementedForTesting: null,
             beforeConsumerTimeoutForTesting: () =>
-                Volatile.Write(ref timeoutThreadId, Environment.CurrentManagedThreadId),
+            {
+                Volatile.Write(ref timeoutThreadId, Environment.CurrentManagedThreadId);
+                Volatile.Write(ref timeoutCallbackActive, 1);
+            },
             afterConsumerTimeoutForTesting: () =>
             {
-                continuationEntered.Task.GetAwaiter().GetResult();
+                Volatile.Write(ref timeoutCallbackActive, 0);
                 timeoutCallbackExited.TrySetResult();
             });
 
@@ -449,11 +452,11 @@ public class MpscFetchBufferTests
             var awaiter = buffer.WaitToReadAsync(1, CancellationToken.None).GetAwaiter();
             awaiter.UnsafeOnCompleted(() =>
             {
-                var continuationThreadId = Environment.CurrentManagedThreadId;
-                continuationEntered.TrySetResult();
+                var ranInline = Volatile.Read(ref timeoutCallbackActive) != 0
+                    && Environment.CurrentManagedThreadId == Volatile.Read(ref timeoutThreadId);
                 try
                 {
-                    continuationFinished.TrySetResult((continuationThreadId, awaiter.GetResult()));
+                    continuationFinished.TrySetResult((ranInline, awaiter.GetResult()));
                 }
                 catch (Exception exception)
                 {
@@ -464,12 +467,11 @@ public class MpscFetchBufferTests
             var completion = await continuationFinished.Task.WaitAsync(TimeSpan.FromSeconds(5));
             await timeoutCallbackExited.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-            await Assert.That(completion.ThreadId).IsNotEqualTo(Volatile.Read(ref timeoutThreadId));
+            await Assert.That(completion.RanInline).IsFalse();
             await Assert.That(completion.Result).IsFalse();
         }
         finally
         {
-            continuationEntered.TrySetResult();
             buffer.Dispose();
         }
     }

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -3175,6 +3175,7 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             topic, leaderId: 1, leaderEpoch: 1, partitionCount: 2));
         var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
         var allRerouted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reroutedBatches = new ConcurrentQueue<ReadyBatch>();
         var reroutedCount = 0;
         var firstBatch = CreateTestBatch(valueTaskSourcePool, topic, partition: 0);
         var secondBatch = CreateTestBatch(valueTaskSourcePool, topic, partition: 1);
@@ -3188,8 +3189,9 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             accumulator,
             onAcknowledgement: (_, _, _, _, _) => { },
             metadataManager,
-            rerouteBatch: (_, _) =>
+            rerouteBatch: (batch, _) =>
             {
+                reroutedBatches.Enqueue(batch);
                 if (Interlocked.Increment(ref reroutedCount) == 2)
                     allRerouted.TrySetResult();
             },
@@ -3228,6 +3230,8 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
 
             await Assert.That(firstResult).IsSameReferenceAs(allRerouted.Task);
             await Assert.That(Volatile.Read(ref metadataRequests)).IsEqualTo(1);
+            await Assert.That(reroutedBatches.Any(batch => ReferenceEquals(batch, firstBatch))).IsTrue();
+            await Assert.That(reroutedBatches.Any(batch => ReferenceEquals(batch, secondBatch))).IsTrue();
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -3176,6 +3176,12 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
         var allRerouted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var reroutedCount = 0;
+        var firstBatch = CreateTestBatch(valueTaskSourcePool, topic, partition: 0);
+        var secondBatch = CreateTestBatch(valueTaskSourcePool, topic, partition: 1);
+        using var waveCoalesceStarted = new ManualResetEventSlim();
+        using var bulkPublishCompleted = new ManualResetEventSlim();
+        var eventChannel = new FirstWriteBlockingChannel<BrokerSender.SendLoopEvent>(
+            () => waveCoalesceStarted.Wait(cancellationToken));
         var sender = CreateSender(
             pool,
             options,
@@ -3186,24 +3192,47 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             {
                 if (Interlocked.Increment(ref reroutedCount) == 2)
                     allRerouted.TrySetResult();
-            });
+            },
+            onWaveCoalesceStarted: () =>
+            {
+                waveCoalesceStarted.Set();
+                bulkPublishCompleted.Wait(cancellationToken);
+            },
+            eventChannel: eventChannel);
+
+        var knownPartitions = (HashSet<TopicPartition>)typeof(BrokerSender).GetField(
+            "_knownPartitions",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
+        knownPartitions.Add(firstBatch.TopicPartition);
+        knownPartitions.Add(secondBatch.TopicPartition);
 
         try
         {
-            sender.EnqueueBulk(
-            [
-                CreateTestBatch(valueTaskSourcePool, topic, partition: 0),
-                CreateTestBatch(valueTaskSourcePool, topic, partition: 1)
-            ]);
+            var bulkPublish = Task.Run(
+                () =>
+                {
+                    try
+                    {
+                        sender.EnqueueBulk([firstBatch, secondBatch]);
+                    }
+                    finally
+                    {
+                        bulkPublishCompleted.Set();
+                    }
+                },
+                CancellationToken.None);
 
             var firstResult = await Task.WhenAny(allRerouted.Task, duplicateMetadataRequest.Task)
                 .WaitAsync(cancellationToken);
+            await bulkPublish.WaitAsync(cancellationToken);
 
             await Assert.That(firstResult).IsSameReferenceAs(allRerouted.Task);
             await Assert.That(Volatile.Read(ref metadataRequests)).IsEqualTo(1);
         }
         finally
         {
+            waveCoalesceStarted.Set();
+            bulkPublishCompleted.Set();
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await valueTaskSourcePool.DisposeAsync();


### PR DESCRIPTION
Closes #2709.
Closes #2714.

## Change

- replace scheduler-dependent `ManualResetEventSlim` waits with asynchronous `TaskCompletionSource` coordination
- run the synthetic stale timeout on a dedicated background thread, leaving the ThreadPool available to process waiter completion
- detect inline continuation execution using callback-active state without blocking the timer worker
- wait for all timeout work before disposing test fixtures

## Validation

- Release builds: net8.0 and net10.0, 0 warnings/errors
- corrected focused fresh-process repetitions: 50/50 on net8.0 and 50/50 on net10.0
- full unit net8.0: 6,871/6,871
- full unit net10.0: 7,007/7,007
- `git diff --check`: pass

Test-only change; no production hot path, benchmark, or stress lane applies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for consumer timeout handling.
  * Added deterministic validation that timeout-triggered continuations complete reliably and do not run on the timer thread.
  * Updated asynchronous timeout scenarios to reduce test flakiness and improve confidence in timeout behavior.
  * Added coverage for parallel send failures, rerouting, and single metadata refresh behavior.

* **User Impact**
  * No direct user-facing feature or behavior changes are included in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->