### PR TITLE
perf(producer): gate carry-over expiry scans

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -448,6 +448,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     {
         private readonly Dictionary<TopicPartition, List<BatchReference>> _partitions = new();
         private int _count;
+        // Conservative lower bound: additions lower it immediately; removals may leave an
+        // earlier value until the next expiry sweep recomputes it from live entries.
+        private long _earliestCreatedTicks = long.MaxValue;
         private bool _mayContainUnreadyBatch;
         private TopicPartition _readdedPrefixPartition;
         private int _readdedPrefixCount;
@@ -476,8 +479,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             }
 
             GetOrCreateQueue(batchRef.Batch.TopicPartition).Add(batchRef);
-            _count++;
-            _mayContainUnreadyBatch |= !batchRef.Batch.IsPreSerialized;
+            TrackAddedBatch(batchRef);
         }
 
         /// <summary>
@@ -493,8 +495,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             }
 
             GetOrCreateQueue(batchRef.Batch.TopicPartition).Insert(0, batchRef);
-            _count++;
-            _mayContainUnreadyBatch |= !batchRef.Batch.IsPreSerialized;
+            TrackAddedBatch(batchRef);
         }
 
         /// <summary>
@@ -512,7 +513,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             }
 
             queue.Insert(_readdedPrefixCount++, batchRef);
-            _count++;
+            TrackAddedBatch(batchRef);
         }
 
         /// <summary>
@@ -540,8 +541,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 insertIdx++;
 
             queue.Insert(insertIdx, batchRef);
-            _count++;
-            _mayContainUnreadyBatch |= !batchRef.Batch.IsPreSerialized;
+            TrackAddedBatch(batchRef);
         }
 
         private void AddLoopExitRedelivery(BatchReference batchRef)
@@ -554,8 +554,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 insertIdx++;
 
             queue.Insert(insertIdx, batchRef);
-            _count++;
-            _mayContainUnreadyBatch |= !batchRef.Batch.IsPreSerialized;
+            TrackAddedBatch(batchRef);
         }
 
         /// <summary>
@@ -579,6 +578,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
 
                 _count = 0;
+                _earliestCreatedTicks = long.MaxValue;
                 return;
             }
 
@@ -612,6 +612,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             }
 
             _mayContainUnreadyBatch = hasUnreadyBatch;
+            if (_count == 0)
+                _earliestCreatedTicks = long.MaxValue;
         }
 
         public void Clear()
@@ -619,6 +621,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             foreach (var kvp in _partitions)
                 kvp.Value.Clear();
             _count = 0;
+            _earliestCreatedTicks = long.MaxValue;
             _mayContainUnreadyBatch = false;
         }
 
@@ -626,6 +629,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         {
             queue.RemoveAt(index);
             _count--;
+            if (_count == 0)
+                _earliestCreatedTicks = long.MaxValue;
         }
 
         /// <summary>Clears one partition's queue in a single pass, keeping the count in sync.</summary>
