### PR TITLE
fix(consumer): preserve topic recreation resets

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -9110,10 +9110,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         }
 
                         var identities = changedTopics[partition.Topic];
+                        // A fetch-clear marker staged before this recovery belongs to the old
+                        // topic identity. The captured epoch still rejects newer invalidations.
                         var reset = ResetOffsetOutOfRangeAsync(
                             partition,
                             fetchBufferEpoch,
-                            cancellationToken);
+                            cancellationToken,
+                            allowPreexistingPendingFetchClear: true);
                         if (reset.IsCompletedSuccessfully)
                         {
                             reset.GetAwaiter().GetResult();
@@ -9781,17 +9784,24 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private async ValueTask ResetOffsetOutOfRangeAsync(
         TopicPartition partition,
         int fetchBufferEpoch,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool allowPreexistingPendingFetchClear = false)
     {
         // Reset fetch position based on auto.offset.reset policy. Without this, the
         // consumer would retry the same invalid offset forever.
-        if (ShouldDropStaleFetchPartition(partition, fetchBufferEpoch))
+        if (ShouldDropOffsetReset(
+                partition,
+                fetchBufferEpoch,
+                allowPreexistingPendingFetchClear))
             return;
 
         var resetTimestamp = AutoOffsetResetStrategy.GetListOffsetsTimestamp(_options, DateTimeOffset.UtcNow, partition);
         if (resetTimestamp == LatestOffsetTimestamp || resetTimestamp == EarliestOffsetTimestamp)
         {
-            if (ShouldDropStaleFetchPartition(partition, fetchBufferEpoch))
+            if (ShouldDropOffsetReset(
+                    partition,
+                    fetchBufferEpoch,
+                    allowPreexistingPendingFetchClear))
                 return;
 
             _fetchPositions[partition] = resetTimestamp;
@@ -9801,7 +9811,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         else
         {
             var resetOffset = await ResolveAutoResetOffsetAsync(partition, resetTimestamp, cancellationToken).ConfigureAwait(false);
-            if (ShouldDropStaleFetchPartition(partition, fetchBufferEpoch))
+            if (ShouldDropOffsetReset(
+                    partition,
+                    fetchBufferEpoch,
+                    allowPreexistingPendingFetchClear))
                 return;
 
             _fetchPositions[partition] = resetOffset;
@@ -9811,6 +9824,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         LogOffsetOutOfRangeReset(partition.Topic, partition.Partition, GetAutoOffsetResetName());
     }
+
+    private bool ShouldDropOffsetReset(
+        TopicPartition partition,
+        int fetchBufferEpoch,
+        bool allowPreexistingPendingFetchClear) =>
+        IsFetchBufferEpochStale(partition, fetchBufferEpoch)
+        || (!allowPreexistingPendingFetchClear
+            && _coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition))
+        || !IsCurrentlyAssigned(partition);
 
     private static bool IsLeaderEpochRefreshError(ErrorCode errorCode) =>
         errorCode is ErrorCode.NotLeaderOrFollower or ErrorCode.FencedLeaderEpoch or ErrorCode.UnknownLeaderEpoch;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -7103,7 +7103,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private void ClearFetchBufferForPartitions(
         IEnumerable<TopicPartition> partitionsToRemove,
         bool invalidateAllFetches = false,
-        bool stagePendingClear = false)
+        bool stagePendingClear = false,
+        bool preserveDivergingEpochResets = false)
     {
         // Create a set for efficient lookup
         var removeSet = partitionsToRemove is HashSet<TopicPartition> set
@@ -7131,8 +7132,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             else
                 InvalidateFetchesForPartitionsLocked(removeSet);
 
-            foreach (var partition in removeSet)
-                _pendingDivergingEpochResets.TryRemove(partition, out _);
+            if (!preserveDivergingEpochResets)
+            {
+                foreach (var partition in removeSet)
+                    _pendingDivergingEpochResets.TryRemove(partition, out _);
+            }
         }
 
         // Filter in-place without allocating a temporary queue
@@ -7314,9 +7318,24 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         var partitionsToRemove = _coordinatorRevokedPartitionsPendingFetchClear.Keys.ToHashSet();
-        partitionsToRemove.ExceptWith(_topicIdentityResetPartitions);
+        HashSet<TopicPartition>? reservedPartitions = null;
+        foreach (var partition in _topicIdentityResetPartitions)
+        {
+            if (partitionsToRemove.Remove(partition))
+                (reservedPartitions ??= []).Add(partition);
+        }
+
+        // A newer marker on a reserved partition must remain available to reject the
+        // in-flight identity reset, but its stale queued fetch still must be discarded.
+        if (reservedPartitions is not null)
+        {
+            ClearFetchBufferForPartitions(
+                reservedPartitions,
+                preserveDivergingEpochResets: true);
+        }
+
         if (partitionsToRemove.Count == 0)
-            return false;
+            return reservedPartitions is not null;
 
         // Keep partitions marked while clearing. Background prefetches use this
         // marker to avoid advancing positions for data that will be discarded.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -9796,33 +9796,40 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             return;
 
         var resetTimestamp = AutoOffsetResetStrategy.GetListOffsetsTimestamp(_options, DateTimeOffset.UtcNow, partition);
-        if (resetTimestamp == LatestOffsetTimestamp || resetTimestamp == EarliestOffsetTimestamp)
-        {
-            if (ShouldDropOffsetReset(
-                    partition,
-                    fetchBufferEpoch,
-                    allowPreexistingPendingFetchClear))
-                return;
+        var resetOffset = resetTimestamp;
+        if (resetTimestamp != LatestOffsetTimestamp && resetTimestamp != EarliestOffsetTimestamp)
+            resetOffset = await ResolveAutoResetOffsetAsync(partition, resetTimestamp, cancellationToken).ConfigureAwait(false);
 
-            _fetchPositions[partition] = resetTimestamp;
-            SetPosition(partition, resetTimestamp, dirty: false);
-            ClearLastConsumedLeaderEpoch(partition);
-        }
-        else
+        if (!TryApplyOffsetReset(
+                partition,
+                fetchBufferEpoch,
+                allowPreexistingPendingFetchClear,
+                resetOffset))
+            return;
+
+        LogOffsetOutOfRangeReset(partition.Topic, partition.Partition, GetAutoOffsetResetName());
+    }
+
+    private bool TryApplyOffsetReset(
+        TopicPartition partition,
+        int fetchBufferEpoch,
+        bool allowPreexistingPendingFetchClear,
+        long resetOffset)
+    {
+        // Keep the final validation and position write atomic with diverging-epoch staging.
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            var resetOffset = await ResolveAutoResetOffsetAsync(partition, resetTimestamp, cancellationToken).ConfigureAwait(false);
             if (ShouldDropOffsetReset(
                     partition,
                     fetchBufferEpoch,
                     allowPreexistingPendingFetchClear))
-                return;
+                return false;
 
             _fetchPositions[partition] = resetOffset;
             SetPosition(partition, resetOffset, dirty: false);
             ClearLastConsumedLeaderEpoch(partition);
+            return true;
         }
