### PR TITLE
feat(consumer): configure partition stop timeout

### DIFF
--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -312,7 +312,7 @@ auto-commit, `LeaveGroup`, assignment cleanup, and resource disposal:
 .WithPartitionStopTimeout(TimeSpan.FromSeconds(30)) // Default: 5 seconds
 ```
 
-The same method accepts `IConsumerAwareRebalanceListener`. Its callbacks receive an
+`WithRebalanceListener` also accepts `IConsumerAwareRebalanceListener`. Its callbacks receive an
 `IRebalanceConsumer` view with safe commit, seek, pause/resume, metadata, and offset
 operations. The view is invalidated as soon as the callback completes.
 

--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -309,15 +309,19 @@ auto-commit, `LeaveGroup`, assignment cleanup, and resource disposal:
 
 ```csharp
 .WithRebalanceListener(new MyRebalanceListener())
+.WithPartitionStopTimeout(TimeSpan.FromSeconds(30)) // Default: 5 seconds
 ```
 
 The same method accepts `IConsumerAwareRebalanceListener`. Its callbacks receive an
 `IRebalanceConsumer` view with safe commit, seek, pause/resume, metadata, and offset
 operations. The view is invalidated as soon as the callback completes.
 
-The stop callback is best-effort and bounded to five seconds. If it observes
-shutdown cancellation, Dekaf still completes local cleanup before rethrowing the
-cancellation from `CloseAsync`.
+`WithPartitionStopTimeout` bounds how long shutdown awaits the stop callback. When
+the timeout expires, Dekaf cancels the callback token and continues local cleanup;
+a callback that ignores cancellation can continue running after the consumer has
+closed. Caller cancellation or `WithDefaultApiTimeout` can shorten the available
+window. `ConsumerCloseOptions` only controls group-membership behavior and does not
+override this timeout.
 
 ## Networking
 

--- a/docs/docs/consumer/consumer-groups.md
+++ b/docs/docs/consumer/consumer-groups.md
@@ -126,6 +126,7 @@ var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
     .WithRebalanceListener(new MyRebalanceListener())
+    .WithPartitionStopTimeout(TimeSpan.FromSeconds(30))
     .BuildAsync();
 ```
 
@@ -138,7 +139,9 @@ Callback semantics:
 | `OnPartitionsLostAsync` | After ownership was lost involuntarily, such as heartbeat timeout or unknown member recovery. | Do not commit offsets for lost partitions unless your application has a separate ownership guarantee. |
 | `OnPartitionsStoppedAsync` | During graceful `CloseAsync` or `DisposeAsync`, after heartbeat, leader-refresh, auto-commit, and prefetch tasks stop and before final auto-commit, `LeaveGroup`, assignment cleanup, and resource disposal. | Drain local work if needed, commit completed offsets, then release resources. |
 
-Non-cancellation callback exceptions are logged and suppressed. `OperationCanceledException` follows the supplied cancellation token.
+Non-cancellation callback exceptions are logged and suppressed. The callback token
+is cancelled by caller cancellation, the aggregate `WithDefaultApiTimeout`, or the
+configured `WithPartitionStopTimeout`.
 
 Use `IConsumerAwareRebalanceListener` when a callback must operate on the consumer
 without capturing its unrestricted instance:
@@ -369,9 +372,21 @@ When a consumer leaves gracefully (`await using` or `CloseAsync`):
 4. Consumer sends `LeaveGroup` and releases resources
 5. Remaining consumers get its partitions
 
-The stop callback is bounded to five seconds. If it is cancelled, Dekaf still
-clears local assignment and releases resources before `CloseAsync` rethrows the
-cancellation.
+The stop callback timeout defaults to five seconds and is configured with
+`WithPartitionStopTimeout`. On expiry, Dekaf cancels the callback token and stops
+awaiting the callback so assignment cleanup and resource disposal can continue. A
+callback that ignores cancellation may keep running after close, so it must not use
+consumer-owned resources after its token is cancelled. Caller cancellation and the
+aggregate `WithDefaultApiTimeout` can end the window sooner; those cancellations are
+re-thrown by `CloseAsync` after local cleanup. `ConsumerCloseOptions` controls only
+whether group membership is retained or left and does not replace the callback
+timeout.
+
+For `KafkaConsumerService`, `KafkaConsumerServiceOptions.ShutdownTimeout`
+independently caps how long the hosted service awaits consumer disposal. Set it
+longer than `WithPartitionStopTimeout` plus remaining close work when the host must
+observe callback completion; the generic host's shutdown timeout can impose a
+further outer cap.
 
 Cancel the token passed to `ConsumeAsync` before closing when you need to stop a pending fetch promptly during shutdown.
 

