### PR TITLE
fix: eliminate topic recreation and NativeAOT flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
     name: NativeAOT Smoke
     needs: changes
     if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
 
     steps:
@@ -390,8 +390,10 @@ jobs:
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
           restore-keys: nuget-${{ runner.os }}-
 
-      - name: Install NativeAOT prerequisites
-        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+      - name: Verify NativeAOT prerequisites
+        run: |
+          clang-18 --version
+          test -f /usr/include/zlib.h
 
       - name: Publish and run core smoke test
         run: |
@@ -402,6 +404,7 @@ jobs:
             --self-contained true \
             --output artifacts/aot/core \
             -p:PublishAot=true \
+            -p:CppCompilerAndLinker=clang-18 \
             -p:ContinuousIntegrationBuild=true \
             -p:TreatWarningsAsErrors=true
           ./artifacts/aot/core/Dekaf.Tests.Aot
@@ -415,6 +418,7 @@ jobs:
             --self-contained true \
             --output artifacts/aot/dependency-injection \
             -p:PublishAot=true \
+            -p:CppCompilerAndLinker=clang-18 \
             -p:ContinuousIntegrationBuild=true \
             -p:TreatWarningsAsErrors=true
           ./artifacts/aot/dependency-injection/Dekaf.Tests.Aot.DependencyInjection
@@ -423,7 +427,7 @@ jobs:
     name: NativeAOT Integration Publish
     needs: changes
     if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
 
     steps:
@@ -443,8 +447,10 @@ jobs:
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
           restore-keys: nuget-${{ runner.os }}-
 
-      - name: Install NativeAOT prerequisites
-        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+      - name: Verify NativeAOT prerequisites
+        run: |
+          clang-18 --version
+          test -f /usr/include/zlib.h
 
       - name: Publish NativeAOT integration executable
         run: |
@@ -455,6 +461,7 @@ jobs:
             --self-contained true \
             --output artifacts/aot/integration \
             -p:PublishAot=true \
