### PR TITLE
perf(producer): avoid traced message clones

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -639,12 +639,12 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         // Apply OnSend interceptors before serialization
         message = ApplyOnSendInterceptors(message);
 
-        var activity = StartPublishActivity(ref message);
+        var activity = StartPublishActivity(message, out var headers);
 
         // Async serializers (per-message I/O, issue #2309) cannot run on the synchronous fast
         // path — divert to the dedicated async-serialization path before any sync serialize.
         if (_hasAsyncSerializers)
-            return ProduceWithAsyncSerializationAsync(message, activity, continuationMode, cancellationToken);
+            return ProduceWithAsyncSerializationAsync(message, headers, activity, continuationMode, cancellationToken);
 
         // If a serializer needs async setup (e.g. a one-time Schema Registry fetch), do it here on the
         // async path so the synchronous serialize never blocks on it. After the first message for a
@@ -654,13 +654,13 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             ValueTask prepare;
             try
             {
-                prepare = PrepareSerializersAsync(message.Topic, message.Key, message.Value, message.Headers, cancellationToken);
+                prepare = PrepareSerializersAsync(message.Topic, message.Key, message.Value, headers, cancellationToken);
             }
             catch (Exception ex)
             {
                 // A preparer that throws synchronously must still stop and tag the started span,
                 // matching the invariant AwaitWithActivity enforces on every other completion path.
-                RecordActivityFault(activity, message.Headers, ex);
+                RecordActivityFault(activity, headers, ex);
                 throw;
             }
 
@@ -669,13 +669,14 @@ public sealed partial class KafkaProducer<TKey, TValue> :
                 return AwaitPrepareThenProduce(
                     prepare,
                     message,
+                    headers,
                     activity,
                     continuationMode,
                     cancellationToken);
             }
         }
 
-        return ProduceAfterPrepare(message, activity, continuationMode, cancellationToken);
+        return ProduceAfterPrepare(message, headers, activity, continuationMode, cancellationToken);
     }
 
     // Stops and error-tags a started span when async serializer preparation fails before the
@@ -695,6 +696,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
 
     private ValueTask<RecordMetadata> ProduceAfterPrepare(
         ProducerMessage<TKey, TValue> message,
+        Headers? headers,
         Activity? activity,
         ProduceContinuationMode continuationMode,
         CancellationToken cancellationToken)
@@ -711,7 +713,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
 
         // Fast path: Try synchronous produce if metadata is initialized and cached.
         // This bypasses channel overhead for 99%+ of calls after warmup.
-        if (TryProduceSyncForAsync(message, runContinuationsAsynchronously, cancellationToken, out var completion))
+        if (TryProduceSyncForAsync(message, headers, runContinuationsAsynchronously, cancellationToken, out var completion))
         {
             // POST-QUEUE: Message appended to a batch (committed to being sent, cancellation
             // only stops the wait) or handed to the slow-path append worker under
@@ -733,12 +735,13 @@ public sealed partial class KafkaProducer<TKey, TValue> :
 
         // Slow path: Fall back to channel-based async processing.
         // This handles first-time metadata initialization or cache misses.
-        return ProduceAsyncSlow(message, activity, continuationMode, cancellationToken);
+        return ProduceAsyncSlow(message, headers, activity, continuationMode, cancellationToken);
     }
 
     private async ValueTask<RecordMetadata> AwaitPrepareThenProduce(
         ValueTask prepare,
         ProducerMessage<TKey, TValue> message,
+        Headers? headers,
         Activity? activity,
         ProduceContinuationMode continuationMode,
         CancellationToken cancellationToken)
@@ -751,12 +754,13 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         {
             // Preparation faulted (e.g. Schema Registry unreachable or cancelled mid-fetch) before the
             // message was appended. Stop and error-tag the span here; ProduceAfterPrepare never runs.
-            RecordActivityFault(activity, message.Headers, ex);
+            RecordActivityFault(activity, headers, ex);
             throw;
         }
 
         return await ProduceAfterPrepare(
             message,
+            headers,
             activity,
             continuationMode,
             cancellationToken).ConfigureAwait(false);
@@ -864,6 +868,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
                     Partition = partition,
                     Timestamp = timestamp
                 },
+                headers,
                 activity: null,
                 continuationMode,
                 cancellationToken);
@@ -926,15 +931,20 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         }
 
         // Cold path: metadata miss only — allocate the full message for the async metadata fetch.
