### PR TITLE
fix(consumer): reject group-less commits

### DIFF
--- a/docs/docs/consumer/manual-assignment.md
+++ b/docs/docs/consumer/manual-assignment.md
@@ -71,6 +71,12 @@ Don't mix `Subscribe` and `Assign` on the same consumer. Use one or the other.
 
 With manual assignment, you're responsible for tracking offsets:
 
+Manual assignment does not require a group ID, but Kafka offset commits do. A consumer built
+without `WithGroupId(...)` must persist offsets in its own storage, as shown below. Calling either
+`CommitAsync` overload without a group ID throws `InvalidOperationException`. If you want Kafka to
+store offsets while retaining manual partition assignment, configure `WithGroupId(...)` before
+building the consumer.
+
 ```csharp
 using Dekaf;
 

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -605,6 +605,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     {
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
+        _ = GetCommitGroupId();
 
         lock (_gate)
         {
@@ -624,12 +625,16 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         ArgumentNullException.ThrowIfNull(offsets);
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
+        var groupId = GetCommitGroupId();
 
-        if (_groupId is not null)
-            _cluster.CommitOffsets(_groupId, offsets);
+        _cluster.CommitOffsets(groupId, offsets);
 
         return ValueTask.CompletedTask;
     }
+
+    private string GetCommitGroupId() => _groupId
+        ?? throw new InvalidOperationException(
+            "Offset commits require a consumer group. Configure one with ConsumerBuilder.WithGroupId(...).");
 
     public void StoreOffset(ConsumeResult<TKey, TValue> result)
     {

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -151,6 +151,10 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// <exception cref="KafkaTimeoutException">
     /// The operation exceeds <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>.
     /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// The consumer was built without a group ID. Configure one with
+    /// <see cref="ConsumerBuilder{TKey,TValue}.WithGroupId"/> before committing offsets.
+    /// </exception>
     ValueTask CommitAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -158,6 +162,10 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// </summary>
     /// <exception cref="KafkaTimeoutException">
     /// The operation exceeds <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// The consumer was built without a group ID. Configure one with
+    /// <see cref="ConsumerBuilder{TKey,TValue}.WithGroupId"/> before committing offsets.
     /// </exception>
     ValueTask CommitAsync(IEnumerable<TopicPartitionOffset> offsets, CancellationToken cancellationToken = default);
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -6359,13 +6359,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
     {
-        // Explicit commit: the caller vouches for everything yielded so far, including
-        // a record still being processed.
-        FlushActiveConsumedPosition();
-        FlushPausedConsumedPositions();
-
-        if (_coordinator is null)
-            return;
+        _ = GetCommitCoordinator();
+        StageExplicitCommitOffsets();
 
         using var apiTimeout = new ApiTimeoutScope(_options.DefaultApiTimeoutMs, cancellationToken);
         try
@@ -6501,8 +6496,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     public async ValueTask CommitAsync(IEnumerable<TopicPartitionOffset> offsets, CancellationToken cancellationToken = default)
     {
-        if (_coordinator is null)
-            return;
+        var coordinator = GetCommitCoordinator();
 
         using var apiTimeout = new ApiTimeoutScope(_options.DefaultApiTimeoutMs, cancellationToken);
         try
@@ -6510,7 +6504,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             // Materialize to list to allow iteration for both commit tracking and interceptors
             var offsetsList = offsets as IReadOnlyList<TopicPartitionOffset> ?? offsets.ToArray();
 
-            await _coordinator.CommitOffsetsAsync(offsetsList, apiTimeout.Token).ConfigureAwait(false);
+            await coordinator.CommitOffsetsAsync(offsetsList, apiTimeout.Token).ConfigureAwait(false);
 
             foreach (var offset in offsetsList)
             {
@@ -6525,6 +6519,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             throw apiTimeout.CreateTimeoutException(nameof(CommitAsync), ex);
         }
+    }
+
+    private ConsumerCoordinator GetCommitCoordinator() => _coordinator
+        ?? throw new InvalidOperationException(
+            "Offset commits require a consumer group. Configure one with ConsumerBuilder.WithGroupId(...).");
+
+    /// <summary>
+    /// Explicit commit staging: the caller vouches for everything yielded so far, including
+    /// a record still being processed.
+    /// </summary>
+    private void StageExplicitCommitOffsets()
+    {
+        FlushActiveConsumedPosition();
+        FlushPausedConsumedPositions();
     }
 
     public void StoreOffset(ConsumeResult<TKey, TValue> result)

--- a/tests/Dekaf.Tests.Integration/ConsumerConfigurationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerConfigurationTests.cs
@@ -190,6 +190,29 @@ public sealed class ConsumerConfigurationTests(KafkaTestContainer kafka) : Kafka
     }
 
     [Test]
+    public async Task Consumer_ManualAssignWithoutGroup_CommitOverloadsThrow()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-consumer-manual-commit")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        await Assert.That(async () => await consumer.CommitAsync(CancellationToken.None))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("WithGroupId");
+        await Assert.That(async () => await consumer.CommitAsync(
+                [new TopicPartitionOffset(topic, 0, 1)],
+                CancellationToken.None))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("WithGroupId");
+    }
+
+    [Test]
     public async Task Consumer_SubscribeThenAssign_BufferedConsumeRecordsGroupPoll()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
@@ -697,7 +697,7 @@ public sealed class ConsumeAsyncRecoveryTests
     }
 
     [Test]
-    public async Task CommitAsync_AfterPartialBatchConsumed_FlushesCurrentPosition()
+    public async Task ExplicitCommitStaging_AfterPartialBatchConsumed_FlushesCurrentPosition()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
         [
@@ -717,7 +717,7 @@ public sealed class ConsumeAsyncRecoveryTests
             await Assert.That(result.Offset).IsEqualTo(20L);
             await Assert.That(positions.TryGetValue(tp, out var position) && position == 21L).IsFalse();
 
-            await consumer.CommitAsync(cts.Token);
+            consumer.StageExplicitCommitOffsetsForTesting();
 
             await Assert.That(positions[tp]).IsEqualTo(21L);
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -597,7 +597,7 @@ public sealed class ConsumeOneFastPathTests
     }
 
     [Test]
-    public async Task CommitAsync_InAutoMode_FlushesActivePositionWithoutPendingQueue()
+    public async Task ExplicitCommitStaging_InAutoMode_FlushesActivePositionWithoutPendingQueue()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
         [
@@ -616,7 +616,7 @@ public sealed class ConsumeOneFastPathTests
         pendingFetches.Clear();
         activeFetch.Dispose();
 
-        await consumer.CommitAsync(CancellationToken.None);
+        consumer.StageExplicitCommitOffsetsForTesting();
 
         await Assert.That(positions[tp]).IsEqualTo(21L);
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
@@ -13,6 +13,28 @@ namespace Dekaf.Tests.Unit.Consumer;
 public sealed class ConsumerDirtyCommitTests
 {
     [Test]
+    public async Task CommitAsync_WithoutConsumerGroup_ThrowsWithGroupIdGuidance()
+    {
+        await using var consumer = CreateConsumer([], ErrorCode.None, groupId: null);
+
+        await Assert.That(async () => await consumer.CommitAsync(CancellationToken.None))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("WithGroupId");
+    }
+
+    [Test]
+    public async Task CommitAsync_WithOffsetsWithoutConsumerGroup_ThrowsWithGroupIdGuidance()
+    {
+        await using var consumer = CreateConsumer([], ErrorCode.None, groupId: null);
+
+        await Assert.That(async () => await consumer.CommitAsync(
+                [new TopicPartitionOffset("topic-a", 0, 10)],
+                CancellationToken.None))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("WithGroupId");
+    }
+
+    [Test]
     public async Task CommitAsync_AfterSuccessfulCommit_CommitsOnlyOffsetsChangedSinceLastCommit()
     {
         var requests = new List<OffsetCommitRequest>();
@@ -774,7 +796,8 @@ public sealed class ConsumerDirtyCommitTests
         Action<CancellationToken>? onOffsetCommit = null,
         int rebalanceTimeoutMs = 60_000,
         Func<CancellationToken, ValueTask>? onOffsetCommitAsync = null,
-        int defaultApiTimeoutMs = 60_000)
+        int defaultApiTimeoutMs = 60_000,
+        string? groupId = "group-a")
         => CreateConsumer(
             requests,
             new Queue<ErrorCode>([responseError]),
@@ -783,7 +806,8 @@ public sealed class ConsumerDirtyCommitTests
             onOffsetCommit,
             rebalanceTimeoutMs,
             onOffsetCommitAsync,
-            defaultApiTimeoutMs);
+            defaultApiTimeoutMs,
+            groupId);
 
     private static KafkaConsumer<string, string> CreateConsumer(
         List<OffsetCommitRequest> requests,
@@ -793,7 +817,8 @@ public sealed class ConsumerDirtyCommitTests
         Action<CancellationToken>? onOffsetCommit = null,
         int rebalanceTimeoutMs = 60_000,
         Func<CancellationToken, ValueTask>? onOffsetCommitAsync = null,
-        int defaultApiTimeoutMs = 60_000)
+        int defaultApiTimeoutMs = 60_000,
+        string? groupId = "group-a")
     {
         var connectionPool = Substitute.For<IConnectionPool>();
         var connection = Substitute.For<IKafkaConnection>();
@@ -856,7 +881,7 @@ public sealed class ConsumerDirtyCommitTests
             new ConsumerOptions
             {
                 BootstrapServers = ["localhost:9092"],
-                GroupId = "group-a",
+                GroupId = groupId,
                 OffsetCommitMode = offsetCommitMode,
                 EnableAutoOffsetStore = enableAutoOffsetStore,
                 RebalanceTimeoutMs = rebalanceTimeoutMs,

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerMaxPollRecordsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerMaxPollRecordsTests.cs
@@ -61,7 +61,7 @@ public sealed class ConsumerMaxPollRecordsTests
     }
 
     [Test]
-    public async Task ConsumeBatchAsync_ExactMaxPollRecordsMultiple_RetainsExhaustedFetchUntilCommit()
+    public async Task ConsumeBatchAsync_ExactMaxPollRecordsMultiple_RetainsExhaustedFetchUntilCommitStaging()
     {
         await using var consumer = CreateConsumerWithPendingFetches(
             maxPollRecords: 2,
@@ -81,7 +81,7 @@ public sealed class ConsumerMaxPollRecordsTests
 
         await Assert.That(GetPendingFetches(consumer).Count).IsEqualTo(1);
 
-        await consumer.CommitAsync(CancellationToken.None);
+        consumer.StageExplicitCommitOffsetsForTesting();
 
         await Assert.That(GetPendingFetches(consumer).Count).IsEqualTo(0);
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerTestExtensions.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerTestExtensions.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using Dekaf.Consumer;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+internal static class KafkaConsumerTestExtensions
+{
+    public static void StageExplicitCommitOffsetsForTesting<TKey, TValue>(
+        this KafkaConsumer<TKey, TValue> consumer)
+    {
+        var method = typeof(KafkaConsumer<TKey, TValue>).GetMethod(
+            "StageExplicitCommitOffsets",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("StageExplicitCommitOffsets method not found.");
+
+        method.Invoke(consumer, null);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -103,7 +103,7 @@ public sealed class OffsetStoreTimingTests
     }
 
     [Test]
-    public async Task CommitAsync_ManualModeAfterPauseReconciliation_VouchesForInDoubtRecord()
+    public async Task ExplicitCommitStaging_ManualModeAfterPauseReconciliation_VouchesForInDoubtRecord()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
         [
@@ -120,7 +120,7 @@ public sealed class OffsetStoreTimingTests
 
         consumer.Pause(tp);
         consumer.Seek(new TopicPartitionOffset(Topic, Partition + 1, 100));
-        await consumer.CommitAsync(CancellationToken.None);
+        consumer.StageExplicitCommitOffsetsForTesting();
 
         await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
     }
@@ -287,7 +287,7 @@ public sealed class OffsetStoreTimingTests
     }
 
     [Test]
-    public async Task CommitAsync_AfterBreak_VouchesForInDoubtRecord()
+    public async Task ExplicitCommitStaging_AfterBreak_VouchesForInDoubtRecord()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
         [
@@ -304,14 +304,14 @@ public sealed class OffsetStoreTimingTests
                 break;
         }
 
-        await consumer.CommitAsync(CancellationToken.None);
+        consumer.StageExplicitCommitOffsetsForTesting();
 
         // Explicit commit is the caller vouching for everything delivered so far.
         await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(22L);
     }
 
     [Test]
-    public async Task CommitAsync_AfterSeek_DoesNotRestoreInDoubtRecord()
+    public async Task ExplicitCommitStaging_AfterSeek_DoesNotRestoreInDoubtRecord()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
         [
@@ -327,14 +327,14 @@ public sealed class OffsetStoreTimingTests
             CancellationToken.None)).IsNotNull();
 
         consumer.Seek(new TopicPartitionOffset(Topic, Partition, 100));
-        await consumer.CommitAsync(CancellationToken.None);
+        consumer.StageExplicitCommitOffsetsForTesting();
 
         await Assert.That(GetPositions(consumer)[tp]).IsEqualTo(100L);
         await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(100L);
     }
 
     [Test]
-    public async Task IncrementalUnassign_AfterConsume_CommitAsyncDoesNotResurrectRevokedPartition()
+    public async Task IncrementalUnassign_AfterConsume_ExplicitCommitStagingDoesNotResurrectRevokedPartition()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
         [
@@ -349,7 +349,7 @@ public sealed class OffsetStoreTimingTests
         await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None)).IsNotNull();
 
         consumer.IncrementalUnassign([tp]);
-        await consumer.CommitAsync(CancellationToken.None);
+        consumer.StageExplicitCommitOffsetsForTesting();
 
         // Partition removal cleared all per-partition state; the stale snapshot must not
         // bring the revoked partition's position or staged offset back to life.
@@ -415,7 +415,7 @@ public sealed class OffsetStoreTimingTests
     }
 
     [Test]
-    public async Task ConsumeBatchAsync_CommitAsyncInAutoMode_VouchesForIteratedRecords()
+    public async Task ConsumeBatchAsync_ExplicitCommitStagingInAutoMode_VouchesForIteratedRecords()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
         [
@@ -431,7 +431,7 @@ public sealed class OffsetStoreTimingTests
             await foreach (var batch in consumer.ConsumeBatchAsync(CancellationToken.None))
             {
                 foreach (var _ in batch) { }
-                await consumer.CommitAsync(CancellationToken.None);
+                consumer.StageExplicitCommitOffsetsForTesting();
                 throw new InvalidOperationException("stop after explicit handoff");
             }
         }).Throws<InvalidOperationException>();
@@ -440,7 +440,7 @@ public sealed class OffsetStoreTimingTests
     }
 
     [Test]
-    public async Task ConsumeRawBatchAsync_CommitAsyncInAutoMode_VouchesForIteratedRecords()
+    public async Task ConsumeRawBatchAsync_ExplicitCommitStagingInAutoMode_VouchesForIteratedRecords()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
         [
@@ -456,7 +456,7 @@ public sealed class OffsetStoreTimingTests
             await foreach (var batch in consumer.ConsumeRawBatchAsync(CancellationToken.None))
             {
                 foreach (var _ in batch) { }
-                await consumer.CommitAsync(CancellationToken.None);
+                consumer.StageExplicitCommitOffsetsForTesting();
                 throw new InvalidOperationException("stop after explicit handoff");
             }
         }).Throws<InvalidOperationException>();
@@ -606,7 +606,7 @@ public sealed class OffsetStoreTimingTests
     [Test]
     [Arguments(false)]
     [Arguments(true)]
-    public async Task ConsumeBatch_FullyEnumeratedBreakThenCommit_VouchesForBatch(bool raw)
+    public async Task ConsumeBatch_FullyEnumeratedBreakThenCommitStaging_VouchesForBatch(bool raw)
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
         [
@@ -634,7 +634,7 @@ public sealed class OffsetStoreTimingTests
             }
         }
 
-        await consumer.CommitAsync(CancellationToken.None);
+        consumer.StageExplicitCommitOffsetsForTesting();
 
         await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(22L);
         await Assert.That(GetPendingFetches(consumer)).IsEmpty();
@@ -735,7 +735,7 @@ public sealed class OffsetStoreTimingTests
     }
 
     [Test]
-    public async Task CommitAsync_InAutoMode_StagesInFlightRecord()
+    public async Task ExplicitCommitStaging_InAutoMode_StagesInFlightRecord()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
         [
@@ -749,7 +749,7 @@ public sealed class OffsetStoreTimingTests
         await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None)).IsNotNull();
         await Assert.That(GetDirtyStoredOffsets(consumer).ContainsKey(tp)).IsFalse();
 
-        await consumer.CommitAsync(CancellationToken.None);
+        consumer.StageExplicitCommitOffsetsForTesting();
 
         await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
     }
@@ -802,7 +802,7 @@ public sealed class OffsetStoreTimingTests
     }
 
     [Test]
-    public async Task CommitAsync_AfterSwitchingToBatch_IgnoresStaleActiveSnapshot()
+    public async Task ExplicitCommitStaging_AfterSwitchingToBatch_IgnoresStaleActiveSnapshot()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
         [
@@ -826,7 +826,7 @@ public sealed class OffsetStoreTimingTests
             await Assert.That(batches.Current.Select(record => record.Offset).ToArray())
                 .IsEquivalentTo([21L, 22L]);
 
-            await consumer.CommitAsync(CancellationToken.None);
+            consumer.StageExplicitCommitOffsetsForTesting();
         }
 
         await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(23L);

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -125,6 +125,22 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task Consumer_WithoutGroup_CommitOverloadsThrow()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var consumer = new InMemoryConsumer<string, string>(cluster);
+
+        await Assert.That(async () => await consumer.CommitAsync(CancellationToken.None))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("WithGroupId");
+        await Assert.That(async () => await consumer.CommitAsync(
+                [new TopicPartitionOffset("orders", 0, 1)],
+                CancellationToken.None))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("WithGroupId");
+    }
+
+    [Test]
     public async Task RunPartitionedAsync_EmptyGroupIdWithAutoCommitDefaults_PassesCommitModeGuard()
     {
         var cluster = new InMemoryKafkaCluster();


### PR DESCRIPTION
## Summary

- reject both Kafka consumer commit overloads when no consumer group exists, with WithGroupId guidance
- keep InMemoryConsumer behavior aligned with the production IKafkaConsumer contract
- document the behavioral break and manual-assignment persistence choices
- preserve explicit commit-staging coverage without relying on invalid group-less commits

## Test plan

- [x] dotnet build --configuration Release
- [x] full unit suite: 7,449 passed
- [x] focused integration test: Consumer_ManualAssignWithoutGroup_CommitOverloadsThrow
- [x] 
pm run build --prefix docs
- [x] git diff --check
- [x] /simplify and self-review

## Performance

Commit is a coordinator/network path, not serialization, produce, consume, fetch, or receive hot path. Successful grouped commits add only a null check and direct local coordinator reuse; no per-message allocation added.

## Breaking behavior

Group-less CommitAsync calls previously returned success without persisting offsets. They now throw InvalidOperationException.

Closes #2763
