### PR TITLE
test(avro): stabilize allocation warmup

### DIFF
--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroPocoSchemaRegistryTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroPocoSchemaRegistryTests.cs
@@ -24,6 +24,8 @@ namespace Dekaf.Tests.Unit.SchemaRegistry;
 
 public sealed class AvroPocoSchemaRegistryTests
 {
+    private const int AllocationWarmupCount = 10_000;
+
     private static readonly string[] LegacyValues = ["ignored", "field"];
     private static readonly byte[] PositiveDecimalWire = [0, 0, 0, 0, 1, 0x04, 0x30, 0x39];
     private static readonly byte[] NegativeDecimalWire = [0, 0, 0, 0, 1, 0x04, 0xCF, 0xC7];
@@ -1673,7 +1675,9 @@ public sealed class AvroPocoSchemaRegistryTests
         var schemaId = BinaryPrimitives.ReadInt32BigEndian(destination.WrittenSpan.Slice(1, 4));
         await deserializer.WarmupAsync(schemaId, context);
 
-        for (var index = 0; index < 16; index++)
+        // Cross the tiered-compilation call-count threshold before measuring. A short
+        // warmup made the generated generic read path promote during the allocation window.
+        for (var index = 0; index < AllocationWarmupCount; index++)
             _ = deserializer.Deserialize(destination.WrittenMemory, context);
 
         var before = GC.GetAllocatedBytesForCurrentThread();
@@ -1682,6 +1686,64 @@ public sealed class AvroPocoSchemaRegistryTests
         var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
 
         await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task GeneratedCodec_RulesPathSubjectResolutionAllocatesZeroUnderParallelPressure()
+    {
+        using var registry = new MockSchemaRegistryClient();
+        var serializerConfig = new AvroSerializerConfig
+        {
+            SubjectNameStrategy = SubjectNameStrategy.TopicRecordName
+        };
+        var deserializerConfig = new AvroDeserializerConfig
+        {
+            SubjectNameStrategy = SubjectNameStrategy.TopicRecordName,
+            RuleExecutor = PassThroughRuleExecutor.Instance
+        };
+        await using var serializer = PocoReadonlyRecord.CreateAvroSerializer(registry, serializerConfig);
+        await using var deserializer = PocoReadonlyRecord.CreateAvroDeserializer(registry, deserializerConfig);
+        var context = new SerializationContext
+        {
+            Topic = "poco-subject-allocation-parallel",
+            Component = SerializationComponent.Value
+        };
+        var destination = new ArrayBufferWriter<byte>(16);
+        serializer.Serialize(new PocoReadonlyRecord { Id = 42 }, ref destination, context);
+        var schemaId = BinaryPrimitives.ReadInt32BigEndian(destination.WrittenSpan.Slice(1, 4));
+        await deserializer.WarmupAsync(schemaId, context);
+
+        var workerCount = Math.Clamp(Environment.ProcessorCount, 4, 16);
+        using var ready = new CountdownEvent(workerCount);
+        using var start = new ManualResetEventSlim();
+        var tasks = new Task<long>[workerCount];
+        for (var taskIndex = 0; taskIndex < tasks.Length; taskIndex++)
+        {
+            tasks[taskIndex] = Task.Run(() =>
+            {
+                try
+                {
+                    for (var index = 0; index < AllocationWarmupCount; index++)
+                        _ = deserializer.Deserialize(destination.WrittenMemory, context);
+                }
+                finally
+                {
+                    ready.Signal();
+                }
+
+                start.Wait();
+                var before = GC.GetAllocatedBytesForCurrentThread();
+                for (var index = 0; index < 1_000; index++)
+                    _ = deserializer.Deserialize(destination.WrittenMemory, context);
+                return GC.GetAllocatedBytesForCurrentThread() - before;
+            });
+        }
+
+        ready.Wait();
+        start.Set();
+        var allocations = await Task.WhenAll(tasks);
+        for (var index = 0; index < allocations.Length; index++)
+            await Assert.That(allocations[index]).IsEqualTo(0);
     }
 
     [Test]


### PR DESCRIPTION
Closes #2803

## Summary

- warm the generated Avro rules read path for 10,000 calls before exact allocation measurement, crossing the .NET tiered-compilation threshold
- add deterministic 4–16 worker pressure coverage against one warmed deserializer
- retain the exact `0 B` assertion; no retries or relaxed budget

## Root cause

The prior 16-call warmup did not reliably promote the shared generated generic read path before the 1,000-call measurement. Under full-suite scheduling, two argument cases could observe tiered-promotion allocations while the later case inherited the promoted code and passed. This matches the existing 10,000-call warmup convention in adjacent allocation gates.

The pressure test synchronizes workers after warmup and measures each worker with `GC.GetAllocatedBytesForCurrentThread()`, proving the per-thread rule-context state and shared caches remain `0 B` under concurrent reads.

## Validation

- Release dual-target build: clean, 0 warnings/errors
- focused net10.0: 4/4 passed
- focused net8.0: 4/4 passed
- full net10.0 suite: 7,455/7,455 passed
- `git diff --check`: clean

Test-only change; no production benchmark required.