-        return ProduceAsyncSlow(new ProducerMessage<TKey, TValue>
-        {
-            Topic = topic,
-            Key = key,
-            Value = value,
-            Headers = headers,
-            Partition = partition,
-            Timestamp = timestamp
-        }, activity: null, continuationMode, cancellationToken);
+        return ProduceAsyncSlow(
+            new ProducerMessage<TKey, TValue>
+            {
+                Topic = topic,
+                Key = key,
+                Value = value,
+                Headers = headers,
+                Partition = partition,
+                Timestamp = timestamp
+            },
+            headers,
+            activity: null,
+            continuationMode,
+            cancellationToken);
     }
 
     private async ValueTask<RecordMetadata> AwaitPrepareThenProduce(
@@ -1099,6 +1109,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryProduceSyncForAsync(
         ProducerMessage<TKey, TValue> message,
+        Headers? headers,
         bool runContinuationsAsynchronously,
         CancellationToken cancellationToken,
         out PooledValueTaskSource<RecordMetadata>? completion)
@@ -1106,7 +1117,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             message.Topic,
             message.Key,
             message.Value,
-            message.Headers,
+            headers,
             message.Partition,
             message.Timestamp,
             runContinuationsAsynchronously,
@@ -1178,6 +1189,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
     [MethodImpl(MethodImplOptions.NoInlining)]
     private async ValueTask<RecordMetadata> ProduceAsyncSlow(
         ProducerMessage<TKey, TValue> message,
+        Headers? headers,
         Activity? activity,
         ProduceContinuationMode continuationMode,
         CancellationToken cancellationToken)
@@ -1191,7 +1203,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         var runContinuationsAsynchronously = continuationMode == ProduceContinuationMode.Async;
 
         // Retry fast path - metadata should already be initialized via InitializeAsync()
-        if (TryProduceSyncForAsync(message, runContinuationsAsynchronously, cancellationToken, out var fastCompletion))
+        if (TryProduceSyncForAsync(message, headers, runContinuationsAsynchronously, cancellationToken, out var fastCompletion))
         {
             return await AwaitProduceCompletionAsync(fastCompletion!, activity, metricsEnabled, message.Topic, cancellationToken).ConfigureAwait(false);
         }
@@ -1200,7 +1212,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         var completion = RentCompletion(runContinuationsAsynchronously);
         try
         {
-            await ProduceInternalAsync(message, completion, cancellationToken).ConfigureAwait(false);
+            await ProduceInternalAsync(message, headers, completion, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -1234,12 +1246,12 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         // Apply OnSend interceptors before serialization
         message = ApplyOnSendInterceptors(message);
 
-        var activity = StartPublishActivity(ref message);
+        var activity = StartPublishActivity(message, out var headers);
 
         // Async serializers cannot run on the synchronous append path — serialize on the async
         // path, then enqueue. Delivery errors are observed and logged (fire-and-forget contract).
         if (_hasAsyncSerializers)
-            return FireWithAsyncSerializationAsync(message, activity, deliveryHandler: null);
+            return FireWithAsyncSerializationAsync(message, headers, activity, deliveryHandler: null);
 
         // Fast path: try thread-local cached topic metadata first
         var inThreadLocalCache = TryGetCachedTopicInfo(message.Topic, out var topicInfo);
@@ -1251,7 +1263,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
 
             try
             {
-                var appendResult = SerializeAndAppendFromSpansAsync(message.Topic, message.Key, message.Value, message.Headers, message.Partition, message.Timestamp, topicInfo!, null);
+                var appendResult = SerializeAndAppendFromSpansAsync(message.Topic, message.Key, message.Value, headers, message.Partition, message.Timestamp, topicInfo!, null);
 
                 if (appendResult.IsCompleted)
                 {
@@ -1270,7 +1282,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             {
                 // BufferMemory backpressure timeout must propagate
                 if (activity is not null) Diagnostics.DekafDiagnostics.RecordException(activity, ex);
-                message.Headers?.RemoveDeferredTraceContext();
+                headers?.RemoveDeferredTraceContext();
                 activity?.Dispose();
                 throw;
             }
@@ -1278,14 +1290,14 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             {
                 // Fire-and-forget: swallow exception but log
                 LogFireAndForgetProduceFailed(ex, message.Topic);
-                message.Headers?.RemoveDeferredTraceContext();
+                headers?.RemoveDeferredTraceContext();
                 activity?.Dispose();
                 return default;
             }
         }
 
         // Metadata miss — full async path
-        return FireAsyncSlow(message, activity);
+        return FireAsyncSlow(message, headers, activity);
     }
 
     /// <inheritdoc />
@@ -1306,6 +1318,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         {
             return FireWithAsyncSerializationAsync(
                 new ProducerMessage<TKey, TValue> { Topic = topic, Key = key, Value = value },
+                headers: null,
                 activity: null,
                 deliveryHandler: null);
         }
@@ -1341,7 +1354,9 @@ public sealed partial class KafkaProducer<TKey, TValue> :
 
         // Metadata miss — allocate ProducerMessage only on cold path
         return FireAsyncSlow(
-            new ProducerMessage<TKey, TValue> { Topic = topic, Key = key, Value = value }, activity: null);
+            new ProducerMessage<TKey, TValue> { Topic = topic, Key = key, Value = value },
+            headers: null,
+            activity: null);
     }
 
     /// <summary>
@@ -1633,9 +1648,13 @@ public sealed partial class KafkaProducer<TKey, TValue> :
     /// Starts a publish activity for tracing, guarded by HasListeners() to avoid
     /// string interpolation allocation when no diagnostic listener is attached.
     /// Sets standard OTel messaging tags and injects trace context into headers.
+    /// Returns the effective headers separately to avoid cloning the immutable message.
     /// </summary>
-    private Activity? StartPublishActivity(ref ProducerMessage<TKey, TValue> message)
+    private Activity? StartPublishActivity(
+        ProducerMessage<TKey, TValue> message,
+        out Headers? headers)
     {
+        headers = message.Headers;
         if (!Diagnostics.DekafDiagnostics.Source.HasListeners())
             return null;
 
@@ -1658,7 +1677,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
                 activity.SetTag(Diagnostics.DekafDiagnostics.MessagingMessageKey, message.Key.ToString());
             if (message.Value is null)
                 activity.SetTag(Diagnostics.DekafDiagnostics.MessagingKafkaTombstone, Diagnostics.DekafDiagnostics.BoxedTrue);
-            message = message with { Headers = Diagnostics.TraceContextPropagator.InjectTraceContext(message.Headers, activity) };
+            headers = Diagnostics.TraceContextPropagator.InjectTraceContext(headers, activity);
         }
 
         return activity;
@@ -1709,7 +1728,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         // Async serializers divert before the synchronous append path; the delivery handler is
         // invoked from a background observer when the batch completes (see FireAsync(message)).
         if (_hasAsyncSerializers)
-            return FireWithAsyncSerializationAsync(message, activity: null, deliveryHandler);
+            return FireWithAsyncSerializationAsync(message, message.Headers, activity: null, deliveryHandler);
 
         // Fast path: try thread-local cached topic metadata first
         var inThreadLocalCache = TryGetCachedTopicInfo(message.Topic, out var topicInfo);
@@ -1749,6 +1768,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
 
     private async ValueTask ProduceInternalAsync(
         ProducerMessage<TKey, TValue> message,
+        Headers? headers,
         PooledValueTaskSource<RecordMetadata> completion,
         CancellationToken cancellationToken)
     {
@@ -1807,8 +1827,8 @@ public sealed partial class KafkaProducer<TKey, TValue> :
                 key = _asyncKeySerializer is not null
                     ? await SerializeToPooledAsync(
                         _asyncKeySerializer, message.Key!, message.Topic,
-                        SerializationComponent.Key, message.Headers, cancellationToken).ConfigureAwait(false)
-                    : SerializeKeyToPooled(message.Key!, message.Topic, message.Headers);
+                        SerializationComponent.Key, headers, cancellationToken).ConfigureAwait(false)
+                    : SerializeKeyToPooled(message.Key!, message.Topic, headers);
             }
 
             if (!valueIsNull)