--- a/docs/docs/hosted-services.md
+++ b/docs/docs/hosted-services.md
@@ -211,9 +211,10 @@ The full stop sequence is: cancel the consume loop → drain buffered messages (
 If the consumer's rebalance listener implements `IPartitionStopListener`, configure
 its close callback with `WithPartitionStopTimeout` (default: 5 seconds).
 `KafkaConsumerServiceOptions.ShutdownTimeout` is an independent outer wait cap for
-consumer disposal; make it longer than the partition-stop timeout plus remaining
-consumer cleanup when shutdown must await the callback. The generic host's own
-shutdown timeout may impose another outer cap.
+draining and consumer disposal. Set it long enough for draining, final commit, DLQ
+flush, the partition-stop timeout, and remaining consumer cleanup when shutdown
+must await the callback. The generic host's own shutdown timeout may impose another
+outer cap.
 
 ## Delivery Semantics
 

--- a/docs/docs/hosted-services.md
+++ b/docs/docs/hosted-services.md
@@ -208,6 +208,13 @@ When you supply a DLQ callback to `AddConsumerService`, it passes the registered
 
 The full stop sequence is: cancel the consume loop → drain buffered messages (if enabled) → commit final offsets → flush and dispose the DLQ producer → dispose the consumer. One safety exception: if shutdown interrupted a record mid-handling — whether it cancelled your `ProcessAsync`, an in-place retry, or an in-flight DLQ/retry-topic write, in the consume loop or during the drain itself — both draining and the final explicit commit are skipped, because pulling more records would mark the interrupted record processed and an explicit commit vouches for it directly. The consumer's close path still commits everything *proven* processed, so only the interrupted record is left uncommitted and redelivered on restart. This follows the consumer's [delivery contract](consumer/delivery-semantics.md): a record whose processing threw is never committed. One configuration is exempt: strict manual commit mode (`WithOffsetCommitMode(OffsetCommitMode.Manual)` + `WithAutoOffsetStore(false)`) still runs the final commit, because there it covers exactly the offsets your code explicitly stored — never the interrupted record. The service implements `IAsyncDisposable`; when registered via `AddHostedService`, the generic host uses the async path automatically, so shutdown never blocks a thread pool thread.
 
+If the consumer's rebalance listener implements `IPartitionStopListener`, configure
+its close callback with `WithPartitionStopTimeout` (default: 5 seconds).
+`KafkaConsumerServiceOptions.ShutdownTimeout` is an independent outer wait cap for
+consumer disposal; make it longer than the partition-stop timeout plus remaining
+consumer cleanup when shutdown must await the callback. The generic host's own
+shutdown timeout may impose another outer cap.
+
 ## Delivery Semantics
 
 The service inherits the consumer's guarantees — at-least-once by default, with offsets staged only for records the loop has yielded. See [Delivery Semantics](consumer/delivery-semantics.md) for the precise commit rules. Two service-specific points:

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1659,6 +1659,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int _maxCachedStringValueEntries = DefaultMaxCachedStringValueEntries;
     private IRebalanceListener? _rebalanceListener;
     private IConsumerAwareRebalanceListener? _consumerAwareRebalanceListener;
+    private TimeSpan _partitionStopTimeout = TimeSpan.FromSeconds(5);
     private Microsoft.Extensions.Logging.ILoggerFactory? _loggerFactory;
     private bool _enablePartitionEof;
     private int _socketSendBufferBytes;
@@ -2504,6 +2505,21 @@ public sealed class ConsumerBuilder<TKey, TValue>
         return this;
     }
 