-
-        LogOffsetOutOfRangeReset(partition.Topic, partition.Partition, GetAutoOffsetResetName());
     }
 
     private bool ShouldDropOffsetReset(
@@ -9830,8 +9837,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         int fetchBufferEpoch,
         bool allowPreexistingPendingFetchClear) =>
         IsFetchBufferEpochStale(partition, fetchBufferEpoch)
-        || (!allowPreexistingPendingFetchClear
-            && _coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition))
+        || (allowPreexistingPendingFetchClear
+            ? _pendingDivergingEpochResets.ContainsKey(partition)
+            : _coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition))
         || !IsCurrentlyAssigned(partition);
 
     private static bool IsLeaderEpochRefreshError(ErrorCode errorCode) =>

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -9094,8 +9094,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 }
 
                 var preexistingPendingFetchClearVersions =
-                    CapturePendingFetchClearVersions(recreatedPartitions);
-                ClearFetchBufferForPartitions(recreatedPartitions);
+                    CapturePendingFetchClearVersionsAndClearFetchBuffer(recreatedPartitions);
                 InvalidatePartitionCache();
                 InvalidateFetchRequestCache();
                 var fetchBufferEpoch = Volatile.Read(ref _fetchBufferEpoch);
@@ -9132,7 +9131,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             cancellationToken,
                             allowedPendingFetchClearVersion:
                                 preexistingPendingFetchClearVersions?.GetValueOrDefault(partition)
-                                ?? NoPendingFetchClearVersion);
+                                ?? NoPendingFetchClearVersion,
+                            expectedAssignmentSnapshot: assignment);
                         if (reset.IsCompletedSuccessfully)
                         {
                             reset.GetAwaiter().GetResult();
@@ -9185,8 +9185,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
-    private Dictionary<TopicPartition, long>? CapturePendingFetchClearVersions(
-        IReadOnlyCollection<TopicPartition> partitions)
+    private Dictionary<TopicPartition, long>? CapturePendingFetchClearVersionsAndClearFetchBuffer(
+        HashSet<TopicPartition> partitions)
     {
         Dictionary<TopicPartition, long>? versions = null;
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
@@ -9195,6 +9195,29 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 if (_coordinatorRevokedPartitionsPendingFetchClear.TryGetValue(partition, out var version))
                     (versions ??= [])[partition] = version;
+            }
+
+            // Claim old-identity markers before a background drain can invalidate the
+            // freshly captured epoch. The lock stays held across the ordered clear, as
+            // it does for the ordinary pending-revocation drain path.
+            ClearFetchBufferForPartitions(partitions);
+
+            if (versions is not null)
+            {
+                foreach (var (partition, version) in versions)
+                {
+                    if (_coordinatorRevokedPartitionsPendingFetchClear.TryGetValue(partition, out var currentVersion)
+                        && currentVersion == version)
+                    {
+                        _coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _);
+                    }
+                }
+            }
+
+            if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
+            {
+                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 0);
+                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
             }
         }
 
@@ -9817,14 +9840,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         TopicPartition partition,
         int fetchBufferEpoch,
         CancellationToken cancellationToken,
-        long allowedPendingFetchClearVersion = NoPendingFetchClearVersion)
+        long allowedPendingFetchClearVersion = NoPendingFetchClearVersion,
+        HashSet<TopicPartition>? expectedAssignmentSnapshot = null)
     {
         // Reset fetch position based on auto.offset.reset policy. Without this, the
         // consumer would retry the same invalid offset forever.
         if (ShouldDropOffsetReset(
                 partition,
                 fetchBufferEpoch,
-                allowedPendingFetchClearVersion))
+                allowedPendingFetchClearVersion,
+                expectedAssignmentSnapshot))
             return;
 
         var resetTimestamp = AutoOffsetResetStrategy.GetListOffsetsTimestamp(_options, DateTimeOffset.UtcNow, partition);
@@ -9836,6 +9861,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 partition,
                 fetchBufferEpoch,
                 allowedPendingFetchClearVersion,
+                expectedAssignmentSnapshot,
                 resetOffset))
             return;
 
@@ -9846,6 +9872,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         TopicPartition partition,
         int fetchBufferEpoch,
         long allowedPendingFetchClearVersion,
+        HashSet<TopicPartition>? expectedAssignmentSnapshot,
         long resetOffset)
     {
         // Keep the final validation and position write atomic with diverging-epoch staging.
@@ -9854,7 +9881,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (ShouldDropOffsetReset(
                     partition,
                     fetchBufferEpoch,
-                    allowedPendingFetchClearVersion))
+                    allowedPendingFetchClearVersion,
+                    expectedAssignmentSnapshot))
                 return false;
 
             _fetchPositions[partition] = resetOffset;
@@ -9867,17 +9895,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private bool ShouldDropOffsetReset(
         TopicPartition partition,
         int fetchBufferEpoch,
-        long allowedPendingFetchClearVersion) =>
+        long allowedPendingFetchClearVersion,
+        HashSet<TopicPartition>? expectedAssignmentSnapshot) =>
         IsFetchBufferEpochStale(partition, fetchBufferEpoch)
         || PendingFetchClearVersionChanged(partition, allowedPendingFetchClearVersion)
+        || (expectedAssignmentSnapshot is not null
+            && !ReferenceEquals(expectedAssignmentSnapshot, _assignmentSnapshot))
         || !IsCurrentlyAssigned(partition);
 
     private bool PendingFetchClearVersionChanged(
         TopicPartition partition,
         long allowedPendingFetchClearVersion) =>
         _coordinatorRevokedPartitionsPendingFetchClear.TryGetValue(partition, out var currentVersion)