@@ -1816,8 +1836,8 @@ public sealed partial class KafkaProducer<TKey, TValue> :
                 value = _asyncValueSerializer is not null
                     ? await SerializeToPooledAsync(
                         _asyncValueSerializer, message.Value!, message.Topic,
-                        SerializationComponent.Value, message.Headers, cancellationToken).ConfigureAwait(false)
-                    : SerializeValueToPooled(message.Value!, message.Topic, message.Headers);
+                        SerializationComponent.Value, headers, cancellationToken).ConfigureAwait(false)
+                    : SerializeValueToPooled(message.Value!, message.Topic, headers);
             }
 
             // Determine partition
@@ -1831,9 +1851,9 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             var timestampMs = timestamp.ToUnixTimeMilliseconds();
 
             // Convert headers with minimal allocations
-            if (message.Headers is not null && message.Headers.Count > 0)
+            if (headers is not null && headers.Count > 0)
             {
-                RentAndFillHeaders(message.Headers, out pooledHeaderArray, out headerCount);
+                RentAndFillHeaders(headers, out pooledHeaderArray, out headerCount);
             }
 
             // Enqueue to per-partition-affine worker instead of calling AppendAsync inline.
@@ -1857,7 +1877,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             key.Return();
             value.Return();
             RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray, headerCount);