+    /// <summary>
+    /// Sets the maximum time to await an <see cref="IPartitionStopListener"/> during
+    /// graceful <c>CloseAsync</c> or <c>DisposeAsync</c>. Default is 5 seconds.
+    /// </summary>
+    /// <param name="timeout">The partition-stop callback timeout. Must be at least one millisecond.</param>
+    public ConsumerBuilder<TKey, TValue> WithPartitionStopTimeout(TimeSpan timeout)
+    {
+        if (timeout < TimeSpan.FromMilliseconds(1))
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Partition stop timeout must be at least one millisecond");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+
+        _partitionStopTimeout = timeout;
+        return this;
+    }
+
     public ConsumerBuilder<TKey, TValue> WithLoggerFactory(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory)
     {
         _loggerFactory = loggerFactory;
@@ -3228,6 +3244,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             AwsMskIamConfig = _awsMskIamConfig,
             RebalanceListener = _rebalanceListener,
             ConsumerAwareRebalanceListener = _consumerAwareRebalanceListener,
+            PartitionStopTimeout = _partitionStopTimeout,
             EnablePartitionEof = _enablePartitionEof,
             SocketSendBufferBytes = _socketSendBufferBytes,
             SocketReceiveBufferBytes = _socketReceiveBufferBytes,

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -375,6 +375,13 @@ public sealed class ConsumerOptions
     public IRebalanceListener? RebalanceListener { get; init; }
 
     /// <summary>
+    /// Maximum time to await <see cref="IPartitionStopListener.OnPartitionsStoppedAsync"/>
+    /// during graceful shutdown. The callback token is cancelled when this timeout expires.
+    /// Default is 5 seconds.
+    /// </summary>
+    public TimeSpan PartitionStopTimeout { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
     /// Rebalance listener that receives a callback-scoped restricted consumer view.
     /// </summary>
     /// <remarks>Takes precedence over <see cref="RebalanceListener"/> when both are set.</remarks>

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -653,11 +653,12 @@ internal interface IConsumerRebalanceEventSource
 /// and disposal. The callback receives the current assigned partitions.
 ///
 /// Non-cancellation exceptions follow the rebalance listener policy: they are caught
-/// and logged at <c>Error</c> level. <see cref="OperationCanceledException"/> follows
-/// the <see cref="IKafkaConsumer{TKey,TValue}.CloseAsync(CancellationToken)"/> token or internal
-/// disposal shutdown token, but close/disposal teardown still runs before
-/// <c>CloseAsync</c> rethrows the cancellation. The callback is bounded by a
-/// five-second timeout.
+/// and logged at <c>Error</c> level. Cancellation caused by
+/// <see cref="ConsumerOptions.PartitionStopTimeout"/> is logged and suppressed so shutdown can
+/// continue. Cancellation from the <see cref="IKafkaConsumer{TKey,TValue}.CloseAsync(CancellationToken)"/>
+/// token or internal disposal shutdown token is deferred until teardown completes, then rethrown
+/// by <c>CloseAsync</c>. The callback token is cancelled after the configured timeout, which
+/// defaults to five seconds.
 /// </remarks>
 public interface IPartitionStopListener
 {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1142,8 +1142,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private const int MaxConsecutiveEmptyParsedFetches = 3;
     private const int MaxRepeatedDeterministicPrefetchFailures = 3;
     private const long FilterRefreshIntervalMilliseconds = 30_000;
-    private static readonly TimeSpan PartitionStopListenerTimeout = TimeSpan.FromSeconds(5);
-
     private readonly ConsumerOptions _options;
 
     /// <summary>
@@ -1677,6 +1675,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         ArgumentOutOfRangeException.ThrowIfLessThan(options.DefaultApiTimeoutMs, 1);
     }
 
+    internal static void ValidatePartitionStopTimeout(ConsumerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.PartitionStopTimeout < TimeSpan.FromMilliseconds(1)
+            || options.PartitionStopTimeout.TotalMilliseconds > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                options.PartitionStopTimeout,
+                "Partition stop timeout must be between one millisecond and Int32.MaxValue milliseconds");
+        }
+    }
+
     private KafkaConsumer(
         ConsumerOptions options,
         IDeserializer<TKey> keyDeserializer,
@@ -1698,6 +1709,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         ArgumentOutOfRangeException.ThrowIfLessThan(options.MaxPollIntervalMs, 1);
         ValidateFetchBufferMemory(options);
         ValidateDefaultApiTimeout(options);
+        ValidatePartitionStopTimeout(options);
         AutoOffsetResetStrategy.ValidateOptions(options);
 
         _options = options;
@@ -11061,10 +11073,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             return null;
 
         LogPartitionStopListenerCall(partitions.Length);
+        using var listenerTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        listenerTimeout.CancelAfter(_options.PartitionStopTimeout);
         try
         {
-            var listenerTask = listener.OnPartitionsStoppedAsync(partitions, cancellationToken).AsTask();
-            await listenerTask.WaitAsync(PartitionStopListenerTimeout, cancellationToken).ConfigureAwait(false);
+            var listenerTask = listener.OnPartitionsStoppedAsync(partitions, listenerTimeout.Token).AsTask();
+            await listenerTask.WaitAsync(listenerTimeout.Token).ConfigureAwait(false);
+            return null;
+        }
+        catch (OperationCanceledException)
+            when (!cancellationToken.IsCancellationRequested && listenerTimeout.IsCancellationRequested)
+        {
+            LogPartitionStopListenerTimedOut(_options.PartitionStopTimeout);
             return null;
         }
         catch (OperationCanceledException ex)
@@ -11500,6 +11520,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     [LoggerMessage(Level = LogLevel.Error, Message = "OnPartitionsStopped partition stop listener callback threw an exception")]
     private partial void LogPartitionStopListenerCallbackError(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "OnPartitionsStopped exceeded timeout {Timeout}; continuing shutdown")]
