### PR TITLE
feat(consumer): add additive rebalance listeners

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1659,6 +1659,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int _maxCachedStringValueEntries = DefaultMaxCachedStringValueEntries;
     private IRebalanceListener? _rebalanceListener;
     private IConsumerAwareRebalanceListener? _consumerAwareRebalanceListener;
+    private List<IRebalanceListener>? _additionalRebalanceListeners;
     private TimeSpan _partitionStopTimeout = TimeSpan.FromSeconds(5);
     private Microsoft.Extensions.Logging.ILoggerFactory? _loggerFactory;
     private bool _enablePartitionEof;
@@ -2506,6 +2507,25 @@ public sealed class ConsumerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Adds a rebalance listener without replacing the listener configured by
+    /// <see cref="WithRebalanceListener(IRebalanceListener)"/> or
+    /// <see cref="WithRebalanceListener(IConsumerAwareRebalanceListener)"/>.
+    /// </summary>
+    /// <remarks>
+    /// Additive listeners run after the configured listener, in registration order.
+    /// Each callback is awaited before the next listener runs. Non-cancellation exceptions
+    /// are logged and do not prevent later listeners from running.
+    /// </remarks>
+    /// <param name="listener">The listener to add.</param>
+    /// <returns>This builder.</returns>
+    public ConsumerBuilder<TKey, TValue> AddRebalanceListener(IRebalanceListener listener)
+    {
+        ArgumentNullException.ThrowIfNull(listener);
+        (_additionalRebalanceListeners ??= []).Add(listener);
+        return this;
+    }
+
+    /// <summary>
     /// Sets the maximum time to await an <see cref="IPartitionStopListener"/> during
     /// graceful <c>CloseAsync</c> or <c>DisposeAsync</c>. Default is 5 seconds.
     /// </summary>
@@ -3244,6 +3264,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             AwsMskIamConfig = _awsMskIamConfig,
             RebalanceListener = _rebalanceListener,
             ConsumerAwareRebalanceListener = _consumerAwareRebalanceListener,
+            AdditionalRebalanceListeners = _additionalRebalanceListeners?.ToArray(),
             PartitionStopTimeout = _partitionStopTimeout,
             EnablePartitionEof = _enablePartitionEof,
             SocketSendBufferBytes = _socketSendBufferBytes,

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -30,6 +30,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private readonly MetadataManager _metadataManager;
     private readonly IRebalanceListener? _rebalanceListener;
     private readonly IConsumerAwareRebalanceListener? _consumerAwareRebalanceListener;
+    private readonly IRebalanceListener[]? _additionalRebalanceListeners;
     // Retained for the public six-parameter constructor and direct coordinator callers.
     // KafkaConsumer uses the pre-publication hook below to invalidate buffered fetches.
     private readonly Action<IReadOnlyList<TopicPartition>>? _onPartitionsRevoked;
@@ -142,6 +143,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         _rebalanceListener = _consumerAwareRebalanceListener is null
             ? options.RebalanceListener
             : null;
+        _additionalRebalanceListeners = options.AdditionalRebalanceListeners;
         _onPartitionsRevoked = onPartitionsRevoked;
         _onPartitionsRevoking = onPartitionsRevoking;
         _onPartitionsRevokedAsync = onPartitionsRevokedAsync;
@@ -871,6 +873,20 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 consumerAwareCallback,
                 newlyAssigned,
                 cancellationToken).ConfigureAwait(false);
+        }
+
+        var additionalListeners = _additionalRebalanceListeners;
+        if (additionalListeners is not null)
+        {
+            for (var index = 0; index < additionalListeners.Length; index++)
+            {
+                await InvokeRebalanceListenerAsync(
+                    callbackName,
+                    partitions,
+                    additionalListeners[index],
+                    callback,
+                    cancellationToken).ConfigureAwait(false);
+            }
         }
 
         var runtimeListener = Volatile.Read(ref _runtimeRebalanceListener);

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -389,6 +389,8 @@ public sealed class ConsumerOptions
     /// <remarks>Takes precedence over <see cref="RebalanceListener"/> when both are set.</remarks>
     public IConsumerAwareRebalanceListener? ConsumerAwareRebalanceListener { get; init; }
 
