### PR TITLE
feat(schema): add association client APIs

### DIFF
--- a/src/Dekaf.SchemaRegistry/AssociationValidation.cs
+++ b/src/Dekaf.SchemaRegistry/AssociationValidation.cs
@@ -1,0 +1,68 @@
+namespace Dekaf.SchemaRegistry;
+
+internal static class AssociationValidation
+{
+    internal static void ValidateGet(
+        string resourceName,
+        string resourceNamespace,
+        string? resourceType,
+        IReadOnlyList<string>? associationTypes,
+        string? lifecycle,
+        int offset,
+        int limit)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceNamespace);
+        ValidateOptionalFilter(resourceType, nameof(resourceType));
+        ValidateOptionalFilter(lifecycle, nameof(lifecycle));
+        ValidateTypes(associationTypes);
+        ArgumentOutOfRangeException.ThrowIfNegative(offset);
+        ArgumentOutOfRangeException.ThrowIfLessThan(limit, -1);
+    }
+
+    internal static void ValidateCreate(AssociationCreateOrUpdateRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceNamespace);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceType);
+        ArgumentNullException.ThrowIfNull(request.Associations);
+        if (request.Associations.Count == 0)
+            throw new ArgumentException("At least one association is required.", nameof(request));
+
+        for (var index = 0; index < request.Associations.Count; index++)
+        {
+            var association = request.Associations[index]
+                ?? throw new ArgumentException("Associations cannot contain null entries.", nameof(request));
+            ArgumentException.ThrowIfNullOrWhiteSpace(association.Subject);
+            ArgumentException.ThrowIfNullOrWhiteSpace(association.AssociationType);
+            ArgumentException.ThrowIfNullOrWhiteSpace(association.Lifecycle);
+        }
+    }
+
+    internal static void ValidateDelete(
+        string resourceId,
+        string? resourceType,
+        IReadOnlyList<string>? associationTypes)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
+        ValidateOptionalFilter(resourceType, nameof(resourceType));
+        ValidateTypes(associationTypes);
+    }
+
+    private static void ValidateTypes(IReadOnlyList<string>? associationTypes)
+    {
+        if (associationTypes is null)
+            return;
+
+        for (var index = 0; index < associationTypes.Count; index++)
+            ArgumentException.ThrowIfNullOrWhiteSpace(associationTypes[index]);
+    }
+
+    private static void ValidateOptionalFilter(string? value, string paramName)
+    {
+        if (value is not null && string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Value cannot be empty or whitespace.", paramName);
+    }
+}

--- a/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
@@ -419,6 +419,56 @@ public interface ISchemaRegistryClient : IDisposable
         bool permanent = false,
         CancellationToken cancellationToken = default)
         => throw new NotSupportedException("This Schema Registry client does not support DEK Registry DEK operations.");