+            -p:CppCompilerAndLinker=clang-18 \
             -p:ContinuousIntegrationBuild=true \
             -p:TreatWarningsAsErrors=true
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -8440,8 +8440,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             if (changedTopics is not null)
             {
-                _coordinator?.RequestRejoin();
-
                 var recreatedPartitions = new HashSet<TopicPartition>();
                 foreach (var partition in assignment)
                 {
@@ -8514,6 +8512,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                 foreach (var (topic, identities) in changedTopics)
                     _observedTopicIds[topic] = identities.Current;
+
+                // Publish recreated-topic state before allowing a background poll to rejoin.
+                // Rejoining first can stage a temporary revocation; the reset's stale-fetch
+                // guard then skips the reset and leaves the old topic's committed position.
+                _coordinator?.RequestRejoin();
             }
 
             // Publish only if no assignment snapshot replaced the marker while resets awaited.

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -1324,6 +1324,62 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task TopicIdentityChange_ResetsBeforeRequestingRejoin()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        metadataManager.SetApiVersion(
+            ApiKey.ListOffsets,
+            ListOffsetsRequest.LowestSupportedVersion,
+            ListOffsetsRequest.HighestSupportedVersion);
+        await using var consumer = CreateGroupConsumer(
+            connectionPool,
+            metadataManager,
+            autoOffsetReset: AutoOffsetReset.ByDuration,
+            autoOffsetResetDuration: TimeSpan.FromMinutes(1));
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([
+            new TopicPartitionOffset(partition.Topic, partition.Partition, 10)
+        ]);
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+
+        var coordinator = GetCoordinator(consumer);
+        SetCoordinatorState(coordinator, CoordinatorState.Stable);
+        var resetStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseReset = new TaskCompletionSource<ListOffsetsResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                Arg.Any<ListOffsetsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                resetStarted.TrySetResult();
+                return new ValueTask<ListOffsetsResponse>(releaseReset.Task);
+            });
+
+        metadataManager.Metadata.Update(CreateMetadataResponse(Guid.NewGuid(), partitionCount: 2));
+        var recovery = InvokeHandleTopicIdentityChangesAsync(consumer).AsTask();
+        await resetStarted.Task;
+
+        try
+        {
+            await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+            await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(10L);
+        }
+        finally
+        {
+            releaseReset.TrySetResult(CreateListOffsetsResponse(partition.Partition, 100));
+            await recovery;
+        }
+
+        await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(100L);
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
+    }
+
+    [Test]
     public async Task TopicIdentityChange_AssignmentMutationDuringReset_IsReobserved()
     {
         var connectionPool = Substitute.For<IConnectionPool>();
@@ -2444,6 +2500,16 @@ public sealed class ConsumerAssignmentFastPathTests
             ?? throw new InvalidOperationException("_coordinator field not found.");
 
         return (ConsumerCoordinator)field.GetValue(consumer)!;
+    }
+
+    private static void SetCoordinatorState(ConsumerCoordinator coordinator, CoordinatorState state)
+    {
+        var field = typeof(ConsumerCoordinator).GetField(
+            "_state",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_state field not found.");
+
+        field.SetValue(coordinator, state);
     }
 
     private static long GetPollVersion(KafkaConsumer<string, string> consumer)


### PR DESCRIPTION
## Summary

- reset recreated-topic fetch positions before requesting a consumer-group rejoin
- add a deterministic synchronization test proving rejoin cannot race ahead of the offset reset
- preserve the existing assignment-version guard and zero-allocation unchanged-metadata fast path

## CI retry audit

Source run: https://github.com/thomhurst/Dekaf/actions/runs/31879352660

| Attempt | Result | Test failures |
| --- | --- | --- |
| 1 | Cancelled | None found. Active AOT lanes had zero failures when the rerun cancelled them. |
| 2 | Failed | `Commit_AgainstRecreatedTopic_DoesNotResurrectStaleOffsets` timed out after 120 s in five fault lanes: net8/Kafka 4.0.2, 4.1.2, 4.2.1 and net10/Kafka 4.1.2, 4.2.1. |
| 3 | Failed | Same 120 s timeout in net8/Kafka 4.2.1 and net10/Kafka 4.1.2, 4.2.1. |
| 4 | Failed | Same timeout in net10/Kafka 4.2.1. |
| 5 | Failed | Same timeout in net10/Kafka 4.2.1. |
| 6 | Passed | No failures. |

Aggregate `CI Passed` failures were consequences of the failed/cancelled matrix jobs, not independent errors. The repeated `digest-mismatch: error` text in setup logs was an action input value, not a runtime failure.

## Root cause

Topic recreation requested a group rejoin before resetting the recreated partitions. A concurrent background poll could observe the rejoin, stage a temporary revocation, and make `ResetOffsetOutOfRangeAsync` reject the reset through its stale-fetch guard. The deleted topic's committed position then survived; log-divergence correction capped it to offset 1, permanently skipping the recreated topic's first record at offset 0. The integration test waited for that record until its 120-second timeout.

The failure artifact showed the bad sequence: topic identity changed and reset to old position 2, generation 2 joined, log truncation reset to 1, then timeout. The successful retry instead reset to earliest (`-2`) before rejoining.

## Validation

- `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- `dotnet build tests/Dekaf.Tests.Integration --configuration Release`
- `ConsumerAssignmentFastPathTests`: 47/47 pass on net8.0; 47/47 pass on net10.0
- recreated-topic integration test passes on net8.0/Kafka 4.2.1 and net10.0/Kafka 4.0.2, 4.1.2, 4.2.1, 4.3.1
- `dotnet format --verify-no-changes` on both changed files
- `/simplify` review: no safe further changes

## Performance

`TopicIdentityCheckBenchmarks`, ShortRun, .NET 10.0.11, i7-12700K:

| Benchmark | Before | After | Allocated before/after |
| --- | ---: | ---: | ---: |
| DelegateControl | 1.773 ns | 1.434 ns | 0 B / 0 B |
| UnchangedMetadataSnapshot | 2.439 ns | 2.384 ns | 0 B / 0 B |

The change only reorders work in the recreated-topic slow path. The unchanged-metadata hot path remains zero-allocation; timing deltas are within/improve on ShortRun noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when a recreated topic is detected.
  * Partition positions now reset and publish correctly before coordinator rejoin.
  * Coordinator state remains stable during recovery and transitions appropriately afterward.

* **Tests**
  * Added coverage for topic-identity recovery ordering and coordinator state transitions.

* **Chores**
  * Updated NativeAOT validation to use Ubuntu 24.04 and explicitly configured compiler tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



## PR CI follow-up

The first PR check exposed a second independent flake in `NativeAOT Integration Publish`: `apt-get update` stalled on `azure.archive.ubuntu.com` from 17:52:48 until the 20-minute job timeout at 18:11:46. The sibling NativeAOT smoke job completed the same install, confirming runner-mirror variance rather than a source failure.

Both NativeAOT jobs now pin `ubuntu-24.04`, verify its preinstalled `clang-18` and zlib headers without network access, and pass `CppCompilerAndLinker=clang-18` explicitly. This removes the flaky apt/mirror dependency while failing immediately if the pinned runner contract changes.

Additional validation:

- `.github/workflows/ci.yml` parses successfully with PyYAML
- `.github/scripts/test_action_pins.py` passes
- first PR run's Kafka 4.3.1 `faults` lane passed in 11m17s
- first PR run's Kafka 4.3.1 `consume` lane passed in 12m27s




## Final PR CI

Run https://github.com/thomhurst/Dekaf/actions/runs/32169952864 passed on its first attempt after hardening. Notable lanes:

- NativeAOT Smoke: 2m37s
- NativeAOT Integration Publish: 6m00s
- NativeAOT Kafka integration smoke: 6m59s
- Kafka 4.3.1 faults: 10m49s
- Kafka 4.3.1 consume: 11m17s
- CodeQL: passed in 21m15s

No retry was used.