+    internal IRebalanceListener[]? AdditionalRebalanceListeners { get; init; }
+
     /// <summary>
     /// Socket send buffer size in bytes. Set to 0 to use system default.
     /// </summary>

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -130,3 +130,4 @@ Dekaf.Serialization.IAsyncDeserializerPreparer<T>.PrepareAsync(System.ReadOnlyMe
 Dekaf.Consumer.ConsumerOptions.PartitionStopTimeout.get -> System.TimeSpan
 Dekaf.Consumer.ConsumerOptions.PartitionStopTimeout.init -> void
 Dekaf.ConsumerBuilder<TKey, TValue>.WithPartitionStopTimeout(System.TimeSpan timeout) -> Dekaf.ConsumerBuilder<TKey, TValue>!
+Dekaf.ConsumerBuilder<TKey, TValue>.AddRebalanceListener(Dekaf.Consumer.IRebalanceListener! listener) -> Dekaf.ConsumerBuilder<TKey, TValue>!

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -130,3 +130,4 @@ Dekaf.Serialization.IAsyncDeserializerPreparer<T>.PrepareAsync(System.ReadOnlyMe
 Dekaf.Consumer.ConsumerOptions.PartitionStopTimeout.get -> System.TimeSpan
 Dekaf.Consumer.ConsumerOptions.PartitionStopTimeout.init -> void
 Dekaf.ConsumerBuilder<TKey, TValue>.WithPartitionStopTimeout(System.TimeSpan timeout) -> Dekaf.ConsumerBuilder<TKey, TValue>!
+Dekaf.ConsumerBuilder<TKey, TValue>.AddRebalanceListener(Dekaf.Consumer.IRebalanceListener! listener) -> Dekaf.ConsumerBuilder<TKey, TValue>!

--- a/tests/Dekaf.Tests.Integration/RebalanceListenerTests.cs
+++ b/tests/Dekaf.Tests.Integration/RebalanceListenerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 
@@ -42,6 +43,48 @@ public class RebalanceListenerTests(KafkaTestContainer kafka) : KafkaIntegration
         await Assert.That(listener.AssignedCallCount).IsGreaterThanOrEqualTo(1);
     }
 
+    [Test]
+    public async Task AddRebalanceListener_InvokesInOrder_AndIsolatesExceptions()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"test-group-{Guid.NewGuid():N}";
+        var callbacks = new ConcurrentQueue<string>();
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "key",
+            Value = "value"
+        }, CancellationToken.None);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithRebalanceListener(new OrderedRebalanceListener("configured", callbacks))
+            .AddRebalanceListener(new OrderedRebalanceListener("failing", callbacks, throwOnAssigned: true))
+            .AddRebalanceListener(new OrderedRebalanceListener("trailing", callbacks))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+        var callbackSnapshot = callbacks.ToArray();
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(callbackSnapshot).Count().IsGreaterThanOrEqualTo(3);
+        await Assert.That(callbackSnapshot[0]).IsEqualTo("configured");
+        await Assert.That(callbackSnapshot[1]).IsEqualTo("failing");
+        await Assert.That(callbackSnapshot[2]).IsEqualTo("trailing");
+    }
+
     private sealed class TestRebalanceListener : IRebalanceListener
     {
         private int _assignedCount;
@@ -63,5 +106,32 @@ public class RebalanceListenerTests(KafkaTestContainer kafka) : KafkaIntegration
         {
             return ValueTask.CompletedTask;
         }
+    }
+
+    private sealed class OrderedRebalanceListener(
+        string name,
+        ConcurrentQueue<string> callbacks,
+        bool throwOnAssigned = false) : IRebalanceListener
+    {
+        public ValueTask OnPartitionsAssignedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            callbacks.Enqueue(name);
+            if (throwOnAssigned)
+            {
+                throw new InvalidOperationException($"{name} assignment failure");
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnPartitionsRevokedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+        public ValueTask OnPartitionsLostAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
     }
 }

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -1,4 +1,5 @@
 using Dekaf.Consumer;