+
+    /// <summary>
+    /// Gets subject associations for an external resource name.
+    /// </summary>
+    /// <param name="resourceName">The resource name, such as a Kafka topic name.</param>
+    /// <param name="resourceNamespace">The resource namespace, or <c>-</c> as a wildcard.</param>
+    /// <param name="resourceType">Optional resource-type filter.</param>
+    /// <param name="associationTypes">Optional repeated association-type filters.</param>
+    /// <param name="lifecycle">Optional lifecycle-policy filter.</param>
+    /// <param name="offset">Zero-based pagination offset.</param>
+    /// <param name="limit">Maximum result count, or -1 for no limit.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Associations matching the resource and filters.</returns>
+    Task<IReadOnlyList<Association>> GetAssociationsByResourceNameAsync(
+        string resourceName,
+        string resourceNamespace = "-",
+        string? resourceType = null,
+        IReadOnlyList<string>? associationTypes = null,
+        string? lifecycle = null,
+        int offset = 0,
+        int limit = -1,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("This Schema Registry client does not support association operations.");
+
+    /// <summary>
+    /// Creates or updates subject associations for an external resource.
+    /// </summary>
+    /// <param name="request">Association create-or-update request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The associations acknowledged by Schema Registry.</returns>
+    Task<AssociationResponse> CreateAssociationAsync(
+        AssociationCreateOrUpdateRequest request,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("This Schema Registry client does not support association operations.");
+
+    /// <summary>
+    /// Deletes subject associations for an external resource.
+    /// </summary>
+    /// <param name="resourceId">The resource identifier.</param>
+    /// <param name="resourceType">Optional resource-type filter.</param>
+    /// <param name="associationTypes">Optional repeated association-type filters.</param>
+    /// <param name="cascadeLifecycle">Whether to cascade lifecycle changes to associated schemas.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DeleteAssociationsAsync(
+        string resourceId,
+        string? resourceType = null,
+        IReadOnlyList<string>? associationTypes = null,
+        bool cascadeLifecycle = false,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("This Schema Registry client does not support association operations.");
 }
 
 /// <summary>

--- a/src/Dekaf.SchemaRegistry/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry/PublicAPI.Unshipped.txt
@@ -143,3 +143,79 @@ static Dekaf.SchemaRegistry.ResolvedSchemaContext.operator !=(Dekaf.SchemaRegist
 static Dekaf.SchemaRegistry.ResolvedSchemaContext.operator ==(Dekaf.SchemaRegistry.ResolvedSchemaContext left, Dekaf.SchemaRegistry.ResolvedSchemaContext right) -> bool
 ~override Dekaf.SchemaRegistry.ResolvedSchemaContext.Equals(object obj) -> bool
 ~override Dekaf.SchemaRegistry.ResolvedSchemaContext.ToString() -> string
+Dekaf.SchemaRegistry.Association
+Dekaf.SchemaRegistry.Association.Association() -> void
+Dekaf.SchemaRegistry.Association.AssociationType.get -> string!
+Dekaf.SchemaRegistry.Association.AssociationType.init -> void
+Dekaf.SchemaRegistry.Association.Frozen.get -> bool
+Dekaf.SchemaRegistry.Association.Frozen.init -> void
+Dekaf.SchemaRegistry.Association.Guid.get -> string!
+Dekaf.SchemaRegistry.Association.Guid.init -> void
+Dekaf.SchemaRegistry.Association.Lifecycle.get -> string!
+Dekaf.SchemaRegistry.Association.Lifecycle.init -> void
+Dekaf.SchemaRegistry.Association.ResourceId.get -> string!
+Dekaf.SchemaRegistry.Association.ResourceId.init -> void
+Dekaf.SchemaRegistry.Association.ResourceName.get -> string!
+Dekaf.SchemaRegistry.Association.ResourceName.init -> void
+Dekaf.SchemaRegistry.Association.ResourceNamespace.get -> string!
+Dekaf.SchemaRegistry.Association.ResourceNamespace.init -> void
+Dekaf.SchemaRegistry.Association.ResourceType.get -> string!
+Dekaf.SchemaRegistry.Association.ResourceType.init -> void
+Dekaf.SchemaRegistry.Association.Subject.get -> string!
+Dekaf.SchemaRegistry.Association.Subject.init -> void
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateInfo
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateInfo.AssociationCreateOrUpdateInfo() -> void
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateInfo.AssociationType.get -> string!
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateInfo.AssociationType.init -> void
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateInfo.Frozen.get -> bool?
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateInfo.Frozen.init -> void
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateInfo.Lifecycle.get -> string!
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateInfo.Lifecycle.init -> void
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateInfo.Normalize.get -> bool?
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateInfo.Normalize.init -> void
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateInfo.Schema.get -> Dekaf.SchemaRegistry.Schema?
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateInfo.Schema.init -> void
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateInfo.Subject.get -> string!
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateInfo.Subject.init -> void
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateRequest
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateRequest.AssociationCreateOrUpdateRequest() -> void
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateRequest.Associations.get -> System.Collections.Generic.IReadOnlyList<Dekaf.SchemaRegistry.AssociationCreateOrUpdateInfo!>!
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateRequest.Associations.init -> void
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateRequest.ResourceId.get -> string!
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateRequest.ResourceId.init -> void
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateRequest.ResourceName.get -> string!
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateRequest.ResourceName.init -> void
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateRequest.ResourceNamespace.get -> string!
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateRequest.ResourceNamespace.init -> void
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateRequest.ResourceType.get -> string!
+Dekaf.SchemaRegistry.AssociationCreateOrUpdateRequest.ResourceType.init -> void
+Dekaf.SchemaRegistry.AssociationInfo
+Dekaf.SchemaRegistry.AssociationInfo.AssociationInfo() -> void
+Dekaf.SchemaRegistry.AssociationInfo.AssociationType.get -> string!
+Dekaf.SchemaRegistry.AssociationInfo.AssociationType.init -> void
+Dekaf.SchemaRegistry.AssociationInfo.Frozen.get -> bool
+Dekaf.SchemaRegistry.AssociationInfo.Frozen.init -> void
+Dekaf.SchemaRegistry.AssociationInfo.Lifecycle.get -> string!
+Dekaf.SchemaRegistry.AssociationInfo.Lifecycle.init -> void
+Dekaf.SchemaRegistry.AssociationInfo.Schema.get -> Dekaf.SchemaRegistry.Schema?
+Dekaf.SchemaRegistry.AssociationInfo.Schema.init -> void
+Dekaf.SchemaRegistry.AssociationInfo.Subject.get -> string!
+Dekaf.SchemaRegistry.AssociationInfo.Subject.init -> void
+Dekaf.SchemaRegistry.AssociationResponse
+Dekaf.SchemaRegistry.AssociationResponse.AssociationResponse() -> void
+Dekaf.SchemaRegistry.AssociationResponse.Associations.get -> System.Collections.Generic.IReadOnlyList<Dekaf.SchemaRegistry.AssociationInfo!>!
+Dekaf.SchemaRegistry.AssociationResponse.Associations.init -> void
+Dekaf.SchemaRegistry.AssociationResponse.ResourceId.get -> string!
+Dekaf.SchemaRegistry.AssociationResponse.ResourceId.init -> void
+Dekaf.SchemaRegistry.AssociationResponse.ResourceName.get -> string!
+Dekaf.SchemaRegistry.AssociationResponse.ResourceName.init -> void
+Dekaf.SchemaRegistry.AssociationResponse.ResourceNamespace.get -> string!
+Dekaf.SchemaRegistry.AssociationResponse.ResourceNamespace.init -> void
+Dekaf.SchemaRegistry.AssociationResponse.ResourceType.get -> string!
+Dekaf.SchemaRegistry.AssociationResponse.ResourceType.init -> void
+Dekaf.SchemaRegistry.ISchemaRegistryClient.CreateAssociationAsync(Dekaf.SchemaRegistry.AssociationCreateOrUpdateRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Dekaf.SchemaRegistry.AssociationResponse!>!
+Dekaf.SchemaRegistry.ISchemaRegistryClient.DeleteAssociationsAsync(string! resourceId, string? resourceType = null, System.Collections.Generic.IReadOnlyList<string!>? associationTypes = null, bool cascadeLifecycle = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Dekaf.SchemaRegistry.ISchemaRegistryClient.GetAssociationsByResourceNameAsync(string! resourceName, string! resourceNamespace = "-", string? resourceType = null, System.Collections.Generic.IReadOnlyList<string!>? associationTypes = null, string? lifecycle = null, int offset = 0, int limit = -1, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Dekaf.SchemaRegistry.Association!>!>!
+Dekaf.SchemaRegistry.SchemaRegistryClient.CreateAssociationAsync(Dekaf.SchemaRegistry.AssociationCreateOrUpdateRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Dekaf.SchemaRegistry.AssociationResponse!>!
+Dekaf.SchemaRegistry.SchemaRegistryClient.DeleteAssociationsAsync(string! resourceId, string? resourceType = null, System.Collections.Generic.IReadOnlyList<string!>? associationTypes = null, bool cascadeLifecycle = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Dekaf.SchemaRegistry.SchemaRegistryClient.GetAssociationsByResourceNameAsync(string! resourceName, string! resourceNamespace = "-", string? resourceType = null, System.Collections.Generic.IReadOnlyList<string!>? associationTypes = null, string? lifecycle = null, int offset = 0, int limit = -1, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Dekaf.SchemaRegistry.Association!>!>!

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryAssociations.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryAssociations.cs
@@ -1,0 +1,121 @@
+namespace Dekaf.SchemaRegistry;
+
+/// <summary>
+/// Describes an association between a Schema Registry subject and an external resource.
+/// </summary>
+public sealed class Association
+{
+    /// <summary>The associated subject name.</summary>
+    public required string Subject { get; init; }
+
+    /// <summary>The globally unique association identifier.</summary>
+    public required string Guid { get; init; }
+
+    /// <summary>The external resource name, such as a Kafka topic name.</summary>
+    public required string ResourceName { get; init; }
+
+    /// <summary>The resource namespace, such as a Kafka cluster ID.</summary>
+    public required string ResourceNamespace { get; init; }
+
+    /// <summary>The resource identifier.</summary>
+    public required string ResourceId { get; init; }
+
+    /// <summary>The resource type, such as <c>topic</c>.</summary>
+    public required string ResourceType { get; init; }
+
+    /// <summary>The association type, such as <c>key</c> or <c>value</c>.</summary>
+    public required string AssociationType { get; init; }
+
+    /// <summary>The association lifecycle policy.</summary>
+    public required string Lifecycle { get; init; }
+
+    /// <summary>Whether the association is frozen.</summary>
+    public bool Frozen { get; init; }
+}
+
+/// <summary>
+/// Describes one subject association to create or update.
+/// </summary>
+public sealed class AssociationCreateOrUpdateInfo
+{
+    /// <summary>The subject name.</summary>
+    public required string Subject { get; init; }
+
+    /// <summary>The association type, such as <c>key</c> or <c>value</c>.</summary>
+    public required string AssociationType { get; init; }
+
+    /// <summary>The lifecycle policy.</summary>
+    public required string Lifecycle { get; init; }
+
+    /// <summary>Whether to freeze the association, or <see langword="null" /> to retain the server default.</summary>
+    public bool? Frozen { get; init; }
+
+    /// <summary>An optional schema to register with the association.</summary>
+    public Schema? Schema { get; init; }
+
+    /// <summary>Whether Schema Registry should normalize <see cref="Schema" />.</summary>
+    public bool? Normalize { get; init; }
+}
+
+/// <summary>
+/// Requests creation or update of subject associations for a resource.
+/// </summary>
+public sealed class AssociationCreateOrUpdateRequest
+{
+    /// <summary>The external resource name, such as a Kafka topic name.</summary>
+    public required string ResourceName { get; init; }
+
+    /// <summary>The resource namespace, such as a Kafka cluster ID.</summary>
+    public required string ResourceNamespace { get; init; }
+
+    /// <summary>The resource identifier.</summary>
+    public required string ResourceId { get; init; }
+
+    /// <summary>The resource type, such as <c>topic</c>.</summary>
+    public required string ResourceType { get; init; }
+
+    /// <summary>The subject associations to create or update.</summary>
+    public required IReadOnlyList<AssociationCreateOrUpdateInfo> Associations { get; init; }
+}
+
+/// <summary>
+/// Describes an association returned after a create or update operation.
+/// </summary>
+public sealed class AssociationInfo
+{
+    /// <summary>The associated subject name.</summary>
+    public required string Subject { get; init; }
+
+    /// <summary>The association type, such as <c>key</c> or <c>value</c>.</summary>
+    public required string AssociationType { get; init; }
+
+    /// <summary>The lifecycle policy.</summary>
+    public required string Lifecycle { get; init; }
+
+    /// <summary>Whether the association is frozen.</summary>
+    public bool Frozen { get; init; }
+
+    /// <summary>The schema registered with the association, when returned by Schema Registry.</summary>
+    public Schema? Schema { get; init; }
+}
+
+/// <summary>
+/// Result of creating or updating associations for a resource.
+/// </summary>
+public sealed class AssociationResponse
+{
+    /// <summary>The external resource name.</summary>
+    public required string ResourceName { get; init; }
+
+    /// <summary>The resource namespace.</summary>
+    public required string ResourceNamespace { get; init; }
+
+    /// <summary>The resource identifier.</summary>
+    public required string ResourceId { get; init; }
+
+    /// <summary>The resource type.</summary>
+    public required string ResourceType { get; init; }
+
+    /// <summary>The associations created or updated by Schema Registry.</summary>
+    public required IReadOnlyList<AssociationInfo> Associations { get; init; }
+}

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -863,13 +863,14 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         int limit = -1,
         CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(resourceName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(resourceNamespace);
-        ValidateOptionalAssociationFilter(resourceType, nameof(resourceType));
-        ValidateOptionalAssociationFilter(lifecycle, nameof(lifecycle));
-        ValidateAssociationTypes(associationTypes);
-        ArgumentOutOfRangeException.ThrowIfNegative(offset);
-        ArgumentOutOfRangeException.ThrowIfLessThan(limit, -1);
+        AssociationValidation.ValidateGet(
+            resourceName,
+            resourceNamespace,
+            resourceType,
+            associationTypes,
+            lifecycle,
+            offset,
+            limit);
 
         var path = WithAssociationQuery(
             $"associations/resources/{Uri.EscapeDataString(resourceNamespace)}/{Uri.EscapeDataString(resourceName)}",
@@ -898,12 +899,11 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         AssociationCreateOrUpdateRequest request,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(request);
-        ValidateAssociationRequest(request);
+        AssociationValidation.ValidateCreate(request);
 
         using var response = await PostAsJsonWithFailoverAsync(
             "associations",
-            ToAssociationRequestDto(request),
+            ToAssociationRequestDto(request, _config.NormalizeSchemas),
             SchemaRegistryJsonContext.Default.AssociationCreateOrUpdateRequestDto,
             cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -928,9 +928,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         bool cascadeLifecycle = false,
         CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
-        ValidateOptionalAssociationFilter(resourceType, nameof(resourceType));
-        ValidateAssociationTypes(associationTypes);
+        AssociationValidation.ValidateDelete(resourceId, resourceType, associationTypes);
 
         var path = WithAssociationQuery(
             $"associations/resources/{Uri.EscapeDataString(resourceId)}",
@@ -942,41 +940,6 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             cascadeLifecycle);
         using var response = await DeleteWithFailoverAsync(path, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
-    }
-
-    private static void ValidateAssociationRequest(AssociationCreateOrUpdateRequest request)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceNamespace);
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceId);
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceType);
-        ArgumentNullException.ThrowIfNull(request.Associations);
-        if (request.Associations.Count == 0)
-            throw new ArgumentException("At least one association is required.", nameof(request));
-
-        for (var index = 0; index < request.Associations.Count; index++)
-        {
-            var association = request.Associations[index]
-                ?? throw new ArgumentException("Associations cannot contain null entries.", nameof(request));
-            ArgumentException.ThrowIfNullOrWhiteSpace(association.Subject);
-            ArgumentException.ThrowIfNullOrWhiteSpace(association.AssociationType);
-            ArgumentException.ThrowIfNullOrWhiteSpace(association.Lifecycle);
-        }
-    }
-
-    private static void ValidateAssociationTypes(IReadOnlyList<string>? associationTypes)
-    {
-        if (associationTypes is null)
-            return;
-
-        for (var index = 0; index < associationTypes.Count; index++)
-            ArgumentException.ThrowIfNullOrWhiteSpace(associationTypes[index]);
-    }
-
-    private static void ValidateOptionalAssociationFilter(string? value, string paramName)
-    {
-        if (value is not null && string.IsNullOrWhiteSpace(value))
-            throw new ArgumentException("Value cannot be empty or whitespace.", paramName);
     }
 
     private static string GetCompatibilityPath(string? subject)
@@ -1279,7 +1242,8 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
     };
 
     private static AssociationCreateOrUpdateRequestDto ToAssociationRequestDto(
-        AssociationCreateOrUpdateRequest request)
+        AssociationCreateOrUpdateRequest request,
+        bool normalizeSchemas)
     {
         var associations = new List<AssociationCreateOrUpdateInfoDto>(request.Associations.Count);
         for (var index = 0; index < request.Associations.Count; index++)
@@ -1292,7 +1256,9 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
                 Lifecycle = association.Lifecycle,
                 Frozen = association.Frozen,
                 Schema = association.Schema is null ? null : CreateRegisterSchemaRequest(association.Schema),
-                Normalize = association.Normalize
+                Normalize = normalizeSchemas && association.Schema is not null
+                    ? true
+                    : association.Normalize
             });
         }
 

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -347,18 +347,54 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
     {
         StringBuilder? builder = null;
         foreach (var (name, value) in parameters)
-        {
-            if (value is null)
-                continue;
-
-            builder ??= new StringBuilder(path);
-            builder.Append(builder.Length == path.Length ? '?' : '&');
-            builder.Append(Uri.EscapeDataString(name));
-            builder.Append('=');
-            builder.Append(Uri.EscapeDataString(value));
-        }
+            AppendQueryParameter(ref builder, path, name, value);
 
         return builder?.ToString() ?? path;
+    }
+
+    private static string WithAssociationQuery(
+        string path,
+        string? resourceType,
+        IReadOnlyList<string>? associationTypes,
+        string? lifecycle,
+        int? offset,
+        int? limit,
+        bool? cascadeLifecycle)
+    {
+        StringBuilder? builder = null;
+        AppendQueryParameter(ref builder, path, "resourceType", resourceType);
+
+        if (associationTypes is not null)
+        {
+            for (var index = 0; index < associationTypes.Count; index++)
+                AppendQueryParameter(ref builder, path, "associationType", associationTypes[index]);
+        }
+
+        AppendQueryParameter(ref builder, path, "lifecycle", lifecycle);
+        AppendQueryParameter(ref builder, path, "offset", IntQuery(offset));
+        AppendQueryParameter(ref builder, path, "limit", IntQuery(limit));
+        AppendQueryParameter(
+            ref builder,
+            path,
+            "cascadeLifecycle",
+            cascadeLifecycle.HasValue ? cascadeLifecycle.Value ? "true" : "false" : null);
+        return builder?.ToString() ?? path;
+    }
+
+    private static void AppendQueryParameter(
+        ref StringBuilder? builder,
+        string path,
+        string name,
+        string? value)
+    {
+        if (value is null)
+            return;
+
+        builder ??= new StringBuilder(path);
+        builder.Append(builder.Length == path.Length ? '?' : '&');
+        builder.Append(Uri.EscapeDataString(name));
+        builder.Append('=');
+        builder.Append(Uri.EscapeDataString(value));
     }
 
     private static string? BoolQuery(bool value) => value ? "true" : null;
@@ -817,6 +853,132 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             SchemaRegistryJsonContext.Default.ListInt32, cancellationToken).ConfigureAwait(false) ?? [];
     }
 
+    public async Task<IReadOnlyList<Association>> GetAssociationsByResourceNameAsync(
+        string resourceName,
+        string resourceNamespace = "-",
+        string? resourceType = null,
+        IReadOnlyList<string>? associationTypes = null,
+        string? lifecycle = null,
+        int offset = 0,
+        int limit = -1,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceNamespace);
+        ValidateOptionalAssociationFilter(resourceType, nameof(resourceType));
+        ValidateOptionalAssociationFilter(lifecycle, nameof(lifecycle));
+        ValidateAssociationTypes(associationTypes);
+        ArgumentOutOfRangeException.ThrowIfNegative(offset);
+        ArgumentOutOfRangeException.ThrowIfLessThan(limit, -1);
+
+        var path = WithAssociationQuery(
+            $"associations/resources/{Uri.EscapeDataString(resourceNamespace)}/{Uri.EscapeDataString(resourceName)}",
+            resourceType,
+            associationTypes,
+            lifecycle,
+            offset == 0 ? null : offset,
+            limit == -1 ? null : limit,
+            cascadeLifecycle: null);
+        using var response = await GetWithFailoverAsync(path, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var result = await response.Content.ReadFromJsonAsync<List<AssociationDto>>(
+            SchemaRegistryJsonContext.Default.ListAssociationDto,
+            cancellationToken).ConfigureAwait(false);
+        if (result is null or { Count: 0 })
+            return [];
+
+        var associations = new Association[result.Count];
+        for (var index = 0; index < result.Count; index++)
+            associations[index] = ToAssociation(result[index]);
+        return associations;
+    }
+
+    public async Task<AssociationResponse> CreateAssociationAsync(
+        AssociationCreateOrUpdateRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ValidateAssociationRequest(request);
+
+        using var response = await PostAsJsonWithFailoverAsync(
+            "associations",
+            ToAssociationRequestDto(request),
+            SchemaRegistryJsonContext.Default.AssociationCreateOrUpdateRequestDto,
+            cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var result = await response.Content.ReadFromJsonAsync<AssociationResponseDto>(
+            SchemaRegistryJsonContext.Default.AssociationResponseDto,
+            cancellationToken).ConfigureAwait(false);
+        if (result is null)
+        {
+            throw new SchemaRegistryException(
+                (int)response.StatusCode,
+                "Schema Registry returned an empty association response");
+        }
+
+        return ToAssociationResponse(result);
+    }
+
+    public async Task DeleteAssociationsAsync(
+        string resourceId,
+        string? resourceType = null,
+        IReadOnlyList<string>? associationTypes = null,
+        bool cascadeLifecycle = false,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
+        ValidateOptionalAssociationFilter(resourceType, nameof(resourceType));
+        ValidateAssociationTypes(associationTypes);
+
+        var path = WithAssociationQuery(
+            $"associations/resources/{Uri.EscapeDataString(resourceId)}",
+            resourceType,
+            associationTypes,
+            lifecycle: null,
+            offset: null,
+            limit: null,
+            cascadeLifecycle);
+        using var response = await DeleteWithFailoverAsync(path, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void ValidateAssociationRequest(AssociationCreateOrUpdateRequest request)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceNamespace);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ResourceType);
+        ArgumentNullException.ThrowIfNull(request.Associations);
+        if (request.Associations.Count == 0)
+            throw new ArgumentException("At least one association is required.", nameof(request));
+
+        for (var index = 0; index < request.Associations.Count; index++)
+        {
+            var association = request.Associations[index]
+                ?? throw new ArgumentException("Associations cannot contain null entries.", nameof(request));
+            ArgumentException.ThrowIfNullOrWhiteSpace(association.Subject);
+            ArgumentException.ThrowIfNullOrWhiteSpace(association.AssociationType);
+            ArgumentException.ThrowIfNullOrWhiteSpace(association.Lifecycle);
+        }
+    }
+
+    private static void ValidateAssociationTypes(IReadOnlyList<string>? associationTypes)
+    {
+        if (associationTypes is null)
+            return;
+
+        for (var index = 0; index < associationTypes.Count; index++)
+            ArgumentException.ThrowIfNullOrWhiteSpace(associationTypes[index]);
+    }
+
+    private static void ValidateOptionalAssociationFilter(string? value, string paramName)
+    {
+        if (value is not null && string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Value cannot be empty or whitespace.", paramName);
+    }
+
     private static string GetCompatibilityPath(string? subject)
     {
         if (subject is null)
@@ -1115,6 +1277,73 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         Metadata = ToMetadataDto(schema.Metadata),
         RuleSet = ToRuleSetDto(schema.RuleSet)
     };
+
+    private static AssociationCreateOrUpdateRequestDto ToAssociationRequestDto(
+        AssociationCreateOrUpdateRequest request)
+    {
+        var associations = new List<AssociationCreateOrUpdateInfoDto>(request.Associations.Count);
+        for (var index = 0; index < request.Associations.Count; index++)
+        {
+            var association = request.Associations[index];
+            associations.Add(new AssociationCreateOrUpdateInfoDto
+            {
+                Subject = association.Subject,
+                AssociationType = association.AssociationType,
+                Lifecycle = association.Lifecycle,
+                Frozen = association.Frozen,
+                Schema = association.Schema is null ? null : CreateRegisterSchemaRequest(association.Schema),
+                Normalize = association.Normalize
+            });
+        }
+
+        return new AssociationCreateOrUpdateRequestDto
+        {
+            ResourceName = request.ResourceName,
+            ResourceNamespace = request.ResourceNamespace,
+            ResourceId = request.ResourceId,
+            ResourceType = request.ResourceType,
+            Associations = associations
+        };
+    }
+
+    private static Association ToAssociation(AssociationDto association) => new()
+    {
+        Subject = association.Subject,
+        Guid = association.Guid,
+        ResourceName = association.ResourceName,
+        ResourceNamespace = association.ResourceNamespace,
+        ResourceId = association.ResourceId,
+        ResourceType = association.ResourceType,
+        AssociationType = association.AssociationType,
+        Lifecycle = association.Lifecycle,
+        Frozen = association.Frozen
+    };
+
+    private static AssociationResponse ToAssociationResponse(AssociationResponseDto response)
+    {
+        var associations = new AssociationInfo[response.Associations.Count];
+        for (var index = 0; index < response.Associations.Count; index++)
+        {
+            var association = response.Associations[index];
+            associations[index] = new AssociationInfo
+            {
+                Subject = association.Subject,
+                AssociationType = association.AssociationType,
+                Lifecycle = association.Lifecycle,
+                Frozen = association.Frozen,
+                Schema = association.Schema is null ? null : CreateSchema(association.Schema)
+            };
+        }
+
+        return new AssociationResponse
+        {
+            ResourceName = response.ResourceName,
+            ResourceNamespace = response.ResourceNamespace,
+            ResourceId = response.ResourceId,
+            ResourceType = response.ResourceType,
+            Associations = associations
+        };
+    }
 
     private static Schema CreateSchema(GetSchemaResponse response) => new()
     {

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -1256,9 +1256,9 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
                 Lifecycle = association.Lifecycle,
                 Frozen = association.Frozen,
                 Schema = association.Schema is null ? null : CreateRegisterSchemaRequest(association.Schema),
-                Normalize = normalizeSchemas && association.Schema is not null
-                    ? true
-                    : association.Normalize
+                Normalize = association.Schema is null
+                    ? association.Normalize
+                    : association.Normalize ?? normalizeSchemas
             });
         }
 

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryJsonContext.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryJsonContext.cs
@@ -22,6 +22,9 @@ namespace Dekaf.SchemaRegistry;
 [JsonSerializable(typeof(GetCompatibilityResponse))]
 [JsonSerializable(typeof(UpdateCompatibilityRequest))]
 [JsonSerializable(typeof(UpdateCompatibilityResponse))]
