### PR TITLE
fix(automation): preserve untracked worktrees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,10 @@ jobs:
         shell: pwsh
         run: ./scripts/Test-AgentLockTokenOwnership.ps1
 
+      - name: Test Worktree Cleanup Safety
+        shell: pwsh
+        run: ./scripts/Test-WorktreeCleanup.ps1
+
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
         with:

--- a/scripts/Remove-MergedWorktrees.ps1
+++ b/scripts/Remove-MergedWorktrees.ps1
@@ -71,7 +71,10 @@ try {
     # Authoritative merge signal: merged-PR head branches AND head tip SHAs (squash-safe).
     # --limit 1000 covers any realistic leftover window for the NAME tier; anything older
     # falls through to the per-commit association tier below.
-    $mergedNames = @{}; $mergedOids = @{}; $openNames = @{}; $openOids = @{}
+    $mergedNames = New-OrdinalStringMap
+    $mergedOids = New-OrdinalStringMap
+    $openNames = New-OrdinalStringMap
+    $openOids = New-OrdinalStringMap
     $rawMerged = gh pr list @repoArgs --state merged --limit 1000 --json headRefName,headRefOid 2>$null
     if ($LASTEXITCODE -ne 0) { Warn "could not list merged PRs (exit $LASTEXITCODE) -- skipping sweep this round"; exit 0 }
     foreach ($p in (($rawMerged -join "`n") | ConvertFrom-Json)) {

--- a/scripts/Remove-MergedWorktrees.ps1
+++ b/scripts/Remove-MergedWorktrees.ps1
@@ -7,8 +7,8 @@
 #   of main and `git merge-base --is-ancestor` reports "not merged". Ancestry is never
 #   used as a merge signal for branches. GitHub's own records are, in four tiers:
 #     1. merged-PR head branch name  (cheap, bulk: one `gh pr list` call)
-#     2. merged-PR head tip SHA      (same call: catches detached/renamed checkouts
-#                                     sitting exactly on a merged PR's tip)
+#     2. merged-PR head tip SHA      (same call: catches detached checkouts sitting
+#                                     exactly on a merged PR's tip)
 #     3. detached HEAD reachable from origin/main (local, free: a detached checkout of
 #                                     an old main commit — A/B baselines etc. Applied to
 #                                     DETACHED worktrees only; a branch is declared
@@ -16,7 +16,9 @@
 #     4. commit→PR association       (`gh api repos/../commits/<sha>/pulls`, one call
 #                                     per still-unmatched worktree: survives squash
 #                                     merges, branch deletion, AND the 1000-PR list
-#                                     window aging out)
+#                                     window aging out). Named worktrees must match the
+#                                     associated PR's head branch; a shared commit alone
+#                                     does not prove that a new branch was merged.
 #
 #   DELIBERATELY NOT a signal: a [gone] upstream branch. [gone] only means the remote
 #   ref was deleted — which also happens when a PR is CLOSED UNMERGED and its branch
@@ -35,7 +37,7 @@
 #   - skip the main checkout and anything inside it (.claude/worktrees is harness-managed)
 #   - skip locked worktrees (an agent session may still own them)
 #   - skip a branch/tip that has an OPEN PR (branch reused for active work)
-#   - PRESERVE any worktree with uncommitted tracked changes (shared helper)
+#   - PRESERVE tracked changes and untracked files outside known generated directories
 #   - worktrees with NO merge evidence are kept and listed; opt in to reaping old
 #     clean ones with -StaleDays <n>
 #
@@ -130,8 +132,9 @@ try {
             if ($LASTEXITCODE -ne 0) { $sha = $null }
             if ($sha -and $openOids.ContainsKey($sha)) { continue }          # tip of an open PR — keep
 
-            # Tier 2: detached or renamed checkout sitting exactly on a merged PR's tip.
-            if ($sha -and $mergedOids.ContainsKey($sha)) { $why = 'merged PR head tip SHA' }
+            # Tier 2: detached checkout sitting exactly on a merged PR's tip. A named
+            # branch expresses independent intent and cannot be identified by SHA alone.
+            if ($sha -and $w.Detached -and $mergedOids.ContainsKey($sha)) { $why = 'merged PR head tip SHA' }
         }
 
         # Tier 3 (detached only): checkout of a commit already reachable from main —
@@ -149,7 +152,9 @@ try {
             if ($LASTEXITCODE -eq 0 -and $assocRaw) {
                 $assoc = @(($assocRaw -join "`n") | ConvertFrom-Json)
                 if (@($assoc | Where-Object { $_.state -eq 'open' }).Count -gt 0) { continue }   # commit belongs to an open PR — keep
-                if (@($assoc | Where-Object { $_.merged_at }).Count -gt 0) { $why = 'merged PR via commit association' }
+                if (Test-WorktreeMatchesMergedPullRequest -Associations $assoc -Branch $w.Branch -Detached $w.Detached) {
+                    $why = 'merged PR via commit association'
+                }
             }
         }
 

--- a/scripts/Test-WorktreeCleanup.ps1
+++ b/scripts/Test-WorktreeCleanup.ps1
@@ -1,0 +1,72 @@
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'WorktreeCleanup.ps1')
+
+function Assert-True([bool]$Condition, [string]$Message) {
+    if (-not $Condition) { throw $Message }
+}
+
+$tempBase = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+$testRoot = [IO.Path]::GetFullPath((Join-Path $tempBase "dekaf-worktree-cleanup-$([Guid]::NewGuid().ToString('N'))"))
+if (-not $testRoot.StartsWith($tempBase, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "Refusing to use test directory outside the system temporary directory: $testRoot"
+}
+
+$repo = Join-Path $testRoot 'repo'
+$sourceWorktree = Join-Path $testRoot 'issue-123-fresh-source'
+$artifactWorktree = Join-Path $testRoot 'issue-124-artifacts-only'
+
+try {
+    New-Item -ItemType Directory -Path $repo | Out-Null
+    git -C $repo init -b main --quiet
+    git -C $repo config user.name 'Worktree Cleanup Test'
+    git -C $repo config user.email 'worktree-cleanup@example.invalid'
+    Set-Content -LiteralPath (Join-Path $repo 'README.md') -Value '# fixture'
+    git -C $repo add README.md
+    git -C $repo commit --quiet -m 'fixture'
+
+    git -C $repo worktree add --quiet -b issue-123-fresh-source $sourceWorktree
+    $newSource = Join-Path $sourceWorktree 'src/NewFeature.cs'
+    New-Item -ItemType Directory -Path (Split-Path $newSource -Parent) | Out-Null
+    Set-Content -LiteralPath $newSource -Value 'internal sealed class NewFeature;'
+
+    Remove-MergedWorktree -Repo $repo -Worktree $sourceWorktree -Label 'source fixture'
+    Assert-True (Test-Path -LiteralPath $sourceWorktree) 'Fresh issue worktree with untracked source was removed.'
+    Assert-True (Test-Path -LiteralPath $newSource) 'Untracked source file was removed.'
+
+    git -C $repo worktree remove --force $sourceWorktree
+    git -C $repo branch -D issue-123-fresh-source | Out-Null
+
+    git -C $repo worktree add --quiet -b issue-124-artifacts-only $artifactWorktree
+    $generatedFile = Join-Path $artifactWorktree 'src/Fixture/bin/generated.dll'
+    New-Item -ItemType Directory -Path (Split-Path $generatedFile -Parent) | Out-Null
+    Set-Content -LiteralPath $generatedFile -Value 'generated'
+
+    Remove-MergedWorktree -Repo $repo -Worktree $artifactWorktree -Label 'artifact fixture'
+    Assert-True (-not (Test-Path -LiteralPath $artifactWorktree)) 'Artifact-only worktree was not removed.'
+
+    $mainAssociation = [pscustomobject]@{
+        state = 'closed'
+        merged_at = '2026-08-19T00:00:00Z'
+        head = [pscustomobject]@{ ref = 'main' }
+    }
+    $issueAssociation = [pscustomobject]@{
+        state = 'closed'
+        merged_at = '2026-08-19T00:00:00Z'
+        head = [pscustomobject]@{ ref = 'issue-123-fresh-source' }
+    }
+
+    Assert-True (-not (Test-WorktreeMatchesMergedPullRequest -Associations @($mainAssociation) -Branch 'issue-123-fresh-source' -Detached $false)) `
+        'Named issue branch matched an unrelated merged PR through a shared commit.'
+    Assert-True (Test-WorktreeMatchesMergedPullRequest -Associations @($issueAssociation) -Branch 'issue-123-fresh-source' -Detached $false) `
+        'Named issue branch did not match its own merged PR.'
+    Assert-True (Test-WorktreeMatchesMergedPullRequest -Associations @($mainAssociation) -Branch $null -Detached $true) `
+        'Detached worktree did not match its merged commit association.'
+
+    Write-Host 'OK worktree cleanup safety tests passed.'
+}
+finally {
+    if (Test-Path -LiteralPath $testRoot) {
+        Remove-Item -LiteralPath $testRoot -Recurse -Force
+    }
+}

--- a/scripts/Test-WorktreeCleanup.ps1
+++ b/scripts/Test-WorktreeCleanup.ps1
@@ -55,13 +55,28 @@ try {
         merged_at = '2026-08-19T00:00:00Z'
         head = [pscustomobject]@{ ref = 'issue-123-fresh-source' }
     }
+    $differentCaseAssociation = [pscustomobject]@{
+        state = 'closed'
+        merged_at = '2026-08-19T00:00:00Z'
+        head = [pscustomobject]@{ ref = 'Issue-123-Fresh-Source' }
+    }
 
     Assert-True (-not (Test-WorktreeMatchesMergedPullRequest -Associations @($mainAssociation) -Branch 'issue-123-fresh-source' -Detached $false)) `
         'Named issue branch matched an unrelated merged PR through a shared commit.'
     Assert-True (Test-WorktreeMatchesMergedPullRequest -Associations @($issueAssociation) -Branch 'issue-123-fresh-source' -Detached $false) `
         'Named issue branch did not match its own merged PR.'
+    Assert-True (-not (Test-WorktreeMatchesMergedPullRequest -Associations @($differentCaseAssociation) -Branch 'issue-123-fresh-source' -Detached $false)) `
+        'Named issue branch matched a differently-cased merged PR branch.'
     Assert-True (Test-WorktreeMatchesMergedPullRequest -Associations @($mainAssociation) -Branch $null -Detached $true) `
         'Detached worktree did not match its merged commit association.'
+
+    $mergedNames = New-OrdinalStringMap
+    $mergedNames['issue-123-fresh-source'] = $true
+    Assert-True (-not $mergedNames.ContainsKey('Issue-123-Fresh-Source')) `
+        'Merged branch map matched a differently-cased branch name.'
+
+    Assert-True (-not (Test-DisposableWorktreePath -Path 'src/Bin/Generated.cs')) `
+        'Differently-cased source directory was treated as disposable output.'
 
     Write-Host 'OK worktree cleanup safety tests passed.'
 }

--- a/scripts/Test-WorktreeCleanup.ps1
+++ b/scripts/Test-WorktreeCleanup.ps1
@@ -77,6 +77,26 @@ try {
 
     Assert-True (-not (Test-DisposableWorktreePath -Path 'src/Bin/Generated.cs')) `
         'Differently-cased source directory was treated as disposable output.'
+    foreach ($generatedPath in @(
+        'BenchmarkDotNet.Artifacts/results/report.csv',
+        'docs/build/index.html',
+        'docs/.docusaurus/client-manifest.json',
+        'docs/.cache/webpack/default-development.pack',
+        'CodeCoverage/report.xml',
+        'src/Fixture/Debug/fixture.dll',
+        'src/Fixture/Release/fixture.dll',
+        'src/Fixture/x64/fixture.dll',
+        'src/Fixture/ARM64/fixture.dll',
+        'logs/build.log',
+        '__pycache__/fixture.pyc',
+        'results/test-output.json',
+        'StrykerOutput/reports/mutation-report.html',
+        'benchmark-results/run/output.log',
+        'temptest/fixture.csproj'
+    )) {
+        Assert-True (Test-DisposableWorktreePath -Path $generatedPath) `
+            "Repository-generated path was not treated as disposable: $generatedPath"
+    }
 
     Write-Host 'OK worktree cleanup safety tests passed.'
 }

--- a/scripts/Test-WorktreeCleanup.ps1
+++ b/scripts/Test-WorktreeCleanup.ps1
@@ -26,7 +26,7 @@ try {
     git -C $repo commit --quiet -m 'fixture'
 
     git -C $repo worktree add --quiet -b issue-123-fresh-source $sourceWorktree
-    $newSource = Join-Path $sourceWorktree 'src/NewFeature.cs'
+    $newSource = Join-Path $sourceWorktree 'src/build/NewFeature.cs'
     New-Item -ItemType Directory -Path (Split-Path $newSource -Parent) | Out-Null
     Set-Content -LiteralPath $newSource -Value 'internal sealed class NewFeature;'
 
@@ -77,6 +77,14 @@ try {
 
     Assert-True (-not (Test-DisposableWorktreePath -Path 'src/Bin/Generated.cs')) `
         'Differently-cased source directory was treated as disposable output.'
+    foreach ($sourcePath in @(
+        'src/build/NewFeature.cs',
+        'src/.cache/NewFeature.cs',
+        'src/.docusaurus/NewFeature.cs'
+    )) {
+        Assert-True (-not (Test-DisposableWorktreePath -Path $sourcePath)) `
+            "Docs-scoped generated directory was treated as disposable outside docs: $sourcePath"
+    }
     foreach ($generatedPath in @(
         'BenchmarkDotNet.Artifacts/results/report.csv',
         'docs/build/index.html',

--- a/scripts/WorktreeCleanup.ps1
+++ b/scripts/WorktreeCleanup.ps1
@@ -21,8 +21,6 @@ function New-OrdinalStringMap {
 $script:DisposableWorktreeGeneratedDirectories = New-OrdinalStringMap
 foreach ($directory in @(
     '.artifacts',
-    '.cache',
-    '.docusaurus',
     '.vs',
     '__pycache__',
     'ARM',
@@ -32,7 +30,6 @@ foreach ($directory in @(
     'BenchmarkDotNet.Artifacts',
     'bin',
     'bld',
-    'build',
     'CodeCoverage',
     'Debug',
     'DebugPublic',
@@ -53,6 +50,12 @@ foreach ($directory in @(
     $script:DisposableWorktreeGeneratedDirectories[$directory] = $true
 }
 
+$script:DisposableWorktreeScopedDirectories = @(
+    'docs/.cache',
+    'docs/.docusaurus',
+    'docs/build'
+)
+
 function Test-DisposableWorktreePath {
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$Path)
@@ -61,7 +64,15 @@ function Test-DisposableWorktreePath {
     # risk classifying an unusual source path as generated output.
     if ($Path.StartsWith('"', [System.StringComparison]::Ordinal)) { return $false }
 
-    foreach ($segment in (($Path -replace '\\', '/') -split '/')) {
+    $normalizedPath = $Path -replace '\\', '/'
+    foreach ($docsGeneratedDirectory in $script:DisposableWorktreeScopedDirectories) {
+        if ($normalizedPath -ceq $docsGeneratedDirectory -or
+            $normalizedPath.StartsWith("$docsGeneratedDirectory/", [System.StringComparison]::Ordinal)) {
+            return $true
+        }
+    }
+
+    foreach ($segment in ($normalizedPath -split '/')) {
         if ($script:DisposableWorktreeGeneratedDirectories.ContainsKey($segment)) { return $true }
     }
 

--- a/scripts/WorktreeCleanup.ps1
+++ b/scripts/WorktreeCleanup.ps1
@@ -19,7 +19,37 @@ function New-OrdinalStringMap {
 }
 
 $script:DisposableWorktreeGeneratedDirectories = New-OrdinalStringMap
-foreach ($directory in @('.artifacts', '.vs', 'artifacts', 'bin', 'node_modules', 'obj', 'TestResults')) {
+foreach ($directory in @(
+    '.artifacts',
+    '.cache',
+    '.docusaurus',
+    '.vs',
+    '__pycache__',
+    'ARM',
+    'ARM64',
+    'artifacts',
+    'benchmark-results',
+    'BenchmarkDotNet.Artifacts',
+    'bin',
+    'bld',
+    'build',
+    'CodeCoverage',
+    'Debug',
+    'DebugPublic',
+    'log',
+    'logs',
+    'node_modules',
+    'obj',
+    'Release',
+    'Releases',
+    'results',
+    'StrykerOutput',
+    'temptest',
+    'TestResults',
+    'Win32',
+    'x64',
+    'x86'
+)) {
     $script:DisposableWorktreeGeneratedDirectories[$directory] = $true
 }
 

--- a/scripts/WorktreeCleanup.ps1
+++ b/scripts/WorktreeCleanup.ps1
@@ -10,6 +10,19 @@
 #     system-wide; the `\\?\` extended-length Remove-Item is kept as a fallback for
 #     environments where that config is missing.
 
+function New-OrdinalStringMap {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Generic.Dictionary[string, bool]])]
+    param()
+
+    return [System.Collections.Generic.Dictionary[string, bool]]::new([System.StringComparer]::Ordinal)
+}
+
+$script:DisposableWorktreeGeneratedDirectories = New-OrdinalStringMap
+foreach ($directory in @('.artifacts', '.vs', 'artifacts', 'bin', 'node_modules', 'obj', 'TestResults')) {
+    $script:DisposableWorktreeGeneratedDirectories[$directory] = $true
+}
+
 function Test-DisposableWorktreePath {
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$Path)
@@ -18,17 +31,8 @@ function Test-DisposableWorktreePath {
     # risk classifying an unusual source path as generated output.
     if ($Path.StartsWith('"', [System.StringComparison]::Ordinal)) { return $false }
 
-    $generatedDirectories = @{
-        '.artifacts' = $true
-        '.vs' = $true
-        'artifacts' = $true
-        'bin' = $true
-        'node_modules' = $true
-        'obj' = $true
-        'TestResults' = $true
-    }
     foreach ($segment in (($Path -replace '\\', '/') -split '/')) {
-        if ($generatedDirectories.ContainsKey($segment)) { return $true }
+        if ($script:DisposableWorktreeGeneratedDirectories.ContainsKey($segment)) { return $true }
     }
 
     return $false
@@ -45,7 +49,7 @@ function Test-WorktreeMatchesMergedPullRequest {
     foreach ($association in $Associations) {
         if (-not $association.merged_at) { continue }
         if ($Detached) { return $true }
-        if ($Branch -and $association.head -and $association.head.ref -eq $Branch) { return $true }
+        if ($Branch -and $association.head -and $association.head.ref -ceq $Branch) { return $true }
     }
 
     return $false

--- a/scripts/WorktreeCleanup.ps1
+++ b/scripts/WorktreeCleanup.ps1
@@ -3,12 +3,53 @@
 # Remove-MergedWorktrees.ps1. Not meant to be run directly.
 #
 # Removal policy (one place, both callers):
-#   - PRESERVE a worktree with uncommitted TRACKED changes (real WIP). Never
-#     force-discard it; the caller logs and moves on.
-#   - CLEAR untracked build artifacts (node_modules/bin/obj) — they are not work.
+#   - PRESERVE a worktree with uncommitted tracked changes or untracked files outside
+#     known generated directories. Never force-discard possible work.
+#   - CLEAR untracked build artifacts (node_modules/bin/obj/etc.) — they are not work.
 #   - Long-path safe: git's own delete now works because core.longpaths=true is set
 #     system-wide; the `\\?\` extended-length Remove-Item is kept as a fallback for
 #     environments where that config is missing.
+
+function Test-DisposableWorktreePath {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Path)
+
+    # Quoted porcelain paths require Git's escape decoding. Preserve them rather than
+    # risk classifying an unusual source path as generated output.
+    if ($Path.StartsWith('"', [System.StringComparison]::Ordinal)) { return $false }
+
+    $generatedDirectories = @{
+        '.artifacts' = $true
+        '.vs' = $true
+        'artifacts' = $true
+        'bin' = $true
+        'node_modules' = $true
+        'obj' = $true
+        'TestResults' = $true
+    }
+    foreach ($segment in (($Path -replace '\\', '/') -split '/')) {
+        if ($generatedDirectories.ContainsKey($segment)) { return $true }
+    }
+
+    return $false
+}
+
+function Test-WorktreeMatchesMergedPullRequest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Associations,
+        [AllowNull()][string]$Branch,
+        [bool]$Detached
+    )
+
+    foreach ($association in $Associations) {
+        if (-not $association.merged_at) { continue }
+        if ($Detached) { return $true }
+        if ($Branch -and $association.head -and $association.head.ref -eq $Branch) { return $true }
+    }
+
+    return $false
+}
 
 function Remove-MergedWorktree {
     [CmdletBinding()]
@@ -23,10 +64,20 @@ function Remove-MergedWorktree {
         return
     }
 
-    # Preserve genuine uncommitted work (tracked changes only — untracked is artifacts).
-    $tracked = git -C $Worktree status --porcelain --untracked-files=no 2>$null
-    if ($tracked) {
-        Write-Host "Preserving dirty worktree $Label : $Worktree (uncommitted tracked changes)"
+    # Preserve tracked work and every untracked/ignored path that is not under a known
+    # generated directory. --force below is safe only after this fail-closed check.
+    $status = @(git -C $Worktree status --porcelain=v1 --untracked-files=all --ignored=matching 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Preserving worktree $Label : $Worktree (could not inspect worktree status)"
+        return
+    }
+
+    $work = @($status | Where-Object {
+        if ($_ -notmatch '^(\?\?|!!) ') { return $true }
+        return -not (Test-DisposableWorktreePath -Path $_.Substring(3))
+    })
+    if ($work.Count -gt 0) {
+        Write-Host "Preserving dirty worktree $Label : $Worktree (uncommitted work)"
         return
     }
 


### PR DESCRIPTION
## Summary
- preserve worktrees containing tracked work or untracked files outside explicit generated directories
- require named worktrees to match the merged PR head branch instead of treating a shared commit SHA as merge evidence
- add CI regression coverage for fresh issue worktrees and artifact-only cleanup

## Verification
- pwsh scripts/Test-WorktreeCleanup.ps1
- pwsh scripts/Test-MergePr.ps1
- pwsh scripts/Remove-MergedWorktrees.ps1 -WhatIf kept the live fresh issue-2792-safe-worktree-cleanup worktree

No src/ code changed; performance benchmarks are not applicable.

Closes #2792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved worktree cleanup safety by preserving worktrees with tracked changes or meaningful untracked files.
  - Limited automatic removal to disposable worktrees and recognized generated artifacts.
  - Improved detection of worktrees associated with merged pull requests, including detached worktrees.
  - Cleanup now fails safely when status checks cannot be completed.

- **Tests**
  - Added automated safety checks covering changed files, generated artifacts, detached worktrees, and merged pull-request scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->