+using NSubstitute;
 
 namespace Dekaf.Tests.Unit.Builder;
 
@@ -491,6 +492,38 @@ public class ConsumerBuilderValidationTests
             .Throws<ArgumentOutOfRangeException>();
         await Assert.That(() => builder.WithPartitionStopTimeout(TimeSpan.FromMilliseconds((double)int.MaxValue + 1)))
             .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task AddRebalanceListener_AccumulatesWithoutReplacingConfiguredListener()
+    {
+        var configured = Substitute.For<IRebalanceListener>();
+        var first = Substitute.For<IRebalanceListener>();
+        var second = Substitute.For<IRebalanceListener>();
+        var builder = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithRebalanceListener(configured);
+
+        var result = builder
+            .AddRebalanceListener(first)
+            .AddRebalanceListener(second);
+        await using var consumer = result.Build();
+        var options = GetConsumerOptions(consumer);
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(options.RebalanceListener).IsSameReferenceAs(configured);
+        await Assert.That(options.AdditionalRebalanceListeners).Count().IsEqualTo(2);
+        await Assert.That(options.AdditionalRebalanceListeners![0]).IsSameReferenceAs(first);
+        await Assert.That(options.AdditionalRebalanceListeners[1]).IsSameReferenceAs(second);
+    }
+
+    [Test]
+    public async Task AddRebalanceListener_Null_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        await Assert.That(() => builder.AddRebalanceListener(null!))
+            .Throws<ArgumentNullException>();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -114,7 +114,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         int maxPollIntervalMs = 300000,
         int retryBackoffMs = 100,
         int retryBackoffMaxMs = 1000,
