### PR TITLE
testing: add deterministic fault-plan engine

### DIFF
--- a/src/Dekaf.Testing/KafkaFaultPlan.cs
+++ b/src/Dekaf.Testing/KafkaFaultPlan.cs
@@ -196,7 +196,55 @@ public sealed class KafkaFaultBarrier
 /// <summary>
 /// Thread-safe ordered fault script for Dekaf in-memory clients.
 /// </summary>
-public sealed class KafkaFaultPlan
+public interface IKafkaFaultPlan
+{
+    /// <summary>
+    /// Raised synchronously after a matching entry is consumed and before its action runs.
+    /// </summary>
+    event Action<KafkaFaultObservation>? FaultConsumed;
+
+    /// <summary>
+    /// Gets the number of queued entries. A next-N failure is one entry.
+    /// </summary>
+    int Count { get; }
+
+    /// <summary>
+    /// Appends a failure consumed by the next matching operations.
+    /// </summary>
+    void Fail(KafkaFaultScope scope, Exception exception, int occurrenceCount = 1);
+
+    /// <summary>
+    /// Appends a failure that every matching operation consumes until it is cleared.
+    /// </summary>
+    void FailPersistently(KafkaFaultScope scope, Exception exception);
+
+    /// <summary>
+    /// Appends a one-shot deterministic barrier and returns its controller.
+    /// </summary>
+    KafkaFaultBarrier PauseNext(KafkaFaultScope scope);
+
+    /// <summary>
+    /// Applies the first matching scripted entry, or completes synchronously when none matches.
+    /// </summary>
+    ValueTask ApplyAsync(
+        KafkaFaultScope operationScope,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes entries configured with exactly the supplied scope and releases their barriers.
+    /// </summary>
+    int Clear(KafkaFaultScope scope);
+
+    /// <summary>
+    /// Removes every entry and releases all queued barriers.
+    /// </summary>
+    int Clear();
+}
+
+/// <summary>
+/// Default thread-safe <see cref="IKafkaFaultPlan"/> implementation.
+/// </summary>
+public sealed class KafkaFaultPlan : IKafkaFaultPlan
 {
     private readonly object _gate = new();
     private readonly List<FaultEntry> _entries = [];

--- a/src/Dekaf.Testing/KafkaFaultPlan.cs
+++ b/src/Dekaf.Testing/KafkaFaultPlan.cs
@@ -173,6 +173,9 @@ public sealed class KafkaFaultBarrier
     /// <summary>
     /// Waits until an operation consumes this barrier.
     /// </summary>
+    /// <exception cref="TaskCanceledException">
+    /// The barrier was removed from its fault plan before an operation consumed it.
+    /// </exception>
     public ValueTask WaitUntilEnteredAsync(CancellationToken cancellationToken = default)
     {
         if (_entered.Task.IsCompletedSuccessfully)
@@ -185,6 +188,12 @@ public sealed class KafkaFaultBarrier
     /// Releases the paused operation. Returns false when already released.
     /// </summary>
     public bool Release() => _released.TrySetResult();
+
+    internal void ClearBeforeEntry()
+    {
+        _entered.TrySetCanceled();
+        _released.TrySetResult();
+    }
 
     internal ValueTask EnterAsync(CancellationToken cancellationToken)
     {
@@ -377,7 +386,7 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
                     continue;
 
                 _entries.RemoveAt(i);
-                entry.Barrier?.Release();
+                entry.Barrier?.ClearBeforeEntry();
                 removed++;
             }
         }
@@ -394,7 +403,7 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
         {
             var removed = _entries.Count;
             for (var i = 0; i < _entries.Count; i++)
-                _entries[i].Barrier?.Release();
+                _entries[i].Barrier?.ClearBeforeEntry();
 
             _entries.Clear();
             return removed;

--- a/src/Dekaf.Testing/KafkaFaultPlan.cs
+++ b/src/Dekaf.Testing/KafkaFaultPlan.cs
@@ -165,6 +165,10 @@ public sealed class KafkaFaultBarrier
     private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TaskCompletionSource _released = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+    internal KafkaFaultBarrier()
+    {
+    }
+
     /// <summary>
     /// Gets whether the barrier has been released.
     /// </summary>

--- a/src/Dekaf.Testing/KafkaFaultPlan.cs
+++ b/src/Dekaf.Testing/KafkaFaultPlan.cs
@@ -92,11 +92,17 @@ public readonly struct KafkaFaultScope
     /// <summary>Gets the optional consumer-group selector.</summary>
     public string? GroupId { get; }
 
-    internal bool Matches(KafkaFaultScope context) =>
-        Operation == context.Operation &&
-        (Topic is null || string.Equals(Topic, context.Topic, StringComparison.Ordinal)) &&
-        (Partition is null || Partition == context.Partition) &&
-        (GroupId is null || string.Equals(GroupId, context.GroupId, StringComparison.Ordinal));
+    internal bool Matches(KafkaFaultScope context)
+    {
+        if (Operation != context.Operation)
+            return false;
+        if (Topic is not null && !string.Equals(Topic, context.Topic, StringComparison.Ordinal))
+            return false;
+        if (Partition is not null && Partition != context.Partition)
+            return false;
+
+        return GroupId is null || string.Equals(GroupId, context.GroupId, StringComparison.Ordinal);
+    }
 
     internal bool EqualsExactly(KafkaFaultScope other) =>
         Operation == other.Operation &&

--- a/src/Dekaf.Testing/KafkaFaultPlan.cs
+++ b/src/Dekaf.Testing/KafkaFaultPlan.cs
@@ -1,0 +1,385 @@
+namespace Dekaf.Testing;
+
+/// <summary>
+/// Identifies an in-memory client operation that can consume a scripted fault.
+/// </summary>
+public enum KafkaFaultOperation
+{
+    /// <summary>A produce acknowledgement.</summary>
+    Produce = 1,
+    /// <summary>A broker fetch.</summary>
+    Fetch,
+    /// <summary>A consumer delivery.</summary>
+    Consume,
+    /// <summary>An offset store.</summary>
+    StoreOffset,
+    /// <summary>An offset commit.</summary>
+    Commit,
+    /// <summary>A consumer-group join.</summary>
+    JoinGroup,
+    /// <summary>A consumer-group sync.</summary>
+    SyncGroup,
+    /// <summary>A rebalance callback or transition.</summary>
+    Rebalance,
+    /// <summary>Transaction initialization.</summary>
+    InitializeTransactions,
+    /// <summary>A produce within a transaction.</summary>
+    TransactionProduce,
+    /// <summary>An offsets-to-transaction operation.</summary>
+    SendOffsetsToTransaction,
+    /// <summary>A transaction commit.</summary>
+    CommitTransaction,
+    /// <summary>A transaction abort.</summary>
+    AbortTransaction,
+    /// <summary>An Admin client operation.</summary>
+    Admin,
+    /// <summary>A Share Consumer delivery.</summary>
+    ShareConsume,
+    /// <summary>A Share Consumer acknowledgement.</summary>
+    ShareAcknowledge
+}
+
+/// <summary>
+/// Identifies the action taken when a fault-plan entry is consumed.
+/// </summary>
+public enum KafkaFaultAction
+{
+    /// <summary>Throw a configured exception.</summary>
+    Throw,
+    /// <summary>Pause at a deterministic barrier.</summary>
+    Pause
+}
+
+/// <summary>
+/// Selects a fault by operation and optional Kafka resource identifiers.
+/// Null selectors are wildcards when the scope is used to configure a rule.
+/// </summary>
+public readonly struct KafkaFaultScope
+{
+    /// <summary>
+    /// Creates a scope. Null resource selectors act as wildcards on configured rules.
+    /// </summary>
+    public KafkaFaultScope(
+        KafkaFaultOperation operation,
+        string? topic = null,
+        int? partition = null,
+        string? groupId = null)
+    {
+        if (operation is < KafkaFaultOperation.Produce or > KafkaFaultOperation.ShareAcknowledge)
+            throw new ArgumentOutOfRangeException(nameof(operation), operation, "Unknown fault operation.");
+        if (topic is not null)
+            ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+        if (partition < 0)
+            throw new ArgumentOutOfRangeException(nameof(partition), partition, "Partition cannot be negative.");
+        if (groupId is not null)
+            ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+
+        Operation = operation;
+        Topic = topic;
+        Partition = partition;
+        GroupId = groupId;
+    }
+
+    /// <summary>Gets the operation selector.</summary>
+    public KafkaFaultOperation Operation { get; }
+
+    /// <summary>Gets the optional topic selector.</summary>
+    public string? Topic { get; }
+
+    /// <summary>Gets the optional partition selector.</summary>
+    public int? Partition { get; }
+
+    /// <summary>Gets the optional consumer-group selector.</summary>
+    public string? GroupId { get; }
+
+    internal bool Matches(KafkaFaultScope context) =>
+        Operation == context.Operation &&
+        (Topic is null || string.Equals(Topic, context.Topic, StringComparison.Ordinal)) &&
+        (Partition is null || Partition == context.Partition) &&
+        (GroupId is null || string.Equals(GroupId, context.GroupId, StringComparison.Ordinal));
+
+    internal bool EqualsExactly(KafkaFaultScope other) =>
+        Operation == other.Operation &&
+        string.Equals(Topic, other.Topic, StringComparison.Ordinal) &&
+        Partition == other.Partition &&
+        string.Equals(GroupId, other.GroupId, StringComparison.Ordinal);
+
+    internal void Validate()
+    {
+        if (Operation is < KafkaFaultOperation.Produce or > KafkaFaultOperation.ShareAcknowledge)
+            throw new ArgumentOutOfRangeException(nameof(Operation), Operation, "Unknown fault operation.");
+    }
+}
+
+/// <summary>
+/// Describes a fault-plan entry at the instant it is consumed.
+/// </summary>
+public readonly struct KafkaFaultObservation
+{
+    internal KafkaFaultObservation(
+        KafkaFaultScope ruleScope,
+        KafkaFaultScope operationScope,
+        KafkaFaultAction action,
+        Exception? exception,
+        bool isPersistent,
+        int? remainingOccurrences)
+    {
+        RuleScope = ruleScope;
+        OperationScope = operationScope;
+        Action = action;
+        Exception = exception;
+        IsPersistent = isPersistent;
+        RemainingOccurrences = remainingOccurrences;
+    }
+
+    /// <summary>Gets the configured rule scope.</summary>
+    public KafkaFaultScope RuleScope { get; }
+
+    /// <summary>Gets the concrete operation scope that matched.</summary>
+    public KafkaFaultScope OperationScope { get; }
+
+    /// <summary>Gets the consumed action.</summary>
+    public KafkaFaultAction Action { get; }
+
+    /// <summary>Gets the configured exception for a throw action.</summary>
+    public Exception? Exception { get; }
+
+    /// <summary>Gets whether the consumed rule remains persistent.</summary>
+    public bool IsPersistent { get; }
+
+    /// <summary>Gets the remaining occurrences, or null for a persistent rule.</summary>
+    public int? RemainingOccurrences { get; }
+}
+
+/// <summary>
+/// Deterministic pause point used to coordinate race tests without timing delays.
+/// </summary>
+public sealed class KafkaFaultBarrier
+{
+    private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _released = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>
+    /// Gets whether the barrier has been released.
+    /// </summary>
+    public bool IsReleased => _released.Task.IsCompleted;
+
+    /// <summary>
+    /// Waits until an operation consumes this barrier.
+    /// </summary>
+    public ValueTask WaitUntilEnteredAsync(CancellationToken cancellationToken = default)
+    {
+        if (_entered.Task.IsCompletedSuccessfully)
+            return ValueTask.CompletedTask;
+
+        return WaitAsync(_entered.Task, cancellationToken);
+    }
+
+    /// <summary>
+    /// Releases the paused operation. Returns false when already released.
+    /// </summary>
+    public bool Release() => _released.TrySetResult();
+
+    internal ValueTask EnterAsync(CancellationToken cancellationToken)
+    {
+        _entered.TrySetResult();
+        if (_released.Task.IsCompletedSuccessfully)
+            return ValueTask.CompletedTask;
+
+        return WaitAsync(_released.Task, cancellationToken);
+    }
+
+    private static async ValueTask WaitAsync(Task task, CancellationToken cancellationToken) =>
+        await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+}
+
+/// <summary>
+/// Thread-safe ordered fault script for Dekaf in-memory clients.
+/// </summary>
+public sealed class KafkaFaultPlan
+{
+    private readonly object _gate = new();
+    private readonly List<FaultEntry> _entries = [];
+
+    /// <summary>
+    /// Raised synchronously after a matching entry is consumed and before its action runs.
+    /// </summary>
+    public event Action<KafkaFaultObservation>? FaultConsumed;
+
+    /// <summary>
+    /// Gets the number of queued entries. A next-N failure is one entry.
+    /// </summary>
+    public int Count
+    {
+        get
+        {
+            lock (_gate)
+                return _entries.Count;
+        }
+    }
+
+    /// <summary>
+    /// Appends a failure consumed by the next matching operations.
+    /// </summary>
+    public void Fail(KafkaFaultScope scope, Exception exception, int occurrenceCount = 1)
+    {
+        scope.Validate();
+        ArgumentNullException.ThrowIfNull(exception);
+        ArgumentOutOfRangeException.ThrowIfLessThan(occurrenceCount, 1);
+
+        lock (_gate)
+            _entries.Add(FaultEntry.Failure(scope, exception, occurrenceCount, isPersistent: false));
+    }
+
+    /// <summary>
+    /// Appends a failure that every matching operation consumes until it is cleared.
+    /// </summary>
+    public void FailPersistently(KafkaFaultScope scope, Exception exception)
+    {
+        scope.Validate();
+        ArgumentNullException.ThrowIfNull(exception);
+
+        lock (_gate)
+            _entries.Add(FaultEntry.Failure(scope, exception, remainingOccurrences: 0, isPersistent: true));
+    }
+
+    /// <summary>
+    /// Appends a one-shot deterministic barrier and returns its controller.
+    /// </summary>
+    public KafkaFaultBarrier PauseNext(KafkaFaultScope scope)
+    {
+        scope.Validate();
+        var barrier = new KafkaFaultBarrier();
+        lock (_gate)
+            _entries.Add(FaultEntry.Pause(scope, barrier));
+
+        return barrier;
+    }
+
+    /// <summary>
+    /// Applies the first matching scripted entry, or completes synchronously when none matches.
+    /// </summary>
+    public ValueTask ApplyAsync(
+        KafkaFaultScope operationScope,
+        CancellationToken cancellationToken = default)
+    {
+        operationScope.Validate();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        FaultEntry? entry = null;
+        KafkaFaultObservation observation = default;
+        Action<KafkaFaultObservation>? observer = null;
+        lock (_gate)
+        {
+            for (var i = 0; i < _entries.Count; i++)
+            {
+                var candidate = _entries[i];
+                if (!candidate.Scope.Matches(operationScope))
+                    continue;
+
+                entry = candidate;
+                if (!candidate.IsPersistent)
+                {
+                    candidate.RemainingOccurrences--;
+                    if (candidate.RemainingOccurrences == 0)
+                        _entries.RemoveAt(i);
+                }
+
+                observation = new KafkaFaultObservation(
+                    candidate.Scope,
+                    operationScope,
+                    candidate.Action,
+                    candidate.Exception,
+                    candidate.IsPersistent,
+                    candidate.IsPersistent ? null : candidate.RemainingOccurrences);
+                observer = FaultConsumed;
+                break;
+            }
+        }
+
+        if (entry is null)
+            return ValueTask.CompletedTask;
+
+        observer?.Invoke(observation);
+        if (entry.Exception is { } exception)
+            return ValueTask.FromException(exception);
+
+        return entry.Barrier!.EnterAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Removes entries configured with exactly the supplied scope and releases their barriers.
+    /// </summary>
+    public int Clear(KafkaFaultScope scope)
+    {
+        scope.Validate();
+        var removed = 0;
+        lock (_gate)
+        {
+            for (var i = _entries.Count - 1; i >= 0; i--)
+            {
+                var entry = _entries[i];
+                if (!entry.Scope.EqualsExactly(scope))
+                    continue;
+
+                _entries.RemoveAt(i);
+                entry.Barrier?.Release();
+                removed++;
+            }
+        }
+
+        return removed;
+    }
+
+    /// <summary>
+    /// Removes every entry and releases all queued barriers.
+    /// </summary>
+    public int Clear()
+    {
+        lock (_gate)
+        {
+            var removed = _entries.Count;
+            for (var i = 0; i < _entries.Count; i++)
+                _entries[i].Barrier?.Release();
+
+            _entries.Clear();
+            return removed;
+        }
+    }
+
+    private sealed class FaultEntry
+    {
+        private FaultEntry(
+            KafkaFaultScope scope,
+            KafkaFaultAction action,
+            Exception? exception,
+            KafkaFaultBarrier? barrier,
+            int remainingOccurrences,
+            bool isPersistent)
+        {
+            Scope = scope;
+            Action = action;
+            Exception = exception;
+            Barrier = barrier;
+            RemainingOccurrences = remainingOccurrences;
+            IsPersistent = isPersistent;
+        }
+
+        public KafkaFaultScope Scope { get; }
+        public KafkaFaultAction Action { get; }
+        public Exception? Exception { get; }
+        public KafkaFaultBarrier? Barrier { get; }
+        public int RemainingOccurrences { get; set; }
+        public bool IsPersistent { get; }
+
+        public static FaultEntry Failure(
+            KafkaFaultScope scope,
+            Exception exception,
+            int remainingOccurrences,
+            bool isPersistent) =>
+            new(scope, KafkaFaultAction.Throw, exception, null, remainingOccurrences, isPersistent);
+
+        public static FaultEntry Pause(KafkaFaultScope scope, KafkaFaultBarrier barrier) =>
+            new(scope, KafkaFaultAction.Pause, null, barrier, remainingOccurrences: 1, isPersistent: false);
+    }
+}

--- a/src/Dekaf.Testing/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.Testing/PublicAPI.Unshipped.txt
@@ -51,6 +51,15 @@ Dekaf.Testing.KafkaFaultOperation.ShareConsume = 15 -> Dekaf.Testing.KafkaFaultO
 Dekaf.Testing.KafkaFaultOperation.StoreOffset = 4 -> Dekaf.Testing.KafkaFaultOperation
 Dekaf.Testing.KafkaFaultOperation.SyncGroup = 7 -> Dekaf.Testing.KafkaFaultOperation
 Dekaf.Testing.KafkaFaultOperation.TransactionProduce = 10 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.IKafkaFaultPlan
+Dekaf.Testing.IKafkaFaultPlan.ApplyAsync(Dekaf.Testing.KafkaFaultScope operationScope, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Dekaf.Testing.IKafkaFaultPlan.Clear() -> int
+Dekaf.Testing.IKafkaFaultPlan.Clear(Dekaf.Testing.KafkaFaultScope scope) -> int
+Dekaf.Testing.IKafkaFaultPlan.Count.get -> int
+Dekaf.Testing.IKafkaFaultPlan.Fail(Dekaf.Testing.KafkaFaultScope scope, System.Exception! exception, int occurrenceCount = 1) -> void
+Dekaf.Testing.IKafkaFaultPlan.FailPersistently(Dekaf.Testing.KafkaFaultScope scope, System.Exception! exception) -> void
+Dekaf.Testing.IKafkaFaultPlan.FaultConsumed -> System.Action<Dekaf.Testing.KafkaFaultObservation>?
+Dekaf.Testing.IKafkaFaultPlan.PauseNext(Dekaf.Testing.KafkaFaultScope scope) -> Dekaf.Testing.KafkaFaultBarrier!
 Dekaf.Testing.KafkaFaultPlan
 Dekaf.Testing.KafkaFaultPlan.ApplyAsync(Dekaf.Testing.KafkaFaultScope operationScope, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Dekaf.Testing.KafkaFaultPlan.Clear() -> int

--- a/src/Dekaf.Testing/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.Testing/PublicAPI.Unshipped.txt
@@ -23,7 +23,6 @@ Dekaf.Testing.KafkaFaultAction.Pause = 1 -> Dekaf.Testing.KafkaFaultAction
 Dekaf.Testing.KafkaFaultAction.Throw = 0 -> Dekaf.Testing.KafkaFaultAction
 Dekaf.Testing.KafkaFaultBarrier
 Dekaf.Testing.KafkaFaultBarrier.IsReleased.get -> bool
-Dekaf.Testing.KafkaFaultBarrier.KafkaFaultBarrier() -> void
 Dekaf.Testing.KafkaFaultBarrier.Release() -> bool
 Dekaf.Testing.KafkaFaultBarrier.WaitUntilEnteredAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Dekaf.Testing.KafkaFaultObservation

--- a/src/Dekaf.Testing/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.Testing/PublicAPI.Unshipped.txt
@@ -18,3 +18,53 @@ Dekaf.Testing.InMemoryStreamsGroupMember.LastUpdate.get -> Dekaf.Streams.Streams
 Dekaf.Testing.InMemoryStreamsGroupMember.ReportTaskOffsetsAsync(Dekaf.Streams.StreamsGroupTaskOffsetReport! report, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Streams.StreamsGroupHeartbeatResult!>
 Dekaf.Testing.InMemoryStreamsGroupMember.Snapshot.get -> Dekaf.Streams.StreamsGroupMemberSnapshot!
 Dekaf.Testing.InMemoryStreamsGroupMember.UpdateAsync(Dekaf.Streams.StreamsGroupMemberUpdate! update, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Streams.StreamsGroupHeartbeatResult!>
+Dekaf.Testing.KafkaFaultAction
+Dekaf.Testing.KafkaFaultAction.Pause = 1 -> Dekaf.Testing.KafkaFaultAction
+Dekaf.Testing.KafkaFaultAction.Throw = 0 -> Dekaf.Testing.KafkaFaultAction
+Dekaf.Testing.KafkaFaultBarrier
+Dekaf.Testing.KafkaFaultBarrier.IsReleased.get -> bool
+Dekaf.Testing.KafkaFaultBarrier.KafkaFaultBarrier() -> void
+Dekaf.Testing.KafkaFaultBarrier.Release() -> bool
+Dekaf.Testing.KafkaFaultBarrier.WaitUntilEnteredAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Dekaf.Testing.KafkaFaultObservation
+Dekaf.Testing.KafkaFaultObservation.Action.get -> Dekaf.Testing.KafkaFaultAction
+Dekaf.Testing.KafkaFaultObservation.Exception.get -> System.Exception?
+Dekaf.Testing.KafkaFaultObservation.IsPersistent.get -> bool
+Dekaf.Testing.KafkaFaultObservation.KafkaFaultObservation() -> void
+Dekaf.Testing.KafkaFaultObservation.OperationScope.get -> Dekaf.Testing.KafkaFaultScope
+Dekaf.Testing.KafkaFaultObservation.RemainingOccurrences.get -> int?
+Dekaf.Testing.KafkaFaultObservation.RuleScope.get -> Dekaf.Testing.KafkaFaultScope
+Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.AbortTransaction = 13 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.Admin = 14 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.Commit = 5 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.CommitTransaction = 12 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.Consume = 3 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.Fetch = 2 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.InitializeTransactions = 9 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.JoinGroup = 6 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.Produce = 1 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.Rebalance = 8 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.SendOffsetsToTransaction = 11 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.ShareAcknowledge = 16 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.ShareConsume = 15 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.StoreOffset = 4 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.SyncGroup = 7 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultOperation.TransactionProduce = 10 -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultPlan
+Dekaf.Testing.KafkaFaultPlan.ApplyAsync(Dekaf.Testing.KafkaFaultScope operationScope, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Dekaf.Testing.KafkaFaultPlan.Clear() -> int
+Dekaf.Testing.KafkaFaultPlan.Clear(Dekaf.Testing.KafkaFaultScope scope) -> int
+Dekaf.Testing.KafkaFaultPlan.Count.get -> int
+Dekaf.Testing.KafkaFaultPlan.Fail(Dekaf.Testing.KafkaFaultScope scope, System.Exception! exception, int occurrenceCount = 1) -> void
+Dekaf.Testing.KafkaFaultPlan.FailPersistently(Dekaf.Testing.KafkaFaultScope scope, System.Exception! exception) -> void
+Dekaf.Testing.KafkaFaultPlan.FaultConsumed -> System.Action<Dekaf.Testing.KafkaFaultObservation>?
+Dekaf.Testing.KafkaFaultPlan.KafkaFaultPlan() -> void
+Dekaf.Testing.KafkaFaultPlan.PauseNext(Dekaf.Testing.KafkaFaultScope scope) -> Dekaf.Testing.KafkaFaultBarrier!
+Dekaf.Testing.KafkaFaultScope
+Dekaf.Testing.KafkaFaultScope.GroupId.get -> string?
+Dekaf.Testing.KafkaFaultScope.KafkaFaultScope() -> void
+Dekaf.Testing.KafkaFaultScope.KafkaFaultScope(Dekaf.Testing.KafkaFaultOperation operation, string? topic = null, int? partition = null, string? groupId = null) -> void
+Dekaf.Testing.KafkaFaultScope.Operation.get -> Dekaf.Testing.KafkaFaultOperation
+Dekaf.Testing.KafkaFaultScope.Partition.get -> int?
+Dekaf.Testing.KafkaFaultScope.Topic.get -> string?

--- a/tests/Dekaf.Tests.Unit/Testing/KafkaFaultPlanTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/KafkaFaultPlanTests.cs
@@ -11,7 +11,7 @@ public sealed class KafkaFaultPlanTests
     [Test]
     public async Task Fail_ConsumesOrderedOneShotAndNextNRules()
     {
-        var plan = new KafkaFaultPlan();
+        IKafkaFaultPlan plan = new KafkaFaultPlan();
         var first = new InvalidOperationException("first");
         var second = new TimeoutException("second");
         plan.Fail(ProduceOrders, first);
@@ -194,7 +194,7 @@ public sealed class KafkaFaultPlanTests
     }
 
     private static async Task AssertFaultAsync(
-        KafkaFaultPlan plan,
+        IKafkaFaultPlan plan,
         KafkaFaultScope context,
         Exception expected)
     {
@@ -202,7 +202,7 @@ public sealed class KafkaFaultPlanTests
         await Assert.That(actual).IsSameReferenceAs(expected);
     }
 
-    private static async Task ApplyIgnoringFaultAsync(KafkaFaultPlan plan, KafkaFaultScope context)
+    private static async Task ApplyIgnoringFaultAsync(IKafkaFaultPlan plan, KafkaFaultScope context)
     {
         try
         {

--- a/tests/Dekaf.Tests.Unit/Testing/KafkaFaultPlanTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/KafkaFaultPlanTests.cs
@@ -130,6 +130,20 @@ public sealed class KafkaFaultPlanTests
     }
 
     [Test]
+    public async Task Clear_ExactScopeCancelsUnenteredBarrierWaiter()
+    {
+        var plan = new KafkaFaultPlan();
+        var barrier = plan.PauseNext(ProduceOrders);
+        var entered = barrier.WaitUntilEnteredAsync().AsTask();
+
+        var removed = plan.Clear(ProduceOrders);
+
+        await Assert.That(removed).IsEqualTo(1);
+        await Assert.That(barrier.IsReleased).IsTrue();
+        _ = await Assert.ThrowsAsync<TaskCanceledException>(() => entered);
+    }
+
+    [Test]
     public async Task PauseNext_BlocksUntilReleasedAndPublishesObservation()
     {
         var plan = new KafkaFaultPlan();
@@ -170,11 +184,13 @@ public sealed class KafkaFaultPlanTests
         var plan = new KafkaFaultPlan();
         plan.Fail(ProduceOrders, new InvalidOperationException("failure"));
         var barrier = plan.PauseNext(new KafkaFaultScope(KafkaFaultOperation.Fetch));
+        var entered = barrier.WaitUntilEnteredAsync().AsTask();
 
         var removed = plan.Clear();
 
         await Assert.That(removed).IsEqualTo(2);
         await Assert.That(barrier.IsReleased).IsTrue();
+        _ = await Assert.ThrowsAsync<TaskCanceledException>(() => entered);
         await plan.ApplyAsync(ProduceOrders);
     }
 

--- a/tests/Dekaf.Tests.Unit/Testing/KafkaFaultPlanTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/KafkaFaultPlanTests.cs
@@ -1,0 +1,215 @@
+using Dekaf.Testing;
+
+namespace Dekaf.Tests.Unit.Testing;
+
+public sealed class KafkaFaultPlanTests
+{
+    private static readonly KafkaFaultScope ProduceOrders = new(
+        KafkaFaultOperation.Produce,
+        topic: "orders");
+
+    [Test]
+    public async Task Fail_ConsumesOrderedOneShotAndNextNRules()
+    {
+        var plan = new KafkaFaultPlan();
+        var first = new InvalidOperationException("first");
+        var second = new TimeoutException("second");
+        plan.Fail(ProduceOrders, first);
+        plan.Fail(ProduceOrders, second, occurrenceCount: 2);
+
+        await AssertFaultAsync(plan, ProduceOrders, first);
+        await AssertFaultAsync(plan, ProduceOrders, second);
+        await AssertFaultAsync(plan, ProduceOrders, second);
+        await plan.ApplyAsync(ProduceOrders);
+
+        await Assert.That(plan.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ApplyAsync_MatchesAllConfiguredSelectorsBeforeConsuming()
+    {
+        var plan = new KafkaFaultPlan();
+        var failure = new InvalidOperationException("scoped");
+        var rule = new KafkaFaultScope(
+            KafkaFaultOperation.Commit,
+            topic: "orders",
+            partition: 2,
+            groupId: "billing");
+        plan.Fail(rule, failure);
+
+        await plan.ApplyAsync(new KafkaFaultScope(KafkaFaultOperation.Commit, "orders", 1, "billing"));
+        await plan.ApplyAsync(new KafkaFaultScope(KafkaFaultOperation.Commit, "orders", 2, "other"));
+        await plan.ApplyAsync(new KafkaFaultScope(KafkaFaultOperation.Consume, "orders", 2, "billing"));
+        await AssertFaultAsync(plan, rule, failure);
+
+        await Assert.That(plan.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ApplyAsync_NullSelectorsMatchConcreteResources()
+    {
+        var plan = new KafkaFaultPlan();
+        var failure = new InvalidOperationException("wildcard");
+        plan.Fail(new KafkaFaultScope(KafkaFaultOperation.Fetch), failure);
+
+        await AssertFaultAsync(
+            plan,
+            new KafkaFaultScope(KafkaFaultOperation.Fetch, "orders", 4, "billing"),
+            failure);
+    }
+
+    [Test]
+    public async Task FailPersistently_RemainsUntilExactScopeIsCleared()
+    {
+        var plan = new KafkaFaultPlan();
+        var failure = new InvalidOperationException("persistent");
+        plan.FailPersistently(ProduceOrders, failure);
+
+        await AssertFaultAsync(plan, ProduceOrders, failure);
+        await AssertFaultAsync(plan, ProduceOrders, failure);
+        await Assert.That(plan.Count).IsEqualTo(1);
+        await Assert.That(plan.Clear(ProduceOrders)).IsEqualTo(1);
+
+        await plan.ApplyAsync(ProduceOrders);
+        await Assert.That(plan.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Fail_IsThreadSafeAndConsumesExactOccurrenceCount()
+    {
+        var plan = new KafkaFaultPlan();
+        plan.Fail(ProduceOrders, new InvalidOperationException("concurrent"), occurrenceCount: 32);
+        var consumed = 0;
+        plan.FaultConsumed += observation =>
+        {
+            if (observation.Action == KafkaFaultAction.Throw)
+                Interlocked.Increment(ref consumed);
+        };
+
+        var operations = new Task[64];
+        for (var i = 0; i < operations.Length; i++)
+            operations[i] = Task.Run(() => ApplyIgnoringFaultAsync(plan, ProduceOrders));
+
+        await Task.WhenAll(operations);
+
+        await Assert.That(consumed).IsEqualTo(32);
+        await Assert.That(plan.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ApplyAsync_PreCanceledTokenDoesNotConsumeRule()
+    {
+        var plan = new KafkaFaultPlan();
+        var failure = new InvalidOperationException("still queued");
+        plan.Fail(ProduceOrders, failure);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(
+            () => plan.ApplyAsync(ProduceOrders, cancellation.Token).AsTask());
+
+        await Assert.That(plan.Count).IsEqualTo(1);
+        await AssertFaultAsync(plan, ProduceOrders, failure);
+    }
+
+    [Test]
+    public async Task Clear_ExactScopeLeavesOtherRulesQueued()
+    {
+        var plan = new KafkaFaultPlan();
+        var otherScope = new KafkaFaultScope(KafkaFaultOperation.Produce, "payments");
+        var otherFailure = new InvalidOperationException("payments");
+        plan.Fail(ProduceOrders, new InvalidOperationException("orders"));
+        plan.Fail(otherScope, otherFailure);
+
+        var removed = plan.Clear(ProduceOrders);
+
+        await Assert.That(removed).IsEqualTo(1);
+        await Assert.That(plan.Count).IsEqualTo(1);
+        await plan.ApplyAsync(ProduceOrders);
+        await AssertFaultAsync(plan, otherScope, otherFailure);
+    }
+
+    [Test]
+    public async Task PauseNext_BlocksUntilReleasedAndPublishesObservation()
+    {
+        var plan = new KafkaFaultPlan();
+        KafkaFaultObservation? observed = null;
+        plan.FaultConsumed += observation => observed = observation;
+        var barrier = plan.PauseNext(ProduceOrders);
+
+        var operation = plan.ApplyAsync(ProduceOrders).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+
+        await Assert.That(operation.IsCompleted).IsFalse();
+        await Assert.That(observed).IsNotNull();
+        await Assert.That(observed!.Value.Action).IsEqualTo(KafkaFaultAction.Pause);
+        await Assert.That(barrier.Release()).IsTrue();
+        await operation;
+        await Assert.That(barrier.Release()).IsFalse();
+    }
+
+    [Test]
+    public async Task PauseNext_CancellationStopsWaitWithoutTimingDelay()
+    {
+        var plan = new KafkaFaultPlan();
+        var barrier = plan.PauseNext(ProduceOrders);
+        using var cancellation = new CancellationTokenSource();
+
+        var operation = plan.ApplyAsync(ProduceOrders, cancellation.Token).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        cancellation.Cancel();
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => operation);
+        await Assert.That(barrier.Release()).IsTrue();
+        await Assert.That(plan.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Clear_RemovesAllRulesAndReleasesPendingBarriers()
+    {
+        var plan = new KafkaFaultPlan();
+        plan.Fail(ProduceOrders, new InvalidOperationException("failure"));
+        var barrier = plan.PauseNext(new KafkaFaultScope(KafkaFaultOperation.Fetch));
+
+        var removed = plan.Clear();
+
+        await Assert.That(removed).IsEqualTo(2);
+        await Assert.That(barrier.IsReleased).IsTrue();
+        await plan.ApplyAsync(ProduceOrders);
+    }
+
+    [Test]
+    public async Task Configuration_RejectsInvalidArguments()
+    {
+        var plan = new KafkaFaultPlan();
+
+        await Assert.That(() => new KafkaFaultScope(KafkaFaultOperation.Produce, partition: -1))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => plan.Fail(ProduceOrders, new InvalidOperationException(), occurrenceCount: 0))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => plan.Fail(ProduceOrders, null!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => plan.Fail(default, new InvalidOperationException()))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    private static async Task AssertFaultAsync(
+        KafkaFaultPlan plan,
+        KafkaFaultScope context,
+        Exception expected)
+    {
+        var actual = await Assert.ThrowsAsync<Exception>(() => plan.ApplyAsync(context).AsTask());
+        await Assert.That(actual).IsSameReferenceAs(expected);
+    }
+
+    private static async Task ApplyIgnoringFaultAsync(KafkaFaultPlan plan, KafkaFaultScope context)
+    {
+        try
+        {
+            await plan.ApplyAsync(context);
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Testing/KafkaFaultPlanTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/KafkaFaultPlanTests.cs
@@ -9,6 +9,10 @@ public sealed class KafkaFaultPlanTests
         topic: "orders");
 
     [Test]
+    public async Task KafkaFaultBarrier_HasNoPublicConstructor() =>
+        await Assert.That(typeof(KafkaFaultBarrier).GetConstructors()).IsEmpty();
+
+    [Test]
     public async Task Fail_ConsumesOrderedOneShotAndNextNRules()
     {
         IKafkaFaultPlan plan = new KafkaFaultPlan();

--- a/tests/Dekaf.Tests.Unit/Testing/KafkaFaultPlanTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/KafkaFaultPlanTests.cs
@@ -210,6 +210,7 @@ public sealed class KafkaFaultPlanTests
         }
         catch (InvalidOperationException)
         {
+            return;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a public thread-safe `KafkaFaultPlan` with operation/topic/partition/group selectors
- support ordered one-shot, next-N, and persistent failures plus exact/all clearing
- add deterministic pause/release barriers and synchronous consumed-fault observations
- keep the engine entirely inside `Dekaf.Testing`; production clients and hot paths are unchanged
- add public API baselines and deterministic concurrency/cancellation coverage

## Verification
- `dotnet build tests/Dekaf.Tests.Unit --configuration Release` — 0 warnings/errors, net8.0 + net10.0
- `KafkaFaultPlanTests` — 11/11 passed on net8.0 and 11/11 on net10.0
- all `InMemory*` testing classes — 66/66 passed on net10.0
- full net10.0 unit suite — 7463/7465 passed; two existing Avro exact-allocation cases observed 7176/7208 B only under full parallel load, while the isolated 3-case diagnostic passed 3/3. Filed #2803; no blind rerun performed.

No benchmark is required for this child: it adds an unattached test-only engine in `Dekaf.Testing`; no production package or runtime path calls it. Adapter integration is tracked by #2799-#2801.

Part of #2757.

Closes #2798

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kafka fault-injection testing tools for simulating failures and pauses.
  * Supports one-time, counted, persistent, and operation-specific faults.
  * Added controls for pausing, resuming, observing, and clearing faults.
  * Supports scoped matching by operation, topic, partition, and consumer group.

* **Tests**
  * Added coverage for fault ordering, wildcard matching, concurrency, cancellation, pausing, clearing, persistence, and configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->