### PR TITLE
feat(schema-registry): add JSONata rule handler

### DIFF
--- a/Dekaf.sln
+++ b/Dekaf.sln
@@ -79,6 +79,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.SchemaRegistry.Kms.Aw
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.SchemaRegistry.Kms.Azure", "src\Dekaf.SchemaRegistry.Kms.Azure\Dekaf.SchemaRegistry.Kms.Azure.csproj", "{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.SchemaRegistry.Jsonata", "src\Dekaf.SchemaRegistry.Jsonata\Dekaf.SchemaRegistry.Jsonata.csproj", "{5A088F71-C070-4BDB-B48B-20831462CF9D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -497,6 +499,18 @@ Global
 		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}.Release|x64.Build.0 = Release|Any CPU
 		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}.Release|x86.ActiveCfg = Release|Any CPU
 		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8}.Release|x86.Build.0 = Release|Any CPU
+		{5A088F71-C070-4BDB-B48B-20831462CF9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A088F71-C070-4BDB-B48B-20831462CF9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A088F71-C070-4BDB-B48B-20831462CF9D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5A088F71-C070-4BDB-B48B-20831462CF9D}.Debug|x64.Build.0 = Debug|Any CPU
+		{5A088F71-C070-4BDB-B48B-20831462CF9D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5A088F71-C070-4BDB-B48B-20831462CF9D}.Debug|x86.Build.0 = Debug|Any CPU
+		{5A088F71-C070-4BDB-B48B-20831462CF9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A088F71-C070-4BDB-B48B-20831462CF9D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A088F71-C070-4BDB-B48B-20831462CF9D}.Release|x64.ActiveCfg = Release|Any CPU
+		{5A088F71-C070-4BDB-B48B-20831462CF9D}.Release|x64.Build.0 = Release|Any CPU
+		{5A088F71-C070-4BDB-B48B-20831462CF9D}.Release|x86.ActiveCfg = Release|Any CPU
+		{5A088F71-C070-4BDB-B48B-20831462CF9D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -536,5 +550,6 @@ Global
 		{170E0071-44E4-4D9B-AB44-4B324DE007F1} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{B7C4FB68-A5F2-4A49-B6A1-C7AC7C6106DD} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{4DA172AF-659C-4F4B-BF0E-9DF2CB6E63D8} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{5A088F71-C070-4BDB-B48B-20831462CF9D} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
     <PackageVersion Include="Grpc.Core.Api" Version="2.83.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.83.0" />
+    <PackageVersion Include="Jsonata.Net.Native" Version="3.0.0" />
     <PackageVersion Include="K4os.Compression.LZ4.Streams" Version="1.3.8" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" />

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -220,6 +220,38 @@ periodically re-resolve latest schemas; `0` refreshes on every use. Historical v
 deleted versions so migration paths remain complete. Custom `ISchemaRegistryClient` implementations
 must override the deleted-version overload; its default implementation fails closed.
 
+### JSONata rules
+
+Install the optional `Dekaf.SchemaRegistry.Jsonata` package and register its handler when a data
+contract contains `JSONATA` rules:
+
+```csharp
+using Dekaf.SchemaRegistry.Jsonata;
+
+var rules = new SchemaRegistryRuleExecutor(
+[
+    new JsonataSchemaRegistryRuleHandler()
+]);
+```
+
+The handler compiles and caches each rule expression, then evaluates JSONata against JSON codec
+payloads for write, read, and migration transforms. For example,
+`$merge([$, {'fullName': first & ' ' & last}])` preserves the input object and adds `fullName`.
+JSONata dependencies remain isolated in the optional package; applications without the handler add
+no JSONata work or allocation.
+
+Transform results may be any JSON value, including `null`, numbers, objects, and collections.
+JSONata's standard sequence semantics apply: a singleton sequence collapses to its value; append
+`[]` when the output must remain an array. An undefined result (for example, a missing-field query)
+fails explicitly rather than emitting invalid JSON. Condition rules must return `true` or `false`;
+`false` fails the rule. Invalid expressions, malformed JSON, and non-JSON payload formats fail with
+`SchemaRegistryRuleException`. Error messages identify the rule and engine error, but never include
+the payload.
+
+Binary Avro and Protobuf codec payloads are not currently supported by the JSONata byte handler and
+are rejected explicitly. Their object-level transforms require codec-specific conversion before
+binary encoding.
+
 ## Schema Registry Configuration
 
 ```csharp

--- a/src/Dekaf.SchemaRegistry.Jsonata/Dekaf.SchemaRegistry.Jsonata.csproj
+++ b/src/Dekaf.SchemaRegistry.Jsonata/Dekaf.SchemaRegistry.Jsonata.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Dekaf.SchemaRegistry.Jsonata</PackageId>
+    <Description>JSONata rule execution for Dekaf Schema Registry data contracts</Description>
+    <PackageTags>kafka;schema-registry;data-contracts;rules;jsonata</PackageTags>
+    <PackageValidationBaselineVersion></PackageValidationBaselineVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj" />
+    <PackageReference Include="Jsonata.Net.Native" />
+  </ItemGroup>
+
+</Project>

--- a/src/Dekaf.SchemaRegistry.Jsonata/JsonataSchemaRegistryRuleHandler.cs
+++ b/src/Dekaf.SchemaRegistry.Jsonata/JsonataSchemaRegistryRuleHandler.cs
@@ -1,0 +1,156 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using Jsonata.Net.Native;
+using Jsonata.Net.Native.Json;
+
+namespace Dekaf.SchemaRegistry.Jsonata;
+
+/// <summary>
+/// Executes Schema Registry JSONata transform and condition rules over JSON codec payloads.
+/// </summary>
+/// <remarks>
+/// Compiled queries are cached per rule and are safe for concurrent evaluation. Binary Avro and
+/// Protobuf payloads require codec-level object conversion and are rejected explicitly.
+/// </remarks>
+public sealed class JsonataSchemaRegistryRuleHandler : ISchemaRegistryRuleHandler
+{
+    private const int MaxRetainedOutputBufferSize = 1024 * 1024;
+
+    /// <summary>
+    /// The Schema Registry rule type handled by this implementation.
+    /// </summary>
+    public const string RuleType = "JSONATA";
+
+    private static readonly UTF8Encoding StrictUtf8 =
+        new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    [ThreadStatic]
+    private static byte[]? t_outputBuffer;
+
+    private readonly ConditionalWeakTable<SchemaRule, JsonataQuery> _queries = new();
+
+    /// <inheritdoc />
+    public string Type => RuleType;
+
+    /// <inheritdoc />
+    public ReadOnlyMemory<byte> TransformSerializedPayload(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleHandlerContext context) => Transform(payload, context);
+
+    /// <inheritdoc />
+    public ReadOnlyMemory<byte> TransformDeserializedPayload(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleHandlerContext context) => Transform(payload, context);
+
+    private ReadOnlyMemory<byte> Transform(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleHandlerContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var rule = context.Rule;
+        if (context.PayloadContext.PayloadFormat != SchemaRegistryPayloadFormat.Json)
+        {
+            throw new SchemaRegistryRuleException(
+                $"JSONata rule '{rule.Name}' requires a JSON payload; " +
+                $"'{context.PayloadContext.PayloadFormat}' is not supported.");
+        }
+
+        JToken result;
+        try
+        {
+            var input = JToken.Parse(StrictUtf8.GetString(payload.Span));
+            var query = _queries.GetValue(rule, static configuredRule => Compile(configuredRule));
+            result = query.Eval(input);
+        }
+        catch (DecoderFallbackException exception)
+        {
+            throw Failure(rule, "payload is not valid UTF-8", exception);
+        }
+        catch (JsonParseException exception)
+        {
+            throw Failure(rule, "payload is not valid JSON", exception);
+        }
+        catch (JsonataException exception)
+        {
+            var position = exception.Position is { } value
+                ? $" at position {value.ToString(System.Globalization.CultureInfo.InvariantCulture)}"
+                : string.Empty;
+            throw Failure(rule, $"evaluation failed with {exception.Code}{position}", exception);
+        }
+
+        if (rule.Kind == SchemaRuleKind.Condition)
+        {
+            if (result.Type != JTokenType.Boolean)
+            {
+                throw new SchemaRegistryRuleException(
+                    $"JSONata condition rule '{rule.Name}' must evaluate to a boolean value, " +
+                    $"but returned {FormatType(result.Type)}.");
+            }
+
+            if (!(bool)result)
+                throw new SchemaRegistryRuleException($"JSONata condition rule '{rule.Name}' evaluated to false.");
+
+            return payload;
+        }
+
+        if (result.Type == JTokenType.Undefined)
+        {
+            throw new SchemaRegistryRuleException(
+                $"JSONata transform rule '{rule.Name}' evaluated to undefined.");
+        }
+
+        if (result.Type == JTokenType.Function)
+        {
+            throw new SchemaRegistryRuleException(
+                $"JSONata transform rule '{rule.Name}' returned a function instead of a JSON value.");
+        }
+
+        return Encode(result.ToFlatString());
+    }
+
+    private static JsonataQuery Compile(SchemaRule rule)
+    {
+        if (string.IsNullOrWhiteSpace(rule.Expr))
+            throw new SchemaRegistryRuleException($"JSONata rule '{rule.Name}' has no expression.");
+
+        try
+        {
+            return new JsonataQuery(rule.Expr);
+        }
+        catch (JsonataException exception)
+        {
+            var position = exception.Position is { } value
+                ? $" at position {value.ToString(System.Globalization.CultureInfo.InvariantCulture)}"
+                : string.Empty;
+            throw Failure(rule, $"expression is invalid ({exception.Code}{position})", exception);
+        }
+    }
+
+    private static ReadOnlyMemory<byte> Encode(string json)
+    {
+        var byteCount = StrictUtf8.GetByteCount(json);
+        var buffer = t_outputBuffer;
+        if (byteCount > MaxRetainedOutputBufferSize)
+        {
+            buffer = GC.AllocateUninitializedArray<byte>(byteCount);
+        }
+        else if (buffer is null || buffer.Length < byteCount)
+        {
+            buffer = GC.AllocateUninitializedArray<byte>(Math.Max(byteCount, 256));
+            t_outputBuffer = buffer;
+        }
+
+        var length = StrictUtf8.GetBytes(json, buffer);
+        return buffer.AsMemory(0, length);
+    }
+
+    private static SchemaRegistryRuleException Failure(
+        SchemaRule rule,
+        string reason,
+        Exception exception) =>
+        new($"JSONata rule '{rule.Name}' {reason}.", exception);
+
+    private static string FormatType(JTokenType type) =>
+        type.ToString().ToLowerInvariant();
+}

--- a/src/Dekaf.SchemaRegistry.Jsonata/PublicAPI.Shipped.txt
+++ b/src/Dekaf.SchemaRegistry.Jsonata/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Dekaf.SchemaRegistry.Jsonata/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry.Jsonata/PublicAPI.Unshipped.txt
@@ -1,0 +1,7 @@
+#nullable enable
+Dekaf.SchemaRegistry.Jsonata.JsonataSchemaRegistryRuleHandler
+Dekaf.SchemaRegistry.Jsonata.JsonataSchemaRegistryRuleHandler.JsonataSchemaRegistryRuleHandler() -> void
+Dekaf.SchemaRegistry.Jsonata.JsonataSchemaRegistryRuleHandler.TransformDeserializedPayload(System.ReadOnlyMemory<byte> payload, Dekaf.SchemaRegistry.SchemaRegistryRuleHandlerContext! context) -> System.ReadOnlyMemory<byte>
+Dekaf.SchemaRegistry.Jsonata.JsonataSchemaRegistryRuleHandler.TransformSerializedPayload(System.ReadOnlyMemory<byte> payload, Dekaf.SchemaRegistry.SchemaRegistryRuleHandlerContext! context) -> System.ReadOnlyMemory<byte>
+Dekaf.SchemaRegistry.Jsonata.JsonataSchemaRegistryRuleHandler.Type.get -> string!
+const Dekaf.SchemaRegistry.Jsonata.JsonataSchemaRegistryRuleHandler.RuleType = "JSONATA" -> string!

--- a/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
+++ b/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\src\Dekaf.Serialization.Routing\Dekaf.Serialization.Routing.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Json\Dekaf.SchemaRegistry.Json.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Jsonata\Dekaf.SchemaRegistry.Jsonata.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Avro\Dekaf.SchemaRegistry.Avro.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Lz4\Dekaf.Compression.Lz4.csproj" />

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryRuleIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryRuleIntegrationTests.cs
@@ -6,6 +6,7 @@ using Avro.Generic;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Jsonata;
 using Dekaf.SchemaRegistry.Avro;
 using Dekaf.SchemaRegistry.Protobuf;
 using Dekaf.Serialization;
@@ -19,6 +20,57 @@ namespace Dekaf.Tests.Integration;
 [ClassDataSource<KafkaWithSchemaRegistryContainer>(Shared = SharedType.PerTestSession)]
 public sealed class SchemaRegistryRuleIntegrationTests(KafkaWithSchemaRegistryContainer testInfra)
 {
+    [Test]
+    public async Task RegisteredJsonataMigrationRule_UseLatestVersion_TransformsPayload()
+    {
+        var topic = await testInfra.CreateTestTopicAsync();
+        var subject = $"{topic}-value";
+        using var registryClient = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = testInfra.RegistryUrl
+        });
+        var v1 = new Schema
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = """{ "type": "object", "properties": { "first": { "type": "string" }, "last": { "type": "string" } }, "additionalProperties": false }"""
+        };
+        var v2 = new Schema
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = """{ "type": "object", "properties": { "first": { "type": "string" }, "last": { "type": "string" }, "fullName": { "type": "string" } }, "additionalProperties": false }""",
+            RuleSet = new SchemaRuleSet
+            {
+                MigrationRules =
+                [
+                    new SchemaRule
+                    {
+                        Name = "add-full-name",
+                        Kind = SchemaRuleKind.Transform,
+                        Mode = SchemaRuleMode.Upgrade,
+                        Type = JsonataSchemaRegistryRuleHandler.RuleType,
+                        Expr = "$merge([$, {'fullName': first & ' ' & last}])"
+                    }
+                ]
+            }
+        };
+        var writerId = await registryClient.RegisterSchemaAsync(subject, v1);
+        await registryClient.RegisterSchemaAsync(subject, v2);
+        var executor = new SchemaRegistryRuleExecutor([new JsonataSchemaRegistryRuleHandler()]);
+        await using var deserializer = new JsonSchemaRegistryDeserializer<System.Text.Json.JsonElement>(
+            registryClient,
+            jsonOptions: null,
+            config: new SchemaRegistryDeserializerConfig { UseLatestVersion = true },
+            ruleExecutor: executor);
+        var payload = """{"first":"Ada","last":"Lovelace"}"""u8;
+        var wire = new byte[5 + payload.Length];
+        System.Buffers.Binary.BinaryPrimitives.WriteInt32BigEndian(wire.AsSpan(1, 4), writerId);
+        payload.CopyTo(wire.AsSpan(5));
+
+        var result = deserializer.Deserialize(wire, CreateContext(topic));
+
+        await Assert.That(result.GetProperty("fullName").GetString()).IsEqualTo("Ada Lovelace");
+    }
+
     [Test]
     public async Task RegisteredMigrationRules_UseLatestVersion_ExecutesUpgradePath()
     {

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryRuleIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryRuleIntegrationTests.cs
@@ -58,8 +58,8 @@ public sealed class SchemaRegistryRuleIntegrationTests(KafkaWithSchemaRegistryCo
         var executor = new SchemaRegistryRuleExecutor([new JsonataSchemaRegistryRuleHandler()]);
         await using var deserializer = new JsonSchemaRegistryDeserializer<System.Text.Json.JsonElement>(
             registryClient,
-            jsonOptions: null,
-            config: new SchemaRegistryDeserializerConfig { UseLatestVersion = true },
+            SchemaRegistryRuleJsonContext.Default.JsonElement,
+            new SchemaRegistryDeserializerConfig { UseLatestVersion = true },
             ruleExecutor: executor);
         var payload = """{"first":"Ada","last":"Lovelace"}"""u8;
         var wire = new byte[5 + payload.Length];
@@ -409,4 +409,5 @@ public sealed class SchemaRegistryRuleIntegrationTests(KafkaWithSchemaRegistryCo
 }
 
 [JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(System.Text.Json.JsonElement))]
 internal sealed partial class SchemaRegistryRuleJsonContext : JsonSerializerContext;

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Aws\Dekaf.SchemaRegistry.Kms.Aws.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Azure\Dekaf.SchemaRegistry.Kms.Azure.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Json\Dekaf.SchemaRegistry.Json.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Jsonata\Dekaf.SchemaRegistry.Jsonata.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Lz4\Dekaf.Compression.Lz4.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Zstd\Dekaf.Compression.Zstd.csproj" />

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/JsonataSchemaRegistryRuleHandlerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/JsonataSchemaRegistryRuleHandlerTests.cs
@@ -1,0 +1,311 @@
+using System.Buffers.Binary;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Jsonata;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public sealed class JsonataSchemaRegistryRuleHandlerTests
+{
+    private static readonly SerializationContext SerializationContext = new()
+    {
+        Topic = "orders",
+        Component = SerializationComponent.Value
+    };
+
+    [Test]
+    [Arguments("$merge([$, {'fullName': first & ' ' & last}])", "fullName", "\"Ada Lovelace\"")]
+    [Arguments("$merge([$, {'total': $sum(items.(price * quantity))}])", "total", "25")]
+    [Arguments("{'ids': items[quantity > 1].id[], 'count': $count(items)}", "ids", "[2]")]
+    [Arguments("missing ? missing : null", "", "null")]
+    public async Task TransformSerializedPayload_ConfluentExpressions_ProduceExpectedJson(
+        string expression,
+        string property,
+        string expectedJson)
+    {
+        var payload = Apply(
+            expression,
+            """
+            {
+              "first": "Ada",
+              "last": "Lovelace",
+              "items": [
+                { "id": 1, "price": 5, "quantity": 1 },
+                { "id": 2, "price": 10, "quantity": 2 }
+              ]
+            }
+            """u8.ToArray(),
+            SchemaRegistryRuleDirection.Write);
+
+        using var actual = JsonDocument.Parse(payload);
+        using var expected = JsonDocument.Parse(expectedJson);
+        var actualValue = string.IsNullOrEmpty(property)
+            ? actual.RootElement
+            : actual.RootElement.GetProperty(property);
+
+        await Assert.That(JsonElement.DeepEquals(actualValue, expected.RootElement)).IsTrue();
+    }
+
+    [Test]
+    public async Task TransformDeserializedPayload_ReadRule_TransformsJson()
+    {
+        var payload = Apply(
+            "$merge([$, {'read': true}])",
+            """{"id":7}"""u8.ToArray(),
+            SchemaRegistryRuleDirection.Read);
+
+        using var document = JsonDocument.Parse(payload);
+        await Assert.That(document.RootElement.GetProperty("id").GetInt32()).IsEqualTo(7);
+        await Assert.That(document.RootElement.GetProperty("read").GetBoolean()).IsTrue();
+    }
+
+    [Test]
+    public async Task ConditionRule_RequiresTrueBoolean()
+    {
+        var payload = """{"total":12}"""u8.ToArray();
+        var passing = Apply(
+            "total >= 10",
+            payload,
+            SchemaRegistryRuleDirection.Write,
+            SchemaRuleKind.Condition);
+
+        await Assert.That(passing.Span.SequenceEqual(payload)).IsTrue();
+        await Assert.That(() => Apply(
+                "total < 10",
+                payload,
+                SchemaRegistryRuleDirection.Write,
+                SchemaRuleKind.Condition))
+            .Throws<SchemaRegistryRuleException>()
+            .WithMessageContaining("evaluated to false");
+        await Assert.That(() => Apply(
+                "total",
+                payload,
+                SchemaRegistryRuleDirection.Write,
+                SchemaRuleKind.Condition))
+            .Throws<SchemaRegistryRuleException>()
+            .WithMessageContaining("must evaluate to a boolean");
+    }
+
+    [Test]
+    public async Task TransformRule_UndefinedResult_FailsPredictably()
+    {
+        await Assert.That(() => Apply(
+                "missing",
+                """{"present":1}"""u8.ToArray(),
+                SchemaRegistryRuleDirection.Write))
+            .Throws<SchemaRegistryRuleException>()
+            .WithMessageContaining("evaluated to undefined");
+    }
+
+    [Test]
+    public async Task InvalidExpression_MalformedPayload_AndBinaryFormat_FailWithoutPayloadLeak()
+    {
+        const string secret = "do-not-leak-this-payload";
+        var malformed = Encoding.UTF8.GetBytes("{\"secret\":\"" + secret + "\"");
+
+        var invalidExpression = await Assert.That(() => Apply(
+                "foo[",
+                "{}"u8.ToArray(),
+                SchemaRegistryRuleDirection.Write))
+            .Throws<SchemaRegistryRuleException>();
+        await Assert.That(invalidExpression!.Message).Contains("expression is invalid");
+
+        var invalidPayload = await Assert.That(() => Apply(
+                "$",
+                malformed,
+                SchemaRegistryRuleDirection.Write))
+            .Throws<SchemaRegistryRuleException>();
+        await Assert.That(invalidPayload!.Message).Contains("payload is not valid JSON");
+        await Assert.That(invalidPayload.Message).DoesNotContain(secret);
+
+        var unsupported = await Assert.That(() => Apply(
+                "$",
+                "{}"u8.ToArray(),
+                SchemaRegistryRuleDirection.Write,
+                payloadFormat: SchemaRegistryPayloadFormat.Avro))
+            .Throws<SchemaRegistryRuleException>();
+        await Assert.That(unsupported!.Message).Contains("requires a JSON payload");
+    }
+
+    [Test]
+    public async Task TransformRule_OversizedOutputBuffer_IsNotRetained()
+    {
+        const int maxRetainedOutputBufferSize = 1024 * 1024;
+        var value = new string('x', maxRetainedOutputBufferSize + 1);
+        var payload = Encoding.UTF8.GetBytes($$"""{"value":"{{value}}"}""");
+
+        var output = Apply("$", payload, SchemaRegistryRuleDirection.Write);
+        var retained = (byte[]?)typeof(JsonataSchemaRegistryRuleHandler)
+            .GetField("t_outputBuffer", BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetValue(null);
+
+        await Assert.That(retained is null || retained.Length <= maxRetainedOutputBufferSize).IsTrue();
+        GC.KeepAlive(output);
+    }
+
+    [Test]
+    public async Task Handler_ConcurrentEvaluation_ReusesCompiledQuerySafely()
+    {
+        var handler = new JsonataSchemaRegistryRuleHandler();
+        var schema = CreateSchema("$merge([$, {'double': value * 2}])");
+        var executor = new SchemaRegistryRuleExecutor([handler]);
+        var failures = new System.Collections.Concurrent.ConcurrentQueue<int>();
+
+        Parallel.For(0, 128, value =>
+        {
+            var context = CreateContext(schema);
+            var input = Encoding.UTF8.GetBytes($"{{\"value\":{value.ToString(System.Globalization.CultureInfo.InvariantCulture)}}}");
+            var output = executor.TransformSerializedPayload(input, context);
+            using var document = JsonDocument.Parse(output);
+            if (document.RootElement.GetProperty("double").GetInt32() != value * 2)
+                failures.Enqueue(value);
+        });
+
+        await Assert.That(failures).IsEmpty();
+    }
+
+    [Test]
+    public async Task MigrationRunner_JsonataUpgrade_TransformsBeforeReaderDeserialization()
+    {
+        var v1 = new Schema { SchemaType = SchemaType.Json, SchemaString = "v1" };
+        var v2 = CreateSchema(
+            "$merge([$, {'fullName': first & ' ' & last}])",
+            SchemaRuleMode.Upgrade,
+            migration: true);
+        var registry = new MigrationRegistryClient(v1, v2);
+        var executor = new SchemaRegistryRuleExecutor([new JsonataSchemaRegistryRuleHandler()]);
+        var runner = new SchemaRegistryMigrationRunner(registry, executor, TimeSpan.FromSeconds(1));
+
+        var result = runner.Transform(
+            """{"first":"Ada","last":"Lovelace"}"""u8.ToArray(),
+            schemaId: 1,
+            "orders-value",
+            v1,
+            SerializationContext,
+            SchemaRegistryPayloadFormat.Json);
+
+        using var document = JsonDocument.Parse(result.Payload);
+        await Assert.That(document.RootElement.GetProperty("fullName").GetString()).IsEqualTo("Ada Lovelace");
+        await Assert.That(result.ReaderSchema.Schema).IsSameReferenceAs(v2);
+    }
+
+    private static ReadOnlyMemory<byte> Apply(
+        string expression,
+        byte[] payload,
+        SchemaRegistryRuleDirection direction,
+        SchemaRuleKind kind = SchemaRuleKind.Transform,
+        SchemaRegistryPayloadFormat payloadFormat = SchemaRegistryPayloadFormat.Json)
+    {
+        var schema = CreateSchema(expression, kind: kind);
+        var executor = new SchemaRegistryRuleExecutor([new JsonataSchemaRegistryRuleHandler()]);
+        var context = CreateContext(schema, payloadFormat);
+        return direction == SchemaRegistryRuleDirection.Write
+            ? executor.TransformSerializedPayload(payload, context)
+            : executor.TransformDeserializedPayload(payload, context);
+    }
+
+    private static Schema CreateSchema(
+        string expression,
+        SchemaRuleMode mode = SchemaRuleMode.WriteRead,
+        SchemaRuleKind kind = SchemaRuleKind.Transform,
+        bool migration = false)
+    {
+        var rule = new SchemaRule
+        {
+            Name = "jsonata-test",
+            Kind = kind,
+            Mode = mode,
+            Type = JsonataSchemaRegistryRuleHandler.RuleType,
+            Expr = expression
+        };
+        return new Schema
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = "{}",
+            RuleSet = migration
+                ? new SchemaRuleSet { MigrationRules = [rule] }
+                : new SchemaRuleSet { DomainRules = [rule], HasFixedRuleCollections = true }
+        };
+    }
+
+    private static SchemaRegistryRuleContext CreateContext(
+        Schema schema,
+        SchemaRegistryPayloadFormat payloadFormat = SchemaRegistryPayloadFormat.Json) =>
+        new()
+        {
+            Topic = "orders",
+            Component = SerializationComponent.Value,
+            SchemaId = 1,
+            Subject = "orders-value",
+            Schema = schema,
+            PayloadFormat = payloadFormat
+        };
+
+    private sealed class MigrationRegistryClient(Schema writer, Schema reader) : ISchemaRegistryClient
+    {
+        private readonly RegisteredSchema _writer = new()
+        {
+            Id = 1,
+            Subject = "orders-value",
+            Version = 1,
+            Schema = writer
+        };
+        private readonly RegisteredSchema _reader = new()
+        {
+            Id = 2,
+            Subject = "orders-value",
+            Version = 2,
+            Schema = reader
+        };
+
+        public Task<Schema> GetSchemaAsync(int id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(id == 1 ? _writer.Schema : _reader.Schema);
+
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(
+            string subject,
+            string version = "latest",
+            CancellationToken cancellationToken = default) => Task.FromResult(_reader);
+
+        public Task<RegisteredSchema> LookupSchemaAsync(
+            string subject,
+            Schema schema,
+            bool ignoreDeletedSchemas = true,
+            bool normalize = false,
+            CancellationToken cancellationToken = default) => Task.FromResult(_writer);
+
+        public Task<int> RegisterSchemaAsync(
+            string subject,
+            Schema schema,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<int> GetOrRegisterSchemaAsync(
+            string subject,
+            Schema schema,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<string>> GetAllSubjectsAsync(
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> GetVersionsAsync(
+            string subject,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<bool> IsCompatibleAsync(
+            string subject,
+            Schema schema,
+            string version = "latest",
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> DeleteSubjectAsync(
+            string subject,
+            bool permanent = false,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistryJsonataRuleBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistryJsonataRuleBenchmarks.cs
@@ -1,0 +1,70 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Jsonata;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Guards no-rule and disabled-rule allocations while reporting enabled JSONata cost separately.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(launchCount: 1, warmupCount: 3, iterationCount: 10)]
+public class SchemaRegistryJsonataRuleBenchmarks
+{
+    private static readonly byte[] Payload = """{"left":20,"right":22}"""u8.ToArray();
+
+    private readonly SchemaRegistryRuleExecutor _executor =
+        new([new JsonataSchemaRegistryRuleHandler()]);
+    private readonly SchemaRegistryRuleContext _withoutRules = CreateContext(rule: null);
+    private readonly SchemaRegistryRuleContext _disabledRule = CreateContext(CreateRule(disabled: true));
+    private readonly SchemaRegistryRuleContext _activeRule = CreateContext(CreateRule(disabled: false));
+
+    [GlobalSetup]
+    public void WarmEnabledPath() => _ = ActiveJsonataRule();
+
+    [Benchmark(Baseline = true)]
+    public ReadOnlyMemory<byte> NoJsonataRule() =>
+        _executor.TransformSerializedPayload(Payload, _withoutRules);
+
+    [Benchmark]
+    public ReadOnlyMemory<byte> DisabledJsonataRule() =>
+        _executor.TransformSerializedPayload(Payload, _disabledRule);
+
+    [Benchmark]
+    public ReadOnlyMemory<byte> ActiveJsonataRule() =>
+        _executor.TransformSerializedPayload(Payload, _activeRule);
+
+    private static SchemaRegistryRuleContext CreateContext(SchemaRule? rule) =>
+        new()
+        {
+            Topic = "benchmark-topic",
+            Component = SerializationComponent.Value,
+            SchemaId = 1,
+            Subject = "benchmark-topic-value",
+            Schema = new Schema
+            {
+                SchemaType = SchemaType.Json,
+                SchemaString = "{}",
+                RuleSet = rule is null
+                    ? null
+                    : new SchemaRuleSet
+                    {
+                        DomainRules = [rule],
+                        HasFixedRuleCollections = true
+                    }
+            },
+            PayloadFormat = SchemaRegistryPayloadFormat.Json
+        };
+
+    private static SchemaRule CreateRule(bool disabled) =>
+        new()
+        {
+            Name = "jsonata-benchmark",
+            Kind = SchemaRuleKind.Transform,
+            Mode = SchemaRuleMode.Write,
+            Type = JsonataSchemaRegistryRuleHandler.RuleType,
+            Expr = "$merge([$, {'sum': left + right}])",
+            Disabled = disabled
+        };
+}

--- a/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
+++ b/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\src\Dekaf.Serialization.Routing\Dekaf.Serialization.Routing.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Avro\Dekaf.SchemaRegistry.Avro.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Json\Dekaf.SchemaRegistry.Json.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Jsonata\Dekaf.SchemaRegistry.Jsonata.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Vault\Dekaf.SchemaRegistry.Kms.Vault.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Kms.Aws\Dekaf.SchemaRegistry.Kms.Aws.csproj" />


### PR DESCRIPTION
## Summary
- add optional `Dekaf.SchemaRegistry.Jsonata` package with cached JSONata transform/condition execution
- cover write, read, migration, errors, concurrency, and oversized-buffer retention
- document JSON-only semantics and keep JSONata dependencies outside base package

## Test plan
- [x] `dotnet build --configuration Release` (0 warnings, 0 errors)
- [x] full unit net10.0: 7,250/7,250
- [x] full unit net8.0: 7,114/7,114
- [x] Schema Registry integration: 1/1 with Docker
- [x] docs production build
- [x] NuGet vulnerability audit: no findings for new package
- [x] `/simplify` and self-review

## Performance
BenchmarkDotNet 0.15.8, .NET 10.0.11, 10 iterations / 3 warmups:

| Path | Mean | Allocated |
|---|---:|---:|
| no JSONata rule | 4.876 ns | 0 B |
| disabled JSONata rule | 9.878 ns | 0 B |
| active JSONata transform | 1.012 us | 4,744 B |

Maintainer explicitly approved the active opt-in `4,744 B/op` exception in #2691. Absent and disabled paths remain allocation-free.

Closes #2691
