### PR TITLE
consumer: expose raw metadata and batch EOF

### DIFF
--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -275,6 +275,17 @@ namespace Dekaf.Consumer
         public long Count => _count;
 
         /// <summary>
+        /// Indicates whether this zero-record batch marks the current end offset of its partition.
+        /// Emitted only when partition EOF reporting is enabled.
+        /// </summary>
+        public bool IsPartitionEof => _pendingFetchData.IsPartitionEof;
+
+        /// <summary>
+        /// Gets the partition end offset for an EOF batch, or <see langword="null"/> for a data batch.
+        /// </summary>
+        public long? PartitionEofOffset => _pendingFetchData.PartitionEofOffset;
+
+        /// <summary>
         /// Returns a struct enumerator that avoids boxing allocation.
         /// </summary>
         public Enumerator GetEnumerator()

--- a/src/Dekaf/Consumer/ConsumeRawBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeRawBatch.cs
@@ -1,15 +1,24 @@
 using System.Collections;
 using System.Runtime.CompilerServices;
+using Dekaf.Serialization;
 
 namespace Dekaf.Consumer
 {
     /// <summary>
     /// Represents a raw (undeserialized) record from a batch.
     /// Provides zero-copy <see cref="ReadOnlyMemory{T}"/> access to key/value data
-    /// without any deserialization, header copying, interceptor, or tracing overhead.
+    /// and headers without any deserialization, header copying, interceptor, or tracing overhead.
     /// </summary>
+    /// <remarks>
+    /// Key, value, header, and header-value memory reference pooled fetch storage. Read or copy
+    /// them before advancing the outer <c>ConsumeRawBatchAsync</c> enumerator to another batch.
+    /// </remarks>
     public readonly struct ConsumeRawRecord
     {
+        private readonly Header[]? _headers;
+        private readonly int _headerCount;
+        private readonly uint _encodedLeaderEpoch;
+
         public long Offset { get; }
         public long TimestampMs { get; }
         public TimestampType TimestampType { get; }
@@ -18,10 +27,26 @@ namespace Dekaf.Consumer
         public bool IsKeyNull { get; }
         public bool IsValueNull { get; }
 
+        /// <summary>
+        /// Gets a zero-copy view of the record headers. The view and each header value share
+        /// the same pooled-storage lifetime as <see cref="Key"/> and <see cref="Value"/>.
+        /// </summary>
+        public ReadOnlyMemory<Header> Headers => _headers is null
+            ? ReadOnlyMemory<Header>.Empty
+            : _headers.AsMemory(0, _headerCount);
+
+        /// <summary>
+        /// Gets the partition leader epoch recorded by Kafka, or <see langword="null"/> when unavailable.
+        /// </summary>
+        public int? LeaderEpoch => _encodedLeaderEpoch == 0
+            ? null
+            : (int)(_encodedLeaderEpoch - 1);
+
         internal ConsumeRawRecord(
             long offset, long timestampMs, TimestampType timestampType,
             ReadOnlyMemory<byte> key, ReadOnlyMemory<byte> value,
-            bool isKeyNull, bool isValueNull)
+            bool isKeyNull, bool isValueNull,
+            Header[]? headers, int headerCount, int leaderEpoch)
         {
             Offset = offset;
             TimestampMs = timestampMs;
@@ -30,6 +55,9 @@ namespace Dekaf.Consumer
             Value = value;
             IsKeyNull = isKeyNull;
             IsValueNull = isValueNull;
+            _headers = headers;
+            _headerCount = headerCount;
+            _encodedLeaderEpoch = leaderEpoch >= 0 ? (uint)leaderEpoch + 1 : 0;
         }
     }
 
@@ -79,6 +107,17 @@ namespace Dekaf.Consumer
         /// This value is only accurate after the batch has been fully enumerated.
         /// </summary>
         public long Count => _count;
+
+        /// <summary>
+        /// Indicates whether this zero-record batch marks the current end offset of its partition.
+        /// Emitted only when partition EOF reporting is enabled.
+        /// </summary>
+        public bool IsPartitionEof => _pendingFetchData.IsPartitionEof;
+
+        /// <summary>
+        /// Gets the partition end offset for an EOF batch, or <see langword="null"/> for a data batch.
+        /// </summary>
+        public long? PartitionEofOffset => _pendingFetchData.PartitionEofOffset;
 
         /// <summary>
         /// Returns a struct enumerator that avoids boxing allocation.