-            ? currentVersion != allowedPendingFetchClearVersion
-            : allowedPendingFetchClearVersion != NoPendingFetchClearVersion;
+        && currentVersion != allowedPendingFetchClearVersion;
 
     private static bool IsLeaderEpochRefreshError(ErrorCode errorCode) =>
         errorCode is ErrorCode.NotLeaderOrFollower or ErrorCode.FencedLeaderEpoch or ErrorCode.UnknownLeaderEpoch;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1314,18 +1314,26 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private int _fetchBufferEpoch;
     private int _minimumFetchBufferEpoch;
     private readonly ConcurrentDictionary<TopicPartition, int> _minimumFetchBufferEpochsByPartition = new();
-    // Coordinator revocations and diverging-epoch corrections share this partition set because
-    // both must stop record iteration before the poll loop clears stale fetch data. The marker
-    // value identifies its publication so recovery can allow one exact preexisting marker while
-    // rejecting later ABA invalidations. The flags avoid dictionary work on the normal path.
+    // Fetch-clear publications share this partition set because they must stop record iteration
+    // before the poll loop clears stale data. Version and source let topic recovery claim one exact
+    // old-identity marker without consuming an explicit position change. The flags avoid dictionary
+    // work on the normal path.
     private readonly object _coordinatorRevokedPartitionsPendingFetchClearLock = new();
     private readonly ConcurrentDictionary<TopicPartition, long> _coordinatorRevokedPartitionsPendingFetchClear = new();
+    private readonly Dictionary<TopicPartition, PendingFetchClearMarkerSource> _pendingFetchClearMarkerSources = [];
     private readonly ConcurrentDictionary<TopicPartition, (long EndOffset, int Epoch)> _pendingDivergingEpochResets = new();
     private long _pendingFetchClearVersion;
     private int _stagedDivergingEpochResetBatches;
     private int _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent;
     private int _coordinatorRevokedPartitionsPendingFetchClearPending;
     private readonly BatchIterationEpoch _batchIterationEpoch = new();
+
+    private enum PendingFetchClearMarkerSource : byte
+    {
+        PositionChange,
+        CoordinatorRevocation,
+        DivergingEpoch
+    }
 
     // Background prefetch support
     private readonly MpscFetchBuffer _prefetchBuffer;
@@ -7028,7 +7036,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // observes the clear without adding another fence to the per-record hot path.
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            SetPendingFetchClearMarkerLocked(partition);
+            SetPendingFetchClearMarkerLocked(partition, PendingFetchClearMarkerSource.PositionChange);
 
             _batchIterationEpoch.BeginPublication();
             try
@@ -7043,13 +7051,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
-    private void SetPendingFetchClearMarkerLocked(TopicPartition partition)
+    private void SetPendingFetchClearMarkerLocked(
+        TopicPartition partition,
+        PendingFetchClearMarkerSource source)
     {
         var version = Interlocked.Increment(ref _pendingFetchClearVersion);
         if (version == NoPendingFetchClearVersion)
             version = Interlocked.Increment(ref _pendingFetchClearVersion);
 
         _coordinatorRevokedPartitionsPendingFetchClear[partition] = version;
+        _pendingFetchClearMarkerSources[partition] = source;
     }
 
     private void ClearFetchBuffer()
@@ -7202,7 +7213,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 // Keep the revocation marker so the consume loop still drains stale buffers.
                 _pendingRebalanceSeeks.TryRemove(partition, out _);
                 _pendingDivergingEpochResets.TryRemove(partition, out _);
-                SetPendingFetchClearMarkerLocked(partition);
+                SetPendingFetchClearMarkerLocked(
+                    partition,
+                    PendingFetchClearMarkerSource.CoordinatorRevocation);
             }
 
             // Invalidate broker fetches that started before the revocation immediately.
@@ -7249,7 +7262,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             return false;
 
         _pendingDivergingEpochResets[partition] = (endOffset, epoch);
-        SetPendingFetchClearMarkerLocked(partition);
+        SetPendingFetchClearMarkerLocked(partition, PendingFetchClearMarkerSource.DivergingEpoch);
         if (startsBatch)
             _stagedDivergingEpochResetBatches++;
         _batchIterationEpoch.BeginPublication();
@@ -7306,7 +7319,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         ClearFetchBufferForPartitions(partitionsToRemove);
 
         foreach (var partition in partitionsToRemove)
+        {
             _coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _);
+            _pendingFetchClearMarkerSources.Remove(partition);
+        }
 
         Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 0);
         Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
@@ -9193,8 +9209,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             foreach (var partition in partitions)
             {
-                if (_coordinatorRevokedPartitionsPendingFetchClear.TryGetValue(partition, out var version))
+                if (_coordinatorRevokedPartitionsPendingFetchClear.TryGetValue(partition, out var version)
+                    && _pendingFetchClearMarkerSources.TryGetValue(partition, out var source)
+                    && source is PendingFetchClearMarkerSource.CoordinatorRevocation
+                        or PendingFetchClearMarkerSource.DivergingEpoch)
+                {
                     (versions ??= [])[partition] = version;
+                }
             }
 
             // Claim old-identity markers before a background drain can invalidate the
@@ -9210,6 +9231,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         && currentVersion == version)
                     {
                         _coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _);
+                        _pendingFetchClearMarkerSources.Remove(partition);
                     }
                 }
             }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1316,11 +1316,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly ConcurrentDictionary<TopicPartition, int> _minimumFetchBufferEpochsByPartition = new();
     // Coordinator revocations and diverging-epoch corrections share this partition set because
     // both must stop record iteration before the poll loop clears stale fetch data. The marker
-    // flag stops iteration as soon as a clear is staged; the pending flag publishes a fully
-    // staged batch without adding dictionary work to the normal path.
+    // value identifies its publication so recovery can allow one exact preexisting marker while
+    // rejecting later ABA invalidations. The flags avoid dictionary work on the normal path.
     private readonly object _coordinatorRevokedPartitionsPendingFetchClearLock = new();
