### PR TITLE
Add missing xml docs and llms.txt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,7 @@ await _channel.Writer.WriteAsync(workItem, cancellationToken);
 
 **FlushAsync:** Can be cancelled throughout the wait. Cancelling stops the caller from waiting, but batches continue sending in background.
 
-**Send (Fire-and-Forget):** Never uses cancellation tokens. Use `FlushAsync(cancellationToken)` if you need cancellable waiting for delivery.
+**FireAsync (Fire-and-Forget):** Never uses cancellation tokens; no overload accepts one. Use `FlushAsync(cancellationToken)` if you need cancellable waiting for delivery.
 
 ```csharp
 // CORRECT: Cancellation before append - message NOT sent

--- a/docs/docs/api-compatibility.md
+++ b/docs/docs/api-compatibility.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+description: "How Dekaf locks its public API surface with analyzer baselines, how to validate a change locally, and how to update a baseline."
 ---
 
 # Public API Compatibility

--- a/docs/docs/benchmarks.md
+++ b/docs/docs/benchmarks.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 13
+description: "Dekaf versus Confluent.Kafka on throughput, latency, and allocations, measured with BenchmarkDotNet and refreshed on every commit to main."
 ---
 
 # Benchmark Results

--- a/docs/docs/compatibility.md
+++ b/docs/docs/compatibility.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+description: "Which .NET targets each Dekaf package supports, the netstandard2.0 restore baseline, and the blocker categories tracked against it."
 ---
 
 # Compatibility

--- a/docs/docs/compression.md
+++ b/docs/docs/compression.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 10
+description: "The available compression codecs, how to install and enable batch compression, and how to pick one for your throughput and CPU budget."
 ---
 
 # Compression

--- a/docs/docs/configuration/client-dns-lookup.md
+++ b/docs/docs/configuration/client-dns-lookup.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+description: "How Dekaf resolves broker hostnames before connecting, the available DNS lookup modes, and the bootstrap resolution deadline."
 ---
 
 # Client DNS Lookup

--- a/docs/docs/configuration/confluent-migration.md
+++ b/docs/docs/configuration/confluent-migration.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+description: "Translate existing Confluent-style configuration to Dekaf, including Aspire setup, a settings compatibility matrix, and CoreWCF Kafka migration."
 ---
 
 # Migrate Confluent configuration

--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: "Complete reference for every consumer setting, covering connection, group coordination, offsets, fetch and session tuning, subscription, and rebalancing."
 ---
 
 # Consumer Options

--- a/docs/docs/configuration/presets.md
+++ b/docs/docs/configuration/presets.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: "Ready-made producer and consumer configurations for common scenarios, how to override individual values, and how to define your own preset."
 ---
 
 # Configuration Presets

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -370,7 +370,7 @@ Maximum memory the producer uses for buffering unsent messages:
 .WithBufferMemory(256 * 1024 * 1024)  // 256MB
 ```
 
-Default: 2GB. When the buffer is full, `ProduceAsync` and `Send` block until space is freed (controlled by `WithMaxBlockMs`). Increase if profiling shows significant time in backpressure waits; decrease in memory-constrained environments.
+Default: 2GB. When the buffer is full, `ProduceAsync` and `FireAsync` block until space is freed (controlled by `WithMaxBlockMs`). Increase if profiling shows significant time in backpressure waits; decrease in memory-constrained environments.
 
 ### WithBufferMemoryAllocationStrategy
 

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+description: "Complete reference for every producer setting, covering connection, delivery guarantees, batching, compression, partitioning, transactions, and security."
 ---
 
 # Producer Options

--- a/docs/docs/consumer/basics.md
+++ b/docs/docs/consumer/basics.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: "Create a consumer, subscribe to topics, and process records with await foreach, including auto offset reset, error handling, and graceful shutdown."
 ---
 
 # Consumer Basics

--- a/docs/docs/consumer/consumer-groups.md
+++ b/docs/docs/consumer/consumer-groups.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+description: "Share partitions across consumer instances, covering rebalancing, static membership, session and heartbeat tuning, and how to scale group members."
 ---
 
 # Consumer Groups

--- a/docs/docs/consumer/dead-letter-queues.md
+++ b/docs/docs/consumer/dead-letter-queues.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+description: "Park repeatedly failing records in a companion topic instead of stalling the consumer, with tiered retry topics, failure counting, and custom routing."
 ---
 
 # Dead Letter Queues and Retry Topics

--- a/docs/docs/consumer/delivery-semantics.md
+++ b/docs/docs/consumer/delivery-semantics.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+description: "The definitive reference for what happens to a message when processing fails, how Dekaf's default compares to other clients, and how to choose a guarantee."
 ---
 
 # Delivery Semantics

--- a/docs/docs/consumer/linq-extensions.md
+++ b/docs/docs/consumer/linq-extensions.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+description: "LINQ-style Where, Select, Take, Batch, and ForEachAsync operators over consumed messages, and why filtering skips records permanently."
 ---
 
 # LINQ Extensions

--- a/docs/docs/consumer/manual-assignment.md
+++ b/docs/docs/consumer/manual-assignment.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+description: "Assign specific partitions directly instead of joining a consumer group, with manual offset management, seeking, and incremental assignment."
 ---
 
 # Manual Partition Assignment

--- a/docs/docs/consumer/offset-management.md
+++ b/docs/docs/consumer/offset-management.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: "Offset commit modes, commit strategies, seeking, and inspecting committed offsets, so you neither lose messages nor reprocess them."
 ---
 
 # Offset Management