-            message.Headers?.RemoveDeferredTraceContext();
+            headers?.RemoveDeferredTraceContext();
             throw;
         }
     }
@@ -4453,6 +4473,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
     [MethodImpl(MethodImplOptions.NoInlining)]
     private async ValueTask FireAsyncSlow(
         ProducerMessage<TKey, TValue> message,
+        Headers? headers,
         Activity? activity)
     {
         try
@@ -4480,7 +4501,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
 
             UpdateCachedTopicInfo(message.Topic, topicInfo);
 
-            var appendResult = await SerializeAndAppendFromSpansAsync(message.Topic, message.Key, message.Value, message.Headers, message.Partition, message.Timestamp, topicInfo, null).ConfigureAwait(false);
+            var appendResult = await SerializeAndAppendFromSpansAsync(message.Topic, message.Key, message.Value, headers, message.Partition, message.Timestamp, topicInfo, null).ConfigureAwait(false);
 
             if (!appendResult)
                 throw new ObjectDisposedException(nameof(KafkaProducer<TKey, TValue>));
@@ -4498,7 +4519,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         }
         finally
         {
-            message.Headers?.RemoveDeferredTraceContext();
+            headers?.RemoveDeferredTraceContext();
             activity?.Dispose();
         }
     }
@@ -4939,6 +4960,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
     /// </summary>
     private async ValueTask<RecordMetadata> ProduceWithAsyncSerializationAsync(
         ProducerMessage<TKey, TValue> message,
+        Headers? headers,
         Activity? activity,
         ProduceContinuationMode continuationMode,
         CancellationToken cancellationToken)
@@ -4953,7 +4975,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         var completion = RentCompletion(runContinuationsAsynchronously);
         try
         {
-            await ProduceInternalAsync(message, completion, cancellationToken).ConfigureAwait(false);
+            await ProduceInternalAsync(message, headers, completion, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -5035,6 +5057,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
 #endif
     private async ValueTask FireWithAsyncSerializationAsync(
         ProducerMessage<TKey, TValue> message,
+        Headers? headers,
         Activity? activity,
         Action<RecordMetadata, Exception?>? deliveryHandler)
     {
@@ -5085,8 +5108,8 @@ public sealed partial class KafkaProducer<TKey, TValue> :
                     key = _asyncKeySerializer is not null
                         ? await SerializeToPooledAsync(
                             _asyncKeySerializer, message.Key!, message.Topic,
-                            SerializationComponent.Key, message.Headers, CancellationToken.None).ConfigureAwait(false)
-                        : SerializeKeyToPooled(message.Key!, message.Topic, message.Headers);
+                            SerializationComponent.Key, headers, CancellationToken.None).ConfigureAwait(false)
+                        : SerializeKeyToPooled(message.Key!, message.Topic, headers);
                 }
 
                 if (!valueIsNull)
@@ -5094,13 +5117,13 @@ public sealed partial class KafkaProducer<TKey, TValue> :
                     value = _asyncValueSerializer is not null
                         ? await SerializeToPooledAsync(
                             _asyncValueSerializer, message.Value!, message.Topic,
-                            SerializationComponent.Value, message.Headers, CancellationToken.None).ConfigureAwait(false)
-                        : SerializeValueToPooled(message.Value!, message.Topic, message.Headers);
+                            SerializationComponent.Value, headers, CancellationToken.None).ConfigureAwait(false)
+                        : SerializeValueToPooled(message.Value!, message.Topic, headers);
                 }
 
                 var appendResult = await AppendSerializedToAccumulatorAsync(
                     message.Topic, key, keyIsNull, value, valueIsNull,
-                    message.Headers, message.Partition, message.Timestamp,
+                    headers, message.Partition, message.Timestamp,
                     topicInfo, deliveryHandler).ConfigureAwait(false);
 
                 if (!appendResult)