-    private readonly ConcurrentDictionary<TopicPartition, byte> _coordinatorRevokedPartitionsPendingFetchClear = new();
+    private readonly ConcurrentDictionary<TopicPartition, long> _coordinatorRevokedPartitionsPendingFetchClear = new();
     private readonly ConcurrentDictionary<TopicPartition, (long EndOffset, int Epoch)> _pendingDivergingEpochResets = new();
+    private long _pendingFetchClearVersion;
     private int _stagedDivergingEpochResetBatches;
     private int _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent;
     private int _coordinatorRevokedPartitionsPendingFetchClearPending;
@@ -1400,6 +1401,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private const long EarliestOffsetTimestamp = -2;
     private const long LatestOffsetTimestamp = -1;
+    private const long NoPendingFetchClearVersion = 0;
 
     // Cached activity names per topic to avoid repeated string interpolation in fetch paths
     // Instance-level to avoid unbounded growth with dynamic topic names across consumer instances
@@ -7026,7 +7028,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // observes the clear without adding another fence to the per-record hot path.
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
+            SetPendingFetchClearMarkerLocked(partition);
 
             _batchIterationEpoch.BeginPublication();
             try
@@ -7039,6 +7041,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 _batchIterationEpoch.EndPublication();
             }
         }
+    }
+
+    private void SetPendingFetchClearMarkerLocked(TopicPartition partition)
+    {
+        var version = Interlocked.Increment(ref _pendingFetchClearVersion);
+        if (version == NoPendingFetchClearVersion)
+            version = Interlocked.Increment(ref _pendingFetchClearVersion);
+
+        _coordinatorRevokedPartitionsPendingFetchClear[partition] = version;
     }
 
     private void ClearFetchBuffer()
@@ -7191,7 +7202,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 // Keep the revocation marker so the consume loop still drains stale buffers.
                 _pendingRebalanceSeeks.TryRemove(partition, out _);
                 _pendingDivergingEpochResets.TryRemove(partition, out _);
-                _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
+                SetPendingFetchClearMarkerLocked(partition);
             }
 
             // Invalidate broker fetches that started before the revocation immediately.
@@ -7238,7 +7249,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             return false;
 
         _pendingDivergingEpochResets[partition] = (endOffset, epoch);
-        _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
+        SetPendingFetchClearMarkerLocked(partition);
         if (startsBatch)
             _stagedDivergingEpochResetBatches++;
         _batchIterationEpoch.BeginPublication();
@@ -9082,6 +9093,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         recreatedPartitions.Add(partition);
                 }
 
+                var preexistingPendingFetchClearVersions =
+                    CapturePendingFetchClearVersions(recreatedPartitions);
                 ClearFetchBufferForPartitions(recreatedPartitions);
                 InvalidatePartitionCache();
                 InvalidateFetchRequestCache();
@@ -9110,13 +9123,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         }
 
                         var identities = changedTopics[partition.Topic];
-                        // A fetch-clear marker staged before this recovery belongs to the old
-                        // topic identity. The captured epoch still rejects newer invalidations.
+                        // Only the exact fetch-clear marker captured before this recovery belongs
+                        // to the old topic identity. New marker versions reject ABA invalidations
+                        // even if assignment cleanup removes their fetch-epoch minimum.
                         var reset = ResetOffsetOutOfRangeAsync(
                             partition,
                             fetchBufferEpoch,
                             cancellationToken,
-                            allowPreexistingPendingFetchClear: true);
+                            allowedPendingFetchClearVersion:
+                                preexistingPendingFetchClearVersions?.GetValueOrDefault(partition)
+                                ?? NoPendingFetchClearVersion);
                         if (reset.IsCompletedSuccessfully)
                         {
                             reset.GetAwaiter().GetResult();
@@ -9167,6 +9183,22 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             SemaphoreHelper.ReleaseSafely(_topicIdentityLock);
         }
+    }
+
+    private Dictionary<TopicPartition, long>? CapturePendingFetchClearVersions(
+        IReadOnlyCollection<TopicPartition> partitions)
+    {
+        Dictionary<TopicPartition, long>? versions = null;
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            foreach (var partition in partitions)
+            {
+                if (_coordinatorRevokedPartitionsPendingFetchClear.TryGetValue(partition, out var version))
+                    (versions ??= [])[partition] = version;
+            }
+        }
+
+        return versions;
     }
 
     private void PruneObservedTopicIds(HashSet<string> assignedTopics)
@@ -9785,14 +9817,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         TopicPartition partition,
         int fetchBufferEpoch,
         CancellationToken cancellationToken,
-        bool allowPreexistingPendingFetchClear = false)
+        long allowedPendingFetchClearVersion = NoPendingFetchClearVersion)
     {
         // Reset fetch position based on auto.offset.reset policy. Without this, the
         // consumer would retry the same invalid offset forever.
         if (ShouldDropOffsetReset(
                 partition,
                 fetchBufferEpoch,
-                allowPreexistingPendingFetchClear))
+                allowedPendingFetchClearVersion))
             return;
 
         var resetTimestamp = AutoOffsetResetStrategy.GetListOffsetsTimestamp(_options, DateTimeOffset.UtcNow, partition);
@@ -9803,7 +9835,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (!TryApplyOffsetReset(
                 partition,
                 fetchBufferEpoch,
-                allowPreexistingPendingFetchClear,
+                allowedPendingFetchClearVersion,
                 resetOffset))
             return;
 
@@ -9813,7 +9845,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private bool TryApplyOffsetReset(
         TopicPartition partition,
         int fetchBufferEpoch,
-        bool allowPreexistingPendingFetchClear,
+        long allowedPendingFetchClearVersion,
         long resetOffset)
     {
         // Keep the final validation and position write atomic with diverging-epoch staging.
@@ -9822,7 +9854,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (ShouldDropOffsetReset(
                     partition,
                     fetchBufferEpoch,
-                    allowPreexistingPendingFetchClear))
+                    allowedPendingFetchClearVersion))
                 return false;
 
             _fetchPositions[partition] = resetOffset;
@@ -9835,12 +9867,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private bool ShouldDropOffsetReset(
         TopicPartition partition,
         int fetchBufferEpoch,
-        bool allowPreexistingPendingFetchClear) =>
+        long allowedPendingFetchClearVersion) =>
         IsFetchBufferEpochStale(partition, fetchBufferEpoch)
