### PR TITLE
fix(ci): resolve Renovate action pins

### DIFF
--- a/.github/scripts/test_action_pins.py
+++ b/.github/scripts/test_action_pins.py
@@ -1,0 +1,41 @@
+import re
+import unittest
+from pathlib import Path
+
+
+WORKFLOW_DIRECTORY = Path(__file__).parents[1] / "workflows"
+TARGET_ACTIONS = {
+    "benchmark-action/github-action-benchmark",
+    "gittools/actions/gitversion/execute",
+    "gittools/actions/gitversion/setup",
+}
+PIN_PATTERN = re.compile(
+    r"^\s*uses:\s*(?P<action>[^@\s]+)@(?P<sha>[0-9a-f]{40})\s+#\s+"
+    r"(?P<tag>v\d+\.\d+\.\d+)\s*$"
+)
+
+
+class ActionPinTests(unittest.TestCase):
+    def test_actions_without_moving_major_tags_use_exact_release_comments(self) -> None:
+        found_actions: set[str] = set()
+
+        for workflow_path in WORKFLOW_DIRECTORY.glob("*.yml"):
+            for line_number, line in enumerate(
+                workflow_path.read_text(encoding="utf-8").splitlines(), start=1
+            ):
+                if not any(f"uses: {action}@" in line for action in TARGET_ACTIONS):
+                    continue
+
+                match = PIN_PATTERN.match(line)
+                self.assertIsNotNone(
+                    match,
+                    f"{workflow_path}:{line_number} must use a SHA pin with an exact "
+                    "release tag comment",
+                )
+                found_actions.add(match.group("action"))
+
+        self.assertEqual(TARGET_ACTIONS, found_actions)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -414,7 +414,7 @@ jobs:
           EOF
 
       - name: Store Benchmark Results
-        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: Dekaf Benchmarks
           tool: 'benchmarkdotnet'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,13 +111,13 @@ jobs:
         run: ./scripts/Test-AgentLockTokenOwnership.ps1
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4
+        uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
         with:
           versionSpec: '6.x'
 
       - name: Determine Version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@7417b1089e2c7de93510f1901d656ddf60bb024f # v4
+        uses: gittools/actions/gitversion/execute@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
         continue-on-error: true  # Don't fail if GitVersion has issues on PR branches
 
       - name: Expose GitHub Actions Runtime
@@ -600,13 +600,13 @@ jobs:
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4
+        uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
         with:
           versionSpec: '6.x'
 
       - name: Determine Version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@7417b1089e2c7de93510f1901d656ddf60bb024f # v4
+        uses: gittools/actions/gitversion/execute@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
         continue-on-error: true
 
       - name: Expose GitHub Actions Runtime


### PR DESCRIPTION
## Summary

- replace nonexistent major-only action version comments with exact release tags
- preserve immutable action SHAs and workflow behavior
- add regression coverage for actions without moving major tags

## Test plan

- [x] `python .github/scripts/test_action_pins.py`
- [x] `python -m unittest discover -s .github/scripts -p 'test_*.py'` (168 passed)
- [x] parse changed workflows with PyYAML
- [x] verify exact GitHub tags resolve to pinned SHAs
- [x] `git diff --check`
- [x] `/simplify`
- [x] self-review before push

No `src/` or runtime hot-path code changed.

Closes #2731