@@ -176,7 +215,10 @@ namespace Dekaf.Consumer
                     key: record.IsKeyNull ? ReadOnlyMemory<byte>.Empty : record.Key,
                     value: record.IsValueNull ? ReadOnlyMemory<byte>.Empty : record.Value,
                     isKeyNull: record.IsKeyNull,
-                    isValueNull: record.IsValueNull);
+                    isValueNull: record.IsValueNull,
+                    headers: record.Headers,
+                    headerCount: record.HeaderCount,
+                    leaderEpoch: pending.CurrentPartitionLeaderEpoch);
 
                 var iterationStatus = _batch._iterationGuard.GetStatusAfterRead(
                     pending.TopicPartition,

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -111,7 +111,8 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// Each batch contains all records from a single partition fetch response.
     /// Records within a batch are iterated synchronously (no async overhead per message).
     /// Position tracking is deferred to batch completion.
-    /// Partition EOF events are not surfaced by this method; use <see cref="ConsumeAsync"/> for EOF notification.
+    /// When partition EOF reporting is enabled, EOF is surfaced as a zero-record batch whose
+    /// <see cref="ConsumeBatch{TKey,TValue}.IsPartitionEof"/> property is <see langword="true"/>.
     /// </summary>
     /// <remarks>
     /// This is an intentionally long-lived stream. <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>
@@ -123,7 +124,8 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// Consumes raw (undeserialized) messages in batches for maximum throughput.
     /// Records provide zero-copy <see cref="ReadOnlyMemory{T}"/> access to key/value data.
     /// No deserialization, header copying, interceptors, or tracing overhead.
-    /// Partition EOF events are not surfaced by this method; use <see cref="ConsumeAsync"/> for EOF notification.
+    /// When partition EOF reporting is enabled, EOF is surfaced as a zero-record batch whose
+    /// <see cref="ConsumeRawBatch.IsPartitionEof"/> property is <see langword="true"/>.
     /// </summary>
     /// <remarks>
     /// This is an intentionally long-lived stream. <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -214,6 +214,8 @@ internal sealed class PendingFetchData : IDisposable
         private set => _snapshotEndOffset = value;
     }
     internal bool IsSnapshotEnd => SnapshotEndOffset >= 0;
+    internal bool IsPartitionEof => _partitionEofOffset >= 0;
+    internal long? PartitionEofOffset => IsPartitionEof ? _partitionEofOffset : null;
 
     private long _emittedMessageCount;
     private long _emittedBytesConsumed;
@@ -331,6 +333,20 @@ internal sealed class PendingFetchData : IDisposable
         instance._batches = Array.Empty<RecordBatch>();
         instance.SnapshotEndOffset = endOffset;
         instance._snapshotMarkerState = snapshot;
+        return instance;
+    }
+
+    public static PendingFetchData CreatePartitionEof(
+        string topic,
+        int partitionIndex,
+        long endOffset)
+    {
+        var instance = Rent();
+        instance.Topic = topic;
+        instance.PartitionIndex = partitionIndex;
+        instance.TopicPartition = new TopicPartition(topic, partitionIndex);
+        instance._batches = Array.Empty<RecordBatch>();
+        instance._partitionEofOffset = endOffset;
         return instance;
     }
 
@@ -868,6 +884,7 @@ internal sealed class PendingFetchData : IDisposable
         FetchEndLeaderEpoch = -1;
         ReachedSnapshotEnd = false;
         SnapshotEndOffset = -1;
+        _partitionEofOffset = -1;
         _emittedMessageCount = 0;
         _emittedBytesConsumed = 0;
         _skipRecordsBelowOffset = -1;
@@ -894,6 +911,7 @@ internal sealed class PendingFetchData : IDisposable
     // support does not move the cache-hot record iteration fields in this pooled object.
     private long _fetchEndOffsetExclusive = -1;
     private long _snapshotEndOffset = -1;
+    private long _partitionEofOffset = -1;
     private long _stopAtOffsetExclusive = -1;
     private int _fetchEndLeaderEpoch = -1;
     private bool _reachedSnapshotEnd;
@@ -3307,11 +3325,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 }
             }
 
