### PR TITLE
test(networking): determinize reconnect deadline

### DIFF
--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -2477,7 +2477,9 @@ public sealed class ConnectionPoolTests
 
                 return new ValueTask<IKafkaConnection>(CreateConnectedConnection(brokerId, host, port));
             },
-            randomDouble: static () => 0.5);
+            randomDouble: static () => 0.5,
+            // Keep the backoff pending even if the test thread is descheduled past 200ms.
+            timestampProvider: static () => 0);
 
         await using (pool)
         {


### PR DESCRIPTION
## Summary
- freeze the injected reconnect-backoff clock in the replacement deadline test
- prevent scheduler stalls from changing the scenario under assertion
- keep production behavior unchanged

## Verification
- focused test: 1 passed
- full unit suite: 7,454 passed

Closes #2791