-        || (allowPreexistingPendingFetchClear
-            ? _pendingDivergingEpochResets.ContainsKey(partition)
-            : _coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition))
+        || PendingFetchClearVersionChanged(partition, allowedPendingFetchClearVersion)
         || !IsCurrentlyAssigned(partition);
+
+    private bool PendingFetchClearVersionChanged(
+        TopicPartition partition,
+        long allowedPendingFetchClearVersion) =>
+        _coordinatorRevokedPartitionsPendingFetchClear.TryGetValue(partition, out var currentVersion)
+            ? currentVersion != allowedPendingFetchClearVersion
+            : allowedPendingFetchClearVersion != NoPendingFetchClearVersion;
 
     private static bool IsLeaderEpochRefreshError(ErrorCode errorCode) =>
         errorCode is ErrorCode.NotLeaderOrFollower or ErrorCode.FencedLeaderEpoch or ErrorCode.UnknownLeaderEpoch;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1321,6 +1321,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly object _coordinatorRevokedPartitionsPendingFetchClearLock = new();
     private readonly ConcurrentDictionary<TopicPartition, long> _coordinatorRevokedPartitionsPendingFetchClear = new();
     private readonly Dictionary<TopicPartition, PendingFetchClearMarkerSource> _pendingFetchClearMarkerSources = [];
+    // Keep newer marker evidence until an in-flight topic-identity reset validates it.
+    private readonly HashSet<TopicPartition> _topicIdentityResetPartitions = [];
     private readonly ConcurrentDictionary<TopicPartition, (long EndOffset, int Epoch)> _pendingDivergingEpochResets = new();
     private long _pendingFetchClearVersion;
     private int _stagedDivergingEpochResetBatches;
@@ -7312,6 +7314,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         var partitionsToRemove = _coordinatorRevokedPartitionsPendingFetchClear.Keys.ToHashSet();
+        partitionsToRemove.ExceptWith(_topicIdentityResetPartitions);
+        if (partitionsToRemove.Count == 0)
+            return false;
 
         // Keep partitions marked while clearing. Background prefetches use this
         // marker to avoid advancing positions for data that will be discarded.
@@ -7324,8 +7329,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             _pendingFetchClearMarkerSources.Remove(partition);
         }
 
-        Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 0);
-        Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
+        var markersRemain = !_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty;
+        Volatile.Write(
+            ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent,
+            markersRemain ? 1 : 0);
+        Volatile.Write(
+            ref _coordinatorRevokedPartitionsPendingFetchClearPending,
+            markersRemain ? 1 : 0);
 
         if (logTruncationException is not null)
             throw logTruncationException;
@@ -9109,16 +9119,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         recreatedPartitions.Add(partition);
                 }
 
-                var preexistingPendingFetchClearVersions =
-                    CapturePendingFetchClearVersionsAndClearFetchBuffer(recreatedPartitions);
-                InvalidatePartitionCache();
-                InvalidateFetchRequestCache();
-                var fetchBufferEpoch = Volatile.Read(ref _fetchBufferEpoch);
+                Dictionary<TopicPartition, long>? preexistingPendingFetchClearVersions = null;
                 Task[]? resetTasks = null;
                 var resetTaskCount = 0;
 
                 try
                 {
+                    preexistingPendingFetchClearVersions =
+                        CapturePendingFetchClearVersionsAndClearFetchBuffer(recreatedPartitions);
+                    InvalidatePartitionCache();
+                    InvalidateFetchRequestCache();
+                    var fetchBufferEpoch = Volatile.Read(ref _fetchBufferEpoch);
+
                     foreach (var partition in recreatedPartitions)
                     {
                         ClearStoredOffset(partition);
@@ -9147,8 +9159,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             cancellationToken,
                             allowedPendingFetchClearVersion:
                                 preexistingPendingFetchClearVersions?.GetValueOrDefault(partition)
-                                ?? NoPendingFetchClearVersion,
-                            expectedAssignmentSnapshot: assignment);
+                                ?? NoPendingFetchClearVersion);
                         if (reset.IsCompletedSuccessfully)
                         {
                             reset.GetAwaiter().GetResult();
@@ -9178,6 +9189,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 {
                     if (resetTasks is not null)
                         ArrayPool<Task>.Shared.Return(resetTasks, clearArray: true);
+
+                    ReleaseTopicIdentityResetReservations(recreatedPartitions);
                 }
 
                 foreach (var (topic, identities) in changedTopics)
@@ -9207,6 +9220,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         Dictionary<TopicPartition, long>? versions = null;
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
+            foreach (var partition in partitions)
+                _topicIdentityResetPartitions.Add(partition);
+
             foreach (var partition in partitions)
             {
                 if (_coordinatorRevokedPartitionsPendingFetchClear.TryGetValue(partition, out var version)
@@ -9244,6 +9260,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         return versions;
+    }
+
+    private void ReleaseTopicIdentityResetReservations(HashSet<TopicPartition> partitions)
+    {
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            foreach (var partition in partitions)
+                _topicIdentityResetPartitions.Remove(partition);
+        }
     }
 
     private void PruneObservedTopicIds(HashSet<string> assignedTopics)
@@ -9862,16 +9887,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         TopicPartition partition,
         int fetchBufferEpoch,
         CancellationToken cancellationToken,
-        long allowedPendingFetchClearVersion = NoPendingFetchClearVersion,
-        HashSet<TopicPartition>? expectedAssignmentSnapshot = null)
+        long allowedPendingFetchClearVersion = NoPendingFetchClearVersion)
     {
         // Reset fetch position based on auto.offset.reset policy. Without this, the
         // consumer would retry the same invalid offset forever.
         if (ShouldDropOffsetReset(
                 partition,
                 fetchBufferEpoch,
-                allowedPendingFetchClearVersion,
-                expectedAssignmentSnapshot))
+                allowedPendingFetchClearVersion))
             return;
 
         var resetTimestamp = AutoOffsetResetStrategy.GetListOffsetsTimestamp(_options, DateTimeOffset.UtcNow, partition);
@@ -9883,7 +9906,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 partition,
                 fetchBufferEpoch,
                 allowedPendingFetchClearVersion,
-                expectedAssignmentSnapshot,
                 resetOffset))
             return;
 
