### PR TITLE
feat(streams): add group membership contracts

### DIFF
--- a/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
+++ b/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
@@ -1,0 +1,264 @@
+using Dekaf.Streams;
+
+namespace Dekaf.Testing;
+
+/// <summary>
+/// Deterministic in-memory implementation of <see cref="IStreamsGroupMember"/> for application tests.
+/// </summary>
+public sealed class InMemoryStreamsGroupMember : IStreamsGroupMember
+{
+    private static readonly StreamsGroupAssignment EmptyAssignment = new()
+    {
+        ActiveTasks = [],
+        StandbyTasks = [],
+        WarmupTasks = []
+    };
+
+    private readonly object _gate = new();
+    private readonly StreamsGroupMemberOptions _options;
+    private StreamsGroupMemberSnapshot _snapshot = new()
+    {
+        Assignment = EmptyAssignment,
+        PartitionsByUserEndpoint = [],
+        Status = []
+    };
+    private StreamsGroupMemberUpdate? _lastUpdate;
+    private StreamsGroupTaskOffsetReport? _lastTaskOffsetReport;
+    private StreamsGroupCloseOptions? _lastCloseOptions;
+
+    public InMemoryStreamsGroupMember(StreamsGroupMemberOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.GroupId);
+        if (options.RebalanceTimeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                "Rebalance timeout must be positive.");
+
+        _options = options;
+    }
+
+    /// <inheritdoc />
+    public string GroupId => _options.GroupId;
+
+    /// <inheritdoc />
+    public string? InstanceId => _options.InstanceId;
+
+    /// <inheritdoc />
+    public StreamsGroupMemberSnapshot Snapshot => Volatile.Read(ref _snapshot);
+
+    /// <summary>Gets the latest state update supplied by the test.</summary>
+    public StreamsGroupMemberUpdate? LastUpdate
+    {
+        get
+        {
+            lock (_gate)
+                return _lastUpdate;
+        }
+    }
+
+    /// <summary>Gets the latest task-offset report supplied by the test.</summary>
+    public StreamsGroupTaskOffsetReport? LastTaskOffsetReport
+    {
+        get
+        {
+            lock (_gate)
+                return _lastTaskOffsetReport;
+        }
+    }
+
+    /// <summary>Gets the options used for the first close operation.</summary>
+    public StreamsGroupCloseOptions? LastCloseOptions
+    {
+        get
+        {
+            lock (_gate)
+                return _lastCloseOptions;
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            ThrowIfClosed();
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<StreamsGroupHeartbeatResult> JoinAsync(
+        StreamsGroupMemberUpdate initialState,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(initialState);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            ThrowIfClosed();
+            if (_snapshot.IsJoined)
+                throw new InvalidOperationException("The Streams group member has already joined.");
+
+            _lastUpdate = initialState;
+            return ValueTask.FromResult(ApplyUpdate(initialState, isJoin: true));
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask<StreamsGroupHeartbeatResult> UpdateAsync(
+        StreamsGroupMemberUpdate update,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            EnsureJoined();
+            _lastUpdate = update;
+            return ValueTask.FromResult(ApplyUpdate(update, isJoin: false));
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask<StreamsGroupHeartbeatResult> ReportTaskOffsetsAsync(
+        StreamsGroupTaskOffsetReport report,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            EnsureJoined();
+            _lastTaskOffsetReport = report;
+            return ValueTask.FromResult(CreateResult(
+                activeTasks: null,
+                standbyTasks: null,
+                warmupTasks: null,
+                endpointInformationEpoch: _snapshot.EndpointInformationEpoch));
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask CloseAsync(CancellationToken cancellationToken = default) =>
+        CloseAsync(new StreamsGroupCloseOptions(), cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask CloseAsync(
+        StreamsGroupCloseOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (!Enum.IsDefined(options.GroupMembershipOperation))
+            throw new ArgumentOutOfRangeException(nameof(options));
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            if (_snapshot.IsClosed)
+                return ValueTask.CompletedTask;
+
+            _lastCloseOptions = options;
+            var remainInGroup = options.GroupMembershipOperation == StreamsGroupMembershipOperation.RemainInGroup
+                || (options.GroupMembershipOperation == StreamsGroupMembershipOperation.Default
+                    && _options.InstanceId is not null);
+            Volatile.Write(ref _snapshot, new StreamsGroupMemberSnapshot
+            {
+                IsJoined = remainInGroup && _snapshot.IsJoined,
+                IsClosed = true,
+                MemberId = remainInGroup ? _snapshot.MemberId : null,
+                MemberEpoch = remainInGroup ? _snapshot.MemberEpoch : 0,
+                Assignment = _snapshot.Assignment,
+                EndpointInformationEpoch = _snapshot.EndpointInformationEpoch,
+                PartitionsByUserEndpoint = _snapshot.PartitionsByUserEndpoint,
+                Status = _snapshot.Status,
+                HeartbeatInterval = _snapshot.HeartbeatInterval,
+                AcceptableRecoveryLag = _snapshot.AcceptableRecoveryLag,
+                TaskOffsetInterval = _snapshot.TaskOffsetInterval
+            });
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => CloseAsync();
+
+    private StreamsGroupHeartbeatResult ApplyUpdate(StreamsGroupMemberUpdate update, bool isJoin)
+    {
+        var activeTasks = Copy(update.ActiveTasks);
+        var standbyTasks = Copy(update.StandbyTasks);
+        var warmupTasks = Copy(update.WarmupTasks);
+        var previous = _snapshot;
+        var assignment = new StreamsGroupAssignment
+        {
+            ActiveTasks = activeTasks ?? previous.Assignment.ActiveTasks,
+            StandbyTasks = standbyTasks ?? previous.Assignment.StandbyTasks,
+            WarmupTasks = warmupTasks ?? previous.Assignment.WarmupTasks
+        };
+        var memberId = isJoin ? "in-memory-streams-member" : previous.MemberId!;
+        var memberEpoch = isJoin ? 1 : previous.MemberEpoch;
+        Volatile.Write(ref _snapshot, new StreamsGroupMemberSnapshot
+        {
+            IsJoined = true,
+            MemberId = memberId,
+            MemberEpoch = memberEpoch,
+            Assignment = assignment,
+            EndpointInformationEpoch = update.EndpointInformationEpoch,
+            PartitionsByUserEndpoint = previous.PartitionsByUserEndpoint,
+            Status = previous.Status,
+            HeartbeatInterval = TimeSpan.FromSeconds(1),
+            TaskOffsetInterval = TimeSpan.FromSeconds(10)
+        });
+
+        return CreateResult(
+            activeTasks,
+            standbyTasks,
+            warmupTasks,
+            update.EndpointInformationEpoch);
+    }
+
+    private StreamsGroupHeartbeatResult CreateResult(
+        IReadOnlyList<StreamsGroupTaskSet>? activeTasks,
+        IReadOnlyList<StreamsGroupTaskSet>? standbyTasks,
+        IReadOnlyList<StreamsGroupTaskSet>? warmupTasks,
+        int endpointInformationEpoch) => new()
+        {
+            MemberId = _snapshot.MemberId!,
+            MemberEpoch = _snapshot.MemberEpoch,
+            HeartbeatInterval = _snapshot.HeartbeatInterval,
+            AcceptableRecoveryLag = _snapshot.AcceptableRecoveryLag,
+            TaskOffsetInterval = _snapshot.TaskOffsetInterval,
+            Status = null,
+            ActiveTasks = activeTasks,
+            StandbyTasks = standbyTasks,
+            WarmupTasks = warmupTasks,
+            EndpointInformationEpoch = endpointInformationEpoch,
+            PartitionsByUserEndpoint = null
+        };
+
+    private static IReadOnlyList<T>? Copy<T>(IReadOnlyList<T>? items)
+    {
+        if (items is null)
+            return null;
+
+        var copy = new T[items.Count];
+        for (var index = 0; index < items.Count; index++)
+            copy[index] = items[index];
+        return copy;
+    }
+
+    private void EnsureJoined()
+    {
+        ThrowIfClosed();
+        if (!_snapshot.IsJoined)
+            throw new InvalidOperationException("The Streams group member has not joined.");
+    }
+
+    private void ThrowIfClosed() => ObjectDisposedException.ThrowIf(_snapshot.IsClosed, this);
+}

--- a/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
+++ b/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
@@ -191,9 +191,9 @@ public sealed class InMemoryStreamsGroupMember : IStreamsGroupMember
 
     private StreamsGroupHeartbeatResult ApplyUpdate(StreamsGroupMemberUpdate update, bool isJoin)
     {
-        var activeTasks = Copy(update.ActiveTasks);
-        var standbyTasks = Copy(update.StandbyTasks);
-        var warmupTasks = Copy(update.WarmupTasks);
+        var activeTasks = CopyTaskSets(update.ActiveTasks);
+        var standbyTasks = CopyTaskSets(update.StandbyTasks);
+        var warmupTasks = CopyTaskSets(update.WarmupTasks);
         var previous = _snapshot;
         var assignment = new StreamsGroupAssignment
         {
@@ -242,14 +242,26 @@ public sealed class InMemoryStreamsGroupMember : IStreamsGroupMember
             PartitionsByUserEndpoint = null
         };
 
-    private static IReadOnlyList<T>? Copy<T>(IReadOnlyList<T>? items)
+    private static IReadOnlyList<StreamsGroupTaskSet>? CopyTaskSets(
+        IReadOnlyList<StreamsGroupTaskSet>? taskSets)
     {
-        if (items is null)
+        if (taskSets is null)
             return null;
 
-        var copy = new T[items.Count];
-        for (var index = 0; index < items.Count; index++)
-            copy[index] = items[index];
+        var copy = new StreamsGroupTaskSet[taskSets.Count];
+        for (var index = 0; index < taskSets.Count; index++)
+        {
+            var taskSet = taskSets[index];
+            var partitions = new int[taskSet.Partitions.Count];
+            for (var partitionIndex = 0; partitionIndex < partitions.Length; partitionIndex++)
+                partitions[partitionIndex] = taskSet.Partitions[partitionIndex];
+            copy[index] = new StreamsGroupTaskSet
+            {
+                SubtopologyId = taskSet.SubtopologyId,
+                Partitions = partitions
+            };
+        }
+
         return copy;
     }
 

--- a/src/Dekaf.Testing/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.Testing/PublicAPI.Unshipped.txt
@@ -3,3 +3,18 @@ Dekaf.Testing.InMemoryConsumer<TKey, TValue>.ConsumeSnapshotAsync(System.Threadi
 Dekaf.Testing.InMemoryConsumer<TKey, TValue>.SeekToTailAsync(Dekaf.TopicPartition partition, int offsetCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.TopicPartitionOffset>
 Dekaf.Testing.InMemoryConsumer<TKey, TValue>.StoreOffsets(System.ReadOnlySpan<Dekaf.TopicPartitionOffset> offsets) -> void
 Dekaf.Testing.InMemoryConsumer<TKey, TValue>.StoreOffsets<TOffsets>(TOffsets offsets) -> void
+Dekaf.Testing.InMemoryStreamsGroupMember
+Dekaf.Testing.InMemoryStreamsGroupMember.CloseAsync(Dekaf.Streams.StreamsGroupCloseOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Dekaf.Testing.InMemoryStreamsGroupMember.CloseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Dekaf.Testing.InMemoryStreamsGroupMember.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Dekaf.Testing.InMemoryStreamsGroupMember.GroupId.get -> string!
+Dekaf.Testing.InMemoryStreamsGroupMember.InitializeAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Dekaf.Testing.InMemoryStreamsGroupMember.InMemoryStreamsGroupMember(Dekaf.Streams.StreamsGroupMemberOptions! options) -> void
+Dekaf.Testing.InMemoryStreamsGroupMember.InstanceId.get -> string?
+Dekaf.Testing.InMemoryStreamsGroupMember.JoinAsync(Dekaf.Streams.StreamsGroupMemberUpdate! initialState, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Streams.StreamsGroupHeartbeatResult!>
+Dekaf.Testing.InMemoryStreamsGroupMember.LastCloseOptions.get -> Dekaf.Streams.StreamsGroupCloseOptions?
+Dekaf.Testing.InMemoryStreamsGroupMember.LastTaskOffsetReport.get -> Dekaf.Streams.StreamsGroupTaskOffsetReport?
+Dekaf.Testing.InMemoryStreamsGroupMember.LastUpdate.get -> Dekaf.Streams.StreamsGroupMemberUpdate?
+Dekaf.Testing.InMemoryStreamsGroupMember.ReportTaskOffsetsAsync(Dekaf.Streams.StreamsGroupTaskOffsetReport! report, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Streams.StreamsGroupHeartbeatResult!>
+Dekaf.Testing.InMemoryStreamsGroupMember.Snapshot.get -> Dekaf.Streams.StreamsGroupMemberSnapshot!
+Dekaf.Testing.InMemoryStreamsGroupMember.UpdateAsync(Dekaf.Streams.StreamsGroupMemberUpdate! update, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Streams.StreamsGroupHeartbeatResult!>

--- a/src/Dekaf/CompatibilitySuppressions.xml
+++ b/src/Dekaf/CompatibilitySuppressions.xml
@@ -554,6 +554,12 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Dekaf.Streams.StreamsGroupMembershipOperation</Target>
+    <Left>lib/netstandard2.0/Dekaf.dll</Left>
+    <Right>lib/net10.0/Dekaf.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
     <Target>T:Dekaf.Telemetry.ApplicationTelemetryMetricKind</Target>
     <Left>lib/netstandard2.0/Dekaf.dll</Left>
     <Right>lib/net10.0/Dekaf.dll</Right>

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -137,3 +137,206 @@ Dekaf.Consumer.ConsumeRawBatch.IsPartitionEof.get -> bool
 Dekaf.Consumer.ConsumeRawBatch.PartitionEofOffset.get -> long?
 Dekaf.Consumer.ConsumeRawRecord.Headers.get -> System.ReadOnlyMemory<Dekaf.Serialization.Header>
 Dekaf.Consumer.ConsumeRawRecord.LeaderEpoch.get -> int?
+Dekaf.Streams.IStreamsGroupMember
+Dekaf.Streams.IStreamsGroupMember.CloseAsync(Dekaf.Streams.StreamsGroupCloseOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Dekaf.Streams.IStreamsGroupMember.CloseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Dekaf.Streams.IStreamsGroupMember.GroupId.get -> string!
+Dekaf.Streams.IStreamsGroupMember.InstanceId.get -> string?
+Dekaf.Streams.IStreamsGroupMember.JoinAsync(Dekaf.Streams.StreamsGroupMemberUpdate! initialState, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Streams.StreamsGroupHeartbeatResult!>
+Dekaf.Streams.IStreamsGroupMember.ReportTaskOffsetsAsync(Dekaf.Streams.StreamsGroupTaskOffsetReport! report, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Streams.StreamsGroupHeartbeatResult!>
+Dekaf.Streams.IStreamsGroupMember.Snapshot.get -> Dekaf.Streams.StreamsGroupMemberSnapshot!
+Dekaf.Streams.IStreamsGroupMember.UpdateAsync(Dekaf.Streams.StreamsGroupMemberUpdate! update, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Streams.StreamsGroupHeartbeatResult!>
+Dekaf.Streams.StreamsGroupAssignment
+Dekaf.Streams.StreamsGroupAssignment.ActiveTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>!
+Dekaf.Streams.StreamsGroupAssignment.ActiveTasks.init -> void
+Dekaf.Streams.StreamsGroupAssignment.StandbyTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>!
+Dekaf.Streams.StreamsGroupAssignment.StandbyTasks.init -> void
+Dekaf.Streams.StreamsGroupAssignment.StreamsGroupAssignment() -> void
+Dekaf.Streams.StreamsGroupAssignment.WarmupTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>!
+Dekaf.Streams.StreamsGroupAssignment.WarmupTasks.init -> void
+Dekaf.Streams.StreamsGroupKeyValue
+Dekaf.Streams.StreamsGroupKeyValue.Key.get -> string!
+Dekaf.Streams.StreamsGroupKeyValue.Key.init -> void
+Dekaf.Streams.StreamsGroupKeyValue.StreamsGroupKeyValue() -> void
+Dekaf.Streams.StreamsGroupKeyValue.Value.get -> string!
+Dekaf.Streams.StreamsGroupKeyValue.Value.init -> void
+Dekaf.Streams.StreamsGroupCloseOptions
+Dekaf.Streams.StreamsGroupCloseOptions.GroupMembershipOperation.get -> Dekaf.Streams.StreamsGroupMembershipOperation
+Dekaf.Streams.StreamsGroupCloseOptions.GroupMembershipOperation.init -> void
+Dekaf.Streams.StreamsGroupCloseOptions.ShutdownApplication.get -> bool
+Dekaf.Streams.StreamsGroupCloseOptions.ShutdownApplication.init -> void
+Dekaf.Streams.StreamsGroupCloseOptions.StreamsGroupCloseOptions() -> void
+Dekaf.Streams.StreamsGroupCopartitionGroup
+Dekaf.Streams.StreamsGroupCopartitionGroup.RepartitionSourceTopics.get -> System.Collections.Generic.IReadOnlyList<short>!
+Dekaf.Streams.StreamsGroupCopartitionGroup.RepartitionSourceTopics.init -> void
+Dekaf.Streams.StreamsGroupCopartitionGroup.SourceTopicRegex.get -> System.Collections.Generic.IReadOnlyList<short>!
+Dekaf.Streams.StreamsGroupCopartitionGroup.SourceTopicRegex.init -> void
+Dekaf.Streams.StreamsGroupCopartitionGroup.SourceTopics.get -> System.Collections.Generic.IReadOnlyList<short>!
+Dekaf.Streams.StreamsGroupCopartitionGroup.SourceTopics.init -> void
+Dekaf.Streams.StreamsGroupCopartitionGroup.StreamsGroupCopartitionGroup() -> void
+Dekaf.Streams.StreamsGroupEndpoint
+Dekaf.Streams.StreamsGroupEndpoint.Host.get -> string!
+Dekaf.Streams.StreamsGroupEndpoint.Host.init -> void
+Dekaf.Streams.StreamsGroupEndpoint.Port.get -> ushort
+Dekaf.Streams.StreamsGroupEndpoint.Port.init -> void
+Dekaf.Streams.StreamsGroupEndpoint.StreamsGroupEndpoint() -> void
+Dekaf.Streams.StreamsGroupEndpointAssignment
+Dekaf.Streams.StreamsGroupEndpointAssignment.ActivePartitions.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTopicPartitions!>!
+Dekaf.Streams.StreamsGroupEndpointAssignment.ActivePartitions.init -> void
+Dekaf.Streams.StreamsGroupEndpointAssignment.StandbyPartitions.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTopicPartitions!>!
+Dekaf.Streams.StreamsGroupEndpointAssignment.StandbyPartitions.init -> void
+Dekaf.Streams.StreamsGroupEndpointAssignment.StreamsGroupEndpointAssignment() -> void
+Dekaf.Streams.StreamsGroupEndpointAssignment.UserEndpoint.get -> Dekaf.Streams.StreamsGroupEndpoint!
+Dekaf.Streams.StreamsGroupEndpointAssignment.UserEndpoint.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult
+Dekaf.Streams.StreamsGroupHeartbeatResult.AcceptableRecoveryLag.get -> int
+Dekaf.Streams.StreamsGroupHeartbeatResult.AcceptableRecoveryLag.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.ActiveTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>?
+Dekaf.Streams.StreamsGroupHeartbeatResult.ActiveTasks.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.EndpointInformationEpoch.get -> int
+Dekaf.Streams.StreamsGroupHeartbeatResult.EndpointInformationEpoch.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.HeartbeatInterval.get -> System.TimeSpan
+Dekaf.Streams.StreamsGroupHeartbeatResult.HeartbeatInterval.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.MemberEpoch.get -> int
+Dekaf.Streams.StreamsGroupHeartbeatResult.MemberEpoch.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.MemberId.get -> string!
+Dekaf.Streams.StreamsGroupHeartbeatResult.MemberId.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.PartitionsByUserEndpoint.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupEndpointAssignment!>?
+Dekaf.Streams.StreamsGroupHeartbeatResult.PartitionsByUserEndpoint.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.StandbyTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>?
+Dekaf.Streams.StreamsGroupHeartbeatResult.StandbyTasks.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.Status.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupStatus!>?
+Dekaf.Streams.StreamsGroupHeartbeatResult.Status.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.StreamsGroupHeartbeatResult() -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.TaskOffsetInterval.get -> System.TimeSpan
+Dekaf.Streams.StreamsGroupHeartbeatResult.TaskOffsetInterval.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.ThrottleTime.get -> System.TimeSpan
+Dekaf.Streams.StreamsGroupHeartbeatResult.ThrottleTime.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.WarmupTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>?
+Dekaf.Streams.StreamsGroupHeartbeatResult.WarmupTasks.init -> void
+Dekaf.Streams.StreamsGroupMemberOptions
+Dekaf.Streams.StreamsGroupMemberOptions.GroupId.get -> string!
+Dekaf.Streams.StreamsGroupMemberOptions.GroupId.init -> void
+Dekaf.Streams.StreamsGroupMemberOptions.InstanceId.get -> string?
+Dekaf.Streams.StreamsGroupMemberOptions.InstanceId.init -> void
+Dekaf.Streams.StreamsGroupMemberOptions.RackId.get -> string?
+Dekaf.Streams.StreamsGroupMemberOptions.RackId.init -> void
+Dekaf.Streams.StreamsGroupMemberOptions.RebalanceTimeout.get -> System.TimeSpan
+Dekaf.Streams.StreamsGroupMemberOptions.RebalanceTimeout.init -> void
+Dekaf.Streams.StreamsGroupMemberOptions.StreamsGroupMemberOptions() -> void
+Dekaf.Streams.StreamsGroupMembershipOperation
+Dekaf.Streams.StreamsGroupMembershipOperation.Default = 0 -> Dekaf.Streams.StreamsGroupMembershipOperation
+Dekaf.Streams.StreamsGroupMembershipOperation.LeaveGroup = 1 -> Dekaf.Streams.StreamsGroupMembershipOperation
+Dekaf.Streams.StreamsGroupMembershipOperation.RemainInGroup = 2 -> Dekaf.Streams.StreamsGroupMembershipOperation
+Dekaf.Streams.StreamsGroupMemberSnapshot
+Dekaf.Streams.StreamsGroupMemberSnapshot.AcceptableRecoveryLag.get -> int
+Dekaf.Streams.StreamsGroupMemberSnapshot.AcceptableRecoveryLag.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.Assignment.get -> Dekaf.Streams.StreamsGroupAssignment!
+Dekaf.Streams.StreamsGroupMemberSnapshot.Assignment.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.EndpointInformationEpoch.get -> int
+Dekaf.Streams.StreamsGroupMemberSnapshot.EndpointInformationEpoch.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.HeartbeatInterval.get -> System.TimeSpan
+Dekaf.Streams.StreamsGroupMemberSnapshot.HeartbeatInterval.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.IsClosed.get -> bool
+Dekaf.Streams.StreamsGroupMemberSnapshot.IsClosed.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.IsJoined.get -> bool
+Dekaf.Streams.StreamsGroupMemberSnapshot.IsJoined.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.MemberEpoch.get -> int
+Dekaf.Streams.StreamsGroupMemberSnapshot.MemberEpoch.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.MemberId.get -> string?
+Dekaf.Streams.StreamsGroupMemberSnapshot.MemberId.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.PartitionsByUserEndpoint.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupEndpointAssignment!>!
+Dekaf.Streams.StreamsGroupMemberSnapshot.PartitionsByUserEndpoint.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.Status.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupStatus!>!
+Dekaf.Streams.StreamsGroupMemberSnapshot.Status.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.StreamsGroupMemberSnapshot() -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.TaskOffsetInterval.get -> System.TimeSpan
+Dekaf.Streams.StreamsGroupMemberSnapshot.TaskOffsetInterval.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate
+Dekaf.Streams.StreamsGroupMemberUpdate.ActiveTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>?
+Dekaf.Streams.StreamsGroupMemberUpdate.ActiveTasks.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.ClientTags.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupKeyValue!>?
+Dekaf.Streams.StreamsGroupMemberUpdate.ClientTags.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.EndpointInformationEpoch.get -> int
+Dekaf.Streams.StreamsGroupMemberUpdate.EndpointInformationEpoch.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.ProcessId.get -> string?
+Dekaf.Streams.StreamsGroupMemberUpdate.ProcessId.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.ShutdownApplication.get -> bool
+Dekaf.Streams.StreamsGroupMemberUpdate.ShutdownApplication.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.StandbyTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>?
+Dekaf.Streams.StreamsGroupMemberUpdate.StandbyTasks.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.StreamsGroupMemberUpdate() -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.TaskEndOffsets.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskOffset!>?
+Dekaf.Streams.StreamsGroupMemberUpdate.TaskEndOffsets.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.TaskOffsets.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskOffset!>?
+Dekaf.Streams.StreamsGroupMemberUpdate.TaskOffsets.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.Topology.get -> Dekaf.Streams.StreamsGroupTopology?
+Dekaf.Streams.StreamsGroupMemberUpdate.Topology.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.UserEndpoint.get -> Dekaf.Streams.StreamsGroupEndpoint?
+Dekaf.Streams.StreamsGroupMemberUpdate.UserEndpoint.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.WarmupTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>?
+Dekaf.Streams.StreamsGroupMemberUpdate.WarmupTasks.init -> void
+Dekaf.Streams.StreamsGroupStatus
+Dekaf.Streams.StreamsGroupStatus.StatusCode.get -> sbyte
+Dekaf.Streams.StreamsGroupStatus.StatusCode.init -> void
+Dekaf.Streams.StreamsGroupStatus.StatusDetail.get -> string!
+Dekaf.Streams.StreamsGroupStatus.StatusDetail.init -> void
+Dekaf.Streams.StreamsGroupStatus.StreamsGroupStatus() -> void
+Dekaf.Streams.StreamsGroupSubtopology
+Dekaf.Streams.StreamsGroupSubtopology.CopartitionGroups.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupCopartitionGroup!>!
+Dekaf.Streams.StreamsGroupSubtopology.CopartitionGroups.init -> void
+Dekaf.Streams.StreamsGroupSubtopology.RepartitionSinkTopics.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Dekaf.Streams.StreamsGroupSubtopology.RepartitionSinkTopics.init -> void
+Dekaf.Streams.StreamsGroupSubtopology.RepartitionSourceTopics.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTopicInfo!>!
+Dekaf.Streams.StreamsGroupSubtopology.RepartitionSourceTopics.init -> void
+Dekaf.Streams.StreamsGroupSubtopology.SourceTopicRegex.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Dekaf.Streams.StreamsGroupSubtopology.SourceTopicRegex.init -> void
+Dekaf.Streams.StreamsGroupSubtopology.SourceTopics.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Dekaf.Streams.StreamsGroupSubtopology.SourceTopics.init -> void
+Dekaf.Streams.StreamsGroupSubtopology.StateChangelogTopics.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTopicInfo!>!
+Dekaf.Streams.StreamsGroupSubtopology.StateChangelogTopics.init -> void
+Dekaf.Streams.StreamsGroupSubtopology.StreamsGroupSubtopology() -> void
+Dekaf.Streams.StreamsGroupSubtopology.SubtopologyId.get -> string!
+Dekaf.Streams.StreamsGroupSubtopology.SubtopologyId.init -> void
+Dekaf.Streams.StreamsGroupTaskOffset
+Dekaf.Streams.StreamsGroupTaskOffset.Offset.get -> long
+Dekaf.Streams.StreamsGroupTaskOffset.Offset.init -> void
+Dekaf.Streams.StreamsGroupTaskOffset.Partition.get -> int
+Dekaf.Streams.StreamsGroupTaskOffset.Partition.init -> void
+Dekaf.Streams.StreamsGroupTaskOffset.StreamsGroupTaskOffset() -> void
+Dekaf.Streams.StreamsGroupTaskOffset.SubtopologyId.get -> string!
+Dekaf.Streams.StreamsGroupTaskOffset.SubtopologyId.init -> void
+Dekaf.Streams.StreamsGroupTaskOffsetReport
+Dekaf.Streams.StreamsGroupTaskOffsetReport.StreamsGroupTaskOffsetReport() -> void
+Dekaf.Streams.StreamsGroupTaskOffsetReport.TaskEndOffsets.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskOffset!>!
+Dekaf.Streams.StreamsGroupTaskOffsetReport.TaskEndOffsets.init -> void
+Dekaf.Streams.StreamsGroupTaskOffsetReport.TaskOffsets.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskOffset!>!
+Dekaf.Streams.StreamsGroupTaskOffsetReport.TaskOffsets.init -> void
+Dekaf.Streams.StreamsGroupTaskSet
+Dekaf.Streams.StreamsGroupTaskSet.Partitions.get -> System.Collections.Generic.IReadOnlyList<int>!
+Dekaf.Streams.StreamsGroupTaskSet.Partitions.init -> void
+Dekaf.Streams.StreamsGroupTaskSet.StreamsGroupTaskSet() -> void
+Dekaf.Streams.StreamsGroupTaskSet.SubtopologyId.get -> string!
+Dekaf.Streams.StreamsGroupTaskSet.SubtopologyId.init -> void
+Dekaf.Streams.StreamsGroupTopicInfo
+Dekaf.Streams.StreamsGroupTopicInfo.Name.get -> string!
+Dekaf.Streams.StreamsGroupTopicInfo.Name.init -> void
+Dekaf.Streams.StreamsGroupTopicInfo.Partitions.get -> int
+Dekaf.Streams.StreamsGroupTopicInfo.Partitions.init -> void
+Dekaf.Streams.StreamsGroupTopicInfo.ReplicationFactor.get -> short
+Dekaf.Streams.StreamsGroupTopicInfo.ReplicationFactor.init -> void
+Dekaf.Streams.StreamsGroupTopicInfo.StreamsGroupTopicInfo() -> void
+Dekaf.Streams.StreamsGroupTopicInfo.TopicConfigs.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupKeyValue!>!
+Dekaf.Streams.StreamsGroupTopicInfo.TopicConfigs.init -> void
+Dekaf.Streams.StreamsGroupTopicPartitions
+Dekaf.Streams.StreamsGroupTopicPartitions.Partitions.get -> System.Collections.Generic.IReadOnlyList<int>!
+Dekaf.Streams.StreamsGroupTopicPartitions.Partitions.init -> void
+Dekaf.Streams.StreamsGroupTopicPartitions.StreamsGroupTopicPartitions() -> void
+Dekaf.Streams.StreamsGroupTopicPartitions.Topic.get -> string!
+Dekaf.Streams.StreamsGroupTopicPartitions.Topic.init -> void
+Dekaf.Streams.StreamsGroupTopology
+Dekaf.Streams.StreamsGroupTopology.Epoch.get -> int
+Dekaf.Streams.StreamsGroupTopology.Epoch.init -> void
+Dekaf.Streams.StreamsGroupTopology.StreamsGroupTopology() -> void
+Dekaf.Streams.StreamsGroupTopology.Subtopologies.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupSubtopology!>!
+Dekaf.Streams.StreamsGroupTopology.Subtopologies.init -> void

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -137,3 +137,206 @@ Dekaf.Consumer.ConsumeRawBatch.IsPartitionEof.get -> bool
 Dekaf.Consumer.ConsumeRawBatch.PartitionEofOffset.get -> long?
 Dekaf.Consumer.ConsumeRawRecord.Headers.get -> System.ReadOnlyMemory<Dekaf.Serialization.Header>
 Dekaf.Consumer.ConsumeRawRecord.LeaderEpoch.get -> int?
+Dekaf.Streams.IStreamsGroupMember
+Dekaf.Streams.IStreamsGroupMember.CloseAsync(Dekaf.Streams.StreamsGroupCloseOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Dekaf.Streams.IStreamsGroupMember.CloseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Dekaf.Streams.IStreamsGroupMember.GroupId.get -> string!
+Dekaf.Streams.IStreamsGroupMember.InstanceId.get -> string?
+Dekaf.Streams.IStreamsGroupMember.JoinAsync(Dekaf.Streams.StreamsGroupMemberUpdate! initialState, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Streams.StreamsGroupHeartbeatResult!>
+Dekaf.Streams.IStreamsGroupMember.ReportTaskOffsetsAsync(Dekaf.Streams.StreamsGroupTaskOffsetReport! report, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Streams.StreamsGroupHeartbeatResult!>
+Dekaf.Streams.IStreamsGroupMember.Snapshot.get -> Dekaf.Streams.StreamsGroupMemberSnapshot!
+Dekaf.Streams.IStreamsGroupMember.UpdateAsync(Dekaf.Streams.StreamsGroupMemberUpdate! update, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Streams.StreamsGroupHeartbeatResult!>
+Dekaf.Streams.StreamsGroupAssignment
+Dekaf.Streams.StreamsGroupAssignment.ActiveTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>!
+Dekaf.Streams.StreamsGroupAssignment.ActiveTasks.init -> void
+Dekaf.Streams.StreamsGroupAssignment.StandbyTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>!
+Dekaf.Streams.StreamsGroupAssignment.StandbyTasks.init -> void
+Dekaf.Streams.StreamsGroupAssignment.StreamsGroupAssignment() -> void
+Dekaf.Streams.StreamsGroupAssignment.WarmupTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>!
+Dekaf.Streams.StreamsGroupAssignment.WarmupTasks.init -> void
+Dekaf.Streams.StreamsGroupKeyValue
+Dekaf.Streams.StreamsGroupKeyValue.Key.get -> string!
+Dekaf.Streams.StreamsGroupKeyValue.Key.init -> void
+Dekaf.Streams.StreamsGroupKeyValue.StreamsGroupKeyValue() -> void
+Dekaf.Streams.StreamsGroupKeyValue.Value.get -> string!
+Dekaf.Streams.StreamsGroupKeyValue.Value.init -> void
+Dekaf.Streams.StreamsGroupCloseOptions
+Dekaf.Streams.StreamsGroupCloseOptions.GroupMembershipOperation.get -> Dekaf.Streams.StreamsGroupMembershipOperation
+Dekaf.Streams.StreamsGroupCloseOptions.GroupMembershipOperation.init -> void
+Dekaf.Streams.StreamsGroupCloseOptions.ShutdownApplication.get -> bool
+Dekaf.Streams.StreamsGroupCloseOptions.ShutdownApplication.init -> void
+Dekaf.Streams.StreamsGroupCloseOptions.StreamsGroupCloseOptions() -> void
+Dekaf.Streams.StreamsGroupCopartitionGroup
+Dekaf.Streams.StreamsGroupCopartitionGroup.RepartitionSourceTopics.get -> System.Collections.Generic.IReadOnlyList<short>!
+Dekaf.Streams.StreamsGroupCopartitionGroup.RepartitionSourceTopics.init -> void
+Dekaf.Streams.StreamsGroupCopartitionGroup.SourceTopicRegex.get -> System.Collections.Generic.IReadOnlyList<short>!
+Dekaf.Streams.StreamsGroupCopartitionGroup.SourceTopicRegex.init -> void
+Dekaf.Streams.StreamsGroupCopartitionGroup.SourceTopics.get -> System.Collections.Generic.IReadOnlyList<short>!
+Dekaf.Streams.StreamsGroupCopartitionGroup.SourceTopics.init -> void
+Dekaf.Streams.StreamsGroupCopartitionGroup.StreamsGroupCopartitionGroup() -> void
+Dekaf.Streams.StreamsGroupEndpoint
+Dekaf.Streams.StreamsGroupEndpoint.Host.get -> string!
+Dekaf.Streams.StreamsGroupEndpoint.Host.init -> void
+Dekaf.Streams.StreamsGroupEndpoint.Port.get -> ushort
+Dekaf.Streams.StreamsGroupEndpoint.Port.init -> void
+Dekaf.Streams.StreamsGroupEndpoint.StreamsGroupEndpoint() -> void
+Dekaf.Streams.StreamsGroupEndpointAssignment
+Dekaf.Streams.StreamsGroupEndpointAssignment.ActivePartitions.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTopicPartitions!>!
+Dekaf.Streams.StreamsGroupEndpointAssignment.ActivePartitions.init -> void
+Dekaf.Streams.StreamsGroupEndpointAssignment.StandbyPartitions.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTopicPartitions!>!
+Dekaf.Streams.StreamsGroupEndpointAssignment.StandbyPartitions.init -> void
+Dekaf.Streams.StreamsGroupEndpointAssignment.StreamsGroupEndpointAssignment() -> void
+Dekaf.Streams.StreamsGroupEndpointAssignment.UserEndpoint.get -> Dekaf.Streams.StreamsGroupEndpoint!
+Dekaf.Streams.StreamsGroupEndpointAssignment.UserEndpoint.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult
+Dekaf.Streams.StreamsGroupHeartbeatResult.AcceptableRecoveryLag.get -> int
+Dekaf.Streams.StreamsGroupHeartbeatResult.AcceptableRecoveryLag.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.ActiveTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>?
+Dekaf.Streams.StreamsGroupHeartbeatResult.ActiveTasks.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.EndpointInformationEpoch.get -> int
+Dekaf.Streams.StreamsGroupHeartbeatResult.EndpointInformationEpoch.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.HeartbeatInterval.get -> System.TimeSpan
+Dekaf.Streams.StreamsGroupHeartbeatResult.HeartbeatInterval.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.MemberEpoch.get -> int
+Dekaf.Streams.StreamsGroupHeartbeatResult.MemberEpoch.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.MemberId.get -> string!
+Dekaf.Streams.StreamsGroupHeartbeatResult.MemberId.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.PartitionsByUserEndpoint.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupEndpointAssignment!>?
+Dekaf.Streams.StreamsGroupHeartbeatResult.PartitionsByUserEndpoint.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.StandbyTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>?
+Dekaf.Streams.StreamsGroupHeartbeatResult.StandbyTasks.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.Status.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupStatus!>?
+Dekaf.Streams.StreamsGroupHeartbeatResult.Status.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.StreamsGroupHeartbeatResult() -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.TaskOffsetInterval.get -> System.TimeSpan
+Dekaf.Streams.StreamsGroupHeartbeatResult.TaskOffsetInterval.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.ThrottleTime.get -> System.TimeSpan
+Dekaf.Streams.StreamsGroupHeartbeatResult.ThrottleTime.init -> void
+Dekaf.Streams.StreamsGroupHeartbeatResult.WarmupTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>?
+Dekaf.Streams.StreamsGroupHeartbeatResult.WarmupTasks.init -> void
+Dekaf.Streams.StreamsGroupMemberOptions
+Dekaf.Streams.StreamsGroupMemberOptions.GroupId.get -> string!
+Dekaf.Streams.StreamsGroupMemberOptions.GroupId.init -> void
+Dekaf.Streams.StreamsGroupMemberOptions.InstanceId.get -> string?
+Dekaf.Streams.StreamsGroupMemberOptions.InstanceId.init -> void
+Dekaf.Streams.StreamsGroupMemberOptions.RackId.get -> string?
+Dekaf.Streams.StreamsGroupMemberOptions.RackId.init -> void
+Dekaf.Streams.StreamsGroupMemberOptions.RebalanceTimeout.get -> System.TimeSpan
+Dekaf.Streams.StreamsGroupMemberOptions.RebalanceTimeout.init -> void
+Dekaf.Streams.StreamsGroupMemberOptions.StreamsGroupMemberOptions() -> void
+Dekaf.Streams.StreamsGroupMembershipOperation
+Dekaf.Streams.StreamsGroupMembershipOperation.Default = 0 -> Dekaf.Streams.StreamsGroupMembershipOperation
+Dekaf.Streams.StreamsGroupMembershipOperation.LeaveGroup = 1 -> Dekaf.Streams.StreamsGroupMembershipOperation
+Dekaf.Streams.StreamsGroupMembershipOperation.RemainInGroup = 2 -> Dekaf.Streams.StreamsGroupMembershipOperation
+Dekaf.Streams.StreamsGroupMemberSnapshot
+Dekaf.Streams.StreamsGroupMemberSnapshot.AcceptableRecoveryLag.get -> int
+Dekaf.Streams.StreamsGroupMemberSnapshot.AcceptableRecoveryLag.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.Assignment.get -> Dekaf.Streams.StreamsGroupAssignment!
+Dekaf.Streams.StreamsGroupMemberSnapshot.Assignment.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.EndpointInformationEpoch.get -> int
+Dekaf.Streams.StreamsGroupMemberSnapshot.EndpointInformationEpoch.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.HeartbeatInterval.get -> System.TimeSpan
+Dekaf.Streams.StreamsGroupMemberSnapshot.HeartbeatInterval.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.IsClosed.get -> bool
+Dekaf.Streams.StreamsGroupMemberSnapshot.IsClosed.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.IsJoined.get -> bool
+Dekaf.Streams.StreamsGroupMemberSnapshot.IsJoined.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.MemberEpoch.get -> int
+Dekaf.Streams.StreamsGroupMemberSnapshot.MemberEpoch.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.MemberId.get -> string?
+Dekaf.Streams.StreamsGroupMemberSnapshot.MemberId.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.PartitionsByUserEndpoint.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupEndpointAssignment!>!
+Dekaf.Streams.StreamsGroupMemberSnapshot.PartitionsByUserEndpoint.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.Status.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupStatus!>!
+Dekaf.Streams.StreamsGroupMemberSnapshot.Status.init -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.StreamsGroupMemberSnapshot() -> void
+Dekaf.Streams.StreamsGroupMemberSnapshot.TaskOffsetInterval.get -> System.TimeSpan
+Dekaf.Streams.StreamsGroupMemberSnapshot.TaskOffsetInterval.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate
+Dekaf.Streams.StreamsGroupMemberUpdate.ActiveTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>?
+Dekaf.Streams.StreamsGroupMemberUpdate.ActiveTasks.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.ClientTags.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupKeyValue!>?
+Dekaf.Streams.StreamsGroupMemberUpdate.ClientTags.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.EndpointInformationEpoch.get -> int
+Dekaf.Streams.StreamsGroupMemberUpdate.EndpointInformationEpoch.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.ProcessId.get -> string?
+Dekaf.Streams.StreamsGroupMemberUpdate.ProcessId.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.ShutdownApplication.get -> bool
+Dekaf.Streams.StreamsGroupMemberUpdate.ShutdownApplication.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.StandbyTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>?
+Dekaf.Streams.StreamsGroupMemberUpdate.StandbyTasks.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.StreamsGroupMemberUpdate() -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.TaskEndOffsets.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskOffset!>?
+Dekaf.Streams.StreamsGroupMemberUpdate.TaskEndOffsets.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.TaskOffsets.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskOffset!>?
+Dekaf.Streams.StreamsGroupMemberUpdate.TaskOffsets.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.Topology.get -> Dekaf.Streams.StreamsGroupTopology?
+Dekaf.Streams.StreamsGroupMemberUpdate.Topology.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.UserEndpoint.get -> Dekaf.Streams.StreamsGroupEndpoint?
+Dekaf.Streams.StreamsGroupMemberUpdate.UserEndpoint.init -> void
+Dekaf.Streams.StreamsGroupMemberUpdate.WarmupTasks.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskSet!>?
+Dekaf.Streams.StreamsGroupMemberUpdate.WarmupTasks.init -> void
+Dekaf.Streams.StreamsGroupStatus
+Dekaf.Streams.StreamsGroupStatus.StatusCode.get -> sbyte
+Dekaf.Streams.StreamsGroupStatus.StatusCode.init -> void
+Dekaf.Streams.StreamsGroupStatus.StatusDetail.get -> string!
+Dekaf.Streams.StreamsGroupStatus.StatusDetail.init -> void
+Dekaf.Streams.StreamsGroupStatus.StreamsGroupStatus() -> void
+Dekaf.Streams.StreamsGroupSubtopology
+Dekaf.Streams.StreamsGroupSubtopology.CopartitionGroups.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupCopartitionGroup!>!
+Dekaf.Streams.StreamsGroupSubtopology.CopartitionGroups.init -> void
+Dekaf.Streams.StreamsGroupSubtopology.RepartitionSinkTopics.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Dekaf.Streams.StreamsGroupSubtopology.RepartitionSinkTopics.init -> void
+Dekaf.Streams.StreamsGroupSubtopology.RepartitionSourceTopics.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTopicInfo!>!
+Dekaf.Streams.StreamsGroupSubtopology.RepartitionSourceTopics.init -> void
+Dekaf.Streams.StreamsGroupSubtopology.SourceTopicRegex.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Dekaf.Streams.StreamsGroupSubtopology.SourceTopicRegex.init -> void
+Dekaf.Streams.StreamsGroupSubtopology.SourceTopics.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Dekaf.Streams.StreamsGroupSubtopology.SourceTopics.init -> void
+Dekaf.Streams.StreamsGroupSubtopology.StateChangelogTopics.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTopicInfo!>!
+Dekaf.Streams.StreamsGroupSubtopology.StateChangelogTopics.init -> void
+Dekaf.Streams.StreamsGroupSubtopology.StreamsGroupSubtopology() -> void
+Dekaf.Streams.StreamsGroupSubtopology.SubtopologyId.get -> string!
+Dekaf.Streams.StreamsGroupSubtopology.SubtopologyId.init -> void
+Dekaf.Streams.StreamsGroupTaskOffset
+Dekaf.Streams.StreamsGroupTaskOffset.Offset.get -> long
+Dekaf.Streams.StreamsGroupTaskOffset.Offset.init -> void
+Dekaf.Streams.StreamsGroupTaskOffset.Partition.get -> int
+Dekaf.Streams.StreamsGroupTaskOffset.Partition.init -> void
+Dekaf.Streams.StreamsGroupTaskOffset.StreamsGroupTaskOffset() -> void
+Dekaf.Streams.StreamsGroupTaskOffset.SubtopologyId.get -> string!
+Dekaf.Streams.StreamsGroupTaskOffset.SubtopologyId.init -> void
+Dekaf.Streams.StreamsGroupTaskOffsetReport
+Dekaf.Streams.StreamsGroupTaskOffsetReport.StreamsGroupTaskOffsetReport() -> void
+Dekaf.Streams.StreamsGroupTaskOffsetReport.TaskEndOffsets.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskOffset!>!
+Dekaf.Streams.StreamsGroupTaskOffsetReport.TaskEndOffsets.init -> void
+Dekaf.Streams.StreamsGroupTaskOffsetReport.TaskOffsets.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupTaskOffset!>!
+Dekaf.Streams.StreamsGroupTaskOffsetReport.TaskOffsets.init -> void
+Dekaf.Streams.StreamsGroupTaskSet
+Dekaf.Streams.StreamsGroupTaskSet.Partitions.get -> System.Collections.Generic.IReadOnlyList<int>!
+Dekaf.Streams.StreamsGroupTaskSet.Partitions.init -> void
+Dekaf.Streams.StreamsGroupTaskSet.StreamsGroupTaskSet() -> void
+Dekaf.Streams.StreamsGroupTaskSet.SubtopologyId.get -> string!
+Dekaf.Streams.StreamsGroupTaskSet.SubtopologyId.init -> void
+Dekaf.Streams.StreamsGroupTopicInfo
+Dekaf.Streams.StreamsGroupTopicInfo.Name.get -> string!
+Dekaf.Streams.StreamsGroupTopicInfo.Name.init -> void
+Dekaf.Streams.StreamsGroupTopicInfo.Partitions.get -> int
+Dekaf.Streams.StreamsGroupTopicInfo.Partitions.init -> void
+Dekaf.Streams.StreamsGroupTopicInfo.ReplicationFactor.get -> short
+Dekaf.Streams.StreamsGroupTopicInfo.ReplicationFactor.init -> void
+Dekaf.Streams.StreamsGroupTopicInfo.StreamsGroupTopicInfo() -> void
+Dekaf.Streams.StreamsGroupTopicInfo.TopicConfigs.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupKeyValue!>!
+Dekaf.Streams.StreamsGroupTopicInfo.TopicConfigs.init -> void
+Dekaf.Streams.StreamsGroupTopicPartitions
+Dekaf.Streams.StreamsGroupTopicPartitions.Partitions.get -> System.Collections.Generic.IReadOnlyList<int>!
+Dekaf.Streams.StreamsGroupTopicPartitions.Partitions.init -> void
+Dekaf.Streams.StreamsGroupTopicPartitions.StreamsGroupTopicPartitions() -> void
+Dekaf.Streams.StreamsGroupTopicPartitions.Topic.get -> string!
+Dekaf.Streams.StreamsGroupTopicPartitions.Topic.init -> void
+Dekaf.Streams.StreamsGroupTopology
+Dekaf.Streams.StreamsGroupTopology.Epoch.get -> int
+Dekaf.Streams.StreamsGroupTopology.Epoch.init -> void
+Dekaf.Streams.StreamsGroupTopology.StreamsGroupTopology() -> void
+Dekaf.Streams.StreamsGroupTopology.Subtopologies.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Streams.StreamsGroupSubtopology!>!
+Dekaf.Streams.StreamsGroupTopology.Subtopologies.init -> void

--- a/src/Dekaf/Streams/IStreamsGroupMember.cs
+++ b/src/Dekaf/Streams/IStreamsGroupMember.cs
@@ -1,0 +1,359 @@
+namespace Dekaf.Streams;
+
+/// <summary>
+/// Participates in a Kafka Streams group without providing a Streams processing runtime.
+/// </summary>
+public interface IStreamsGroupMember : IInitializableKafkaClient, IAsyncDisposable
+{
+    /// <summary>Gets the configured group ID.</summary>
+    string GroupId { get; }
+
+    /// <summary>Gets the configured static member ID, or <see langword="null"/> for a dynamic member.</summary>
+    string? InstanceId { get; }
+
+    /// <summary>Gets the latest complete membership and assignment snapshot.</summary>
+    StreamsGroupMemberSnapshot Snapshot { get; }
+
+    /// <summary>Joins the group and publishes the member's initial state.</summary>
+    ValueTask<StreamsGroupHeartbeatResult> JoinAsync(
+        StreamsGroupMemberUpdate initialState,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Publishes changed member state. Nullable fields mean that the corresponding state did not change.
+    /// </summary>
+    ValueTask<StreamsGroupHeartbeatResult> UpdateAsync(
+        StreamsGroupMemberUpdate update,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Reports current and end offsets for stateful tasks.</summary>
+    ValueTask<StreamsGroupHeartbeatResult> ReportTaskOffsetsAsync(
+        StreamsGroupTaskOffsetReport report,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Closes the member using Kafka's default dynamic/static membership behavior.</summary>
+    ValueTask CloseAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Closes the member using the specified group-membership behavior.</summary>
+    ValueTask CloseAsync(
+        StreamsGroupCloseOptions options,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Configuration shared by all heartbeats from one Streams group member.</summary>
+public sealed class StreamsGroupMemberOptions
+{
+    /// <summary>Gets the Streams group ID.</summary>
+    public required string GroupId { get; init; }
+
+    /// <summary>Gets the stable instance ID. A non-null value enables static membership.</summary>
+    public string? InstanceId { get; init; }
+
+    /// <summary>Gets the rack ID used by the group assignor.</summary>
+    public string? RackId { get; init; }
+
+    /// <summary>Gets the maximum time allowed for a rebalance.</summary>
+    public TimeSpan RebalanceTimeout { get; init; } = TimeSpan.FromSeconds(30);
+}
+
+/// <summary>A nullable state delta sent by a join or subsequent heartbeat.</summary>
+public sealed class StreamsGroupMemberUpdate
+{
+    /// <summary>Gets the endpoint-information epoch.</summary>
+    public int EndpointInformationEpoch { get; init; }
+
+    /// <summary>Gets a changed topology, or <see langword="null"/> when unchanged.</summary>
+    public StreamsGroupTopology? Topology { get; init; }
+
+    /// <summary>Gets changed active tasks, or <see langword="null"/> when unchanged.</summary>
+    public IReadOnlyList<StreamsGroupTaskSet>? ActiveTasks { get; init; }
+
+    /// <summary>Gets changed standby tasks, or <see langword="null"/> when unchanged.</summary>
+    public IReadOnlyList<StreamsGroupTaskSet>? StandbyTasks { get; init; }
+
+    /// <summary>Gets changed warmup tasks, or <see langword="null"/> when unchanged.</summary>
+    public IReadOnlyList<StreamsGroupTaskSet>? WarmupTasks { get; init; }
+
+    /// <summary>Gets the process ID, or <see langword="null"/> when unchanged.</summary>
+    public string? ProcessId { get; init; }
+
+    /// <summary>Gets the interactive-query endpoint, or <see langword="null"/> when unchanged.</summary>
+    public StreamsGroupEndpoint? UserEndpoint { get; init; }
+
+    /// <summary>Gets changed client tags, or <see langword="null"/> when unchanged.</summary>
+    public IReadOnlyList<StreamsGroupKeyValue>? ClientTags { get; init; }
+
+    /// <summary>Gets changed task offsets, or <see langword="null"/> when unchanged.</summary>
+    public IReadOnlyList<StreamsGroupTaskOffset>? TaskOffsets { get; init; }
+
+    /// <summary>Gets changed task end offsets, or <see langword="null"/> when unchanged.</summary>
+    public IReadOnlyList<StreamsGroupTaskOffset>? TaskEndOffsets { get; init; }
+
+    /// <summary>Gets whether this heartbeat requests application-wide shutdown.</summary>
+    public bool ShutdownApplication { get; init; }
+}
+
+/// <summary>Task offsets reported independently of other member-state changes.</summary>
+public sealed class StreamsGroupTaskOffsetReport
+{
+    /// <summary>Gets the member's current task offsets.</summary>
+    public required IReadOnlyList<StreamsGroupTaskOffset> TaskOffsets { get; init; }
+
+    /// <summary>Gets the task end offsets used to calculate recovery lag.</summary>
+    public required IReadOnlyList<StreamsGroupTaskOffset> TaskEndOffsets { get; init; }
+}
+
+/// <summary>The successful broker response to a Streams group heartbeat.</summary>
+/// <remarks>Broker error responses surface as Kafka exceptions instead of successful results.</remarks>
+public sealed class StreamsGroupHeartbeatResult
+{
+    /// <summary>Gets the broker throttle time.</summary>
+    public TimeSpan ThrottleTime { get; init; }
+
+    /// <summary>Gets the broker-assigned member ID.</summary>
+    public required string MemberId { get; init; }
+
+    /// <summary>Gets the current member epoch.</summary>
+    public int MemberEpoch { get; init; }
+
+    /// <summary>Gets the broker-directed heartbeat interval.</summary>
+    public TimeSpan HeartbeatInterval { get; init; }
+
+    /// <summary>Gets the maximum acceptable recovery lag.</summary>
+    public int AcceptableRecoveryLag { get; init; }
+
+    /// <summary>Gets the broker-directed task-offset reporting interval.</summary>
+    public TimeSpan TaskOffsetInterval { get; init; }
+
+    /// <summary>Gets status changes, or <see langword="null"/> when unchanged.</summary>
+    public IReadOnlyList<StreamsGroupStatus>? Status { get; init; }
+
+    /// <summary>Gets changed active tasks, or <see langword="null"/> when unchanged.</summary>
+    public IReadOnlyList<StreamsGroupTaskSet>? ActiveTasks { get; init; }
+
+    /// <summary>Gets changed standby tasks, or <see langword="null"/> when unchanged.</summary>
+    public IReadOnlyList<StreamsGroupTaskSet>? StandbyTasks { get; init; }
+
+    /// <summary>Gets changed warmup tasks, or <see langword="null"/> when unchanged.</summary>
+    public IReadOnlyList<StreamsGroupTaskSet>? WarmupTasks { get; init; }
+
+    /// <summary>Gets the endpoint-information epoch.</summary>
+    public int EndpointInformationEpoch { get; init; }
+
+    /// <summary>Gets endpoint partition changes, or <see langword="null"/> when unchanged.</summary>
+    public IReadOnlyList<StreamsGroupEndpointAssignment>? PartitionsByUserEndpoint { get; init; }
+}
+
+/// <summary>A complete point-in-time membership snapshot.</summary>
+public sealed class StreamsGroupMemberSnapshot
+{
+    /// <summary>Gets whether the member has joined its group.</summary>
+    public bool IsJoined { get; init; }
+
+    /// <summary>Gets whether the member has been closed.</summary>
+    public bool IsClosed { get; init; }
+
+    /// <summary>Gets the member ID, or <see langword="null"/> before the first successful join.</summary>
+    public string? MemberId { get; init; }
+
+    /// <summary>Gets the current member epoch.</summary>
+    public int MemberEpoch { get; init; }
+
+    /// <summary>Gets the current assignment.</summary>
+    public required StreamsGroupAssignment Assignment { get; init; }
+
+    /// <summary>Gets the current endpoint-information epoch.</summary>
+    public int EndpointInformationEpoch { get; init; }
+
+    /// <summary>Gets the latest endpoint partition snapshot.</summary>
+    public required IReadOnlyList<StreamsGroupEndpointAssignment> PartitionsByUserEndpoint { get; init; }
+
+    /// <summary>Gets the latest member statuses.</summary>
+    public required IReadOnlyList<StreamsGroupStatus> Status { get; init; }
+
+    /// <summary>Gets the broker-directed heartbeat interval.</summary>
+    public TimeSpan HeartbeatInterval { get; init; }
+
+    /// <summary>Gets the maximum acceptable recovery lag.</summary>
+    public int AcceptableRecoveryLag { get; init; }
+
+    /// <summary>Gets the broker-directed task-offset reporting interval.</summary>
+    public TimeSpan TaskOffsetInterval { get; init; }
+}
+
+/// <summary>A complete active, standby, and warmup task assignment.</summary>
+public sealed class StreamsGroupAssignment
+{
+    /// <summary>Gets active task partitions.</summary>
+    public required IReadOnlyList<StreamsGroupTaskSet> ActiveTasks { get; init; }
+
+    /// <summary>Gets standby task partitions.</summary>
+    public required IReadOnlyList<StreamsGroupTaskSet> StandbyTasks { get; init; }
+
+    /// <summary>Gets warmup task partitions.</summary>
+    public required IReadOnlyList<StreamsGroupTaskSet> WarmupTasks { get; init; }
+}
+
+/// <summary>A Streams topology supplied to the group coordinator.</summary>
+public sealed class StreamsGroupTopology
+{
+    /// <summary>Gets the topology epoch.</summary>
+    public int Epoch { get; init; }
+
+    /// <summary>Gets subtopologies in protocol index order.</summary>
+    public required IReadOnlyList<StreamsGroupSubtopology> Subtopologies { get; init; }
+}
+
+/// <summary>A subtopology and its external/internal topic metadata.</summary>
+public sealed class StreamsGroupSubtopology
+{
+    /// <summary>Gets the subtopology ID.</summary>
+    public required string SubtopologyId { get; init; }
+
+    /// <summary>Gets source topic names.</summary>
+    public required IReadOnlyList<string> SourceTopics { get; init; }
+
+    /// <summary>Gets source topic regular expressions.</summary>
+    public required IReadOnlyList<string> SourceTopicRegex { get; init; }
+
+    /// <summary>Gets state changelog topic definitions.</summary>
+    public required IReadOnlyList<StreamsGroupTopicInfo> StateChangelogTopics { get; init; }
+
+    /// <summary>Gets repartition sink topic names.</summary>
+    public required IReadOnlyList<string> RepartitionSinkTopics { get; init; }
+
+    /// <summary>Gets repartition source topic definitions.</summary>
+    public required IReadOnlyList<StreamsGroupTopicInfo> RepartitionSourceTopics { get; init; }
+
+    /// <summary>Gets copartition constraints whose indexes refer to the preceding topic lists.</summary>
+    public required IReadOnlyList<StreamsGroupCopartitionGroup> CopartitionGroups { get; init; }
+}
+
+/// <summary>Topic metadata used by a Streams topology.</summary>
+public sealed class StreamsGroupTopicInfo
+{
+    /// <summary>Gets the topic name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Gets the requested partition count.</summary>
+    public int Partitions { get; init; }
+
+    /// <summary>Gets the requested replication factor.</summary>
+    public short ReplicationFactor { get; init; }
+
+    /// <summary>Gets topic configuration entries.</summary>
+    public required IReadOnlyList<StreamsGroupKeyValue> TopicConfigs { get; init; }
+}
+
+/// <summary>Indexes of topics that must have the same partition count.</summary>
+public sealed class StreamsGroupCopartitionGroup
+{
+    /// <summary>Gets indexes into <see cref="StreamsGroupSubtopology.SourceTopics"/>.</summary>
+    public required IReadOnlyList<short> SourceTopics { get; init; }
+
+    /// <summary>Gets indexes into <see cref="StreamsGroupSubtopology.SourceTopicRegex"/>.</summary>
+    public required IReadOnlyList<short> SourceTopicRegex { get; init; }
+
+    /// <summary>Gets indexes into <see cref="StreamsGroupSubtopology.RepartitionSourceTopics"/>.</summary>
+    public required IReadOnlyList<short> RepartitionSourceTopics { get; init; }
+}
+
+/// <summary>A client tag or topic configuration entry.</summary>
+public sealed class StreamsGroupKeyValue
+{
+    /// <summary>Gets the entry key.</summary>
+    public required string Key { get; init; }
+
+    /// <summary>Gets the entry value.</summary>
+    public required string Value { get; init; }
+}
+
+/// <summary>An interactive-query endpoint.</summary>
+public sealed class StreamsGroupEndpoint
+{
+    /// <summary>Gets the endpoint host.</summary>
+    public required string Host { get; init; }
+
+    /// <summary>Gets the endpoint port.</summary>
+    public ushort Port { get; init; }
+}
+
+/// <summary>A task offset identified by subtopology and partition.</summary>
+public sealed class StreamsGroupTaskOffset
+{
+    /// <summary>Gets the subtopology ID.</summary>
+    public required string SubtopologyId { get; init; }
+
+    /// <summary>Gets the task partition.</summary>
+    public int Partition { get; init; }
+
+    /// <summary>Gets the cumulative changelog offset.</summary>
+    public long Offset { get; init; }
+}
+
+/// <summary>Task partitions grouped by subtopology.</summary>
+public sealed class StreamsGroupTaskSet
+{
+    /// <summary>Gets the subtopology ID.</summary>
+    public required string SubtopologyId { get; init; }
+
+    /// <summary>Gets task partitions within the subtopology.</summary>
+    public required IReadOnlyList<int> Partitions { get; init; }
+}
+
+/// <summary>A member status returned by the group coordinator.</summary>
+public sealed class StreamsGroupStatus
+{
+    /// <summary>Gets the protocol-defined status code.</summary>
+    public sbyte StatusCode { get; init; }
+
+    /// <summary>Gets the status detail.</summary>
+    public required string StatusDetail { get; init; }
+}
+
+/// <summary>Topic partitions routed to one interactive-query endpoint.</summary>
+public sealed class StreamsGroupEndpointAssignment
+{
+    /// <summary>Gets the interactive-query endpoint.</summary>
+    public required StreamsGroupEndpoint UserEndpoint { get; init; }
+
+    /// <summary>Gets active topic partitions routed to the endpoint.</summary>
+    public required IReadOnlyList<StreamsGroupTopicPartitions> ActivePartitions { get; init; }
+
+    /// <summary>Gets standby topic partitions routed to the endpoint.</summary>
+    public required IReadOnlyList<StreamsGroupTopicPartitions> StandbyPartitions { get; init; }
+}
+
+/// <summary>Partitions grouped by topic name.</summary>
+public sealed class StreamsGroupTopicPartitions
+{
+    /// <summary>Gets the topic name.</summary>
+    public required string Topic { get; init; }
+
+    /// <summary>Gets partitions for the topic.</summary>
+    public required IReadOnlyList<int> Partitions { get; init; }
+}
+
+/// <summary>Specifies how close affects Streams-group membership.</summary>
+public enum StreamsGroupMembershipOperation
+{
+    /// <summary>Dynamic members leave; static members retain membership.</summary>
+    Default,
+
+    /// <summary>Permanently leaves the group, including static membership.</summary>
+    LeaveGroup,
+
+    /// <summary>Stops without a terminal heartbeat; membership remains until session expiry.</summary>
+    RemainInGroup
+}
+
+/// <summary>Options controlling Streams group member shutdown.</summary>
+public sealed class StreamsGroupCloseOptions
+{
+    /// <summary>Gets how close affects group membership.</summary>
+    public StreamsGroupMembershipOperation GroupMembershipOperation { get; init; } =
+        StreamsGroupMembershipOperation.Default;
+
+    /// <summary>Gets whether the terminal heartbeat requests application-wide shutdown.</summary>
+    public bool ShutdownApplication { get; init; }
+}

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
@@ -1,0 +1,155 @@
+using Dekaf.Streams;
+using Dekaf.Testing;
+
+namespace Dekaf.Tests.Unit.Testing;
+
+public sealed class InMemoryStreamsGroupMemberTests
+{
+    [Test]
+    public async Task JoinAsync_PublishesInitialAssignmentAndSnapshot()
+    {
+        await using var member = new InMemoryStreamsGroupMember(new StreamsGroupMemberOptions
+        {
+            GroupId = "streams-group",
+            InstanceId = "instance-a",
+            RackId = "rack-a"
+        });
+        var activeTasks = new[]
+        {
+            new StreamsGroupTaskSet { SubtopologyId = "sub-0", Partitions = [0, 1] }
+        };
+        var update = new StreamsGroupMemberUpdate
+        {
+            EndpointInformationEpoch = 7,
+            Topology = CreateTopology(),
+            ActiveTasks = activeTasks,
+            StandbyTasks = [],
+            WarmupTasks = [],
+            ProcessId = "process-a",
+            UserEndpoint = new StreamsGroupEndpoint { Host = "localhost", Port = 8080 },
+            ClientTags = [new StreamsGroupKeyValue { Key = "zone", Value = "a" }],
+            TaskOffsets = [new StreamsGroupTaskOffset { SubtopologyId = "sub-0", Partition = 0, Offset = 10 }],
+            TaskEndOffsets = [new StreamsGroupTaskOffset { SubtopologyId = "sub-0", Partition = 0, Offset = 20 }]
+        };
+
+        var result = await member.JoinAsync(update);
+
+        await Assert.That(member.GroupId).IsEqualTo("streams-group");
+        await Assert.That(member.InstanceId).IsEqualTo("instance-a");
+        await Assert.That(member.LastUpdate).IsSameReferenceAs(update);
+        await Assert.That(result.MemberEpoch).IsEqualTo(1);
+        await Assert.That(result.ActiveTasks![0].SubtopologyId).IsEqualTo("sub-0");
+        await Assert.That(member.Snapshot.IsJoined).IsTrue();
+        await Assert.That(member.Snapshot.IsClosed).IsFalse();
+        await Assert.That(member.Snapshot.EndpointInformationEpoch).IsEqualTo(7);
+        await Assert.That(member.Snapshot.Assignment.ActiveTasks[0].Partitions).IsEquivalentTo([0, 1]);
+    }
+
+    [Test]
+    public async Task UpdateAndReportOffsets_PreserveUnchangedAssignment()
+    {
+        await using var member = CreateMember();
+        await member.JoinAsync(new StreamsGroupMemberUpdate
+        {
+            ActiveTasks = [new StreamsGroupTaskSet { SubtopologyId = "sub-0", Partitions = [2] }],
+            StandbyTasks = [],
+            WarmupTasks = []
+        });
+
+        var updateResult = await member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            EndpointInformationEpoch = 3,
+            ClientTags = [new StreamsGroupKeyValue { Key = "build", Value = "42" }]
+        });
+        var report = new StreamsGroupTaskOffsetReport
+        {
+            TaskOffsets = [new StreamsGroupTaskOffset { SubtopologyId = "sub-0", Partition = 2, Offset = 5 }],
+            TaskEndOffsets = [new StreamsGroupTaskOffset { SubtopologyId = "sub-0", Partition = 2, Offset = 8 }]
+        };
+        var reportResult = await member.ReportTaskOffsetsAsync(report);
+
+        await Assert.That(updateResult.ActiveTasks).IsNull();
+        await Assert.That(member.Snapshot.Assignment.ActiveTasks[0].Partitions).IsEquivalentTo([2]);
+        await Assert.That(member.Snapshot.EndpointInformationEpoch).IsEqualTo(3);
+        await Assert.That(member.LastTaskOffsetReport).IsSameReferenceAs(report);
+        await Assert.That(reportResult.ActiveTasks).IsNull();
+    }
+
+    [Test]
+    [Arguments(null, StreamsGroupMembershipOperation.Default, false)]
+    [Arguments("static-a", StreamsGroupMembershipOperation.Default, true)]
+    [Arguments(null, StreamsGroupMembershipOperation.RemainInGroup, true)]
+    [Arguments("static-a", StreamsGroupMembershipOperation.LeaveGroup, false)]
+    public async Task CloseAsync_AppliesExplicitMembershipBehavior(
+        string? instanceId,
+        StreamsGroupMembershipOperation operation,
+        bool remainsJoined)
+    {
+        var member = new InMemoryStreamsGroupMember(new StreamsGroupMemberOptions
+        {
+            GroupId = "streams-group",
+            InstanceId = instanceId
+        });
+        await member.JoinAsync(new StreamsGroupMemberUpdate());
+        var closeOptions = new StreamsGroupCloseOptions
+        {
+            GroupMembershipOperation = operation,
+            ShutdownApplication = true
+        };
+
+        await member.CloseAsync(closeOptions);
+
+        await Assert.That(member.Snapshot.IsClosed).IsTrue();
+        await Assert.That(member.Snapshot.IsJoined).IsEqualTo(remainsJoined);
+        await Assert.That(member.LastCloseOptions).IsSameReferenceAs(closeOptions);
+        await member.DisposeAsync();
+    }
+
+    [Test]
+    public async Task UpdateAsync_BeforeJoin_Throws()
+    {
+        await using var member = CreateMember();
+
+        var action = async () => await member.UpdateAsync(new StreamsGroupMemberUpdate());
+
+        await Assert.That(action).Throws<InvalidOperationException>();
+    }
+
+    private static InMemoryStreamsGroupMember CreateMember() =>
+        new(new StreamsGroupMemberOptions { GroupId = "streams-group" });
+
+    private static StreamsGroupTopology CreateTopology() => new()
+    {
+        Epoch = 4,
+        Subtopologies =
+        [
+            new StreamsGroupSubtopology
+            {
+                SubtopologyId = "sub-0",
+                SourceTopics = ["input"],
+                SourceTopicRegex = ["input-.*"],
+                StateChangelogTopics =
+                [
+                    new StreamsGroupTopicInfo
+                    {
+                        Name = "store-changelog",
+                        Partitions = 2,
+                        ReplicationFactor = 3,
+                        TopicConfigs = [new StreamsGroupKeyValue { Key = "cleanup.policy", Value = "compact" }]
+                    }
+                ],
+                RepartitionSinkTopics = ["sink"],
+                RepartitionSourceTopics = [],
+                CopartitionGroups =
+                [
+                    new StreamsGroupCopartitionGroup
+                    {
+                        SourceTopics = [0],
+                        SourceTopicRegex = [0],
+                        RepartitionSourceTopics = []
+                    }
+                ]
+            }
+        ]
+    };
+}

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
@@ -76,6 +76,43 @@ public sealed class InMemoryStreamsGroupMemberTests
     }
 
     [Test]
+    public async Task JoinAndUpdateAsync_DeepCopyPublishedTaskSets()
+    {
+        await using var member = CreateMember();
+        var joinPartitions = new List<int> { 0, 1 };
+        var joinTasks = new List<StreamsGroupTaskSet>
+        {
+            new() { SubtopologyId = "join", Partitions = joinPartitions }
+        };
+
+        var joinResult = await member.JoinAsync(new StreamsGroupMemberUpdate
+        {
+            ActiveTasks = joinTasks
+        });
+
+        joinPartitions[0] = 99;
+        joinTasks.Clear();
+        await Assert.That(joinResult.ActiveTasks![0].Partitions).IsEquivalentTo([0, 1]);
+        await Assert.That(member.Snapshot.Assignment.ActiveTasks[0].Partitions).IsEquivalentTo([0, 1]);
+
+        var updatePartitions = new List<int> { 2, 3 };
+        var updateTasks = new List<StreamsGroupTaskSet>
+        {
+            new() { SubtopologyId = "update", Partitions = updatePartitions }
+        };
+
+        var updateResult = await member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            StandbyTasks = updateTasks
+        });
+
+        updatePartitions.Add(4);
+        updateTasks[0] = new StreamsGroupTaskSet { SubtopologyId = "replacement", Partitions = [9] };
+        await Assert.That(updateResult.StandbyTasks![0].Partitions).IsEquivalentTo([2, 3]);
+        await Assert.That(member.Snapshot.Assignment.StandbyTasks[0].Partitions).IsEquivalentTo([2, 3]);
+    }
+
+    [Test]
     [Arguments(null, StreamsGroupMembershipOperation.Default, false)]
     [Arguments("static-a", StreamsGroupMembershipOperation.Default, true)]
     [Arguments(null, StreamsGroupMembershipOperation.RemainInGroup, true)]


### PR DESCRIPTION
Closes #2786

## Summary
- add a narrow interface-first Streams group membership API
- model every StreamsGroupHeartbeat v0 input/output without exposing protocol DTOs
- make static membership and close-without-leave behavior explicit
- add deterministic Dekaf.Testing fake, XML docs, and public API baselines

## Validation
- `dotnet build src/Dekaf.Testing/Dekaf.Testing.csproj --configuration Release --no-restore` — 0 warnings
- focused `InMemoryStreamsGroupMemberTests` — 7/7 passed
- full unit suite — 7475/7475 passed
- core and testing package validation — passed
- public API parity across net10.0/netstandard2.0 — identical

## Performance
No producer/consumer/protocol hot paths changed. New code is public contracts plus a test-only in-memory fake; no benchmark gate applies.

## Self-review
Reviewed full diff before push for v0 protocol completeness, lifecycle/concurrency semantics, API compatibility, and hot-path impact. No findings remained.