@@ -5137,7 +5160,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         }
         finally
         {
-            message.Headers?.RemoveDeferredTraceContext();
+            headers?.RemoveDeferredTraceContext();
             activity?.Dispose();
         }
     }

--- a/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
@@ -235,7 +235,8 @@ public sealed class KafkaClientStatusTests
             BindingFlags.NonPublic | BindingFlags.Instance)!;
         object?[] arguments =
         [
-            new ProducerMessage<string, string> { Topic = "orders", Key = "key", Value = "value" }
+            new ProducerMessage<string, string> { Topic = "orders", Key = "key", Value = "value" },
+            null
         ];
         return (Activity?)method.Invoke(producer, arguments);
     }

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -163,6 +163,50 @@ public class KafkaProducerFastPathTests
     }
 
     [Test]
+    public async Task FireAsync_Tracing_AppendsTraceHeaderWithoutReplacingMessage()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == DekafDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await using var producer = new KafkaProducer<string, string>(
+            new ProducerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = "test-producer",
+                BufferMemory = ulong.MaxValue,
+                BatchSize = 4096,
+                LingerMs = 10,
+                RequestTimeoutMs = 500,
+                DeliveryTimeoutMs = 1000,
+                CloseTimeoutMs = 1000
+            },
+            Serializers.String,
+            Serializers.String);
+        await StopProducerBackgroundLoopsAsync(producer);
+        SeedProducerMetadata(producer);
+        SetInstanceField(producer, "_initialized", true);
+        var message = new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Key = "key",
+            Value = "value"
+        };
+
+        await producer.FireAsync(message);
+
+        await Assert.That(message.Headers).IsNull();
+        var readyBatch = CompleteCurrentBatch(producer.RecordAccumulator, new TopicPartition(Topic, 0));
+        var record = readyBatch.RecordBatch.Records[0];
+        await Assert.That(record.HeaderCount).IsEqualTo(1);
+        await Assert.That(record.Headers![0].Key).IsEqualTo("traceparent");
+        readyBatch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow);
+    }
+
+    [Test]
     public async Task TransactionProduceAsync_CompletesContinuationInlineOnSenderThread()
     {
         var options = new ProducerOptions
@@ -653,17 +697,18 @@ public class KafkaProducerFastPathTests
             binder: null,
             [
                 typeof(ProducerMessage<string, string>),
+                typeof(Headers),
                 typeof(bool),
                 typeof(CancellationToken),
                 typeof(PooledValueTaskSource<RecordMetadata>).MakeByRefType()
             ],
             modifiers: null);
-        object?[] arguments = [message, runContinuationsAsynchronously, CancellationToken.None, null];
+        object?[] arguments = [message, message.Headers, runContinuationsAsynchronously, CancellationToken.None, null];
 
         try
         {
             var result = (bool)method!.Invoke(producer, arguments)!;
-            completion = (PooledValueTaskSource<RecordMetadata>?)arguments[3];
+            completion = (PooledValueTaskSource<RecordMetadata>?)arguments[4];
             return result;
         }
         catch (TargetInvocationException ex) when (ex.InnerException is not null)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/TransactionalProduceAllocationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/TransactionalProduceAllocationBenchmarks.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Reflection;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Engines;
@@ -6,7 +8,6 @@ using Dekaf.Metadata;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Producer;
-using System.Reflection;
 
 namespace Dekaf.Benchmarks.Benchmarks.Client;
 
@@ -37,6 +38,10 @@ public class TransactionalProduceAllocationBenchmarks
     private TopicPartition _topicPartition;
     private long _offset;
     private CancellationTokenSource _cancellation = null!;
+    private ActivityListener? _activityListener;
+
+    [Params(false, true)]
+    public bool TracingEnabled { get; set; }
 
     [GlobalSetup]
     public async Task Setup()
@@ -47,6 +52,15 @@ public class TransactionalProduceAllocationBenchmarks
             .WithBufferMemory(ulong.MaxValue)
             .WithLinger(TimeSpan.Zero)
             .Build();