--- a/docs/docs/consumer/partitioned-processing-api.md
+++ b/docs/docs/consumer/partitioned-processing-api.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+description: "RunPartitionedAsync keeps per-key work ordered while processing partitions in parallel, covering commit semantics, backpressure, and error policy."
 ---
 
 # Partitioned Async Processing

--- a/docs/docs/dependency-injection.md
+++ b/docs/docs/dependency-injection.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 11
+description: "Register Dekaf producers and consumers in the ASP.NET Core container, including multiple clients, global interceptors, appsettings binding, and NativeAOT."
 ---
 
 # Dependency Injection

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+description: "Install Dekaf, run Kafka locally, and write your first producer and consumer."
 ---
 
 # Getting Started

--- a/docs/docs/hosted-services.md
+++ b/docs/docs/hosted-services.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 12
+description: "KafkaConsumerService runs a consumer for your application's lifetime, handling scoped dependencies, failure handling, and shutdown behaviour."
 ---
 
 # Hosted Consumer Services

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 slug: /
+description: "Dekaf is a high-performance, pure C# Apache Kafka client for .NET, implemented from the wire protocol up with no librdkafka or JVM dependency."
 ---
 
 # Introduction

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -46,7 +46,7 @@ Dekaf emits spans following the [OpenTelemetry messaging semantic conventions](h
 
 | Span | Kind | When |
 |------|------|------|
-| `send {topic}` | `Producer` | Each `ProduceAsync` / `Send` |
+| `send {topic}` | `Producer` | Each `ProduceAsync` / `FireAsync` |
 | `process {topic}` | `Consumer` | Each message from streaming `ConsumeAsync` |
 | `poll {topic}` | `Client` | Each message from `ConsumeOne` / `ConsumeOneAsync` |
 

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 12
+description: "Dekaf's built-in ActivitySource and Meter for OpenTelemetry tracing and metrics, plus broker-side telemetry (KIP-714). Zero cost when nothing is listening."
 ---
 
 # Observability (OpenTelemetry)

--- a/docs/docs/performance.md
+++ b/docs/docs/performance.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 12
+description: "What makes Dekaf fast, how to tune batching and compression for your workload, what throughput to expect, and the common mistakes that cost you."
 ---
 
 # Performance

--- a/docs/docs/producer/basics.md
+++ b/docs/docs/producer/basics.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: "Create a producer and send messages, covering acks and delivery guarantees, batching, compression, the idempotent producer, and ordering."
 ---
 
 # Producer Basics

--- a/docs/docs/producer/batch-production.md
+++ b/docs/docs/producer/batch-production.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+description: "ProduceAllAsync sends many messages concurrently without the pitfalls of awaiting ValueTask in a loop, including partial success handling."
 ---
 
 # Batch Production

--- a/docs/docs/producer/fire-and-forget.md
+++ b/docs/docs/producer/fire-and-forget.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: "FireAsync enqueues records without waiting for broker acknowledgment, how it differs from ProduceAsync, and how to still guarantee delivery."
 ---
 
 # Fire-and-Forget Production

--- a/docs/docs/producer/headers.md
+++ b/docs/docs/producer/headers.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+description: "Attach metadata such as trace IDs and message types to records, read headers on the consumer side, and understand their performance cost."
 ---
 
 # Message Headers

--- a/docs/docs/producer/outbox.md
+++ b/docs/docs/producer/outbox.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 8
+description: "At-least-once publishing from your database to Kafka without distributed transactions, covering schema, ordering, deduplication, tuning, and custom stores."
 ---
 
 # Transactional Outbox

--- a/docs/docs/producer/partitioning.md
+++ b/docs/docs/producer/partitioning.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+description: "How keys map to partitions, the available partitioner types, explicit partition assignment, and the ordering guarantees each choice gives you."
 ---
 
 # Partitioning

--- a/docs/docs/producer/topic-producer.md
+++ b/docs/docs/producer/topic-producer.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+description: "ITopicProducer binds to a single topic at construction so you skip the topic argument on every call, with disposal semantics and DI wiring."
 ---
 
 # Topic-Specific Producers

--- a/docs/docs/producer/transactions.md
+++ b/docs/docs/producer/transactions.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+description: "Atomic writes across partitions and topics for exactly-once semantics, covering consume-transform-produce, isolation levels, timeouts, and error handling."
 ---
 
 # Transactions

--- a/docs/docs/rfcs/dekaf-streams.md
+++ b/docs/docs/rfcs/dekaf-streams.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: "RFC (deferred): why a Dekaf.Streams runtime stays out of the core client, and the prototype, correctness, and benchmark gates required to reopen it."
 ---
 
 # RFC: Evaluate a Separate Dekaf.Streams Runtime

--- a/docs/docs/security/oauth.md
+++ b/docs/docs/security/oauth.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: "OAUTHBEARER authentication with custom token providers, JWT-bearer and client assertion grants, Azure AD, AWS MSK IAM, and token refresh."
 ---
 
 # OAuth / OAUTHBEARER

--- a/docs/docs/security/sasl.md
+++ b/docs/docs/security/sasl.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+description: "SASL/PLAIN, SCRAM, GSSAPI (Kerberos), and AWS_MSK_IAM authentication for Dekaf, including Confluent Cloud setup and securing credentials."
 ---
 
 # SASL Authentication

--- a/docs/docs/security/tls.md
+++ b/docs/docs/security/tls.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: "Encrypt broker connections with TLS, supply a custom CA certificate, configure mutual TLS, and troubleshoot common handshake failures."
 ---
 
 # TLS Encryption

--- a/docs/docs/serialization/built-in.md
+++ b/docs/docs/serialization/built-in.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: "The serializers Dekaf selects automatically for strings, byte arrays, ReadOnlyMemory, integers, and Guid, and how to specify them explicitly."
 ---
 
 # Built-in Serializers

--- a/docs/docs/serialization/custom.md
+++ b/docs/docs/serialization/custom.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+description: "Implement ISerializer and IDeserializer, write a zero-allocation serializer, use SerializationContext, and handle nulls and async serdes."
 ---
 
 # Custom Serializers

--- a/docs/docs/serialization/json.md
+++ b/docs/docs/serialization/json.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+description: "System.Text.Json serialization for Dekaf, with custom JsonSerializerOptions, polymorphic types, NativeAOT support, and error handling."
 ---
 
 # JSON Serialization

--- a/docs/docs/serialization/routing.md
+++ b/docs/docs/serialization/routing.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+description: "Route heterogeneous records by topic or by schema ID without allocating in steady state, on both the produce and consume sides."
 ---
 
 # Routing Serdes

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: "Confluent Schema Registry with Avro and Protobuf, JSON Schema validation, and client-side field-level encryption via AWS, Azure, GCP, or Vault KMS."
 ---
 
 # Schema Registry

--- a/docs/docs/soak-tests.md
+++ b/docs/docs/soak-tests.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 15
+description: "The 24-hour mixed producer and consumer soak run, the failure gates it enforces, and how to run it locally."
 ---
 
 # 24-hour soak tests

--- a/docs/docs/stress-tests.md
+++ b/docs/docs/stress-tests.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 14
+description: "Long-running throughput and stability comparisons between Dekaf and Confluent.Kafka under sustained real-world load."
 ---
 
 # Stress Test Results

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 12
+description: "Dekaf.Testing provides in-memory producers and consumers for fast unit tests, plus DI wiring, admin and offset fakes, and NativeAOT smoke validation."
 ---
 
 # Testing

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,6 +1,35 @@
 // @ts-check
 import {themes as prismThemes} from 'prism-react-renderer';
 
+/**
+ * Docusaurus renders a "Direct link to ..." anchor inside every heading. Converting the
+ * built HTML back to Markdown would carry those into each emitted .md file and into
+ * llms-full.txt, so drop them before the conversion runs.
+ *
+ * Hand-rolled rather than using unist-util-visit, which is only a transitive dependency.
+ *
+ * @returns {(tree: import('hast').Root) => void}
+ */
+function rehypeStripHeadingAnchors() {
+  const isHashLink = (/** @type {any} */ node) =>
+    node.type === 'element' &&
+    node.tagName === 'a' &&
+    []
+      .concat(node.properties?.className ?? [])
+      .includes('hash-link');
+
+  return (tree) => {
+    const walk = (/** @type {any} */ node) => {
+      if (!Array.isArray(node.children)) {
+        return;
+      }
+      node.children = node.children.filter((child) => !isHashLink(child));
+      node.children.forEach(walk);
+    };
+    walk(tree);
+  };
+}
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Dekaf',
@@ -45,6 +74,36 @@ const config = {
   ],
 
   onBrokenLinks: 'throw',
+
+  plugins: [
+    [
+      '@signalwire/docusaurus-plugin-llms-txt',
+      /** @type {import('@signalwire/docusaurus-plugin-llms-txt').PluginOptions} */
+      ({
+        siteTitle: 'Dekaf',
+        siteDescription:
+          'High-performance, pure C# Apache Kafka client library for .NET 10+. A native, zero-allocation implementation with no interop overhead or JVM dependency.',
+        // Categories come from URL path segments. Under /Dekaf/docs/, deeper values give
+        // every root-level page its own single-entry section, so keep the index flat and
+        // let each link's title and description carry the signal.
+        depth: 1,
+        enableDescriptions: true,
+        content: {
+          // Serve raw Markdown alongside each HTML page.
+          enableMarkdownFiles: true,
+          // Off by default; this is the single-file full corpus.
+          enableLlmsFullTxt: true,
+          // Emit absolute URLs. Relative links omit the /Dekaf/ baseUrl, which 404s
+          // once llms.txt is fetched away from the site.
+          relativePaths: false,
+          includeDocs: true,
+          includeBlog: false,
+          includePages: false,
+          beforeDefaultRehypePlugins: [rehypeStripHeadingAnchors],
+        },
+      }),
+    ],
+  ],
 
   markdown: {
     hooks: {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -11,6 +11,7 @@
         "@docusaurus/core": "^3.10.2",
         "@docusaurus/preset-classic": "^3.10.2",
         "@mdx-js/react": "^3.1.1",
+        "@signalwire/docusaurus-plugin-llms-txt": "^1.2.2",
         "clsx": "^2.1.1",
         "prism-react-renderer": "^2.4.1",
         "react": "^19.2.8",
@@ -4662,6 +4663,44 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
+    "node_modules/@signalwire/docusaurus-plugin-llms-txt": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@signalwire/docusaurus-plugin-llms-txt/-/docusaurus-plugin-llms-txt-1.2.2.tgz",
+      "integrity": "sha512-Qo5ZBDZpyXFlcrWwise77vs6B0R3m3/qjIIm1IHf4VzW6sVYgaR/y46BJwoAxMrV3WJkn0CVGpyYC+pMASFBZw==",
+      "license": "MIT",
+      "dependencies": {
+        "fs-extra": "^11.0.0",
+        "hast-util-select": "^6.0.4",
+        "hast-util-to-html": "^9.0.5",
+        "hast-util-to-string": "^3.0.1",
+        "p-map": "^7.0.2",
+        "rehype-parse": "^9",
+        "rehype-remark": "^10",
+        "remark-gfm": "^4",
+        "remark-stringify": "^11",
+        "string-width": "^5.0.0",
+        "unified": "^11",
+        "unist-util-visit": "^5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0"
+      }
+    },
+    "node_modules/@signalwire/docusaurus-plugin-llms-txt/node_modules/p-map": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -5844,6 +5883,16 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="
     },
+    "node_modules/bcp-47-match": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -6993,6 +7042,22 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-selector-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
+      "integrity": "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/css-tree": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
@@ -7386,6 +7451,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/direction": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
+      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
+      "license": "MIT",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dns-packet": {
@@ -8569,6 +8647,38 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-embedded": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
+      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
@@ -8588,12 +8698,85 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-body-ok-link": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
+      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-minify-whitespace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
+      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-parse-selector": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
       "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-is-body-ok-link": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8617,6 +8800,33 @@
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.0",
         "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-select": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
+      "integrity": "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "bcp-47-match": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.0.0",
+        "direction": "^2.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "nth-check": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
         "zwitch": "^2.0.0"
       },
       "funding": {
@@ -8651,6 +8861,29 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -8677,6 +8910,32 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-mdast": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
+      "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-minify-whitespace": "^6.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
@@ -8689,6 +8948,35 @@
         "space-separated-tokens": "^2.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -14611,6 +14899,35 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/rehype-minify-whitespace": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
+      "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-parse": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-raw": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
@@ -14633,6 +14950,23 @@
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
         "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-remark": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
+      "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "hast-util-to-mdast": "^10.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -16037,6 +16371,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/trim-trailing-lines": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/trough": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
@@ -16196,6 +16540,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/unist-util-is": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,7 @@
     "@docusaurus/core": "^3.10.2",
     "@docusaurus/preset-classic": "^3.10.2",
     "@mdx-js/react": "^3.1.1",
+    "@signalwire/docusaurus-plugin-llms-txt": "^1.2.2",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.8",

--- a/src/Dekaf.Outbox.EntityFrameworkCore/EfCoreOutboxServiceCollectionExtensions.cs
+++ b/src/Dekaf.Outbox.EntityFrameworkCore/EfCoreOutboxServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ public static class EfCoreOutboxServiceCollectionExtensions
     /// <summary>
     /// Registers <see cref="EfCoreOutboxStore{TContext}"/> as the <see cref="IOutboxStore"/>.
     /// Requires an <c>AddDbContextFactory&lt;TContext&gt;</c> registration, and the context's
-    /// model must call <see cref="OutboxModelBuilderExtensions.UseDekafOutbox"/>.
+    /// model must call <see cref="OutboxModelBuilderExtensions.UseDekafOutbox(ModelBuilder, string)"/>.
     /// </summary>
     /// <typeparam name="TContext">The application's context type containing the outbox model.</typeparam>
     public static IServiceCollection AddDekafEntityFrameworkCoreOutboxStore<TContext>(

--- a/src/Dekaf.Outbox.EntityFrameworkCore/EfCoreOutboxStore.cs
+++ b/src/Dekaf.Outbox.EntityFrameworkCore/EfCoreOutboxStore.cs
@@ -7,7 +7,7 @@ namespace Dekaf.Outbox.EntityFrameworkCore;
 /// </summary>
 /// <remarks>
 /// <para>Requires the context model to include the outbox entities via
-/// <see cref="OutboxModelBuilderExtensions.UseDekafOutbox"/> and an
+/// <see cref="OutboxModelBuilderExtensions.UseDekafOutbox(ModelBuilder, string)"/> and an
 /// <see cref="IDbContextFactory{TContext}"/> registration (the relay runs outside any
 /// request scope).</para>
 /// <para>Lease mutations use guarded set-based <c>ExecuteUpdate</c> statements (the

--- a/src/Dekaf.Outbox/OutboxMessage.cs
+++ b/src/Dekaf.Outbox/OutboxMessage.cs
@@ -34,7 +34,7 @@ public class OutboxMessage
     public required Guid MessageId { get; init; }
 
     /// <summary>
-    /// Ordering bucket computed from the record key via <see cref="OutboxBucket.Compute(byte[]?, Guid, int)"/>.
+    /// Ordering bucket computed from the record key via <see cref="OutboxBucket.Compute(byte[], Guid, int)"/>.
     /// Each bucket has a single publishing relay at any time, so records that share a key
     /// (and therefore a bucket) are published in enqueue order.
     /// </summary>

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaFieldCache.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaFieldCache.cs
@@ -17,7 +17,7 @@ internal static class AvroSchemaFieldCache
     /// Returns <c>null</c> if the type does not have such a field.
     /// </summary>
     /// <remarks>
-    /// The result is cached per type via <see cref="ConcurrentDictionary{TKey,TValue}.GetOrAdd"/>.
+    /// The result is cached per type via <see cref="ConcurrentDictionary{TKey,TValue}.GetOrAdd(TKey, TValue)"/>.
     /// Under concurrent first access for the same type, the value factory (reflection lookup) may
     /// execute more than once; however, the reflection call is idempotent and only one result is
     /// stored and returned for subsequent lookups.

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -170,8 +170,8 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// </summary>
     /// <param name="bufferMemory">The buffer memory limit in bytes.</param>
     /// <remarks>
-    /// When the buffer is full, <see cref="KafkaProducer{TKey,TValue}.ProduceAsync"/> will block
-    /// until space becomes available or the delivery timeout expires.
+    /// When the buffer is full, <see cref="KafkaProducer{TKey,TValue}.ProduceAsync(ProducerMessage{TKey,TValue}, CancellationToken)"/>
+    /// will block until space becomes available or the delivery timeout expires.
     /// Default is 256 MB.
     /// </remarks>
     public ProducerBuilder<TKey, TValue> WithBufferMemory(ulong bufferMemory)
@@ -1145,7 +1145,7 @@ public sealed class ProducerBuilder<TKey, TValue>
 
     /// <summary>
     /// Sets the application-level retry policy for produce operations.
-    /// When set, retriable exceptions from <see cref="IKafkaProducer{TKey,TValue}.ProduceAsync"/>
+    /// When set, retriable exceptions from <see cref="IKafkaProducer{TKey,TValue}.ProduceAsync(ProducerMessage{TKey,TValue}, CancellationToken)"/>
     /// will be retried according to this policy.
     /// </summary>
     /// <param name="retryPolicy">The retry policy to use.</param>
@@ -1290,7 +1290,7 @@ public sealed class ProducerBuilder<TKey, TValue>
 
     /// <summary>
     /// Builds and initializes the producer, ready for immediate use.
-    /// This is equivalent to calling <see cref="Build"/> followed by <see cref="IKafkaProducer{TKey,TValue}.InitializeAsync"/>.
+    /// This is equivalent to calling <see cref="Build"/> followed by <see cref="IInitializableKafkaClient.InitializeAsync"/>.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token for the initialization.</param>
     /// <returns>An initialized producer ready to produce messages.</returns>
@@ -3090,7 +3090,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
 
     /// <summary>
     /// Builds and initializes the consumer, ready for immediate use.
-    /// This is equivalent to calling <see cref="Build"/> followed by <see cref="IKafkaConsumer{TKey,TValue}.InitializeAsync"/>.
+    /// This is equivalent to calling <see cref="Build"/> followed by <see cref="IInitializableKafkaClient.InitializeAsync"/>.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token for the initialization.</param>
     /// <returns>An initialized consumer ready to consume messages.</returns>

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -475,7 +475,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     /// <summary>
     /// Forces the coordinator to rejoin the group on the next
-    /// <see cref="EnsureActiveGroupAsync"/> call by transitioning to <see cref="CoordinatorState.Unjoined"/>.
+    /// <see cref="EnsureActiveGroupAsync(StringSet, CancellationToken)"/> call by transitioning to <see cref="CoordinatorState.Unjoined"/>.
     /// </summary>
     internal void RequestRejoin()
     {

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -652,7 +652,7 @@ internal interface IConsumerRebalanceEventSource
 
 /// <summary>
 /// Optional companion interface for observing graceful partition stop during
-/// <see cref="IKafkaConsumer{TKey,TValue}.CloseAsync"/> or
+/// <see cref="IKafkaConsumer{TKey,TValue}.CloseAsync(CancellationToken)"/> or
 /// <see cref="IAsyncDisposable.DisposeAsync"/>.
 /// </summary>
 /// <remarks>
@@ -666,7 +666,7 @@ internal interface IConsumerRebalanceEventSource
 ///
 /// Non-cancellation exceptions follow the rebalance listener policy: they are caught
 /// and logged at <c>Error</c> level. <see cref="OperationCanceledException"/> follows
-/// the <see cref="IKafkaConsumer{TKey,TValue}.CloseAsync"/> token or internal
+/// the <see cref="IKafkaConsumer{TKey,TValue}.CloseAsync(CancellationToken)"/> token or internal
 /// disposal shutdown token, but close/disposal teardown still runs before
 /// <c>CloseAsync</c> rethrows the cancellation. The callback is bounded by a
 /// five-second timeout.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -5737,7 +5737,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// record the way an explicit <see cref="CommitAsync(CancellationToken)"/> does — the
     /// consumer may be closing precisely because that record's processing failed.
     /// The background auto-commit loop uses a third, narrower scope: already-staged
-    /// offsets only, via <see cref="CommitStoredOffsetsAsync"/> directly.
+    /// offsets only, via <see cref="CommitStoredOffsetsAsync(CancellationToken)"/> directly.
     /// </summary>
     private async ValueTask<bool> CommitProvenOffsetsAsync(CancellationToken cancellationToken)
     {
@@ -9601,12 +9601,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     /// <summary>
-    /// Builds a fresh <see cref="FetchRequestTopic"/> list from a partition template dictionary.
-    /// Works for both the shared cache and freshly-built dictionaries (cache-miss path) —
-    /// in both cases, each call creates new <see cref="FetchRequestPartition"/> objects with
-    /// snapshot offsets from <paramref name="fetchPositions"/>, so concurrent callers
-    /// cannot observe each other's offset values.
-    /// Allocation is per fetch cycle (per-batch), not per-message.
+    /// Resolves the topic name for a fetch response topic. Topic-ID-keyed responses are mapped
+    /// through the request metadata snapshot, then the fetch session's ID-to-name cache; an
+    /// unresolvable ID falls back to the name carried on the response.
     /// </summary>
     private string ResolveTopicName(
         FetchResponseTopic topicResponse,
@@ -9632,6 +9629,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         return topicResponse.Topic ?? string.Empty;
     }
 
+    /// <summary>
+    /// Builds a fresh <see cref="FetchRequestTopic"/> list from a partition template dictionary.
+    /// Works for both the shared cache and freshly-built dictionaries (cache-miss path) —
+    /// in both cases, each call creates new <see cref="FetchRequestPartition"/> objects with
+    /// snapshot offsets from <paramref name="fetchPositions"/>, so concurrent callers
+    /// cannot observe each other's offset values.
+    /// Allocation is per fetch cycle (per-batch), not per-message.
+    /// </summary>
     internal static List<FetchRequestTopic> BuildFetchResult(
         Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>> templateDict,
         ConcurrentDictionary<TopicPartition, long> fetchPositions,
@@ -10007,7 +10012,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     /// <summary>
     /// Background auto-commit timer loop. Offset-safety contract: this loop commits only
-    /// stored offsets (<see cref="CommitStoredOffsetsAsync"/>), which are populated at
+    /// stored offsets (<see cref="CommitStoredOffsetsAsync(CancellationToken)"/>), which are populated at
     /// fetch-boundary position flushes — i.e. only for records the caller has already
     /// iterated past. It never reads the active consumed snapshot, so a record that has
     /// been yielded but not yet processed (or prefetched but not yet yielded) can never be
@@ -10096,7 +10101,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     /// <summary>
-    /// Core teardown logic shared by <see cref="CloseAsync"/> and <see cref="DisposeAsync"/>.
+    /// Core teardown logic shared by <see cref="CloseAsync(CancellationToken)"/> and <see cref="DisposeAsync"/>.
     /// Callers must ensure this is invoked at most once via an atomic CAS on <c>_closed</c>.
     /// </summary>
     private async ValueTask CloseAsyncCore(

--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -172,7 +172,7 @@ internal static class PoolSizing
     /// Returns the total response-buffer working set across brokers, pipeline slots, and
     /// connections. The native response pool uses this as one global retention allowance
     /// across capacity buckets so adaptive response sizes cannot multiply unmanaged memory.
-    /// The managed <see cref="ArrayPool{T}"/> uses the same depth independently per bucket.
+    /// The managed <see cref="System.Buffers.ArrayPool{T}"/> uses the same depth independently per bucket.
     /// </summary>
     internal static int ForConsumerResponseBuffers(
         int brokerCount,

--- a/src/Dekaf/Internal/RatchetableArrayPool.cs
+++ b/src/Dekaf/Internal/RatchetableArrayPool.cs
@@ -23,13 +23,13 @@ internal sealed class RatchetableArrayPool<T>
     }
 
     /// <summary>
-    /// Gets the current pool instance. Uses <see cref="Volatile.Read{T}(ref T)"/> to ensure
+    /// Gets the current pool instance. Uses <c>Volatile.Read</c> to ensure
     /// visibility of pool replacements from <see cref="RatchetBucketCapacity"/>.
     /// </summary>
     internal ArrayPool<T> Pool => Volatile.Read(ref _pool);
 
     /// <summary>
-    /// Gets the current per-bucket array capacity. Uses <see cref="Volatile.Read(ref int)"/>
+    /// Gets the current per-bucket array capacity. Uses <c>Volatile.Read</c>
     /// for cross-thread visibility.
     /// </summary>
     internal int CurrentArraysPerBucket => Volatile.Read(ref _currentArraysPerBucket);

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -2006,7 +2006,7 @@ public sealed partial class KafkaConnection :
     /// <summary>
     /// Writes one complete frame while holding the write lock, then releases the lock and
     /// returns the serialization buffer. The socket write is deliberately not cancellable:
-    /// cancelling <see cref="Stream.WriteAsync(ReadOnlyMemory{byte}, CancellationToken)"/>
+    /// cancelling the underlying <see cref="Stream"/> write
     /// mid-frame can leave a partial frame on the wire, desyncing the outgoing stream so the
     /// broker misparses it (broker-side InvalidRequestException on PRODUCE followed by a socket
     /// close). Callers that time out abandon the await instead (<see cref="AwaitFrameWriteAsync"/>);
@@ -2207,7 +2207,7 @@ public sealed partial class KafkaConnection :
 
     /// <summary>
     /// Marks the connection unusable after a frame write faulted or stayed stuck past its grace
-    /// period. A faulted <see cref="Stream.WriteAsync(ReadOnlyMemory{byte}, CancellationToken)"/>
+    /// period. A faulted <see cref="Stream"/> write
     /// can have transmitted part of the frame, so the outgoing stream is no longer frame-aligned:
     /// any further request written to it is misparsed by the broker (surfacing as broker-side
     /// InvalidRequestException on PRODUCE, after which the broker closes the socket while the

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -38,7 +38,7 @@ internal readonly record struct BrokerBudgetProbeEvent(
 /// The batch gate is multi-writer and amortizes compare/exchange reservations across many
 /// records. The adaptive controller is single-writer: only the owning broker response loop
 /// calls <see cref="OnAcked"/>,
-/// <see cref="CompleteAckedPass"/>, and <see cref="SetCap"/>. It publishes one byte limit and
+/// <see cref="CompleteAckedPass"/>, and <see cref="SetCap(long, long)"/>. It publishes one byte limit and
 /// generation for appenders to read.
 /// </para>
 /// </summary>

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -207,7 +207,7 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// <remarks>
     /// Transactional produce continuations run inline on a broker sender thread shared by
     /// other partitions using that broker connection. Code after each transactional
-    /// <see cref="ITransaction{TKey, TValue}.ProduceAsync"/> call must remain non-blocking
+    /// <see cref="ITransaction{TKey, TValue}.ProduceAsync(ProducerMessage{TKey, TValue}, CancellationToken)"/> call must remain non-blocking
     /// and avoid long-running synchronous work. Configure
     /// <see cref="ProducerBuilder{TKey,TValue}.WithInlineTransactionCompletions"/> with
     /// <see langword="false"/> when continuation code cannot meet this constraint.

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -22,7 +22,7 @@ namespace Dekaf.Producer;
 ///   <item><see cref="TryClaim"/> — called by <see cref="RecordAccumulator.DrainPendingAppends"/>
 ///   when buffer space is freed.</item>
 ///   <item>Timeout — <see cref="_timer"/> fires when max.block.ms deadline expires.</item>
-///   <item>Cancellation — <see cref="CancellationToken.Register"/> callback.</item>
+///   <item>Cancellation — <see cref="CancellationToken.Register(Action{object}, object)"/> callback.</item>
 ///   <item>Disposal — <see cref="TryFail"/> called during <see cref="RecordAccumulator.DisposeAsync"/>.</item>
 /// </list>
 /// </para>

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -162,9 +162,9 @@ public sealed class ProducerOptions
 
     /// <summary>
     /// Total memory buffer size in bytes for pending messages.
-    /// When the buffer is full, <see cref="KafkaProducer{TKey,TValue}.Send"/> and
-    /// <see cref="KafkaProducer{TKey,TValue}.ProduceAsync"/> block until space is available
-    /// (controlled by <see cref="MaxBlockMs"/>).
+    /// When the buffer is full, <see cref="KafkaProducer{TKey,TValue}.FireAsync(ProducerMessage{TKey,TValue})"/> and
+    /// <see cref="KafkaProducer{TKey,TValue}.ProduceAsync(ProducerMessage{TKey,TValue}, CancellationToken)"/>
+    /// block until space is available (controlled by <see cref="MaxBlockMs"/>).
     /// <para>
     /// <b>Default (auto-tuned):</b> When not set explicitly, this value is derived from the
     /// process-global <c>DekafMemoryBudget</c>, which claims 40% of available system memory
@@ -410,9 +410,9 @@ public sealed class ProducerOptions
     public int CloseTimeoutMs { get; init; } = 30000;
 
     /// <summary>
-    /// Maximum time in milliseconds that <see cref="KafkaProducer{TKey,TValue}.ProduceAsync"/>
-    /// and <see cref="KafkaProducer{TKey,TValue}.Send"/> will block when the producer's buffer
-    /// is full or metadata is unavailable.
+    /// Maximum time in milliseconds that <see cref="KafkaProducer{TKey,TValue}.ProduceAsync(ProducerMessage{TKey,TValue}, CancellationToken)"/>
+    /// and <see cref="KafkaProducer{TKey,TValue}.FireAsync(ProducerMessage{TKey,TValue})"/> will block
+    /// when the producer's buffer is full or metadata is unavailable.
     /// <para>
     /// This controls how long the producer waits for buffer space (backpressure), initial
     /// metadata when producing to a new topic for the first time, and transaction coordinator
@@ -656,7 +656,7 @@ public sealed class ProducerOptions
     internal ClientDnsEndpointResolver DnsResolver { get; init; } = ClientDnsEndpointResolver.Default;
 
     /// <summary>
-    /// Application-level retry policy for <see cref="KafkaProducer{TKey,TValue}.ProduceAsync"/>.
+    /// Application-level retry policy for <see cref="KafkaProducer{TKey,TValue}.ProduceAsync(ProducerMessage{TKey,TValue}, CancellationToken)"/>.
     /// When set, retriable exceptions that escape the internal protocol-level retries will be
     /// retried according to this policy. When <c>null</c>, no application-level retries occur.
     /// </summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -760,7 +760,7 @@ internal sealed class BatchArena
     }
 
     /// <summary>
-    /// Number of times <see cref="RentOrCreate"/> found the pool empty and had to allocate a new arena.
+    /// Number of times <see cref="RentOrCreate(int)"/> found the pool empty and had to allocate a new arena.
     /// Use this to diagnose pool sizing — sustained misses under load indicate the pool is too small.
     /// </summary>
     internal static long Misses => s_pool.Misses;
@@ -2330,7 +2330,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     /// <summary>
     /// Schedules a partition to be re-enqueued into <see cref="_readyPartitions"/> after
-    /// <paramref name="delayMs"/> milliseconds. Uses a fire-and-forget <see cref="Task.Delay"/>
+    /// <paramref name="delayMs"/> milliseconds. Uses a fire-and-forget <see cref="Task.Delay(int, CancellationToken)"/>
     /// so the sender loop is not churning on partitions still in retry backoff.
     /// One allocation per retry batch (not per message) — acceptable per allocation guidelines.
     /// Respects <see cref="_disposalCts"/> so the timer cancels promptly on disposal,
@@ -5446,19 +5446,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     /// <summary>
     /// Tries to get an existing batch for the given topic-partition.
-    /// Used by KafkaProducer to access the batch's arena for direct serialization.
-    /// </summary>
-    /// <param name="topicPartition">The topic-partition to look up.</param>
-    /// <param name="batch">The batch if found, null otherwise.</param>
-    /// <summary>
-    /// Checks for batches that have exceeded linger time.
-    /// Uses conditional removal to avoid race conditions where a new batch might be created
-    /// between Complete() and TryRemove() calls.
-    /// </summary>
-    /// <summary>
-    /// Tries to get an existing batch for the given topic-partition.
     /// Used by tests for batch introspection.
     /// </summary>
+    /// <param name="topic">The topic to look up.</param>
+    /// <param name="partition">The partition to look up.</param>
+    /// <param name="batch">The batch if found, null otherwise.</param>
     internal bool TryGetBatch(string topic, int partition, out PartitionBatch? batch)
     {
         if (Volatile.Read(ref _disposed) != 0)
@@ -5496,6 +5488,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Checks for batches that have exceeded linger time.
+    /// Uses conditional removal to avoid race conditions where a new batch might be created
+    /// between Complete() and TryRemove() calls.
+    /// </summary>
     /// <remarks>
     /// Optimized with multiple fast paths:
     /// 1. No-unsealed-batch check avoids linger work entirely.

--- a/src/Dekaf/Protocol/IKafkaMessage.cs
+++ b/src/Dekaf/Protocol/IKafkaMessage.cs
@@ -34,11 +34,11 @@ public interface IKafkaRequest<TResponse> : IKafkaMessage
     /// </summary>
     void Write(ref KafkaProtocolWriter writer, short version);
 
+#if !NETSTANDARD2_0
     /// <summary>
     /// Returns true if this API version uses flexible encoding.
     /// With Kafka 4.0+ all supported versions are flexible.
     /// </summary>
-#if !NETSTANDARD2_0
     static virtual bool IsFlexibleVersion(short version) => true;
 
     /// <summary>

--- a/src/Dekaf/Security/Sasl/GssapiConfig.cs
+++ b/src/Dekaf/Security/Sasl/GssapiConfig.cs
@@ -26,7 +26,7 @@ public sealed class GssapiConfig
     /// The client principal name (e.g., "user@REALM.COM").
     /// </summary>
     /// <remarks>
-    /// When set, Dekaf passes this value to <see cref="NegotiateAuthenticationClientOptions.Credential"/>
+    /// When set, Dekaf passes this value to <c>NegotiateAuthenticationClientOptions.Credential</c>
     /// as the client identity. The underlying platform must still be able to satisfy that
     /// identity from its credential cache or configured client keytab; Dekaf does not store a
     /// Kerberos password.
@@ -40,7 +40,7 @@ public sealed class GssapiConfig
     /// On Unix-like platforms, Dekaf sets <c>KRB5_CLIENT_KTNAME</c> before the first
     /// authentication attempt. MIT/Heimdal Kerberos treat this as a process-wide setting, so
     /// different keytabs in the same process are rejected. Windows keytab selection is not
-    /// supported by <see cref="NegotiateAuthentication"/> and fails during build/initialization.
+    /// supported by <c>NegotiateAuthentication</c> and fails during build/initialization.
     /// </remarks>
     public string? KeytabPath { get; init; }
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,15 +10,10 @@
     <!-- Ships IntelliSense docs in the NuGet package alongside each lib asset. -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--
-      Doc-comment diagnostics only surface once the documentation file is generated, and
-      TreatWarningsAsErrors would turn every pre-existing gap into a build error.
-      CS1591: public member has no doc comment (~2400 sites, mostly Protocol/Admin).
+      CS1591: public member has no doc comment
       CS1573: member documents some parameters but not all.
-      CS0419: cref names an overload group; the compiler still emits a valid link to one overload.
-      CS1574/CS1584/CS1658/CS1587/CS1734/CS1572: stale or malformed crefs and tags (61 sites).
-      Each is a documentation-quality gap to close, not a code defect.
     -->
-    <NoWarn>$(NoWarn);CS1591;CS1573;CS0419;CS1574;CS1584;CS1658;CS1587;CS1734;CS1572</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,6 +7,21 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Ships IntelliSense docs in the NuGet package alongside each lib asset. -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!--
+      Doc-comment diagnostics only surface once the documentation file is generated, and
+      TreatWarningsAsErrors would turn every pre-existing gap into a build error.
+      CS1591: public member has no doc comment (~2400 sites, mostly Protocol/Admin).
+      CS1573: member documents some parameters but not all.
+      CS0419: cref names an overload group; the compiler still emits a valid link to one overload.
+      CS1574/CS1584/CS1658/CS1587/CS1734/CS1572: stale or malformed crefs and tags (61 sites).
+      Each is a documentation-quality gap to close, not a code defect.
+    -->
+    <NoWarn>$(NoWarn);CS1591;CS1573;CS0419;CS1574;CS1584;CS1658;CS1587;CS1734;CS1572</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <EnablePackageValidation>true</EnablePackageValidation>
     <EnableStrictModeForCompatibleFrameworksInPackage>true</EnableStrictModeForCompatibleFrameworksInPackage>
     <ApiCompatEnableRuleAttributesMustMatch>true</ApiCompatEnableRuleAttributesMustMatch>


### PR DESCRIPTION
Hiya, just a quick fix so the nuget package ships with its xml docs as they're missing at the minute, had to fix a bunch of broken crefs to get this working. Also updated the docs to add llms.txt and fontmatter descriptions so "go convert this project from kafka to dekaf" goes a bit smoother.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation descriptions across producer, consumer, configuration, security, serialization, performance, and testing guides.
  * Clarified the fire-and-forget producer operation as `FireAsync`, including cancellation, buffering, acknowledgment, and delivery behavior.
  * Improved API references and examples throughout the developer documentation.
* **New Features**
  * Added generated Markdown documentation and a consolidated content corpus for easier documentation discovery and tooling.
  * Added clearer guidance for supported platforms, compatibility, benchmarks, and validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->