-            // Drain any pending EOF events (batch API does not surface partition EOF;
-            // callers who need EOF notification should use ConsumeAsync instead)
-            while (_pendingEofEvents.TryDequeue(out _))
+            while (_pendingEofEvents.TryDequeue(out var eofEvent))
             {
-                // Discarded — EOF is informational and not relevant for batch throughput
+                using var eofPending = PendingFetchData.CreatePartitionEof(
+                    eofEvent.Partition.Topic,
+                    eofEvent.Partition.Partition,
+                    eofEvent.Offset);
+                yield return new ConsumeBatch<TKey, TValue>(
+                    eofPending,
+                    _keyDeserializer,
+                    _valueDeserializer);
+                await RecordPollAsync(cancellationToken).ConfigureAwait(false);
             }
         }
     }
@@ -3460,11 +3484,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 }
             }
 
-            // Drain any pending EOF events (raw batch API does not surface partition EOF;
-            // callers who need EOF notification should use ConsumeAsync instead)
-            while (_pendingEofEvents.TryDequeue(out _))
+            while (_pendingEofEvents.TryDequeue(out var eofEvent))
             {
-                // Discarded — EOF is informational and not relevant for raw batch throughput
+                using var eofPending = PendingFetchData.CreatePartitionEof(
+                    eofEvent.Partition.Topic,
+                    eofEvent.Partition.Partition,
+                    eofEvent.Offset);
+                yield return new ConsumeRawBatch(eofPending);
+                await RecordPollAsync(cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -131,3 +131,9 @@ Dekaf.Consumer.ConsumerOptions.PartitionStopTimeout.get -> System.TimeSpan
 Dekaf.Consumer.ConsumerOptions.PartitionStopTimeout.init -> void
 Dekaf.ConsumerBuilder<TKey, TValue>.WithPartitionStopTimeout(System.TimeSpan timeout) -> Dekaf.ConsumerBuilder<TKey, TValue>!
 Dekaf.ConsumerBuilder<TKey, TValue>.AddRebalanceListener(Dekaf.Consumer.IRebalanceListener! listener) -> Dekaf.ConsumerBuilder<TKey, TValue>!
+Dekaf.Consumer.ConsumeBatch<TKey, TValue>.IsPartitionEof.get -> bool
+Dekaf.Consumer.ConsumeBatch<TKey, TValue>.PartitionEofOffset.get -> long?
+Dekaf.Consumer.ConsumeRawBatch.IsPartitionEof.get -> bool
+Dekaf.Consumer.ConsumeRawBatch.PartitionEofOffset.get -> long?
+Dekaf.Consumer.ConsumeRawRecord.Headers.get -> System.ReadOnlyMemory<Dekaf.Serialization.Header>
+Dekaf.Consumer.ConsumeRawRecord.LeaderEpoch.get -> int?

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -131,3 +131,9 @@ Dekaf.Consumer.ConsumerOptions.PartitionStopTimeout.get -> System.TimeSpan
 Dekaf.Consumer.ConsumerOptions.PartitionStopTimeout.init -> void
 Dekaf.ConsumerBuilder<TKey, TValue>.WithPartitionStopTimeout(System.TimeSpan timeout) -> Dekaf.ConsumerBuilder<TKey, TValue>!
 Dekaf.ConsumerBuilder<TKey, TValue>.AddRebalanceListener(Dekaf.Consumer.IRebalanceListener! listener) -> Dekaf.ConsumerBuilder<TKey, TValue>!
+Dekaf.Consumer.ConsumeBatch<TKey, TValue>.IsPartitionEof.get -> bool
+Dekaf.Consumer.ConsumeBatch<TKey, TValue>.PartitionEofOffset.get -> long?
+Dekaf.Consumer.ConsumeRawBatch.IsPartitionEof.get -> bool
+Dekaf.Consumer.ConsumeRawBatch.PartitionEofOffset.get -> long?
+Dekaf.Consumer.ConsumeRawRecord.Headers.get -> System.ReadOnlyMemory<Dekaf.Serialization.Header>
+Dekaf.Consumer.ConsumeRawRecord.LeaderEpoch.get -> int?

--- a/tests/Dekaf.Tests.Integration/HeaderRoundTripTests.cs
+++ b/tests/Dekaf.Tests.Integration/HeaderRoundTripTests.cs
@@ -139,6 +139,64 @@ public class HeaderRoundTripTests(KafkaTestContainer kafka) : KafkaIntegrationTe
     }
 
     [Test]
+    public async Task ConsumeRawBatch_HeadersAndLeaderEpoch_DecodeFromBrokerFetch()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var partition = new TopicPartition(topic, 0);
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+        var headers = new Headers()
+            .Add("null-header", (byte[]?)null)
+            .Add("normal-header", "has-value");
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Partition = partition.Partition,
+            Key = "key",
+            Value = "value",
+            Headers = headers
+        }, CancellationToken.None);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithQueuedMinMessages(1)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+        consumer.Assign(partition);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await using var batches = consumer.ConsumeRawBatchAsync(timeout.Token).GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        var batch = batches.Current;
+        using var records = batch.GetEnumerator();
+        await Assert.That(records.MoveNext()).IsTrue();
+        var record = records.Current;
+        var decodedHeaders = record.Headers;
+        var leaderEpoch = record.LeaderEpoch;
+        var sawNullHeader = false;
+        string? normalHeaderValue = null;
+        for (var index = 0; index < decodedHeaders.Length; index++)
+        {
+            var header = decodedHeaders.Span[index];
+            if (header.Key == "null-header")
+                sawNullHeader = header.IsValueNull;
+            else if (header.Key == "normal-header")
+                normalHeaderValue = Encoding.UTF8.GetString(header.Value.Span);
+        }
+
+        await Assert.That(batch.TopicPartition).IsEqualTo(partition);
+        await Assert.That(leaderEpoch).IsNotNull();
+        await Assert.That(leaderEpoch!.Value).IsGreaterThanOrEqualTo(0);
+        await Assert.That(sawNullHeader).IsTrue();
+        await Assert.That(normalHeaderValue).IsEqualTo("has-value");
+        await Assert.That(records.MoveNext()).IsFalse();
+    }
+
+    [Test]
     public async Task EmptyHeaderValue_Preserved()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync();

