### PR TITLE
Address PR #2728 review feedback

### DIFF
--- a/docs/docs/benchmarks.md
+++ b/docs/docs/benchmarks.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 13
-description: "Dekaf versus Confluent.Kafka on throughput, latency, and allocations, measured with BenchmarkDotNet and refreshed on every commit to main."
+description: "Dekaf versus Confluent.Kafka on throughput, latency, and allocations, measured with BenchmarkDotNet in automated runs from main."
 ---
 
 # Benchmark Results
 
-How Dekaf compares to Confluent.Kafka, measured with BenchmarkDotNet on GitHub Actions and refreshed on every commit to main.
+How Dekaf compares to Confluent.Kafka, measured with BenchmarkDotNet in automated GitHub Actions runs from main.
 
 **Last Updated:** 2026-08-16 14:42 UTC
 
@@ -231,4 +231,4 @@ Wire protocol serialization/deserialization. **Allocated = `-` means zero heap a
 
 </details>
 
-*Benchmarks are automatically run on every push to main.*
+*Benchmarks automatically run on pushes to main that include changes outside this page.*

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -370,7 +370,7 @@ Maximum memory the producer uses for buffering unsent messages:
 .WithBufferMemory(256 * 1024 * 1024)  // 256MB
 ```
 
-Default: 2GB. When the buffer is full, `ProduceAsync` and `FireAsync` block until space is freed (controlled by `WithMaxBlockMs`). Increase if profiling shows significant time in backpressure waits; decrease in memory-constrained environments.
+Default: 2GB. When the buffer is full, `ProduceAsync` and `FireAsync` block until space is freed (controlled by `WithMaxBlock`). Increase if profiling shows significant time in backpressure waits; decrease in memory-constrained environments.
 
 ### WithBufferMemoryAllocationStrategy
 

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -370,7 +370,7 @@ Maximum memory the producer uses for buffering unsent messages:
 .WithBufferMemory(256 * 1024 * 1024)  // 256MB
 ```
 
-Default: 2GB. When the buffer is full, `ProduceAsync` and `FireAsync` block until space is freed (controlled by `WithMaxBlock`). Increase if profiling shows significant time in backpressure waits; decrease in memory-constrained environments.
+Default: 2GB. When the buffer is full, `ProduceAsync` and `FireAsync` wait for space for up to the `WithMaxBlock` duration. Increase if profiling shows significant time in backpressure waits; decrease in memory-constrained environments.
 
 ### WithBufferMemoryAllocationStrategy
 

--- a/docs/docs/consumer/offset-management.md
+++ b/docs/docs/consumer/offset-management.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-description: "Offset commit modes, commit strategies, seeking, and inspecting committed offsets, so you neither lose messages nor reprocess them."
+description: "Offset commit modes, commit strategies, seeking, and inspecting committed offsets, so you can choose the right delivery guarantee."
 ---
 
 # Offset Management

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5490,8 +5490,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     /// <summary>
     /// Checks active partitions for batches that have reached their linger deadline
-    /// and seals eligible current batches. The sweep drains <c>_lingerPartitions</c>
-    /// and conditionally detaches <c>CurrentBatch</c> while holding each partition lock.
+    /// and seals eligible current batches. Each sweep processes at most the captured
+    /// <c>_lingerPartitions</c> count, leaving later notifications queued for the next pass.
+    /// Eligible batches are detached while holding each partition lock.
     /// </summary>
     /// <remarks>
     /// Optimized with multiple fast paths:

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5489,9 +5489,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
-    /// Checks for batches that have exceeded linger time.
-    /// Uses conditional removal to avoid race conditions where a new batch might be created
-    /// between Complete() and TryRemove() calls.
+    /// Checks active partitions for batches that have reached their linger deadline
+    /// and seals eligible current batches. The sweep drains <c>_lingerPartitions</c>
+    /// and conditionally detaches <c>CurrentBatch</c> while holding each partition lock.
     /// </summary>
     /// <remarks>
     /// Optimized with multiple fast paths:


### PR DESCRIPTION
## Summary

- correct benchmark refresh wording to match the workflow path exclusion
- use the canonical `WithMaxBlock` API name and describe offset delivery trade-offs accurately
- update `ExpireLingerAsync` XML documentation to match its queue and locking behavior

## Why

Addresses all four unresolved review comments from #2728 after that contributor PR was merged. This keeps user-facing and XML documentation accurate without changing runtime behavior.

## Validation

- `dotnet build src/Dekaf/Dekaf.csproj --configuration Release --no-restore`
- `npm run build` from `docs/`

No performance benchmark required: changes affect Markdown and XML comments only; generated runtime code is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how benchmark results are measured and when benchmarks run.
  * Updated producer configuration guidance to reference the current buffer-blocking option.
  * Improved consumer offset-management documentation covering commits, seeking, and offset inspection.
  * Clarified producer batch expiration behavior in technical documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->