+[JsonSerializable(typeof(AssociationCreateOrUpdateRequestDto))]
+[JsonSerializable(typeof(AssociationResponseDto))]
+[JsonSerializable(typeof(List<AssociationDto>))]
 [JsonSerializable(typeof(ErrorResponse))]
 [JsonSerializable(typeof(List<string>))]
 [JsonSerializable(typeof(List<int>))]
@@ -163,6 +166,56 @@ internal sealed class UpdateCompatibilityRequest
 internal sealed class UpdateCompatibilityResponse
 {
     public string? Compatibility { get; init; }
+}
+
+internal sealed class AssociationDto
+{
+    public required string Subject { get; init; }
+    public required string Guid { get; init; }
+    public required string ResourceName { get; init; }
+    public required string ResourceNamespace { get; init; }
+    public required string ResourceId { get; init; }
+    public required string ResourceType { get; init; }
+    public required string AssociationType { get; init; }
+    public required string Lifecycle { get; init; }
+    public bool Frozen { get; init; }
+}
+
+internal sealed class AssociationCreateOrUpdateInfoDto
+{
+    public required string Subject { get; init; }
+    public required string AssociationType { get; init; }
+    public required string Lifecycle { get; init; }
+    public bool? Frozen { get; init; }
+    public RegisterSchemaRequest? Schema { get; init; }
+    public bool? Normalize { get; init; }
+}
+
+internal sealed class AssociationCreateOrUpdateRequestDto
+{
+    public required string ResourceName { get; init; }
+    public required string ResourceNamespace { get; init; }
+    public required string ResourceId { get; init; }
+    public required string ResourceType { get; init; }
+    public required List<AssociationCreateOrUpdateInfoDto> Associations { get; init; }
+}
+
+internal sealed class AssociationInfoDto
+{
+    public required string Subject { get; init; }
+    public required string AssociationType { get; init; }
+    public required string Lifecycle { get; init; }
+    public bool Frozen { get; init; }
+    public GetSchemaResponse? Schema { get; init; }
+}
+
+internal sealed class AssociationResponseDto
+{
+    public required string ResourceName { get; init; }
+    public required string ResourceNamespace { get; init; }
+    public required string ResourceId { get; init; }
+    public required string ResourceType { get; init; }
+    public required List<AssociationInfoDto> Associations { get; init; }
 }
 
 internal sealed class ErrorResponse