--- a/tests/Dekaf.Tests.Integration/PartitionEofTests.cs
+++ b/tests/Dekaf.Tests.Integration/PartitionEofTests.cs
@@ -1,3 +1,4 @@
+using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 
@@ -339,6 +340,89 @@ public class PartitionEofTests(KafkaTestContainer kafka) : KafkaIntegrationTest(
         // Assert - should have received EOF with no messages
         await Assert.That(eofReceived).IsTrue();
         await Assert.That(messagesReceived).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ConsumeBatchAsync_EmptyPartition_YieldsEofBatch()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithPartitionEof(true)
+            .WithQueuedMinMessages(1)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+        var partition = new TopicPartition(topic, 0);
+        consumer.Assign(partition);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        await using var batches = consumer.ConsumeBatchAsync(timeout.Token).GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        var eofBatch = batches.Current;
+
+        await Assert.That(eofBatch.TopicPartition).IsEqualTo(partition);
+        await Assert.That(eofBatch.IsPartitionEof).IsTrue();
+        await Assert.That(eofBatch.PartitionEofOffset).IsEqualTo(0);
+        using var records = eofBatch.GetEnumerator();
+        await Assert.That(records.MoveNext()).IsFalse();
+    }
+
+    [Test]
+    public async Task ConsumeRawBatchAsync_CompactedAwayTailShape_YieldsEofAtHighWatermark()
+    {
+        // DeleteRecords deterministically creates the same non-zero empty offset range a
+        // compacted-away tail exposes, without depending on the asynchronous log cleaner.
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        await using (var producer = await Kafka.CreateProducer<string, string>()
+                         .WithBootstrapServers(KafkaContainer.BootstrapServers)
+                         .WithAcks(Acks.All)
+                         .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+                         .BuildAsync())
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                await producer.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic,
+                    Key = "same-key",
+                    Value = $"value-{i}"
+                }, CancellationToken.None);
+            }
+        }
+
+        var partition = new TopicPartition(topic, 0);
+        await using (var admin = Kafka.CreateAdminClient()
+                         .WithBootstrapServers(KafkaContainer.BootstrapServers)
+                         .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+                         .Build())
+        {
+            var deleted = await admin.DeleteRecordsAsync(new Dictionary<TopicPartition, long>
+            {
+                [partition] = 3
+            });
+            await Assert.That(deleted[partition]).IsGreaterThanOrEqualTo(3);
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithPartitionEof(true)
+            .WithQueuedMinMessages(1)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+        consumer.Assign(partition);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        await using var batches = consumer.ConsumeRawBatchAsync(timeout.Token).GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        var eofBatch = batches.Current;
+
+        await Assert.That(eofBatch.TopicPartition).IsEqualTo(partition);
+        await Assert.That(eofBatch.IsPartitionEof).IsTrue();
+        await Assert.That(eofBatch.PartitionEofOffset).IsEqualTo(3);
+        using var records = eofBatch.GetEnumerator();
+        await Assert.That(records.MoveNext()).IsFalse();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
@@ -84,6 +84,19 @@ public class ConsumeBatchTests
     }
 
     [Test]