+        if (TracingEnabled)
+        {
+            _activityListener = new ActivityListener
+            {
+                ShouldListenTo = static source => source.Name == Diagnostics.DekafDiagnostics.ActivitySourceName,
+                Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+            };
+            ActivitySource.AddActivityListener(_activityListener);
+        }
         var producer = (KafkaProducer<string, string>)_producer;
         await producer.StopSenderLoopsForTestingAsync();
 
@@ -66,6 +80,13 @@ public class TransactionalProduceAllocationBenchmarks
             Value = "value"
         };
         _cancellation = new CancellationTokenSource();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _activityListener?.Dispose();
+        _cancellation.Dispose();
     }
 
     [Benchmark(Baseline = true)]
@@ -113,6 +134,9 @@ public class TransactionalProduceAllocationBenchmarks
         }
 
         _ = produce.GetAwaiter().GetResult();
+        // AwaitWithActivity completes on a worker in this synchronous harness. Reset the
+        // benchmark thread's ambient span so later invocations do not become nested children.
+        Activity.Current = null;
     }
 
     private static void SeedMetadata(MetadataManager metadataManager) =>


### PR DESCRIPTION
## Summary

- stop cloning `ProducerMessage<TKey, TValue>` solely to carry injected trace headers
- thread the effective `Headers?` separately through sync, async-serializer, metadata-miss, and cleanup paths
- preserve caller-owned header restoration and immutable message semantics
- add regression coverage proving FireAsync emits `traceparent` without replacing `message.Headers`

## Performance proof

Exact baseline: `b4273eca045192f9a8f9ff1b720cc2086063c87e`
Candidate: `cb723f8946eaa6ec9a8e85001667ea7fa33bf507`

BenchmarkDotNet 0.15.8; .NET 10.0.11; Windows 11; i7-12700K; `ProducerFireHotPathBenchmarks`; 1,000-byte message; 12 partitions; delivery-latency target 0; 5 warmups + 10 measured iterations; `[MemoryDiagnoser]`.

| Tracing | Serializer | Before | After | CPU delta | Before alloc | After alloc | Alloc delta |
|---|---|---:|---:|---:|---:|---:|---:|
| off | standard | 214.6 ns | 217.2 ns | +1.2% | 0 B | 0 B | 0 B |
| off | prepared | 214.4 ns | 212.8 ns | -0.7% | 0 B | 0 B | 0 B |
| on | standard | 748.8 ns | 752.5 ns | +0.5% | 984 B | 904 B | -80 B (-8.1%) |
| on | prepared | 769.4 ns | 764.2 ns | -0.7% | 984 B | 920 B | -64 B (-6.5%) |

CPU confidence intervals overlap in every pair; no material CPU regression detected. The untraced hot path remains 0 B. Traced Gen0 frequency fell from 0.0745 to 0.0684 collections/1,000 operations.

### Awaited message-based `ProduceAsync`

Benchmark harness: `a0c198ff7146d83f8e93dc4f37542fffc0ee2d6f`. Same machine/runtime and exact harness on both product SHAs; `TransactionalProduceAllocationBenchmarks.ProducerProduceAsync`; 1,000 invocations/iteration; 5 warmups + 10 measured iterations; `[MemoryDiagnoser]`.

| Tracing | Before | After | CPU delta | Before alloc | After alloc | Alloc delta |
|---|---:|---:|---:|---:|---:|---:|
| off | 3.383 us | 3.257 us | -3.7% | 0 B | 0 B | 0 B |
| on | 7.817 us | 7.830 us | +0.17% | 1368 B | 1288 B | -80 B (-5.85%) |

Traced timing confidence intervals overlap (`7.058–8.577 us` before; `6.997–8.664 us` after), so no material CPU/latency regression is detected. The untraced awaited hot path remains `0 B`; traced awaited allocation improves by `80 B/message`.
A producer stress lane was not dispatched: current lanes do not install an ActivityListener, so they cannot exercise this changed branch. The broker-free benchmark measures the complete traced FireAsync front end directly.

## Validation

- `dotnet build --configuration Release`: passed, 0 warnings/errors
- net10 unit suite: 7,438 passed, 0 failed
- focused tracing regression: passed
- permanent traced/untraced awaited `ProduceAsync` benchmark coverage committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tracing header handling for synchronous, asynchronous, retry, and callback-based message production.
  - Ensured trace headers are added to produced records without modifying the original message.
  - Improved cleanup of tracing context when publishing fails or completes.
  - Standardized header handling during asynchronous serialization and publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->