### PR TITLE
fix(consumer): honor rebalance timeout

### DIFF
--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -100,6 +100,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithMaxPollRecords(...)` | `MaxPollRecords` | Integer |
 | `WithSessionTimeout(...)` | `SessionTimeoutMs` | Milliseconds |
 | `WithHeartbeatInterval(...)` | `HeartbeatIntervalMs` | Milliseconds |
+| Runtime-configured | `RebalanceTimeoutMs` | Broker-visible KIP-848 rebalance window in milliseconds; default 60000 |
 | `WithIsolationLevel(...)` | `IsolationLevel` | `ReadUncommitted` or `ReadCommitted` |
 | `WithPartitionEof(...)` | `EnablePartitionEof` | Boolean |
 | `WithQueuedMinMessages(...)` | `QueuedMinMessages` | Integer |

--- a/docs/docs/consumer/consumer-groups.md
+++ b/docs/docs/consumer/consumer-groups.md
@@ -140,6 +140,19 @@ Callback semantics:
 
 Non-cancellation callback exceptions are logged and suppressed. `OperationCanceledException` follows the supplied cancellation token.
 
+During a cooperative revoke, Dekaf awaits its automatic revoked-offset commit and
+`OnPartitionsRevokedAsync` before completing the assignment transfer. The initial
+KIP-848 heartbeat advertises `ConsumerOptions.RebalanceTimeoutMs` (60 seconds by
+default), which is the broker-visible window for completing that rebalance. The
+automatic revoked-offset commit is cancelled at the same limit. Listener callbacks
+receive the consumer operation/lifetime token rather than a separate timeout token,
+so revoke work should still complete within `RebalanceTimeoutMs`; exceeding the
+broker window can cause the member to lose its assignment.
+
+`MaxPollIntervalMs` is separate: it limits time between foreground polls and is not
+sent as the rebalance timeout. Configuration-bound consumers can set the window with
+the `RebalanceTimeoutMs` key.
+
 Use `IConsumerAwareRebalanceListener` when a callback must operate on the consumer
 without capturing its unrestricted instance:
 

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1521,7 +1521,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 MemberId = memberId,
                 MemberEpoch = memberEpoch,
                 InstanceId = _options.GroupInstanceId,
-                RebalanceTimeoutMs = isInitial ? _options.MaxPollIntervalMs : -1,
+                RebalanceTimeoutMs = isInitial ? _options.RebalanceTimeoutMs : -1,
                 RackId = isInitial ? _options.ClientRack : null,
                 SubscribedTopicNames = subscribedTopics,
                 SubscribedTopicRegex = subscribedTopicRegex,

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -187,7 +187,9 @@ public sealed class ConsumerOptions
     public int HeartbeatIntervalMs { get; init; } = 3000;
 
     /// <summary>
-    /// Rebalance timeout in milliseconds.
+    /// Maximum time in milliseconds for the consumer to complete a group rebalance.
+    /// Sent to the broker on the initial KIP-848 heartbeat and used to bound the
+    /// automatic revoked-offset commit. Default is 60000.
     /// </summary>
     public int RebalanceTimeoutMs { get; init; } = 60000;
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -454,7 +454,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
-    public async Task ConsumerProtocol_InitialJoin_SendsMaxPollIntervalAsRebalanceTimeout()
+    public async Task ConsumerProtocol_InitialJoin_SendsConfiguredRebalanceTimeout()
     {
         SetupSuccessfulConsumerProtocolJoin();
         var options = CreateConsumerProtocolOptions(
@@ -465,7 +465,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
 
         await _connection.Received().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
-            Arg.Is<ConsumerGroupHeartbeatRequest>(request => request != null && request.RebalanceTimeoutMs == 12_345),
+            Arg.Is<ConsumerGroupHeartbeatRequest>(request => request != null && request.RebalanceTimeoutMs == 30_000),
             Arg.Any<short>(),
             Arg.Any<CancellationToken>());
     }


### PR DESCRIPTION
## Summary
- send `ConsumerOptions.RebalanceTimeoutMs` on initial KIP-848 heartbeats instead of `MaxPollIntervalMs`
- keep steady-state heartbeat sentinel behavior unchanged
- document broker rebalance window, revoked-offset commit bound, and listener cancellation semantics
- assert the configured field is transmitted with distinct rebalance and max-poll values

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- [x] focused TDD test (failed before source fix, passed after)
- [x] `ConsumerCoordinatorKip848Tests`: 107/107 passed
- [x] full unit suite: 7446/7446 passed
- [x] `dotnet build tests/Dekaf.Tests.Integration --configuration Release`
- [x] `RebalanceEdgeCaseTests/RebalanceTimeout_SlowConsumer_RemovedFromGroup`: passed against Kafka 4.3.1
- [x] `npm run build --prefix docs`

## Performance
Coordinator-heartbeat cadence only. No per-message produce/consume/serialization path, allocation, async state-machine, or dispatch change.

Closes #2767