@@ -9894,7 +9916,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         TopicPartition partition,
         int fetchBufferEpoch,
         long allowedPendingFetchClearVersion,
-        HashSet<TopicPartition>? expectedAssignmentSnapshot,
         long resetOffset)
     {
         // Keep the final validation and position write atomic with diverging-epoch staging.
@@ -9903,8 +9924,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (ShouldDropOffsetReset(
                     partition,
                     fetchBufferEpoch,
-                    allowedPendingFetchClearVersion,
-                    expectedAssignmentSnapshot))
+                    allowedPendingFetchClearVersion))
                 return false;
 
             _fetchPositions[partition] = resetOffset;
@@ -9917,12 +9937,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private bool ShouldDropOffsetReset(
         TopicPartition partition,
         int fetchBufferEpoch,
-        long allowedPendingFetchClearVersion,
-        HashSet<TopicPartition>? expectedAssignmentSnapshot) =>
+        long allowedPendingFetchClearVersion) =>
         IsFetchBufferEpochStale(partition, fetchBufferEpoch)
         || PendingFetchClearVersionChanged(partition, allowedPendingFetchClearVersion)
-        || (expectedAssignmentSnapshot is not null
-            && !ReferenceEquals(expectedAssignmentSnapshot, _assignmentSnapshot))
         || !IsCurrentlyAssigned(partition);
 
     private bool PendingFetchClearVersionChanged(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -1403,6 +1403,59 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task TopicIdentityChange_PendingRevocationDrainDuringReset_DoesNotSuppressReset()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        metadataManager.SetApiVersion(
+            ApiKey.ListOffsets,
+            ListOffsetsRequest.LowestSupportedVersion,
+            ListOffsetsRequest.HighestSupportedVersion);
+        await using var consumer = CreateGroupConsumer(
+            connectionPool,
+            metadataManager,
+            autoOffsetReset: AutoOffsetReset.ByDuration,
+            autoOffsetResetDuration: TimeSpan.FromMinutes(1));
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([
+            new TopicPartitionOffset(partition.Topic, partition.Partition, 10)
+        ]);
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+
+        var resetStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseReset = new TaskCompletionSource<ListOffsetsResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                Arg.Any<ListOffsetsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                resetStarted.TrySetResult();
+                return new ValueTask<ListOffsetsResponse>(releaseReset.Task);
+            });
+
+        QueueCoordinatorRevokedPartitionsForFetchClear(consumer, [partition]);
+        metadataManager.Metadata.Update(CreateMetadataResponse(Guid.NewGuid(), partitionCount: 2));
+        var recovery = InvokeHandleTopicIdentityChangesAsync(consumer).AsTask();
+        await resetStarted.Task;
+
+        try
+        {
+            await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsFalse();
+        }
+        finally
+        {
+            releaseReset.TrySetResult(CreateListOffsetsResponse(partition.Partition, 100));
+            await recovery;
+        }
+
+        await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(100L);
+    }
+
+    [Test]
     public async Task TopicIdentityChange_DivergingEpochStagedDuringReset_DoesNotGetOverwritten()
     {
         var connectionPool = Substitute.For<IConnectionPool>();
@@ -1508,6 +1561,7 @@ public sealed class ConsumerAssignmentFastPathTests
         try
         {
             QueueCoordinatorRevokedPartitionsForFetchClear(consumer, [partition]);
+            await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
             PublishAssignmentSnapshot(consumer);
             RemovePartitionState(consumer, [partition]);
             SetPosition(consumer, partition, 20);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -1380,6 +1380,29 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task TopicIdentityChange_PreexistingRevocation_DoesNotSuppressReset()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        await using var consumer = CreateGroupConsumer(
+            connectionPool,
+            metadataManager,
+            autoOffsetReset: AutoOffsetReset.Earliest);
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([
+            new TopicPartitionOffset(partition.Topic, partition.Partition, 10)
+        ]);
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+
+        QueueCoordinatorRevokedPartitionsForFetchClear(consumer, [partition]);
+        metadataManager.Metadata.Update(CreateMetadataResponse(Guid.NewGuid(), partitionCount: 2));
+
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+
+        await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(-2L);
+    }
+
+    [Test]
     public async Task TopicIdentityChange_AssignmentMutationDuringReset_IsReobserved()
     {
         var connectionPool = Substitute.For<IConnectionPool>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -1463,6 +1463,69 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task TopicIdentityChange_CoordinatorAbaDuringReset_DoesNotOverwriteReinitializedPosition()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        metadataManager.SetApiVersion(
+            ApiKey.ListOffsets,
+            ListOffsetsRequest.LowestSupportedVersion,
+            ListOffsetsRequest.HighestSupportedVersion);
+        await using var consumer = CreateGroupConsumer(
+            connectionPool,
+            metadataManager,
+            autoOffsetReset: AutoOffsetReset.ByDuration,
+            autoOffsetResetDuration: TimeSpan.FromMinutes(1));
+        var partition = new TopicPartition("test-topic", 1);
+        consumer.IncrementalAssign([
+            new TopicPartitionOffset(partition.Topic, partition.Partition, 10)
+        ]);
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+
+        var resetStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseReset = new TaskCompletionSource<ListOffsetsResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                Arg.Any<ListOffsetsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var requestedPartition = call.ArgAt<ListOffsetsRequest>(0).Topics[0].Partitions[0].PartitionIndex;
+                if (requestedPartition != partition.Partition)
+                    return ValueTask.FromResult(CreateListOffsetsResponse(requestedPartition, 100));
+
+                resetStarted.TrySetResult();
+                return new ValueTask<ListOffsetsResponse>(releaseReset.Task);
+            });
+
+        metadataManager.Metadata.Update(CreateMetadataResponse(Guid.NewGuid(), partitionCount: 2));
+        var recovery = InvokeHandleTopicIdentityChangesAsync(consumer).AsTask();
+        await resetStarted.Task;
+
+        try
+        {
+            QueueCoordinatorRevokedPartitionsForFetchClear(consumer, [partition]);
+            PublishAssignmentSnapshot(consumer);
+            RemovePartitionState(consumer, [partition]);
+            SetPosition(consumer, partition, 20);
+            GetFetchPositions(consumer)[partition] = 20;
+
+            await Assert.That(consumer.Assignment).Contains(partition);
+            await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(20L);
+        }
+        finally
+        {
+            releaseReset.TrySetResult(CreateListOffsetsResponse(partition.Partition, 100));
+            await recovery;
+        }
+
+        await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(20L);
+    }
+
+    [Test]
     public async Task TopicIdentityChange_AssignmentMutationDuringReset_IsReobserved()
     {
         var connectionPool = Substitute.For<IConnectionPool>();
@@ -2298,7 +2361,7 @@ public sealed class ConsumerAssignmentFastPathTests
         return (ConcurrentDictionary<TopicPartition, int>)field.GetValue(consumer)!;
     }
 