--- a/tests/Dekaf.Tests.Aot/Program.cs
+++ b/tests/Dekaf.Tests.Aot/Program.cs
@@ -46,6 +46,7 @@ internal static class AotSmoke
         RunSchemaRegistryHttpPipelineConstructionSmoke();
         await RunSchemaRegistrySmokeAsync();
         await RunSchemaRegistryCompatibilitySmokeAsync();
+        await RunSchemaRegistryAssociationSmokeAsync();
         await RunSchemaRegistryPackageSmokeAsync();
         await RunCoreSmokeAsync();
     }
@@ -166,6 +167,51 @@ internal static class AotSmoke
         Require(current == SchemaCompatibilityLevel.Backward, "Compatibility GET smoke failed.");
         Require(updated == SchemaCompatibilityLevel.FullTransitive, "Compatibility PUT smoke failed.");
         Require(handler.RequestCount == 2, "Compatibility request count mismatch.");
+    }
+
+    private static async Task RunSchemaRegistryAssociationSmokeAsync()
+    {
+        using var handler = new AssociationHandler();
+        using var registry = new SchemaRegistryClient(
+            new SchemaRegistryConfig { Url = "https://schema-registry.example.test" },
+            handler);
+        var request = new AssociationCreateOrUpdateRequest
+        {
+            ResourceName = "aot-topic",
+            ResourceNamespace = "lkc-aot",
+            ResourceId = "lkc-aot:aot-topic",
+            ResourceType = "topic",
+            Associations =
+            [
+                new AssociationCreateOrUpdateInfo
+                {
+                    Subject = "aot-topic-value",
+                    AssociationType = "value",
+                    Lifecycle = "STRONG",
+                    Schema = new Schema
+                    {
+                        SchemaString = AotPayloadJsonSchema,
+                        SchemaType = SchemaType.Json
+                    }
+                }
+            ]
+        };
+
+        var created = await registry.CreateAssociationAsync(request);
+        var found = await registry.GetAssociationsByResourceNameAsync(
+            "aot-topic",
+            "lkc-aot",
+            associationTypes: ["value"]);
+        await registry.DeleteAssociationsAsync(
+            "lkc-aot:aot-topic",
+            associationTypes: ["value"],
+            cascadeLifecycle: true);
+
+        Require(created.Associations.Count == 1, "Association create smoke failed.");
+        Require(created.Associations[0].Schema?.SchemaType == SchemaType.Json,
+            "Association schema mapping smoke failed.");
+        Require(found.Count == 1, "Association list smoke failed.");
+        Require(handler.RequestCount == 3, "Association request count mismatch.");
     }
 
     private static async Task RunSchemaRegistryPackageSmokeAsync()
@@ -374,6 +420,73 @@ internal static class AotSmoke
             Require(body.Contains("\"compatibility\":\"FULL_TRANSITIVE\"", StringComparison.Ordinal),
                 "Compatibility PUT body mismatch.");
             return JsonResponse("""{ "compatibility": "FULL_TRANSITIVE" }""");