-        IConsumerAwareRebalanceListener? consumerAwareRebalanceListener = null) => new()
+        IConsumerAwareRebalanceListener? consumerAwareRebalanceListener = null,
+        IRebalanceListener[]? additionalRebalanceListeners = null) => new()
         {
             BootstrapServers = ["localhost:9092"],
             GroupId = groupId,
@@ -123,6 +124,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             ClientRack = clientRack,
             RebalanceListener = rebalanceListener,
             ConsumerAwareRebalanceListener = consumerAwareRebalanceListener,
+            AdditionalRebalanceListeners = additionalRebalanceListeners,
             HeartbeatIntervalMs = heartbeatIntervalMs,
             RebalanceTimeoutMs = rebalanceTimeoutMs,
             MaxPollIntervalMs = maxPollIntervalMs,
@@ -2389,6 +2391,146 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
 
         await Assert.That(assignedPartitions).Count().IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_Assignment_InvokesAdditiveListenersInOrderAndIsolatesFailure()
+    {
+        var assignment = CreateAssignment(TestTopicId, 0);
+        SetupSuccessfulConsumerProtocolJoin(assignment: assignment);
+        var calls = new List<string>();
+        var configured = CreateListener("configured");
+        var failing = CreateListener("failing", fail: true);
+        var additional = CreateListener("additional");
+        var runtime = CreateListener("runtime");
+        var options = CreateConsumerProtocolOptions(
+            rebalanceListener: configured,
+            additionalRebalanceListeners: [failing, additional]);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        using var runtimeRegistration = coordinator.RegisterRuntimeRebalanceListener(runtime);
+
+        await coordinator.EnsureActiveGroupAsync(
+            new HashSet<string> { "test-topic" },
+            CancellationToken.None);
+
+        await Assert.That(calls).Count().IsEqualTo(4);
+        await Assert.That(calls[0]).IsEqualTo("configured");
+        await Assert.That(calls[1]).IsEqualTo("failing");
+        await Assert.That(calls[2]).IsEqualTo("additional");
+        await Assert.That(calls[3]).IsEqualTo("runtime");
+
+        IRebalanceListener CreateListener(string name, bool fail = false)
+        {
+            var listener = Substitute.For<IRebalanceListener>();
+            listener.OnPartitionsAssignedAsync(
+                    Arg.Any<IEnumerable<TopicPartition>>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    calls.Add(name);
+                    return fail
+                        ? ValueTask.FromException(new InvalidOperationException("listener failed"))
+                        : ValueTask.CompletedTask;
+                });
+            return listener;
+        }
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_Revocation_InvokesAllAdditiveListenersInOrder()
+    {
+        SetupFindCoordinator();
+        var heartbeatCount = 0;
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var count = Interlocked.Increment(ref heartbeatCount);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = count,
+                    HeartbeatIntervalMs = 60_000,
+                    Assignment = count == 1
+                        ? CreateAssignment(TestTopicId, 0, 1)
+                        : CreateAssignment(TestTopicId, 1)
+                });
+            });
+        var calls = new List<string>();
+        var options = CreateConsumerProtocolOptions(
+            heartbeatIntervalMs: 60_000,
+            rebalanceListener: CreateListener("configured"),
+            additionalRebalanceListeners:
+            [
+                CreateListener("first"),
+                CreateListener("second")
+            ]);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(
+            new HashSet<string> { "test-topic" },
+            CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+        await InvokeSteadyConsumerGroupHeartbeatAsync(coordinator);
+
+        await Assert.That(calls).Count().IsEqualTo(3);
+        await Assert.That(calls[0]).IsEqualTo("configured");
+        await Assert.That(calls[1]).IsEqualTo("first");
+        await Assert.That(calls[2]).IsEqualTo("second");
+
+        IRebalanceListener CreateListener(string name)
+        {
+            var listener = Substitute.For<IRebalanceListener>();
+            listener.OnPartitionsRevokedAsync(
+                    Arg.Any<IEnumerable<TopicPartition>>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    calls.Add(name);
+                    return ValueTask.CompletedTask;
+                });
+            return listener;
+        }
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_Lost_InvokesAllAdditiveListenersInOrder()
+    {
+        var calls = new List<string>();
+        var options = CreateConsumerProtocolOptions(
+            rebalanceListener: CreateListener("configured"),
+            additionalRebalanceListeners:
+            [
+                CreateListener("first"),
+                CreateListener("second")
+            ]);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await InvokePartitionsLostAsync(
+            coordinator,
+            [new TopicPartition("test-topic", 0)]);
+
+        await Assert.That(calls).Count().IsEqualTo(3);
+        await Assert.That(calls[0]).IsEqualTo("configured");
+        await Assert.That(calls[1]).IsEqualTo("first");
+        await Assert.That(calls[2]).IsEqualTo("second");
+
+        IRebalanceListener CreateListener(string name)
+        {
+            var listener = Substitute.For<IRebalanceListener>();
+            listener.OnPartitionsLostAsync(
+                    Arg.Any<IEnumerable<TopicPartition>>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    calls.Add(name);
+                    return ValueTask.CompletedTask;
+                });
+            return listener;
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- add ordered additive rebalance listeners alongside the configured and runtime listener slots
- snapshot registrations into an array and dispatch with indexed iteration on the rebalance cold path
- isolate non-cancellation listener failures so later listeners still run

## Verification
- Release build: 0 warnings, 0 errors
- focused unit tests: 5 passed
- full unit suite: 7,459 passed
- broker integration test: 1 passed
- pack: net10.0 and netstandard2.0 succeeded

No performance benchmark added: this changes only rebalance-event dispatch and does not touch fetch, consume, serialization, or per-message paths.

Closes #2760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for registering multiple additional rebalance listeners through the consumer builder.
  - Listeners run in registration order for assignment, revocation, and partition-loss events.
  - Failures in one listener no longer prevent subsequent listeners from running.
  - Listener registration supports fluent builder configuration and validates null values.

- **Tests**
  - Added coverage for listener ordering, accumulation, validation, and exception isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->