### PR TITLE
Execute Schema Registry migration rules

### DIFF
--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -211,7 +211,13 @@ first action for upgrade and the second for downgrade. Disabled rules are skippe
 Using the latest reader schema without active migration rules does not require a rule executor. If
 an active migration path exists, configure the built-in `SchemaRegistryRuleExecutor`; Dekaf fails
 closed instead of silently skipping the transform. Warm cached no-migration, disabled-migration, and
-active pass-through paths remain allocation-free.
+active pass-through paths remain allocation-free, including interleaved writer schema IDs.
+
+Migration plans follow `SchemaRegistryConfig.LatestCacheTtlSecs`. The Confluent-compatible default
+is `-1`, which disables time-based expiry. Set a non-negative TTL to
+periodically re-resolve latest schemas; `0` refreshes on every use. Historical version lookup includes
+deleted versions so migration paths remain complete. Custom `ISchemaRegistryClient` implementations
+must override the deleted-version overload; its default implementation fails closed.
 
 ## Schema Registry Configuration
 

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -175,6 +175,44 @@ CPU cost when enabled because each payload must be parsed and evaluated. Steady-
 zero-allocation; disabled serializers remain validation-neutral and do not load the optional JSON
 Schema package.
 
+## Migration rules
+
+Set `UseLatestVersion = true` on a deserializer config to select the subject's latest registered
+schema as the reader schema. Dekaf resolves the writer's exact subject version, walks every adjacent
+version, and executes active migration rules before deserializing with the reader schema:
+
+```csharp
+var rules = new SchemaRegistryRuleExecutor([migrationHandler]);
+
+var config = new AvroDeserializerConfig
+{
+    UseLatestVersion = true,
+    RuleExecutor = rules
+};
+
+var consumer = await Kafka.CreateConsumer<string, GenericRecord>()
+    .WithBootstrapServers("localhost:9092")
+    .WithGroupId("orders")
+    .UseAvroSchemaRegistry(registry, config)
+    .BuildAsync();
+```
+
+`SchemaRegistryDeserializerConfig`, `AvroDeserializerConfig`, and `ProtobufDeserializerConfig`
+all expose `UseLatestVersion`. Avro does not allow `UseLatestVersion` together with an explicit
+`ReaderSchema`.
+
+Ordering matches Schema Registry behavior. Read encoding rules run against the writer schema first;
+upgrade or downgrade rules then run for each version edge; read domain rules run against the final
+reader schema last. The higher schema owns each edge's migration rules. Upgrade paths visit versions
+and rules in ascending/forward order. Downgrade paths visit versions and rules in descending/reverse
+order. `UpDown` rules participate in both directions, and paired success/failure actions select the
+first action for upgrade and the second for downgrade. Disabled rules are skipped.
+
+Using the latest reader schema without active migration rules does not require a rule executor. If
+an active migration path exists, configure the built-in `SchemaRegistryRuleExecutor`; Dekaf fails
+closed instead of silently skipping the transform. Warm cached no-migration, disabled-migration, and
+active pass-through paths remain allocation-free.
+
 ## Schema Registry Configuration
 
 ```csharp

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
@@ -46,6 +46,7 @@ public sealed class AvroSchemaRegistryDeserializer<
     private readonly ISchemaRegistryClient _schemaRegistry;
     private readonly AvroDeserializerConfig _config;
     private readonly bool _ownsClient;
+    private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
     private readonly ConcurrentDictionary<int, Lazy<Task<AvroSchema>>> _schemaCache = new();
     private readonly ConcurrentDictionary<AvroSchemaPair, GenericDatumReader<GenericRecord>> _genericReaders =
         new(AvroSchemaPairReferenceComparer.Instance);
@@ -53,6 +54,7 @@ public sealed class AvroSchemaRegistryDeserializer<
         new(AvroSchemaPairReferenceComparer.Instance);
     private readonly AvroSchema? _readerSchema;
     private readonly DeserializerSubjectNameCache? _subjectNames;
+    private readonly SchemaRegistryMigrationRunner? _migrationRunner;
 
     /// <summary>
     /// Creates a new Avro Schema Registry deserializer.
@@ -67,11 +69,27 @@ public sealed class AvroSchemaRegistryDeserializer<
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _config = config ?? new AvroDeserializerConfig();
+        _ruleExecutor = _config.RuleExecutor;
         _ownsClient = ownsClient;
+        if (_config.UseLatestVersion && !string.IsNullOrEmpty(_config.ReaderSchema))
+        {
+            throw new ArgumentException(
+                $"{nameof(AvroDeserializerConfig.UseLatestVersion)} and {nameof(AvroDeserializerConfig.ReaderSchema)} cannot both be configured.",
+                nameof(config));
+        }
+
         _subjectNames = DeserializerSubjectNameCache.Create(
             _config.SubjectNameStrategy,
             _config.CustomSubjectNameStrategy,
             _config.UseLegacySubjectNames);
+        if (_config.UseLatestVersion)
+        {
+            _migrationRunner = new SchemaRegistryMigrationRunner(
+                schemaRegistry,
+                _config.RuleExecutor,
+                SchemaRegistryTimeout);
+            _ruleExecutor ??= SchemaRegistryMigrationRunner.MarkerRuleExecutor;
+        }
 
         // Parse custom reader schema if provided, otherwise derive from type
         _readerSchema = GetReaderSchema();
@@ -123,7 +141,8 @@ public sealed class AvroSchemaRegistryDeserializer<
 
         // Extract Avro payload. Array-backed payloads decode in place; other memory falls back to a pooled copy.
         var payloadMemory = data.Slice(5);
-        if (_config.RuleExecutor is not null)
+        AvroSchema? migrationReaderSchema = null;
+        if (_ruleExecutor is not null)
         {
             string subject;
             if (_subjectNames is null)
@@ -139,25 +158,40 @@ public sealed class AvroSchemaRegistryDeserializer<
             }
 
             var schema = _schemaRegistry.GetSchemaSync(schemaId, subject, SchemaRegistryTimeout);
-            var ruleContext = SchemaRegistryRuleContext.Rent(
-                context.Topic,
-                context.Component,
-                schemaId,
-                subject,
-                schema,
-                SchemaRegistryPayloadFormat.Avro);
-            try
+            if (_migrationRunner is null)
             {
-                payloadMemory = _config.RuleExecutor.TransformDeserializedPayload(payloadMemory, ruleContext);
+                var ruleContext = SchemaRegistryRuleContext.Rent(
+                    context.Topic,
+                    context.Component,
+                    schemaId,
+                    subject,
+                    schema,
+                    SchemaRegistryPayloadFormat.Avro);
+                try
+                {
+                    payloadMemory = _ruleExecutor.TransformDeserializedPayload(payloadMemory, ruleContext);
+                }
+                finally
+                {
+                    ruleContext.Return();
+                }
             }
-            finally
+            else
             {
-                ruleContext.Return();
+                var migration = _migrationRunner.Transform(
+                    payloadMemory,
+                    schemaId,
+                    subject,
+                    schema,
+                    context,
+                    SchemaRegistryPayloadFormat.Avro);
+                payloadMemory = migration.Payload;
+                migrationReaderSchema = GetWriterSchemaCached(migration.ReaderSchema.Id);
             }
         }
 
         var codecState = AvroCodecThreadStateCache.Deserialization ??= new AvroDeserializationThreadState();
-        return ReadAvroPayload(payloadMemory, writerSchema, codecState);
+        return ReadAvroPayload(payloadMemory, writerSchema, migrationReaderSchema, codecState);
     }
 
     private string GetSubjectName(int schemaId, Schema schema, SerializationContext context)
@@ -175,6 +209,7 @@ public sealed class AvroSchemaRegistryDeserializer<
     private T ReadAvroPayload(
         ReadOnlyMemory<byte> payloadMemory,
         AvroSchema writerSchema,
+        AvroSchema? migrationReaderSchema,
         AvroDeserializationThreadState codecState)
     {
         var memoryStream = codecState.Stream;
@@ -184,7 +219,7 @@ public sealed class AvroSchemaRegistryDeserializer<
             memoryStream.Reset(segment.Array, segment.Offset, segment.Count);
             try
             {
-                return ReadAvroValue(writerSchema, codecState.Decoder);
+                return ReadAvroValue(writerSchema, migrationReaderSchema, codecState.Decoder);
             }
             finally
             {
@@ -199,7 +234,7 @@ public sealed class AvroSchemaRegistryDeserializer<
             payload.CopyTo(rentedBuffer);
             memoryStream.Reset(rentedBuffer, payload.Length);
 
-            return ReadAvroValue(writerSchema, codecState.Decoder);
+            return ReadAvroValue(writerSchema, migrationReaderSchema, codecState.Decoder);
         }
         finally
         {
@@ -208,9 +243,12 @@ public sealed class AvroSchemaRegistryDeserializer<
         }
     }
 
-    private T ReadAvroValue(AvroSchema writerSchema, BinaryDecoder decoder)
+    private T ReadAvroValue(
+        AvroSchema writerSchema,
+        AvroSchema? migrationReaderSchema,
+        BinaryDecoder decoder)
     {
-        var readerSchema = _readerSchema ?? writerSchema;
+        var readerSchema = migrationReaderSchema ?? _readerSchema ?? writerSchema;
 
         if (typeof(T) == typeof(GenericRecord))
         {

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
@@ -52,6 +52,8 @@ public sealed class AvroSchemaRegistryDeserializer<
         new(AvroSchemaPairReferenceComparer.Instance);
     private readonly ConcurrentDictionary<AvroSchemaPair, SpecificDatumReader<T>> _specificReaders =
         new(AvroSchemaPairReferenceComparer.Instance);
+    private readonly ConcurrentDictionary<AvroSchema, byte> _validatedSpecificMigrationSchemas =
+        new(AvroSchemaReferenceComparer.Instance);
     private readonly AvroSchema? _readerSchema;
     private readonly DeserializerSubjectNameCache? _subjectNames;
     private readonly SchemaRegistryMigrationRunner? _migrationRunner;
@@ -84,11 +86,10 @@ public sealed class AvroSchemaRegistryDeserializer<
             _config.UseLegacySubjectNames);
         if (_config.UseLatestVersion)
         {
-            _migrationRunner = new SchemaRegistryMigrationRunner(
+            (_migrationRunner, _ruleExecutor) = SchemaRegistryMigrationRunner.Create(
                 schemaRegistry,
                 _config.RuleExecutor,
                 SchemaRegistryTimeout);
-            _ruleExecutor ??= SchemaRegistryMigrationRunner.MarkerRuleExecutor;
         }
 
         // Parse custom reader schema if provided, otherwise derive from type
@@ -248,10 +249,9 @@ public sealed class AvroSchemaRegistryDeserializer<
         AvroSchema? migrationReaderSchema,
         BinaryDecoder decoder)
     {
-        var readerSchema = migrationReaderSchema ?? _readerSchema ?? writerSchema;
-
         if (typeof(T) == typeof(GenericRecord))
         {
+            var readerSchema = migrationReaderSchema ?? _readerSchema ?? writerSchema;
             var reader = _genericReaders.GetOrAdd(
                 new AvroSchemaPair(writerSchema, readerSchema),
                 static key => new GenericDatumReader<GenericRecord>(key.WriterSchema, key.ReaderSchema));
@@ -261,6 +261,20 @@ public sealed class AvroSchemaRegistryDeserializer<
 
         if (typeof(ISpecificRecord).IsAssignableFrom(typeof(T)))
         {
+            var readerSchema = _readerSchema ?? throw new InvalidOperationException(
+                $"Specific Avro type {typeof(T)} does not expose a static _SCHEMA field.");
+            if (migrationReaderSchema is not null &&
+                !_validatedSpecificMigrationSchemas.TryGetValue(migrationReaderSchema, out _))
+            {
+                if (!readerSchema.CanRead(migrationReaderSchema))
+                {
+                    throw new InvalidOperationException(
+                        $"The latest Schema Registry schema is incompatible with specific Avro type {typeof(T)}.");
+                }
+
+                _validatedSpecificMigrationSchemas.TryAdd(migrationReaderSchema, 0);
+            }
+
             var reader = _specificReaders.GetOrAdd(
                 new AvroSchemaPair(writerSchema, readerSchema),
                 static key => new SpecificDatumReader<T>(key.WriterSchema, key.ReaderSchema));

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSerializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSerializerConfig.cs
@@ -58,6 +58,12 @@ public sealed class AvroSerializerConfig
 public sealed class AvroDeserializerConfig
 {
     /// <summary>
+    /// Whether to use the latest registered subject version as the reader schema and execute
+    /// any migration rules between the writer and reader versions.
+    /// </summary>
+    public bool UseLatestVersion { get; init; }
+
+    /// <summary>
     /// Subject-name strategy used when deserialization rules execute.
     /// </summary>
     public SubjectNameStrategy SubjectNameStrategy { get; init; } = SubjectNameStrategy.TopicName;

--- a/src/Dekaf.SchemaRegistry.Avro/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry.Avro/PublicAPI.Unshipped.txt
@@ -6,3 +6,5 @@ Dekaf.SchemaRegistry.Avro.AvroDeserializerConfig.SubjectNameStrategy.get -> Deka
 Dekaf.SchemaRegistry.Avro.AvroDeserializerConfig.SubjectNameStrategy.init -> void
 Dekaf.SchemaRegistry.Avro.AvroDeserializerConfig.UseLegacySubjectNames.get -> bool
 Dekaf.SchemaRegistry.Avro.AvroDeserializerConfig.UseLegacySubjectNames.init -> void
+Dekaf.SchemaRegistry.Avro.AvroDeserializerConfig.UseLatestVersion.get -> bool
+Dekaf.SchemaRegistry.Avro.AvroDeserializerConfig.UseLatestVersion.init -> void

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufDeserializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufDeserializerConfig.cs
@@ -6,6 +6,12 @@ namespace Dekaf.SchemaRegistry.Protobuf;
 public sealed class ProtobufDeserializerConfig
 {
     /// <summary>
+    /// Whether to use the latest registered subject version as the reader schema and execute
+    /// any migration rules between the writer and reader versions.
+    /// </summary>
+    public bool UseLatestVersion { get; init; }
+
+    /// <summary>
     /// Subject-name strategy used when deserialization rules execute.
     /// </summary>
     public SubjectNameStrategy SubjectNameStrategy { get; init; } = SubjectNameStrategy.TopicName;

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
@@ -28,8 +28,10 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
     private readonly ISchemaRegistryClient _schemaRegistry;
     private readonly ProtobufDeserializerConfig _config;
     private readonly bool _ownsClient;
+    private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
     private readonly MessageParser<T> _parser;
     private readonly DeserializerSubjectNameCache? _subjectNames;
+    private readonly SchemaRegistryMigrationRunner? _migrationRunner;
 
     /// <summary>
     /// Creates a new Protobuf Schema Registry deserializer.
@@ -44,12 +46,21 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _config = config ?? new ProtobufDeserializerConfig();
+        _ruleExecutor = _config.RuleExecutor;
         _ownsClient = ownsClient;
         _parser = new MessageParser<T>(() => new T());
         _subjectNames = DeserializerSubjectNameCache.Create(
             _config.SubjectNameStrategy,
             _config.CustomSubjectNameStrategy,
             _config.UseLegacySubjectNames);
+        if (_config.UseLatestVersion)
+        {
+            _migrationRunner = new SchemaRegistryMigrationRunner(
+                schemaRegistry,
+                _config.RuleExecutor,
+                SchemaRegistryTimeout);
+            _ruleExecutor ??= SchemaRegistryMigrationRunner.MarkerRuleExecutor;
+        }
     }
 
     /// <inheritdoc />
@@ -70,7 +81,7 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
         // Optionally validate the schema exists (with timeout to prevent indefinite hang)
         Schema? schema = null;
         string? ruleSubject = null;
-        if (!_config.SkipSchemaValidation || _config.RuleExecutor is SchemaRegistryRuleExecutor)
+        if (!_config.SkipSchemaValidation || _config.RuleExecutor is SchemaRegistryRuleExecutor || _migrationRunner is not null)
         {
             if (_config.RuleExecutor is not null && _subjectNames is null)
             {
@@ -106,25 +117,39 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
 
         // The rest is the protobuf message
         var protobufData = payloadMemory.Slice(bytesRead);
-        if (_config.RuleExecutor is not null)
+        if (_ruleExecutor is not null)
         {
             var subject = ruleSubject ?? GetSubjectName(schemaId, schema, context);
             if (schema is not null && ruleSubject is null)
                 schema = _schemaRegistry.GetSchemaSync(schemaId, subject, SchemaRegistryTimeout);
-            var ruleContext = SchemaRegistryRuleContext.Rent(
-                context.Topic,
-                context.Component,
-                schemaId,
-                subject,
-                schema,
-                SchemaRegistryPayloadFormat.Protobuf);
-            try
+            if (_migrationRunner is null)
             {
-                protobufData = _config.RuleExecutor.TransformDeserializedPayload(protobufData, ruleContext);
+                var ruleContext = SchemaRegistryRuleContext.Rent(
+                    context.Topic,
+                    context.Component,
+                    schemaId,
+                    subject,
+                    schema,
+                    SchemaRegistryPayloadFormat.Protobuf);
+                try
+                {
+                    protobufData = _ruleExecutor.TransformDeserializedPayload(protobufData, ruleContext);
+                }
+                finally
+                {
+                    ruleContext.Return();
+                }
             }
-            finally
+            else
             {
-                ruleContext.Return();
+                var migration = _migrationRunner.Transform(
+                    protobufData,
+                    schemaId,
+                    subject,
+                    schema!,
+                    context,
+                    SchemaRegistryPayloadFormat.Protobuf);
+                protobufData = migration.Payload;
             }
         }
 

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
@@ -55,11 +55,10 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
             _config.UseLegacySubjectNames);
         if (_config.UseLatestVersion)
         {
-            _migrationRunner = new SchemaRegistryMigrationRunner(
+            (_migrationRunner, _ruleExecutor) = SchemaRegistryMigrationRunner.Create(
                 schemaRegistry,
                 _config.RuleExecutor,
                 SchemaRegistryTimeout);
-            _ruleExecutor ??= SchemaRegistryMigrationRunner.MarkerRuleExecutor;
         }
     }
 

--- a/src/Dekaf.SchemaRegistry.Protobuf/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry.Protobuf/PublicAPI.Unshipped.txt
@@ -5,6 +5,8 @@ Dekaf.SchemaRegistry.Protobuf.ProtobufDeserializerConfig.SubjectNameStrategy.get
 Dekaf.SchemaRegistry.Protobuf.ProtobufDeserializerConfig.SubjectNameStrategy.init -> void
 Dekaf.SchemaRegistry.Protobuf.ProtobufDeserializerConfig.UseLegacySubjectNames.get -> bool
 Dekaf.SchemaRegistry.Protobuf.ProtobufDeserializerConfig.UseLegacySubjectNames.init -> void
+Dekaf.SchemaRegistry.Protobuf.ProtobufDeserializerConfig.UseLatestVersion.get -> bool
+Dekaf.SchemaRegistry.Protobuf.ProtobufDeserializerConfig.UseLatestVersion.init -> void
 Dekaf.SchemaRegistry.Protobuf.IReferenceSubjectNameStrategy
 Dekaf.SchemaRegistry.Protobuf.IReferenceSubjectNameStrategy.GetSubjectName(string! topic, string! referenceName, bool isKey) -> string!
 Dekaf.SchemaRegistry.Protobuf.ProtobufSchemaRegistrySerializer<T>.PrepareAsync(string! topic, T value, bool isKey = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.SchemaRegistry.ResolvedSchemaContext>

--- a/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
@@ -68,6 +68,21 @@ public interface ISchemaRegistryClient : IDisposable
     Task<RegisteredSchema> GetSchemaBySubjectAsync(string subject, string version = "latest", CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets the schema registered under a subject at a specific version, optionally including deleted versions.
+    /// </summary>
+    /// <param name="subject">The subject name.</param>
+    /// <param name="version">The version number, or "latest" for latest.</param>
+    /// <param name="ignoreDeletedSchemas">Whether deleted schemas are excluded.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The registered schema with metadata.</returns>
+    Task<RegisteredSchema> GetSchemaBySubjectAsync(
+        string subject,
+        string version,
+        bool ignoreDeletedSchemas,
+        CancellationToken cancellationToken = default) =>
+        GetSchemaBySubjectAsync(subject, version, cancellationToken);
+
+    /// <summary>
     /// Looks up an exact schema under a subject without registering it.
     /// </summary>
     /// <param name="subject">The subject name.</param>

--- a/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
@@ -8,6 +8,12 @@ namespace Dekaf.SchemaRegistry;
 public interface ISchemaRegistryClient : IDisposable
 {
     /// <summary>
+    /// TTL in seconds for cached latest-schema resolutions, or -1 for no expiry.
+    /// The default is -1.
+    /// </summary>
+    int LatestCacheTtlSecs => -1;
+
+    /// <summary>
     /// Registers a schema under a subject. If the schema is already registered,
     /// returns the existing schema ID.
     /// </summary>
@@ -79,8 +85,16 @@ public interface ISchemaRegistryClient : IDisposable
         string subject,
         string version,
         bool ignoreDeletedSchemas,
-        CancellationToken cancellationToken = default) =>
-        GetSchemaBySubjectAsync(subject, version, cancellationToken);
+        CancellationToken cancellationToken = default)
+    {
+        if (!ignoreDeletedSchemas)
+        {
+            throw new NotSupportedException(
+                $"This {nameof(ISchemaRegistryClient)} implementation does not support looking up deleted schema versions.");
+        }
+
+        return GetSchemaBySubjectAsync(subject, version, cancellationToken);
+    }
 
     /// <summary>
     /// Looks up an exact schema under a subject without registering it.

--- a/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
+++ b/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
@@ -718,8 +718,10 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
         _subjectNames = DeserializerSubjectNameCache.Create(config);
         if (config.UseLatestVersion)
         {
-            _migrationRunner = new SchemaRegistryMigrationRunner(schemaRegistry, ruleExecutor, SchemaRegistryTimeout);
-            _ruleExecutor ??= SchemaRegistryMigrationRunner.MarkerRuleExecutor;
+            (_migrationRunner, _ruleExecutor) = SchemaRegistryMigrationRunner.Create(
+                schemaRegistry,
+                ruleExecutor,
+                SchemaRegistryTimeout);
         }
     }
 
@@ -792,8 +794,10 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
         _subjectNames = DeserializerSubjectNameCache.Create(config);
         if (config.UseLatestVersion)
         {
-            _migrationRunner = new SchemaRegistryMigrationRunner(schemaRegistry, ruleExecutor, SchemaRegistryTimeout);
-            _ruleExecutor ??= SchemaRegistryMigrationRunner.MarkerRuleExecutor;
+            (_migrationRunner, _ruleExecutor) = SchemaRegistryMigrationRunner.Create(
+                schemaRegistry,
+                ruleExecutor,
+                SchemaRegistryTimeout);
         }
     }
 

--- a/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
+++ b/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
@@ -678,6 +678,7 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
     private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
     private readonly IJsonSchemaValidatorFactory? _validatorFactory;
     private readonly DeserializerSubjectNameCache? _subjectNames;
+    private readonly SchemaRegistryMigrationRunner? _migrationRunner;
 
     /// <summary>
     /// Creates a new JSON Schema Registry deserializer.
@@ -715,6 +716,11 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
     {
         ArgumentNullException.ThrowIfNull(config);
         _subjectNames = DeserializerSubjectNameCache.Create(config);
+        if (config.UseLatestVersion)
+        {
+            _migrationRunner = new SchemaRegistryMigrationRunner(schemaRegistry, ruleExecutor, SchemaRegistryTimeout);
+            _ruleExecutor ??= SchemaRegistryMigrationRunner.MarkerRuleExecutor;
+        }
     }
 
     /// <summary>
@@ -784,6 +790,11 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
     {
         ArgumentNullException.ThrowIfNull(config);
         _subjectNames = DeserializerSubjectNameCache.Create(config);
+        if (config.UseLatestVersion)
+        {
+            _migrationRunner = new SchemaRegistryMigrationRunner(schemaRegistry, ruleExecutor, SchemaRegistryTimeout);
+            _ruleExecutor ??= SchemaRegistryMigrationRunner.MarkerRuleExecutor;
+        }
     }
 
     /// <summary>
@@ -848,20 +859,35 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
             }
 
             schema = _schemaRegistry.GetSchemaSync(schemaId, subject, SchemaRegistryTimeout);
-            var ruleContext = SchemaRegistryRuleContext.Rent(
-                context.Topic,
-                context.Component,
-                schemaId,
-                subject,
-                schema,
-                SchemaRegistryPayloadFormat.Json);
-            try
+            if (_migrationRunner is null)
             {
-                payload = _ruleExecutor.TransformDeserializedPayload(payload, ruleContext);
+                var ruleContext = SchemaRegistryRuleContext.Rent(
+                    context.Topic,
+                    context.Component,
+                    schemaId,
+                    subject,
+                    schema,
+                    SchemaRegistryPayloadFormat.Json);
+                try
+                {
+                    payload = _ruleExecutor!.TransformDeserializedPayload(payload, ruleContext);
+                }
+                finally
+                {
+                    ruleContext.Return();
+                }
             }
-            finally
+            else
             {
-                ruleContext.Return();
+                var migration = _migrationRunner.Transform(
+                    payload,
+                    schemaId,
+                    subject,
+                    schema,
+                    context,
+                    SchemaRegistryPayloadFormat.Json);
+                payload = migration.Payload;
+                schema = migration.ReaderSchema.Schema;
             }
         }
         else

--- a/src/Dekaf.SchemaRegistry/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry/PublicAPI.Unshipped.txt
@@ -1,4 +1,9 @@
 #nullable enable
+Dekaf.SchemaRegistry.SchemaRegistryDeserializerConfig.UseLatestVersion.get -> bool
+Dekaf.SchemaRegistry.SchemaRegistryDeserializerConfig.UseLatestVersion.init -> void
+Dekaf.SchemaRegistry.SchemaRegistryRuleContext.RuleMode.get -> Dekaf.SchemaRegistry.SchemaRuleMode?
+Dekaf.SchemaRegistry.SchemaRegistryRuleContext.SourceSchema.get -> Dekaf.SchemaRegistry.Schema?
+Dekaf.SchemaRegistry.SchemaRegistryRuleContext.TargetSchema.get -> Dekaf.SchemaRegistry.Schema?
 Dekaf.SchemaRegistry.ISchemaRegistryCache.TryGetCachedSchema(int id, string! subject, out Dekaf.SchemaRegistry.Schema! schema) -> bool
 Dekaf.SchemaRegistry.ISchemaRegistryClient.GetSchemaAsync(int id, string! subject, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Dekaf.SchemaRegistry.Schema!>!
 Dekaf.SchemaRegistry.SchemaRegistryClient.GetSchemaAsync(int id, string! subject, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Dekaf.SchemaRegistry.Schema!>!
@@ -126,7 +131,9 @@ Dekaf.SchemaRegistry.SchemaRegistryTlsConfig.ValidateServerCertificateHostName.i
 Dekaf.SchemaRegistry.SchemaRegistrySerializer<T>.PrepareAsync(string! topic, T value, bool isKey = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.SchemaRegistry.ResolvedSchemaContext>
 Dekaf.SchemaRegistry.SchemaRegistrySerializer<T>.PrepareAsync(T value, Dekaf.Serialization.SerializationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Dekaf.SchemaRegistry.ISchemaRegistryClient.GetDekAsync(string! kekName, string! subject, int version, Dekaf.SchemaRegistry.DekAlgorithm algorithm, bool deleted = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Dekaf.SchemaRegistry.Dek!>!
+Dekaf.SchemaRegistry.ISchemaRegistryClient.GetSchemaBySubjectAsync(string! subject, string! version, bool ignoreDeletedSchemas, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Dekaf.SchemaRegistry.RegisteredSchema!>!
 Dekaf.SchemaRegistry.SchemaRegistryClient.GetDekAsync(string! kekName, string! subject, int version, Dekaf.SchemaRegistry.DekAlgorithm algorithm, bool deleted = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Dekaf.SchemaRegistry.Dek!>!
+Dekaf.SchemaRegistry.SchemaRegistryClient.GetSchemaBySubjectAsync(string! subject, string! version, bool ignoreDeletedSchemas, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Dekaf.SchemaRegistry.RegisteredSchema!>!
 override Dekaf.SchemaRegistry.ResolvedSchemaContext.GetHashCode() -> int
 static Dekaf.SchemaRegistry.ResolvedSchemaContext.operator !=(Dekaf.SchemaRegistry.ResolvedSchemaContext left, Dekaf.SchemaRegistry.ResolvedSchemaContext right) -> bool
 static Dekaf.SchemaRegistry.ResolvedSchemaContext.operator ==(Dekaf.SchemaRegistry.ResolvedSchemaContext left, Dekaf.SchemaRegistry.ResolvedSchemaContext right) -> bool

--- a/src/Dekaf.SchemaRegistry/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry/PublicAPI.Unshipped.txt
@@ -1,4 +1,8 @@
 #nullable enable
+Dekaf.SchemaRegistry.ISchemaRegistryClient.LatestCacheTtlSecs.get -> int
+Dekaf.SchemaRegistry.SchemaRegistryClient.LatestCacheTtlSecs.get -> int
+Dekaf.SchemaRegistry.SchemaRegistryConfig.LatestCacheTtlSecs.get -> int
+Dekaf.SchemaRegistry.SchemaRegistryConfig.LatestCacheTtlSecs.init -> void
 Dekaf.SchemaRegistry.SchemaRegistryDeserializerConfig.UseLatestVersion.get -> bool
 Dekaf.SchemaRegistry.SchemaRegistryDeserializerConfig.UseLatestVersion.init -> void
 Dekaf.SchemaRegistry.SchemaRegistryRuleContext.RuleMode.get -> Dekaf.SchemaRegistry.SchemaRuleMode?

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -517,10 +517,22 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
     public bool TryGetCachedSchema(int id, string subject, out Schema schema)
         => _schemaBySubjectAndIdCache.TryGetValue((id, subject), out schema!);
 
-    public async Task<RegisteredSchema> GetSchemaBySubjectAsync(string subject, string version = "latest", CancellationToken cancellationToken = default)
+    public Task<RegisteredSchema> GetSchemaBySubjectAsync(
+        string subject,
+        string version = "latest",
+        CancellationToken cancellationToken = default) =>
+        GetSchemaBySubjectAsync(subject, version, ignoreDeletedSchemas: true, cancellationToken);
+
+    public async Task<RegisteredSchema> GetSchemaBySubjectAsync(
+        string subject,
+        string version,
+        bool ignoreDeletedSchemas,
+        CancellationToken cancellationToken = default)
     {
         using var response = await GetWithFailoverAsync(
-            $"subjects/{Uri.EscapeDataString(subject)}/versions/{Uri.EscapeDataString(version)}",
+            WithQuery(
+                $"subjects/{Uri.EscapeDataString(subject)}/versions/{Uri.EscapeDataString(version)}",
+                ("deleted", ignoreDeletedSchemas ? null : "true")),
             cancellationToken).ConfigureAwait(false);
 
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -103,6 +103,9 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
     internal int CachedSchemaBySubjectAndIdCount => _schemaBySubjectAndIdCache.Count;
     internal int CachedSchemaIdCount => _idBySchemaCache.Count;
 
+    /// <inheritdoc />
+    public int LatestCacheTtlSecs => _config.LatestCacheTtlSecs;
+
     internal static HttpMessageHandler CreateConfiguredHttpHandler(SchemaRegistryConfig? config)
     {
         ArgumentNullException.ThrowIfNull(config);
@@ -168,6 +171,13 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             throw new ArgumentOutOfRangeException(
                 nameof(config),
                 "RequestTimeoutMs must be positive or -1 for an infinite timeout.");
+        }
+
+        if (config.LatestCacheTtlSecs < -1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(config),
+                "LatestCacheTtlSecs must be non-negative or -1 for no expiry.");
         }
 
         if (!config.UseProxy && config.Proxy is not null)
@@ -1489,6 +1499,12 @@ public sealed class SchemaRegistryConfig
     /// Maximum number of schemas to cache.
     /// </summary>
     public int MaxCachedSchemas { get; init; } = 1000;
+
+    /// <summary>
+    /// TTL in seconds for caches holding latest schemas. Use -1 for no expiry.
+    /// Default is -1.
+    /// </summary>
+    public int LatestCacheTtlSecs { get; init; } = -1;
 
     /// <summary>
     /// Whether schema registration, lookup, and compatibility requests should

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryDeserializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryDeserializerConfig.cs
@@ -6,6 +6,12 @@ namespace Dekaf.SchemaRegistry;
 public sealed class SchemaRegistryDeserializerConfig
 {
     /// <summary>
+    /// Whether to use the latest registered subject version as the reader schema and execute
+    /// any migration rules between the writer and reader versions.
+    /// </summary>
+    public bool UseLatestVersion { get; init; }
+
+    /// <summary>
     /// Strategy used to reconstruct the subject associated with the consumed schema.
     /// </summary>
     public SubjectNameStrategy SubjectNameStrategy { get; init; } = SubjectNameStrategy.TopicName;

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryMigrationRunner.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryMigrationRunner.cs
@@ -15,7 +15,7 @@ internal sealed class SchemaRegistryMigrationRunner
     private readonly SchemaRegistryRuleExecutor? _schemaRuleExecutor;
     private readonly SchemaResolutionCache<MigrationPlan> _plans = new();
     private readonly TimeSpan _timeout;
-    private readonly CachedPlanSlot _lastPlan = new();
+    private MigrationPlan? _lastPlan;
     private readonly long _latestCacheTtlMilliseconds;
 
     internal SchemaRegistryMigrationRunner(
@@ -56,7 +56,10 @@ internal sealed class SchemaRegistryMigrationRunner
         SchemaRegistryPayloadFormat payloadFormat)
     {
         var isNewPlan = false;
-        if (!_lastPlan.TryRead(schemaId, subject, out var plan))
+        var plan = Volatile.Read(ref _lastPlan);
+        if (plan is null ||
+            plan.WriterSchemaId != schemaId ||
+            !string.Equals(plan.Subject, subject, StringComparison.Ordinal))
         {
             if (!_plans.TryGet(subject, writerSchema, out plan))
             {
@@ -64,7 +67,7 @@ internal sealed class SchemaRegistryMigrationRunner
                 isNewPlan = true;
             }
 
-            _lastPlan.TryWrite(schemaId, subject, plan);
+            Volatile.Write(ref _lastPlan, plan);
         }
 
         if (!isNewPlan &&
@@ -73,7 +76,7 @@ internal sealed class SchemaRegistryMigrationRunner
         {
             _plans.TryRemove(subject, writerSchema, plan);
             plan = _plans.Resolve(subject, writerSchema, this, s_createPlan, _timeout);
-            _lastPlan.TryWrite(schemaId, subject, plan);
+            Volatile.Write(ref _lastPlan, plan);
         }
 
         if (_schemaRuleExecutor is null)
@@ -179,7 +182,7 @@ internal sealed class SchemaRegistryMigrationRunner
             .ConfigureAwait(false);
 
         if (writer.Version == reader.Version)
-            return new MigrationPlan(reader, [], Environment.TickCount64);
+            return new MigrationPlan(writer.Id, subject, reader, [], Environment.TickCount64);
 
         var steps = new List<MigrationStep>();
         if (writer.Version < reader.Version)
@@ -219,7 +222,7 @@ internal sealed class SchemaRegistryMigrationRunner
             }
         }
 
-        return new MigrationPlan(reader, [.. steps], Environment.TickCount64);
+        return new MigrationPlan(writer.Id, subject, reader, [.. steps], Environment.TickCount64);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -235,61 +238,17 @@ internal sealed class SchemaRegistryMigrationRunner
         RegisteredSchema ReaderSchema);
 
     private sealed class MigrationPlan(
+        int writerSchemaId,
+        string subject,
         RegisteredSchema readerSchema,
         MigrationStep[] steps,
         long createdAtMilliseconds)
     {
+        internal int WriterSchemaId { get; } = writerSchemaId;
+        internal string Subject { get; } = subject;
         internal RegisteredSchema ReaderSchema { get; } = readerSchema;
         internal MigrationStep[] Steps { get; } = steps;
         internal long CreatedAtMilliseconds { get; } = createdAtMilliseconds;
-    }
-
-    private sealed class CachedPlanSlot
-    {
-        private int _version;
-        private int _schemaId;
-        private string? _subject;
-        private MigrationPlan? _plan;
-
-        internal bool TryRead(int schemaId, string subject, out MigrationPlan plan)
-        {
-            var version = Volatile.Read(ref _version);
-            if ((version & 1) != 0)
-            {
-                plan = null!;
-                return false;
-            }
-
-            var cachedSchemaId = _schemaId;
-            var cachedSubject = _subject;
-            var cachedPlan = _plan;
-            if (version == Volatile.Read(ref _version) &&
-                cachedSchemaId == schemaId &&
-                cachedPlan is not null &&
-                string.Equals(cachedSubject, subject, StringComparison.Ordinal))
-            {
-                plan = cachedPlan;
-                return true;
-            }
-
-            plan = null!;
-            return false;
-        }
-
-        internal void TryWrite(int schemaId, string subject, MigrationPlan plan)
-        {
-            var version = Volatile.Read(ref _version);
-            if ((version & 1) != 0 ||
-                Interlocked.CompareExchange(ref _version, unchecked(version + 1), version) != version)
-            {
-                return;
-            }
-
-            _schemaId = schemaId;
-            _subject = subject;
-            _plan = plan;
-            Volatile.Write(ref _version, unchecked(version + 2));
-        }
     }
 
     private readonly record struct MigrationStep(

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryMigrationRunner.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryMigrationRunner.cs
@@ -1,0 +1,229 @@
+using System.Runtime.CompilerServices;
+using Dekaf.Serialization;
+
+namespace Dekaf.SchemaRegistry;
+
+internal sealed class SchemaRegistryMigrationRunner
+{
+    internal static ISchemaRegistryRuleExecutor MarkerRuleExecutor { get; } = new MigrationMarkerRuleExecutor();
+
+    private static readonly Func<SchemaRegistryMigrationRunner, string, Schema, Task<MigrationPlan>> s_createPlan =
+        static (runner, subject, writerSchema) => runner.CreatePlanAsync(subject, writerSchema);
+
+    private readonly ISchemaRegistryClient _schemaRegistry;
+    private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
+    private readonly SchemaRegistryRuleExecutor? _schemaRuleExecutor;
+    private readonly SchemaResolutionCache<MigrationPlan> _plans = new();
+    private readonly TimeSpan _timeout;
+    private CachedPlan? _lastPlan;
+
+    internal SchemaRegistryMigrationRunner(
+        ISchemaRegistryClient schemaRegistry,
+        ISchemaRegistryRuleExecutor? ruleExecutor,
+        TimeSpan timeout)
+    {
+        _schemaRegistry = schemaRegistry;
+        _ruleExecutor = ruleExecutor;
+        _schemaRuleExecutor = ruleExecutor as SchemaRegistryRuleExecutor;
+        _timeout = timeout;
+    }
+
+    internal MigrationResult Transform(
+        ReadOnlyMemory<byte> payload,
+        int schemaId,
+        string subject,
+        Schema writerSchema,
+        SerializationContext serializationContext,
+        SchemaRegistryPayloadFormat payloadFormat)
+    {
+        var cached = Volatile.Read(ref _lastPlan);
+        MigrationPlan plan;
+        if (cached is not null &&
+            cached.SchemaId == schemaId &&
+            string.Equals(cached.Subject, subject, StringComparison.Ordinal))
+        {
+            plan = cached.Plan;
+        }
+        else
+        {
+            plan = _plans.Resolve(subject, writerSchema, this, s_createPlan, _timeout);
+            Volatile.Write(ref _lastPlan, new CachedPlan(schemaId, subject, plan));
+        }
+        if (_schemaRuleExecutor is null)
+        {
+            if (plan.Steps.Length != 0)
+            {
+                throw new SchemaRegistryRuleException(
+                    $"Migration rules require {nameof(SchemaRegistryRuleExecutor)}.");
+            }
+
+            if (_ruleExecutor is null)
+                return new MigrationResult(payload, plan.ReaderSchema);
+
+            var readerContext = SchemaRegistryRuleContext.Rent(
+                serializationContext.Topic,
+                serializationContext.Component,
+                plan.ReaderSchema.Id,
+                subject,
+                plan.ReaderSchema.Schema,
+                payloadFormat);
+            try
+            {
+                payload = _ruleExecutor.TransformDeserializedPayload(payload, readerContext);
+            }
+            finally
+            {
+                readerContext.Return();
+            }
+
+            return new MigrationResult(payload, plan.ReaderSchema);
+        }
+
+        var context = SchemaRegistryRuleContext.Rent(
+            serializationContext.Topic,
+            serializationContext.Component,
+            schemaId,
+            subject,
+            writerSchema,
+            payloadFormat);
+        try
+        {
+            payload = _schemaRuleExecutor.TransformDeserializedEncodingPayload(payload, context);
+        }
+        finally
+        {
+            context.Return();
+        }
+
+        var steps = plan.Steps;
+        for (var i = 0; i < steps.Length; i++)
+        {
+            ref readonly var step = ref steps[i];
+            var owner = step.Mode == SchemaRuleMode.Upgrade ? step.Target.Schema : step.Source.Schema;
+            context = SchemaRegistryRuleContext.Rent(
+                serializationContext.Topic,
+                serializationContext.Component,
+                schemaId,
+                subject,
+                owner,
+                payloadFormat,
+                step.Source.Schema,
+                step.Target.Schema,
+                step.Mode);
+            try
+            {
+                payload = _schemaRuleExecutor.TransformMigrationPayload(payload, context, step.Mode);
+            }
+            finally
+            {
+                context.Return();
+            }
+        }
+
+        context = SchemaRegistryRuleContext.Rent(
+            serializationContext.Topic,
+            serializationContext.Component,
+            plan.ReaderSchema.Id,
+            subject,
+            plan.ReaderSchema.Schema,
+            payloadFormat);
+        try
+        {
+            payload = _schemaRuleExecutor.TransformDeserializedDomainPayload(payload, context);
+        }
+        finally
+        {
+            context.Return();
+        }
+
+        return new MigrationResult(payload, plan.ReaderSchema);
+    }
+
+    private async Task<MigrationPlan> CreatePlanAsync(string subject, Schema writerSchema)
+    {
+        var writer = await _schemaRegistry.LookupSchemaAsync(
+                subject,
+                writerSchema,
+                ignoreDeletedSchemas: false,
+                normalize: false,
+                CancellationToken.None)
+            .ConfigureAwait(false);
+        var reader = await _schemaRegistry.GetSchemaBySubjectAsync(subject, "latest", CancellationToken.None)
+            .ConfigureAwait(false);
+
+        if (writer.Version == reader.Version)
+            return new MigrationPlan(reader, []);
+
+        var steps = new List<MigrationStep>();
+        if (writer.Version < reader.Version)
+        {
+            var previous = writer;
+            for (var version = writer.Version + 1; version <= reader.Version; version++)
+            {
+                var current = version == reader.Version
+                    ? reader
+                    : await GetVersionAsync(subject, version).ConfigureAwait(false);
+                if (SchemaRegistryRuleExecutor.HasActiveMigrationRule(
+                        current.Schema.RuleSet,
+                        SchemaRuleMode.Upgrade))
+                {
+                    steps.Add(new MigrationStep(SchemaRuleMode.Upgrade, previous, current));
+                }
+
+                previous = current;
+            }
+        }
+        else
+        {
+            var current = writer;
+            for (var version = writer.Version - 1; version >= reader.Version; version--)
+            {
+                var previous = version == reader.Version
+                    ? reader
+                    : await GetVersionAsync(subject, version).ConfigureAwait(false);
+                if (SchemaRegistryRuleExecutor.HasActiveMigrationRule(
+                        current.Schema.RuleSet,
+                        SchemaRuleMode.Downgrade))
+                {
+                    steps.Add(new MigrationStep(SchemaRuleMode.Downgrade, current, previous));
+                }
+
+                current = previous;
+            }
+        }
+
+        return new MigrationPlan(reader, [.. steps]);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private Task<RegisteredSchema> GetVersionAsync(string subject, int version) =>
+        _schemaRegistry.GetSchemaBySubjectAsync(
+            subject,
+            version.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ignoreDeletedSchemas: false,
+            CancellationToken.None);
+
+    internal readonly record struct MigrationResult(
+        ReadOnlyMemory<byte> Payload,
+        RegisteredSchema ReaderSchema);
+
+    private sealed record MigrationPlan(RegisteredSchema ReaderSchema, MigrationStep[] Steps);
+
+    private sealed record CachedPlan(int SchemaId, string Subject, MigrationPlan Plan);
+
+    private readonly record struct MigrationStep(
+        SchemaRuleMode Mode,
+        RegisteredSchema Source,
+        RegisteredSchema Target);
+
+    private sealed class MigrationMarkerRuleExecutor : ISchemaRegistryRuleExecutor
+    {
+        public ReadOnlyMemory<byte> TransformSerializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleContext context) => payload;
+
+        public ReadOnlyMemory<byte> TransformDeserializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleContext context) => payload;
+    }
+}

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryMigrationRunner.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryMigrationRunner.cs
@@ -15,7 +15,8 @@ internal sealed class SchemaRegistryMigrationRunner
     private readonly SchemaRegistryRuleExecutor? _schemaRuleExecutor;
     private readonly SchemaResolutionCache<MigrationPlan> _plans = new();
     private readonly TimeSpan _timeout;
-    private CachedPlan? _lastPlan;
+    private readonly CachedPlanSlot _lastPlan = new();
+    private readonly long _latestCacheTtlMilliseconds;
 
     internal SchemaRegistryMigrationRunner(
         ISchemaRegistryClient schemaRegistry,
@@ -26,7 +27,25 @@ internal sealed class SchemaRegistryMigrationRunner
         _ruleExecutor = ruleExecutor;
         _schemaRuleExecutor = ruleExecutor as SchemaRegistryRuleExecutor;
         _timeout = timeout;
+        var latestCacheTtlSecs = schemaRegistry.LatestCacheTtlSecs;
+        if (latestCacheTtlSecs < -1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(schemaRegistry),
+                "LatestCacheTtlSecs must be non-negative or -1 for no expiry.");
+        }
+
+        _latestCacheTtlMilliseconds = (long)latestCacheTtlSecs * 1000;
     }
+
+    internal static (
+        SchemaRegistryMigrationRunner Runner,
+        ISchemaRegistryRuleExecutor EffectiveRuleExecutor) Create(
+        ISchemaRegistryClient schemaRegistry,
+        ISchemaRegistryRuleExecutor? ruleExecutor,
+        TimeSpan timeout) =>
+        (new SchemaRegistryMigrationRunner(schemaRegistry, ruleExecutor, timeout),
+         ruleExecutor ?? MarkerRuleExecutor);
 
     internal MigrationResult Transform(
         ReadOnlyMemory<byte> payload,
@@ -36,19 +55,27 @@ internal sealed class SchemaRegistryMigrationRunner
         SerializationContext serializationContext,
         SchemaRegistryPayloadFormat payloadFormat)
     {
-        var cached = Volatile.Read(ref _lastPlan);
-        MigrationPlan plan;
-        if (cached is not null &&
-            cached.SchemaId == schemaId &&
-            string.Equals(cached.Subject, subject, StringComparison.Ordinal))
+        var isNewPlan = false;
+        if (!_lastPlan.TryRead(schemaId, subject, out var plan))
         {
-            plan = cached.Plan;
+            if (!_plans.TryGet(subject, writerSchema, out plan))
+            {
+                plan = _plans.Resolve(subject, writerSchema, this, s_createPlan, _timeout);
+                isNewPlan = true;
+            }
+
+            _lastPlan.TryWrite(schemaId, subject, plan);
         }
-        else
+
+        if (!isNewPlan &&
+            _latestCacheTtlMilliseconds >= 0 &&
+            Environment.TickCount64 - plan.CreatedAtMilliseconds >= _latestCacheTtlMilliseconds)
         {
+            _plans.TryRemove(subject, writerSchema, plan);
             plan = _plans.Resolve(subject, writerSchema, this, s_createPlan, _timeout);
-            Volatile.Write(ref _lastPlan, new CachedPlan(schemaId, subject, plan));
+            _lastPlan.TryWrite(schemaId, subject, plan);
         }
+
         if (_schemaRuleExecutor is null)
         {
             if (plan.Steps.Length != 0)
@@ -152,7 +179,7 @@ internal sealed class SchemaRegistryMigrationRunner
             .ConfigureAwait(false);
 
         if (writer.Version == reader.Version)
-            return new MigrationPlan(reader, []);
+            return new MigrationPlan(reader, [], Environment.TickCount64);
 
         var steps = new List<MigrationStep>();
         if (writer.Version < reader.Version)
@@ -192,7 +219,7 @@ internal sealed class SchemaRegistryMigrationRunner
             }
         }
 
-        return new MigrationPlan(reader, [.. steps]);
+        return new MigrationPlan(reader, [.. steps], Environment.TickCount64);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -207,9 +234,63 @@ internal sealed class SchemaRegistryMigrationRunner
         ReadOnlyMemory<byte> Payload,
         RegisteredSchema ReaderSchema);
 
-    private sealed record MigrationPlan(RegisteredSchema ReaderSchema, MigrationStep[] Steps);
+    private sealed class MigrationPlan(
+        RegisteredSchema readerSchema,
+        MigrationStep[] steps,
+        long createdAtMilliseconds)
+    {
+        internal RegisteredSchema ReaderSchema { get; } = readerSchema;
+        internal MigrationStep[] Steps { get; } = steps;
+        internal long CreatedAtMilliseconds { get; } = createdAtMilliseconds;
+    }
 
-    private sealed record CachedPlan(int SchemaId, string Subject, MigrationPlan Plan);
+    private sealed class CachedPlanSlot
+    {
+        private int _version;
+        private int _schemaId;
+        private string? _subject;
+        private MigrationPlan? _plan;
+
+        internal bool TryRead(int schemaId, string subject, out MigrationPlan plan)
+        {
+            var version = Volatile.Read(ref _version);
+            if ((version & 1) != 0)
+            {
+                plan = null!;
+                return false;
+            }
+
+            var cachedSchemaId = _schemaId;
+            var cachedSubject = _subject;
+            var cachedPlan = _plan;
+            if (version == Volatile.Read(ref _version) &&
+                cachedSchemaId == schemaId &&
+                cachedPlan is not null &&
+                string.Equals(cachedSubject, subject, StringComparison.Ordinal))
+            {
+                plan = cachedPlan;
+                return true;
+            }
+
+            plan = null!;
+            return false;
+        }
+
+        internal void TryWrite(int schemaId, string subject, MigrationPlan plan)
+        {
+            var version = Volatile.Read(ref _version);
+            if ((version & 1) != 0 ||
+                Interlocked.CompareExchange(ref _version, unchecked(version + 1), version) != version)
+            {
+                return;
+            }
+
+            _schemaId = schemaId;
+            _subject = subject;
+            _plan = plan;
+            Volatile.Write(ref _version, unchecked(version + 2));
+        }
+    }
 
     private readonly record struct MigrationStep(
         SchemaRuleMode Mode,

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryRules.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryRules.cs
@@ -50,6 +50,9 @@ public sealed class SchemaRegistryRuleContext
     private int _schemaId;
     private string? _subject;
     private Schema? _schema;
+    private Schema? _sourceSchema;
+    private Schema? _targetSchema;
+    private SchemaRuleMode? _ruleMode;
     private SchemaRegistryPayloadFormat _payloadFormat;
     private bool _inUse;
     private SchemaRegistryRuleContext? _next;
@@ -117,6 +120,21 @@ public sealed class SchemaRegistryRuleContext
     }
 
     /// <summary>
+    /// Gets the source schema for a migration rule, or <see langword="null" /> outside migration execution.
+    /// </summary>
+    public Schema? SourceSchema => _sourceSchema;
+
+    /// <summary>
+    /// Gets the target schema for a migration rule, or <see langword="null" /> outside migration execution.
+    /// </summary>
+    public Schema? TargetSchema => _targetSchema;
+
+    /// <summary>
+    /// Gets the active migration mode, or <see langword="null" /> outside migration execution.
+    /// </summary>
+    public SchemaRuleMode? RuleMode => _ruleMode;
+
+    /// <summary>
     /// Gets the codec payload format.
     /// </summary>
     public required SchemaRegistryPayloadFormat PayloadFormat
@@ -135,7 +153,10 @@ public sealed class SchemaRegistryRuleContext
         int schemaId,
         string? subject,
         Schema? schema,
-        SchemaRegistryPayloadFormat payloadFormat)
+        SchemaRegistryPayloadFormat payloadFormat,
+        Schema? sourceSchema = null,
+        Schema? targetSchema = null,
+        SchemaRuleMode? ruleMode = null)
     {
         var context = t_primary;
         if (context is null)
@@ -149,13 +170,14 @@ public sealed class SchemaRegistryRuleContext
                 Schema = schema,
                 PayloadFormat = payloadFormat
             };
+            context.SetMigration(sourceSchema, targetSchema, ruleMode);
             context._inUse = true;
             t_primary = context;
         }
         else if (!context._inUse)
         {
             context._inUse = true;
-            context.Reset(topic, component, schemaId, subject, schema, payloadFormat);
+            context.Reset(topic, component, schemaId, subject, schema, payloadFormat, sourceSchema, targetSchema, ruleMode);
         }
         else
         {
@@ -171,12 +193,13 @@ public sealed class SchemaRegistryRuleContext
                     Schema = schema,
                     PayloadFormat = payloadFormat
                 };
+                context.SetMigration(sourceSchema, targetSchema, ruleMode);
             }
             else
             {
                 t_overflow = context._next;
                 context._next = null;
-                context.Reset(topic, component, schemaId, subject, schema, payloadFormat);
+                context.Reset(topic, component, schemaId, subject, schema, payloadFormat, sourceSchema, targetSchema, ruleMode);
             }
         }
 
@@ -189,6 +212,9 @@ public sealed class SchemaRegistryRuleContext
         _topic = null!;
         _subject = null;
         _schema = null;
+        _sourceSchema = null;
+        _targetSchema = null;
+        _ruleMode = null;
 
         if (ReferenceEquals(this, t_primary))
         {
@@ -213,7 +239,10 @@ public sealed class SchemaRegistryRuleContext
         int schemaId,
         string? subject,
         Schema? schema,
-        SchemaRegistryPayloadFormat payloadFormat)
+        SchemaRegistryPayloadFormat payloadFormat,
+        Schema? sourceSchema,
+        Schema? targetSchema,
+        SchemaRuleMode? ruleMode)
     {
         _topic = topic;
         _component = component;
@@ -221,6 +250,15 @@ public sealed class SchemaRegistryRuleContext
         _subject = subject;
         _schema = schema;
         _payloadFormat = payloadFormat;
+        SetMigration(sourceSchema, targetSchema, ruleMode);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void SetMigration(Schema? sourceSchema, Schema? targetSchema, SchemaRuleMode? ruleMode)
+    {
+        _sourceSchema = sourceSchema;
+        _targetSchema = targetSchema;
+        _ruleMode = ruleMode;
     }
 }
 
@@ -557,6 +595,98 @@ public sealed class SchemaRegistryRuleExecutor : ISchemaRegistryRuleExecutor
         SchemaRegistryRuleContext context)
         => ApplyRules(payload, context, SchemaRegistryRuleDirection.Read);
 
+    internal ReadOnlyMemory<byte> TransformDeserializedEncodingPayload(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleContext context)
+        => ApplyReadRuleCollection(payload, context, useEncodingRules: true);
+
+    internal ReadOnlyMemory<byte> TransformDeserializedDomainPayload(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleContext context)
+        => ApplyReadRuleCollection(payload, context, useEncodingRules: false);
+
+    internal ReadOnlyMemory<byte> TransformMigrationPayload(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleContext context,
+        SchemaRuleMode mode)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var ruleSet = context.Schema?.RuleSet;
+        var rules = ruleSet?.MigrationRules;
+        if (rules is null || rules.Count == 0 || !ShouldExecute(ruleSet!))
+            return payload;
+
+        var isUpgrade = mode == SchemaRuleMode.Upgrade;
+        var index = isUpgrade ? 0 : rules.Count - 1;
+        var end = isUpgrade ? rules.Count : -1;
+        var step = isUpgrade ? 1 : -1;
+        var direction = isUpgrade ? SchemaRegistryRuleDirection.Write : SchemaRegistryRuleDirection.Read;
+        for (; index != end; index += step)
+        {
+            var rule = rules[index];
+            if (!IsActiveMigrationRule(rule, mode))
+                continue;
+
+            _handlers.TryGetValue(rule.Type, out var handler);
+            payload = ApplyRule(payload, context, rule, handler, direction);
+        }
+
+        return payload;
+    }
+
+    internal static bool HasActiveMigrationRule(SchemaRuleSet? ruleSet, SchemaRuleMode mode)
+    {
+        if (ruleSet is null || !ShouldExecute(ruleSet))
+            return false;
+
+        var rules = ruleSet.MigrationRules;
+        if (rules is null)
+            return false;
+
+        for (var i = 0; i < rules.Count; i++)
+        {
+            if (IsActiveMigrationRule(rules[i], mode))
+                return true;
+        }
+
+        return false;
+    }
+
+    private ReadOnlyMemory<byte> ApplyReadRuleCollection(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleContext context,
+        bool useEncodingRules)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var ruleSet = context.Schema?.RuleSet;
+        if (ruleSet is null || !ruleSet.HasDomainOrEncodingRules || !ShouldExecute(ruleSet))
+            return payload;
+
+        if (ruleSet.HasFixedRuleCollections)
+        {
+            var plan = _executionPlans.GetValue(ruleSet, _createExecutionPlan);
+            var start = useEncodingRules ? 0 : plan.ReadEncodingStepCount;
+            var count = useEncodingRules
+                ? plan.ReadEncodingStepCount
+                : plan.ReadSteps.Length - plan.ReadEncodingStepCount;
+            return ApplyRules(
+                payload,
+                context,
+                plan.ReadSteps,
+                start,
+                count,
+                SchemaRegistryRuleDirection.Read);
+        }
+
+        return ApplyRules(
+            payload,
+            context,
+            useEncodingRules ? ruleSet.EncodingRules : ruleSet.DomainRules,
+            SchemaRegistryRuleDirection.Read);
+    }
+
     private ReadOnlyMemory<byte> ApplyRules(
         ReadOnlyMemory<byte> payload,
         SchemaRegistryRuleContext context,
@@ -568,16 +698,8 @@ public sealed class SchemaRegistryRuleExecutor : ISchemaRegistryRuleExecutor
         if (ruleSet is null || !ruleSet.HasDomainOrEncodingRules)
             return payload;
 
-        switch (ruleSet.EnableAt)
-        {
-            case null or "" or "ALL" or "CLIENT":
-                break;
-            case "GATEWAY" or "SERVER" or "NONE":
-                return payload;
-            case { } enabledEnvironment:
-                throw new SchemaRegistryRuleException(
-                    $"Unknown Schema Registry rule execution environment '{enabledEnvironment}'.");
-        }
+        if (!ShouldExecute(ruleSet))
+            return payload;
 
         if (ruleSet.HasFixedRuleCollections)
         {
@@ -759,8 +881,13 @@ public sealed class SchemaRegistryRuleExecutor : ISchemaRegistryRuleExecutor
 
         var readSteps = new List<RuleExecutionStep>();
         AddExecutionSteps(readSteps, ruleSet.EncodingRules, SchemaRegistryRuleDirection.Read, reverse: true);
+        var readEncodingStepCount = readSteps.Count;
         AddExecutionSteps(readSteps, ruleSet.DomainRules, SchemaRegistryRuleDirection.Read, reverse: true);
-        return new RuleExecutionPlan([.. writeSteps], writeDomainStepCount, [.. readSteps]);
+        return new RuleExecutionPlan(
+            [.. writeSteps],
+            writeDomainStepCount,
+            [.. readSteps],
+            readEncodingStepCount);
     }
 
     private void AddExecutionSteps(
@@ -864,7 +991,7 @@ public sealed class SchemaRegistryRuleExecutor : ISchemaRegistryRuleExecutor
         if (configuredAction is null)
             return null;
 
-        if (ruleMode != SchemaRuleMode.WriteRead)
+        if (ruleMode is not (SchemaRuleMode.WriteRead or SchemaRuleMode.UpDown))
             return new RuleActionName(configuredAction);
 
         var separator = configuredAction.IndexOf(',');
@@ -893,10 +1020,36 @@ public sealed class SchemaRegistryRuleExecutor : ISchemaRegistryRuleExecutor
             : rule.Mode is SchemaRuleMode.Read or SchemaRuleMode.WriteRead;
     }
 
+    private static bool IsActiveMigrationRule(SchemaRule rule, SchemaRuleMode mode)
+    {
+        if (rule.Disabled || string.IsNullOrWhiteSpace(rule.Type))
+            return false;
+
+        if (rule.Kind is not (SchemaRuleKind.Transform or SchemaRuleKind.Condition))
+            return false;
+
+        return rule.Mode == mode || rule.Mode == SchemaRuleMode.UpDown;
+    }
+
+    private static bool ShouldExecute(SchemaRuleSet ruleSet)
+    {
+        switch (ruleSet.EnableAt)
+        {
+            case null or "" or "ALL" or "CLIENT":
+                return true;
+            case "GATEWAY" or "SERVER" or "NONE":
+                return false;
+            case { } enabledEnvironment:
+                throw new SchemaRegistryRuleException(
+                    $"Unknown Schema Registry rule execution environment '{enabledEnvironment}'.");
+        }
+    }
+
     private sealed record RuleExecutionPlan(
         RuleExecutionStep[] WriteSteps,
         int WriteDomainStepCount,
-        RuleExecutionStep[] ReadSteps);
+        RuleExecutionStep[] ReadSteps,
+        int ReadEncodingStepCount);
 
     private readonly record struct RuleExecutionStep(
         SchemaRule Rule,

--- a/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
@@ -820,8 +820,10 @@ public sealed class SchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisp
         _subjectNames = DeserializerSubjectNameCache.Create(config);
         if (config?.UseLatestVersion == true)
         {
-            _migrationRunner = new SchemaRegistryMigrationRunner(schemaRegistry, ruleExecutor, SchemaRegistryTimeout);
-            _ruleExecutor ??= SchemaRegistryMigrationRunner.MarkerRuleExecutor;
+            (_migrationRunner, _ruleExecutor) = SchemaRegistryMigrationRunner.Create(
+                schemaRegistry,
+                ruleExecutor,
+                SchemaRegistryTimeout);
         }
     }
 

--- a/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
@@ -778,6 +778,7 @@ public sealed class SchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisp
     private readonly bool _ownsClient;
     private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
     private readonly DeserializerSubjectNameCache? _subjectNames;
+    private readonly SchemaRegistryMigrationRunner? _migrationRunner;
 
     /// <summary>
     /// Creates a new Schema Registry deserializer.
@@ -817,6 +818,11 @@ public sealed class SchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisp
         _ownsClient = ownsClient;
         _ruleExecutor = ruleExecutor;
         _subjectNames = DeserializerSubjectNameCache.Create(config);
+        if (config?.UseLatestVersion == true)
+        {
+            _migrationRunner = new SchemaRegistryMigrationRunner(schemaRegistry, ruleExecutor, SchemaRegistryTimeout);
+            _ruleExecutor ??= SchemaRegistryMigrationRunner.MarkerRuleExecutor;
+        }
     }
 
     public T Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
@@ -849,20 +855,35 @@ public sealed class SchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisp
             }
 
             schema = _schemaRegistry.GetSchemaSync(schemaId, subject, SchemaRegistryTimeout);
-            var ruleContext = SchemaRegistryRuleContext.Rent(
-                context.Topic,
-                context.Component,
-                schemaId,
-                subject,
-                schema,
-                SchemaRegistryPayloadFormat.Custom);
-            try
+            if (_migrationRunner is null)
             {
-                payload = _ruleExecutor.TransformDeserializedPayload(payload, ruleContext);
+                var ruleContext = SchemaRegistryRuleContext.Rent(
+                    context.Topic,
+                    context.Component,
+                    schemaId,
+                    subject,
+                    schema,
+                    SchemaRegistryPayloadFormat.Custom);
+                try
+                {
+                    payload = _ruleExecutor!.TransformDeserializedPayload(payload, ruleContext);
+                }
+                finally
+                {
+                    ruleContext.Return();
+                }
             }
-            finally
+            else
             {
-                ruleContext.Return();
+                var migration = _migrationRunner.Transform(
+                    payload,
+                    schemaId,
+                    subject,
+                    schema,
+                    context,
+                    SchemaRegistryPayloadFormat.Custom);
+                payload = migration.Payload;
+                schema = migration.ReaderSchema.Schema;
             }
         }
         else

--- a/src/Dekaf.SchemaRegistry/SchemaResolutionCache.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaResolutionCache.cs
@@ -9,7 +9,7 @@ internal sealed class SchemaResolutionCache<TValue>
         new(SchemaResolutionKeyComparer.Instance);
     private readonly ConcurrentDictionary<SchemaResolutionKey, Entry> _inFlight =
         new(SchemaResolutionKeyComparer.Instance);
-    private readonly ConcurrentQueue<SchemaResolutionKey> _evictionQueue = new();
+    private readonly ConcurrentQueue<KeyValuePair<SchemaResolutionKey, TValue>> _evictionQueue = new();
     private readonly int _maxCachedEntries;
     private int _cacheCount;
 
@@ -20,6 +20,21 @@ internal sealed class SchemaResolutionCache<TValue>
     }
 
     internal int CachedEntryCount => Volatile.Read(ref _cacheCount);
+
+    internal bool TryGet(string subject, Schema schema, out TValue value) =>
+        _cache.TryGetValue(new SchemaResolutionKey(subject, schema, default), out value!);
+
+    internal bool TryRemove(string subject, Schema schema, TValue value)
+    {
+        var entry = new KeyValuePair<SchemaResolutionKey, TValue>(
+            new SchemaResolutionKey(subject, schema, default),
+            value);
+        if (!((ICollection<KeyValuePair<SchemaResolutionKey, TValue>>)_cache).Remove(entry))
+            return false;
+
+        Interlocked.Decrement(ref _cacheCount);
+        return true;
+    }
 
     internal ValueTask<TValue> ResolveAsync<TState>(
         string subject,
@@ -131,7 +146,7 @@ internal sealed class SchemaResolutionCache<TValue>
             return;
 
         Interlocked.Increment(ref _cacheCount);
-        _evictionQueue.Enqueue(key);
+        _evictionQueue.Enqueue(new KeyValuePair<SchemaResolutionKey, TValue>(key, value));
         TrimOverflow();
     }
 
@@ -149,7 +164,7 @@ internal sealed class SchemaResolutionCache<TValue>
             var removed = false;
             while (_evictionQueue.TryDequeue(out var oldest))
             {
-                if (_cache.TryRemove(oldest, out _))
+                if (((ICollection<KeyValuePair<SchemaResolutionKey, TValue>>)_cache).Remove(oldest))
                 {
                     removed = true;
                     break;

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryRuleIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryRuleIntegrationTests.cs
@@ -20,6 +20,58 @@ namespace Dekaf.Tests.Integration;
 public sealed class SchemaRegistryRuleIntegrationTests(KafkaWithSchemaRegistryContainer testInfra)
 {
     [Test]
+    public async Task RegisteredMigrationRules_UseLatestVersion_ExecutesUpgradePath()
+    {
+        var topic = await testInfra.CreateTestTopicAsync();
+        var subject = $"{topic}-value";
+        using var registryClient = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = testInfra.RegistryUrl
+        });
+        var v1 = new Schema
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = """{ "type": "string", "title": "MigrationV1" }"""
+        };
+        var v2 = new Schema
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = """{ "type": "string", "title": "MigrationV2" }""",
+            RuleSet = new SchemaRuleSet
+            {
+                MigrationRules =
+                [
+                    new SchemaRule
+                    {
+                        Name = "append-version",
+                        Kind = SchemaRuleKind.Transform,
+                        Mode = SchemaRuleMode.Upgrade,
+                        Type = AppendMigrationRuleHandler.RuleType
+                    }
+                ]
+            }
+        };
+        var writerId = await registryClient.RegisterSchemaAsync(subject, v1);
+        await registryClient.RegisterSchemaAsync(subject, v2);
+        var calls = new ConcurrentQueue<string>();
+        var executor = new SchemaRegistryRuleExecutor([new AppendMigrationRuleHandler(calls)]);
+        await using var deserializer = SchemaRegistryDeserializer.Create(
+            registryClient,
+            static (ReadOnlyMemory<byte> payload, Schema _) => Encoding.UTF8.GetString(payload.Span),
+            new SchemaRegistryDeserializerConfig { UseLatestVersion = true },
+            ruleExecutor: executor);
+        var payload = "payload"u8;
+        var wire = new byte[5 + payload.Length];
+        System.Buffers.Binary.BinaryPrimitives.WriteInt32BigEndian(wire.AsSpan(1, 4), writerId);
+        payload.CopyTo(wire.AsSpan(5));
+
+        var result = deserializer.Deserialize(wire, CreateContext(topic));
+
+        await Assert.That(result).IsEqualTo("payload|v2");
+        await Assert.That(calls).IsEquivalentTo(["Upgrade:MigrationV1->MigrationV2"]);
+    }
+
+    [Test]
     public async Task RegisteredDomainRules_ProduceAndConsume_RoundTrip()
     {
         var topic = await testInfra.CreateTestTopicAsync();
@@ -265,6 +317,41 @@ public sealed class SchemaRegistryRuleIntegrationTests(KafkaWithSchemaRegistryCo
                 result[i] ^= mask;
 
             return result;
+        }
+    }
+
+    private sealed class AppendMigrationRuleHandler(ConcurrentQueue<string> calls)
+        : ISchemaRegistryRuleHandler
+    {
+        internal const string RuleType = "APPEND-MIGRATION";
+
+        public string Type => RuleType;
+
+        public ReadOnlyMemory<byte> TransformSerializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context) => Transform(payload, context);
+
+        public ReadOnlyMemory<byte> TransformDeserializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context) => Transform(payload, context);
+
+        private ReadOnlyMemory<byte> Transform(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context)
+        {
+            calls.Enqueue(
+                $"{context.PayloadContext.RuleMode}:{GetTitle(context.PayloadContext.SourceSchema!)}->{GetTitle(context.PayloadContext.TargetSchema!)}");
+            var suffix = "|v2"u8;
+            var result = new byte[payload.Length + suffix.Length];
+            payload.Span.CopyTo(result);
+            suffix.CopyTo(result.AsSpan(payload.Length));
+            return result;
+        }
+
+        private static string GetTitle(Schema schema)
+        {
+            using var document = System.Text.Json.JsonDocument.Parse(schema.SchemaString);
+            return document.RootElement.GetProperty("title").GetString()!;
         }
     }
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -120,6 +120,30 @@ public sealed class AvroSerializerTests
         }
         """;
 
+    internal const string SpecificMigrationRecordSchema = """
+        {
+            "type": "record",
+            "name": "SpecificMigrationRecord",
+            "namespace": "Dekaf.Tests.Unit.SchemaRegistry",
+            "fields": [
+                { "name": "name", "type": "string" },
+                { "name": "age", "type": "int" }
+            ]
+        }
+        """;
+
+    private const string SpecificMigrationReorderedSchema = """
+        {
+            "type": "record",
+            "name": "SpecificMigrationRecord",
+            "namespace": "Dekaf.Tests.Unit.SchemaRegistry",
+            "fields": [
+                { "name": "age", "type": "int" },
+                { "name": "name", "type": "string" }
+            ]
+        }
+        """;
+
     private const string AllFieldTypesSchema = """
         {
             "type": "record",
@@ -1846,6 +1870,28 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Deserializer_UseLatestVersion_SpecificRecordUsesGeneratedFieldIndexes()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        var writerId = await schemaRegistry.RegisterSchemaAsync(
+            "test-topic-value",
+            new RegistrySchema { SchemaType = SchemaType.Avro, SchemaString = SpecificMigrationRecordSchema });
+        await schemaRegistry.RegisterSchemaAsync(
+            "test-topic-value",
+            new RegistrySchema { SchemaType = SchemaType.Avro, SchemaString = SpecificMigrationReorderedSchema });
+        var record = new SpecificMigrationRecord { Name = "Ada", Age = 36 };
+        var wire = CreateWireFormat(writerId, SerializeSpecificAvroRecord(record));
+        await using var deserializer = new AvroSchemaRegistryDeserializer<SpecificMigrationRecord>(
+            schemaRegistry,
+            new AvroDeserializerConfig { UseLatestVersion = true });
+
+        var result = deserializer.Deserialize(wire, CreateContext());
+
+        await Assert.That(result.Name).IsEqualTo("Ada");
+        await Assert.That(result.Age).IsEqualTo(36);
+    }
+
+    [Test]
     public async Task Serializer_WarmupAsync_RetriesAfterTransientSchemaIdFailure()
     {
         using var schemaRegistry = new MockSchemaRegistryClient
@@ -2382,5 +2428,36 @@ public sealed class AvroSerializerTests
             ? Name
             : throw new ArgumentOutOfRangeException(nameof(fieldPos));
         public void Put(int fieldPos, object fieldValue) => throw new NotSupportedException();
+    }
+}
+
+public sealed class SpecificMigrationRecord : ISpecificRecord
+{
+    public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(AvroSerializerTests.SpecificMigrationRecordSchema);
+
+    public string Name { get; set; } = string.Empty;
+    public int Age { get; set; }
+    public AvroSchema Schema => _SCHEMA;
+
+    public object Get(int fieldPos) => fieldPos switch
+    {
+        0 => Name,
+        1 => Age,
+        _ => throw new ArgumentOutOfRangeException(nameof(fieldPos))
+    };
+
+    public void Put(int fieldPos, object fieldValue)
+    {
+        switch (fieldPos)
+        {
+            case 0:
+                Name = (string)fieldValue;
+                break;
+            case 1:
+                Age = (int)fieldValue;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(fieldPos));
+        }
     }
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaPreparationTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaPreparationTests.cs
@@ -724,6 +724,33 @@ public sealed class SchemaPreparationTests
     }
 
     [Test]
+    public async Task ResolutionCache_ExactRemoval_AllowsReplacement()
+    {
+        var cache = new SchemaResolutionCache<int>();
+        var schema = new Schema { SchemaType = SchemaType.Json, SchemaString = "{}" };
+        var first = await cache.ResolveAsync(
+            "orders-value",
+            schema,
+            0,
+            static (_, _, _) => Task.FromResult(1),
+            CancellationToken.None);
+
+        var removed = cache.TryRemove("orders-value", schema, first);
+        var removedAgain = cache.TryRemove("orders-value", schema, first);
+        var replacement = await cache.ResolveAsync(
+            "orders-value",
+            schema,
+            0,
+            static (_, _, _) => Task.FromResult(2),
+            CancellationToken.None);
+
+        await Assert.That(removed).IsTrue();
+        await Assert.That(removedAgain).IsFalse();
+        await Assert.That(replacement).IsEqualTo(2);
+        await Assert.That(cache.CachedEntryCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ResolutionCache_CoalescesConcurrentMissWhenAtCapacity()
     {
         var cache = new SchemaResolutionCache<int>(maxCachedEntries: 1);

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryDataContractTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryDataContractTests.cs
@@ -113,6 +113,8 @@ public sealed class SchemaRegistryDataContractTests
             "2",
             ignoreDeletedSchemas: false);
 
+        await Assert.That(handler.LastRequestUri!.AbsolutePath)
+            .IsEqualTo("/subjects/orders-value/versions/2");
         await Assert.That(handler.LastRequestUri!.Query).IsEqualTo("?deleted=true");
     }
 

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryDataContractTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryDataContractTests.cs
@@ -92,6 +92,31 @@ public sealed class SchemaRegistryDataContractTests
     }
 
     [Test]
+    public async Task GetSchemaBySubjectAsync_IncludesDeletedVersionWhenRequested()
+    {
+        var handler = new CapturingSchemaRegistryHandler("""
+            {
+              "subject": "orders-value",
+              "version": 2,
+              "id": 42,
+              "schema": "{\"type\":\"object\"}",
+              "schemaType": "JSON"
+            }
+            """);
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://schema-registry.local"
+        }, handler);
+
+        await client.GetSchemaBySubjectAsync(
+            "orders-value",
+            "2",
+            ignoreDeletedSchemas: false);
+
+        await Assert.That(handler.LastRequestUri!.Query).IsEqualTo("?deleted=true");
+    }
+
+    [Test]
     public async Task LookupSchemaAsync_PostsExactSchemaAndReturnsRegisteredVersion()
     {
         var handler = new CapturingSchemaRegistryHandler("""

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryHttpPipelineTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryHttpPipelineTests.cs
@@ -130,6 +130,19 @@ public sealed class SchemaRegistryHttpPipelineTests
     }
 
     [Test]
+    public async Task Config_LatestCacheTtlBelowMinusOne_IsRejected()
+    {
+        var config = new SchemaRegistryConfig
+        {
+            Url = "http://schema-registry.local",
+            LatestCacheTtlSecs = -2
+        };
+
+        await Assert.That(() => new SchemaRegistryClient(config, new TrackingHandler()))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
     public async Task Config_ContentHeader_IsRejected()
     {
         var config = new SchemaRegistryConfig

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryMigrationTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryMigrationTests.cs
@@ -1,0 +1,497 @@
+using System.Buffers.Binary;
+using System.Text;
+using System.Text.Json;
+using Dekaf.SchemaRegistry;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public sealed class SchemaRegistryMigrationTests
+{
+    private static readonly SerializationContext SerializationContext = new()
+    {
+        Component = SerializationComponent.Value,
+        Topic = "orders"
+    };
+
+    [Test]
+    public async Task Transform_UpgradePath_UsesHigherSchemasAndForwardRuleOrder()
+    {
+        var registry = new MigrationRegistryClient();
+        var v1 = CreateSchema("v1");
+        var v2 = CreateSchema(
+            "v2",
+            CreateRule("v2-up", SchemaRuleMode.Upgrade),
+            CreateRule("v2-both", SchemaRuleMode.UpDown),
+            CreateRule("v2-disabled", SchemaRuleMode.Upgrade, disabled: true));
+        var v3 = CreateSchema("v3", CreateRule("v3-up", SchemaRuleMode.Upgrade));
+        var v1Id = registry.Register("orders-value", v1);
+        registry.Register("orders-value", v2);
+        var v3Id = registry.Register("orders-value", v3);
+        var calls = new List<string>();
+        var executor = new SchemaRegistryRuleExecutor([new CapturingMigrationHandler(calls)]);
+        var runner = new SchemaRegistryMigrationRunner(registry, executor, TimeSpan.FromSeconds(1));
+
+        var result = runner.Transform(
+            "payload"u8.ToArray(),
+            v1Id,
+            "orders-value",
+            v1,
+            SerializationContext,
+            SchemaRegistryPayloadFormat.Json);
+
+        await Assert.That(Encoding.UTF8.GetString(result.Payload.Span))
+            .IsEqualTo("payload|v2-up|v2-both|v3-up");
+        await Assert.That(result.ReaderSchema.Id).IsEqualTo(v3Id);
+        await Assert.That(string.Join('|', calls)).IsEqualTo(
+            "v2-up:Upgrade:Write:v1->v2|v2-both:Upgrade:Write:v1->v2|v3-up:Upgrade:Write:v2->v3");
+    }
+
+    [Test]
+    public async Task Transform_DowngradePath_ReversesVersionsAndRulesAndSelectsSecondAction()
+    {
+        var registry = new MigrationRegistryClient { LatestVersion = 1 };
+        var v1 = CreateSchema("v1");
+        var v2 = CreateSchema("v2", CreateRule("v2-down", SchemaRuleMode.Downgrade));
+        var v3 = CreateSchema(
+            "v3",
+            CreateRule("v3-down", SchemaRuleMode.Downgrade),
+            CreateRule("v3-both", SchemaRuleMode.UpDown, onSuccess: "NONE,CAPTURE"));
+        var v1Id = registry.Register("orders-value", v1);
+        registry.Register("orders-value", v2);
+        var v3Id = registry.Register("orders-value", v3);
+        var calls = new List<string>();
+        var executor = new SchemaRegistryRuleExecutor(
+            [new CapturingMigrationHandler(calls)],
+            [new CapturingAction(calls)]);
+        var runner = new SchemaRegistryMigrationRunner(registry, executor, TimeSpan.FromSeconds(1));
+
+        var result = runner.Transform(
+            "payload"u8.ToArray(),
+            v3Id,
+            "orders-value",
+            v3,
+            SerializationContext,
+            SchemaRegistryPayloadFormat.Json);
+
+        await Assert.That(Encoding.UTF8.GetString(result.Payload.Span))
+            .IsEqualTo("payload|v3-both|v3-down|v2-down");
+        await Assert.That(result.ReaderSchema.Id).IsEqualTo(v1Id);
+        await Assert.That(string.Join('|', calls)).IsEqualTo(
+            "v3-both:Downgrade:Read:v3->v2|action:v3-both:Downgrade|" +
+            "v3-down:Downgrade:Read:v3->v2|v2-down:Downgrade:Read:v2->v1");
+    }
+
+    [Test]
+    public async Task Transform_MissingIntermediateVersion_ThrowsAndDoesNotCacheFailure()
+    {
+        var registry = new MigrationRegistryClient();
+        var v1 = CreateSchema("v1");
+        var v2 = CreateSchema("v2", CreateRule("v2-up", SchemaRuleMode.Upgrade));
+        var v3 = CreateSchema("v3", CreateRule("v3-up", SchemaRuleMode.Upgrade));
+        var v1Id = registry.Register("orders-value", v1);
+        registry.Register("orders-value", v2);
+        registry.Register("orders-value", v3);
+        registry.RemoveVersion(2);
+        var runner = new SchemaRegistryMigrationRunner(
+            registry,
+            new SchemaRegistryRuleExecutor([new CapturingMigrationHandler([])]),
+            TimeSpan.FromSeconds(1));
+
+        await Assert.That(() => runner.Transform(
+                "payload"u8.ToArray(),
+                v1Id,
+                "orders-value",
+                v1,
+                SerializationContext,
+                SchemaRegistryPayloadFormat.Json))
+            .Throws<SchemaRegistryException>();
+
+        await Assert.That(() => runner.Transform(
+                "payload"u8.ToArray(),
+                v1Id,
+                "orders-value",
+                v1,
+                SerializationContext,
+                SchemaRegistryPayloadFormat.Json))
+            .Throws<SchemaRegistryException>();
+        await Assert.That(registry.LookupCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Transform_NoMigration_CachesNeutralPlanAndReturnsOriginalPayload()
+    {
+        var registry = new MigrationRegistryClient();
+        var schema = CreateSchema("v1");
+        var schemaId = registry.Register("orders-value", schema);
+        var calls = new List<string>();
+        var runner = new SchemaRegistryMigrationRunner(
+            registry,
+            new SchemaRegistryRuleExecutor([new CapturingMigrationHandler(calls)]),
+            TimeSpan.FromSeconds(1));
+        var payload = "payload"u8.ToArray();
+
+        var first = runner.Transform(
+            payload,
+            schemaId,
+            "orders-value",
+            schema,
+            SerializationContext,
+            SchemaRegistryPayloadFormat.Json);
+        var second = runner.Transform(
+            payload,
+            schemaId,
+            "orders-value",
+            schema,
+            SerializationContext,
+            SchemaRegistryPayloadFormat.Json);
+
+        await Assert.That(first.Payload.ToArray()).IsEquivalentTo(payload);
+        await Assert.That(second.Payload.ToArray()).IsEquivalentTo(payload);
+        await Assert.That(calls).IsEmpty();
+        await Assert.That(registry.LookupCount).IsEqualTo(1);
+        await Assert.That(registry.LatestCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task JsonDeserializer_UseLatestVersion_ExecutesEncodingMigrationDomainThenReadsTarget()
+    {
+        var registry = new MigrationRegistryClient();
+        var v1 = new Schema
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = "v1",
+            RuleSet = new SchemaRuleSet
+            {
+                EncodingRules = [CreateRule("decode", SchemaRuleMode.Read, ReplacingRuleHandler.RuleType)]
+            }
+        };
+        var v2 = new Schema
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = "v2",
+            RuleSet = new SchemaRuleSet
+            {
+                MigrationRules = [CreateRule("migrate", SchemaRuleMode.Upgrade, ReplacingRuleHandler.RuleType)],
+                DomainRules = [CreateRule("domain", SchemaRuleMode.Read, ReplacingRuleHandler.RuleType)]
+            }
+        };
+        var writerId = registry.Register("orders-value", v1);
+        registry.Register("orders-value", v2);
+        var calls = new List<string>();
+        var executor = new SchemaRegistryRuleExecutor([new ReplacingRuleHandler(calls)]);
+        await using var deserializer = new JsonSchemaRegistryDeserializer<MigrationPayload>(
+            registry,
+            jsonOptions: null,
+            new SchemaRegistryDeserializerConfig { UseLatestVersion = true },
+            ruleExecutor: executor);
+        var json = "{\"name\":\"encoded\"}"u8;
+        var wire = new byte[5 + json.Length];
+        BinaryPrimitives.WriteInt32BigEndian(wire.AsSpan(1, 4), writerId);
+        json.CopyTo(wire.AsSpan(5));
+
+        var result = deserializer.Deserialize(wire, SerializationContext);
+
+        await Assert.That(result.Name).IsEqualTo("final");
+        await Assert.That(string.Join('|', calls)).IsEqualTo(
+            "decode:Read:null|migrate:Write:Upgrade|domain:Read:null");
+    }
+
+    [Test]
+    public async Task GenericDeserializer_UseLatestWithoutRules_SelectsReaderSchemaWithoutExecutor()
+    {
+        var registry = new MigrationRegistryClient();
+        var v1 = CreateSchema("v1");
+        var v2 = CreateSchema("v2");
+        var writerId = registry.Register("orders-value", v1);
+        registry.Register("orders-value", v2);
+        Schema? observedSchema = null;
+        await using var deserializer = SchemaRegistryDeserializer.Create(
+            registry,
+            (ReadOnlyMemory<byte> payload, Schema schema) =>
+            {
+                observedSchema = schema;
+                return Encoding.UTF8.GetString(payload.Span);
+            },
+            new SchemaRegistryDeserializerConfig { UseLatestVersion = true });
+        var payload = "payload"u8;
+        var wire = new byte[5 + payload.Length];
+        BinaryPrimitives.WriteInt32BigEndian(wire.AsSpan(1, 4), writerId);
+        payload.CopyTo(wire.AsSpan(5));
+
+        var result = deserializer.Deserialize(wire, SerializationContext);
+
+        await Assert.That(result).IsEqualTo("payload");
+        await Assert.That(observedSchema).IsSameReferenceAs(v2);
+    }
+
+    [Test]
+    public async Task GenericDeserializer_ActiveMigrationWithoutBuiltInExecutor_FailsClosed()
+    {
+        var registry = new MigrationRegistryClient();
+        var v1 = CreateSchema("v1");
+        var v2 = CreateSchema("v2", CreateRule("upgrade", SchemaRuleMode.Upgrade));
+        var writerId = registry.Register("orders-value", v1);
+        registry.Register("orders-value", v2);
+        await using var deserializer = SchemaRegistryDeserializer.Create(
+            registry,
+            static (ReadOnlyMemory<byte> payload, Schema _) => payload,
+            new SchemaRegistryDeserializerConfig { UseLatestVersion = true });
+        var wire = new byte[6];
+        BinaryPrimitives.WriteInt32BigEndian(wire.AsSpan(1, 4), writerId);
+
+        await Assert.That(() => deserializer.Deserialize(wire, SerializationContext))
+            .Throws<SchemaRegistryRuleException>()
+            .WithMessageContaining(nameof(SchemaRegistryRuleExecutor));
+    }
+
+    [Test]
+    public async Task GenericDeserializer_ServerMigrationWithoutExecutor_SelectsLatest()
+    {
+        var registry = new MigrationRegistryClient();
+        var v1 = CreateSchema("v1");
+        var v2 = new Schema
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = "v2",
+            RuleSet = new SchemaRuleSet
+            {
+                EnableAt = "SERVER",
+                MigrationRules = [CreateRule("upgrade", SchemaRuleMode.Upgrade)]
+            }
+        };
+        var writerId = registry.Register("orders-value", v1);
+        registry.Register("orders-value", v2);
+        Schema? observedSchema = null;
+        await using var deserializer = SchemaRegistryDeserializer.Create(
+            registry,
+            (ReadOnlyMemory<byte> payload, Schema schema) =>
+            {
+                observedSchema = schema;
+                return payload;
+            },
+            new SchemaRegistryDeserializerConfig { UseLatestVersion = true });
+        var wire = new byte[6];
+        BinaryPrimitives.WriteInt32BigEndian(wire.AsSpan(1, 4), writerId);
+
+        _ = deserializer.Deserialize(wire, SerializationContext);
+
+        await Assert.That(observedSchema).IsSameReferenceAs(v2);
+    }
+
+    private static Schema CreateSchema(string name, params SchemaRule[] migrationRules) =>
+        new()
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = name,
+            RuleSet = new SchemaRuleSet { MigrationRules = migrationRules }
+        };
+
+    private static SchemaRule CreateRule(
+        string name,
+        SchemaRuleMode mode,
+        bool disabled = false,
+        string? onSuccess = null) =>
+        CreateRule(name, mode, CapturingMigrationHandler.RuleType, disabled, onSuccess);
+
+    private static SchemaRule CreateRule(
+        string name,
+        SchemaRuleMode mode,
+        string type,
+        bool disabled = false,
+        string? onSuccess = null) =>
+        new()
+        {
+            Name = name,
+            Kind = SchemaRuleKind.Transform,
+            Mode = mode,
+            Type = type,
+            Disabled = disabled,
+            OnSuccess = onSuccess
+        };
+
+    private sealed class CapturingMigrationHandler(List<string> calls) : ISchemaRegistryRuleHandler
+    {
+        internal const string RuleType = "MIGRATE";
+
+        public string Type => RuleType;
+
+        public ReadOnlyMemory<byte> TransformSerializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context) => Transform(payload, context);
+
+        public ReadOnlyMemory<byte> TransformDeserializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context) => Transform(payload, context);
+
+        private ReadOnlyMemory<byte> Transform(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context)
+        {
+            var migration = context.PayloadContext;
+            calls.Add(
+                $"{context.Rule.Name}:{migration.RuleMode}:{context.Direction}:{migration.SourceSchema!.SchemaString}->{migration.TargetSchema!.SchemaString}");
+            var suffix = Encoding.UTF8.GetBytes($"|{context.Rule.Name}");
+            var result = new byte[payload.Length + suffix.Length];
+            payload.Span.CopyTo(result);
+            suffix.CopyTo(result.AsSpan(payload.Length));
+            return result;
+        }
+    }
+
+    private sealed class CapturingAction(List<string> calls) : ISchemaRegistryRuleAction
+    {
+        public string Type => "CAPTURE";
+
+        public void Run(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context,
+            SchemaRegistryRuleException? exception) =>
+            calls.Add($"action:{context.Rule.Name}:{context.PayloadContext.RuleMode}");
+    }
+
+    private sealed class ReplacingRuleHandler(List<string> calls) : ISchemaRegistryRuleHandler
+    {
+        internal const string RuleType = "REPLACE";
+
+        public string Type => RuleType;
+
+        public ReadOnlyMemory<byte> TransformSerializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context) => Transform(payload, context);
+
+        public ReadOnlyMemory<byte> TransformDeserializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context) => Transform(payload, context);
+
+        private ReadOnlyMemory<byte> Transform(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context)
+        {
+            calls.Add($"{context.Rule.Name}:{context.Direction}:{context.PayloadContext.RuleMode?.ToString() ?? "null"}");
+            var json = Encoding.UTF8.GetString(payload.Span);
+            var transformed = context.Rule.Name switch
+            {
+                "decode" => json.Replace("encoded", "writer", StringComparison.Ordinal),
+                "migrate" => json.Replace("writer", "migrated", StringComparison.Ordinal),
+                "domain" => json.Replace("migrated", "final", StringComparison.Ordinal),
+                _ => json
+            };
+            return Encoding.UTF8.GetBytes(transformed);
+        }
+    }
+
+    private sealed class MigrationPayload
+    {
+        public string Name { get; init; } = "";
+    }
+
+    private sealed class MigrationRegistryClient : ISchemaRegistryClient
+    {
+        private readonly Dictionary<int, RegisteredSchema> _byId = [];
+        private readonly Dictionary<int, RegisteredSchema> _byVersion = [];
+        private int _nextId = 1;
+
+        internal int LatestVersion { get; init; }
+        internal int LookupCount { get; private set; }
+        internal int LatestCount { get; private set; }
+
+        internal int Register(string subject, Schema schema)
+        {
+            var id = _nextId++;
+            var registered = new RegisteredSchema
+            {
+                Id = id,
+                Subject = subject,
+                Version = id,
+                Schema = schema
+            };
+            _byId.Add(id, registered);
+            _byVersion.Add(id, registered);
+            return id;
+        }
+
+        internal void RemoveVersion(int version) => _byVersion.Remove(version);
+
+        public Task<Schema> GetSchemaAsync(int id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_byId[id].Schema);
+
+        public Task<Schema> GetSchemaAsync(
+            int id,
+            string subject,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(_byId[id].Schema);
+
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(
+            string subject,
+            string version = "latest",
+            CancellationToken cancellationToken = default)
+        {
+            if (version == "latest")
+                LatestCount++;
+
+            var requestedVersion = version == "latest"
+                ? LatestVersion == 0 ? _byVersion.Keys.Max() : LatestVersion
+                : int.Parse(version, System.Globalization.CultureInfo.InvariantCulture);
+            if (!_byVersion.TryGetValue(requestedVersion, out var schema))
+                throw new SchemaRegistryException(40402, $"Version {requestedVersion} not found.");
+
+            return Task.FromResult(schema);
+        }
+
+        public Task<RegisteredSchema> LookupSchemaAsync(
+            string subject,
+            Schema schema,
+            bool ignoreDeletedSchemas = true,
+            bool normalize = false,
+            CancellationToken cancellationToken = default)
+        {
+            LookupCount++;
+            foreach (var registered in _byId.Values)
+            {
+                if (ReferenceEquals(registered.Schema, schema))
+                    return Task.FromResult(registered);
+            }
+
+            throw new SchemaRegistryException(40403, "Schema not found.");
+        }
+
+        public Task<int> RegisterSchemaAsync(
+            string subject,
+            Schema schema,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<int> GetOrRegisterSchemaAsync(
+            string subject,
+            Schema schema,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<string>> GetAllSubjectsAsync(
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> GetVersionsAsync(
+            string subject,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<bool> IsCompatibleAsync(
+            string subject,
+            Schema schema,
+            string version = "latest",
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> DeleteSubjectAsync(
+            string subject,
+            bool permanent = false,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryMigrationTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryMigrationTests.cs
@@ -154,6 +154,53 @@ public sealed class SchemaRegistryMigrationTests
     }
 
     [Test]
+    public async Task Transform_ExpiredLatestPlan_RefreshesReaderSchema()
+    {
+        var registry = new MigrationRegistryClient { LatestCacheTtlSecs = 0 };
+        var v1 = CreateSchema("v1");
+        var v2 = CreateSchema("v2");
+        var v1Id = registry.Register("orders-value", v1);
+        var v2Id = registry.Register("orders-value", v2);
+        var runner = new SchemaRegistryMigrationRunner(registry, ruleExecutor: null, TimeSpan.FromSeconds(1));
+
+        var first = runner.Transform(
+            "payload"u8.ToArray(),
+            v1Id,
+            "orders-value",
+            v1,
+            SerializationContext,
+            SchemaRegistryPayloadFormat.Json);
+        var v3 = CreateSchema("v3");
+        var v3Id = registry.Register("orders-value", v3);
+        var second = runner.Transform(
+            "payload"u8.ToArray(),
+            v1Id,
+            "orders-value",
+            v1,
+            SerializationContext,
+            SchemaRegistryPayloadFormat.Json);
+
+        await Assert.That(first.ReaderSchema.Id).IsEqualTo(v2Id);
+        await Assert.That(second.ReaderSchema.Id).IsEqualTo(v3Id);
+        await Assert.That(registry.LatestCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task DeletedVersionLookup_DefaultImplementation_FailsClosed()
+    {
+        ISchemaRegistryClient registry = new MockSchemaRegistryClient();
+        async Task LookupDeletedVersionAsync() =>
+            _ = await registry.GetSchemaBySubjectAsync(
+                "orders-value",
+                "2",
+                ignoreDeletedSchemas: false);
+
+        await Assert.That(LookupDeletedVersionAsync)
+            .Throws<NotSupportedException>()
+            .WithMessageContaining("deleted schema versions");
+    }
+
+    [Test]
     public async Task JsonDeserializer_UseLatestVersion_ExecutesEncodingMigrationDomainThenReadsTarget()
     {
         var registry = new MigrationRegistryClient();
@@ -392,6 +439,7 @@ public sealed class SchemaRegistryMigrationTests
         private readonly Dictionary<int, RegisteredSchema> _byVersion = [];
         private int _nextId = 1;
 
+        public int LatestCacheTtlSecs { get; init; } = -1;
         internal int LatestVersion { get; init; }
         internal int LookupCount { get; private set; }
         internal int LatestCount { get; private set; }
@@ -439,6 +487,13 @@ public sealed class SchemaRegistryMigrationTests
             return Task.FromResult(schema);
         }
 
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(
+            string subject,
+            string version,
+            bool ignoreDeletedSchemas,
+            CancellationToken cancellationToken = default) =>
+            GetSchemaBySubjectAsync(subject, version, cancellationToken);
+
         public Task<RegisteredSchema> LookupSchemaAsync(
             string subject,
             Schema schema,
@@ -447,13 +502,9 @@ public sealed class SchemaRegistryMigrationTests
             CancellationToken cancellationToken = default)
         {
             LookupCount++;
-            foreach (var registered in _byId.Values)
-            {
-                if (ReferenceEquals(registered.Schema, schema))
-                    return Task.FromResult(registered);
-            }
-
-            throw new SchemaRegistryException(40403, "Schema not found.");
+            var registered = _byId.Values.SingleOrDefault(candidate => ReferenceEquals(candidate.Schema, schema))
+                ?? throw new SchemaRegistryException(40403, "Schema not found.");
+            return Task.FromResult(registered);
         }
 
         public Task<int> RegisterSchemaAsync(

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryRuleExecutorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryRuleExecutorTests.cs
@@ -27,8 +27,20 @@ public sealed class SchemaRegistryRuleExecutorTests
 
         overflow.Return();
         primary.Return();
-        var primaryReferencesCleared = primary.Topic is null && primary.Subject is null && primary.Schema is null;
-        var overflowReferencesCleared = overflow.Topic is null && overflow.Subject is null && overflow.Schema is null;
+        var primaryReferencesCleared =
+            primary.Topic is null &&
+            primary.Subject is null &&
+            primary.Schema is null &&
+            primary.SourceSchema is null &&
+            primary.TargetSchema is null &&
+            primary.RuleMode is null;
+        var overflowReferencesCleared =
+            overflow.Topic is null &&
+            overflow.Subject is null &&
+            overflow.Schema is null &&
+            overflow.SourceSchema is null &&
+            overflow.TargetSchema is null &&
+            overflow.RuleMode is null;
 
         var reused = SchemaRegistryRuleContext.Rent(
             "reused",

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistryMigrationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistryMigrationBenchmarks.cs
@@ -1,0 +1,216 @@
+using System.Buffers.Binary;
+using Avro.IO;
+using Avro.Specific;
+using BenchmarkDotNet.Attributes;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Avro;
+using Dekaf.Serialization;
+using AvroSchema = Avro.Schema;
+using RegistrySchema = Dekaf.SchemaRegistry.Schema;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Guards specific-record schema migration field mapping and allocation overhead.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(launchCount: 1, warmupCount: 3, iterationCount: 10)]
+public class AvroSchemaRegistryMigrationBenchmarks
+{
+    internal const string GeneratedSchema = """
+        {
+          "type": "record",
+          "name": "MigrationSpecificBenchmarkRecord",
+          "namespace": "Dekaf.Benchmarks.Benchmarks.Unit",
+          "fields": [
+            { "name": "name", "type": "string" },
+            { "name": "age", "type": "int" }
+          ]
+        }
+        """;
+
+    private const string ReorderedLatestSchema = """
+        {
+          "type": "record",
+          "name": "MigrationSpecificBenchmarkRecord",
+          "namespace": "Dekaf.Benchmarks.Benchmarks.Unit",
+          "fields": [
+            { "name": "age", "type": "int" },
+            { "name": "name", "type": "string" }
+          ]
+        }
+        """;
+
+    private static readonly SerializationContext Context = new()
+    {
+        Topic = "benchmark-topic",
+        Component = SerializationComponent.Value
+    };
+
+    private AvroSchemaRegistryDeserializer<MigrationSpecificBenchmarkRecord> _baseline = null!;
+    private AvroSchemaRegistryDeserializer<MigrationSpecificBenchmarkRecord> _latest = null!;
+    private byte[] _wire = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var registry = new MigrationBenchmarkRegistryClient();
+        _baseline = new AvroSchemaRegistryDeserializer<MigrationSpecificBenchmarkRecord>(registry);
+        _latest = new AvroSchemaRegistryDeserializer<MigrationSpecificBenchmarkRecord>(
+            registry,
+            new AvroDeserializerConfig { UseLatestVersion = true });
+        _wire = CreateWirePayload();
+
+        _ = Baseline();
+        _ = UseLatestVersion();
+    }
+
+    [Benchmark(Baseline = true)]
+    public MigrationSpecificBenchmarkRecord Baseline() => _baseline.Deserialize(_wire, Context);
+
+    [Benchmark]
+    public MigrationSpecificBenchmarkRecord UseLatestVersion() => _latest.Deserialize(_wire, Context);
+
+    private static byte[] CreateWirePayload()
+    {
+        using var stream = new MemoryStream();
+        var record = new MigrationSpecificBenchmarkRecord { Name = "Ada", Age = 36 };
+        var writer = new SpecificDefaultWriter(record.Schema);
+        writer.Write(record.Schema, record, new BinaryEncoder(stream));
+        var payload = stream.ToArray();
+        var wire = new byte[payload.Length + 5];
+        BinaryPrimitives.WriteInt32BigEndian(wire.AsSpan(1, 4), 1);
+        payload.CopyTo(wire.AsSpan(5));
+        return wire;
+    }
+
+    private sealed class MigrationBenchmarkRegistryClient : ISchemaRegistryClient, ISchemaRegistryCache
+    {
+        private static readonly RegistrySchema WriterSchema = new()
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = GeneratedSchema
+        };
+        private static readonly RegistrySchema ReaderSchema = new()
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = ReorderedLatestSchema
+        };
+        private static readonly RegisteredSchema Writer = new()
+        {
+            Id = 1,
+            Subject = "benchmark-topic-value",
+            Version = 1,
+            Schema = WriterSchema
+        };
+        private static readonly RegisteredSchema Reader = new()
+        {
+            Id = 2,
+            Subject = "benchmark-topic-value",
+            Version = 2,
+            Schema = ReaderSchema
+        };
+
+        public Task<RegistrySchema> GetSchemaAsync(
+            int id,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(id == 1 ? WriterSchema : ReaderSchema);
+
+        public Task<RegistrySchema> GetSchemaAsync(
+            int id,
+            string subject,
+            CancellationToken cancellationToken = default) =>
+            GetSchemaAsync(id, cancellationToken);
+
+        public bool TryGetCachedSchema(int id, out RegistrySchema schema)
+        {
+            schema = id == 1 ? WriterSchema : ReaderSchema;
+            return true;
+        }
+
+        public bool TryGetCachedSchema(int id, string subject, out RegistrySchema schema) =>
+            TryGetCachedSchema(id, out schema);
+
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(
+            string subject,
+            string version = "latest",
+            CancellationToken cancellationToken = default) => Task.FromResult(Reader);
+
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(
+            string subject,
+            string version,
+            bool ignoreDeletedSchemas,
+            CancellationToken cancellationToken = default) => Task.FromResult(Reader);
+
+        public Task<RegisteredSchema> LookupSchemaAsync(
+            string subject,
+            RegistrySchema schema,
+            bool ignoreDeletedSchemas = true,
+            bool normalize = false,
+            CancellationToken cancellationToken = default) => Task.FromResult(Writer);
+
+        public Task<int> RegisterSchemaAsync(
+            string subject,
+            RegistrySchema schema,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<int> GetOrRegisterSchemaAsync(
+            string subject,
+            RegistrySchema schema,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<string>> GetAllSubjectsAsync(
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> GetVersionsAsync(
+            string subject,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<bool> IsCompatibleAsync(
+            string subject,
+            RegistrySchema schema,
+            string version = "latest",
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> DeleteSubjectAsync(
+            string subject,
+            bool permanent = false,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public void Dispose()
+        {
+        }
+    }
+}
+
+public sealed class MigrationSpecificBenchmarkRecord : ISpecificRecord
+{
+    public static readonly AvroSchema _SCHEMA =
+        AvroSchema.Parse(AvroSchemaRegistryMigrationBenchmarks.GeneratedSchema);
+
+    public string Name { get; set; } = string.Empty;
+    public int Age { get; set; }
+    public AvroSchema Schema => _SCHEMA;
+
+    public object Get(int fieldPos) => fieldPos switch
+    {
+        0 => Name,
+        1 => Age,
+        _ => throw new ArgumentOutOfRangeException(nameof(fieldPos))
+    };
+
+    public void Put(int fieldPos, object fieldValue)
+    {
+        switch (fieldPos)
+        {
+            case 0:
+                Name = (string)fieldValue;
+                break;
+            case 1:
+                Age = (int)fieldValue;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(fieldPos));
+        }
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistryRuleExecutorBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistryRuleExecutorBenchmarks.cs
@@ -447,3 +447,185 @@ public class SchemaRegistryRuleContextBenchmarks
         }
     }
 }
+
+/// <summary>
+/// Guards cached migration planning and disabled/active migration execution allocations.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(launchCount: 1, warmupCount: 3, iterationCount: 10)]
+public class SchemaRegistryMigrationBenchmarks
+{
+    private static readonly byte[] Payload = "benchmark-payload"u8.ToArray();
+    private static readonly SerializationContext Context = new()
+    {
+        Topic = "benchmark-topic",
+        Component = SerializationComponent.Value
+    };
+
+    private SchemaRegistryMigrationRunner _noMigration = null!;
+    private SchemaRegistryMigrationRunner _disabledMigration = null!;
+    private SchemaRegistryMigrationRunner _activeMigration = null!;
+    private Schema _noMigrationWriter = null!;
+    private Schema _disabledWriter = null!;
+    private Schema _activeWriter = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var executor = new SchemaRegistryRuleExecutor([PassThroughMigrationHandler.Instance]);
+        (_noMigration, _noMigrationWriter) = CreateRunner(executor, targetRule: null, sameVersion: true);
+        (_disabledMigration, _disabledWriter) = CreateRunner(
+            executor,
+            CreateMigrationRule(disabled: true),
+            sameVersion: false);
+        (_activeMigration, _activeWriter) = CreateRunner(
+            executor,
+            CreateMigrationRule(disabled: false),
+            sameVersion: false);
+
+        _ = NoMigration();
+        _ = DisabledMigration();
+        _ = ActiveMigration();
+    }
+
+    [Benchmark(Baseline = true)]
+    public ReadOnlyMemory<byte> NoMigration() =>
+        _noMigration.Transform(
+            Payload,
+            1,
+            "benchmark-topic-value",
+            _noMigrationWriter,
+            Context,
+            SchemaRegistryPayloadFormat.Json).Payload;
+
+    [Benchmark]
+    public ReadOnlyMemory<byte> DisabledMigration() =>
+        _disabledMigration.Transform(
+            Payload,
+            1,
+            "benchmark-topic-value",
+            _disabledWriter,
+            Context,
+            SchemaRegistryPayloadFormat.Json).Payload;
+
+    [Benchmark]
+    public ReadOnlyMemory<byte> ActiveMigration() =>
+        _activeMigration.Transform(
+            Payload,
+            1,
+            "benchmark-topic-value",
+            _activeWriter,
+            Context,
+            SchemaRegistryPayloadFormat.Json).Payload;
+
+    private static (SchemaRegistryMigrationRunner Runner, Schema Writer) CreateRunner(
+        SchemaRegistryRuleExecutor executor,
+        SchemaRule? targetRule,
+        bool sameVersion)
+    {
+        var writer = new Schema { SchemaType = SchemaType.Json, SchemaString = "writer" };
+        var reader = sameVersion
+            ? writer
+            : new Schema
+            {
+                SchemaType = SchemaType.Json,
+                SchemaString = "reader",
+                RuleSet = new SchemaRuleSet { MigrationRules = targetRule is null ? [] : [targetRule] }
+            };
+        var client = new MigrationBenchmarkRegistryClient(writer, reader);
+        return (new SchemaRegistryMigrationRunner(client, executor, TimeSpan.FromSeconds(1)), writer);
+    }
+
+    private static SchemaRule CreateMigrationRule(bool disabled) =>
+        new()
+        {
+            Name = "benchmark-migration",
+            Kind = SchemaRuleKind.Transform,
+            Mode = SchemaRuleMode.Upgrade,
+            Type = PassThroughMigrationHandler.RuleType,
+            Disabled = disabled
+        };
+
+    private sealed class PassThroughMigrationHandler : ISchemaRegistryRuleHandler
+    {
+        internal const string RuleType = "MIGRATION-BENCHMARK";
+        internal static PassThroughMigrationHandler Instance { get; } = new();
+
+        public string Type => RuleType;
+
+        public ReadOnlyMemory<byte> TransformSerializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context) => payload;
+
+        public ReadOnlyMemory<byte> TransformDeserializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context) => payload;
+    }
+
+    private sealed class MigrationBenchmarkRegistryClient(
+        Schema writer,
+        Schema reader) : ISchemaRegistryClient
+    {
+        private readonly RegisteredSchema _writer = new()
+        {
+            Id = 1,
+            Subject = "benchmark-topic-value",
+            Version = 1,
+            Schema = writer
+        };
+        private readonly RegisteredSchema _reader = new()
+        {
+            Id = ReferenceEquals(writer, reader) ? 1 : 2,
+            Subject = "benchmark-topic-value",
+            Version = ReferenceEquals(writer, reader) ? 1 : 2,
+            Schema = reader
+        };
+
+        public Task<Schema> GetSchemaAsync(int id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(id == 1 ? _writer.Schema : _reader.Schema);
+
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(
+            string subject,
+            string version = "latest",
+            CancellationToken cancellationToken = default) => Task.FromResult(_reader);
+
+        public Task<RegisteredSchema> LookupSchemaAsync(
+            string subject,
+            Schema schema,
+            bool ignoreDeletedSchemas = true,
+            bool normalize = false,
+            CancellationToken cancellationToken = default) => Task.FromResult(_writer);
+
+        public Task<int> RegisterSchemaAsync(
+            string subject,
+            Schema schema,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<int> GetOrRegisterSchemaAsync(
+            string subject,
+            Schema schema,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<string>> GetAllSubjectsAsync(
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> GetVersionsAsync(
+            string subject,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<bool> IsCompatibleAsync(
+            string subject,
+            Schema schema,
+            string version = "latest",
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> DeleteSubjectAsync(
+            string subject,
+            bool permanent = false,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistryRuleExecutorBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistryRuleExecutorBenchmarks.cs
@@ -465,9 +465,13 @@ public class SchemaRegistryMigrationBenchmarks
     private SchemaRegistryMigrationRunner _noMigration = null!;
     private SchemaRegistryMigrationRunner _disabledMigration = null!;
     private SchemaRegistryMigrationRunner _activeMigration = null!;
+    private SchemaRegistryMigrationRunner _alternatingMigration = null!;
     private Schema _noMigrationWriter = null!;
     private Schema _disabledWriter = null!;
     private Schema _activeWriter = null!;
+    private Schema _alternatingWriterOne = null!;
+    private Schema _alternatingWriterTwo = null!;
+    private int _alternatingSchemaId = 1;
 
     [GlobalSetup]
     public void Setup()
@@ -482,10 +486,14 @@ public class SchemaRegistryMigrationBenchmarks
             executor,
             CreateMigrationRule(disabled: false),
             sameVersion: false);
+        (_alternatingMigration, _alternatingWriterOne, _alternatingWriterTwo) =
+            CreateAlternatingRunner(executor);
 
         _ = NoMigration();
         _ = DisabledMigration();
         _ = ActiveMigration();
+        _ = AlternatingWriterSchemas();
+        _ = AlternatingWriterSchemas();
     }
 
     [Benchmark(Baseline = true)]
@@ -518,6 +526,21 @@ public class SchemaRegistryMigrationBenchmarks
             Context,
             SchemaRegistryPayloadFormat.Json).Payload;
 
+    [Benchmark]
+    public ReadOnlyMemory<byte> AlternatingWriterSchemas()
+    {
+        var schemaId = _alternatingSchemaId;
+        _alternatingSchemaId = schemaId == 1 ? 2 : 1;
+        var writer = schemaId == 1 ? _alternatingWriterOne : _alternatingWriterTwo;
+        return _alternatingMigration.Transform(
+            Payload,
+            schemaId,
+            "benchmark-topic-value",
+            writer,
+            Context,
+            SchemaRegistryPayloadFormat.Json).Payload;
+    }
+
     private static (SchemaRegistryMigrationRunner Runner, Schema Writer) CreateRunner(
         SchemaRegistryRuleExecutor executor,
         SchemaRule? targetRule,
@@ -534,6 +557,18 @@ public class SchemaRegistryMigrationBenchmarks
             };
         var client = new MigrationBenchmarkRegistryClient(writer, reader);
         return (new SchemaRegistryMigrationRunner(client, executor, TimeSpan.FromSeconds(1)), writer);
+    }
+
+    private static (SchemaRegistryMigrationRunner Runner, Schema WriterOne, Schema WriterTwo)
+        CreateAlternatingRunner(SchemaRegistryRuleExecutor executor)
+    {
+        var writerOne = new Schema { SchemaType = SchemaType.Json, SchemaString = "writer-one" };
+        var writerTwo = new Schema { SchemaType = SchemaType.Json, SchemaString = "writer-two" };
+        var client = new AlternatingMigrationBenchmarkRegistryClient(writerOne, writerTwo);
+        return (
+            new SchemaRegistryMigrationRunner(client, executor, TimeSpan.FromSeconds(1)),
+            writerOne,
+            writerTwo);
     }
 
     private static SchemaRule CreateMigrationRule(bool disabled) =>
@@ -589,12 +624,92 @@ public class SchemaRegistryMigrationBenchmarks
             string version = "latest",
             CancellationToken cancellationToken = default) => Task.FromResult(_reader);
 
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(
+            string subject,
+            string version,
+            bool ignoreDeletedSchemas,
+            CancellationToken cancellationToken = default) => Task.FromResult(_reader);
+
         public Task<RegisteredSchema> LookupSchemaAsync(
             string subject,
             Schema schema,
             bool ignoreDeletedSchemas = true,
             bool normalize = false,
             CancellationToken cancellationToken = default) => Task.FromResult(_writer);
+
+        public Task<int> RegisterSchemaAsync(
+            string subject,
+            Schema schema,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<int> GetOrRegisterSchemaAsync(
+            string subject,
+            Schema schema,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<string>> GetAllSubjectsAsync(
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> GetVersionsAsync(
+            string subject,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<bool> IsCompatibleAsync(
+            string subject,
+            Schema schema,
+            string version = "latest",
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> DeleteSubjectAsync(
+            string subject,
+            bool permanent = false,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class AlternatingMigrationBenchmarkRegistryClient(
+        Schema writerOne,
+        Schema writerTwo) : ISchemaRegistryClient
+    {
+        private readonly RegisteredSchema _writerOne = new()
+        {
+            Id = 1,
+            Subject = "benchmark-topic-value",
+            Version = 1,
+            Schema = writerOne
+        };
+        private readonly RegisteredSchema _writerTwo = new()
+        {
+            Id = 2,
+            Subject = "benchmark-topic-value",
+            Version = 2,
+            Schema = writerTwo
+        };
+
+        public Task<Schema> GetSchemaAsync(int id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(id == 1 ? _writerOne.Schema : _writerTwo.Schema);
+
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(
+            string subject,
+            string version = "latest",
+            CancellationToken cancellationToken = default) => Task.FromResult(_writerTwo);
+
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(
+            string subject,
+            string version,
+            bool ignoreDeletedSchemas,
+            CancellationToken cancellationToken = default) => Task.FromResult(_writerTwo);
+
+        public Task<RegisteredSchema> LookupSchemaAsync(
+            string subject,
+            Schema schema,
+            bool ignoreDeletedSchemas = true,
+            bool normalize = false,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(ReferenceEquals(schema, _writerOne.Schema) ? _writerOne : _writerTwo);
 
         public Task<int> RegisterSchemaAsync(
             string subject,


### PR DESCRIPTION
## Summary
- add `UseLatestVersion` to generic, JSON, Avro, and Protobuf Schema Registry deserializers
- resolve exact writer/latest reader versions and execute adjacent upgrade/downgrade rules in Schema Registry order
- split read encoding, migration, and read domain phases with pooled migration context
- use bounded plan caching plus lock-free single-schema fast cache
- include deleted intermediate versions while keeping latest reader active
- document behavior and fail closed when active migrations lack the built-in executor

Closes #2690

## Correctness
- upgrade: versions ascending, rules forward
- downgrade: versions descending, rules reverse
- higher schema owns each edge
- `UpDown` uses first action for upgrade, second for downgrade
- disabled and non-client (`NONE`/`SERVER`/`GATEWAY`) rules skipped
- Avro latest schema used for native reader resolution

## Validation
- `dotnet build Dekaf.sln --configuration Release --no-restore`: 0 warnings, 0 errors
- unit net10: 7034 passed
- unit net8: 6898 passed
- Schema Registry integration class: 3 passed against real Schema Registry
- NativeAOT build net10/net8: 0 warnings, 0 errors
- `git diff --check`: clean

## Performance
BenchmarkDotNet, .NET 10.0.11, i7-12700K, MemoryDiagnoser:

| Cached migration path | Mean | Allocated |
|---|---:|---:|
| No migration | 25.24 ns | 0 B |
| Disabled migration | 24.71 ns | 0 B |
| Active pass-through migration | 52.17 ns | 0 B |

Protected existing `DeserializeWithRuleExecutor` path:

| Revision/run | Mean | 99.9% error | Allocated |
|---|---:|---:|---:|
| exact parent `0fa413c6` | 13.62 ns | 0.472 ns | 0 B |
| candidate run 1 | 13.889 ns | — | 0 B |
| candidate repeat | 15.18 ns | 1.700 ns | 0 B |

Verdict: **INCONCLUSIVE** for timing. Parent and repeat 99.9% confidence intervals overlap; first candidate was +2.0%, repeat was noisy. Allocation remains 0 B. Per project policy, stopped repeating identical measurements and report all evidence; no protected trade accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional latest-schema deserialization for Avro, Protobuf, JSON, and generic serializers.
  * Added schema migration support, including upgrade and downgrade paths with configurable migration rules.
  * Added support for retrieving deleted schema versions when requested.
  * Added configurable caching for latest schema versions.
* **Documentation**
  * Documented schema migration behavior, rule ordering, directionality, and failure handling.
* **Tests**
  * Added coverage for migrations, schema selection, deleted schemas, caching, and fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->