### PR TITLE
fix(schema-registry): handle value tombstones

### DIFF
--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
@@ -27,6 +27,11 @@ namespace Dekaf.SchemaRegistry.Avro;
 /// cached schema without any blocking or async overhead.
 /// </para>
 /// <para>
+/// Kafka value tombstones return <see langword="default"/> without reading Confluent framing
+/// or contacting Schema Registry. This is <see langword="null"/> for reference and nullable
+/// types; non-nullable value types receive their normal default value.
+/// </para>
+/// <para>
 /// For high-throughput scenarios where you know the schema IDs in advance, use
 /// <see cref="WarmupAsync"/> to pre-warm the cache before starting consumption. This ensures
 /// the synchronous <see cref="Deserialize"/> method never blocks on Schema Registry calls.
@@ -111,7 +116,12 @@ public sealed class AvroSchemaRegistryDeserializer<
         var span = data.Span;
 
         if (span.Length < 5)
+        {
+            if (context is { IsNull: true, Component: SerializationComponent.Value })
+                return default!;
+
             throw new InvalidOperationException("Message too short to contain Schema Registry wire format");
+        }
 
         if (span[0] != MagicByte)
             throw new InvalidOperationException($"Unknown magic byte: {span[0]}. Expected Schema Registry format (0x00).");

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
@@ -16,6 +16,11 @@ namespace Dekaf.SchemaRegistry.Protobuf;
 /// <para>
 /// The blocking call includes a timeout to prevent indefinite hangs.
 /// </para>
+/// <para>
+/// Kafka value tombstones return <see langword="default"/> without reading Confluent framing
+/// or contacting Schema Registry. This is <see langword="null"/> for reference and nullable
+/// types; non-nullable value types receive their normal default value.
+/// </para>
 /// </remarks>
 /// <typeparam name="T">The Protobuf message type to deserialize.</typeparam>
 public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisposable
@@ -58,7 +63,12 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
         var span = data.Span;
 
         if (span.Length < 5)
+        {
+            if (context is { IsNull: true, Component: SerializationComponent.Value })
+                return default!;
+
             throw new InvalidOperationException("Message too short to contain Schema Registry wire format");
+        }
 
         // Verify magic byte
         if (span[0] != MagicByte)

--- a/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
+++ b/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
@@ -660,6 +660,11 @@ public sealed class JsonSchemaRegistrySerializer<T> :
 /// <para>
 /// The blocking call includes a timeout to prevent indefinite hangs.
 /// </para>
+/// <para>
+/// Kafka value tombstones return <see langword="default"/> without reading Confluent framing
+/// or contacting Schema Registry. This is <see langword="null"/> for reference and nullable
+/// types; non-nullable value types receive their normal default value.
+/// </para>
 /// </remarks>
 /// <typeparam name="T">The type to deserialize.</typeparam>
 public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisposable
@@ -822,7 +827,12 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
         var span = data.Span;
 
         if (span.Length < 5)
+        {
+            if (context is { IsNull: true, Component: SerializationComponent.Value })
+                return default!;
+
             throw new InvalidOperationException("Message too short to contain Schema Registry wire format");
+        }
 
         if (span[0] != MagicByte)
             throw new InvalidOperationException($"Unknown magic byte: {span[0]}. Expected Schema Registry format.");

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
@@ -177,17 +177,23 @@ public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposa
     /// <summary>
     /// Creates a unique topic for a test and returns the topic name.
     /// </summary>
-    public async Task<string> CreateTestTopicAsync(int partitions = 1)
+    public async Task<string> CreateTestTopicAsync(
+        int partitions = 1,
+        IReadOnlyDictionary<string, string>? configs = null)
     {
         var topicName = $"test-topic-{Guid.NewGuid():N}";
-        await CreateTopicAsync(topicName, partitions).ConfigureAwait(false);
+        await CreateTopicAsync(topicName, partitions, configs: configs).ConfigureAwait(false);
         return topicName;
     }
 
     /// <summary>
     /// Creates a topic with the specified name.
     /// </summary>