+        }
+
+        private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class AssociationHandler : HttpMessageHandler
+    {
+        internal int RequestCount { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            if (RequestCount == 1)
+            {
+                Require(request.Method == HttpMethod.Post, "Association POST method mismatch.");
+                var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+                Require(body.Contains("\"schemaType\":\"JSON\"", StringComparison.Ordinal),
+                    "Association schema body mismatch.");
+                return JsonResponse("""
+                    {
+                      "resourceName": "aot-topic",
+                      "resourceNamespace": "lkc-aot",
+                      "resourceId": "lkc-aot:aot-topic",
+                      "resourceType": "topic",
+                      "associations": [
+                        {
+                          "subject": "aot-topic-value",
+                          "associationType": "value",
+                          "lifecycle": "STRONG",
+                          "frozen": false,
+                          "schema": {
+                            "schema": "{}",
+                            "schemaType": "JSON"
+                          }
+                        }
+                      ]
+                    }
+                    """);
+            }
+
+            if (RequestCount == 2)
+            {
+                Require(request.Method == HttpMethod.Get, "Association GET method mismatch.");
+                return JsonResponse("""
+                    [
+                      {
+                        "subject": "aot-topic-value",
+                        "guid": "guid-aot",
+                        "resourceName": "aot-topic",
+                        "resourceNamespace": "lkc-aot",
+                        "resourceId": "lkc-aot:aot-topic",
+                        "resourceType": "topic",
+                        "associationType": "value",
+                        "lifecycle": "STRONG",
+                        "frozen": false
+                      }
+                    ]
+                    """);
+            }
+
+            Require(request.Method == HttpMethod.Delete, "Association DELETE method mismatch.");
+            return new HttpResponseMessage(HttpStatusCode.NoContent);
         }
 
         private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryAssociationIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryAssociationIntegrationTests.cs
@@ -3,6 +3,7 @@ using Dekaf.SchemaRegistry;
 namespace Dekaf.Tests.Integration;
 
 [ClassDataSource<KafkaWithAssociationSchemaRegistryContainer>(Shared = SharedType.PerTestSession)]
+[Category("Serialization")]
 public sealed class SchemaRegistryAssociationIntegrationTests(KafkaWithAssociationSchemaRegistryContainer testInfra)
 {
     [Test]

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryAssociationIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryAssociationIntegrationTests.cs
@@ -1,0 +1,70 @@
+using Dekaf.SchemaRegistry;
+
+namespace Dekaf.Tests.Integration;
+
+[ClassDataSource<KafkaWithAssociationSchemaRegistryContainer>(Shared = SharedType.PerTestSession)]
+public sealed class SchemaRegistryAssociationIntegrationTests(KafkaWithAssociationSchemaRegistryContainer testInfra)
+{
+    [Test]
+    public async Task Association_CreateListDelete_RoundTripsAgainstSchemaRegistry()
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var resourceName = $"orders-{suffix}";
+        var resourceNamespace = $"cluster-{suffix}";
+        var resourceId = $"{resourceNamespace}:{resourceName}";
+        var subject = $"{resourceName}-value";
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = testInfra.RegistryUrl
+        });
+        await client.RegisterSchemaAsync(subject, new Schema
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = "{\"type\":\"object\"}"
+        });
+        var request = new AssociationCreateOrUpdateRequest
+        {
+            ResourceName = resourceName,
+            ResourceNamespace = resourceNamespace,
+            ResourceId = resourceId,
+            ResourceType = "topic",
+            Associations =
+            [
+                new AssociationCreateOrUpdateInfo
+                {
+                    Subject = subject,
+                    AssociationType = "value",
+                    Lifecycle = "WEAK",
+                    Frozen = false
+                }
+            ]
+        };
+
+        var created = await client.CreateAssociationAsync(request);
+        try
+        {
+            var found = await client.GetAssociationsByResourceNameAsync(
+                resourceName,
+                resourceNamespace: "-",
+                resourceType: "topic",
+                associationTypes: ["value"],
+                lifecycle: "WEAK");
+
+            await Assert.That(created.ResourceId).IsEqualTo(resourceId);
+            await Assert.That(created.Associations).Count().IsEqualTo(1);
+            await Assert.That(found).Count().IsEqualTo(1);
+            await Assert.That(found[0].Subject).IsEqualTo(subject);
+        }
+        finally
+        {
+            await client.DeleteAssociationsAsync(
+                resourceId,
+                resourceType: "topic",
+                associationTypes: ["value"]);
+        }
+
+        var remaining = await client.GetAssociationsByResourceNameAsync(resourceName, resourceNamespace);
+
+        await Assert.That(remaining).IsEmpty();
+    }
+}

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
@@ -14,7 +14,7 @@ namespace Dekaf.Tests.Integration;
 /// </summary>
 public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposable
 {
-    private static readonly ContainerImageBootstrapCoordinator ImageBootstrapCoordinator = new();
+    private static readonly ConcurrentDictionary<string, ContainerImageBootstrapCoordinator> ImageBootstrapCoordinators = new();
 
     private KafkaContainer? _kafkaContainer;
     private IContainer? _schemaRegistryContainer;
@@ -34,6 +34,8 @@ public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposa
     /// The Schema Registry URL.
     /// </summary>
     public string RegistryUrl => _registryUrl;
+
+    protected virtual string SchemaRegistryImage => "confluentinc/cp-schema-registry:7.9.0";
 
     public async Task InitializeAsync()
     {
@@ -55,7 +57,10 @@ public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposa
         }
 
         // A complete first startup guarantees Testcontainers has pulled both images.
-        await ImageBootstrapCoordinator.RunAsync(StartLocalContainersAsync).ConfigureAwait(false);
+        var bootstrapCoordinator = ImageBootstrapCoordinators.GetOrAdd(
+            SchemaRegistryImage,
+            static _ => new ContainerImageBootstrapCoordinator());
+        await bootstrapCoordinator.RunAsync(StartLocalContainersAsync).ConfigureAwait(false);
     }
 
     private async Task StartLocalContainersAsync()
@@ -92,7 +97,7 @@ public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposa
         Console.WriteLine("[KafkaWithSchemaRegistry] Starting Schema Registry container...");
 
         // Start Schema Registry connected to Kafka via network
-        _schemaRegistryContainer = new ContainerBuilder("confluentinc/cp-schema-registry:7.9.0")
+        _schemaRegistryContainer = new ContainerBuilder(SchemaRegistryImage)
             .WithNetwork(_network)
             .WithNetworkAliases("schema-registry")
             .WithPortBinding(8081, true)
@@ -251,4 +256,9 @@ public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposa
 
         GC.SuppressFinalize(this);
     }
+}
+
+public sealed class KafkaWithAssociationSchemaRegistryContainer : KafkaWithSchemaRegistryContainer
+{
+    protected override string SchemaRegistryImage => "confluentinc/cp-schema-registry:8.2.0";
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroPocoSchemaRegistryTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroPocoSchemaRegistryTests.cs
@@ -1642,6 +1642,7 @@ public sealed class AvroPocoSchemaRegistryTests
     }
 
     [Test]
+    [NotInParallel]
     [Arguments(SubjectNameStrategy.TopicRecordName, false)]
     [Arguments(SubjectNameStrategy.TopicRecordName, true)]
     [Arguments(SubjectNameStrategy.RecordName, true)]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/MockSchemaRegistryClient.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/MockSchemaRegistryClient.cs
@@ -355,10 +355,22 @@ internal sealed class MockSchemaRegistryClient : ISchemaRegistryClient, ISchemaR
         ThrowIfDisposed();
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!_associationsByResource.TryGetValue((resourceNamespace, resourceName), out var stored))
+        IEnumerable<Association> filtered;
+        if (resourceNamespace == "-")
+        {
+            filtered = _associationsByResource
+                .Where(entry => entry.Key.Name == resourceName)
+                .SelectMany(static entry => entry.Value);
+        }
+        else if (_associationsByResource.TryGetValue((resourceNamespace, resourceName), out var stored))
+        {
+            filtered = stored;
+        }
+        else
+        {
             return Task.FromResult<IReadOnlyList<Association>>([]);
+        }
 
-        IEnumerable<Association> filtered = stored;
         if (resourceType is not null)
             filtered = filtered.Where(association => association.ResourceType == resourceType);
         if (associationTypes is { Count: > 0 })

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/MockSchemaRegistryClient.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/MockSchemaRegistryClient.cs
@@ -353,6 +353,14 @@ internal sealed class MockSchemaRegistryClient : ISchemaRegistryClient, ISchemaR
         CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
+        AssociationValidation.ValidateGet(
+            resourceName,
+            resourceNamespace,
+            resourceType,
+            associationTypes,
+            lifecycle,
+            offset,
+            limit);
         cancellationToken.ThrowIfCancellationRequested();
 
         IEnumerable<Association> filtered;
@@ -390,6 +398,7 @@ internal sealed class MockSchemaRegistryClient : ISchemaRegistryClient, ISchemaR
         CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
+        AssociationValidation.ValidateCreate(request);
         cancellationToken.ThrowIfCancellationRequested();
 
         var key = (request.ResourceNamespace, request.ResourceName);
@@ -446,6 +455,7 @@ internal sealed class MockSchemaRegistryClient : ISchemaRegistryClient, ISchemaR
         CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