+    public async Task ConsumeBatch_PartitionEofMarker_IsEmptyAndCarriesOffset()
+    {
+        using var pending = PendingFetchData.CreatePartitionEof("test-topic", 4, 73);
+        var batch = new ConsumeBatch<string, string>(pending, Serializers.String, Serializers.String);
+
+        await Assert.That(batch.TopicPartition).IsEqualTo(new TopicPartition("test-topic", 4));
+        await Assert.That(batch.IsPartitionEof).IsTrue();
+        await Assert.That(batch.PartitionEofOffset).IsEqualTo(73);
+        using var records = batch.GetEnumerator();
+        await Assert.That(records.MoveNext()).IsFalse();
+    }
+
+    [Test]
     public async Task ConsumeBatch_Records_HaveDeserializedKeyAndValue()
     {
         using var pending = CreatePendingFetchData("test-topic", partitionIndex: 0, baseOffset: 0, messageCount: 2);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeRawBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeRawBatchTests.cs
@@ -1,11 +1,18 @@
 using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
 public class ConsumeRawBatchTests
 {
+    [Test]
+    public async Task ConsumeRawRecord_Default_HasNoLeaderEpoch()
+    {
+        await Assert.That(default(ConsumeRawRecord).LeaderEpoch).IsNull();
+    }
+
     [Test]
     public async Task ConsumeRawBatch_EnumeratesAllRecords()
     {
@@ -84,6 +91,60 @@ public class ConsumeRawBatchTests
         await Assert.That(Encoding.UTF8.GetString(results[1].Value.Span)).IsEqualTo("value-1");
         await Assert.That(results[0].IsKeyNull).IsFalse();
         await Assert.That(results[0].IsValueNull).IsFalse();
+    }
+
+    [Test]
+    public async Task ConsumeRawBatch_Records_ExposeZeroCopyHeadersAndLeaderEpoch()
+    {
+        var expectedValue = "trace-value"u8.ToArray();
+        var headers = new[]
+        {
+            new Header("trace-id", expectedValue),
+            new Header("nullable", value: null)
+        };
+        var records = new[]
+        {
+            new Record
+            {
+                OffsetDelta = 0,
+                Key = "key"u8.ToArray(),
+                Value = "value"u8.ToArray(),
+                Headers = headers,
+                HeaderCount = headers.Length
+            }
+        };
+        var recordBatch = new RecordBatch
+        {
+            BaseOffset = 10,
+            PartitionLeaderEpoch = 7,
+            Records = records
+        };
+        using var pending = PendingFetchData.Create("test-topic", 0, [recordBatch]);
+        pending.EagerParseAll();
+        var batch = new ConsumeRawBatch(pending);
+
+        using var enumerator = batch.GetEnumerator();
+        await Assert.That(enumerator.MoveNext()).IsTrue();
+        var record = enumerator.Current;
+
+        await Assert.That(record.LeaderEpoch).IsEqualTo(7);
+        await Assert.That(record.Headers.Length).IsEqualTo(2);
+        await Assert.That(record.Headers.Span[0].Key).IsEqualTo("trace-id");
+        await Assert.That(record.Headers.Span[0].Value.Span.SequenceEqual(expectedValue)).IsTrue();
+        await Assert.That(record.Headers.Span[1].IsValueNull).IsTrue();
+    }
+
+    [Test]
+    public async Task ConsumeRawBatch_PartitionEofMarker_IsEmptyAndCarriesOffset()
+    {
+        using var pending = PendingFetchData.CreatePartitionEof("test-topic", 3, 42);
+        var batch = new ConsumeRawBatch(pending);
+
+        await Assert.That(batch.TopicPartition).IsEqualTo(new TopicPartition("test-topic", 3));
+        await Assert.That(batch.IsPartitionEof).IsTrue();
+        await Assert.That(batch.PartitionEofOffset).IsEqualTo(42);
+        using var records = batch.GetEnumerator();
+        await Assert.That(records.MoveNext()).IsFalse();
     }
 
     [Test]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerHotPathBenchmarks.cs
@@ -27,6 +27,7 @@ public class ConsumerHotPathBenchmarks
         new(Serializers.String, maxCachedBytes: 4 * 1024, maxCachedEntries: 128);
     private CachingStringDeserializer _uniqueValuesCachedStringDeserializer = null!;
     private Record[] _records = null!;
+    private Record[] _recordsWithHeaders = null!;
     private Record[] _repeated1KbValueRecords = null!;
     private string _topic = null!;
     private long _timestampMs;
@@ -37,6 +38,18 @@ public class ConsumerHotPathBenchmarks
         _topic = "consumer-hot-path";
         _timestampMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         _records = new Record[MessageCount];
+        _recordsWithHeaders = new Record[MessageCount];
+        Header[] headers =
+        [
+            new("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"u8.ToArray()),
+            new("tracestate", "vendor=value"u8.ToArray()),
+            new("correlation-id", "order-123456"u8.ToArray()),
+            new("content-type", "application/json"u8.ToArray()),
+            new("tenant-id", "tenant-a"u8.ToArray()),
+            new("source", "benchmark"u8.ToArray()),
+            new("attempt", "1"u8.ToArray()),
+            new("nullable", value: null)
+        ];
 
         for (var i = 0; i < MessageCount; i++)
         {
@@ -53,6 +66,18 @@ public class ConsumerHotPathBenchmarks
                 IsValueNull = false,
                 Headers = null,
                 HeaderCount = 0,
+            };
+
+            _recordsWithHeaders[i] = new Record
+            {
+                OffsetDelta = i,
+                TimestampDelta = i,
+                Key = key,
+                Value = value,
+                IsKeyNull = false,
+                IsValueNull = false,
+                Headers = headers,
+                HeaderCount = headers.Length,
             };
         }
 
@@ -93,6 +118,21 @@ public class ConsumerHotPathBenchmarks
     public int ConsumeRawBatch_Enumerate()
     {
         using var pending = CreatePendingFetchData();
+        var batch = new ConsumeRawBatch(pending);
+        var bytes = 0;
+
+        foreach (var record in batch)
+        {
+            bytes += record.Value.Length;
+        }
+
+        return bytes;
+    }
+
+    [Benchmark(OperationsPerInvoke = MessageCount, Description = "Raw batch enumerate (8 headers)")]
+    public int ConsumeRawBatch_EnumerateWithHeaders()
+    {
+        using var pending = CreatePendingFetchData(_recordsWithHeaders);
         var batch = new ConsumeRawBatch(pending);
         var bytes = 0;
 


### PR DESCRIPTION
## Summary

- expose zero-copy pooled header views and leader epochs on `ConsumeRawRecord`
- surface partition EOF as zero-record `ConsumeBatch` and `ConsumeRawBatch` values
- document pooled-memory lifetime and add public API baselines
- cover empty partitions and deterministic compacted-tail-equivalent non-zero empty ranges

## Performance

Exact configuration: `ConsumerHotPathBenchmarks.ConsumeRawBatch_Enumerate`, ShortRun, .NET 10.0.11, 262,144,000 measured operations per iteration.

| Revision | Mean | Median | Min | Max | Allocated |
|---|---:|---:|---:|---:|---:|
| baseline `3fc3a145` | 3.408 ns | 3.431 ns | 3.353 ns | 3.441 ns | 0 B/op |
| candidate `ef764c21` | 3.292 ns | 3.281 ns | 3.267 ns | 3.329 ns | 0 B/op |
| delta | -3.4% | -4.4% | -2.6% | -3.3% | unchanged |

No throughput-proxy or allocation regression. This isolated enumerator benchmark does not report network latency or CPU/message; those paths are unchanged.

## Verification

- Release unit build: net8.0 + net10.0, 0 warnings
- unit suite: 7,458 passed
- focused raw/typed batch unit tests: 27 passed
- Release integration build: net8.0 + net10.0, 0 warnings
- focused live Kafka integration tests: 2 passed
- NativeAOT test project Release build: net8.0 + net10.0, 0 warnings
- Dekaf Release pack/API compatibility: passed
- `/simplify`: complete
- pre-push self-review: clean

Closes #2762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consumer batches now report partition EOF events and their optional offsets.
  * Raw records now expose headers and optional leader epoch metadata.
  * EOF events are delivered as empty batches when enabled.

* **Bug Fixes**
  * Partition EOF notifications are no longer discarded during consumption.

* **Tests**
  * Added coverage for EOF batches, offsets, headers, and leader epoch metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->