-    private static ConcurrentDictionary<TopicPartition, byte> GetCoordinatorRevokedPartitionsPendingFetchClear(
+    private static ConcurrentDictionary<TopicPartition, long> GetCoordinatorRevokedPartitionsPendingFetchClear(
         KafkaConsumer<string, string> consumer)
     {
         var field = typeof(KafkaConsumer<string, string>).GetField(
@@ -2306,7 +2369,7 @@ public sealed class ConsumerAssignmentFastPathTests
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("_coordinatorRevokedPartitionsPendingFetchClear field not found.");
 
-        return (ConcurrentDictionary<TopicPartition, byte>)field.GetValue(consumer)!;
+        return (ConcurrentDictionary<TopicPartition, long>)field.GetValue(consumer)!;
     }
 
     private static int GetCoordinatorRevokedPartitionsPendingFetchClearPending(
@@ -2474,6 +2537,29 @@ public sealed class ConsumerAssignmentFastPathTests
             ?? throw new InvalidOperationException("RemovePartitionState method not found.");
 
         method.Invoke(consumer, [partitions]);
+    }
+
+    private static void PublishAssignmentSnapshot(KafkaConsumer<string, string> consumer)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "PublishAssignmentSnapshot",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("PublishAssignmentSnapshot method not found.");
+
+        method.Invoke(consumer, []);
+    }
+
+    private static void SetPosition(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition partition,
+        long position)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "SetPosition",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("SetPosition method not found.");
+
+        method.Invoke(consumer, [partition, position, false]);
     }
 
     private static bool StageDivergingEpochReset(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -1403,6 +1403,66 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task TopicIdentityChange_DivergingEpochStagedDuringReset_DoesNotGetOverwritten()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        metadataManager.SetApiVersion(
+            ApiKey.ListOffsets,
+            ListOffsetsRequest.LowestSupportedVersion,
+            ListOffsetsRequest.HighestSupportedVersion);
+        await using var consumer = CreateGroupConsumer(
+            connectionPool,
+            metadataManager,
+            autoOffsetReset: AutoOffsetReset.ByDuration,
+            autoOffsetResetDuration: TimeSpan.FromMinutes(1));
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([
+            new TopicPartitionOffset(partition.Topic, partition.Partition, 10)
+        ]);
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+
+        var resetStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseReset = new TaskCompletionSource<ListOffsetsResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                Arg.Any<ListOffsetsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                resetStarted.TrySetResult();
+                return new ValueTask<ListOffsetsResponse>(releaseReset.Task);
+            });
+
+        metadataManager.Metadata.Update(CreateMetadataResponse(Guid.NewGuid(), partitionCount: 2));
+        var recovery = InvokeHandleTopicIdentityChangesAsync(consumer).AsTask();
+        await resetStarted.Task;
+
+        try
+        {
+            var staged = StageDivergingEpochReset(
+                consumer,
+                partition,
+                endOffset: 5,
+                epoch: 7,
+                GetFetchBufferEpoch(consumer));
+            CompleteDivergingEpochResets(consumer);
+
+            await Assert.That(staged).IsTrue();
+        }
+        finally
+        {
+            releaseReset.TrySetResult(CreateListOffsetsResponse(partition.Partition, 100));
+            await recovery;
+        }
+
+        await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(10L);
+    }
+
+    [Test]
     public async Task TopicIdentityChange_AssignmentMutationDuringReset_IsReobserved()
     {
         var connectionPool = Substitute.For<IConnectionPool>();
@@ -2416,7 +2476,7 @@ public sealed class ConsumerAssignmentFastPathTests
         method.Invoke(consumer, [partitions]);
     }
 