+        AssociationValidation.ValidateDelete(resourceId, resourceType, associationTypes);
         cancellationToken.ThrowIfCancellationRequested();
 
         foreach (var stored in _associationsByResource.Values)

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/MockSchemaRegistryClient.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/MockSchemaRegistryClient.cs
@@ -10,6 +10,7 @@ internal sealed class MockSchemaRegistryClient : ISchemaRegistryClient, ISchemaR
 {
     private readonly Dictionary<int, Schema> _schemasById = new();
     private readonly Dictionary<string, List<(int Version, int Id, Schema Schema)>> _schemasBySubject = new();
+    private readonly Dictionary<(string Namespace, string Name), List<Association>> _associationsByResource = new();
     private TaskCompletionSource? _getSchemaEntered;
     private TaskCompletionSource? _getSchemaRelease;
     private TaskCompletionSource? _getOrRegisterSchemaEntered;
@@ -339,6 +340,111 @@ internal sealed class MockSchemaRegistryClient : ISchemaRegistryClient, ISchemaR
         _schemasBySubject.Remove(subject);
 
         return Task.FromResult<IReadOnlyList<int>>(versions);
+    }
+
+    public Task<IReadOnlyList<Association>> GetAssociationsByResourceNameAsync(
+        string resourceName,
+        string resourceNamespace = "-",
+        string? resourceType = null,
+        IReadOnlyList<string>? associationTypes = null,
+        string? lifecycle = null,
+        int offset = 0,
+        int limit = -1,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_associationsByResource.TryGetValue((resourceNamespace, resourceName), out var stored))
+            return Task.FromResult<IReadOnlyList<Association>>([]);
+
+        IEnumerable<Association> filtered = stored;
+        if (resourceType is not null)
+            filtered = filtered.Where(association => association.ResourceType == resourceType);
+        if (associationTypes is { Count: > 0 })
+            filtered = filtered.Where(association => associationTypes.Contains(association.AssociationType));
+        if (lifecycle is not null)
+            filtered = filtered.Where(association => association.Lifecycle == lifecycle);
+        if (offset > 0)
+            filtered = filtered.Skip(offset);
+        if (limit >= 0)
+            filtered = filtered.Take(limit);
+
+        return Task.FromResult<IReadOnlyList<Association>>(filtered.ToArray());
+    }
+
+    public Task<AssociationResponse> CreateAssociationAsync(
+        AssociationCreateOrUpdateRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var key = (request.ResourceNamespace, request.ResourceName);
+        if (!_associationsByResource.TryGetValue(key, out var stored))
+        {
+            stored = [];
+            _associationsByResource[key] = stored;
+        }
+
+        var responseAssociations = new AssociationInfo[request.Associations.Count];
+        for (var index = 0; index < request.Associations.Count; index++)
+        {
+            var association = request.Associations[index];
+            stored.RemoveAll(existing =>
+                existing.Subject == association.Subject &&
+                existing.AssociationType == association.AssociationType);
+            stored.Add(new Association
+            {
+                Subject = association.Subject,
+                Guid = $"mock-{request.ResourceId}-{association.AssociationType}",
+                ResourceName = request.ResourceName,
+                ResourceNamespace = request.ResourceNamespace,
+                ResourceId = request.ResourceId,
+                ResourceType = request.ResourceType,
+                AssociationType = association.AssociationType,
+                Lifecycle = association.Lifecycle,
+                Frozen = association.Frozen ?? false
+            });
+            responseAssociations[index] = new AssociationInfo
+            {
+                Subject = association.Subject,
+                AssociationType = association.AssociationType,
+                Lifecycle = association.Lifecycle,
+                Frozen = association.Frozen ?? false,
+                Schema = association.Schema
+            };
+        }
+
+        return Task.FromResult(new AssociationResponse
+        {
+            ResourceName = request.ResourceName,
+            ResourceNamespace = request.ResourceNamespace,
+            ResourceId = request.ResourceId,
+            ResourceType = request.ResourceType,
+            Associations = responseAssociations
+        });
+    }
+
+    public Task DeleteAssociationsAsync(
+        string resourceId,
+        string? resourceType = null,
+        IReadOnlyList<string>? associationTypes = null,
+        bool cascadeLifecycle = false,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        foreach (var stored in _associationsByResource.Values)
+        {
+            stored.RemoveAll(association =>
+                association.ResourceId == resourceId &&
+                (resourceType is null || association.ResourceType == resourceType) &&
+                (associationTypes is not { Count: > 0 } || associationTypes.Contains(association.AssociationType)));
+        }
+
+        return Task.CompletedTask;
     }
 
     public void Dispose()

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryAssociationTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryAssociationTests.cs
@@ -96,7 +96,7 @@ public sealed class SchemaRegistryAssociationTests
     }
 
     [Test]
