### PR TITLE
test(producer): make transaction deadline deterministic

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -131,6 +131,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
     // the fail-fast produce guard for context. ErrorCode is short-backed, so volatile is valid.
     internal volatile ErrorCode _lastTransactionError = ErrorCode.None;
     private readonly SemaphoreSlim _transactionLock = new(1, 1);
+    private readonly Func<long>? _transactionTimestampProvider;
     private readonly System.Threading.Lock _epochBumpLock = new();
     internal readonly System.Threading.Lock _partitionsInTransactionLock = new();
     internal readonly HashSet<TopicPartition> _partitionsInTransaction = [];
@@ -247,7 +248,8 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         ILoggerFactory? loggerFactory = null,
         Func<IReadOnlyList<TopicPartition>, CancellationToken, ValueTask>? addPartitionsToTransaction = null,
         IAsyncSerializer<TKey>? asyncKeySerializer = null,
-        IAsyncSerializer<TValue>? asyncValueSerializer = null)
+        IAsyncSerializer<TValue>? asyncValueSerializer = null,
+        Func<long>? transactionTimestampProvider = null)
         : this(
             options,
             keySerializer,
@@ -258,7 +260,8 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             memoryBudget,
             addPartitionsToTransaction,
             asyncKeySerializer,
-            asyncValueSerializer)
+            asyncValueSerializer,
+            transactionTimestampProvider)
     {
     }
 
@@ -345,11 +348,13 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         IDekafMemoryBudget memoryBudget,
         Func<IReadOnlyList<TopicPartition>, CancellationToken, ValueTask>? addPartitionsToTransaction = null,
         IAsyncSerializer<TKey>? asyncKeySerializer = null,
