### PR TITLE
test(producer): remove retry coalescing race

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -1425,7 +1425,7 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             TaskCreationOptions.RunContinuationsAsynchronously);
         var p1FollowupStarted = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        var releaseP0OnlyRetry = new TaskCompletionSource(
+        var p1FollowupResponse = new TaskCompletionSource<ProduceResponse>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var connection = new TestKafkaConnection { CaptureProduceRequests = true };
         connection.SendProducePipelinedAfterWrite = () =>
@@ -1438,9 +1438,9 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             var partitions = new List<(int partition, ErrorCode errorCode, long baseOffset)>(
                 requestedTopics.Count);
             var includesPartitionOne = false;
-            foreach (var requestedTopic in requestedTopics)
+            for (var i = 0; i < requestedTopics.Count; i++)
             {
-                var partition = requestedTopic.Partition;
+                var partition = requestedTopics[i].Partition;
                 includesPartitionOne |= partition == 1;
                 var attempt = Interlocked.Increment(ref partitionAttempts[partition]);
                 partitions.Add(partition switch
@@ -1461,18 +1461,21 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             if (includesPartitionOne)
             {
                 p1FollowupStarted.TrySetResult();
-                return new ValueTask<Task<ProduceResponse>>(Task.FromResult(response));
+                return new ValueTask<Task<ProduceResponse>>(p1FollowupResponse.Task);
             }
 
             p0OnlyRetryStarted.TrySetResult();
-            return new ValueTask<Task<ProduceResponse>>(CompleteP0RetryAsync(response));
+            return new ValueTask<Task<ProduceResponse>>(Task.FromResult(response));
         };
         var pool = Substitute.For<IConnectionPool>();
         var connectionAvailable = new TaskCompletionSource<IKafkaConnection>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(_ => new ValueTask<IKafkaConnection>(connectionAvailable.Task));
-        var options = CreateOptions(maxInFlight: 2);
+        var options = CreateOptions(
+            maxInFlight: 2,
+            retryBackoffMs: int.MaxValue,
+            retryBackoffMaxMs: int.MaxValue);
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
 
@@ -1515,25 +1518,23 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             await Assert.That(firstRequest.Select(static topic => topic.Partition))
                 .IsEquivalentTo([0, 1]);
 
-            // Enqueue C while the first response is held. After p0 becomes muted, C must
-            // still send; the p0 retry and C may legally share a request or use two requests.
+            // Enqueue C while the first response is held. After p0 becomes muted and enters
+            // retry backoff, C must still send without waiting for p0 to become retry-ready.
             var batchC = CreateTestBatch(vtPool, "test-topic", 1);
             sender.Enqueue(batchC);
 
             firstResponse.SetResult(firstResponsePayload);
 
-            var firstFollowup = await Task.WhenAny(
-                    p0OnlyRetryStarted.Task,
-                    p1FollowupStarted.Task)
-                .WaitAsync(TimeSpan.FromSeconds(30), ct);
-            if (ReferenceEquals(firstFollowup, p0OnlyRetryStarted.Task))
-            {
-                // A p0-only retry is in flight. C must still dispatch before that retry
-                // completes, proving p0's mute does not stall the unmuted partition.
-                await p1FollowupStarted.Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
-            }
+            // p0 has a practically-unbounded retry backoff. C must dispatch while p0 cannot
+            // become retry-ready, proving p0's mute does not stall p1.
+            await p1FollowupStarted.Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
+            await Assert.That(p0OnlyRetryStarted.Task.IsCompleted).IsFalse();
+            await Assert.That(Volatile.Read(ref partitionAttempts[0])).IsEqualTo(1);
 
-            releaseP0OnlyRetry.TrySetResult();
+            batchA.RetryNotBefore = 0;
+            p1FollowupResponse.SetResult(CreateMultiPartitionResponse(
+                "test-topic",
+                (1, ErrorCode.None, 201)));
 
             await allAcknowledged.Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
 
@@ -1544,22 +1545,16 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             await Assert.That(remaining[0]).IsEqualTo((0, 100L));
             await Assert.That(remaining[1]).IsEqualTo((1, 201L));
             await Assert.That(partitionAttempts).IsEquivalentTo([2, 2]);
-            await Assert.That(Volatile.Read(ref sendCount)).IsBetween(2, 3);
+            await Assert.That(Volatile.Read(ref sendCount)).IsEqualTo(3);
         }
         finally
         {
             connectionAvailable.TrySetResult(connection);
             firstResponse.TrySetCanceled(CancellationToken.None);
-            releaseP0OnlyRetry.TrySetResult();
+            p1FollowupResponse.TrySetCanceled(CancellationToken.None);
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await vtPool.DisposeAsync();
-        }
-
-        async Task<ProduceResponse> CompleteP0RetryAsync(ProduceResponse response)
-        {
-            await releaseP0OnlyRetry.Task;
-            return response;
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -1421,6 +1421,12 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             TaskCreationOptions.RunContinuationsAsynchronously);
         var firstResponse = new TaskCompletionSource<ProduceResponse>(
             TaskCreationOptions.RunContinuationsAsynchronously);
+        var p0OnlyRetryStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var p1FollowupStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseP0OnlyRetry = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         var connection = new TestKafkaConnection { CaptureProduceRequests = true };
         connection.SendProducePipelinedAfterWrite = () =>
         {
@@ -1431,9 +1437,11 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
 
             var partitions = new List<(int partition, ErrorCode errorCode, long baseOffset)>(
                 requestedTopics.Count);
+            var includesPartitionOne = false;
             foreach (var requestedTopic in requestedTopics)
             {
                 var partition = requestedTopic.Partition;
+                includesPartitionOne |= partition == 1;
                 var attempt = Interlocked.Increment(ref partitionAttempts[partition]);
                 partitions.Add(partition switch
                 {
@@ -1444,18 +1452,27 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             }
 
             var response = CreateMultiPartitionResponse("test-topic", partitions.ToArray());
-            if (send != 1)
-                return new ValueTask<Task<ProduceResponse>>(Task.FromResult(response));
+            if (send == 1)
+            {
+                firstSend.TrySetResult(response);
+                return new ValueTask<Task<ProduceResponse>>(firstResponse.Task);
+            }
 
-            firstSend.TrySetResult(response);
-            return new ValueTask<Task<ProduceResponse>>(firstResponse.Task);
+            if (includesPartitionOne)
+            {
+                p1FollowupStarted.TrySetResult();
+                return new ValueTask<Task<ProduceResponse>>(Task.FromResult(response));
+            }
+
+            p0OnlyRetryStarted.TrySetResult();
+            return new ValueTask<Task<ProduceResponse>>(CompleteP0RetryAsync(response));
         };
         var pool = Substitute.For<IConnectionPool>();
         var connectionAvailable = new TaskCompletionSource<IKafkaConnection>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(_ => new ValueTask<IKafkaConnection>(connectionAvailable.Task));
-        var options = CreateOptions();
+        var options = CreateOptions(maxInFlight: 2);
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
 
@@ -1505,6 +1522,19 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
 
             firstResponse.SetResult(firstResponsePayload);
 
+            var firstFollowup = await Task.WhenAny(
+                    p0OnlyRetryStarted.Task,
+                    p1FollowupStarted.Task)
+                .WaitAsync(TimeSpan.FromSeconds(30), ct);
+            if (ReferenceEquals(firstFollowup, p0OnlyRetryStarted.Task))
+            {
+                // A p0-only retry is in flight. C must still dispatch before that retry
+                // completes, proving p0's mute does not stall the unmuted partition.
+                await p1FollowupStarted.Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
+            }
+
+            releaseP0OnlyRetry.TrySetResult();
+
             await allAcknowledged.Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
 
             // p1 succeeds on the first response; both the p0 retry and p1 C then complete.
@@ -1518,9 +1548,18 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
         }
         finally
         {
+            connectionAvailable.TrySetResult(connection);
+            firstResponse.TrySetCanceled(CancellationToken.None);
+            releaseP0OnlyRetry.TrySetResult();
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await vtPool.DisposeAsync();
+        }
+
+        async Task<ProduceResponse> CompleteP0RetryAsync(ProduceResponse response)
+        {
+            await releaseP0OnlyRetry.Task;
+            return response;
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -1415,24 +1415,46 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
     [Timeout(30_000)]
     public async Task RetriableError_OnOnePartition_DoesNotBlockOtherPartitions(CancellationToken ct)
     {
-        // Send 1: batch A (p0) + batch B (p1) coalesced → p0 error, p1 success
-        // Send 2: batch A retry (p0) + batch C (p1) coalesced → both succeed
-        var tcs1 = new TaskCompletionSource<ProduceResponse>();
-        var tcs2 = new TaskCompletionSource<ProduceResponse>();
-        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>();
-        responseQueue.Enqueue(tcs1);
-        responseQueue.Enqueue(tcs2);
-
         var sendCount = 0;
-        var sendSignals = new[] { new TaskCompletionSource(), new TaskCompletionSource() };
-
-        var (pool, _) = CreateMockConnection(responseQueue, onSend: () =>
+        var partitionAttempts = new int[2];
+        var firstSend = new TaskCompletionSource<ProduceResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstResponse = new TaskCompletionSource<ProduceResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var connection = new TestKafkaConnection { CaptureProduceRequests = true };
+        connection.SendProducePipelinedAfterWrite = () =>
         {
-            var idx = Interlocked.Increment(ref sendCount) - 1;
-            if (idx < sendSignals.Length)
-                sendSignals[idx].TrySetResult();
-        });
-        ct = GuardUnscriptedSends(ct);
+            var send = Interlocked.Increment(ref sendCount);
+            IReadOnlyList<(string Name, Guid TopicId, int Partition)> requestedTopics;
+            lock (connection.CapturedProduceRequests)
+                requestedTopics = connection.CapturedProduceRequests[^1].Topics;
+
+            var partitions = new List<(int partition, ErrorCode errorCode, long baseOffset)>(
+                requestedTopics.Count);
+            foreach (var requestedTopic in requestedTopics)
+            {
+                var partition = requestedTopic.Partition;
+                var attempt = Interlocked.Increment(ref partitionAttempts[partition]);
+                partitions.Add(partition switch
+                {
+                    0 when attempt == 1 => (partition, ErrorCode.NotLeaderOrFollower, -1),
+                    0 => (partition, ErrorCode.None, 100),
+                    _ => (partition, ErrorCode.None, 199 + attempt)
+                });
+            }
+
+            var response = CreateMultiPartitionResponse("test-topic", partitions.ToArray());
+            if (send != 1)
+                return new ValueTask<Task<ProduceResponse>>(Task.FromResult(response));
+
+            firstSend.TrySetResult(response);
+            return new ValueTask<Task<ProduceResponse>>(firstResponse.Task);
+        };
+        var pool = Substitute.For<IConnectionPool>();
+        var connectionAvailable = new TaskCompletionSource<IKafkaConnection>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask<IKafkaConnection>(connectionAvailable.Task));
         var options = CreateOptions();
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1457,47 +1479,42 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
 
         try
         {
-            // Enqueue batch A (p0) and batch B (p1) — they'll coalesce
+            SeedKnownPartitions(
+                sender,
+                new TopicPartition("test-topic", 0),
+                new TopicPartition("test-topic", 1));
+
+            // Hold connection acquisition until both first-wave batches are visible.
             var batchA = CreateTestBatch(vtPool, "test-topic", 0);
             var batchB = CreateTestBatch(vtPool, "test-topic", 1);
             sender.Enqueue(batchA);
             sender.Enqueue(batchB);
+            connectionAvailable.SetResult(connection);
 
-            // Wait for send 1 (coalesced A+B)
-            await sendSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
+            var firstResponsePayload = await firstSend.Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
+            IReadOnlyList<(string Name, Guid TopicId, int Partition)> firstRequest;
+            lock (connection.CapturedProduceRequests)
+                firstRequest = connection.CapturedProduceRequests[0].Topics;
+            await Assert.That(firstRequest.Select(static topic => topic.Partition))
+                .IsEquivalentTo([0, 1]);
 
-            // Enqueue batch C (p1) while send 1 is still in flight, BEFORE releasing the
-            // response. Enqueuing after the response completes races the send loop: the p0
-            // retry can dispatch alone before C's channel event is drained, splitting send 2
-            // into two sends and breaking the script. With C already in the channel when the
-            // loop wakes, the same iteration drains it and coalesces it with the retry.
+            // Enqueue C while the first response is held. After p0 becomes muted, C must
+            // still send; the p0 retry and C may legally share a request or use two requests.
             var batchC = CreateTestBatch(vtPool, "test-topic", 1);
             sender.Enqueue(batchC);
 
-            // p0 gets retriable error, p1 succeeds; C proceeds (p1 is not muted)
-            tcs1.SetResult(CreateMultiPartitionResponse("test-topic",
-                (0, ErrorCode.NotLeaderOrFollower, -1),
-                (1, ErrorCode.None, 200)));
-
-            // Wait for send 2 (batch A retry + batch C coalesced — both partitions)
-            await sendSignals[1].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
-
-            // Both succeed
-            tcs2.SetResult(CreateMultiPartitionResponse("test-topic",
-                (0, ErrorCode.None, 100),
-                (1, ErrorCode.None, 201)));
+            firstResponse.SetResult(firstResponsePayload);
 
             await allAcknowledged.Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
 
-            // Verify p1 was acknowledged first (from send 1), then p0 retry + p1 from send 2
+            // p1 succeeds on the first response; both the p0 retry and p1 C then complete.
             await Assert.That(ackPartitions).Count().IsEqualTo(3);
-            // First ack must be p1 (from the first response where p1 succeeded)
             await Assert.That(ackPartitions[0]).IsEqualTo((1, 200L));
-            // Remaining: A retry (p0) and C (p1) from send 2
             var remaining = ackPartitions.Skip(1).OrderBy(a => a.partition).ToList();
             await Assert.That(remaining[0]).IsEqualTo((0, 100L));
             await Assert.That(remaining[1]).IsEqualTo((1, 201L));
-            await Assert.That(Volatile.Read(ref sendCount)).IsEqualTo(2);
+            await Assert.That(partitionAttempts).IsEquivalentTo([2, 2]);
+            await Assert.That(Volatile.Read(ref sendCount)).IsBetween(2, 3);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using Dekaf.Compression;
@@ -39,6 +40,10 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
     private static readonly Type BatchReferenceType = typeof(BrokerSender).GetNestedType(
         "BatchReference",
         BindingFlags.NonPublic)!;
+
+    private static readonly FieldInfo MutedPartitionsField = typeof(BrokerSender).GetField(
+        "_mutedPartitions",
+        BindingFlags.Instance | BindingFlags.NonPublic)!;
 
     private static ProducerOptions CreateOptions(Acks acks = Acks.All, int maxInFlight = 1,
         int retryBackoffMs = 0, int retryBackoffMaxMs = 0,
@@ -1423,7 +1428,7 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             TaskCreationOptions.RunContinuationsAsynchronously);
         var p0OnlyRetryStarted = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        var p1FollowupStarted = new TaskCompletionSource(
+        var p1FollowupStarted = new TaskCompletionSource<ProduceResponse>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var p1FollowupResponse = new TaskCompletionSource<ProduceResponse>(
             TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1460,7 +1465,7 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
 
             if (includesPartitionOne)
             {
-                p1FollowupStarted.TrySetResult();
+                p1FollowupStarted.TrySetResult(response);
                 return new ValueTask<Task<ProduceResponse>>(p1FollowupResponse.Task);
             }
 
@@ -1496,6 +1501,9 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
                 }
             }
         });
+        var mutedPartitions =
+            (ConcurrentDictionary<TopicPartition, byte>)MutedPartitionsField.GetValue(sender)!;
+        var partitionZero = new TopicPartition("test-topic", 0);
 
         try
         {
@@ -1518,23 +1526,26 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             await Assert.That(firstRequest.Select(static topic => topic.Partition))
                 .IsEquivalentTo([0, 1]);
 
-            // Enqueue C while the first response is held. After p0 becomes muted and enters
-            // retry backoff, C must still send without waiting for p0 to become retry-ready.
+            firstResponse.SetResult(firstResponsePayload);
+
+            // Observe p0's mute before making C visible. This prevents C from dispatching
+            // against the still-in-flight first request and bypassing the state under test.
+            await Assert.That(() => mutedPartitions.ContainsKey(partitionZero))
+                .Eventually(isMuted => isMuted.IsTrue(), DiagnosticWaitTimeout);
+            await Assert.That(Volatile.Read(ref partitionAttempts[0])).IsEqualTo(1);
+
             var batchC = CreateTestBatch(vtPool, "test-topic", 1);
             sender.Enqueue(batchC);
 
-            firstResponse.SetResult(firstResponsePayload);
-
             // p0 has a practically-unbounded retry backoff. C must dispatch while p0 cannot
             // become retry-ready, proving p0's mute does not stall p1.
-            await p1FollowupStarted.Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
+            var p1FollowupPayload = await p1FollowupStarted.Task
+                .WaitAsync(TimeSpan.FromSeconds(30), ct);
             await Assert.That(p0OnlyRetryStarted.Task.IsCompleted).IsFalse();
             await Assert.That(Volatile.Read(ref partitionAttempts[0])).IsEqualTo(1);
 
             batchA.RetryNotBefore = 0;
-            p1FollowupResponse.SetResult(CreateMultiPartitionResponse(
-                "test-topic",
-                (1, ErrorCode.None, 201)));
+            p1FollowupResponse.SetResult(p1FollowupPayload);
 
             await allAcknowledged.Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
 
@@ -1551,6 +1562,7 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
         {
             connectionAvailable.TrySetResult(connection);
             firstResponse.TrySetCanceled(CancellationToken.None);
+            p1FollowupStarted.TrySetCanceled(CancellationToken.None);
             p1FollowupResponse.TrySetCanceled(CancellationToken.None);
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -463,6 +463,7 @@ public class KafkaProducerFastPathTests
     {
         await using var producer = await CreateBufferBoundaryProducerAsync(maxBlockMs: 30_000);
         var accumulator = producer.RecordAccumulator;
+        var topicPartition = new TopicPartition(Topic, 0);
         AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
 
         await Assert.That(accumulator.TryReserveMemoryForTest(BufferMemoryLimit)).IsTrue();
@@ -491,14 +492,15 @@ public class KafkaProducerFastPathTests
             accumulator.ReleaseMemory(BufferMemoryLimit);
             syntheticReservationRemaining = 0;
 
+            // The drainer temporarily removes active work from _pendingAppends, so queue
+            // emptiness is not a completion fence. Worker ownership reaches zero only after
+            // AppendAsync has committed the record.
             await TestWait.UntilAsync(
-                () => accumulator.PendingAppendCountForTest == 0,
+                () => GetSlowPathAppendCount(accumulator, topicPartition) == 0,
                 TimeSpan.FromSeconds(5));
-            await TestWait.UntilAsync(
-                () => HasCompletableCurrentBatch(accumulator, new TopicPartition(Topic, 0)),
-                TimeSpan.FromSeconds(5));
+            await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(0);
 
-            var readyBatch = CompleteCurrentBatch(accumulator, new TopicPartition(Topic, 0));
+            var readyBatch = CompleteCurrentBatch(accumulator, topicPartition);
             await Assert.That(readyBatch.RecordBatch.Records.Count).IsEqualTo(1);
             readyBatch.CompleteSend(baseOffset: 3, DateTimeOffset.UtcNow);
 
@@ -743,7 +745,7 @@ public class KafkaProducerFastPathTests
         throw new InvalidOperationException("Partition deque did not contain a current or sealed batch.");
     }
 
-    private static bool HasCompletableCurrentBatch(
+    private static int GetSlowPathAppendCount(
         RecordAccumulator accumulator,
         TopicPartition topicPartition)
     {
@@ -751,12 +753,10 @@ public class KafkaProducerFastPathTests
         var tryGetValueMethod = deques.GetType().GetMethod("TryGetValue");
         var parameters = new object[] { topicPartition, null! };
         if (!(bool)tryGetValueMethod!.Invoke(deques, parameters)!)
-            return false;
+            return 0;
 
         var partitionDeque = parameters[1]!;
-        return GetInstanceField<object?>(partitionDeque, "CurrentBatch") is not null
-            && !GetInstanceField<bool>(partitionDeque, "AppendInProgress")
-            && !GetInstanceField<bool>(partitionDeque, "RotationInProgress");
+        return GetInstanceField<int>(partitionDeque, "SlowPathAppendCount");
     }
 
     private static ValueTask StopProducerBackgroundLoopsAsync(KafkaProducer<string, string> producer)


### PR DESCRIPTION
## Summary
- replace whole-request response scripting with responses derived from captured partition contents
- deterministically gate the first A+B request while allowing retry/C to use either one combined request or two split requests
- assert exact acknowledgements and per-partition attempts without delays or fixed coalescing assumptions

## Verification
- Release build: 0 warnings/errors
- `BrokerSenderMuteOrderingTests`: 25/25 passed
- full unit suite after rebase: 7,481/7,481 passed
- `/simplify` completed
- `KafkaProducerFastPathTests`: 12/12 passed; failing race case repeated 50/50 passed
- pre-push self-review: no findings

Performance benchmark: not applicable; test-only change.

Closes #2776

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for independent message processing across partitions.
  * Added validation for concurrent activity, retry behavior, send attempts, and acknowledgement ordering.
  * Improved test reliability with dynamically controlled responses and precise synchronization.
  * Strengthened buffer-full scenarios by waiting for background processing to complete before validating batch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## CI follow-up
- fixed an unrelated flaky producer test exposed by CI: `_pendingAppends.Count` can transiently reach zero while a drainer owns the operation
- wait now uses per-partition `SlowPathAppendCount`, which reaches zero only after `AppendAsync` commits the record