+    private partial void LogPartitionStopListenerTimedOut(TimeSpan timeout);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Committed pending offsets during close")]
     private partial void LogCommittedPendingOffsets();

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -127,3 +127,6 @@ Dekaf.Producer.KafkaProducer<TKey, TValue>.GetStatus() -> Dekaf.Diagnostics.Kafk
 Dekaf.Serialization.IAsyncDeserializerPreparer<T> (forwarded, contained in Dekaf.Abstractions)
 Dekaf.Serialization.IAsyncDeserializerPreparer<T>.TryDeserialize(System.ReadOnlyMemory<byte> data, Dekaf.Serialization.SerializationContext context, out T value) -> bool (forwarded, contained in Dekaf.Abstractions)
 Dekaf.Serialization.IAsyncDeserializerPreparer<T>.PrepareAsync(System.ReadOnlyMemory<byte> data, Dekaf.Serialization.SerializationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask (forwarded, contained in Dekaf.Abstractions)
+Dekaf.Consumer.ConsumerOptions.PartitionStopTimeout.get -> System.TimeSpan
+Dekaf.Consumer.ConsumerOptions.PartitionStopTimeout.init -> void
+Dekaf.ConsumerBuilder<TKey, TValue>.WithPartitionStopTimeout(System.TimeSpan timeout) -> Dekaf.ConsumerBuilder<TKey, TValue>!

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -127,3 +127,6 @@ Dekaf.Producer.KafkaProducer<TKey, TValue>.GetStatus() -> Dekaf.Diagnostics.Kafk
 Dekaf.Serialization.IAsyncDeserializerPreparer<T> (forwarded, contained in Dekaf.Abstractions)
 Dekaf.Serialization.IAsyncDeserializerPreparer<T>.TryDeserialize(System.ReadOnlyMemory<byte> data, Dekaf.Serialization.SerializationContext context, out T value) -> bool (forwarded, contained in Dekaf.Abstractions)
 Dekaf.Serialization.IAsyncDeserializerPreparer<T>.PrepareAsync(System.ReadOnlyMemory<byte> data, Dekaf.Serialization.SerializationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask (forwarded, contained in Dekaf.Abstractions)
+Dekaf.Consumer.ConsumerOptions.PartitionStopTimeout.get -> System.TimeSpan
+Dekaf.Consumer.ConsumerOptions.PartitionStopTimeout.init -> void
+Dekaf.ConsumerBuilder<TKey, TValue>.WithPartitionStopTimeout(System.TimeSpan timeout) -> Dekaf.ConsumerBuilder<TKey, TValue>!

--- a/tests/Dekaf.Tests.Integration/RealWorld/GracefulShutdownTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/GracefulShutdownTests.cs
@@ -123,6 +123,55 @@ public sealed class GracefulShutdownTests(KafkaTestContainer kafka) : KafkaInteg
     }
 
     [Test]
+    public async Task GracefulShutdown_PartitionStopTimeout_CancelsCallbackAndCloses()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"stop-timeout-{Guid.NewGuid():N}";
+        var listener = new BlockingStopRebalanceListener();
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "key",
+            Value = "value"
+        }, CancellationToken.None);
+
+        var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithRebalanceListener(listener)
+            .WithPartitionStopTimeout(TimeSpan.FromMilliseconds(50))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+
+        try
+        {
+            consumer.Subscribe(topic);
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var message = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+            await Assert.That(message).IsNotNull();
+
+            var close = consumer.CloseAsync().AsTask();
+
+            await listener.CancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await close.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(listener.Completed.Task.IsCompleted).IsFalse();
+            await Assert.That(consumer.Assignment).IsEmpty();
+        }
+        finally
+        {
+            listener.Release.TrySetResult();
+            await listener.Completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await consumer.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task GracefulShutdown_AtLeastOnceProcessing_NoMessageLoss()
     {
         // Simulate at-least-once: commit only after successful processing
@@ -488,6 +537,47 @@ public sealed class GracefulShutdownTests(KafkaTestContainer kafka) : KafkaInteg
         {
             StoppedPartitions.Add(partitions.ToList());
             return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class BlockingStopRebalanceListener : IRebalanceListener, IPartitionStopListener
+    {
+        public TaskCompletionSource CancellationObserved { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Completed { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ValueTask OnPartitionsAssignedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+        public ValueTask OnPartitionsRevokedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+        public ValueTask OnPartitionsLostAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+        public async ValueTask OnPartitionsStoppedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            using var registration = cancellationToken.Register(
+                static state => ((TaskCompletionSource)state!).TrySetResult(),
+                CancellationObserved);
+            try
+            {
+                await Release.Task.ConfigureAwait(false);
+            }
+            finally
+            {
+                Completed.TrySetResult();
+            }
         }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -467,6 +467,33 @@ public class ConsumerBuilderValidationTests
     }
 
     [Test]
+    public async Task WithPartitionStopTimeout_SetsOptions()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithPartitionStopTimeout(TimeSpan.FromSeconds(12))
+            .Build();
+
+        var options = GetConsumerOptions(consumer);
+        await Assert.That(options.PartitionStopTimeout).IsEqualTo(TimeSpan.FromSeconds(12));
+    }
+
+    [Test]
+    public async Task WithPartitionStopTimeout_OutsideMillisecondRange_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        await Assert.That(() => builder.WithPartitionStopTimeout(TimeSpan.Zero))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => builder.WithPartitionStopTimeout(TimeSpan.FromMilliseconds(-1)))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => builder.WithPartitionStopTimeout(TimeSpan.FromTicks(1)))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => builder.WithPartitionStopTimeout(TimeSpan.FromMilliseconds((double)int.MaxValue + 1)))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
     public async Task UseTls_ReturnsSameBuilder()
     {
         var builder = Kafka.CreateConsumer<string, string>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
@@ -8,6 +8,29 @@ namespace Dekaf.Tests.Unit.Consumer;
 public sealed class ConsumerPartitionStopListenerTests
 {
     [Test]
+    public async Task ConsumerOptions_PartitionStopTimeout_DefaultsToFiveSeconds()
+    {
+        var options = new ConsumerOptions { BootstrapServers = ["localhost:9092"] };
+
+        await Assert.That(options.PartitionStopTimeout).IsEqualTo(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ConsumerOptions_PartitionStopTimeout_RejectsInvalidValue()
+    {
+        await Assert.That(() => new KafkaConsumer<string, string>(
+                new ConsumerOptions
+                {
+                    BootstrapServers = ["localhost:9092"],
+                    QueuedMinMessages = 1,
+                    PartitionStopTimeout = TimeSpan.Zero
+                },
+                Serializers.String,
+                Serializers.String))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
     public async Task CloseAsync_InvokesPartitionStopListenerWithCurrentAssignment()
     {
         var listener = new TrackingPartitionStopListener();
@@ -80,6 +103,54 @@ public sealed class ConsumerPartitionStopListenerTests
     }
 
     [Test]
+    public async Task CloseAsync_PartitionStopTimeout_CancelsListenerAndContinuesCleanup()
+    {
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseListener = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var listenerCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var listener = new TrackingPartitionStopListener
+        {
+            OnStopped = async (_, cancellationToken) =>
+            {
+                using var registration = cancellationToken.Register(
+                    static state => ((TaskCompletionSource)state!).TrySetResult(),
+                    cancellationObserved);
+                try
+                {
+                    await releaseListener.Task.ConfigureAwait(false);
+                }
+                finally
+                {
+                    listenerCompleted.TrySetResult();
+                }
+            }
+        };
+        var consumer = CreateConsumer(
+            listener,
+            partitionStopTimeout: TimeSpan.FromMilliseconds(50));
+        var partition = new TopicPartition("topic-a", 0);
+        consumer.Assign(partition);
+
+        try
+        {
+            var close = consumer.CloseAsync().AsTask();
+
+            await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await close.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(listener.CancellationTokens[0].IsCancellationRequested).IsTrue();
+            await Assert.That(listenerCompleted.Task.IsCompleted).IsFalse();
+            await Assert.That(consumer.Assignment).IsEmpty();
+        }
+        finally
+        {
+            releaseListener.TrySetResult();
+            await listenerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await consumer.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task CloseAsync_BlockingHeartbeatShutdown_ObservesAggregateCancellation()
     {
         await using var consumer = CreateGroupConsumer(defaultApiTimeoutMs: 60_000);
@@ -128,7 +199,8 @@ public sealed class ConsumerPartitionStopListenerTests
 
     private static KafkaConsumer<string, string> CreateConsumer(
         IRebalanceListener listener,
-        int defaultApiTimeoutMs = 60_000)
+        int defaultApiTimeoutMs = 60_000,
+        TimeSpan? partitionStopTimeout = null)
     {
         return new KafkaConsumer<string, string>(
             new ConsumerOptions
@@ -137,7 +209,8 @@ public sealed class ConsumerPartitionStopListenerTests
                 OffsetCommitMode = OffsetCommitMode.Manual,
                 QueuedMinMessages = 1,
                 RebalanceListener = listener,
-                DefaultApiTimeoutMs = defaultApiTimeoutMs
+                DefaultApiTimeoutMs = defaultApiTimeoutMs,
+                PartitionStopTimeout = partitionStopTimeout ?? TimeSpan.FromSeconds(5)
             },
             Serializers.String,
             Serializers.String);


### PR DESCRIPTION
## Summary
- add `ConsumerOptions.PartitionStopTimeout` and `WithPartitionStopTimeout(TimeSpan)`, preserving the 5-second default
- cancel the listener token and continue local cleanup when the configured window expires
- document interactions with close, API, hosted-service, and generic-host timeouts
- cover direct options, builder validation, listener abandonment, and real Kafka shutdown behavior

## Performance
This only changes graceful shutdown. It adds no per-message, serialization, produce, consume, fetch, or protocol-path work, so no hot-path benchmark is applicable.

## Test plan
- `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- `tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe` — 7,451 passed
- `dotnet build tests/Dekaf.Tests.Integration --configuration Release`
- `tests/Dekaf.Tests.Integration/bin/Release/net10.0/Dekaf.Tests.Integration.exe --treenode-filter '/*/*/GracefulShutdownTests/GracefulShutdown_PartitionStopTimeout_CancelsCallbackAndCloses'` — 1 passed
- `npm run build --prefix docs`
- `/simplify` and self-review — no findings

Closes #2764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable timeouts for partition-stop callbacks during graceful consumer shutdown.
  - Callbacks are cancelled when the configured timeout expires, while shutdown and cleanup continue.
  - Added validation for supported timeout values, with a five-second default.

- **Documentation**
  - Expanded shutdown guidance, timeout interactions, cancellation behavior, and configuration examples.

- **Tests**
  - Added coverage for default values, validation, callback cancellation, assignment cleanup, and graceful shutdown completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->