-        IAsyncSerializer<TValue>? asyncValueSerializer = null)
+        IAsyncSerializer<TValue>? asyncValueSerializer = null,
+        Func<long>? transactionTimestampProvider = null)
     {
         ExponentialRetryBackoff.Validate(options.RetryBackoffMs, options.RetryBackoffMaxMs);
         _options = options;
         _addPartitionsToTransaction = addPartitionsToTransaction ?? AddPartitionsToTransactionAsync;
+        _transactionTimestampProvider = transactionTimestampProvider;
         // When an async serializer is configured for a component, its sync slot is forced to the
         // throwing placeholder here — by construction, not by builder convention — so a direct
         // constructor caller can never pair an async serializer with a live sync one that would
@@ -2542,7 +2547,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
 
     private TransactionRetryBudget CreateTransactionRetryBudget()
     {
-        var startedAtMs = MonotonicClock.GetMilliseconds();
+        var startedAtMs = GetTransactionTimestampMilliseconds();
         var deadlineMs = long.MaxValue - startedAtMs > _options.MaxBlockMs
             ? startedAtMs + _options.MaxBlockMs
             : long.MaxValue;
@@ -2564,11 +2569,11 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         return true;
     }
 
-    private static bool TryGetTransactionRemainingMilliseconds(
+    private bool TryGetTransactionRemainingMilliseconds(
         TransactionRetryBudget retryBudget,
         out int remainingMs)
     {
-        var remaining = retryBudget.DeadlineMs - MonotonicClock.GetMilliseconds();
+        var remaining = retryBudget.DeadlineMs - GetTransactionTimestampMilliseconds();
         if (remaining <= 0)
         {
             remainingMs = 0;
@@ -2579,13 +2584,13 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         return true;
     }
 
-    private static CancellationTokenSource CreateTransactionRetryCancellationSource(
+    private CancellationTokenSource CreateTransactionRetryCancellationSource(
         TransactionRetryBudget retryBudget,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var remainingMs = Math.Max(0, retryBudget.DeadlineMs - MonotonicClock.GetMilliseconds());
+        var remainingMs = Math.Max(0, retryBudget.DeadlineMs - GetTransactionTimestampMilliseconds());
         timeoutCts.CancelAfter(TimeSpan.FromMilliseconds(remainingMs));
         return timeoutCts;
     }
@@ -2596,7 +2601,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         int attempts,
         Exception? innerException = null)
     {
-        var elapsedMs = Math.Max(0, MonotonicClock.GetMilliseconds() - retryBudget.StartedAtMs);
+        var elapsedMs = Math.Max(0, GetTransactionTimestampMilliseconds() - retryBudget.StartedAtMs);
         var configured = TimeSpan.FromMilliseconds(_options.MaxBlockMs);
         var message =
             $"{operation} did not complete within max.block.ms ({_options.MaxBlockMs}ms) after {attempts} attempts.";
@@ -2613,6 +2618,12 @@ public sealed partial class KafkaProducer<TKey, TValue> :
                 message,
                 innerException);
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal long GetTransactionTimestampMilliseconds() =>
+        _transactionTimestampProvider is null
+            ? MonotonicClock.GetMilliseconds()
+            : _transactionTimestampProvider();
 
     internal async ValueTask ReinitializeProducerIdAsync(
         CancellationToken cancellationToken,

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -621,22 +621,24 @@ public sealed class TransactionTests
     public async Task InitTransactionsAsync_SharedDeadlineSpansCoordinatorAndProducerId(
         CancellationToken cancellationToken)
     {
+        var transactionClock = new FakeTransactionClock();
         await using var harness = BuildPreparedCompletionHarness(
             PreparedTransactionState.Empty,
             currentProducerId: 2002,
             currentProducerEpoch: 9,
-            initProducerIdWaitsForCancellation: true,
-            findCoordinatorDelayMs: 1200,
-            maxBlockMs: 2000);
+            initProducerIdRetriableFailuresBeforeSuccess: 1,
+            transactionClock: transactionClock,
+            findCoordinatorAdvanceMs: 20_000,
+            initProducerIdAdvanceMs: 40_000,
+            maxBlockMs: 60_000);
         harness.Producer._transactionState = TransactionState.Uninitialized;
-        var stopwatch = Stopwatch.StartNew();
 
         var exception = await Assert.That(() => harness.Producer.InitTransactionsAsync(
                 cancellationToken).AsTask())
             .Throws<KafkaTimeoutException>();
 
         await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
-        await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(2800));
+        await Assert.That(exception.Elapsed).IsEqualTo(TimeSpan.FromSeconds(60));
         await Assert.That(harness.FindCoordinatorRequests).IsEqualTo(1);
         await Assert.That(harness.InitProducerIdRequests).IsEqualTo(1);
     }
@@ -1441,6 +1443,9 @@ public sealed class TransactionTests
         int emptyCoordinatorResponsesBeforeSuccess = 0,
         ErrorCode addPartitionsRetriableError = ErrorCode.CoordinatorLoadInProgress,
         int retryBackoffMs = 0,
+        FakeTransactionClock? transactionClock = null,
+        int findCoordinatorAdvanceMs = 0,
+        int initProducerIdAdvanceMs = 0,
         int maxBlockMs = 1000)
     {
         var connection = new LeaseTrackingConnection(
@@ -1458,7 +1463,10 @@ public sealed class TransactionTests
             initProducerIdWaitsBeforeWriteForCancellation: initProducerIdWaitsBeforeWriteForCancellation,
             findCoordinatorDelayMs: findCoordinatorDelayMs,
             emptyCoordinatorResponsesBeforeSuccess: emptyCoordinatorResponsesBeforeSuccess,
-            addPartitionsRetriableError: addPartitionsRetriableError);
+            addPartitionsRetriableError: addPartitionsRetriableError,
+            transactionClock: transactionClock,
+            findCoordinatorAdvanceMs: findCoordinatorAdvanceMs,
+            initProducerIdAdvanceMs: initProducerIdAdvanceMs);
 
         var connectionPool = new ConnectionPool(
             clientId: "test-producer",
@@ -1506,7 +1514,8 @@ public sealed class TransactionTests
             Serializers.String,
             connectionPool,
             metadataManager,
-            DekafMemoryBudget.Global);
+            DekafMemoryBudget.Global,
+            transactionTimestampProvider: transactionClock is null ? null : transactionClock.GetMilliseconds);
 
         SetInstanceField(producer, "_initialized", true);
         SetInstanceField(producer, "_producerId", currentProducerId);
@@ -1603,7 +1612,10 @@ public sealed class TransactionTests
         bool initProducerIdWaitsBeforeWriteForCancellation,
         int findCoordinatorDelayMs,
         int emptyCoordinatorResponsesBeforeSuccess,