-    public async Task CreateTopicAsync(string topicName, int partitions = 1, int replicationFactor = 1)
+    public async Task CreateTopicAsync(
+        string topicName,
+        int partitions = 1,
+        int replicationFactor = 1,
+        IReadOnlyDictionary<string, string>? configs = null)
     {
         if (_createdTopics.ContainsKey(topicName))
         {
@@ -208,7 +214,8 @@ public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposa
                 {
                     Name = topicName,
                     NumPartitions = partitions,
-                    ReplicationFactor = (short)replicationFactor
+                    ReplicationFactor = (short)replicationFactor,
+                    Configs = configs
                 }
             ]).ConfigureAwait(false);
         }

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryTombstoneIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryTombstoneIntegrationTests.cs
@@ -1,0 +1,82 @@
+using Avro.Generic;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Avro;
+using Dekaf.SchemaRegistry.Protobuf;
+using Dekaf.Serialization;
+using Dekaf.Tests.Integration.Protos;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Serialization")]
+[ClassDataSource<KafkaWithSchemaRegistryContainer>(Shared = SharedType.PerTestSession)]
+public sealed class SchemaRegistryTombstoneIntegrationTests(KafkaWithSchemaRegistryContainer testInfra)
+{
+    [Test]
+    public async Task AvroDeserializer_ConsumesTombstoneFromCompactedTopic()
+    {
+        using var registry = CreateRegistryClient();
+        await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(registry);
+
+        await AssertTombstoneAsync(deserializer);
+    }
+
+    [Test]
+    public async Task ProtobufDeserializer_ConsumesTombstoneFromCompactedTopic()
+    {
+        using var registry = CreateRegistryClient();
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestPerson>(registry);
+
+        await AssertTombstoneAsync(deserializer);
+    }
+
+    [Test]
+    public async Task JsonSchemaDeserializer_ConsumesTombstoneFromCompactedTopic()
+    {
+        using var registry = CreateRegistryClient();
+        await using var deserializer = new JsonSchemaRegistryDeserializer<TestOrder>(
+            registry,
+            JsonSchemaRegistryIntegrationJsonContext.Default.TestOrder);
+
+        await AssertTombstoneAsync(deserializer);
+    }
+
+    private SchemaRegistryClient CreateRegistryClient() =>
+        new(new SchemaRegistryConfig { Url = testInfra.RegistryUrl });
+
+    private async Task AssertTombstoneAsync<T>(IDeserializer<T> deserializer)
+        where T : class
+    {
+        var topic = await testInfra.CreateTestTopicAsync(
+            configs: new Dictionary<string, string> { ["cleanup.policy"] = "compact" });
+
+        await using var producer = await Kafka.CreateProducer<string, string?>()
+            .WithBootstrapServers(testInfra.BootstrapServers)
+            .WithValueSerializer(Serializers.NullableString)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, string?>
+        {
+            Topic = topic,
+            Key = "deleted-key",
+            Value = null
+        }, CancellationToken.None);
+
+        await using var consumer = await Kafka.CreateConsumer<string, T>()
+            .WithBootstrapServers(testInfra.BootstrapServers)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithValueDeserializer(deserializer)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Value).IsNull();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryTombstoneDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryTombstoneDeserializerTests.cs
@@ -1,0 +1,133 @@
+using Avro.Generic;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Avro;
+using Dekaf.SchemaRegistry.Protobuf;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+[NotInParallel("AvroSerialization")]
+public sealed class SchemaRegistryTombstoneDeserializerTests
+{
+    [Test]
+    public async Task Avro_ValueTombstone_ReturnsNullWithoutRegistryAccess()
+    {
+        using var registry = new MockSchemaRegistryClient();
+        await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(registry);
+
+        var result = deserializer.Deserialize(ReadOnlyMemory<byte>.Empty, CreateContext(isNull: true));
+
+        await Assert.That(result).IsNull();
+        await AssertNoRegistryAccess(registry);
+    }
+
+    [Test]
+    public async Task Protobuf_ValueTombstone_ReturnsNullWithoutRegistryAccess()
+    {
+        using var registry = new MockSchemaRegistryClient();
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry);
+
+        var result = deserializer.Deserialize(ReadOnlyMemory<byte>.Empty, CreateContext(isNull: true));
+
+        await Assert.That(result).IsNull();
+        await AssertNoRegistryAccess(registry);
+    }
+
+    [Test]
+    public async Task JsonSchema_ValueTombstone_ReturnsNullWithoutRegistryAccess()
+    {
+        using var registry = new MockSchemaRegistryClient();
+        await using var deserializer = new JsonSchemaRegistryDeserializer<string>(registry);
+
+        var result = deserializer.Deserialize(ReadOnlyMemory<byte>.Empty, CreateContext(isNull: true));
+
+        await Assert.That(result).IsNull();
+        await AssertNoRegistryAccess(registry);
+    }
+
+    [Test]
+    public async Task Avro_NonNullEmptyPayload_StillFailsFramingValidation()
+    {
+        using var registry = new MockSchemaRegistryClient();
+        await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(registry);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Task.FromResult(deserializer.Deserialize(ReadOnlyMemory<byte>.Empty, CreateContext())));
+
+        await Assert.That(exception!.Message).Contains("too short");
+    }
+
+    [Test]
+    public async Task Protobuf_NonNullEmptyPayload_StillFailsFramingValidation()
+    {
+        using var registry = new MockSchemaRegistryClient();
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Task.FromResult(deserializer.Deserialize(ReadOnlyMemory<byte>.Empty, CreateContext())));
+
+        await Assert.That(exception!.Message).Contains("too short");
+    }
+
+    [Test]
+    public async Task JsonSchema_NonNullEmptyPayload_StillFailsFramingValidation()
+    {
+        using var registry = new MockSchemaRegistryClient();
+        await using var deserializer = new JsonSchemaRegistryDeserializer<string>(registry);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Task.FromResult(deserializer.Deserialize(ReadOnlyMemory<byte>.Empty, CreateContext())));
+
+        await Assert.That(exception!.Message).Contains("too short");
+    }
+
+    [Test]
+    public async Task Avro_NullKey_StillFailsFramingValidation()
+    {
+        using var registry = new MockSchemaRegistryClient();
+        await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(registry);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Task.FromResult(deserializer.Deserialize(ReadOnlyMemory<byte>.Empty, CreateContext(isKey: true, isNull: true))));
+
+        await Assert.That(exception!.Message).Contains("too short");
+    }
+
+    [Test]
+    public async Task Protobuf_NullKey_StillFailsFramingValidation()
+    {
+        using var registry = new MockSchemaRegistryClient();
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Task.FromResult(deserializer.Deserialize(ReadOnlyMemory<byte>.Empty, CreateContext(isKey: true, isNull: true))));
+
+        await Assert.That(exception!.Message).Contains("too short");
+    }
+
+    [Test]
+    public async Task JsonSchema_NullKey_StillFailsFramingValidation()
+    {
+        using var registry = new MockSchemaRegistryClient();
+        await using var deserializer = new JsonSchemaRegistryDeserializer<string>(registry);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Task.FromResult(deserializer.Deserialize(ReadOnlyMemory<byte>.Empty, CreateContext(isKey: true, isNull: true))));
+
+        await Assert.That(exception!.Message).Contains("too short");
+    }
+
+    private static SerializationContext CreateContext(bool isKey = false, bool isNull = false) =>
+        new()
+        {
+            Topic = "tombstone-topic",
+            Component = isKey ? SerializationComponent.Key : SerializationComponent.Value,
+            IsNull = isNull
+        };
+
+    private static async Task AssertNoRegistryAccess(MockSchemaRegistryClient registry)
+    {
+        await Assert.That(registry.TryGetCachedSchemaCallCount).IsEqualTo(0);
+        await Assert.That(registry.GetSchemaCallCount).IsEqualTo(0);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryTombstoneDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryTombstoneDeserializerTests.cs
@@ -46,37 +46,52 @@ public sealed class SchemaRegistryTombstoneDeserializerTests
     }
 
     [Test]