@@ -633,6 +638,30 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         {
             _count -= queue.Count;
             queue.Clear();
+            if (_count == 0)
+                _earliestCreatedTicks = long.MaxValue;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool MayContainExpiredBatch(long now, long deliveryTimeoutTicks)
+        {
+            var earliestCreatedTicks = _earliestCreatedTicks;
+            return earliestCreatedTicks != long.MaxValue
+                && now >= earliestCreatedTicks + deliveryTimeoutTicks;
+        }
+
+        public void SetEarliestCreatedTicks(long earliestCreatedTicks)
+            => _earliestCreatedTicks = earliestCreatedTicks;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void TrackAddedBatch(BatchReference batchRef)
+        {
+            var batch = batchRef.Batch;
+            _count++;
+            _mayContainUnreadyBatch |= !batch.IsPreSerialized;
+
+            var createdTicks = batch.StopwatchCreatedTicks;
+            _earliestCreatedTicks = Math.Min(_earliestCreatedTicks, createdTicks);
         }
 
         public bool HasRetry(TopicPartition topicPartition)
@@ -5196,6 +5225,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     {
         var now = _getTimestamp();
         var deliveryTimeoutTicks = _options.DeliveryTimeoutTicks;
+        if (!carryOver.MayContainExpiredBatch(now, deliveryTimeoutTicks))
+            return;
+
+        var earliestCreatedTicks = long.MaxValue;
 
         foreach (var kvp in carryOver.Partitions)
         {
@@ -5210,8 +5243,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
 
                 var batch = batchRef.Batch;
-                if (now < batch.StopwatchCreatedTicks + deliveryTimeoutTicks)
+                var createdTicks = batch.StopwatchCreatedTicks;
+                if (now < createdTicks + deliveryTimeoutTicks)
+                {
+                    if (createdTicks < earliestCreatedTicks)
+                        earliestCreatedTicks = createdTicks;
                     continue;
+                }
 
                 if (batch.IsRetry)
                 {
@@ -5232,6 +5270,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 carryOver.RemoveAt(queue, i);
             }
         }
+
+        carryOver.SetEarliestCreatedTicks(earliestCreatedTicks);
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Producer/PartitionCarryOverExpiryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PartitionCarryOverExpiryTests.cs
@@ -1,0 +1,51 @@
+using Dekaf.Producer;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public sealed class PartitionCarryOverExpiryTests
+{
+    [Test]
+    public async Task MayContainExpiredBatch_TracksEarliestBatch()
+    {
+        const long Now = 10_000;
+        const long DeliveryTimeoutTicks = 1_000;
+        var carryOver = new BrokerSender.PartitionCarryOver();
+
+        carryOver.Add(CreateBatchReference(partition: 0, createdTicks: 9_500));
+
+        await Assert.That(carryOver.MayContainExpiredBatch(Now, DeliveryTimeoutTicks)).IsFalse();
+
+        carryOver.Add(CreateBatchReference(partition: 1, createdTicks: 8_500));
+
+        await Assert.That(carryOver.MayContainExpiredBatch(Now, DeliveryTimeoutTicks)).IsTrue();
+    }
+
+    [Test]
+    public async Task MayContainExpiredBatch_EmptyAfterDrain_ReturnsFalse()
+    {
+        const long Now = 10_000;
+        var carryOver = new BrokerSender.PartitionCarryOver();
+        carryOver.Add(CreateBatchReference(partition: 0, createdTicks: 1));
+
+        carryOver.DrainTo([]);
+
+        await Assert.That(carryOver.Count).IsEqualTo(0);
+        await Assert.That(carryOver.MayContainExpiredBatch(Now, deliveryTimeoutTicks: 1)).IsFalse();
+    }
+
+    private static BrokerSender.BatchReference CreateBatchReference(int partition, long createdTicks)
+    {
+        var batch = new ReadyBatch();
+        batch.Initialize(
+            new TopicPartition("carry-over-expiry", partition),
+            new RecordBatch { Records = [] },
+            completionSourcesArray: null,
+            completionSourcesCount: 0,
+            recordCount: 0,
+            dataSize: 0,
+            createdStopwatchTimestamp: createdTicks);
+        batch.MarkPreSerialized();
+        return new BrokerSender.BatchReference(batch, batch.Generation);
+    }
+}


### PR DESCRIPTION
## Summary

- cache the earliest carry-over batch creation timestamp
- skip the O(partitions × queued batches) delivery-expiry sweep until expiration is possible
- recompute the conservative hint after a real sweep and reset it when carry-over empties
- preserve zero allocation and existing stale-incarnation cleanup semantics

## Root cause

`SweepExpiredCarryOver` ran after every coalescing pass while carry-over was non-empty. Most calls happened well before any delivery deadline, but still enumerated every carry-over partition and batch. CPU profiling attributed 13.49% of sampled sender CPU to this sweep under sustained production.

The new hint is conservative: additions lower it immediately; removals may leave an earlier timestamp, causing at worst an unnecessary sweep. It cannot defer an expired batch.

## Benchmark evidence

Environment: BenchmarkDotNet 0.15.8, .NET 10.0.11, Windows 11, Intel i7-12700K. Ten measurement iterations, five warmups. The temporary validation benchmark compared the previous scan and the new guard side-by-side; it was removed after measurement because it is change-validation-only.

| Carry-over shape | Previous scan | Earliest-deadline guard | Delta | Allocated |
|---|---:|---:|---:|---:|
| 1 partition × 1 batch | 1.7764 ns | 0.1266 ns | -92.9% | 0 B |
| 6 partitions × 3 batches | 21.6915 ns | 0.1179 ns | -99.5% | 0 B |
| 12 partitions × 3 batches | 41.1042 ns | 0.1166 ns | -99.7% | 0 B |
| 100 partitions × 3 batches | 490.3997 ns | 0.1272 ns | -99.97% | 0 B |

Secondary carry-over enqueue/drain gate:

| Metric | Baseline | Candidate | Delta |
|---|---:|---:|---:|
| Enqueue and drain ready retries | 17.71 ns/batch | 17.46 ns/batch | -1.4% |
| Allocation | 0 B | 0 B | unchanged |

## Exact-SHA producer gate

[Stress run 32243029084](https://github.com/thomhurst/Dekaf/actions/runs/32243029084) ran the `producer-1b` lane for five minutes per segment on one paid runner: baseline `b4273eca045192f9a8f9ff1b720cc2086063c87e` → candidate `4e68a0fc871616e12ee83ef078195e6348644b60` → baseline.

**Formal verdict: PASS**

| Metric | Baseline A | Candidate B | Baseline A2 | B vs baseline mean | Gate |
|---|---:|---:|---:|---:|---|
| Delivered throughput | 1,325,141 msg/s | 1,418,100 msg/s | 1,435,286 msg/s | +2.74% | pass |
| Median interval throughput | 1,318,446 msg/s | 1,408,251 msg/s | 1,448,055 msg/s | +1.81% | pass |
| Latency p50 | 12.650 ms | 8.450 ms | 9.450 ms | -23.53% | pass |
| Latency p95 | 19.050 ms | 13.350 ms | 13.550 ms | -18.10% | pass |
| Latency p99 | 27.550 ms | 18.350 ms | 20.450 ms | -23.54% | pass |
| CPU | 0.812 µs/msg | 0.796 µs/msg | 0.767 µs/msg | +0.78% | pass |
| Allocation | 0.881 B/msg | 0.550 B/msg | 0.586 B/msg | -25.01% | pass |
| Steady/peak ratio | 0.927 | 1.000 | 0.944 | +6.93% | pass |
| Maximum latency | 105.795 ms | 73.360 ms | 99.900 ms | -28.67% | recorded |
| Average request | 1,023 KiB | 1,019 KiB | 1,023 KiB | -0.35% | recorded |

Baseline throughput controls drifted 7.98–9.37%, below the comparator's 10% maximum. Allocation control drift was high, so the allocation decrease is not claimed as a causal improvement; the formal gate nevertheless found no protected-metric regression.

## Validation

- `dotnet build --configuration Release`: passed, 0 warnings/errors
- complete net10 unit suite: 7,439 passed, 0 failed
- focused expiry tests: 2 passed
- BenchmarkDotNet expiry and enqueue/drain gates: 0 B
- exact-SHA producer A-B-A stress gate: PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved expired-batch detection by tracking the earliest batch creation time.
  * Skips unnecessary expiration scans when no batches can have expired.
  * Recalculates expiration state after batches are removed or cleared.

* **Bug Fixes**
  * Ensured expiration tracking resets correctly when all queued batches are drained.

* **Tests**
  * Added coverage for expiration tracking across partitions and empty queues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->