-        ErrorCode addPartitionsRetriableError) : IKafkaConnection, IRetirableKafkaConnection,
+        ErrorCode addPartitionsRetriableError,
+        FakeTransactionClock? transactionClock,
+        int findCoordinatorAdvanceMs,
+        int initProducerIdAdvanceMs) : IKafkaConnection, IRetirableKafkaConnection,
         IKafkaPipelinedWriteCompletionConnection, IKafkaRequestWriteObserverConnection
     {
         private readonly TrackingResponseSource<EndTxnResponse> _pipelinedResponseSource = new();
@@ -1732,6 +1744,7 @@ public sealed class TransactionTests
         private FindCoordinatorResponse CreateFindCoordinatorResponse(FindCoordinatorRequest request)
         {
             FindCoordinatorRequests++;
+            transactionClock?.Advance(findCoordinatorAdvanceMs);
             if (FindCoordinatorRequests <= emptyCoordinatorResponsesBeforeSuccess)
                 return new FindCoordinatorResponse { Coordinators = [] };
 
@@ -1756,6 +1769,7 @@ public sealed class TransactionTests
         private InitProducerIdResponse CreateInitProducerIdResponse()
         {
             InitProducerIdRequests++;
+            transactionClock?.Advance(initProducerIdAdvanceMs);
             return new InitProducerIdResponse
             {
                 ErrorCode = InitProducerIdRequests <= initProducerIdRetriableFailuresBeforeSuccess
@@ -1873,6 +1887,15 @@ public sealed class TransactionTests
             where TRequest : IKafkaRequest<TResponse>
             where TResponse : IKafkaResponse
             => throw new NotSupportedException();
+    }
+
+    private sealed class FakeTransactionClock
+    {
+        private long _milliseconds;
+
+        public long GetMilliseconds() => Volatile.Read(ref _milliseconds);
+
+        public void Advance(int milliseconds) => Interlocked.Add(ref _milliseconds, milliseconds);
     }
 
     private sealed class TrackingResponseSource<TResponse> : IPipelinedResponseSource<TResponse>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TransactionRetryClockBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TransactionRetryClockBenchmarks.cs
@@ -1,0 +1,19 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Producer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+public class TransactionRetryClockBenchmarks
+{
+    private KafkaProducer<string, string> _producer = null!;
+
+    [GlobalSetup]
+    public void Setup() =>
+        _producer = (KafkaProducer<string, string>)RuntimeHelpers.GetUninitializedObject(
+            typeof(KafkaProducer<string, string>));
+
+    [Benchmark(Description = "Read default transaction retry clock")]
+    public long ReadDefaultTransactionRetryClock() => _producer.GetTransactionTimestampMilliseconds();
+}


### PR DESCRIPTION
Closes #2712.

## Summary

- inject an instance-scoped monotonic timestamp source into transaction retry budgets while keeping the production default on `MonotonicClock`;
- replace the wall-clock cutoff test with deterministic logical-time advancement across FindCoordinator and InitProducerId;
- add a MemoryDiagnoser gate for the default transaction clock path.

The test advances 20 seconds during coordinator discovery and 40 seconds during one retriable producer-ID response. With one shared 60-second budget it times out immediately with exactly 60 seconds elapsed; resetting the budget between phases would instead retry and succeed, so the original contract remains covered without wall-clock inference.

## Validation

- Release unit and benchmark builds: 0 warnings/errors.
- Focused shared-deadline test: pass on net8.0 and net10.0.
- CPU contention: 25/25 on net8.0 and 25/25 on net10.0 with eight concurrent CPU burners.
- TransactionTests: 69/69 on both TFMs.
- Full units: 6,871/6,871 net8.0; 7,007/7,007 net10.0.

Exact-parent MemoryDiagnoser (`6572c163` → `a8bb0ffc`, identical harness):

| SHA | Mean | 99.9% CI | Allocated |
|---|---:|---:|---:|
| `6572c163` | 1.145 ns | 1.119–1.171 ns | 0 B |
| `a8bb0ffc` | 1.187 ns | 1.156–1.219 ns | 0 B |

Delta: +0.042 ns (+3.7%); confidence intervals overlap. This executes only during transaction control operations, not per-message produce, and remains 0 B. No Kafka stress lane: the changed operation is an in-process transaction-budget clock read and the causal microbenchmark directly covers it.

`/simplify` and immediate pre-push self-review: clear.

@claude review
@codex review
@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction timeout handling so a single deadline consistently covers coordinator discovery and producer initialization.
  * Enhanced retry and cancellation timing accuracy while retaining the default monotonic clock behavior.

* **Tests**
  * Added coverage validating shared transaction deadlines with controlled time progression.

* **Performance**
  * Added benchmarking for transaction retry clock reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->