-    public async Task Avro_NonNullEmptyPayload_StillFailsFramingValidation()
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(2)]
+    [Arguments(3)]
+    [Arguments(4)]
+    public async Task Avro_NonNullTruncatedPayload_StillFailsFramingValidation(int payloadLength)
     {
         using var registry = new MockSchemaRegistryClient();
         await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(registry);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            Task.FromResult(deserializer.Deserialize(ReadOnlyMemory<byte>.Empty, CreateContext())));
+            Task.FromResult(deserializer.Deserialize(new byte[payloadLength], CreateContext())));
 
         await Assert.That(exception!.Message).Contains("too short");
     }
 
     [Test]
-    public async Task Protobuf_NonNullEmptyPayload_StillFailsFramingValidation()
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(2)]
+    [Arguments(3)]
+    [Arguments(4)]
+    public async Task Protobuf_NonNullTruncatedPayload_StillFailsFramingValidation(int payloadLength)
     {
         using var registry = new MockSchemaRegistryClient();
         await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            Task.FromResult(deserializer.Deserialize(ReadOnlyMemory<byte>.Empty, CreateContext())));
+            Task.FromResult(deserializer.Deserialize(new byte[payloadLength], CreateContext())));
 
         await Assert.That(exception!.Message).Contains("too short");
     }
 
     [Test]