-    public async Task CreateAssociationAsync_ClientNormalization_NormalizesEmbeddedSchema()
+    public async Task CreateAssociationAsync_ClientNormalization_RespectsPerAssociationSetting()
     {
         var handler = new AssociationHandler(HttpStatusCode.OK, """
             {
@@ -128,6 +128,14 @@ public sealed class SchemaRegistryAssociationTests
                 Subject = "orders-key",
                 AssociationType = "key",
                 Lifecycle = "STRONG"
+            },
+            new AssociationCreateOrUpdateInfo
+            {
+                Subject = "legacy-value",
+                AssociationType = "value",
+                Lifecycle = "STRONG",
+                Schema = new Schema { SchemaString = "{}" },
+                Normalize = false
             }
         ]);
 
@@ -139,6 +147,9 @@ public sealed class SchemaRegistryAssociationTests
             .IsTrue();
         await Assert.That(body.RootElement.GetProperty("associations")[1]
                 .TryGetProperty("normalize", out _))
+            .IsFalse();
+        await Assert.That(body.RootElement.GetProperty("associations")[2]
+                .GetProperty("normalize").GetBoolean())
             .IsFalse();
     }
 

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryAssociationTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryAssociationTests.cs
@@ -1,0 +1,299 @@
+using System.Net;
+using System.Text.Json;
+using Dekaf.SchemaRegistry;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public sealed class SchemaRegistryAssociationTests
+{
+    [Test]
+    public async Task CreateAssociationAsync_SendsCompatibleContractAndMapsResponse()
+    {
+        var handler = new AssociationHandler(HttpStatusCode.OK, """
+            {
+              "resourceName": "orders/eu",
+              "resourceNamespace": "lkc-123",
+              "resourceId": "lkc-123:orders/eu",
+              "resourceType": "topic",
+              "associations": [
+                {
+                  "subject": "orders-value",
+                  "associationType": "value",
+                  "lifecycle": "STRONG",
+                  "frozen": true,
+                  "schema": {
+                    "schema": "{\"type\":\"object\"}",
+                    "schemaType": "JSON",
+                    "references": [
+                      { "name": "common", "subject": "common-value", "version": 2 }
+                    ]
+                  }
+                }
+              ]
+            }
+            """);
+        using var client = CreateClient(handler);
+        var request = new AssociationCreateOrUpdateRequest
+        {
+            ResourceName = "orders/eu",
+            ResourceNamespace = "lkc-123",
+            ResourceId = "lkc-123:orders/eu",
+            ResourceType = "topic",
+            Associations =
+            [
+                new AssociationCreateOrUpdateInfo
+                {
+                    Subject = "orders-value",
+                    AssociationType = "value",
+                    Lifecycle = "STRONG",
+                    Frozen = true,
+                    Normalize = true,
+                    Schema = new Schema
+                    {
+                        SchemaString = "{\"type\":\"object\"}",
+                        SchemaType = SchemaType.Json,
+                        References =
+                        [
+                            new SchemaReference
+                            {
+                                Name = "common",
+                                Subject = "common-value",
+                                Version = 2
+                            }
+                        ]
+                    }
+                }
+            ]
+        };
+
+        var result = await client.CreateAssociationAsync(request);
+
+        await Assert.That(handler.Method).IsEqualTo(HttpMethod.Post);
+        await Assert.That(handler.RequestUri!.AbsolutePath).IsEqualTo("/associations");
+        using var body = JsonDocument.Parse(handler.RequestBody!);
+        var root = body.RootElement;
+        await Assert.That(root.GetProperty("resourceName").GetString()).IsEqualTo("orders/eu");
+        await Assert.That(root.GetProperty("resourceNamespace").GetString()).IsEqualTo("lkc-123");
+        await Assert.That(root.GetProperty("resourceId").GetString()).IsEqualTo("lkc-123:orders/eu");
+        await Assert.That(root.GetProperty("resourceType").GetString()).IsEqualTo("topic");
+        var association = root.GetProperty("associations")[0];
+        await Assert.That(association.GetProperty("subject").GetString()).IsEqualTo("orders-value");
+        await Assert.That(association.GetProperty("associationType").GetString()).IsEqualTo("value");
+        await Assert.That(association.GetProperty("lifecycle").GetString()).IsEqualTo("STRONG");
+        await Assert.That(association.GetProperty("frozen").GetBoolean()).IsTrue();
+        await Assert.That(association.GetProperty("normalize").GetBoolean()).IsTrue();
+        var schema = association.GetProperty("schema");
+        await Assert.That(schema.GetProperty("schema").GetString()).IsEqualTo("{\"type\":\"object\"}");
+        await Assert.That(schema.GetProperty("schemaType").GetString()).IsEqualTo("JSON");
+        await Assert.That(schema.GetProperty("references")[0].GetProperty("subject").GetString())
+            .IsEqualTo("common-value");
+
+        await Assert.That(result.ResourceName).IsEqualTo("orders/eu");
+        await Assert.That(result.Associations).Count().IsEqualTo(1);
+        await Assert.That(result.Associations[0].Subject).IsEqualTo("orders-value");
+        await Assert.That(result.Associations[0].Schema!.SchemaType).IsEqualTo(SchemaType.Json);
+        await Assert.That(result.Associations[0].Schema!.References![0].Version).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task GetAssociationsByResourceNameAsync_UsesCompatiblePathAndRepeatedFilters()
+    {
+        var handler = new AssociationHandler(HttpStatusCode.OK, """
+            [
+              {
+                "subject": "orders-key",
+                "guid": "guid-1",
+                "resourceName": "orders/eu",
+                "resourceNamespace": "lkc 123",
+                "resourceId": "resource-1",
+                "resourceType": "topic",
+                "associationType": "key",
+                "lifecycle": "WEAK",
+                "frozen": false
+              }
+            ]
+            """);
+        using var client = CreateClient(handler);
+
+        var result = await client.GetAssociationsByResourceNameAsync(
+            "orders/eu",
+            "lkc 123",
+            resourceType: "topic/name",
+            associationTypes: ["key", "value with space"],
+            lifecycle: "WEAK",
+            offset: 3,
+            limit: 10);
+
+        await Assert.That(handler.Method).IsEqualTo(HttpMethod.Get);
+        await Assert.That(handler.RequestUri!.AbsolutePath)
+            .IsEqualTo("/associations/resources/lkc%20123/orders%2Feu");
+        await Assert.That(handler.RequestUri.Query)
+            .IsEqualTo("?resourceType=topic%2Fname&associationType=key&associationType=value%20with%20space&lifecycle=WEAK&offset=3&limit=10");
+        await Assert.That(result).Count().IsEqualTo(1);
+        await Assert.That(result[0].Guid).IsEqualTo("guid-1");
+        await Assert.That(result[0].ResourceNamespace).IsEqualTo("lkc 123");
+    }
+
+    [Test]
+    public async Task GetAssociationsByResourceNameAsync_Defaults_OmitOptionalQuery()
+    {
+        var handler = new AssociationHandler(HttpStatusCode.OK, "[]");
+        using var client = CreateClient(handler);
+
+        var result = await client.GetAssociationsByResourceNameAsync("orders", "-");
+
+        await Assert.That(result).IsEmpty();
+        await Assert.That(handler.RequestUri!.PathAndQuery)
+            .IsEqualTo("/associations/resources/-/orders");
+    }
+
+    [Test]
+    public async Task DeleteAssociationsAsync_SendsFiltersAndAcceptsNoContent()
+    {
+        var handler = new AssociationHandler(HttpStatusCode.NoContent, null);
+        using var client = CreateClient(handler);
+
+        await client.DeleteAssociationsAsync(
+            "lkc-123:orders/eu",
+            resourceType: "topic",
+            associationTypes: ["key", "value"],
+            cascadeLifecycle: true);
+
+        await Assert.That(handler.Method).IsEqualTo(HttpMethod.Delete);
+        await Assert.That(handler.RequestUri!.AbsolutePath)
+            .IsEqualTo("/associations/resources/lkc-123%3Aorders%2Feu");
+        await Assert.That(handler.RequestUri.Query)
+            .IsEqualTo("?resourceType=topic&associationType=key&associationType=value&cascadeLifecycle=true");
+    }
+
+    [Test]
+    public async Task DeleteAssociationsAsync_Defaults_IncludeFalseCascade()
+    {
+        var handler = new AssociationHandler(HttpStatusCode.NoContent, null);
+        using var client = CreateClient(handler);
+
+        await client.DeleteAssociationsAsync("resource-1");
+
+        await Assert.That(handler.RequestUri!.PathAndQuery)
+            .IsEqualTo("/associations/resources/resource-1?cascadeLifecycle=false");
+    }
+
+    [Test]
+    public async Task AssociationOperations_ValidateArguments()
+    {
+        using var client = CreateClient(new AssociationHandler(HttpStatusCode.OK, "[]"));
+
+        await Assert.That(async () => _ = await client.GetAssociationsByResourceNameAsync("", "-"))
+            .Throws<ArgumentException>();
+        await Assert.That(async () => _ = await client.GetAssociationsByResourceNameAsync("orders", "", offset: 0))
+            .Throws<ArgumentException>();
+        await Assert.That(async () => _ = await client.GetAssociationsByResourceNameAsync("orders", "-", offset: -1))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(async () => _ = await client.GetAssociationsByResourceNameAsync("orders", "-", limit: -2))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(async () => _ = await client.CreateAssociationAsync(null!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => client.DeleteAssociationsAsync(""))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task GetAssociationsByResourceNameAsync_PropagatesCancellation()
+    {
+        var handler = new AssociationHandler(HttpStatusCode.OK, "[]");
+        using var client = CreateClient(handler);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.That(async () => _ = await client.GetAssociationsByResourceNameAsync(
+                "orders",
+                "-",
+                cancellationToken: cts.Token))
+            .Throws<OperationCanceledException>();
+        await Assert.That(handler.CancellationToken.IsCancellationRequested).IsTrue();
+    }
+
+    [Test]
+    public async Task GetAssociationsByResourceNameAsync_MapsRegistryError()
+    {
+        var handler = new AssociationHandler(HttpStatusCode.NotFound, """
+            { "error_code": 40401, "message": "association not found" }
+            """);
+        using var client = CreateClient(handler);
+
+        var exception = await Assert.That(async () => _ = await client.GetAssociationsByResourceNameAsync("orders", "-"))
+            .Throws<SchemaRegistryException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(40401);
+        await Assert.That(exception.Message).IsEqualTo("association not found");
+    }
+
+    [Test]
+    public async Task MockSchemaRegistryClient_AssociationOperationsRoundTrip()
+    {
+        using var client = new MockSchemaRegistryClient();
+        var request = new AssociationCreateOrUpdateRequest
+        {
+            ResourceName = "orders",
+            ResourceNamespace = "lkc-123",
+            ResourceId = "lkc-123:orders",
+            ResourceType = "topic",
+            Associations =
+            [
+                new AssociationCreateOrUpdateInfo
+                {
+                    Subject = "orders-value",
+                    AssociationType = "value",
+                    Lifecycle = "STRONG"
+                }
+            ]
+        };
+
+        var created = await client.CreateAssociationAsync(request);
+        var found = await client.GetAssociationsByResourceNameAsync(
+            "orders",
+            "lkc-123",
+            associationTypes: ["value"]);
+
+        await Assert.That(created.Associations[0].Subject).IsEqualTo("orders-value");
+        await Assert.That(found).Count().IsEqualTo(1);
+        await Assert.That(found[0].ResourceId).IsEqualTo("lkc-123:orders");
+
+        await client.DeleteAssociationsAsync(
+            "lkc-123:orders",
+            associationTypes: ["value"]);
+        found = await client.GetAssociationsByResourceNameAsync("orders", "lkc-123");
+
+        await Assert.That(found).IsEmpty();
+    }
+
+    private static SchemaRegistryClient CreateClient(HttpMessageHandler handler) => new(
+        new SchemaRegistryConfig { Url = "http://schema-registry.local" },
+        handler);
+
+    private sealed class AssociationHandler(HttpStatusCode statusCode, string? responseBody) : HttpMessageHandler
+    {
+        public HttpMethod? Method { get; private set; }
+        public Uri? RequestUri { get; private set; }
+        public string? RequestBody { get; private set; }
+        public CancellationToken CancellationToken { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Method = request.Method;
+            RequestUri = request.RequestUri;
+            CancellationToken = cancellationToken;
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (request.Content is not null)
+                RequestBody = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            return new HttpResponseMessage(statusCode)
+            {
+                Content = responseBody is null ? null : new StringContent(responseBody)
+            };
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryAssociationTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryAssociationTests.cs
@@ -252,7 +252,7 @@ public sealed class SchemaRegistryAssociationTests
         var created = await client.CreateAssociationAsync(request);
         var found = await client.GetAssociationsByResourceNameAsync(
             "orders",
-            "lkc-123",
+            "-",
             associationTypes: ["value"]);
 
         await Assert.That(created.Associations[0].Subject).IsEqualTo("orders-value");

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryAssociationTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryAssociationTests.cs
@@ -96,6 +96,53 @@ public sealed class SchemaRegistryAssociationTests
     }
 
     [Test]
+    public async Task CreateAssociationAsync_ClientNormalization_NormalizesEmbeddedSchema()
+    {
+        var handler = new AssociationHandler(HttpStatusCode.OK, """
+            {
+              "resourceName": "orders",
+              "resourceNamespace": "lkc-123",
+              "resourceId": "lkc-123:orders",
+              "resourceType": "topic",
+              "associations": []
+            }
+            """);
+        using var client = new SchemaRegistryClient(
+            new SchemaRegistryConfig
+            {
+                Url = "http://schema-registry.local",
+                NormalizeSchemas = true
+            },
+            handler);
+        var request = CreateAssociationRequest(associations:
+        [
+            new AssociationCreateOrUpdateInfo
+            {
+                Subject = "orders-value",
+                AssociationType = "value",
+                Lifecycle = "STRONG",
+                Schema = new Schema { SchemaString = "{}" }
+            },
+            new AssociationCreateOrUpdateInfo
+            {
+                Subject = "orders-key",
+                AssociationType = "key",
+                Lifecycle = "STRONG"
+            }
+        ]);
+
+        await client.CreateAssociationAsync(request);
+
+        using var body = JsonDocument.Parse(handler.RequestBody!);
+        await Assert.That(body.RootElement.GetProperty("associations")[0]
+                .GetProperty("normalize").GetBoolean())
+            .IsTrue();
+        await Assert.That(body.RootElement.GetProperty("associations")[1]
+                .TryGetProperty("normalize", out _))
+            .IsFalse();
+    }
+
+    [Test]
     public async Task GetAssociationsByResourceNameAsync_UsesCompatiblePathAndRepeatedFilters()
     {
         var handler = new AssociationHandler(HttpStatusCode.OK, """
@@ -266,6 +313,90 @@ public sealed class SchemaRegistryAssociationTests
 
         await Assert.That(found).IsEmpty();
     }
+
+    [Test]
+    public async Task MockSchemaRegistryClient_GetAssociations_ValidatesLikePublicClient()
+    {
+        using var client = new MockSchemaRegistryClient();
+
+        await Assert.That(async () => _ = await client.GetAssociationsByResourceNameAsync("", "-"))
+            .Throws<ArgumentException>();
+        await Assert.That(async () => _ = await client.GetAssociationsByResourceNameAsync("orders", " "))
+            .Throws<ArgumentException>();
+        await Assert.That(async () => _ = await client.GetAssociationsByResourceNameAsync("orders", "-", resourceType: ""))
+            .Throws<ArgumentException>();
+        await Assert.That(async () => _ = await client.GetAssociationsByResourceNameAsync("orders", "-", associationTypes: [""]))
+            .Throws<ArgumentException>();
+        await Assert.That(async () => _ = await client.GetAssociationsByResourceNameAsync("orders", "-", lifecycle: " "))
+            .Throws<ArgumentException>();
+        await Assert.That(async () => _ = await client.GetAssociationsByResourceNameAsync("orders", "-", offset: -1))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(async () => _ = await client.GetAssociationsByResourceNameAsync("orders", "-", limit: -2))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task MockSchemaRegistryClient_CreateAssociation_ValidatesLikePublicClient()
+    {
+        using var client = new MockSchemaRegistryClient();
+
+        await Assert.That(async () => _ = await client.CreateAssociationAsync(null!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(async () => _ = await client.CreateAssociationAsync(CreateAssociationRequest(resourceName: "")))
+            .Throws<ArgumentException>();
+        await Assert.That(async () => _ = await client.CreateAssociationAsync(CreateAssociationRequest(resourceNamespace: "")))
+            .Throws<ArgumentException>();
+        await Assert.That(async () => _ = await client.CreateAssociationAsync(CreateAssociationRequest(resourceId: "")))
+            .Throws<ArgumentException>();
+        await Assert.That(async () => _ = await client.CreateAssociationAsync(CreateAssociationRequest(resourceType: "")))
+            .Throws<ArgumentException>();
+        await Assert.That(async () => _ = await client.CreateAssociationAsync(CreateAssociationRequest(associations: [])))
+            .Throws<ArgumentException>();
+        await Assert.That(async () => _ = await client.CreateAssociationAsync(CreateAssociationRequest(associations:
+        [
+            new AssociationCreateOrUpdateInfo
+            {
+                Subject = "",
+                AssociationType = "value",
+                Lifecycle = "STRONG"
+            }
+        ]))).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task MockSchemaRegistryClient_DeleteAssociations_ValidatesLikePublicClient()
+    {
+        using var client = new MockSchemaRegistryClient();
+
+        await Assert.That(() => client.DeleteAssociationsAsync(""))
+            .Throws<ArgumentException>();
+        await Assert.That(() => client.DeleteAssociationsAsync("resource-1", resourceType: " "))
+            .Throws<ArgumentException>();
+        await Assert.That(() => client.DeleteAssociationsAsync("resource-1", associationTypes: [""]))
+            .Throws<ArgumentException>();
+    }
+
+    private static AssociationCreateOrUpdateRequest CreateAssociationRequest(
+        string resourceName = "orders",
+        string resourceNamespace = "lkc-123",
+        string resourceId = "lkc-123:orders",
+        string resourceType = "topic",
+        IReadOnlyList<AssociationCreateOrUpdateInfo>? associations = null) => new()
+    {
+        ResourceName = resourceName,
+        ResourceNamespace = resourceNamespace,
+        ResourceId = resourceId,
+        ResourceType = resourceType,
+        Associations = associations ??
+        [
+            new AssociationCreateOrUpdateInfo
+            {
+                Subject = "orders-value",
+                AssociationType = "value",
+                Lifecycle = "STRONG"
+            }
+        ]
+    };
 
     private static SchemaRegistryClient CreateClient(HttpMessageHandler handler) => new(
         new SchemaRegistryConfig { Url = "http://schema-registry.local" },

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryJsonAotTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryJsonAotTests.cs
@@ -123,6 +123,35 @@ public sealed class SchemaRegistryJsonAotTests
         var updateCompatibility = JsonSerializer.Deserialize(
             """{ "compatibility": "FORWARD" }""",
             SchemaRegistryJsonContext.Default.UpdateCompatibilityResponse);
+        var associationJson = JsonSerializer.SerializeToUtf8Bytes(
+            new AssociationCreateOrUpdateRequestDto
+            {
+                ResourceName = "orders",
+                ResourceNamespace = "lkc-123",
+                ResourceId = "lkc-123:orders",
+                ResourceType = "topic",
+                Associations =
+                [
+                    new AssociationCreateOrUpdateInfoDto
+                    {
+                        Subject = "orders-value",
+                        AssociationType = "value",
+                        Lifecycle = "STRONG"
+                    }
+                ]
+            },
+            SchemaRegistryJsonContext.Default.AssociationCreateOrUpdateRequestDto);
+        var associationResponse = JsonSerializer.Deserialize(
+            """
+            {
+              "resourceName": "orders",
+              "resourceNamespace": "lkc-123",
+              "resourceId": "lkc-123:orders",
+              "resourceType": "topic",
+              "associations": []
+            }
+            """,
+            SchemaRegistryJsonContext.Default.AssociationResponseDto);
         var errorJson = JsonSerializer.SerializeToUtf8Bytes(
             new ErrorResponse { ErrorCode = 40401, Message = "missing" },
             SchemaRegistryJsonContext.Default.ErrorResponse);
@@ -143,6 +172,10 @@ public sealed class SchemaRegistryJsonAotTests
             .IsEqualTo("FULL_TRANSITIVE");
         await Assert.That(getCompatibility!.CompatibilityLevel).IsEqualTo("BACKWARD");
         await Assert.That(updateCompatibility!.Compatibility).IsEqualTo("FORWARD");
+        using var associationDocument = JsonDocument.Parse(associationJson);
+        await Assert.That(associationDocument.RootElement.GetProperty("associations")[0]
+            .GetProperty("subject").GetString()).IsEqualTo("orders-value");
+        await Assert.That(associationResponse!.ResourceId).IsEqualTo("lkc-123:orders");
         await Assert.That(errorDocument.RootElement.TryGetProperty("error_code", out _)).IsTrue();
     }
 


### PR DESCRIPTION
## Summary

- add public Schema Registry association contracts and client APIs
- implement GET, POST, and DELETE association endpoints through the existing auth/failover/error pipeline
- add source-generated JSON metadata, mock-client parity, and managed/NativeAOT smoke coverage
- validate the real create/list/delete lifecycle against Schema Registry 8.2, including wildcard namespace lookup
- preserve the shared Schema Registry 7.9 fixture for existing CSFLE coverage

## Performance

No serializer, produce, consume, protocol, or per-message hot path changed. Association operations are cold Schema Registry HTTP control-plane calls. Benchmark/MemoryDiagnoser run: N/A.

## Verification

- `dotnet build tests/Dekaf.Tests.Unit --configuration Release`: 0 warnings, 0 errors
- full unit suite: **7458/7458 passed**
- `dotnet build tests/Dekaf.Tests.Integration --configuration Release`: 0 warnings, 0 errors
- Schema Registry integration subset: **44/44 passed**
- live association create/list/delete test on Schema Registry 8.2: passed
- existing CSFLE integration test on Schema Registry 7.9: passed
- managed AOT smoke: passed
- NativeAOT publish: managed compilation passed; native link unavailable because this machine lacks the Visual C++ linker workload
- final `/simplify` and `/review`: clean

Closes #2772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Schema Registry association management.
  * Associations can now be created, updated, queried by resource name, filtered, paginated, and deleted.
  * Added models for association metadata, schemas, lifecycle, frozen state, and resource details.
* **Bug Fixes**
  * Improved request validation, cancellation handling, filtering, and registry error mapping.
* **Tests**
  * Added unit, integration, and AOT coverage for association workflows, serialization, and round-trip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->