-    private static void StageDivergingEpochReset(
+    private static bool StageDivergingEpochReset(
         KafkaConsumer<string, string> consumer,
         TopicPartition partition,
         long endOffset,
@@ -2428,7 +2488,7 @@ public sealed class ConsumerAssignmentFastPathTests
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("StageDivergingEpochReset method not found.");
 
-        method.Invoke(consumer, [partition, endOffset, epoch, fetchBufferEpoch, true]);
+        return (bool)method.Invoke(consumer, [partition, endOffset, epoch, fetchBufferEpoch, true])!;
     }
 
     private static void CompleteDivergingEpochResets(KafkaConsumer<string, string> consumer)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -1403,6 +1403,28 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task TopicIdentityChange_ExplicitSeekMarker_DoesNotGetClaimed()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([
+            new TopicPartitionOffset(partition.Topic, partition.Partition, 10)
+        ]);
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+
+        GetPendingFetches(consumer).Enqueue(
+            CreateFetch(partition: partition.Partition, baseOffset: 10, value: "stale"));
+        consumer.SeekToBeginning(partition);
+        metadataManager.Metadata.Update(CreateMetadataResponse(Guid.NewGuid(), partitionCount: 2));
+
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+
+        await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(0L);
+    }
+
+    [Test]
     public async Task TopicIdentityChange_PendingRevocationDrainDuringReset_DoesNotSuppressReset()
     {
         var connectionPool = Substitute.For<IConnectionPool>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -1582,8 +1582,11 @@ public sealed class ConsumerAssignmentFastPathTests
 
         try
         {
+            GetPendingFetches(consumer).Enqueue(
+                CreateFetch(partition: partition.Partition, baseOffset: 10, value: "stale"));
             QueueCoordinatorRevokedPartitionsForFetchClear(consumer, [partition]);
-            await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsFalse();
+            await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+            await Assert.That(GetPendingFetches(consumer)).IsEmpty();
             PublishAssignmentSnapshot(consumer);
             RemovePartitionState(consumer, [partition]);
             SetPosition(consumer, partition, 20);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -1583,7 +1583,7 @@ public sealed class ConsumerAssignmentFastPathTests
         try
         {
             QueueCoordinatorRevokedPartitionsForFetchClear(consumer, [partition]);
-            await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+            await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsFalse();
             PublishAssignmentSnapshot(consumer);
             RemovePartitionState(consumer, [partition]);
             SetPosition(consumer, partition, 20);
@@ -1599,6 +1599,60 @@ public sealed class ConsumerAssignmentFastPathTests
         }
 
         await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(20L);
+    }
+
+    [Test]
+    public async Task TopicIdentityChange_UnrelatedAssignmentUpdateDuringReset_DoesNotSuppressReset()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        metadataManager.SetApiVersion(
+            ApiKey.ListOffsets,
+            ListOffsetsRequest.LowestSupportedVersion,
+            ListOffsetsRequest.HighestSupportedVersion);
+        await using var consumer = CreateGroupConsumer(
+            connectionPool,
+            metadataManager,
+            autoOffsetReset: AutoOffsetReset.ByDuration,
+            autoOffsetResetDuration: TimeSpan.FromMinutes(1));
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([
+            new TopicPartitionOffset(partition.Topic, partition.Partition, 10)
+        ]);
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+
+        var resetStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseReset = new TaskCompletionSource<ListOffsetsResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                Arg.Any<ListOffsetsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                resetStarted.TrySetResult();
+                return new ValueTask<ListOffsetsResponse>(releaseReset.Task);
+            });
+
+        metadataManager.Metadata.Update(CreateMetadataResponse(Guid.NewGuid(), partitionCount: 2));
+        var recovery = InvokeHandleTopicIdentityChangesAsync(consumer).AsTask();
+        await resetStarted.Task;
+
+        try
+        {
+            consumer.IncrementalAssign([
+                new TopicPartitionOffset("other-topic", 0, 0)
+            ]);
+        }
+        finally
+        {
+            releaseReset.TrySetResult(CreateListOffsetsResponse(partition.Partition, 100));
+            await recovery;
+        }
+
+        await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(100L);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDiagnosticSnapshotTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDiagnosticSnapshotTests.cs
@@ -31,7 +31,7 @@ public sealed class ConsumerDiagnosticSnapshotTests
         consumer.IncrementalAssign(
             [new TopicPartitionOffset(partition.Topic, partition.Partition, 42)]);
 
-        GetField<ConcurrentDictionary<TopicPartition, byte>>(
+        GetField<ConcurrentDictionary<TopicPartition, long>>(
             consumer,
             "_coordinatorRevokedPartitionsPendingFetchClear")[partition] = 0;
         GetField<ConcurrentDictionary<TopicPartition, int>>(


### PR DESCRIPTION
## Summary

- preserve authoritative topic-recreation offset resets when a coordinator revocation was already staged
- reject resets invalidated by newer same-partition fetch, assignment, divergence, or explicit-seek evidence
- reserve recreated partitions during asynchronous `ListOffsets` recovery while still discarding stale queued fetches immediately
- classify and version pending-clear markers so only the exact old-identity marker may be claimed
- add deterministic regressions for revocation-before-identity, marker-drain, divergence, ABA, explicit-seek, and unrelated-assignment orderings

## Root cause

Latest manual `main` CI run [32253845400](https://github.com/thomhurst/Dekaf/actions/runs/32253845400) failed five release-matrix fault lanes across Kafka 4.0.2-4.2.1. Every lane timed out in `Commit_AgainstRecreatedTopic_DoesNotResurrectStaleOffsets`.

Topic recreation reused the generic offset-out-of-range stale-fetch guard. A coordinator revocation staged before topic-identity recovery left a fetch-clear marker, so the authoritative `auto.offset.reset` was suppressed. The old committed position `2` survived; broker log-truncation recovery corrected it only to new log end `1`, skipping recreated record offset `0` and leaving the test waiting until its 120-second timeout.

Topic-recreation recovery now claims only old-identity coordinator or divergence markers and records their monotonic versions. Recreated partitions remain reserved during the asynchronous reset, preventing a background drain from erasing newer validation evidence. A drain still discards stale queued fetches for reserved partitions but preserves their marker and divergence payload. Final validation and position writes use the same synchronization lock as marker staging. Newer same-partition markers, explicit seeks, revocations, and ABA reassignments therefore reject stale resets; unrelated partition assignment changes do not.

## Validation

- `dotnet build --no-restore --configuration Release`: passed, 0 warnings/errors
- full net10 unit suite: 7,446 passed
- ten deterministic `TopicIdentityChange_*` regressions pass
- red/green evidence: preexisting revocation failed on `main` (`10`, expected `-2`); concurrent divergence failed before locking (`100`, expected `10`); ABA reinitialization failed before marker versioning (`100`, expected `20`); pending-marker drain failed before atomic claim (`10`, expected `100`); explicit seek failed before source classification (`-1`, expected `0`); unrelated assignment update failed before per-partition reservation (`10`, expected `100`); reserved stale fetch drain returned false and retained the fetch before split clear/marker handling
- failing integration test: passed 8/8 across net8/net10 and Kafka 4.0.2, 4.1.2, 4.2.1, 4.3.1
- full `TopicRecreationIntegrationTests`: 5/5 on Kafka 4.1.2 and 5/5 on Kafka 4.3.1
- `TopicIdentityCheckBenchmarks` `[MemoryDiagnoser]`:
  - `main`: 2.333 ns, 0 B
  - final candidate: 2.024 ns, 0 B
  - delta: -13.2%, allocation unchanged

`dotnet format --verify-no-changes --include` passes for all changed files. The repository-wide format command still reports existing whitespace findings in unrelated files; CI marks that check informational.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved offset recovery when offsets are unavailable, including resets based on special positions or timestamps.
  - Preserved valid pending resets during topic-identity recovery.
  - Prevented stale or conflicting recovery operations from overwriting newer assignment, position, or coordinator changes.
  - Ensured recovery markers are cleared accurately without affecting explicit position changes.
  - Continued rejecting resets for stale fetch epochs and unassigned partitions.
- **Tests**
  - Added regression coverage for pending revocations, coordinator changes, topic-identity resets, and explicit seek positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