-    public async Task JsonSchema_NonNullEmptyPayload_StillFailsFramingValidation()
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(2)]
+    [Arguments(3)]
+    [Arguments(4)]
+    public async Task JsonSchema_NonNullTruncatedPayload_StillFailsFramingValidation(int payloadLength)
     {
         using var registry = new MockSchemaRegistryClient();
         await using var deserializer = new JsonSchemaRegistryDeserializer<string>(registry);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            Task.FromResult(deserializer.Deserialize(ReadOnlyMemory<byte>.Empty, CreateContext())));
+            Task.FromResult(deserializer.Deserialize(new byte[payloadLength], CreateContext())));
 
         await Assert.That(exception!.Message).Contains("too short");
     }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistryTombstoneDeserializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistryTombstoneDeserializerBenchmarks.cs
@@ -1,0 +1,183 @@
+using System.Buffers.Binary;
+using Avro.Generic;
+using Avro.IO;
+using BenchmarkDotNet.Attributes;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Avro;
+using Dekaf.SchemaRegistry.Protobuf;
+using Dekaf.Serialization;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using AvroSchema = Avro.Schema;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser(displayGenColumns: false)]
+public class SchemaRegistryTombstoneDeserializerBenchmarks
+{
+    private const int SchemaId = 1;
+    private const string RecordSchema =
+        """
+        {
+          "type": "record",
+          "name": "BenchmarkRecord",
+          "fields": [{ "name": "id", "type": "int" }]
+        }
+        """;
+
+    private AvroSchemaRegistryDeserializer<GenericRecord> _avro = null!;
+    private ProtobufSchemaRegistryDeserializer<StringValue> _protobuf = null!;
+    private JsonSchemaRegistryDeserializer<string> _json = null!;
+    private byte[] _avroWireData = null!;
+    private byte[] _protobufWireData = null!;
+    private byte[] _jsonWireData = null!;
+    private SerializationContext _valueContext;
+    private SerializationContext _tombstoneContext;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        var avroRegistry = new BenchmarkSchemaRegistryClient(new Schema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = RecordSchema
+        });
+        var protobufRegistry = new BenchmarkSchemaRegistryClient(new Schema
+        {
+            SchemaType = SchemaType.Protobuf,
+            SchemaString = "syntax = \"proto3\";"
+        });
+        var jsonRegistry = new BenchmarkSchemaRegistryClient(new Schema
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = "{}"
+        });
+
+        _avro = new AvroSchemaRegistryDeserializer<GenericRecord>(avroRegistry, ownsClient: true);
+        _protobuf = new ProtobufSchemaRegistryDeserializer<StringValue>(protobufRegistry, ownsClient: true);
+        _json = new JsonSchemaRegistryDeserializer<string>(jsonRegistry, ownsClient: true);
+
+        await _avro.WarmupAsync(SchemaId).ConfigureAwait(false);
+        _avroWireData = CreateAvroWireData();
+        _protobufWireData = CreateProtobufWireData();
+        _jsonWireData = CreateWireData("\"benchmark\""u8);
+        _valueContext = new SerializationContext
+        {
+            Topic = "benchmark-topic",
+            Component = SerializationComponent.Value
+        };
+        _tombstoneContext = new SerializationContext
+        {
+            Topic = "benchmark-topic",
+            Component = SerializationComponent.Value,
+            IsNull = true
+        };
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _avro.DisposeAsync().ConfigureAwait(false);
+        await _protobuf.DisposeAsync().ConfigureAwait(false);
+        await _json.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public GenericRecord AvroNonNull() => _avro.Deserialize(_avroWireData, _valueContext);
+
+    [Benchmark]
+    public StringValue ProtobufNonNull() => _protobuf.Deserialize(_protobufWireData, _valueContext);
+
+    [Benchmark]
+    public string JsonNonNull() => _json.Deserialize(_jsonWireData, _valueContext);
+
+    [Benchmark]
+    public GenericRecord? AvroTombstone() => _avro.Deserialize(ReadOnlyMemory<byte>.Empty, _tombstoneContext);
+
+    [Benchmark]
+    public StringValue? ProtobufTombstone() => _protobuf.Deserialize(ReadOnlyMemory<byte>.Empty, _tombstoneContext);
+
+    [Benchmark]
+    public string? JsonTombstone() => _json.Deserialize(ReadOnlyMemory<byte>.Empty, _tombstoneContext);
+
+    private static byte[] CreateAvroWireData()
+    {
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(RecordSchema);
+        var record = new GenericRecord(schema);
+        record.Add("id", 42);
+        using var payload = new MemoryStream();
+        var writer = new GenericDatumWriter<GenericRecord>(schema);
+        var encoder = new BinaryEncoder(payload);
+        writer.Write(record, encoder);
+        encoder.Flush();
+        return CreateWireData(payload.ToArray());
+    }
+
+    private static byte[] CreateProtobufWireData()
+    {
+        var payload = new StringValue { Value = "benchmark" }.ToByteArray();
+        var wireData = new byte[6 + payload.Length];
+        wireData[0] = 0;
+        BinaryPrimitives.WriteInt32BigEndian(wireData.AsSpan(1, 4), SchemaId);
+        wireData[5] = 0;
+        payload.CopyTo(wireData.AsSpan(6));
+        return wireData;
+    }
+
+    private static byte[] CreateWireData(ReadOnlySpan<byte> payload)
+    {
+        var wireData = new byte[5 + payload.Length];
+        wireData[0] = 0;
+        BinaryPrimitives.WriteInt32BigEndian(wireData.AsSpan(1, 4), SchemaId);
+        payload.CopyTo(wireData.AsSpan(5));
+        return wireData;
+    }
+
+    private sealed class BenchmarkSchemaRegistryClient(Schema schema)
+        : ISchemaRegistryClient, ISchemaRegistryCache
+    {
+        public bool TryGetCachedSchema(int id, out Schema cachedSchema)
+        {
+            cachedSchema = schema;
+            return true;
+        }
+
+        public Task<Schema> GetSchemaAsync(int id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(schema);
+
+        public Task<int> RegisterSchemaAsync(
+            string subject,
+            Schema candidate,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(
+            string subject,
+            string version = "latest",
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<int> GetOrRegisterSchemaAsync(
+            string subject,
+            Schema candidate,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<string>> GetAllSubjectsAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> GetVersionsAsync(
+            string subject,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<bool> IsCompatibleAsync(
+            string subject,
+            Schema candidate,
+            string version = "latest",
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> DeleteSubjectAsync(
+            string subject,
+            bool permanent = false,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
## Summary
- return `default` for Schema Registry value tombstones before Confluent framing or registry lookup
- preserve null-key and non-null empty-payload framing validation
- cover Avro, Protobuf, and JSON with unit, real Kafka/Schema Registry integration, and MemoryDiagnoser benchmarks
- fold tombstone handling into the existing short-frame branch so normal records execute no additional condition

Closes #2564

## Validation
- `dotnet build Dekaf.sln --configuration Release`: 0 warnings, 0 errors
- full unit net10: 7,176 passed
- full unit net8: 7,040 passed
- focused tombstone unit net10/net8: 9 passed each
- Schema Registry tombstone integration: 3 passed against real Kafka + Schema Registry
- `git diff --check`: clean

## Performance
BenchmarkDotNet, .NET 10.0.11, i7-12700K, MemoryDiagnoser.

Tombstone candidate ShortRun:

| Path | Mean | Allocated |
|---|---:|---:|
| Avro | 2.22 ns | 0 B |
| Protobuf | 4.07 ns | 0 B |
| JSON | 1.89 ns | 0 B |

Improved non-null comparison: 1 launch, 5 warmups, 15 measured iterations, exact parent `4baf5d19` → candidate `4f332e8e`.

| Non-null path | Parent | Candidate | Allocation parent/candidate |
|---|---:|---:|---:|
| Avro | 50.58 ns | 54.11 ns (noisy/bimodal; 99.9% CIs overlap) | 120 B / 120 B |
| Protobuf | 32.43 ns | 32.92 ns (99.9% CIs overlap) | 72 B / 72 B |
| JSON | 40.47 ns | 39.45 ns (99.9% CIs overlap) | 40 B / 40 B |

Timing verdict: **INCONCLUSIVE**; stopped repeating per policy. Allocation is unchanged. The final causal design nests the new checks inside the preexisting `span.Length < 5` branch, so the normal path executes the same condition as the parent. No protected trade is accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Kafka tombstone records across Avro, Protobuf, and JSON Schema deserialization.
  - Value tombstones now deserialize as `null` without requiring schema access or complete framing data.
- **Bug Fixes**
  - Preserved validation errors for malformed non-tombstone messages and null keys.
- **Tests**
  - Added unit and integration coverage for compacted-topic tombstones and invalid payload handling.
- **Performance**
  - Added benchmarks comparing regular and tombstone deserialization across supported schema formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->