### PR TITLE
consumer: implement streams-group membership coordinator

### DIFF
--- a/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
+++ b/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
@@ -30,10 +30,13 @@ public sealed class InMemoryStreamsGroupMember : IStreamsGroupMember
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentException.ThrowIfNullOrWhiteSpace(options.GroupId);
-        if (options.RebalanceTimeout <= TimeSpan.Zero)
+        if (options.RebalanceTimeout.TotalMilliseconds < 1
+            || options.RebalanceTimeout.TotalMilliseconds > int.MaxValue)
+        {
             throw new ArgumentOutOfRangeException(
                 nameof(options),
-                "Rebalance timeout must be positive.");
+                "RebalanceTimeout must be greater than zero and no greater than Int32.MaxValue milliseconds.");
+        }
 
         _options = options;
     }

--- a/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
+++ b/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
@@ -95,6 +95,8 @@ public sealed class InMemoryStreamsGroupMember : IStreamsGroupMember
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(initialState);
+        if (initialState.Topology is null)
+            throw new ArgumentException("The initial Streams group state must include a topology.", nameof(initialState));
         cancellationToken.ThrowIfCancellationRequested();
 
         lock (_gate)

--- a/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
+++ b/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
@@ -197,11 +197,14 @@ public sealed class InMemoryStreamsGroupMember : IStreamsGroupMember
         var standbyTasks = CopyTaskSets(update.StandbyTasks);
         var warmupTasks = CopyTaskSets(update.WarmupTasks);
         var previous = _snapshot;
+        var fallbackAssignment = !isJoin && update.Topology is not null
+            ? EmptyAssignment
+            : previous.Assignment;
         var assignment = new StreamsGroupAssignment
         {
-            ActiveTasks = activeTasks ?? previous.Assignment.ActiveTasks,
-            StandbyTasks = standbyTasks ?? previous.Assignment.StandbyTasks,
-            WarmupTasks = warmupTasks ?? previous.Assignment.WarmupTasks
+            ActiveTasks = activeTasks ?? fallbackAssignment.ActiveTasks,
+            StandbyTasks = standbyTasks ?? fallbackAssignment.StandbyTasks,
+            WarmupTasks = warmupTasks ?? fallbackAssignment.WarmupTasks
         };
         var memberId = isJoin ? "in-memory-streams-member" : previous.MemberId!;
         var memberEpoch = isJoin ? 1 : previous.MemberEpoch;

--- a/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
+++ b/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
@@ -193,12 +193,12 @@ public sealed class InMemoryStreamsGroupMember : IStreamsGroupMember
 
     private StreamsGroupHeartbeatResult ApplyUpdate(StreamsGroupMemberUpdate update, bool isJoin)
     {
-        var isTopologyRejoin = !isJoin && update.Topology is not null;
-        var activeTasks = isTopologyRejoin ? null : CopyTaskSets(update.ActiveTasks);
-        var standbyTasks = isTopologyRejoin ? null : CopyTaskSets(update.StandbyTasks);
-        var warmupTasks = isTopologyRejoin ? null : CopyTaskSets(update.WarmupTasks);
+        var isTopologyJoin = update.Topology is not null;
+        var activeTasks = isTopologyJoin ? null : CopyTaskSets(update.ActiveTasks);
+        var standbyTasks = isTopologyJoin ? null : CopyTaskSets(update.StandbyTasks);
+        var warmupTasks = isTopologyJoin ? null : CopyTaskSets(update.WarmupTasks);
         var previous = _snapshot;
-        var fallbackAssignment = isTopologyRejoin ? EmptyAssignment : previous.Assignment;
+        var fallbackAssignment = isTopologyJoin ? EmptyAssignment : previous.Assignment;
         var assignment = new StreamsGroupAssignment
         {
             ActiveTasks = activeTasks ?? fallbackAssignment.ActiveTasks,

--- a/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
+++ b/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
@@ -25,6 +25,7 @@ public sealed class InMemoryStreamsGroupMember : IStreamsGroupMember
     private StreamsGroupMemberUpdate? _lastUpdate;
     private StreamsGroupTaskOffsetReport? _lastTaskOffsetReport;
     private StreamsGroupCloseOptions? _lastCloseOptions;
+    private bool _initialized;
 
     public InMemoryStreamsGroupMember(StreamsGroupMemberOptions options)
     {
@@ -87,6 +88,7 @@ public sealed class InMemoryStreamsGroupMember : IStreamsGroupMember
         lock (_gate)
         {
             ThrowIfClosed();
+            _initialized = true;
         }
 
         return ValueTask.CompletedTask;
@@ -105,6 +107,7 @@ public sealed class InMemoryStreamsGroupMember : IStreamsGroupMember
         lock (_gate)
         {
             ThrowIfClosed();
+            ThrowIfNotInitialized();
             if (_snapshot.IsJoined)
                 throw new InvalidOperationException("The Streams group member has already joined.");
 
@@ -275,8 +278,18 @@ public sealed class InMemoryStreamsGroupMember : IStreamsGroupMember
     private void EnsureJoined()
     {
         ThrowIfClosed();
+        ThrowIfNotInitialized();
         if (!_snapshot.IsJoined)
             throw new InvalidOperationException("The Streams group member has not joined.");
+    }
+
+    private void ThrowIfNotInitialized()
+    {
+        if (!_initialized)
+        {
+            throw new InvalidOperationException(
+                "The Streams group member is not initialized. Call InitializeAsync() before joining.");
+        }
     }
 
     private void ThrowIfClosed() => ObjectDisposedException.ThrowIf(_snapshot.IsClosed, this);

--- a/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
+++ b/src/Dekaf.Testing/InMemoryStreamsGroupMember.cs
@@ -193,13 +193,12 @@ public sealed class InMemoryStreamsGroupMember : IStreamsGroupMember
 
     private StreamsGroupHeartbeatResult ApplyUpdate(StreamsGroupMemberUpdate update, bool isJoin)
     {
-        var activeTasks = CopyTaskSets(update.ActiveTasks);
-        var standbyTasks = CopyTaskSets(update.StandbyTasks);
-        var warmupTasks = CopyTaskSets(update.WarmupTasks);
+        var isTopologyRejoin = !isJoin && update.Topology is not null;
+        var activeTasks = isTopologyRejoin ? null : CopyTaskSets(update.ActiveTasks);
+        var standbyTasks = isTopologyRejoin ? null : CopyTaskSets(update.StandbyTasks);
+        var warmupTasks = isTopologyRejoin ? null : CopyTaskSets(update.WarmupTasks);
         var previous = _snapshot;
-        var fallbackAssignment = !isJoin && update.Topology is not null
-            ? EmptyAssignment
-            : previous.Assignment;
+        var fallbackAssignment = isTopologyRejoin ? EmptyAssignment : previous.Assignment;
         var assignment = new StreamsGroupAssignment
         {
             ActiveTasks = activeTasks ?? fallbackAssignment.ActiveTasks,

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -10,6 +10,7 @@ using Dekaf.Producer;
 using Dekaf.Retry;
 using Dekaf.Security;
 using Dekaf.Security.Sasl;
+using Dekaf.Streams;
 using Microsoft.Extensions.Logging;
 
 /// <summary>
@@ -57,6 +58,21 @@ public sealed class KafkaClient : IAsyncDisposable
     {
         ThrowIfDisposed();
         return new AdminClientBuilder(_infrastructure);
+    }
+
+    /// <summary>
+    /// Creates a Kafka Streams group member that uses this client's shared connections and metadata.
+    /// </summary>
+    public IStreamsGroupMember CreateStreamsGroupMember(StreamsGroupMemberOptions options)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(options);
+        return new StreamsGroupMember(
+            options,
+            _infrastructure.ConnectionPool,
+            _infrastructure.MetadataManager,
+            _infrastructure.RetryBackoffMs,
+            _infrastructure.RetryBackoffMaxMs);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -79,6 +79,7 @@ static Dekaf.ConsumerFacetExtensions.GetCommittedOffsetsAsync<TKey, TValue>(this
 static Dekaf.Protocol.Messages.MetadataRequest.GetRequestHeaderVersion(short version) -> short
 static Dekaf.Protocol.Messages.MetadataRequest.GetResponseHeaderVersion(short version) -> short
 static Dekaf.Protocol.Messages.MetadataRequest.IsFlexibleVersion(short version) -> bool
+Dekaf.KafkaClient.CreateStreamsGroupMember(Dekaf.Streams.StreamsGroupMemberOptions! options) -> Dekaf.Streams.IStreamsGroupMember!
 Dekaf.Consumer.BoundedConsumerExtensions
 Dekaf.Consumer.IBoundedKafkaConsumer<TKey, TValue>
 Dekaf.Consumer.IBoundedKafkaConsumer<TKey, TValue>.ConsumeSnapshotAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Dekaf.Consumer.ConsumeResult<TKey, TValue>>!

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -79,6 +79,7 @@ static Dekaf.ConsumerFacetExtensions.GetCommittedOffsetsAsync<TKey, TValue>(this
 static Dekaf.Protocol.Messages.MetadataRequest.GetRequestHeaderVersion(short version) -> short
 static Dekaf.Protocol.Messages.MetadataRequest.GetResponseHeaderVersion(short version) -> short
 static Dekaf.Protocol.Messages.MetadataRequest.IsFlexibleVersion(short version) -> bool
+Dekaf.KafkaClient.CreateStreamsGroupMember(Dekaf.Streams.StreamsGroupMemberOptions! options) -> Dekaf.Streams.IStreamsGroupMember!
 Dekaf.Consumer.BoundedConsumerExtensions
 Dekaf.Consumer.IBoundedKafkaConsumer<TKey, TValue>
 Dekaf.Consumer.IBoundedKafkaConsumer<TKey, TValue>.ConsumeSnapshotAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Dekaf.Consumer.ConsumeResult<TKey, TValue>>!

--- a/src/Dekaf/Streams/StreamsGroupHeartbeatRequestCache.cs
+++ b/src/Dekaf/Streams/StreamsGroupHeartbeatRequestCache.cs
@@ -11,8 +11,20 @@ internal sealed class StreamsGroupHeartbeatRequestCache
         string memberId,
         int memberEpoch,
         int endpointInformationEpoch,
-        string? instanceId) =>
-        _request ??= new StreamsGroupHeartbeatRequest
+        string? instanceId)
+    {
+        var request = _request;
+        if (request is not null
+            && request.MemberEpoch == memberEpoch
+            && request.EndpointInformationEpoch == endpointInformationEpoch
+            && string.Equals(request.GroupId, groupId, StringComparison.Ordinal)
+            && string.Equals(request.MemberId, memberId, StringComparison.Ordinal)
+            && string.Equals(request.InstanceId, instanceId, StringComparison.Ordinal))
+        {
+            return request;
+        }
+
+        return _request = new StreamsGroupHeartbeatRequest
         {
             GroupId = groupId,
             MemberId = memberId,
@@ -20,6 +32,7 @@ internal sealed class StreamsGroupHeartbeatRequestCache
             EndpointInformationEpoch = endpointInformationEpoch,
             InstanceId = instanceId
         };
+    }
 
     internal void Invalidate() => _request = null;
 }

--- a/src/Dekaf/Streams/StreamsGroupHeartbeatRequestCache.cs
+++ b/src/Dekaf/Streams/StreamsGroupHeartbeatRequestCache.cs
@@ -1,0 +1,25 @@
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Streams;
+
+internal sealed class StreamsGroupHeartbeatRequestCache
+{
+    private StreamsGroupHeartbeatRequest? _request;
+
+    internal StreamsGroupHeartbeatRequest Get(
+        string groupId,
+        string memberId,
+        int memberEpoch,
+        int endpointInformationEpoch,
+        string? instanceId) =>
+        _request ??= new StreamsGroupHeartbeatRequest
+        {
+            GroupId = groupId,
+            MemberId = memberId,
+            MemberEpoch = memberEpoch,
+            EndpointInformationEpoch = endpointInformationEpoch,
+            InstanceId = instanceId
+        };
+
+    internal void Invalidate() => _request = null;
+}

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Threading.Channels;
 using Dekaf.Errors;
 using Dekaf.Metadata;
@@ -477,8 +478,15 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             response = await SendWithRecoveryAsync(
                     request,
                     command.CancellationToken,
-                    recoveryJoinEpoch: recoveryJoinEpoch)
+                    recoveryJoinEpoch: recoveryJoinEpoch,
+                    trackAmbiguousRequestFailure: true)
                 .ConfigureAwait(false);
+        }
+        catch (AmbiguousHeartbeatException exception)
+        {
+            MarkUnjoined();
+            ExceptionDispatchInfo.Capture(exception.InnerException!).Throw();
+            throw;
         }
         catch
         {
@@ -508,9 +516,12 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         }
         catch (Exception exception)
         {
+            var fatal = IsFatalHeartbeatFailure(exception);
+            if (fatal)
+                MarkUnjoined();
             Volatile.Write(
                 ref _backgroundFailure,
-                IsFatalHeartbeatFailure(exception) ? exception : null);
+                fatal ? exception : null);
         }
 
         if (Volatile.Read(ref _closeRequested) == 0 && Volatile.Read(ref _backgroundFailure) is null)
@@ -577,7 +588,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         StreamsGroupHeartbeatRequest request,
         CancellationToken cancellationToken,
         int? recoveryJoinEpoch = null,
-        bool recoverFencing = true)
+        bool recoverFencing = true,
+        bool trackAmbiguousRequestFailure = false)
     {
         var fencedRecoveryAttempted = false;
         var shutdownApplication = request.ShutdownApplication;
@@ -585,6 +597,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         long unreleasedStartedAt = -1;
         var attemptLimit = 5;
         var fencingObserved = false;
+        var ambiguousCompletionObserved = false;
         try
         {
             for (var attempt = 0; attempt < attemptLimit; attempt++)
@@ -593,6 +606,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                     await FindCoordinatorAsync(cancellationToken).ConfigureAwait(false);
 
                 StreamsGroupHeartbeatResponse response;
+                var requestAttempted = false;
                 try
                 {
                     using var lease = await _connectionPool.LeaseConnectionAsync(_coordinatorId, cancellationToken)
@@ -610,16 +624,32 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                         ApiKey.StreamsGroupHeartbeat,
                         StreamsGroupHeartbeatRequest.LowestSupportedVersion,
                         StreamsGroupHeartbeatRequest.HighestSupportedVersion);
+                    requestAttempted = true;
                     response = await connection.SendAsync<StreamsGroupHeartbeatRequest, StreamsGroupHeartbeatResponse>(
                         request,
                         version,
                         cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception exception) when (
+                    trackAmbiguousRequestFailure
+                    && requestAttempted
+                    && exception is OperationCanceledException
+                    && cancellationToken.IsCancellationRequested)
+                {
+                    ambiguousCompletionObserved = true;
+                    throw;
+                }
+                catch (Exception exception) when (
                     RetryHelper.IsRetriableRequestFailure(exception)
                     && (exception is not OperationCanceledException || !cancellationToken.IsCancellationRequested))
                 {
                     _coordinatorId = -1;
+                    if (trackAmbiguousRequestFailure && requestAttempted)
+                    {
+                        // Later retry responses cannot prove whether an earlier request
+                        // reached the broker when its completion was lost.
+                        ambiguousCompletionObserved = true;
+                    }
                     if (attempt == attemptLimit - 1)
                         throw;
                     if (recoverFencing)
@@ -627,7 +657,6 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                     await DelayForRetryAsync(attempt + 1, cancellationToken).ConfigureAwait(false);
                     continue;
                 }
-
                 if (response.ErrorCode == ErrorCode.None)
                     return response;
 
@@ -696,15 +725,19 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                 $"StreamsGroupHeartbeat failed after {attemptLimit} coordinator attempts.")
             { GroupId = GroupId };
         }
+        catch (Exception exception) when (trackAmbiguousRequestFailure && ambiguousCompletionObserved)
+        {
+            throw new AmbiguousHeartbeatException(exception);
+        }
         catch
         {
             if (fencingObserved)
-                MarkUnjoinedAfterFencing();
+                MarkUnjoined();
             throw;
         }
     }
 
-    private void MarkUnjoinedAfterFencing()
+    private void MarkUnjoined()
     {
         _memberEpoch = 0;
         _steadyRequestCache.Invalidate();
@@ -1320,6 +1353,10 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         IReadOnlyList<StreamsGroupHeartbeatTaskOffset>? TaskOffsets,
         IReadOnlyList<StreamsGroupHeartbeatTaskOffset>? TaskEndOffsets,
         int EndpointInformationEpoch);
+
+    private sealed class AmbiguousHeartbeatException(Exception innerException) : Exception(
+        "StreamsGroupHeartbeat completion is ambiguous.",
+        innerException);
 
     private enum MemberCommandKind : byte
     {

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -293,36 +293,48 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         if (command.Kind == MemberCommandKind.Join && _memberEpoch > 0)
             throw new InvalidOperationException("The Streams group member has already joined.");
 
-        StreamsGroupHeartbeatRequest request;
-        int? recoveryJoinEpoch = command.Kind == MemberCommandKind.Join ? 0 : null;
-        switch (command.Kind)
+        var previousState = CaptureOperationState();
+        StreamsGroupHeartbeatResponse response;
+        try
         {
-            case MemberCommandKind.Join:
-                ApplyUpdate(command.Update!);
-                request = CreateJoinRequest();
-                break;
-            case MemberCommandKind.Update:
-                var update = command.Update!;
-                ApplyUpdate(update);
-                request = update.Topology is null
-                    ? CreateDeltaRequest(update)
-                    : CreateJoinRequest();
-                recoveryJoinEpoch = update.Topology is not null ? 0 : null;
-                break;
-            case MemberCommandKind.ReportOffsets:
-                _taskOffsets = MapTaskOffsets(command.OffsetReport!.TaskOffsets);
-                _taskEndOffsets = MapTaskOffsets(command.OffsetReport.TaskEndOffsets);
-                request = CreateOffsetRequest();
-                break;
-            default:
-                throw new InvalidOperationException($"Unsupported command {command.Kind}.");
+            StreamsGroupHeartbeatRequest request;
+            int? recoveryJoinEpoch = command.Kind == MemberCommandKind.Join ? 0 : null;
+            switch (command.Kind)
+            {
+                case MemberCommandKind.Join:
+                    var initialState = command.Update!;
+                    ApplyUpdate(initialState);
+                    request = CreateJoinRequest(shutdownApplication: initialState.ShutdownApplication);
+                    break;
+                case MemberCommandKind.Update:
+                    var update = command.Update!;
+                    ApplyUpdate(update);
+                    request = update.Topology is null
+                        ? CreateDeltaRequest(update)
+                        : CreateJoinRequest(shutdownApplication: update.ShutdownApplication);
+                    recoveryJoinEpoch = update.Topology is not null ? 0 : null;
+                    break;
+                case MemberCommandKind.ReportOffsets:
+                    _taskOffsets = MapTaskOffsets(command.OffsetReport!.TaskOffsets);
+                    _taskEndOffsets = MapTaskOffsets(command.OffsetReport.TaskEndOffsets);
+                    request = CreateOffsetRequest();
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unsupported command {command.Kind}.");
+            }
+
+            response = await SendWithRecoveryAsync(
+                    request,
+                    CancellationToken.None,
+                    recoveryJoinEpoch: recoveryJoinEpoch)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            RestoreOperationState(previousState);
+            throw;
         }
 
-        var response = await SendWithRecoveryAsync(
-                request,
-                CancellationToken.None,
-                recoveryJoinEpoch: recoveryJoinEpoch)
-            .ConfigureAwait(false);
         var result = ApplyResponse(response, createResult: true)!;
         ScheduleHeartbeat();
         return result;
@@ -407,6 +419,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         bool recoverFencing = true)
     {
         var fencedRecoveryAttempted = false;
+        var shutdownApplication = request.ShutdownApplication;
         var unreleasedFailureCount = 0;
         long unreleasedStartedAt = -1;
         for (var attempt = 0; attempt < 5; attempt++)
@@ -445,7 +458,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                 if (attempt == 4)
                     throw;
                 if (recoverFencing)
-                    request = CreateRecoveryRequest(recoveryJoinEpoch);
+                    request = CreateRecoveryRequest(recoveryJoinEpoch, shutdownApplication);
                 await DelayForRetryAsync(attempt + 1, cancellationToken).ConfigureAwait(false);
                 continue;
             }
@@ -492,7 +505,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                 if (response.ErrorCode != ErrorCode.CoordinatorLoadInProgress)
                     _coordinatorId = -1;
                 if (recoverFencing)
-                    request = CreateRecoveryRequest(recoveryJoinEpoch);
+                    request = CreateRecoveryRequest(recoveryJoinEpoch, shutdownApplication);
                 await DelayForRetryAsync(attempt + 1, cancellationToken).ConfigureAwait(false);
                 continue;
             }
@@ -503,9 +516,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             {
                 fencedRecoveryAttempted = true;
                 recoveryJoinEpoch = InstanceId is null ? 0 : -2;
-                _memberEpoch = recoveryJoinEpoch.Value;
                 _steadyRequestCache.Invalidate();
-                request = CreateJoinRequest(recoveryJoinEpoch.Value);
+                request = CreateJoinRequest(recoveryJoinEpoch.Value, shutdownApplication);
                 continue;
             }
 
@@ -762,7 +774,36 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         _steadyRequestCache.Invalidate();
     }
 
-    private StreamsGroupHeartbeatRequest CreateJoinRequest(int memberEpoch = 0) => new()
+    private OperationState CaptureOperationState() => new(
+        _topology,
+        _activeTasks,
+        _standbyTasks,
+        _warmupTasks,
+        _processId,
+        _userEndpoint,
+        _clientTags,
+        _taskOffsets,
+        _taskEndOffsets,
+        _endpointInformationEpoch);
+
+    private void RestoreOperationState(in OperationState state)
+    {
+        _topology = state.Topology;
+        _activeTasks = state.ActiveTasks;
+        _standbyTasks = state.StandbyTasks;
+        _warmupTasks = state.WarmupTasks;
+        _processId = state.ProcessId;
+        _userEndpoint = state.UserEndpoint;
+        _clientTags = state.ClientTags;
+        _taskOffsets = state.TaskOffsets;
+        _taskEndOffsets = state.TaskEndOffsets;
+        _endpointInformationEpoch = state.EndpointInformationEpoch;
+        _steadyRequestCache.Invalidate();
+    }
+
+    private StreamsGroupHeartbeatRequest CreateJoinRequest(
+        int memberEpoch = 0,
+        bool shutdownApplication = false) => new()
     {
         GroupId = GroupId,
         MemberId = _memberId,
@@ -779,13 +820,16 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         UserEndpoint = _userEndpoint,
         ClientTags = _clientTags,
         TaskOffsets = _taskOffsets,
-        TaskEndOffsets = _taskEndOffsets
+        TaskEndOffsets = _taskEndOffsets,
+        ShutdownApplication = shutdownApplication
     };
 
-    private StreamsGroupHeartbeatRequest CreateRecoveryRequest(int? recoveryJoinEpoch) =>
+    private StreamsGroupHeartbeatRequest CreateRecoveryRequest(
+        int? recoveryJoinEpoch,
+        bool shutdownApplication) =>
         recoveryJoinEpoch is not null || _memberEpoch <= 0
-            ? CreateJoinRequest(recoveryJoinEpoch ?? _memberEpoch)
-            : CreateFullRequest();
+            ? CreateJoinRequest(recoveryJoinEpoch ?? _memberEpoch, shutdownApplication)
+            : CreateFullRequest(shutdownApplication);
 
     private StreamsGroupHeartbeatRequest CreateDeltaRequest(StreamsGroupMemberUpdate update) => new()
     {
@@ -816,7 +860,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         TaskEndOffsets = _taskEndOffsets
     };
 
-    private StreamsGroupHeartbeatRequest CreateFullRequest() => new()
+    private StreamsGroupHeartbeatRequest CreateFullRequest(bool shutdownApplication) => new()
     {
         GroupId = GroupId,
         MemberId = _memberId,
@@ -832,7 +876,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         UserEndpoint = _userEndpoint,
         ClientTags = _clientTags,
         TaskOffsets = _taskOffsets,
-        TaskEndOffsets = _taskEndOffsets
+        TaskEndOffsets = _taskEndOffsets,
+        ShutdownApplication = shutdownApplication
     };
 
     internal StreamsGroupHeartbeatRequest GetOrCreateSteadyRequest() =>
@@ -1047,6 +1092,18 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             result[i] = source[i];
         return result;
     }
+
+    private readonly record struct OperationState(
+        StreamsGroupHeartbeatTopology? Topology,
+        IReadOnlyList<StreamsGroupHeartbeatTaskIds>? ActiveTasks,
+        IReadOnlyList<StreamsGroupHeartbeatTaskIds>? StandbyTasks,
+        IReadOnlyList<StreamsGroupHeartbeatTaskIds>? WarmupTasks,
+        string? ProcessId,
+        StreamsGroupHeartbeatEndpoint? UserEndpoint,
+        IReadOnlyList<StreamsGroupHeartbeatKeyValue>? ClientTags,
+        IReadOnlyList<StreamsGroupHeartbeatTaskOffset>? TaskOffsets,
+        IReadOnlyList<StreamsGroupHeartbeatTaskOffset>? TaskEndOffsets,
+        int EndpointInformationEpoch);
 
     private enum MemberCommandKind : byte
     {

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -514,18 +514,39 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             ApplyResponse(response, createResult: false);
             Volatile.Write(ref _backgroundFailure, null);
         }
-        catch (Exception exception)
+        catch (KafkaException exception)
         {
-            var fatal = IsFatalHeartbeatFailure(exception);
-            if (fatal)
-                MarkUnjoined();
-            Volatile.Write(
-                ref _backgroundFailure,
-                fatal ? exception : null);
+            HandleBackgroundHeartbeatFailure(exception);
+        }
+        catch (IOException exception)
+        {
+            HandleBackgroundHeartbeatFailure(exception);
+        }
+        catch (System.Net.Sockets.SocketException exception)
+        {
+            HandleBackgroundHeartbeatFailure(exception);
+        }
+        catch (TimeoutException exception)
+        {
+            HandleBackgroundHeartbeatFailure(exception);
+        }
+        catch (DnsResolutionException exception)
+        {
+            HandleBackgroundHeartbeatFailure(exception);
         }
 
         if (Volatile.Read(ref _closeRequested) == 0 && Volatile.Read(ref _backgroundFailure) is null)
             ScheduleHeartbeat();
+    }
+
+    private void HandleBackgroundHeartbeatFailure(Exception exception)
+    {
+        var fatal = IsFatalHeartbeatFailure(exception);
+        if (fatal)
+            MarkUnjoined();
+        Volatile.Write(
+            ref _backgroundFailure,
+            fatal ? exception : null);
     }
 
     private async ValueTask ProcessCloseAsync(StreamsGroupCloseOptions options)
@@ -858,6 +879,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
     private static bool IsFatalHeartbeatFailure(Exception? exception) => exception switch
     {
         BrokerVersionException => true,
+        AuthenticationException or AuthorizationException => true,
         GroupException { ErrorCode: ErrorCode.UnknownServerError } => false,
         GroupException { ErrorCode: { } errorCode } => !errorCode.IsRetriable(),
         _ => false

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -742,7 +742,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                     fencedRecoveryAttempted = true;
                     attemptLimit++;
                     recoveryJoinEpoch = InstanceId is null ? 0 : -2;
-                    _steadyRequestCache.Invalidate();
+                    ResetTaskAssignment(markUnjoined: false);
                     request = CreateJoinRequest(recoveryJoinEpoch.Value, shutdownApplication);
                     continue;
                 }
@@ -770,16 +770,24 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
     private void MarkUnjoined()
     {
         _memberEpoch = 0;
+        ResetTaskAssignment(markUnjoined: true);
+    }
+
+    private void ResetTaskAssignment(bool markUnjoined)
+    {
+        _activeTasks = [];
+        _standbyTasks = [];
+        _warmupTasks = [];
         _steadyRequestCache.Invalidate();
         var current = _snapshot;
         _snapshot = new StreamsGroupMemberSnapshot
         {
-            IsJoined = false,
+            IsJoined = !markUnjoined && current.IsJoined,
             MemberId = current.MemberId,
-            MemberEpoch = 0,
+            MemberEpoch = markUnjoined ? 0 : current.MemberEpoch,
             Assignment = EmptyAssignment,
             EndpointInformationEpoch = current.EndpointInformationEpoch,
-            PartitionsByUserEndpoint = [],
+            PartitionsByUserEndpoint = markUnjoined ? [] : current.PartitionsByUserEndpoint,
             Status = current.Status,
             HeartbeatInterval = current.HeartbeatInterval,
             AcceptableRecoveryLag = current.AcceptableRecoveryLag,

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -385,15 +385,16 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             _ => throw new ArgumentOutOfRangeException(nameof(options))
         };
         var retainMembership = terminalEpoch is null or -2;
+        var heartbeatEpoch = terminalEpoch ?? (options.ShutdownApplication ? _memberEpoch : null);
         try
         {
-            if (_memberEpoch > 0 && terminalEpoch is not null)
+            if (_memberEpoch > 0 && heartbeatEpoch is not null)
             {
                 var request = new StreamsGroupHeartbeatRequest
                 {
                     GroupId = GroupId,
                     MemberId = _memberId,
-                    MemberEpoch = terminalEpoch.Value,
+                    MemberEpoch = heartbeatEpoch.Value,
                     EndpointInformationEpoch = _endpointInformationEpoch,
                     InstanceId = InstanceId,
                     ShutdownApplication = options.ShutdownApplication
@@ -410,8 +411,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             {
                 IsJoined = retainMembership && current.IsJoined,
                 IsClosed = true,
-                MemberId = current.MemberId,
-                MemberEpoch = current.MemberEpoch,
+                MemberId = retainMembership ? current.MemberId : null,
+                MemberEpoch = retainMembership ? current.MemberEpoch : 0,
                 Assignment = current.Assignment,
                 EndpointInformationEpoch = current.EndpointInformationEpoch,
                 PartitionsByUserEndpoint = current.PartitionsByUserEndpoint,

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -585,6 +585,12 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         var heartbeatEpoch = terminalEpoch ?? (options.ShutdownApplication ? _memberEpoch : null);
         try
         {
+            if (_ambiguousMembership && terminalEpoch is null && options.ShutdownApplication)
+            {
+                throw new InvalidOperationException(
+                    "Cannot request application shutdown while retaining an ambiguous Streams group membership because its member epoch is unknown.");
+            }
+
             if (heartbeatEpoch is not null
                 && (_memberEpoch > 0 || (_ambiguousMembership && terminalEpoch is not null)))
             {

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -203,7 +203,10 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                     ObserveFault(command.Completion.Task);
                     throw;
                 }
-                CompleteRejectedClose();
+                finally
+                {
+                    CompleteRejectedClose();
+                }
             }
         }
 
@@ -464,7 +467,10 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         try
         {
             StreamsGroupHeartbeatRequest request;
-            var joinEpoch = InstanceId is not null && _snapshot.MemberId is not null ? -2 : 0;
+            var joinEpoch = InstanceId is not null &&
+                (_snapshot.MemberId is not null || _ambiguousMembership)
+                    ? -2
+                    : 0;
             int? recoveryJoinEpoch = command.Kind == MemberCommandKind.Join ? joinEpoch : null;
             switch (command.Kind)
             {

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Threading.Channels;
 using Dekaf.Errors;
 using Dekaf.Metadata;
@@ -169,7 +170,15 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             return;
         }
 
-        await command.Completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await command.Completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            ObserveFault(command.Completion.Task);
+            throw;
+        }
         await _workerTask.WaitAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -181,6 +190,11 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         try
         {
             await CloseAsync().ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Explicit CloseAsync callers receive terminal-heartbeat failures. Disposal is
+            // best-effort cleanup and must still release the timer after observing the fault.
         }
         finally
         {
@@ -325,10 +339,12 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         }
         catch (Exception exception)
         {
-            Volatile.Write(ref _backgroundFailure, exception);
+            Volatile.Write(
+                ref _backgroundFailure,
+                IsFatalHeartbeatFailure(exception) ? exception : null);
         }
 
-        if (Volatile.Read(ref _closeRequested) == 0 && !IsFatalHeartbeatFailure(_backgroundFailure))
+        if (Volatile.Read(ref _closeRequested) == 0 && Volatile.Read(ref _backgroundFailure) is null)
             ScheduleHeartbeat();
     }
 
@@ -337,9 +353,9 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         _heartbeatTimer.Change(Timeout.Infinite, Timeout.Infinite);
         try
         {
-            var terminalEpoch = options.GroupMembershipOperation switch
+            int? terminalEpoch = options.GroupMembershipOperation switch
             {
-                StreamsGroupMembershipOperation.RemainInGroup => (int?)null,
+                StreamsGroupMembershipOperation.RemainInGroup => null,
                 StreamsGroupMembershipOperation.LeaveGroup => -1,
                 StreamsGroupMembershipOperation.Default when InstanceId is not null => -2,
                 _ => -1
@@ -386,6 +402,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         bool recoverFencing = true)
     {
         var fencedRecoveryAttempted = false;
+        var unreleasedFailureCount = 0;
+        long unreleasedStartedAt = -1;
         for (var attempt = 0; attempt < 5; attempt++)
         {
             if (_coordinatorId < 0)
@@ -435,6 +453,30 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                     "The broker rejected StreamsGroupHeartbeat although it advertised API 88. " +
                     "Enable the Streams rebalance protocol (streams.version >= 1 and " +
                     "group.coordinator.rebalance.protocols containing 'streams').");
+            }
+
+            if (response.ErrorCode == ErrorCode.UnreleasedInstanceId
+                && InstanceId is not null
+                && request.MemberEpoch == 0)
+            {
+                if (unreleasedStartedAt < 0)
+                    unreleasedStartedAt = Stopwatch.GetTimestamp();
+                var elapsed = Stopwatch.GetElapsedTime(unreleasedStartedAt);
+                if (elapsed >= _options.RebalanceTimeout)
+                    throw CreateGroupException(response);
+
+                var remainingMs = Math.Max(
+                    1,
+                    (int)Math.Ceiling((_options.RebalanceTimeout - elapsed).TotalMilliseconds));
+                var delayMs = Math.Min(
+                    remainingMs,
+                    Math.Max(1, ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                        _retryBackoffMs,
+                        _retryBackoffMaxMs,
+                        ++unreleasedFailureCount)));
+                await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
+                attempt--;
+                continue;
             }
 
             if (response.ErrorCode is ErrorCode.NotCoordinator

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -11,6 +11,8 @@ namespace Dekaf.Streams;
 
 internal sealed class StreamsGroupMember : IStreamsGroupMember
 {
+    private const int CommandCapacity = 64;
+
     private static readonly StreamsGroupAssignment EmptyAssignment = new()
     {
         ActiveTasks = [],
@@ -21,9 +23,15 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
     private readonly StreamsGroupMemberOptions _options;
     private readonly IConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
-    private readonly Channel<MemberCommand> _commands = Channel.CreateUnbounded<MemberCommand>(
-        new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+    private readonly Channel<MemberCommand> _commands = Channel.CreateBounded<MemberCommand>(
+        new BoundedChannelOptions(CommandCapacity)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.Wait
+        });
     private readonly object _commandWriteGate = new();
+    private readonly CancellationTokenSource _commandAdmissionCancellation = new();
     private readonly SemaphoreSlim _initializeLock = new(1, 1);
     private readonly StreamsGroupHeartbeatRequestCache _steadyRequestCache = new();
     private readonly Timer _heartbeatTimer;
@@ -56,6 +64,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
     private IReadOnlyList<StreamsGroupHeartbeatTaskOffset>? _taskOffsets;
     private IReadOnlyList<StreamsGroupHeartbeatTaskOffset>? _taskEndOffsets;
     private int _endpointInformationEpoch;
+    private MemberCommand? _closeCommand;
 
     internal StreamsGroupMember(
         StreamsGroupMemberOptions options,
@@ -154,6 +163,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         ArgumentNullException.ThrowIfNull(options);
         if (!Enum.IsDefined(options.GroupMembershipOperation))
             throw new ArgumentOutOfRangeException(nameof(options));
+        cancellationToken.ThrowIfCancellationRequested();
         MemberCommand? command = null;
         lock (_commandWriteGate)
         {
@@ -161,8 +171,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             {
                 Volatile.Write(ref _closeRequested, 1);
                 command = MemberCommand.Close(options);
-                if (!_commands.Writer.TryWrite(command))
-                    throw new ObjectDisposedException(nameof(StreamsGroupMember));
+                Volatile.Write(ref _closeCommand, command);
             }
         }
 
@@ -170,6 +179,14 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         {
             await _workerTask.WaitAsync(cancellationToken).ConfigureAwait(false);
             return;
+        }
+
+        _commandAdmissionCancellation.Cancel();
+        if (!_commands.Writer.TryWrite(command) && _workerTask.IsCompleted)
+        {
+            command.Completion.TrySetException(
+                Volatile.Read(ref _backgroundFailure) ??
+                new ObjectDisposedException(nameof(StreamsGroupMember)));
         }
 
         try
@@ -215,12 +232,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         if (backgroundFailure is not null)
             throw CreateBackgroundFailureException(backgroundFailure);
 
-        lock (_commandWriteGate)
-        {
-            ThrowIfClosed();
-            if (!_commands.Writer.TryWrite(command))
-                throw new ObjectDisposedException(nameof(StreamsGroupMember));
-        }
+        command.CancellationToken = cancellationToken;
+        await EnqueueCommandAsync(command, cancellationToken).ConfigureAwait(false);
 
         try
         {
@@ -233,14 +246,71 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         }
     }
 
+    private ValueTask EnqueueCommandAsync(MemberCommand command, CancellationToken cancellationToken)
+    {
+        lock (_commandWriteGate)
+        {
+            ThrowIfClosed();
+            if (_commands.Writer.TryWrite(command))
+                return ValueTask.CompletedTask;
+        }
+
+        return EnqueueCommandSlowAsync(command, cancellationToken);
+    }
+
+    private async ValueTask EnqueueCommandSlowAsync(
+        MemberCommand command,
+        CancellationToken cancellationToken)
+    {
+        using var admissionCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            _commandAdmissionCancellation.Token);
+        try
+        {
+            await _commands.Writer.WriteAsync(command, admissionCancellation.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (
+            _commandAdmissionCancellation.IsCancellationRequested &&
+            !cancellationToken.IsCancellationRequested)
+        {
+            throw new ObjectDisposedException(nameof(StreamsGroupMember));
+        }
+        catch (ChannelClosedException)
+        {
+            throw new ObjectDisposedException(nameof(StreamsGroupMember));
+        }
+    }
+
     private async Task RunAsync()
     {
         try
         {
             while (await _commands.Reader.WaitToReadAsync().ConfigureAwait(false))
             {
-                while (_commands.Reader.TryRead(out var command))
+                while (true)
                 {
+                    if (Volatile.Read(ref _closeCommand) is { } closeCommand)
+                    {
+                        await CompleteCloseAsync(closeCommand).ConfigureAwait(false);
+                        return;
+                    }
+
+                    if (!_commands.Reader.TryRead(out var command))
+                        break;
+
+                    if (Volatile.Read(ref _closeCommand) is { } racedCloseCommand)
+                    {
+                        if (!ReferenceEquals(command, racedCloseCommand) &&
+                            command.Kind != MemberCommandKind.Heartbeat)
+                        {
+                            CompleteAbandonedCommand(
+                                command,
+                                new ObjectDisposedException(nameof(StreamsGroupMember)));
+                        }
+                        await CompleteCloseAsync(racedCloseCommand).ConfigureAwait(false);
+                        return;
+                    }
+
                     if (command.Kind == MemberCommandKind.Heartbeat)
                     {
                         await ProcessBackgroundHeartbeatAsync().ConfigureAwait(false);
@@ -249,18 +319,14 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
 
                     if (command.Kind == MemberCommandKind.Close)
                     {
-                        try
-                        {
-                            await ProcessCloseAsync(command.CloseOptions!).ConfigureAwait(false);
-                            command.Completion.TrySetResult(null);
-                        }
-                        catch (Exception exception)
-                        {
-                            command.Completion.TrySetException(exception);
-                        }
-
-                        _commands.Writer.TryComplete();
+                        await CompleteCloseAsync(command).ConfigureAwait(false);
                         return;
+                    }
+
+                    if (command.CancellationToken.IsCancellationRequested)
+                    {
+                        command.Completion.TrySetCanceled(command.CancellationToken);
+                        continue;
                     }
 
                     var backgroundFailure = Volatile.Read(ref _backgroundFailure);
@@ -287,6 +353,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         {
             Volatile.Write(ref _backgroundFailure, exception);
             _commands.Writer.TryComplete(exception);
+            Volatile.Read(ref _closeCommand)?.Completion.TrySetException(exception);
             while (_commands.Reader.TryRead(out var command))
                 command.Completion.TrySetException(exception);
         }
@@ -294,6 +361,38 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         {
             _heartbeatTimer.Change(Timeout.Infinite, Timeout.Infinite);
         }
+    }
+
+    private async ValueTask CompleteCloseAsync(MemberCommand command)
+    {
+        try
+        {
+            await ProcessCloseAsync(command.CloseOptions!).ConfigureAwait(false);
+            command.Completion.TrySetResult(null);
+        }
+        catch (Exception exception)
+        {
+            command.Completion.TrySetException(exception);
+        }
+
+        _commands.Writer.TryComplete();
+        var disposed = new ObjectDisposedException(nameof(StreamsGroupMember));
+        while (_commands.Reader.TryRead(out var pending))
+        {
+            if (ReferenceEquals(pending, command) || pending.Kind == MemberCommandKind.Heartbeat)
+                continue;
+            CompleteAbandonedCommand(pending, disposed);
+        }
+    }
+
+    private static void CompleteAbandonedCommand(
+        MemberCommand command,
+        ObjectDisposedException disposed)
+    {
+        if (command.CancellationToken.IsCancellationRequested)
+            command.Completion.TrySetCanceled(command.CancellationToken);
+        else
+            command.Completion.TrySetException(disposed);
     }
 
     private async ValueTask<StreamsGroupHeartbeatResult> ProcessOperationAsync(MemberCommand command)
@@ -434,7 +533,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         var shutdownApplication = request.ShutdownApplication;
         var unreleasedFailureCount = 0;
         long unreleasedStartedAt = -1;
-        for (var attempt = 0; attempt < 5; attempt++)
+        var attemptLimit = 5;
+        for (var attempt = 0; attempt < attemptLimit; attempt++)
         {
             if (_coordinatorId < 0)
                 await FindCoordinatorAsync(cancellationToken).ConfigureAwait(false);
@@ -467,7 +567,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                 && (exception is not OperationCanceledException || !cancellationToken.IsCancellationRequested))
             {
                 _coordinatorId = -1;
-                if (attempt == 4)
+                if (attempt == attemptLimit - 1)
                     throw;
                 if (recoverFencing)
                     request = CreateRecoveryRequest(recoveryJoinEpoch, shutdownApplication);
@@ -527,6 +627,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                 && response.ErrorCode is ErrorCode.FencedMemberEpoch or ErrorCode.UnknownMemberId)
             {
                 fencedRecoveryAttempted = true;
+                attemptLimit++;
                 recoveryJoinEpoch = InstanceId is null ? 0 : -2;
                 _steadyRequestCache.Invalidate();
                 request = CreateJoinRequest(recoveryJoinEpoch.Value, shutdownApplication);
@@ -538,7 +639,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
 
         throw new GroupException(
             ErrorCode.CoordinatorNotAvailable,
-            "StreamsGroupHeartbeat failed after 5 coordinator attempts.")
+            $"StreamsGroupHeartbeat failed after {attemptLimit} coordinator attempts.")
         { GroupId = GroupId };
     }
 
@@ -902,8 +1003,19 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
 
     private void QueueHeartbeat()
     {
-        if (Volatile.Read(ref _closeRequested) == 0)
-            _commands.Writer.TryWrite(MemberCommand.Heartbeat);
+        if (Volatile.Read(ref _closeRequested) == 0 &&
+            !_commands.Writer.TryWrite(MemberCommand.Heartbeat))
+        {
+            try
+            {
+                if (Volatile.Read(ref _closeRequested) == 0)
+                    ScheduleHeartbeat();
+            }
+            catch (ObjectDisposedException) when (Volatile.Read(ref _disposed) != 0)
+            {
+                // DisposeAsync can release the timer after the callback's close check.
+            }
+        }
     }
 
     private void ScheduleHeartbeat() =>
@@ -1139,6 +1251,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         internal StreamsGroupMemberUpdate? Update { get; init; }
         internal StreamsGroupTaskOffsetReport? OffsetReport { get; init; }
         internal StreamsGroupCloseOptions? CloseOptions { get; init; }
+        internal CancellationToken CancellationToken { get; set; }
         internal TaskCompletionSource<StreamsGroupHeartbeatResult?> Completion { get; } = new(
             TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -35,6 +35,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
     private readonly CancellationTokenSource _commandAdmissionCancellation = new();
     private readonly SemaphoreSlim _initializeLock = new(1, 1);
     private readonly StreamsGroupHeartbeatRequestCache _steadyRequestCache = new();
+    private readonly Action _requestWriteStartedCallback;
     private readonly Timer _heartbeatTimer;
     private readonly Task _workerTask;
     private readonly int _retryBackoffMs;
@@ -55,6 +56,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
     private int _memberEpoch;
     private int _heartbeatIntervalMs = 5_000;
     private bool _ambiguousMembership;
+    private bool _requestWriteStarted;
 
     private StreamsGroupHeartbeatTopology? _topology;
     private IReadOnlyList<StreamsGroupHeartbeatTaskIds>? _activeTasks;
@@ -93,6 +95,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         ExponentialRetryBackoff.Validate(retryBackoffMs, retryBackoffMaxMs);
         _retryBackoffMs = retryBackoffMs;
         _retryBackoffMaxMs = retryBackoffMaxMs;
+        _requestWriteStartedCallback = MarkRequestWriteStarted;
         _heartbeatTimer = new Timer(
             static state => ((StreamsGroupMember)state!).QueueHeartbeat(),
             this,
@@ -370,7 +373,11 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
 
                     try
                     {
-                        var result = await ProcessOperationAsync(command).ConfigureAwait(false);
+                        using var operationCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                            command.CancellationToken,
+                            _commandAdmissionCancellation.Token);
+                        var result = await ProcessOperationAsync(command, operationCancellation.Token)
+                            .ConfigureAwait(false);
                         command.Completion.TrySetResult(result);
                     }
                     catch (Exception exception)
@@ -443,7 +450,9 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             command.Completion.TrySetException(disposed);
     }
 
-    private async ValueTask<StreamsGroupHeartbeatResult> ProcessOperationAsync(MemberCommand command)
+    private async ValueTask<StreamsGroupHeartbeatResult> ProcessOperationAsync(
+        MemberCommand command,
+        CancellationToken cancellationToken)
     {
         if (command.Kind != MemberCommandKind.Join && _memberEpoch <= 0)
             throw new InvalidOperationException("JoinAsync must complete before updating a Streams group member.");
@@ -466,10 +475,11 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                 case MemberCommandKind.Update:
                     var update = command.Update!;
                     ApplyUpdate(update);
+                    var topologyJoinEpoch = InstanceId is null ? 0 : -2;
                     request = update.Topology is null
                         ? CreateDeltaRequest(update)
-                        : CreateJoinRequest(shutdownApplication: update.ShutdownApplication);
-                    recoveryJoinEpoch = update.Topology is not null ? 0 : null;
+                        : CreateJoinRequest(topologyJoinEpoch, update.ShutdownApplication);
+                    recoveryJoinEpoch = update.Topology is not null ? topologyJoinEpoch : null;
                     break;
                 case MemberCommandKind.ReportOffsets:
                     _taskOffsets = MapTaskOffsets(command.OffsetReport!.TaskOffsets);
@@ -482,7 +492,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
 
             response = await SendWithRecoveryAsync(
                     request,
-                    command.CancellationToken,
+                    cancellationToken,
                     recoveryJoinEpoch: recoveryJoinEpoch,
                     trackAmbiguousRequestFailure: true)
                 .ConfigureAwait(false);
@@ -658,7 +668,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                     await FindCoordinatorAsync(cancellationToken).ConfigureAwait(false);
 
                 StreamsGroupHeartbeatResponse response;
-                var requestAttempted = false;
+                _requestWriteStarted = false;
                 try
                 {
                     using var lease = await _connectionPool.LeaseConnectionAsync(_coordinatorId, cancellationToken)
@@ -676,15 +686,30 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                         ApiKey.StreamsGroupHeartbeat,
                         StreamsGroupHeartbeatRequest.LowestSupportedVersion,
                         StreamsGroupHeartbeatRequest.HighestSupportedVersion);
-                    requestAttempted = true;
-                    response = await connection.SendAsync<StreamsGroupHeartbeatRequest, StreamsGroupHeartbeatResponse>(
-                        request,
-                        version,
-                        cancellationToken).ConfigureAwait(false);
+                    if (connection is IKafkaRequestWriteObserverConnection writeObserverConnection)
+                    {
+                        response = await writeObserverConnection
+                            .SendWithWriteObservationAsync<StreamsGroupHeartbeatRequest, StreamsGroupHeartbeatResponse>(
+                                request,
+                                version,
+                                _requestWriteStartedCallback,
+                                cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        _requestWriteStarted = true;
+                        response = await connection
+                            .SendAsync<StreamsGroupHeartbeatRequest, StreamsGroupHeartbeatResponse>(
+                                request,
+                                version,
+                                cancellationToken)
+                            .ConfigureAwait(false);
+                    }
                 }
                 catch (Exception exception) when (
                     trackAmbiguousRequestFailure
-                    && requestAttempted
+                    && _requestWriteStarted
                     && exception is OperationCanceledException
                     && cancellationToken.IsCancellationRequested)
                 {
@@ -696,7 +721,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                     && (exception is not OperationCanceledException || !cancellationToken.IsCancellationRequested))
                 {
                     _coordinatorId = -1;
-                    if (trackAmbiguousRequestFailure && requestAttempted)
+                    if (trackAmbiguousRequestFailure && _requestWriteStarted)
                     {
                         // Later retry responses cannot prove whether an earlier request
                         // reached the broker when its completion was lost.
@@ -798,6 +823,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         _ambiguousMembership = false;
         ResetTaskAssignment(markUnjoined: true);
     }
+
+    private void MarkRequestWriteStarted() => _requestWriteStarted = true;
 
     private void ResetTaskAssignment(bool markUnjoined)
     {

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -54,6 +54,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
     private int _coordinatorId = -1;
     private int _memberEpoch;
     private int _heartbeatIntervalMs = 5_000;
+    private bool _ambiguousMembership;
 
     private StreamsGroupHeartbeatTopology? _topology;
     private IReadOnlyList<StreamsGroupHeartbeatTaskIds>? _activeTasks;
@@ -489,6 +490,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         catch (AmbiguousHeartbeatException exception)
         {
             MarkUnjoined();
+            _ambiguousMembership = true;
             ExceptionDispatchInfo.Capture(exception.InnerException!).Throw();
             throw;
         }
@@ -572,7 +574,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         var heartbeatEpoch = terminalEpoch ?? (options.ShutdownApplication ? _memberEpoch : null);
         try
         {
-            if (_memberEpoch > 0 && heartbeatEpoch is not null)
+            if (heartbeatEpoch is not null
+                && (_memberEpoch > 0 || (_ambiguousMembership && terminalEpoch is not null)))
             {
                 var request = new StreamsGroupHeartbeatRequest
                 {
@@ -583,9 +586,27 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                     InstanceId = InstanceId,
                     ShutdownApplication = options.ShutdownApplication
                 };
-                await SendWithRecoveryAsync(request, CancellationToken.None, recoverFencing: false)
+                await SendWithRecoveryAsync(
+                        request,
+                        CancellationToken.None,
+                        recoverFencing: false,
+                        trackAmbiguousRequestFailure: !retainMembership)
                     .ConfigureAwait(false);
             }
+        }
+        catch (AmbiguousHeartbeatException exception)
+            when (!retainMembership
+                && exception.InnerException is GroupException
+                {
+                    ErrorCode: ErrorCode.FencedMemberEpoch or ErrorCode.UnknownMemberId
+                })
+        {
+            // A prior leave attempt may have succeeded before its response was lost.
+        }
+        catch (AmbiguousHeartbeatException exception)
+        {
+            ExceptionDispatchInfo.Capture(exception.InnerException!).Throw();
+            throw;
         }
         catch (GroupException exception)
             when (exception.ErrorCode is ErrorCode.FencedMemberEpoch or ErrorCode.UnknownMemberId)
@@ -596,6 +617,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         finally
         {
             _memberEpoch = 0;
+            _ambiguousMembership = false;
             var current = _snapshot;
             _snapshot = new StreamsGroupMemberSnapshot
             {
@@ -773,6 +795,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
     private void MarkUnjoined()
     {
         _memberEpoch = 0;
+        _ambiguousMembership = false;
         ResetTaskAssignment(markUnjoined: true);
     }
 
@@ -938,6 +961,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         bool createResult,
         bool clearOmittedAssignment)
     {
+        _ambiguousMembership = false;
         var heartbeatRequestChanged = response.MemberEpoch != _memberEpoch
             || response.EndpointInformationEpoch != _endpointInformationEpoch
             || (!string.IsNullOrEmpty(response.MemberId) && response.MemberId != _memberId);

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -304,7 +304,10 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         }
         catch (ChannelClosedException)
         {
-            throw new ObjectDisposedException(nameof(StreamsGroupMember));
+            var backgroundFailure = Volatile.Read(ref _backgroundFailure);
+            throw backgroundFailure is null
+                ? new ObjectDisposedException(nameof(StreamsGroupMember))
+                : CreateBackgroundFailureException(backgroundFailure);
         }
     }
 

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -182,11 +182,18 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         }
 
         _commandAdmissionCancellation.Cancel();
-        if (!_commands.Writer.TryWrite(command) && _workerTask.IsCompleted)
+        if (!_commands.Writer.TryWrite(command))
         {
-            command.Completion.TrySetException(
-                Volatile.Read(ref _backgroundFailure) ??
-                new ObjectDisposedException(nameof(StreamsGroupMember)));
+            try
+            {
+                await _workerTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                ObserveFault(command.Completion.Task);
+                throw;
+            }
+            CompleteRejectedClose();
         }
 
         try
@@ -218,8 +225,15 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         finally
         {
             _heartbeatTimer.Dispose();
+            _commandAdmissionCancellation.Dispose();
+            _initializeLock.Dispose();
         }
     }
+
+    private void CompleteRejectedClose() =>
+        Volatile.Read(ref _closeCommand)?.Completion.TrySetException(
+            Volatile.Read(ref _backgroundFailure) ??
+            new ObjectDisposedException(nameof(StreamsGroupMember)));
 
     private async ValueTask<StreamsGroupHeartbeatResult> QueueOperationAsync(
         MemberCommand command,
@@ -229,7 +243,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         ThrowIfNotInitialized();
 
         var backgroundFailure = Volatile.Read(ref _backgroundFailure);
-        if (backgroundFailure is not null)
+        if (backgroundFailure is not null && command.Kind != MemberCommandKind.Join)
             throw CreateBackgroundFailureException(backgroundFailure);
 
         command.CancellationToken = cancellationToken;
@@ -330,7 +344,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                     }
 
                     var backgroundFailure = Volatile.Read(ref _backgroundFailure);
-                    if (backgroundFailure is not null)
+                    if (backgroundFailure is not null && command.Kind != MemberCommandKind.Join)
                     {
                         command.Completion.TrySetException(
                             CreateBackgroundFailureException(backgroundFailure));
@@ -461,6 +475,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         }
 
         var result = ApplyResponse(response, createResult: true)!;
+        if (command.Kind == MemberCommandKind.Join)
+            Volatile.Write(ref _backgroundFailure, null);
         ScheduleHeartbeat();
         return result;
     }
@@ -550,113 +566,144 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         var unreleasedFailureCount = 0;
         long unreleasedStartedAt = -1;
         var attemptLimit = 5;
-        for (var attempt = 0; attempt < attemptLimit; attempt++)
+        var fencingObserved = false;
+        try
         {
-            if (_coordinatorId < 0)
-                await FindCoordinatorAsync(cancellationToken).ConfigureAwait(false);
-
-            StreamsGroupHeartbeatResponse response;
-            try
+            for (var attempt = 0; attempt < attemptLimit; attempt++)
             {
-                using var lease = await _connectionPool.LeaseConnectionAsync(_coordinatorId, cancellationToken)
-                    .ConfigureAwait(false);
-                var connection = lease.Connection;
-                if (!_metadataManager.HasApiKey(connection, ApiKey.StreamsGroupHeartbeat))
+                if (_coordinatorId < 0)
+                    await FindCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+
+                StreamsGroupHeartbeatResponse response;
+                try
                 {
-                    throw new BrokerVersionException(
-                        "The target Kafka broker does not support StreamsGroupHeartbeat " +
-                        "(KIP-1071). Streams group membership requires Kafka 4.2 or later.");
+                    using var lease = await _connectionPool.LeaseConnectionAsync(_coordinatorId, cancellationToken)
+                        .ConfigureAwait(false);
+                    var connection = lease.Connection;
+                    if (!_metadataManager.HasApiKey(connection, ApiKey.StreamsGroupHeartbeat))
+                    {
+                        throw new BrokerVersionException(
+                            "The target Kafka broker does not support StreamsGroupHeartbeat " +
+                            "(KIP-1071). Streams group membership requires Kafka 4.2 or later.");
+                    }
+
+                    var version = _metadataManager.GetNegotiatedApiVersion(
+                        connection,
+                        ApiKey.StreamsGroupHeartbeat,
+                        StreamsGroupHeartbeatRequest.LowestSupportedVersion,
+                        StreamsGroupHeartbeatRequest.HighestSupportedVersion);
+                    response = await connection.SendAsync<StreamsGroupHeartbeatRequest, StreamsGroupHeartbeatResponse>(
+                        request,
+                        version,
+                        cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception exception) when (
+                    RetryHelper.IsRetriableRequestFailure(exception)
+                    && (exception is not OperationCanceledException || !cancellationToken.IsCancellationRequested))
+                {
+                    _coordinatorId = -1;
+                    if (attempt == attemptLimit - 1)
+                        throw;
+                    if (recoverFencing)
+                        request = CreateRecoveryRequest(recoveryJoinEpoch, shutdownApplication);
+                    await DelayForRetryAsync(attempt + 1, cancellationToken).ConfigureAwait(false);
+                    continue;
                 }
 
-                var version = _metadataManager.GetNegotiatedApiVersion(
-                    connection,
-                    ApiKey.StreamsGroupHeartbeat,
-                    StreamsGroupHeartbeatRequest.LowestSupportedVersion,
-                    StreamsGroupHeartbeatRequest.HighestSupportedVersion);
-                response = await connection.SendAsync<StreamsGroupHeartbeatRequest, StreamsGroupHeartbeatResponse>(
-                    request,
-                    version,
-                    cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception exception) when (
-                RetryHelper.IsRetriableRequestFailure(exception)
-                && (exception is not OperationCanceledException || !cancellationToken.IsCancellationRequested))
-            {
-                _coordinatorId = -1;
-                if (attempt == attemptLimit - 1)
-                    throw;
-                if (recoverFencing)
-                    request = CreateRecoveryRequest(recoveryJoinEpoch, shutdownApplication);
-                await DelayForRetryAsync(attempt + 1, cancellationToken).ConfigureAwait(false);
-                continue;
-            }
+                if (response.ErrorCode == ErrorCode.None)
+                    return response;
 
-            if (response.ErrorCode == ErrorCode.None)
-                return response;
+                if (response.ErrorCode == ErrorCode.UnsupportedVersion)
+                {
+                    throw new BrokerVersionException(
+                        "The broker rejected StreamsGroupHeartbeat although it advertised API 88. " +
+                        "Enable the Streams rebalance protocol (streams.version >= 1 and " +
+                        "group.coordinator.rebalance.protocols containing 'streams').");
+                }
 
-            if (response.ErrorCode == ErrorCode.UnsupportedVersion)
-            {
-                throw new BrokerVersionException(
-                    "The broker rejected StreamsGroupHeartbeat although it advertised API 88. " +
-                    "Enable the Streams rebalance protocol (streams.version >= 1 and " +
-                    "group.coordinator.rebalance.protocols containing 'streams').");
-            }
+                if (response.ErrorCode == ErrorCode.UnreleasedInstanceId
+                    && InstanceId is not null
+                    && request.MemberEpoch == 0)
+                {
+                    if (unreleasedStartedAt < 0)
+                        unreleasedStartedAt = Stopwatch.GetTimestamp();
+                    var elapsed = Stopwatch.GetElapsedTime(unreleasedStartedAt);
+                    if (elapsed >= _options.RebalanceTimeout)
+                        throw CreateGroupException(response);
 
-            if (response.ErrorCode == ErrorCode.UnreleasedInstanceId
-                && InstanceId is not null
-                && request.MemberEpoch == 0)
-            {
-                if (unreleasedStartedAt < 0)
-                    unreleasedStartedAt = Stopwatch.GetTimestamp();
-                var elapsed = Stopwatch.GetElapsedTime(unreleasedStartedAt);
-                if (elapsed >= _options.RebalanceTimeout)
-                    throw CreateGroupException(response);
+                    var remainingMs = Math.Max(
+                        1,
+                        (int)Math.Ceiling((_options.RebalanceTimeout - elapsed).TotalMilliseconds));
+                    var delayMs = Math.Min(
+                        remainingMs,
+                        Math.Max(1, ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                            _retryBackoffMs,
+                            _retryBackoffMaxMs,
+                            ++unreleasedFailureCount)));
+                    await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
+                    attempt--;
+                    continue;
+                }
 
-                var remainingMs = Math.Max(
-                    1,
-                    (int)Math.Ceiling((_options.RebalanceTimeout - elapsed).TotalMilliseconds));
-                var delayMs = Math.Min(
-                    remainingMs,
-                    Math.Max(1, ExponentialRetryBackoff.CalculateDelayMilliseconds(
-                        _retryBackoffMs,
-                        _retryBackoffMaxMs,
-                        ++unreleasedFailureCount)));
-                await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-                attempt--;
-                continue;
-            }
+                if (response.ErrorCode is ErrorCode.NotCoordinator
+                    or ErrorCode.CoordinatorNotAvailable
+                    or ErrorCode.CoordinatorLoadInProgress)
+                {
+                    if (response.ErrorCode != ErrorCode.CoordinatorLoadInProgress)
+                        _coordinatorId = -1;
+                    if (recoverFencing)
+                        request = CreateRecoveryRequest(recoveryJoinEpoch, shutdownApplication);
+                    await DelayForRetryAsync(attempt + 1, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
 
-            if (response.ErrorCode is ErrorCode.NotCoordinator
-                or ErrorCode.CoordinatorNotAvailable
-                or ErrorCode.CoordinatorLoadInProgress)
-            {
-                if (response.ErrorCode != ErrorCode.CoordinatorLoadInProgress)
-                    _coordinatorId = -1;
-                if (recoverFencing)
-                    request = CreateRecoveryRequest(recoveryJoinEpoch, shutdownApplication);
-                await DelayForRetryAsync(attempt + 1, cancellationToken).ConfigureAwait(false);
-                continue;
+                if (recoverFencing
+                    && !fencedRecoveryAttempted
+                    && response.ErrorCode is ErrorCode.FencedMemberEpoch or ErrorCode.UnknownMemberId)
+                {
+                    fencingObserved = true;
+                    fencedRecoveryAttempted = true;
+                    attemptLimit++;
+                    recoveryJoinEpoch = InstanceId is null ? 0 : -2;
+                    _steadyRequestCache.Invalidate();
+                    request = CreateJoinRequest(recoveryJoinEpoch.Value, shutdownApplication);
+                    continue;
+                }
+
+                throw CreateGroupException(response);
             }
 
-            if (recoverFencing
-                && !fencedRecoveryAttempted
-                && response.ErrorCode is ErrorCode.FencedMemberEpoch or ErrorCode.UnknownMemberId)
-            {
-                fencedRecoveryAttempted = true;
-                attemptLimit++;
-                recoveryJoinEpoch = InstanceId is null ? 0 : -2;
-                _steadyRequestCache.Invalidate();
-                request = CreateJoinRequest(recoveryJoinEpoch.Value, shutdownApplication);
-                continue;
-            }
-
-            throw CreateGroupException(response);
+            throw new GroupException(
+                ErrorCode.CoordinatorNotAvailable,
+                $"StreamsGroupHeartbeat failed after {attemptLimit} coordinator attempts.")
+            { GroupId = GroupId };
         }
+        catch
+        {
+            if (fencingObserved)
+                MarkUnjoinedAfterFencing();
+            throw;
+        }
+    }
 
-        throw new GroupException(
-            ErrorCode.CoordinatorNotAvailable,
-            $"StreamsGroupHeartbeat failed after {attemptLimit} coordinator attempts.")
-        { GroupId = GroupId };
+    private void MarkUnjoinedAfterFencing()
+    {
+        _memberEpoch = 0;
+        _steadyRequestCache.Invalidate();
+        var current = _snapshot;
+        _snapshot = new StreamsGroupMemberSnapshot
+        {
+            IsJoined = false,
+            MemberId = current.MemberId,
+            MemberEpoch = 0,
+            Assignment = EmptyAssignment,
+            EndpointInformationEpoch = current.EndpointInformationEpoch,
+            PartitionsByUserEndpoint = [],
+            Status = current.Status,
+            HeartbeatInterval = current.HeartbeatInterval,
+            AcceptableRecoveryLag = current.AcceptableRecoveryLag,
+            TaskOffsetInterval = current.TaskOffsetInterval
+        };
     }
 
     private async ValueTask FindCoordinatorAsync(CancellationToken cancellationToken)
@@ -1017,21 +1064,24 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             _endpointInformationEpoch,
             InstanceId);
 
-    private void QueueHeartbeat()
+    private bool QueueHeartbeat()
     {
-        if (Volatile.Read(ref _closeRequested) == 0 &&
-            !_commands.Writer.TryWrite(MemberCommand.Heartbeat))
+        if (Volatile.Read(ref _closeRequested) != 0)
+            return false;
+        if (_commands.Writer.TryWrite(MemberCommand.Heartbeat))
+            return true;
+
+        try
         {
-            try
-            {
-                if (Volatile.Read(ref _closeRequested) == 0)
-                    ScheduleHeartbeat();
-            }
-            catch (ObjectDisposedException) when (Volatile.Read(ref _disposed) != 0)
-            {
-                // DisposeAsync can release the timer after the callback's close check.
-            }
+            if (Volatile.Read(ref _closeRequested) == 0)
+                ScheduleHeartbeat();
         }
+        catch (ObjectDisposedException) when (Volatile.Read(ref _disposed) != 0)
+        {
+            // DisposeAsync can release the timer after the callback's close check.
+        }
+
+        return false;
     }
 
     private void ScheduleHeartbeat() =>

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -670,7 +670,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                     throw;
                 }
                 catch (Exception exception) when (
-                    RetryHelper.IsRetriableRequestFailure(exception)
+                    IsRetriableConnectionFailure(exception)
                     && (exception is not OperationCanceledException || !cancellationToken.IsCancellationRequested))
                 {
                     _coordinatorId = -1;
@@ -846,7 +846,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                 return;
             }
             catch (Exception exception) when (
-                RetryHelper.IsRetriableRequestFailure(exception)
+                IsRetriableConnectionFailure(exception)
                 && !cancellationToken.IsCancellationRequested)
             {
                 if (attempt == 4)
@@ -866,6 +866,10 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             "FindCoordinator failed after 5 attempts.")
         { GroupId = GroupId };
     }
+
+    private bool IsRetriableConnectionFailure(Exception exception) =>
+        RetryHelper.IsRetriableRequestFailure(exception)
+        || (exception is ObjectDisposedException && Volatile.Read(ref _closeRequested) == 0);
 
     private static void ObserveFault(Task task)
     {

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -546,19 +546,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         {
             HandleBackgroundHeartbeatFailure(exception);
         }
-        catch (IOException exception)
-        {
-            HandleBackgroundHeartbeatFailure(exception);
-        }
-        catch (System.Net.Sockets.SocketException exception)
-        {
-            HandleBackgroundHeartbeatFailure(exception);
-        }
-        catch (TimeoutException exception)
-        {
-            HandleBackgroundHeartbeatFailure(exception);
-        }
-        catch (DnsResolutionException exception)
+        catch (Exception exception) when (IsRetriableConnectionFailure(exception))
         {
             HandleBackgroundHeartbeatFailure(exception);
         }

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -381,6 +381,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         }
         catch (Exception exception)
         {
+            MarkUnjoined();
             Volatile.Write(ref _backgroundFailure, exception);
             _commands.Writer.TryComplete(exception);
             Volatile.Read(ref _closeCommand)?.Completion.TrySetException(exception);
@@ -497,7 +498,12 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             throw;
         }
 
-        var result = ApplyResponse(response, createResult: true)!;
+        var clearOmittedAssignment = command is
+        {
+            Kind: MemberCommandKind.Update,
+            Update.Topology: not null
+        };
+        var result = ApplyResponse(response, createResult: true, clearOmittedAssignment)!;
         if (command.Kind == MemberCommandKind.Join)
             Volatile.Write(ref _backgroundFailure, null);
         ScheduleHeartbeat();
@@ -514,7 +520,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             var request = GetOrCreateSteadyRequest();
             var response = await SendWithRecoveryAsync(request, CancellationToken.None)
                 .ConfigureAwait(false);
-            ApplyResponse(response, createResult: false);
+            ApplyResponse(response, createResult: false, clearOmittedAssignment: false);
             Volatile.Write(ref _backgroundFailure, null);
         }
         catch (KafkaException exception)
@@ -785,7 +791,12 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
     {
         var brokers = _metadataManager.Metadata.GetBrokers();
         if (brokers.Count == 0)
-            throw new InvalidOperationException("No brokers available for Streams group coordinator discovery.");
+        {
+            throw new GroupException(
+                ErrorCode.CoordinatorNotAvailable,
+                "No brokers available for Streams group coordinator discovery.")
+            { GroupId = GroupId };
+        }
 
         var request = new FindCoordinatorRequest { Key = GroupId, KeyType = CoordinatorType.Group };
         for (var attempt = 0; attempt < 5; attempt++)
@@ -909,7 +920,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
 
     private StreamsGroupHeartbeatResult? ApplyResponse(
         StreamsGroupHeartbeatResponse response,
-        bool createResult)
+        bool createResult,
+        bool clearOmittedAssignment)
     {
         var heartbeatRequestChanged = response.MemberEpoch != _memberEpoch
             || response.EndpointInformationEpoch != _endpointInformationEpoch
@@ -922,14 +934,15 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             _heartbeatIntervalMs = response.HeartbeatIntervalMs;
 
         var current = _snapshot;
+        var fallbackAssignment = clearOmittedAssignment ? EmptyAssignment : current.Assignment;
         var active = response.ActiveTasks is null
-            ? current.Assignment.ActiveTasks
+            ? fallbackAssignment.ActiveTasks
             : MapTaskSets(response.ActiveTasks);
         var standby = response.StandbyTasks is null
-            ? current.Assignment.StandbyTasks
+            ? fallbackAssignment.StandbyTasks
             : MapTaskSets(response.StandbyTasks);
         var warmup = response.WarmupTasks is null
-            ? current.Assignment.WarmupTasks
+            ? fallbackAssignment.WarmupTasks
             : MapTaskSets(response.WarmupTasks);
         var status = response.Status is null ? current.Status : MapStatus(response.Status);
         var endpoints = response.PartitionsByUserEndpoint is null
@@ -945,9 +958,24 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         _endpointInformationEpoch = response.EndpointInformationEpoch;
         if (heartbeatRequestChanged)
             _steadyRequestCache.Invalidate();
-        var assignmentChanged = response.ActiveTasks is not null
+        var assignmentReturned = response.ActiveTasks is not null
             || response.StandbyTasks is not null
             || response.WarmupTasks is not null;
+        var assignmentChanged = clearOmittedAssignment || assignmentReturned;
+        var assignment = current.Assignment;
+        if (clearOmittedAssignment && !assignmentReturned)
+        {
+            assignment = EmptyAssignment;
+        }
+        else if (assignmentReturned)
+        {
+            assignment = new StreamsGroupAssignment
+            {
+                ActiveTasks = active,
+                StandbyTasks = standby,
+                WarmupTasks = warmup
+            };
+        }
         var snapshotChanged = current.IsJoined != (response.MemberEpoch > 0)
             || current.MemberId != _memberId
             || current.MemberEpoch != response.MemberEpoch
@@ -965,14 +993,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                 IsJoined = response.MemberEpoch > 0,
                 MemberId = _memberId,
                 MemberEpoch = response.MemberEpoch,
-                Assignment = assignmentChanged
-                    ? new StreamsGroupAssignment
-                    {
-                        ActiveTasks = active,
-                        StandbyTasks = standby,
-                        WarmupTasks = warmup
-                    }
-                    : current.Assignment,
+                Assignment = assignment,
                 EndpointInformationEpoch = response.EndpointInformationEpoch,
                 PartitionsByUserEndpoint = endpoints,
                 Status = status,

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -726,6 +726,9 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                     or ErrorCode.CoordinatorNotAvailable
                     or ErrorCode.CoordinatorLoadInProgress)
                 {
+                    if (attempt == attemptLimit - 1)
+                        throw CreateGroupException(response);
+
                     if (response.ErrorCode != ErrorCode.CoordinatorLoadInProgress)
                         _coordinatorId = -1;
                     if (recoverFencing)

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -577,6 +577,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         };
         var retainMembership = terminalEpoch is null or -2;
         var heartbeatEpoch = terminalEpoch ?? (options.ShutdownApplication ? _memberEpoch : null);
+        var membershipWasAmbiguous = _ambiguousMembership;
         try
         {
             if (_ambiguousMembership && terminalEpoch is null && options.ShutdownApplication)
@@ -618,6 +619,13 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         {
             ExceptionDispatchInfo.Capture(exception.InnerException!).Throw();
             throw;
+        }
+        catch (GroupException exception)
+            when (!retainMembership
+                && membershipWasAmbiguous
+                && exception.ErrorCode is ErrorCode.FencedMemberEpoch or ErrorCode.UnknownMemberId)
+        {
+            // Membership loss proves an ambiguously completed join or update is no longer active.
         }
         catch (GroupException exception)
             when (exception.ErrorCode is ErrorCode.FencedMemberEpoch or ErrorCode.UnknownMemberId)

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -294,6 +294,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             throw new InvalidOperationException("The Streams group member has already joined.");
 
         StreamsGroupHeartbeatRequest request;
+        int? recoveryJoinEpoch = command.Kind == MemberCommandKind.Join ? 0 : null;
         switch (command.Kind)
         {
             case MemberCommandKind.Join:
@@ -306,8 +307,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                 request = update.Topology is null
                     ? CreateDeltaRequest(update)
                     : CreateJoinRequest();
-                if (update.Topology is not null)
-                    _memberEpoch = 0;
+                recoveryJoinEpoch = update.Topology is not null ? 0 : null;
                 break;
             case MemberCommandKind.ReportOffsets:
                 _taskOffsets = MapTaskOffsets(command.OffsetReport!.TaskOffsets);
@@ -318,7 +318,11 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                 throw new InvalidOperationException($"Unsupported command {command.Kind}.");
         }
 
-        var response = await SendWithRecoveryAsync(request, CancellationToken.None).ConfigureAwait(false);
+        var response = await SendWithRecoveryAsync(
+                request,
+                CancellationToken.None,
+                recoveryJoinEpoch: recoveryJoinEpoch)
+            .ConfigureAwait(false);
         var result = ApplyResponse(response, createResult: true)!;
         ScheduleHeartbeat();
         return result;
@@ -399,6 +403,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
     private async ValueTask<StreamsGroupHeartbeatResponse> SendWithRecoveryAsync(
         StreamsGroupHeartbeatRequest request,
         CancellationToken cancellationToken,
+        int? recoveryJoinEpoch = null,
         bool recoverFencing = true)
     {
         var fencedRecoveryAttempted = false;
@@ -439,7 +444,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                 _coordinatorId = -1;
                 if (attempt == 4)
                     throw;
-                request = _memberEpoch <= 0 ? CreateJoinRequest() : CreateFullRequest();
+                if (recoverFencing)
+                    request = CreateRecoveryRequest(recoveryJoinEpoch);
                 await DelayForRetryAsync(attempt + 1, cancellationToken).ConfigureAwait(false);
                 continue;
             }
@@ -485,7 +491,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             {
                 if (response.ErrorCode != ErrorCode.CoordinatorLoadInProgress)
                     _coordinatorId = -1;
-                request = _memberEpoch <= 0 ? CreateJoinRequest() : CreateFullRequest();
+                if (recoverFencing)
+                    request = CreateRecoveryRequest(recoveryJoinEpoch);
                 await DelayForRetryAsync(attempt + 1, cancellationToken).ConfigureAwait(false);
                 continue;
             }
@@ -495,9 +502,10 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                 && response.ErrorCode is ErrorCode.FencedMemberEpoch or ErrorCode.UnknownMemberId)
             {
                 fencedRecoveryAttempted = true;
-                _memberEpoch = 0;
+                recoveryJoinEpoch = InstanceId is null ? 0 : -2;
+                _memberEpoch = recoveryJoinEpoch.Value;
                 _steadyRequestCache.Invalidate();
-                request = CreateJoinRequest();
+                request = CreateJoinRequest(recoveryJoinEpoch.Value);
                 continue;
             }
 
@@ -611,10 +619,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
     private static bool IsFatalHeartbeatFailure(Exception? exception) => exception switch
     {
         BrokerVersionException => true,
-        GroupException { ErrorCode: ErrorCode.StreamsInvalidTopology
-            or ErrorCode.StreamsInvalidTopologyEpoch
-            or ErrorCode.StreamsTopologyFenced
-            or ErrorCode.UnreleasedInstanceId } => true,
+        GroupException { ErrorCode: ErrorCode.UnknownServerError } => false,
+        GroupException { ErrorCode: { } errorCode } => !errorCode.IsRetriable(),
         _ => false
     };
 
@@ -756,11 +762,11 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         _steadyRequestCache.Invalidate();
     }
 
-    private StreamsGroupHeartbeatRequest CreateJoinRequest() => new()
+    private StreamsGroupHeartbeatRequest CreateJoinRequest(int memberEpoch = 0) => new()
     {
         GroupId = GroupId,
         MemberId = _memberId,
-        MemberEpoch = 0,
+        MemberEpoch = memberEpoch,
         EndpointInformationEpoch = _endpointInformationEpoch,
         InstanceId = InstanceId,
         RackId = _options.RackId,
@@ -775,6 +781,11 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         TaskOffsets = _taskOffsets,
         TaskEndOffsets = _taskEndOffsets
     };
+
+    private StreamsGroupHeartbeatRequest CreateRecoveryRequest(int? recoveryJoinEpoch) =>
+        recoveryJoinEpoch is not null || _memberEpoch <= 0
+            ? CreateJoinRequest(recoveryJoinEpoch ?? _memberEpoch)
+            : CreateFullRequest();
 
     private StreamsGroupHeartbeatRequest CreateDeltaRequest(StreamsGroupMemberUpdate update) => new()
     {

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -33,6 +33,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         });
     private readonly object _commandWriteGate = new();
     private readonly CancellationTokenSource _commandAdmissionCancellation = new();
+    // CloseAsync remains idempotent after disposal, so concurrent close callers can still drain initialization.
     private readonly SemaphoreSlim _initializeLock = new(1, 1);
     private readonly StreamsGroupHeartbeatRequestCache _steadyRequestCache = new();
     private readonly Action _requestWriteStartedCallback;
@@ -243,7 +244,6 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         {
             _heartbeatTimer.Dispose();
             _commandAdmissionCancellation.Dispose();
-            _initializeLock.Dispose();
         }
     }
 

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -476,7 +476,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
 
             response = await SendWithRecoveryAsync(
                     request,
-                    CancellationToken.None,
+                    command.CancellationToken,
                     recoveryJoinEpoch: recoveryJoinEpoch)
                 .ConfigureAwait(false);
         }

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -152,6 +152,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(options);
+        if (!Enum.IsDefined(options.GroupMembershipOperation))
+            throw new ArgumentOutOfRangeException(nameof(options));
         MemberCommand? command = null;
         lock (_commandWriteGate)
         {
@@ -375,16 +377,16 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
     private async ValueTask ProcessCloseAsync(StreamsGroupCloseOptions options)
     {
         _heartbeatTimer.Change(Timeout.Infinite, Timeout.Infinite);
+        int? terminalEpoch = options.GroupMembershipOperation switch
+        {
+            StreamsGroupMembershipOperation.RemainInGroup => null,
+            StreamsGroupMembershipOperation.LeaveGroup => -1,
+            StreamsGroupMembershipOperation.Default => InstanceId is null ? -1 : -2,
+            _ => throw new ArgumentOutOfRangeException(nameof(options))
+        };
+        var retainMembership = terminalEpoch is null or -2;
         try
         {
-            int? terminalEpoch = options.GroupMembershipOperation switch
-            {
-                StreamsGroupMembershipOperation.RemainInGroup => null,
-                StreamsGroupMembershipOperation.LeaveGroup => -1,
-                StreamsGroupMembershipOperation.Default when InstanceId is not null => -2,
-                _ => -1
-            };
-
             if (_memberEpoch > 0 && terminalEpoch is not null)
             {
                 var request = new StreamsGroupHeartbeatRequest
@@ -406,6 +408,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             var current = _snapshot;
             _snapshot = new StreamsGroupMemberSnapshot
             {
+                IsJoined = retainMembership && current.IsJoined,
                 IsClosed = true,
                 MemberId = current.MemberId,
                 MemberEpoch = current.MemberEpoch,

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -464,13 +464,14 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         try
         {
             StreamsGroupHeartbeatRequest request;
-            int? recoveryJoinEpoch = command.Kind == MemberCommandKind.Join ? 0 : null;
+            var joinEpoch = InstanceId is not null && _snapshot.MemberId is not null ? -2 : 0;
+            int? recoveryJoinEpoch = command.Kind == MemberCommandKind.Join ? joinEpoch : null;
             switch (command.Kind)
             {
                 case MemberCommandKind.Join:
                     var initialState = command.Update!;
                     ApplyUpdate(initialState);
-                    request = CreateJoinRequest(shutdownApplication: initialState.ShutdownApplication);
+                    request = CreateJoinRequest(joinEpoch, initialState.ShutdownApplication);
                     break;
                 case MemberCommandKind.Update:
                     var update = command.Update!;

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -112,10 +112,12 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         await _initializeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
+            ThrowIfClosed();
             if (_initialized)
                 return;
 
             await _metadataManager.InitializeAsync(cancellationToken).ConfigureAwait(false);
+            ThrowIfClosed();
             _initialized = true;
         }
         finally
@@ -201,6 +203,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
 
         try
         {
+            await WaitForInitializationDrainAsync(cancellationToken).ConfigureAwait(false);
             await command.Completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -209,6 +212,12 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
             throw;
         }
         await _workerTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask WaitForInitializationDrainAsync(CancellationToken cancellationToken)
+    {
+        await _initializeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        _initializeLock.Release();
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -164,7 +164,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         if (!Enum.IsDefined(options.GroupMembershipOperation))
             throw new ArgumentOutOfRangeException(nameof(options));
         cancellationToken.ThrowIfCancellationRequested();
-        MemberCommand? command = null;
+        MemberCommand command;
+        var enqueueClose = false;
         lock (_commandWriteGate)
         {
             if (Volatile.Read(ref _closeRequested) == 0)
@@ -172,28 +173,30 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                 Volatile.Write(ref _closeRequested, 1);
                 command = MemberCommand.Close(options);
                 Volatile.Write(ref _closeCommand, command);
+                enqueueClose = true;
+            }
+            else
+            {
+                command = Volatile.Read(ref _closeCommand)!;
             }
         }
 
-        if (command is null)
+        if (enqueueClose)
         {
-            await _workerTask.WaitAsync(cancellationToken).ConfigureAwait(false);
-            return;
-        }
-
-        _commandAdmissionCancellation.Cancel();
-        if (!_commands.Writer.TryWrite(command))
-        {
-            try
+            _commandAdmissionCancellation.Cancel();
+            if (!_commands.Writer.TryWrite(command))
             {
-                await _workerTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await _workerTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    ObserveFault(command.Completion.Task);
+                    throw;
+                }
+                CompleteRejectedClose();
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                ObserveFault(command.Completion.Task);
-                throw;
-            }
-            CompleteRejectedClose();
         }
 
         try

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -1,0 +1,1041 @@
+using System.Threading.Channels;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Retry;
+
+namespace Dekaf.Streams;
+
+internal sealed class StreamsGroupMember : IStreamsGroupMember
+{
+    private static readonly StreamsGroupAssignment EmptyAssignment = new()
+    {
+        ActiveTasks = [],
+        StandbyTasks = [],
+        WarmupTasks = []
+    };
+
+    private readonly StreamsGroupMemberOptions _options;
+    private readonly IConnectionPool _connectionPool;
+    private readonly MetadataManager _metadataManager;
+    private readonly Channel<MemberCommand> _commands = Channel.CreateUnbounded<MemberCommand>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+    private readonly object _commandWriteGate = new();
+    private readonly SemaphoreSlim _initializeLock = new(1, 1);
+    private readonly StreamsGroupHeartbeatRequestCache _steadyRequestCache = new();
+    private readonly Timer _heartbeatTimer;
+    private readonly Task _workerTask;
+    private readonly int _retryBackoffMs;
+    private readonly int _retryBackoffMaxMs;
+    private string _memberId = Guid.NewGuid().ToString();
+
+    private volatile StreamsGroupMemberSnapshot _snapshot = new()
+    {
+        Assignment = EmptyAssignment,
+        PartitionsByUserEndpoint = [],
+        Status = []
+    };
+    private Exception? _backgroundFailure;
+    private volatile bool _initialized;
+    private int _closeRequested;
+    private int _disposed;
+    private int _coordinatorId = -1;
+    private int _memberEpoch;
+    private int _heartbeatIntervalMs = 5_000;
+
+    private StreamsGroupHeartbeatTopology? _topology;
+    private IReadOnlyList<StreamsGroupHeartbeatTaskIds>? _activeTasks;
+    private IReadOnlyList<StreamsGroupHeartbeatTaskIds>? _standbyTasks;
+    private IReadOnlyList<StreamsGroupHeartbeatTaskIds>? _warmupTasks;
+    private string? _processId;
+    private StreamsGroupHeartbeatEndpoint? _userEndpoint;
+    private IReadOnlyList<StreamsGroupHeartbeatKeyValue>? _clientTags;
+    private IReadOnlyList<StreamsGroupHeartbeatTaskOffset>? _taskOffsets;
+    private IReadOnlyList<StreamsGroupHeartbeatTaskOffset>? _taskEndOffsets;
+    private int _endpointInformationEpoch;
+
+    internal StreamsGroupMember(
+        StreamsGroupMemberOptions options,
+        IConnectionPool connectionPool,
+        MetadataManager metadataManager,
+        int retryBackoffMs = 100,
+        int retryBackoffMaxMs = 1_000)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(connectionPool);
+        ArgumentNullException.ThrowIfNull(metadataManager);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.GroupId);
+        if (options.RebalanceTimeout.TotalMilliseconds < 1
+            || options.RebalanceTimeout.TotalMilliseconds > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                "RebalanceTimeout must be greater than zero and no greater than Int32.MaxValue milliseconds.");
+        }
+
+        _options = options;
+        _connectionPool = connectionPool;
+        _metadataManager = metadataManager;
+        ExponentialRetryBackoff.Validate(retryBackoffMs, retryBackoffMaxMs);
+        _retryBackoffMs = retryBackoffMs;
+        _retryBackoffMaxMs = retryBackoffMaxMs;
+        _heartbeatTimer = new Timer(
+            static state => ((StreamsGroupMember)state!).QueueHeartbeat(),
+            this,
+            Timeout.Infinite,
+            Timeout.Infinite);
+        _workerTask = RunAsync();
+    }
+
+    public string GroupId => _options.GroupId;
+    public string? InstanceId => _options.InstanceId;
+    public StreamsGroupMemberSnapshot Snapshot => _snapshot;
+
+    public async ValueTask InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfClosed();
+        if (_initialized)
+            return;
+
+        await _initializeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_initialized)
+                return;
+
+            await _metadataManager.InitializeAsync(cancellationToken).ConfigureAwait(false);
+            _initialized = true;
+        }
+        finally
+        {
+            _initializeLock.Release();
+        }
+    }
+
+    internal void MarkInitializedForTesting() => _initialized = true;
+
+    public ValueTask<StreamsGroupHeartbeatResult> JoinAsync(
+        StreamsGroupMemberUpdate initialState,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(initialState);
+        if (initialState.Topology is null)
+            throw new ArgumentException("The initial Streams group state must include a topology.", nameof(initialState));
+
+        return QueueOperationAsync(MemberCommand.Join(initialState), cancellationToken);
+    }
+
+    public ValueTask<StreamsGroupHeartbeatResult> UpdateAsync(
+        StreamsGroupMemberUpdate update,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+        return QueueOperationAsync(MemberCommand.ForUpdate(update), cancellationToken);
+    }
+
+    public ValueTask<StreamsGroupHeartbeatResult> ReportTaskOffsetsAsync(
+        StreamsGroupTaskOffsetReport report,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        return QueueOperationAsync(MemberCommand.ReportOffsets(report), cancellationToken);
+    }
+
+    public ValueTask CloseAsync(CancellationToken cancellationToken = default) =>
+        CloseAsync(new StreamsGroupCloseOptions(), cancellationToken);
+
+    public async ValueTask CloseAsync(
+        StreamsGroupCloseOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        MemberCommand? command = null;
+        lock (_commandWriteGate)
+        {
+            if (Volatile.Read(ref _closeRequested) == 0)
+            {
+                Volatile.Write(ref _closeRequested, 1);
+                command = MemberCommand.Close(options);
+                if (!_commands.Writer.TryWrite(command))
+                    throw new ObjectDisposedException(nameof(StreamsGroupMember));
+            }
+        }
+
+        if (command is null)
+        {
+            await _workerTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        await command.Completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await _workerTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        try
+        {
+            await CloseAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _heartbeatTimer.Dispose();
+        }
+    }
+
+    private async ValueTask<StreamsGroupHeartbeatResult> QueueOperationAsync(
+        MemberCommand command,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfNotInitialized();
+
+        var backgroundFailure = Volatile.Read(ref _backgroundFailure);
+        if (backgroundFailure is not null)
+            throw CreateBackgroundFailureException(backgroundFailure);
+
+        lock (_commandWriteGate)
+        {
+            ThrowIfClosed();
+            if (!_commands.Writer.TryWrite(command))
+                throw new ObjectDisposedException(nameof(StreamsGroupMember));
+        }
+
+        try
+        {
+            return (await command.Completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false))!;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            ObserveFault(command.Completion.Task);
+            throw;
+        }
+    }
+
+    private async Task RunAsync()
+    {
+        try
+        {
+            while (await _commands.Reader.WaitToReadAsync().ConfigureAwait(false))
+            {
+                while (_commands.Reader.TryRead(out var command))
+                {
+                    if (command.Kind == MemberCommandKind.Heartbeat)
+                    {
+                        await ProcessBackgroundHeartbeatAsync().ConfigureAwait(false);
+                        continue;
+                    }
+
+                    if (command.Kind == MemberCommandKind.Close)
+                    {
+                        try
+                        {
+                            await ProcessCloseAsync(command.CloseOptions!).ConfigureAwait(false);
+                            command.Completion.TrySetResult(null);
+                        }
+                        catch (Exception exception)
+                        {
+                            command.Completion.TrySetException(exception);
+                        }
+
+                        _commands.Writer.TryComplete();
+                        return;
+                    }
+
+                    try
+                    {
+                        var result = await ProcessOperationAsync(command).ConfigureAwait(false);
+                        command.Completion.TrySetResult(result);
+                    }
+                    catch (Exception exception)
+                    {
+                        command.Completion.TrySetException(exception);
+                    }
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            Volatile.Write(ref _backgroundFailure, exception);
+            _commands.Writer.TryComplete(exception);
+            while (_commands.Reader.TryRead(out var command))
+                command.Completion.TrySetException(exception);
+        }
+        finally
+        {
+            _heartbeatTimer.Change(Timeout.Infinite, Timeout.Infinite);
+        }
+    }
+
+    private async ValueTask<StreamsGroupHeartbeatResult> ProcessOperationAsync(MemberCommand command)
+    {
+        if (command.Kind != MemberCommandKind.Join && _memberEpoch <= 0)
+            throw new InvalidOperationException("JoinAsync must complete before updating a Streams group member.");
+        if (command.Kind == MemberCommandKind.Join && _memberEpoch > 0)
+            throw new InvalidOperationException("The Streams group member has already joined.");
+
+        StreamsGroupHeartbeatRequest request;
+        switch (command.Kind)
+        {
+            case MemberCommandKind.Join:
+                ApplyUpdate(command.Update!);
+                request = CreateJoinRequest();
+                break;
+            case MemberCommandKind.Update:
+                var update = command.Update!;
+                ApplyUpdate(update);
+                request = update.Topology is null
+                    ? CreateDeltaRequest(update)
+                    : CreateJoinRequest();
+                if (update.Topology is not null)
+                    _memberEpoch = 0;
+                break;
+            case MemberCommandKind.ReportOffsets:
+                _taskOffsets = MapTaskOffsets(command.OffsetReport!.TaskOffsets);
+                _taskEndOffsets = MapTaskOffsets(command.OffsetReport.TaskEndOffsets);
+                request = CreateOffsetRequest();
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported command {command.Kind}.");
+        }
+
+        var response = await SendWithRecoveryAsync(request, CancellationToken.None).ConfigureAwait(false);
+        var result = ApplyResponse(response, createResult: true)!;
+        ScheduleHeartbeat();
+        return result;
+    }
+
+    private async ValueTask ProcessBackgroundHeartbeatAsync()
+    {
+        if (_memberEpoch <= 0 || Volatile.Read(ref _closeRequested) != 0)
+            return;
+
+        try
+        {
+            var request = GetOrCreateSteadyRequest();
+            var response = await SendWithRecoveryAsync(request, CancellationToken.None)
+                .ConfigureAwait(false);
+            ApplyResponse(response, createResult: false);
+            Volatile.Write(ref _backgroundFailure, null);
+        }
+        catch (Exception exception)
+        {
+            Volatile.Write(ref _backgroundFailure, exception);
+        }
+
+        if (Volatile.Read(ref _closeRequested) == 0 && !IsFatalHeartbeatFailure(_backgroundFailure))
+            ScheduleHeartbeat();
+    }
+
+    private async ValueTask ProcessCloseAsync(StreamsGroupCloseOptions options)
+    {
+        _heartbeatTimer.Change(Timeout.Infinite, Timeout.Infinite);
+        try
+        {
+            var terminalEpoch = options.GroupMembershipOperation switch
+            {
+                StreamsGroupMembershipOperation.RemainInGroup => (int?)null,
+                StreamsGroupMembershipOperation.LeaveGroup => -1,
+                StreamsGroupMembershipOperation.Default when InstanceId is not null => -2,
+                _ => -1
+            };
+
+            if (_memberEpoch > 0 && terminalEpoch is not null)
+            {
+                var request = new StreamsGroupHeartbeatRequest
+                {
+                    GroupId = GroupId,
+                    MemberId = _memberId,
+                    MemberEpoch = terminalEpoch.Value,
+                    EndpointInformationEpoch = _endpointInformationEpoch,
+                    InstanceId = InstanceId,
+                    ShutdownApplication = options.ShutdownApplication
+                };
+                await SendWithRecoveryAsync(request, CancellationToken.None, recoverFencing: false)
+                    .ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _memberEpoch = 0;
+            var current = _snapshot;
+            _snapshot = new StreamsGroupMemberSnapshot
+            {
+                IsClosed = true,
+                MemberId = current.MemberId,
+                MemberEpoch = current.MemberEpoch,
+                Assignment = current.Assignment,
+                EndpointInformationEpoch = current.EndpointInformationEpoch,
+                PartitionsByUserEndpoint = current.PartitionsByUserEndpoint,
+                Status = current.Status,
+                HeartbeatInterval = current.HeartbeatInterval,
+                AcceptableRecoveryLag = current.AcceptableRecoveryLag,
+                TaskOffsetInterval = current.TaskOffsetInterval
+            };
+        }
+    }
+
+    private async ValueTask<StreamsGroupHeartbeatResponse> SendWithRecoveryAsync(
+        StreamsGroupHeartbeatRequest request,
+        CancellationToken cancellationToken,
+        bool recoverFencing = true)
+    {
+        var fencedRecoveryAttempted = false;
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            if (_coordinatorId < 0)
+                await FindCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+
+            StreamsGroupHeartbeatResponse response;
+            try
+            {
+                using var lease = await _connectionPool.LeaseConnectionAsync(_coordinatorId, cancellationToken)
+                    .ConfigureAwait(false);
+                var connection = lease.Connection;
+                if (!_metadataManager.HasApiKey(connection, ApiKey.StreamsGroupHeartbeat))
+                {
+                    throw new BrokerVersionException(
+                        "The target Kafka broker does not support StreamsGroupHeartbeat " +
+                        "(KIP-1071). Streams group membership requires Kafka 4.2 or later.");
+                }
+
+                var version = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    ApiKey.StreamsGroupHeartbeat,
+                    StreamsGroupHeartbeatRequest.LowestSupportedVersion,
+                    StreamsGroupHeartbeatRequest.HighestSupportedVersion);
+                response = await connection.SendAsync<StreamsGroupHeartbeatRequest, StreamsGroupHeartbeatResponse>(
+                    request,
+                    version,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception exception) when (
+                RetryHelper.IsRetriableRequestFailure(exception)
+                && (exception is not OperationCanceledException || !cancellationToken.IsCancellationRequested))
+            {
+                _coordinatorId = -1;
+                if (attempt == 4)
+                    throw;
+                request = _memberEpoch <= 0 ? CreateJoinRequest() : CreateFullRequest();
+                await DelayForRetryAsync(attempt + 1, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+            if (response.ErrorCode == ErrorCode.None)
+                return response;
+
+            if (response.ErrorCode == ErrorCode.UnsupportedVersion)
+            {
+                throw new BrokerVersionException(
+                    "The broker rejected StreamsGroupHeartbeat although it advertised API 88. " +
+                    "Enable the Streams rebalance protocol (streams.version >= 1 and " +
+                    "group.coordinator.rebalance.protocols containing 'streams').");
+            }
+
+            if (response.ErrorCode is ErrorCode.NotCoordinator
+                or ErrorCode.CoordinatorNotAvailable
+                or ErrorCode.CoordinatorLoadInProgress)
+            {
+                if (response.ErrorCode != ErrorCode.CoordinatorLoadInProgress)
+                    _coordinatorId = -1;
+                request = _memberEpoch <= 0 ? CreateJoinRequest() : CreateFullRequest();
+                await DelayForRetryAsync(attempt + 1, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+            if (recoverFencing
+                && !fencedRecoveryAttempted
+                && response.ErrorCode is ErrorCode.FencedMemberEpoch or ErrorCode.UnknownMemberId)
+            {
+                fencedRecoveryAttempted = true;
+                _memberEpoch = 0;
+                _steadyRequestCache.Invalidate();
+                request = CreateJoinRequest();
+                continue;
+            }
+
+            throw CreateGroupException(response);
+        }
+
+        throw new GroupException(
+            ErrorCode.CoordinatorNotAvailable,
+            "StreamsGroupHeartbeat failed after 5 coordinator attempts.")
+        { GroupId = GroupId };
+    }
+
+    private async ValueTask FindCoordinatorAsync(CancellationToken cancellationToken)
+    {
+        var brokers = _metadataManager.Metadata.GetBrokers();
+        if (brokers.Count == 0)
+            throw new InvalidOperationException("No brokers available for Streams group coordinator discovery.");
+
+        var request = new FindCoordinatorRequest { Key = GroupId, KeyType = CoordinatorType.Group };
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            try
+            {
+                var broker = brokers[attempt % brokers.Count];
+                using var lease = await _connectionPool.LeaseConnectionAsync(broker.NodeId, cancellationToken)
+                    .ConfigureAwait(false);
+                var connection = lease.Connection;
+                var version = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    ApiKey.FindCoordinator,
+                    FindCoordinatorRequest.LowestSupportedVersion,
+                    FindCoordinatorRequest.HighestSupportedVersion);
+                var response = await connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                    request,
+                    version,
+                    cancellationToken).ConfigureAwait(false);
+                if (response.Coordinators.Count == 0)
+                {
+                    throw new GroupException(
+                        ErrorCode.CoordinatorNotAvailable,
+                        "FindCoordinator returned no Streams group coordinator.")
+                    { GroupId = GroupId };
+                }
+
+                var coordinator = response.Coordinators[0];
+                if (coordinator.ErrorCode is ErrorCode.CoordinatorNotAvailable
+                    or ErrorCode.CoordinatorLoadInProgress)
+                {
+                    if (attempt == 4)
+                        break;
+                    await DelayForRetryAsync(attempt + 1, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+                if (coordinator.ErrorCode != ErrorCode.None)
+                {
+                    throw new GroupException(
+                        coordinator.ErrorCode,
+                        $"FindCoordinator failed for Streams group '{GroupId}': {coordinator.ErrorCode}.")
+                    { GroupId = GroupId };
+                }
+
+                _connectionPool.RegisterBroker(coordinator.NodeId, coordinator.Host, coordinator.Port);
+                _coordinatorId = coordinator.NodeId;
+                return;
+            }
+            catch (Exception exception) when (
+                RetryHelper.IsRetriableRequestFailure(exception)
+                && !cancellationToken.IsCancellationRequested)
+            {
+                if (attempt == 4)
+                {
+                    throw new GroupException(
+                        ErrorCode.CoordinatorNotAvailable,
+                        $"FindCoordinator failed after 5 attempts: {exception.Message}",
+                        exception)
+                    { GroupId = GroupId };
+                }
+                await DelayForRetryAsync(attempt + 1, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        throw new GroupException(
+            ErrorCode.CoordinatorNotAvailable,
+            "FindCoordinator failed after 5 attempts.")
+        { GroupId = GroupId };
+    }
+
+    private static void ObserveFault(Task task)
+    {
+        if (task.IsCompleted)
+        {
+            _ = task.Exception;
+            return;
+        }
+
+        _ = task.ContinueWith(
+            static completed => _ = completed.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private Task DelayForRetryAsync(int failureCount, CancellationToken cancellationToken) =>
+        Task.Delay(
+            ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                _retryBackoffMs,
+                _retryBackoffMaxMs,
+                failureCount),
+            cancellationToken);
+
+    private static bool IsFatalHeartbeatFailure(Exception? exception) => exception switch
+    {
+        BrokerVersionException => true,
+        GroupException { ErrorCode: ErrorCode.StreamsInvalidTopology
+            or ErrorCode.StreamsInvalidTopologyEpoch
+            or ErrorCode.StreamsTopologyFenced
+            or ErrorCode.UnreleasedInstanceId } => true,
+        _ => false
+    };
+
+    private Exception CreateBackgroundFailureException(Exception exception) => exception switch
+    {
+        BrokerVersionException => new BrokerVersionException(
+            "The Streams group heartbeat loop stopped because the broker does not support the protocol.",
+            exception),
+        GroupException { ErrorCode: { } errorCode } => new GroupException(
+            errorCode,
+            "The Streams group heartbeat loop failed.",
+            exception)
+            { GroupId = GroupId },
+        _ => new GroupException("The Streams group heartbeat loop failed.", exception)
+            { GroupId = GroupId }
+    };
+
+    private GroupException CreateGroupException(StreamsGroupHeartbeatResponse response) => new(
+        response.ErrorCode,
+        $"StreamsGroupHeartbeat failed: {response.ErrorCode} - {response.ErrorMessage}")
+        { GroupId = GroupId };
+
+    private StreamsGroupHeartbeatResult? ApplyResponse(
+        StreamsGroupHeartbeatResponse response,
+        bool createResult)
+    {
+        var heartbeatRequestChanged = response.MemberEpoch != _memberEpoch
+            || response.EndpointInformationEpoch != _endpointInformationEpoch
+            || (!string.IsNullOrEmpty(response.MemberId) && response.MemberId != _memberId);
+        if (!string.IsNullOrEmpty(response.MemberId))
+            _memberId = response.MemberId;
+
+        _memberEpoch = response.MemberEpoch;
+        if (response.HeartbeatIntervalMs > 0)
+            _heartbeatIntervalMs = response.HeartbeatIntervalMs;
+
+        var current = _snapshot;
+        var active = response.ActiveTasks is null
+            ? current.Assignment.ActiveTasks
+            : MapTaskSets(response.ActiveTasks);
+        var standby = response.StandbyTasks is null
+            ? current.Assignment.StandbyTasks
+            : MapTaskSets(response.StandbyTasks);
+        var warmup = response.WarmupTasks is null
+            ? current.Assignment.WarmupTasks
+            : MapTaskSets(response.WarmupTasks);
+        var status = response.Status is null ? current.Status : MapStatus(response.Status);
+        var endpoints = response.PartitionsByUserEndpoint is null
+            ? current.PartitionsByUserEndpoint
+            : MapEndpointAssignments(response.PartitionsByUserEndpoint);
+        var heartbeatInterval = response.HeartbeatIntervalMs > 0
+            ? TimeSpan.FromMilliseconds(response.HeartbeatIntervalMs)
+            : current.HeartbeatInterval;
+        var taskOffsetInterval = response.TaskOffsetIntervalMs > 0
+            ? TimeSpan.FromMilliseconds(response.TaskOffsetIntervalMs)
+            : current.TaskOffsetInterval;
+
+        _endpointInformationEpoch = response.EndpointInformationEpoch;
+        if (heartbeatRequestChanged)
+            _steadyRequestCache.Invalidate();
+        var assignmentChanged = response.ActiveTasks is not null
+            || response.StandbyTasks is not null
+            || response.WarmupTasks is not null;
+        var snapshotChanged = current.IsJoined != (response.MemberEpoch > 0)
+            || current.MemberId != _memberId
+            || current.MemberEpoch != response.MemberEpoch
+            || assignmentChanged
+            || response.Status is not null
+            || response.PartitionsByUserEndpoint is not null
+            || current.EndpointInformationEpoch != response.EndpointInformationEpoch
+            || current.HeartbeatInterval != heartbeatInterval
+            || current.AcceptableRecoveryLag != response.AcceptableRecoveryLag
+            || current.TaskOffsetInterval != taskOffsetInterval;
+        if (snapshotChanged)
+        {
+            _snapshot = new StreamsGroupMemberSnapshot
+            {
+                IsJoined = response.MemberEpoch > 0,
+                MemberId = _memberId,
+                MemberEpoch = response.MemberEpoch,
+                Assignment = assignmentChanged
+                    ? new StreamsGroupAssignment
+                    {
+                        ActiveTasks = active,
+                        StandbyTasks = standby,
+                        WarmupTasks = warmup
+                    }
+                    : current.Assignment,
+                EndpointInformationEpoch = response.EndpointInformationEpoch,
+                PartitionsByUserEndpoint = endpoints,
+                Status = status,
+                HeartbeatInterval = heartbeatInterval,
+                AcceptableRecoveryLag = response.AcceptableRecoveryLag,
+                TaskOffsetInterval = taskOffsetInterval
+            };
+        }
+
+        if (!createResult)
+            return null;
+
+        return new StreamsGroupHeartbeatResult
+        {
+            ThrottleTime = TimeSpan.FromMilliseconds(response.ThrottleTimeMs),
+            MemberId = _memberId,
+            MemberEpoch = response.MemberEpoch,
+            HeartbeatInterval = heartbeatInterval,
+            AcceptableRecoveryLag = response.AcceptableRecoveryLag,
+            TaskOffsetInterval = taskOffsetInterval,
+            Status = response.Status is null ? null : status,
+            ActiveTasks = response.ActiveTasks is null ? null : active,
+            StandbyTasks = response.StandbyTasks is null ? null : standby,
+            WarmupTasks = response.WarmupTasks is null ? null : warmup,
+            EndpointInformationEpoch = response.EndpointInformationEpoch,
+            PartitionsByUserEndpoint = response.PartitionsByUserEndpoint is null ? null : endpoints
+        };
+    }
+
+    private void ApplyUpdate(StreamsGroupMemberUpdate update)
+    {
+        _endpointInformationEpoch = update.EndpointInformationEpoch;
+        if (update.Topology is not null)
+            _topology = MapTopology(update.Topology);
+        if (update.ActiveTasks is not null)
+            _activeTasks = MapTaskSets(update.ActiveTasks);
+        if (update.StandbyTasks is not null)
+            _standbyTasks = MapTaskSets(update.StandbyTasks);
+        if (update.WarmupTasks is not null)
+            _warmupTasks = MapTaskSets(update.WarmupTasks);
+        if (update.ProcessId is not null)
+            _processId = update.ProcessId;
+        if (update.UserEndpoint is not null)
+            _userEndpoint = MapEndpoint(update.UserEndpoint);
+        if (update.ClientTags is not null)
+            _clientTags = MapKeyValues(update.ClientTags);
+        if (update.TaskOffsets is not null)
+            _taskOffsets = MapTaskOffsets(update.TaskOffsets);
+        if (update.TaskEndOffsets is not null)
+            _taskEndOffsets = MapTaskOffsets(update.TaskEndOffsets);
+        _steadyRequestCache.Invalidate();
+    }
+
+    private StreamsGroupHeartbeatRequest CreateJoinRequest() => new()
+    {
+        GroupId = GroupId,
+        MemberId = _memberId,
+        MemberEpoch = 0,
+        EndpointInformationEpoch = _endpointInformationEpoch,
+        InstanceId = InstanceId,
+        RackId = _options.RackId,
+        RebalanceTimeoutMs = checked((int)_options.RebalanceTimeout.TotalMilliseconds),
+        Topology = _topology,
+        ActiveTasks = [],
+        StandbyTasks = [],
+        WarmupTasks = [],
+        ProcessId = _processId,
+        UserEndpoint = _userEndpoint,
+        ClientTags = _clientTags,
+        TaskOffsets = _taskOffsets,
+        TaskEndOffsets = _taskEndOffsets
+    };
+
+    private StreamsGroupHeartbeatRequest CreateDeltaRequest(StreamsGroupMemberUpdate update) => new()
+    {
+        GroupId = GroupId,
+        MemberId = _memberId,
+        MemberEpoch = _memberEpoch,
+        EndpointInformationEpoch = update.EndpointInformationEpoch,
+        InstanceId = InstanceId,
+        ActiveTasks = update.ActiveTasks is null ? null : _activeTasks,
+        StandbyTasks = update.StandbyTasks is null ? null : _standbyTasks,
+        WarmupTasks = update.WarmupTasks is null ? null : _warmupTasks,
+        ProcessId = update.ProcessId,
+        UserEndpoint = update.UserEndpoint is null ? null : _userEndpoint,
+        ClientTags = update.ClientTags is null ? null : _clientTags,
+        TaskOffsets = update.TaskOffsets is null ? null : _taskOffsets,
+        TaskEndOffsets = update.TaskEndOffsets is null ? null : _taskEndOffsets,
+        ShutdownApplication = update.ShutdownApplication
+    };
+
+    private StreamsGroupHeartbeatRequest CreateOffsetRequest() => new()
+    {
+        GroupId = GroupId,
+        MemberId = _memberId,
+        MemberEpoch = _memberEpoch,
+        EndpointInformationEpoch = _endpointInformationEpoch,
+        InstanceId = InstanceId,
+        TaskOffsets = _taskOffsets,
+        TaskEndOffsets = _taskEndOffsets
+    };
+
+    private StreamsGroupHeartbeatRequest CreateFullRequest() => new()
+    {
+        GroupId = GroupId,
+        MemberId = _memberId,
+        MemberEpoch = _memberEpoch,
+        EndpointInformationEpoch = _endpointInformationEpoch,
+        InstanceId = InstanceId,
+        RackId = _options.RackId,
+        RebalanceTimeoutMs = checked((int)_options.RebalanceTimeout.TotalMilliseconds),
+        ActiveTasks = _activeTasks,
+        StandbyTasks = _standbyTasks,
+        WarmupTasks = _warmupTasks,
+        ProcessId = _processId,
+        UserEndpoint = _userEndpoint,
+        ClientTags = _clientTags,
+        TaskOffsets = _taskOffsets,
+        TaskEndOffsets = _taskEndOffsets
+    };
+
+    internal StreamsGroupHeartbeatRequest GetOrCreateSteadyRequest() =>
+        _steadyRequestCache.Get(
+            GroupId,
+            _memberId,
+            _memberEpoch,
+            _endpointInformationEpoch,
+            InstanceId);
+
+    private void QueueHeartbeat()
+    {
+        if (Volatile.Read(ref _closeRequested) == 0)
+            _commands.Writer.TryWrite(MemberCommand.Heartbeat);
+    }
+
+    private void ScheduleHeartbeat() =>
+        _heartbeatTimer.Change(Math.Max(_heartbeatIntervalMs, 1), Timeout.Infinite);
+
+    private void ThrowIfClosed()
+    {
+        if (Volatile.Read(ref _closeRequested) != 0)
+            throw new ObjectDisposedException(nameof(StreamsGroupMember));
+    }
+
+    private void ThrowIfNotInitialized()
+    {
+        if (!_initialized)
+        {
+            throw new InvalidOperationException(
+                "The Streams group member is not initialized. Call InitializeAsync() before joining.");
+        }
+    }
+
+    private static StreamsGroupHeartbeatTopology MapTopology(StreamsGroupTopology source)
+    {
+        var subtopologies = new StreamsGroupHeartbeatSubtopology[source.Subtopologies.Count];
+        for (var i = 0; i < subtopologies.Length; i++)
+        {
+            var item = source.Subtopologies[i];
+            subtopologies[i] = new StreamsGroupHeartbeatSubtopology
+            {
+                SubtopologyId = item.SubtopologyId,
+                SourceTopics = Copy(item.SourceTopics),
+                SourceTopicRegex = Copy(item.SourceTopicRegex),
+                StateChangelogTopics = MapTopicInfo(item.StateChangelogTopics),
+                RepartitionSinkTopics = Copy(item.RepartitionSinkTopics),
+                RepartitionSourceTopics = MapTopicInfo(item.RepartitionSourceTopics),
+                CopartitionGroups = MapCopartitionGroups(item.CopartitionGroups)
+            };
+        }
+
+        return new StreamsGroupHeartbeatTopology { Epoch = source.Epoch, Subtopologies = subtopologies };
+    }
+
+    private static StreamsGroupHeartbeatTopicInfo[] MapTopicInfo(IReadOnlyList<StreamsGroupTopicInfo> source)
+    {
+        var result = new StreamsGroupHeartbeatTopicInfo[source.Count];
+        for (var i = 0; i < result.Length; i++)
+        {
+            var item = source[i];
+            result[i] = new StreamsGroupHeartbeatTopicInfo
+            {
+                Name = item.Name,
+                Partitions = item.Partitions,
+                ReplicationFactor = item.ReplicationFactor,
+                TopicConfigs = MapKeyValues(item.TopicConfigs)
+            };
+        }
+        return result;
+    }
+
+    private static StreamsGroupHeartbeatCopartitionGroup[] MapCopartitionGroups(
+        IReadOnlyList<StreamsGroupCopartitionGroup> source)
+    {
+        var result = new StreamsGroupHeartbeatCopartitionGroup[source.Count];
+        for (var i = 0; i < result.Length; i++)
+        {
+            var item = source[i];
+            result[i] = new StreamsGroupHeartbeatCopartitionGroup
+            {
+                SourceTopics = Copy(item.SourceTopics),
+                SourceTopicRegex = Copy(item.SourceTopicRegex),
+                RepartitionSourceTopics = Copy(item.RepartitionSourceTopics)
+            };
+        }
+        return result;
+    }
+
+    private static StreamsGroupHeartbeatTaskIds[] MapTaskSets(IReadOnlyList<StreamsGroupTaskSet> source)
+    {
+        var result = new StreamsGroupHeartbeatTaskIds[source.Count];
+        for (var i = 0; i < result.Length; i++)
+        {
+            var item = source[i];
+            result[i] = new StreamsGroupHeartbeatTaskIds
+            {
+                SubtopologyId = item.SubtopologyId,
+                Partitions = Copy(item.Partitions)
+            };
+        }
+        return result;
+    }
+
+    private static StreamsGroupTaskSet[] MapTaskSets(IReadOnlyList<StreamsGroupHeartbeatTaskIds> source)
+    {
+        var result = new StreamsGroupTaskSet[source.Count];
+        for (var i = 0; i < result.Length; i++)
+        {
+            var item = source[i];
+            result[i] = new StreamsGroupTaskSet
+            {
+                SubtopologyId = item.SubtopologyId,
+                Partitions = Copy(item.Partitions)
+            };
+        }
+        return result;
+    }
+
+    private static StreamsGroupHeartbeatTaskOffset[] MapTaskOffsets(
+        IReadOnlyList<StreamsGroupTaskOffset> source)
+    {
+        var result = new StreamsGroupHeartbeatTaskOffset[source.Count];
+        for (var i = 0; i < result.Length; i++)
+        {
+            var item = source[i];
+            result[i] = new StreamsGroupHeartbeatTaskOffset
+            {
+                SubtopologyId = item.SubtopologyId,
+                Partition = item.Partition,
+                Offset = item.Offset
+            };
+        }
+        return result;
+    }
+
+    private static StreamsGroupHeartbeatKeyValue[] MapKeyValues(IReadOnlyList<StreamsGroupKeyValue> source)
+    {
+        var result = new StreamsGroupHeartbeatKeyValue[source.Count];
+        for (var i = 0; i < result.Length; i++)
+        {
+            var item = source[i];
+            result[i] = new StreamsGroupHeartbeatKeyValue { Key = item.Key, Value = item.Value };
+        }
+        return result;
+    }
+
+    private static StreamsGroupHeartbeatEndpoint MapEndpoint(StreamsGroupEndpoint source) => new()
+    {
+        Host = source.Host,
+        Port = source.Port
+    };
+
+    private static StreamsGroupStatus[] MapStatus(IReadOnlyList<StreamsGroupHeartbeatStatus> source)
+    {
+        var result = new StreamsGroupStatus[source.Count];
+        for (var i = 0; i < result.Length; i++)
+        {
+            var item = source[i];
+            result[i] = new StreamsGroupStatus
+            {
+                StatusCode = item.StatusCode,
+                StatusDetail = item.StatusDetail
+            };
+        }
+        return result;
+    }
+
+    private static StreamsGroupEndpointAssignment[] MapEndpointAssignments(
+        IReadOnlyList<StreamsGroupHeartbeatEndpointPartitions> source)
+    {
+        var result = new StreamsGroupEndpointAssignment[source.Count];
+        for (var i = 0; i < result.Length; i++)
+        {
+            var item = source[i];
+            result[i] = new StreamsGroupEndpointAssignment
+            {
+                UserEndpoint = new StreamsGroupEndpoint
+                {
+                    Host = item.UserEndpoint.Host,
+                    Port = item.UserEndpoint.Port
+                },
+                ActivePartitions = MapTopicPartitions(item.ActivePartitions),
+                StandbyPartitions = MapTopicPartitions(item.StandbyPartitions)
+            };
+        }
+        return result;
+    }
+
+    private static StreamsGroupTopicPartitions[] MapTopicPartitions(
+        IReadOnlyList<StreamsGroupHeartbeatTopicPartitions> source)
+    {
+        var result = new StreamsGroupTopicPartitions[source.Count];
+        for (var i = 0; i < result.Length; i++)
+        {
+            var item = source[i];
+            result[i] = new StreamsGroupTopicPartitions
+            {
+                Topic = item.Topic,
+                Partitions = Copy(item.Partitions)
+            };
+        }
+        return result;
+    }
+
+    private static T[] Copy<T>(IReadOnlyList<T> source)
+    {
+        if (source.Count == 0)
+            return [];
+        var result = new T[source.Count];
+        for (var i = 0; i < result.Length; i++)
+            result[i] = source[i];
+        return result;
+    }
+
+    private enum MemberCommandKind : byte
+    {
+        Heartbeat,
+        Join,
+        Update,
+        ReportOffsets,
+        Close
+    }
+
+    private sealed class MemberCommand
+    {
+        internal static readonly MemberCommand Heartbeat = new(MemberCommandKind.Heartbeat);
+
+        private MemberCommand(MemberCommandKind kind)
+        {
+            Kind = kind;
+        }
+
+        internal MemberCommandKind Kind { get; }
+        internal StreamsGroupMemberUpdate? Update { get; init; }
+        internal StreamsGroupTaskOffsetReport? OffsetReport { get; init; }
+        internal StreamsGroupCloseOptions? CloseOptions { get; init; }
+        internal TaskCompletionSource<StreamsGroupHeartbeatResult?> Completion { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal static MemberCommand Join(StreamsGroupMemberUpdate update) => new(MemberCommandKind.Join)
+        {
+            Update = update
+        };
+
+        internal static MemberCommand ForUpdate(StreamsGroupMemberUpdate update) => new(MemberCommandKind.Update)
+        {
+            Update = update
+        };
+
+        internal static MemberCommand ReportOffsets(StreamsGroupTaskOffsetReport report) =>
+            new(MemberCommandKind.ReportOffsets) { OffsetReport = report };
+
+        internal static MemberCommand Close(StreamsGroupCloseOptions options) => new(MemberCommandKind.Close)
+        {
+            CloseOptions = options
+        };
+    }
+}

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -534,6 +534,12 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                     .ConfigureAwait(false);
             }
         }
+        catch (GroupException exception)
+            when (exception.ErrorCode is ErrorCode.FencedMemberEpoch or ErrorCode.UnknownMemberId)
+        {
+            retainMembership = false;
+            throw;
+        }
         finally
         {
             _memberEpoch = 0;
@@ -930,13 +936,21 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
     {
         _endpointInformationEpoch = update.EndpointInformationEpoch;
         if (update.Topology is not null)
+        {
             _topology = MapTopology(update.Topology);
-        if (update.ActiveTasks is not null)
-            _activeTasks = MapTaskSets(update.ActiveTasks);
-        if (update.StandbyTasks is not null)
-            _standbyTasks = MapTaskSets(update.StandbyTasks);
-        if (update.WarmupTasks is not null)
-            _warmupTasks = MapTaskSets(update.WarmupTasks);
+            _activeTasks = [];
+            _standbyTasks = [];
+            _warmupTasks = [];
+        }
+        else
+        {
+            if (update.ActiveTasks is not null)
+                _activeTasks = MapTaskSets(update.ActiveTasks);
+            if (update.StandbyTasks is not null)
+                _standbyTasks = MapTaskSets(update.StandbyTasks);
+            if (update.WarmupTasks is not null)
+                _warmupTasks = MapTaskSets(update.WarmupTasks);
+        }
         if (update.ProcessId is not null)
             _processId = update.ProcessId;
         if (update.UserEndpoint is not null)

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -867,9 +867,9 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         { GroupId = GroupId };
     }
 
-    private bool IsRetriableConnectionFailure(Exception exception) =>
+    private static bool IsRetriableConnectionFailure(Exception exception) =>
         RetryHelper.IsRetriableRequestFailure(exception)
-        || (exception is ObjectDisposedException && Volatile.Read(ref _closeRequested) == 0);
+        || exception is ObjectDisposedException;
 
     private static void ObserveFault(Task task)
     {

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -365,15 +365,12 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
 
     private async ValueTask CompleteCloseAsync(MemberCommand command)
     {
-        try
-        {
-            await ProcessCloseAsync(command.CloseOptions!).ConfigureAwait(false);
-            command.Completion.TrySetResult(null);
-        }
-        catch (Exception exception)
-        {
-            command.Completion.TrySetException(exception);
-        }
+        await ProcessCloseAsync(command.CloseOptions!).AsTask().ContinueWith(
+            static (task, state) => CompleteCloseCommand(task, (MemberCommand)state!),
+            command,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default).ConfigureAwait(false);
 
         _commands.Writer.TryComplete();
         var disposed = new ObjectDisposedException(nameof(StreamsGroupMember));
@@ -383,6 +380,25 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                 continue;
             CompleteAbandonedCommand(pending, disposed);
         }
+    }
+
+    private static void CompleteCloseCommand(Task task, MemberCommand command)
+    {
+        if (task.Status == TaskStatus.RanToCompletion)
+        {
+            command.Completion.TrySetResult(null);
+            return;
+        }
+
+        if (task.IsCanceled)
+        {
+            command.Completion.TrySetCanceled();
+            return;
+        }
+
+        var aggregate = task.Exception!;
+        command.Completion.TrySetException(
+            aggregate.InnerExceptions.Count == 1 ? aggregate.InnerException! : aggregate);
     }
 
     private static void CompleteAbandonedCommand(

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -261,6 +261,14 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
                         return;
                     }
 
+                    var backgroundFailure = Volatile.Read(ref _backgroundFailure);
+                    if (backgroundFailure is not null)
+                    {
+                        command.Completion.TrySetException(
+                            CreateBackgroundFailureException(backgroundFailure));
+                        continue;
+                    }
+
                     try
                     {
                         var result = await ProcessOperationAsync(command).ConfigureAwait(false);

--- a/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
@@ -72,7 +72,7 @@ public class KafkaContainerDefault : KafkaTestContainer
             // 2. group.coordinator.rebalance.protocols must include "share"
             //    for the coordinator to handle share group state
             .WithEnvironment("KAFKA_GROUP_SHARE_ENABLE", "true")
-            .WithEnvironment("KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS", "classic,consumer,share")
+            .WithEnvironment("KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS", "classic,consumer,share,streams")
             .WithEnvironment("KAFKA_GROUP_SHARE_RECORD_LOCK_DURATION_MS", "15000")
             .WithEnvironment("KAFKA_GROUP_SHARE_MIN_RECORD_LOCK_DURATION_MS", "5000")
             .WithEnvironment("KAFKA_GROUP_SHARE_MAX_RECORD_LOCK_DURATION_MS", "60000")

--- a/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
@@ -73,6 +73,7 @@ public class KafkaContainerDefault : KafkaTestContainer
             //    for the coordinator to handle share group state
             .WithEnvironment("KAFKA_GROUP_SHARE_ENABLE", "true")
             .WithEnvironment("KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS", "classic,consumer,share,streams")
+            .WithEnvironment("KAFKA_STREAMS_VERSION", "1")
             .WithEnvironment("KAFKA_GROUP_SHARE_RECORD_LOCK_DURATION_MS", "15000")
             .WithEnvironment("KAFKA_GROUP_SHARE_MIN_RECORD_LOCK_DURATION_MS", "5000")
             .WithEnvironment("KAFKA_GROUP_SHARE_MAX_RECORD_LOCK_DURATION_MS", "60000")

--- a/tests/Dekaf.Tests.Integration/StreamsGroupMemberIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/StreamsGroupMemberIntegrationTests.cs
@@ -1,0 +1,52 @@
+using Dekaf.Streams;
+
+namespace Dekaf.Tests.Integration;
+
+[SupportsKafka(420)]
+public sealed class StreamsGroupMemberIntegrationTests(KafkaTestContainer kafka)
+    : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task MemberJoinsAndLeavesStreamsGroup()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        await using var client = Kafka.Connect(KafkaContainer.BootstrapServers, builder =>
+            builder.WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()));
+        await using var member = client.CreateStreamsGroupMember(new StreamsGroupMemberOptions
+        {
+            GroupId = $"streams-group-{Guid.NewGuid():N}"
+        });
+        await member.InitializeAsync();
+
+        var result = await member.JoinAsync(new StreamsGroupMemberUpdate
+        {
+            Topology = new StreamsGroupTopology
+            {
+                Epoch = 0,
+                Subtopologies =
+                [
+                    new StreamsGroupSubtopology
+                    {
+                        SubtopologyId = "0",
+                        SourceTopics = [topic],
+                        SourceTopicRegex = [],
+                        StateChangelogTopics = [],
+                        RepartitionSinkTopics = [],
+                        RepartitionSourceTopics = [],
+                        CopartitionGroups = []
+                    }
+                ]
+            },
+            ActiveTasks = [],
+            StandbyTasks = [],
+            WarmupTasks = [],
+            ProcessId = "integration-process",
+            ClientTags = []
+        });
+
+        await Assert.That(result.MemberEpoch).IsGreaterThan(0);
+        await Assert.That(member.Snapshot.IsJoined).IsTrue();
+        await member.CloseAsync();
+        await Assert.That(member.Snapshot.IsClosed).IsTrue();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -5,11 +5,31 @@ using Dekaf.Networking;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.Security.Sasl;
+using Dekaf.Streams;
 
 namespace Dekaf.Tests.Unit.Builder;
 
 public sealed class KafkaClientBuilderTests
 {
+    [Test]
+    public async Task RootClient_CreatedStreamsGroupMemberUsesSharedInfrastructure()
+    {
+        await using var client = Kafka.Connect("localhost:9092");
+        await using var producer = client.CreateProducer<string, string>().Build();
+        await using var member = client.CreateStreamsGroupMember(new StreamsGroupMemberOptions
+        {
+            GroupId = "streams-group",
+            InstanceId = "instance-1"
+        });
+
+        var producerMetadata = GetField<MetadataManager>(producer, "_metadataManager");
+        var memberMetadata = GetField<MetadataManager>(member, "_metadataManager");
+
+        await Assert.That(ReferenceEquals(producerMetadata, memberMetadata)).IsTrue();
+        await Assert.That(member.GroupId).IsEqualTo("streams-group");
+        await Assert.That(member.InstanceId).IsEqualTo("instance-1");
+    }
+
     [Test]
     public async Task RootClient_MetadataClusterCheck_IsAppliedToSharedMetadataManager()
     {

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -1362,6 +1362,22 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task CloseAsync_AfterDisposeObservesCompletedClose()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Success(epoch: -1));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.DisposeAsync();
+        await fixture.Member.CloseAsync();
+
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(2);
+    }
+
+    [Test]
     public async Task CloseAsync_WhenCallerCancelsObservesLaterTerminalFailure()
     {
         var connection = new ScriptedConnection();

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -425,31 +425,26 @@ public sealed class StreamsGroupMemberTests
     {
         var connection = new ScriptedConnection();
         connection.EnqueueHeartbeat(Success(epoch: 1, heartbeatIntervalMs: 1));
-        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        var pendingHeartbeat = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(pendingHeartbeat.Task);
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        await connection.SecondHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var update = fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            ProcessId = "process-2"
+        }).AsTask();
+        pendingHeartbeat.SetResult(new StreamsGroupHeartbeatResponse
         {
             ErrorCode = ErrorCode.GroupAuthorizationFailed,
             MemberId = "member-1"
         });
-        connection.EnqueueHeartbeat(Success(epoch: 2));
-        await using var fixture = CreateFixture(connection);
-        await fixture.Member.JoinAsync(CreateInitialUpdate());
-        await connection.SecondHeartbeatCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        GroupException? failure = null;
-        for (var attempt = 0; attempt < 2 && failure is null; attempt++)
-        {
-            try
-            {
-                await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate { ProcessId = "process-2" });
-            }
-            catch (GroupException exception)
-            {
-                failure = exception;
-            }
-        }
-
-        await Assert.That(failure).IsNotNull();
+        var failure = await Assert.ThrowsAsync<GroupException>(async () => await update);
         await Assert.That(failure!.ErrorCode).IsEqualTo(ErrorCode.GroupAuthorizationFailed);
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(2);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -957,6 +957,75 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task CloseAsync_DuringInitializationWaitsAndInitializationFailsClosed(bool dispose)
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        var refreshStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRefresh = new TaskCompletionSource<MetadataResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(connection));
+        connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                Arg.Any<ApiVersionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys =
+                [
+                    new ApiVersion(
+                        ApiKey.Metadata,
+                        MetadataRequest.LowestSupportedVersion,
+                        MetadataRequest.HighestSupportedVersion)
+                ]
+            });
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                refreshStarted.TrySetResult();
+                return new ValueTask<MetadataResponse>(releaseRefresh.Task);
+            });
+        var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        var member = new StreamsGroupMember(
+            new StreamsGroupMemberOptions { GroupId = "streams-group" },
+            pool,
+            metadataManager);
+        var metadataResponse = new MetadataResponse
+        {
+            Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
+            Topics = []
+        };
+
+        try
+        {
+            var initialize = member.InitializeAsync().AsTask();
+            await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var close = dispose
+                ? member.DisposeAsync().AsTask()
+                : member.CloseAsync().AsTask();
+
+            await Assert.That(close.IsCompleted).IsFalse();
+            releaseRefresh.SetResult(metadataResponse);
+            _ = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+                initialize.WaitAsync(TimeSpan.FromSeconds(5)));
+            await close.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            releaseRefresh.TrySetResult(metadataResponse);
+            await metadataManager.DisposeAsync();
+            await member.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task CloseAsync_BypassesCanceledForegroundBacklog()
     {
         var connection = new ScriptedConnection();

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -345,6 +345,25 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task CloseAsync_RetiredConnectionRediscoversAndRetries()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Task.FromException<StreamsGroupHeartbeatResponse>(
+            new ObjectDisposedException("KafkaConnection")));
+        connection.EnqueueHeartbeat(Success(epoch: -1));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.CloseAsync();
+
+        await Assert.That(connection.FindCoordinatorRequestCount).IsEqualTo(2);
+        await Assert.That(connection.HeartbeatRequests[1].MemberEpoch).IsEqualTo(-1);
+        await Assert.That(connection.HeartbeatRequests[2].MemberEpoch).IsEqualTo(-1);
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
+    }
+
+    [Test]
     public async Task CloseAsync_RemainInGroupSendsNoTerminalHeartbeat()
     {
         var connection = new ScriptedConnection();

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -486,6 +486,59 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(fixture.Member.Snapshot.IsJoined).IsFalse();
     }
 
+    [Arguments(null, StreamsGroupMembershipOperation.Default, true, ErrorCode.UnknownMemberId)]
+    [Arguments(null, StreamsGroupMembershipOperation.Default, true, ErrorCode.FencedMemberEpoch)]
+    [Arguments("instance-1", StreamsGroupMembershipOperation.LeaveGroup, false, ErrorCode.UnknownMemberId)]
+    [Arguments("instance-1", StreamsGroupMembershipOperation.LeaveGroup, false, ErrorCode.FencedMemberEpoch)]
+    [Test]
+    public async Task CloseAsync_PreexistingAmbiguousMembershipLossCompletesSuccessfully(
+        string? instanceId,
+        StreamsGroupMembershipOperation operation,
+        bool ambiguousJoin,
+        ErrorCode errorCode)
+    {
+        var connection = new ScriptedConnection();
+        var pendingHeartbeat = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!ambiguousJoin)
+            connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(pendingHeartbeat.Task);
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = errorCode,
+            MemberId = "member-1"
+        });
+        await using var fixture = CreateFixture(connection, instanceId);
+        using var cancellation = new CancellationTokenSource();
+
+        Task ambiguousOperation;
+        if (ambiguousJoin)
+        {
+            ambiguousOperation = fixture.Member.JoinAsync(CreateInitialUpdate(), cancellation.Token).AsTask();
+        }
+        else
+        {
+            await fixture.Member.JoinAsync(CreateInitialUpdate());
+            ambiguousOperation = fixture.Member.UpdateAsync(
+                new StreamsGroupMemberUpdate { ProcessId = "process-2" },
+                cancellation.Token).AsTask();
+        }
+        await (ambiguousJoin
+                ? connection.FirstHeartbeatStarted.Task
+                : connection.SecondHeartbeatStarted.Task)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => ambiguousOperation);
+
+        await fixture.Member.CloseAsync(new StreamsGroupCloseOptions
+        {
+            GroupMembershipOperation = operation
+        });
+
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
+        await Assert.That(fixture.Member.Snapshot.IsJoined).IsFalse();
+    }
+
     [Arguments(StreamsGroupMembershipOperation.Default, false, -2, ErrorCode.FencedMemberEpoch)]
     [Arguments(StreamsGroupMembershipOperation.RemainInGroup, true, 1, ErrorCode.UnknownMemberId)]
     [Test]

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -679,6 +679,31 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task BackgroundHeartbeat_UnexpectedFailureIsPreservedAfterWorkerStops()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1, heartbeatIntervalMs: 1));
+        var unexpectedFailure = new InvalidOperationException("unexpected heartbeat failure");
+        connection.EnqueueHeartbeat(Task.FromException<StreamsGroupHeartbeatResponse>(unexpectedFailure));
+        var fixture = CreateFixture(connection);
+        try
+        {
+            await fixture.Member.JoinAsync(CreateInitialUpdate());
+            await GetWorkerTask(fixture.Member).WaitAsync(TimeSpan.FromSeconds(5));
+
+            var failure = await Assert.ThrowsAsync<GroupException>(async () =>
+                await fixture.Member.JoinAsync(CreateInitialUpdate()));
+
+            await Assert.That(failure!.InnerException).IsSameReferenceAs(unexpectedFailure);
+            await Assert.That(failure.GroupId).IsEqualTo("streams-group");
+        }
+        finally
+        {
+            await fixture.DisposeMemberAndMetadataAsync();
+        }
+    }
+
+    [Test]
     public async Task BackgroundHeartbeat_PermanentProtocolFailureAllowsExplicitRejoin()
     {
         var connection = new ScriptedConnection();
@@ -1268,6 +1293,7 @@ public sealed class StreamsGroupMemberTests
     private static readonly FieldInfo HeartbeatTimerField = GetMemberField("_heartbeatTimer");
     private static readonly FieldInfo HeartbeatIntervalMsField = GetMemberField("_heartbeatIntervalMs");
     private static readonly FieldInfo CommandsField = GetMemberField("_commands");
+    private static readonly FieldInfo WorkerTaskField = GetMemberField("_workerTask");
     private static readonly MethodInfo QueueHeartbeatMethod = typeof(StreamsGroupMember).GetMethod(
         "QueueHeartbeat",
         BindingFlags.Instance | BindingFlags.NonPublic)!;
@@ -1280,6 +1306,9 @@ public sealed class StreamsGroupMemberTests
 
     private static bool QueueHeartbeat(StreamsGroupMember member) =>
         (bool)QueueHeartbeatMethod.Invoke(member, null)!;
+
+    private static Task GetWorkerTask(StreamsGroupMember member) =>
+        (Task)WorkerTaskField.GetValue(member)!;
 
     private static bool CompleteCommandWriter(StreamsGroupMember member)
     {
@@ -1309,6 +1338,12 @@ public sealed class StreamsGroupMemberTests
                     GroupMembershipOperation = StreamsGroupMembershipOperation.RemainInGroup
                 });
             }
+            await Member.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+
+        public async ValueTask DisposeMemberAndMetadataAsync()
+        {
             await Member.DisposeAsync();
             await metadataManager.DisposeAsync();
         }

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -385,6 +385,40 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(fixture.Member.Snapshot.MemberEpoch).IsEqualTo(1);
     }
 
+    [Arguments(StreamsGroupMembershipOperation.Default, false, ErrorCode.FencedMemberEpoch)]
+    [Arguments(StreamsGroupMembershipOperation.Default, false, ErrorCode.UnknownMemberId)]
+    [Arguments(StreamsGroupMembershipOperation.RemainInGroup, true, ErrorCode.FencedMemberEpoch)]
+    [Arguments(StreamsGroupMembershipOperation.RemainInGroup, true, ErrorCode.UnknownMemberId)]
+    [Test]
+    public async Task CloseAsync_MembershipLossClearsRetainedIdentity(
+        StreamsGroupMembershipOperation operation,
+        bool shutdownApplication,
+        ErrorCode errorCode)
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = errorCode,
+            MemberId = "member-1"
+        });
+        await using var fixture = CreateFixture(connection, instanceId: "instance-1");
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        var failure = await Assert.ThrowsAsync<GroupException>(async () =>
+            await fixture.Member.CloseAsync(new StreamsGroupCloseOptions
+            {
+                GroupMembershipOperation = operation,
+                ShutdownApplication = shutdownApplication
+            }));
+
+        await Assert.That(failure!.ErrorCode).IsEqualTo(errorCode);
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
+        await Assert.That(fixture.Member.Snapshot.IsJoined).IsFalse();
+        await Assert.That(fixture.Member.Snapshot.MemberId).IsNull();
+        await Assert.That(fixture.Member.Snapshot.MemberEpoch).IsEqualTo(0);
+    }
+
     [Test]
     public async Task CloseAsync_InvalidMembershipOperationDoesNotLeaveOrClose()
     {
@@ -667,6 +701,40 @@ public sealed class StreamsGroupMemberTests
         var retry = connection.HeartbeatRequests[2];
         await Assert.That(retry.MemberEpoch).IsEqualTo(0);
         await Assert.That(retry.Topology!.Epoch).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task UpdateAsync_TopologyChangeClearsTaskAcknowledgementsForRecovery()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        connection.EnqueueHeartbeat(Success(epoch: 3));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.NotCoordinator,
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(Success(epoch: 4));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            ActiveTasks = [new StreamsGroupTaskSet { SubtopologyId = "active", Partitions = [0] }],
+            StandbyTasks = [new StreamsGroupTaskSet { SubtopologyId = "standby", Partitions = [1] }],
+            WarmupTasks = [new StreamsGroupTaskSet { SubtopologyId = "warmup", Partitions = [2] }]
+        });
+        await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            Topology = CreateInitialUpdate(topologyEpoch: 2).Topology
+        });
+
+        await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate { ProcessId = "process-2" });
+
+        var recovery = connection.HeartbeatRequests[4];
+        await Assert.That(recovery.ActiveTasks).IsEmpty();
+        await Assert.That(recovery.StandbyTasks).IsEmpty();
+        await Assert.That(recovery.WarmupTasks).IsEmpty();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -724,6 +724,33 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task CloseAsync_FaultedWorkerCompletesSharedCloseCommand()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        var workerFailure = new InvalidOperationException("unexpected worker failure");
+        var fixture = CreateFixture(connection);
+        try
+        {
+            await fixture.Member.JoinAsync(CreateInitialUpdate());
+            await Assert.That(CompleteCommandWriter(fixture.Member)).IsTrue();
+            await GetWorkerTask(fixture.Member).WaitAsync(TimeSpan.FromSeconds(5));
+            WorkerTaskField.SetValue(fixture.Member, Task.FromException(workerFailure));
+
+            var initialFailure = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                fixture.Member.CloseAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+            _ = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+                fixture.Member.CloseAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+
+            await Assert.That(initialFailure).IsSameReferenceAs(workerFailure);
+        }
+        finally
+        {
+            await fixture.DisposeMemberAndMetadataAsync();
+        }
+    }
+
+    [Test]
     public async Task DisposeAsync_WaitsForInFlightHeartbeatWithoutDeadlock()
     {
         var connection = new ScriptedConnection();
@@ -1024,6 +1051,29 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(recovery.MemberEpoch).IsEqualTo(expectedEpoch);
         await Assert.That(recovery.ProcessId).IsEqualTo("process-2");
         await Assert.That(result.MemberEpoch).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task JoinAsync_StaticAmbiguousInitialJoinReclaimsInstance()
+    {
+        var connection = new ScriptedConnection();
+        var pendingJoin = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(pendingJoin.Task);
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Success(epoch: -2));
+        await using var fixture = CreateFixture(connection, instanceId: "instance-1");
+        using var cancellation = new CancellationTokenSource();
+
+        var join = fixture.Member.JoinAsync(CreateInitialUpdate(), cancellation.Token).AsTask();
+        await connection.FirstHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => join);
+
+        var result = await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await Assert.That(connection.HeartbeatRequests[1].MemberEpoch).IsEqualTo(-2);
+        await Assert.That(result.MemberEpoch).IsEqualTo(1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -123,6 +124,38 @@ public sealed class StreamsGroupMemberTests
         await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate { ProcessId = "process-2" });
 
         await Assert.That(connection.HeartbeatRequests[2].MemberEpoch).IsEqualTo(-2);
+    }
+
+    [Test]
+    public async Task UpdateAsync_FencedOnFinalOrdinaryAttemptStillSendsRecoveryJoin()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        for (var attempt = 0; attempt < 4; attempt++)
+        {
+            connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+            {
+                ErrorCode = ErrorCode.CoordinatorNotAvailable,
+                MemberId = "member-1"
+            });
+        }
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.FencedMemberEpoch,
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        var result = await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            ProcessId = "process-2"
+        });
+
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(7);
+        await Assert.That(connection.HeartbeatRequests[6].MemberEpoch).IsEqualTo(0);
+        await Assert.That(result.MemberEpoch).IsEqualTo(2);
     }
 
     [Test]
@@ -373,6 +406,26 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task CloseAsync_PreCanceledTokenDoesNotClaimClose()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Success(epoch: -1));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(
+            async () => await fixture.Member.CloseAsync(cancellation.Token));
+
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(1);
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsFalse();
+        await fixture.Member.CloseAsync();
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(2);
+    }
+
+    [Test]
     public async Task DisposeAsync_WaitsForInFlightHeartbeatWithoutDeadlock()
     {
         var connection = new ScriptedConnection();
@@ -429,6 +482,44 @@ public sealed class StreamsGroupMemberTests
 
         var heartbeatSnapshot = fixture.Member.Snapshot;
         await Assert.That(heartbeatSnapshot).IsNotSameReferenceAs(joinedSnapshot);
+    }
+
+    [Test]
+    public async Task BackgroundHeartbeat_WhenCommandQueueIsFullRetriesAfterCapacityReturns()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        var blockedUpdate = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(blockedUpdate.Task);
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Success(epoch: -1));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        HeartbeatTimer(fixture.Member).Change(Timeout.Infinite, Timeout.Infinite);
+        HeartbeatIntervalMs(fixture.Member) = 1;
+        var activeUpdate = fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            ProcessId = "active"
+        }).AsTask();
+        await connection.SecondHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        using var cancellation = new CancellationTokenSource();
+        var queued = new Task[64];
+        for (var index = 0; index < queued.Length; index++)
+        {
+            queued[index] = fixture.Member.UpdateAsync(
+                new StreamsGroupMemberUpdate { ProcessId = $"queued-{index}" },
+                cancellation.Token).AsTask();
+        }
+
+        QueueHeartbeat(fixture.Member);
+        cancellation.Cancel();
+        blockedUpdate.SetException(new NotSupportedException("update failed"));
+
+        _ = await Assert.ThrowsAsync<NotSupportedException>(() => activeUpdate);
+        for (var index = 0; index < queued.Length; index++)
+            _ = await Assert.ThrowsAsync<OperationCanceledException>(() => queued[index]);
+        await connection.ThirdHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     [Test]
@@ -714,6 +805,42 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
     }
 
+    [Test]
+    public async Task CloseAsync_BypassesCanceledForegroundBacklog()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        var blockedUpdate = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(blockedUpdate.Task);
+        connection.EnqueueHeartbeat(Success(epoch: 0));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        var activeUpdate = fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            ProcessId = "active"
+        }).AsTask();
+        await connection.SecondHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        using var cancellation = new CancellationTokenSource();
+        var queued = new Task[128];
+        for (var index = 0; index < queued.Length; index++)
+        {
+            queued[index] = fixture.Member.UpdateAsync(
+                new StreamsGroupMemberUpdate { ProcessId = $"queued-{index}" },
+                cancellation.Token).AsTask();
+        }
+
+        cancellation.Cancel();
+        for (var index = 0; index < queued.Length; index++)
+            _ = await Assert.ThrowsAsync<OperationCanceledException>(() => queued[index]);
+        var close = fixture.Member.CloseAsync().AsTask();
+        blockedUpdate.SetResult(Success(epoch: 2));
+
+        await activeUpdate.WaitAsync(TimeSpan.FromSeconds(5));
+        await close.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(3);
+    }
+
     private static Fixture CreateFixture(ScriptedConnection connection, string? instanceId = null)
     {
         var pool = Substitute.For<IConnectionPool>();
@@ -782,6 +909,15 @@ public sealed class StreamsGroupMemberTests
             HeartbeatIntervalMs = heartbeatIntervalMs,
             ActiveTasks = active
         };
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_heartbeatTimer")]
+    private static extern ref Timer HeartbeatTimer(StreamsGroupMember member);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_heartbeatIntervalMs")]
+    private static extern ref int HeartbeatIntervalMs(StreamsGroupMember member);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "QueueHeartbeat")]
+    private static extern void QueueHeartbeat(StreamsGroupMember member);
 
     private sealed class Fixture(
         StreamsGroupMember member,

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+using System.Reflection;
 using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -426,6 +426,33 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task CloseAsync_WhenWriterClosesBeforeWorkerStopsDoesNotHang()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        var pendingUpdate = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(pendingUpdate.Task);
+        connection.EnqueueHeartbeat(Success(epoch: -1));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        StopHeartbeatTimer(fixture.Member);
+        var update = fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            ProcessId = "blocked"
+        }).AsTask();
+        await connection.SecondHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(CompleteCommandWriter(fixture.Member)).IsTrue();
+        await Assert.That(QueueHeartbeat(fixture.Member)).IsFalse();
+
+        var close = fixture.Member.CloseAsync().AsTask();
+        pendingUpdate.SetResult(Success(epoch: 2));
+
+        _ = await update;
+        await close.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
     public async Task DisposeAsync_WaitsForInFlightHeartbeatWithoutDeadlock()
     {
         var connection = new ScriptedConnection();
@@ -496,8 +523,8 @@ public sealed class StreamsGroupMemberTests
         connection.EnqueueHeartbeat(Success(epoch: -1));
         await using var fixture = CreateFixture(connection);
         await fixture.Member.JoinAsync(CreateInitialUpdate());
-        HeartbeatTimer(fixture.Member).Change(Timeout.Infinite, Timeout.Infinite);
-        HeartbeatIntervalMs(fixture.Member) = 1;
+        StopHeartbeatTimer(fixture.Member);
+        SetHeartbeatIntervalMs(fixture.Member, 1);
         var activeUpdate = fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
         {
             ProcessId = "active"
@@ -512,7 +539,7 @@ public sealed class StreamsGroupMemberTests
                 cancellation.Token).AsTask();
         }
 
-        QueueHeartbeat(fixture.Member);
+        await Assert.That(QueueHeartbeat(fixture.Member)).IsFalse();
         cancellation.Cancel();
         blockedUpdate.SetException(new NotSupportedException("update failed"));
 
@@ -643,7 +670,7 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
-    public async Task UpdateAsync_WhenFencedRejoinFails_PreservesJoinedEpoch()
+    public async Task UpdateAsync_WhenFencedRejoinFailsMarksMemberUnjoined()
     {
         var connection = new ScriptedConnection();
         connection.EnqueueHeartbeat(Success(epoch: 1));
@@ -664,10 +691,45 @@ public sealed class StreamsGroupMemberTests
 
         await Assert.ThrowsAsync<GroupException>(async () =>
             await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate { ProcessId = "process-2" }));
-        var result = await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate { ProcessId = "process-3" });
+        var snapshot = fixture.Member.Snapshot;
+        await Assert.That(snapshot.IsJoined).IsFalse();
+        await Assert.That(snapshot.MemberEpoch).IsEqualTo(0);
+        await Assert.That(snapshot.Assignment.ActiveTasks).IsEmpty();
 
-        await Assert.That(connection.HeartbeatRequests[3].MemberEpoch).IsEqualTo(1);
+        var result = await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await Assert.That(connection.HeartbeatRequests[3].MemberEpoch).IsEqualTo(0);
         await Assert.That(result.MemberEpoch).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task BackgroundHeartbeat_FencedRecoveryFailureAllowsExplicitRejoin()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1, heartbeatIntervalMs: 1));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.FencedMemberEpoch,
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.StreamsInvalidTopology,
+            ErrorMessage = "topology rejected",
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        await connection.ThirdHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(() => fixture.Member.Snapshot.IsJoined)
+            .Eventually(joined => joined.IsFalse(), TimeSpan.FromSeconds(5));
+
+        var result = await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await Assert.That(connection.HeartbeatRequests[3].MemberEpoch).IsEqualTo(0);
+        await Assert.That(result.MemberEpoch).IsEqualTo(2);
+        await Assert.That(fixture.Member.Snapshot.IsJoined).IsTrue();
     }
 
     [Test]
@@ -910,14 +972,34 @@ public sealed class StreamsGroupMemberTests
             ActiveTasks = active
         };
 
-    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_heartbeatTimer")]
-    private static extern ref Timer HeartbeatTimer(StreamsGroupMember member);
+    private static readonly FieldInfo HeartbeatTimerField = GetMemberField("_heartbeatTimer");
+    private static readonly FieldInfo HeartbeatIntervalMsField = GetMemberField("_heartbeatIntervalMs");
+    private static readonly FieldInfo CommandsField = GetMemberField("_commands");
+    private static readonly MethodInfo QueueHeartbeatMethod = typeof(StreamsGroupMember).GetMethod(
+        "QueueHeartbeat",
+        BindingFlags.Instance | BindingFlags.NonPublic)!;
 
-    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_heartbeatIntervalMs")]
-    private static extern ref int HeartbeatIntervalMs(StreamsGroupMember member);
+    private static void StopHeartbeatTimer(StreamsGroupMember member) =>
+        ((Timer)HeartbeatTimerField.GetValue(member)!).Change(Timeout.Infinite, Timeout.Infinite);
 
-    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "QueueHeartbeat")]
-    private static extern void QueueHeartbeat(StreamsGroupMember member);
+    private static void SetHeartbeatIntervalMs(StreamsGroupMember member, int value) =>
+        HeartbeatIntervalMsField.SetValue(member, value);
+
+    private static bool QueueHeartbeat(StreamsGroupMember member) =>
+        (bool)QueueHeartbeatMethod.Invoke(member, null)!;
+
+    private static bool CompleteCommandWriter(StreamsGroupMember member)
+    {
+        var channel = CommandsField.GetValue(member)!;
+        var writerProperty = CommandsField.FieldType.GetProperty("Writer")!;
+        var writer = writerProperty.GetValue(channel)!;
+        var tryComplete = writerProperty.PropertyType.GetMethod("TryComplete")!;
+        return (bool)tryComplete.Invoke(writer, [null])!;
+    }
+
+    private static FieldInfo GetMemberField(string name) => typeof(StreamsGroupMember).GetField(
+        name,
+        BindingFlags.Instance | BindingFlags.NonPublic)!;
 
     private sealed class Fixture(
         StreamsGroupMember member,

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -656,6 +656,93 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task BackgroundHeartbeat_PermanentProtocolFailureAllowsExplicitRejoin()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1, heartbeatIntervalMs: 1));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.StreamsInvalidTopology,
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        await Assert.That(() => fixture.Member.Snapshot.IsJoined)
+            .Eventually(joined => joined.IsFalse(), TimeSpan.FromSeconds(5));
+
+        var result = await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await Assert.That(connection.HeartbeatRequests[2].MemberEpoch).IsEqualTo(0);
+        await Assert.That(result.MemberEpoch).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task UpdateAsync_AmbiguousCancellationRetainsStateForExplicitRejoin()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        var pendingUpdate = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(pendingUpdate.Task);
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        using var cancellation = new CancellationTokenSource();
+
+        var update = fixture.Member.UpdateAsync(
+            new StreamsGroupMemberUpdate { ProcessId = "process-2" },
+            cancellation.Token).AsTask();
+        await connection.SecondHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => update);
+
+        await Assert.That(() => fixture.Member.Snapshot.IsJoined)
+            .Eventually(joined => joined.IsFalse(), TimeSpan.FromSeconds(5));
+        var result = await fixture.Member.JoinAsync(new StreamsGroupMemberUpdate
+        {
+            Topology = CreateInitialUpdate().Topology
+        });
+
+        var recovery = connection.HeartbeatRequests[2];
+        await Assert.That(recovery.MemberEpoch).IsEqualTo(0);
+        await Assert.That(recovery.ProcessId).IsEqualTo("process-2");
+        await Assert.That(result.MemberEpoch).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task UpdateAsync_AmbiguousTransportThenRejectionRetainsStateForExplicitRejoin()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Task.FromException<StreamsGroupHeartbeatResponse>(
+            new IOException("response lost")));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.StreamsInvalidTopology,
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        var failure = await Assert.ThrowsAsync<GroupException>(async () =>
+            await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate { ProcessId = "process-2" }));
+
+        await Assert.That(failure!.ErrorCode).IsEqualTo(ErrorCode.StreamsInvalidTopology);
+        await Assert.That(fixture.Member.Snapshot.IsJoined).IsFalse();
+        var result = await fixture.Member.JoinAsync(new StreamsGroupMemberUpdate
+        {
+            Topology = CreateInitialUpdate().Topology
+        });
+
+        var recovery = connection.HeartbeatRequests[3];
+        await Assert.That(recovery.MemberEpoch).IsEqualTo(0);
+        await Assert.That(recovery.ProcessId).IsEqualTo("process-2");
+        await Assert.That(result.MemberEpoch).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task UpdateAsync_FailedTopologyChangePreservesJoinedEpoch()
     {
         var connection = new ScriptedConnection();
@@ -1082,7 +1169,8 @@ public sealed class StreamsGroupMemberTests
 
         _ = await Assert.ThrowsAsync<OperationCanceledException>(() => update);
         await fixture.Member.CloseAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
-        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(3);
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(2);
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
     }
 
     private static Fixture CreateFixture(ScriptedConnection connection, string? instanceId = null)

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -1061,6 +1061,30 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(3);
     }
 
+    [Test]
+    public async Task UpdateAsync_CancellationStopsInFlightHeartbeatAndUnblocksClose()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        var blockedUpdate = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(blockedUpdate.Task);
+        connection.EnqueueHeartbeat(Success(epoch: 0));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        using var cancellation = new CancellationTokenSource();
+
+        var update = fixture.Member.UpdateAsync(
+            new StreamsGroupMemberUpdate { ProcessId = "cancelled" },
+            cancellation.Token).AsTask();
+        await connection.SecondHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => update);
+        await fixture.Member.CloseAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(3);
+    }
+
     private static Fixture CreateFixture(ScriptedConnection connection, string? instanceId = null)
     {
         var pool = Substitute.For<IConnectionPool>();

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -914,6 +914,27 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task CloseAsync_ConcurrentCallersObserveTerminalHeartbeatFailure()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        var terminalHeartbeat = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(terminalHeartbeat.Task);
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        var firstClose = fixture.Member.CloseAsync().AsTask();
+        await connection.SecondHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var secondClose = fixture.Member.CloseAsync().AsTask();
+        terminalHeartbeat.SetException(new NotSupportedException("terminal heartbeat failed"));
+
+        _ = await Assert.ThrowsAsync<NotSupportedException>(() => firstClose);
+        _ = await Assert.ThrowsAsync<NotSupportedException>(() => secondClose);
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
+    }
+
+    [Test]
     public async Task CloseAsync_WhenCallerCancelsObservesLaterTerminalFailure()
     {
         var connection = new ScriptedConnection();
@@ -1077,10 +1098,13 @@ public sealed class StreamsGroupMemberTests
 
         public async ValueTask DisposeAsync()
         {
-            await Member.CloseAsync(new StreamsGroupCloseOptions
+            if (!Member.Snapshot.IsClosed)
             {
-                GroupMembershipOperation = StreamsGroupMembershipOperation.RemainInGroup
-            });
+                await Member.CloseAsync(new StreamsGroupCloseOptions
+                {
+                    GroupMembershipOperation = StreamsGroupMembershipOperation.RemainInGroup
+                });
+            }
             await Member.DisposeAsync();
             await metadataManager.DisposeAsync();
         }

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -1,0 +1,506 @@
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Streams;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Streams;
+
+public sealed class StreamsGroupMemberTests
+{
+    [Test]
+    public async Task JoinAsync_ReconcilesAllTaskRolesAndEpochs()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.None,
+            MemberId = "member-1",
+            MemberEpoch = 7,
+            HeartbeatIntervalMs = 60_000,
+            AcceptableRecoveryLag = 10_000,
+            TaskOffsetIntervalMs = 5_000,
+            EndpointInformationEpoch = 4,
+            ActiveTasks = [TaskIds("active", 1, 2)],
+            StandbyTasks = [TaskIds("standby", 3)],
+            WarmupTasks = [TaskIds("warmup", 4)],
+            Status = [new StreamsGroupHeartbeatStatus { StatusCode = 1, StatusDetail = "ready" }]
+        });
+        await using var fixture = CreateFixture(connection);
+
+        var result = await fixture.Member.JoinAsync(CreateInitialUpdate(topologyEpoch: 3));
+
+        var request = connection.HeartbeatRequests[0];
+        await Assert.That(request.MemberEpoch).IsEqualTo(0);
+        await Assert.That(request.Topology!.Epoch).IsEqualTo(3);
+        await Assert.That(request.ActiveTasks).IsEmpty();
+        await Assert.That(request.StandbyTasks).IsEmpty();
+        await Assert.That(request.WarmupTasks).IsEmpty();
+        await Assert.That(result.MemberEpoch).IsEqualTo(7);
+        await Assert.That(fixture.Member.Snapshot.MemberEpoch).IsEqualTo(7);
+        await Assert.That(fixture.Member.Snapshot.Assignment.ActiveTasks[0].SubtopologyId)
+            .IsEqualTo("active");
+        await Assert.That(fixture.Member.Snapshot.Assignment.StandbyTasks[0].SubtopologyId)
+            .IsEqualTo("standby");
+        await Assert.That(fixture.Member.Snapshot.Assignment.WarmupTasks[0].SubtopologyId)
+            .IsEqualTo("warmup");
+        await Assert.That(fixture.Member.Snapshot.EndpointInformationEpoch).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task UpdateAsync_SendsAssignmentAcknowledgementAndOnlyChangedMetadata()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1, active: [TaskIds("topology", 0)]));
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            EndpointInformationEpoch = 2,
+            ActiveTasks =
+            [
+                new StreamsGroupTaskSet { SubtopologyId = "topology", Partitions = [0] }
+            ],
+            ClientTags = [new StreamsGroupKeyValue { Key = "zone", Value = "a" }]
+        });
+
+        var request = connection.HeartbeatRequests[1];
+        await Assert.That(request.MemberEpoch).IsEqualTo(1);
+        await Assert.That(request.Topology).IsNull();
+        await Assert.That(request.ProcessId).IsNull();
+        await Assert.That(request.ClientTags).Count().IsEqualTo(1);
+        await Assert.That(request.ActiveTasks![0].Partitions).IsEquivalentTo([0]);
+        await Assert.That(request.StandbyTasks).IsNull();
+        await Assert.That(request.WarmupTasks).IsNull();
+    }
+
+    [Test]
+    public async Task UpdateAsync_WhenMemberFenced_RejoinsWithCompleteState()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.FencedMemberEpoch,
+            ErrorMessage = "lost response",
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate(topologyEpoch: 5));
+
+        var result = await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            EndpointInformationEpoch = 6,
+            ProcessId = "process-2"
+        });
+
+        var rejoin = connection.HeartbeatRequests[2];
+        await Assert.That(rejoin.MemberEpoch).IsEqualTo(0);
+        await Assert.That(rejoin.Topology!.Epoch).IsEqualTo(5);
+        await Assert.That(rejoin.ProcessId).IsEqualTo("process-2");
+        await Assert.That(result.MemberEpoch).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ReportTaskOffsetsAsync_SendsCurrentAndEndOffsets()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.ReportTaskOffsetsAsync(new StreamsGroupTaskOffsetReport
+        {
+            TaskOffsets =
+            [
+                new StreamsGroupTaskOffset { SubtopologyId = "0", Partition = 1, Offset = 42 }
+            ],
+            TaskEndOffsets =
+            [
+                new StreamsGroupTaskOffset { SubtopologyId = "0", Partition = 1, Offset = 50 }
+            ]
+        });
+
+        var request = connection.HeartbeatRequests[1];
+        await Assert.That(request.TaskOffsets![0].Offset).IsEqualTo(42);
+        await Assert.That(request.TaskEndOffsets![0].Offset).IsEqualTo(50);
+    }
+
+    [Test]
+    public async Task UpdateAsync_NotCoordinatorRediscoversAndRetriesCompleteMetadata()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.NotCoordinator,
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        var result = await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            EndpointInformationEpoch = 1,
+            ProcessId = "process-2"
+        });
+
+        var retry = connection.HeartbeatRequests[2];
+        await Assert.That(retry.ProcessId).IsEqualTo("process-2");
+        await Assert.That(retry.ClientTags).IsNotNull();
+        await Assert.That(result.MemberEpoch).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task JoinAsync_WhenCoordinatorDiscoveryTransportFails_RetriesDiscovery()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueFindCoordinator(Task.FromException<FindCoordinatorResponse>(
+            new IOException("transient discovery failure")));
+        connection.EnqueueFindCoordinator(ScriptedConnection.SuccessfulCoordinator());
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        await using var fixture = CreateFixture(connection);
+
+        var result = await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await Assert.That(connection.FindCoordinatorRequestCount).IsEqualTo(2);
+        await Assert.That(result.MemberEpoch).IsEqualTo(1);
+    }
+
+    [Arguments(ErrorCode.StreamsInvalidTopology)]
+    [Arguments(ErrorCode.StreamsInvalidTopologyEpoch)]
+    [Arguments(ErrorCode.StreamsTopologyFenced)]
+    [Test]
+    public async Task JoinAsync_TopologyErrorPreservesKafkaErrorCode(ErrorCode errorCode)
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = errorCode,
+            ErrorMessage = "topology rejected",
+            MemberId = "member-1"
+        });
+        await using var fixture = CreateFixture(connection);
+
+        var exception = await Assert.ThrowsAsync<GroupException>(
+            async () => await fixture.Member.JoinAsync(CreateInitialUpdate()));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(errorCode);
+        await Assert.That(fixture.Member.Snapshot.IsJoined).IsFalse();
+    }
+
+    [Test]
+    public async Task JoinAsync_UnsupportedVersionExplainsBrokerFeatureGate()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.UnsupportedVersion,
+            MemberId = "member-1"
+        });
+        await using var fixture = CreateFixture(connection);
+
+        var exception = await Assert.ThrowsAsync<BrokerVersionException>(
+            async () => await fixture.Member.JoinAsync(CreateInitialUpdate()));
+
+        await Assert.That(exception!.Message).Contains("streams.version >= 1");
+        await Assert.That(exception.Message).Contains("group.coordinator.rebalance.protocols");
+    }
+
+    [Arguments(null, -1)]
+    [Arguments("instance-1", -2)]
+    [Test]
+    public async Task CloseAsync_DefaultUsesMembershipSpecificTerminalEpoch(
+        string? instanceId,
+        int expectedEpoch)
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Success(epoch: expectedEpoch));
+        await using var fixture = CreateFixture(connection, instanceId);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.CloseAsync();
+
+        await Assert.That(connection.HeartbeatRequests[1].MemberEpoch).IsEqualTo(expectedEpoch);
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
+    }
+
+    [Test]
+    public async Task CloseAsync_RemainInGroupSendsNoTerminalHeartbeat()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        await using var fixture = CreateFixture(connection, instanceId: "instance-1");
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.CloseAsync(new StreamsGroupCloseOptions
+        {
+            GroupMembershipOperation = StreamsGroupMembershipOperation.RemainInGroup
+        });
+
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task DisposeAsync_WaitsForInFlightHeartbeatWithoutDeadlock()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1, heartbeatIntervalMs: 1));
+        var pendingHeartbeat = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(pendingHeartbeat.Task);
+        connection.EnqueueHeartbeat(Success(epoch: -2));
+        var fixture = CreateFixture(connection, instanceId: "instance-1");
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        await connection.SecondHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var dispose = fixture.Member.DisposeAsync().AsTask();
+        await Assert.That(dispose.IsCompleted).IsFalse();
+        pendingHeartbeat.SetResult(Success(epoch: 1));
+        await dispose.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
+        await fixture.DisposeAsync();
+    }
+
+    [Test]
+    public async Task BackgroundHeartbeat_AppliesIntervalChangeWithoutRace()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1, heartbeatIntervalMs: 1));
+        connection.EnqueueHeartbeat(Success(epoch: 1, heartbeatIntervalMs: 60_000));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        var joinedSnapshot = fixture.Member.Snapshot;
+
+        await connection.SecondHeartbeatCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(() => fixture.Member.Snapshot.HeartbeatInterval)
+            .Eventually(interval => interval.IsEqualTo(TimeSpan.FromSeconds(60)), TimeSpan.FromSeconds(5));
+
+        var heartbeatSnapshot = fixture.Member.Snapshot;
+        await Assert.That(heartbeatSnapshot).IsNotSameReferenceAs(joinedSnapshot);
+    }
+
+    [Test]
+    public async Task BackgroundHeartbeat_DoesNotAcknowledgeUnreconciledTargetAssignment()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(
+            epoch: 1,
+            heartbeatIntervalMs: 1,
+            active: [TaskIds("topology", 0)]));
+        connection.EnqueueHeartbeat(Success(epoch: 1, heartbeatIntervalMs: 60_000));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await connection.SecondHeartbeatCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(connection.HeartbeatRequests[1].ActiveTasks).IsNull();
+    }
+
+    [Test]
+    public async Task CloseAsync_WhenTerminalHeartbeatFailsStillStopsWorker()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await fixture.Member.CloseAsync());
+        await fixture.Member.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
+    }
+
+    private static Fixture CreateFixture(ScriptedConnection connection, string? instanceId = null)
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+        var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        metadataManager.SetApiVersion(
+            ApiKey.FindCoordinator,
+            FindCoordinatorRequest.LowestSupportedVersion,
+            FindCoordinatorRequest.HighestSupportedVersion);
+        metadataManager.SetApiVersion(
+            ApiKey.StreamsGroupHeartbeat,
+            StreamsGroupHeartbeatRequest.LowestSupportedVersion,
+            StreamsGroupHeartbeatRequest.HighestSupportedVersion);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
+            Topics = []
+        });
+        var member = new StreamsGroupMember(
+            new StreamsGroupMemberOptions
+            {
+                GroupId = "streams-group",
+                InstanceId = instanceId,
+                RackId = "rack-a"
+            },
+            pool,
+            metadataManager,
+            retryBackoffMs: 0,
+            retryBackoffMaxMs: 0);
+        member.MarkInitializedForTesting();
+        return new Fixture(member, metadataManager);
+    }
+
+    private static StreamsGroupMemberUpdate CreateInitialUpdate(int topologyEpoch = 0) => new()
+    {
+        EndpointInformationEpoch = 0,
+        Topology = new StreamsGroupTopology
+        {
+            Epoch = topologyEpoch,
+            Subtopologies = []
+        },
+        ActiveTasks = [],
+        StandbyTasks = [],
+        WarmupTasks = [],
+        ProcessId = "process-1",
+        ClientTags = [],
+        TaskOffsets = [],
+        TaskEndOffsets = []
+    };
+
+    private static StreamsGroupHeartbeatTaskIds TaskIds(string id, params int[] partitions) => new()
+    {
+        SubtopologyId = id,
+        Partitions = partitions
+    };
+
+    private static StreamsGroupHeartbeatResponse Success(
+        int epoch,
+        int heartbeatIntervalMs = 60_000,
+        IReadOnlyList<StreamsGroupHeartbeatTaskIds>? active = null) => new()
+        {
+            ErrorCode = ErrorCode.None,
+            MemberId = "member-1",
+            MemberEpoch = epoch,
+            HeartbeatIntervalMs = heartbeatIntervalMs,
+            ActiveTasks = active
+        };
+
+    private sealed class Fixture(
+        StreamsGroupMember member,
+        MetadataManager metadataManager) : IAsyncDisposable
+    {
+        public StreamsGroupMember Member { get; } = member;
+
+        public async ValueTask DisposeAsync()
+        {
+            await Member.CloseAsync(new StreamsGroupCloseOptions
+            {
+                GroupMembershipOperation = StreamsGroupMembershipOperation.RemainInGroup
+            });
+            await Member.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    private sealed class ScriptedConnection : IKafkaConnection
+    {
+        private readonly Queue<Task<FindCoordinatorResponse>> _findCoordinatorResponses = new();
+        private readonly Queue<Task<StreamsGroupHeartbeatResponse>> _heartbeatResponses = new();
+
+        public int BrokerId => 1;
+        public string Host => "localhost";
+        public int Port => 9092;
+        public bool IsConnected => true;
+        public int FindCoordinatorRequestCount { get; private set; }
+        public List<StreamsGroupHeartbeatRequest> HeartbeatRequests { get; } = [];
+        public TaskCompletionSource SecondHeartbeatStarted { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource SecondHeartbeatCompleted { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void EnqueueFindCoordinator(FindCoordinatorResponse response) =>
+            _findCoordinatorResponses.Enqueue(Task.FromResult(response));
+
+        public void EnqueueFindCoordinator(Task<FindCoordinatorResponse> response) =>
+            _findCoordinatorResponses.Enqueue(response);
+
+        public void EnqueueHeartbeat(StreamsGroupHeartbeatResponse response) =>
+            _heartbeatResponses.Enqueue(Task.FromResult(response));
+
+        public void EnqueueHeartbeat(Task<StreamsGroupHeartbeatResponse> response) =>
+            _heartbeatResponses.Enqueue(response);
+
+        public async ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            if (request is FindCoordinatorRequest)
+            {
+                FindCoordinatorRequestCount++;
+                var response = _findCoordinatorResponses.Count == 0
+                    ? SuccessfulCoordinator()
+                    : await _findCoordinatorResponses.Dequeue().WaitAsync(cancellationToken);
+                return (TResponse)(IKafkaResponse)response;
+            }
+
+            if (request is StreamsGroupHeartbeatRequest heartbeat)
+            {
+                HeartbeatRequests.Add(heartbeat);
+                if (HeartbeatRequests.Count == 2)
+                    SecondHeartbeatStarted.TrySetResult();
+                var response = await _heartbeatResponses.Dequeue().WaitAsync(cancellationToken);
+                if (HeartbeatRequests.Count == 2)
+                    SecondHeartbeatCompleted.TrySetResult();
+                return (TResponse)(IKafkaResponse)response;
+            }
+
+            throw new NotSupportedException(typeof(TRequest).Name);
+        }
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(TRequest request, short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse =>
+            throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(TRequest request, short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse =>
+            throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request,
+            short apiVersion, CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse =>
+            throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request,
+            short apiVersion, CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse =>
+            throw new NotSupportedException();
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        internal static FindCoordinatorResponse SuccessfulCoordinator() => new()
+        {
+            Coordinators =
+            [
+                new Coordinator
+                {
+                    Key = "streams-group",
+                    NodeId = 1,
+                    Host = "localhost",
+                    Port = 9092,
+                    ErrorCode = ErrorCode.None
+                }
+            ]
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -137,6 +137,20 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task UpdateAsync_StaticTopologyChangeUsesStaticRejoinEpoch()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection, instanceId: "instance-1");
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.UpdateAsync(CreateInitialUpdate(topologyEpoch: 2));
+
+        await Assert.That(connection.HeartbeatRequests[1].MemberEpoch).IsEqualTo(-2);
+    }
+
+    [Test]
     public async Task UpdateAsync_FencedOnFinalOrdinaryAttemptStillSendsRecoveryJoin()
     {
         var connection = new ScriptedConnection();
@@ -660,9 +674,8 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(QueueHeartbeat(fixture.Member)).IsFalse();
 
         var close = fixture.Member.CloseAsync().AsTask();
-        pendingUpdate.SetResult(Success(epoch: 2));
 
-        _ = await update;
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => update);
         await close.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
@@ -995,6 +1008,29 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(recovery.MemberEpoch).IsEqualTo(0);
         await Assert.That(recovery.ProcessId).IsEqualTo("process-2");
         await Assert.That(result.MemberEpoch).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task UpdateAsync_PreWriteTransportFailureThenRejectionRestoresState()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.StreamsInvalidTopology,
+            MemberId = "member-1"
+        });
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        connection.EnqueuePreWriteHeartbeatFailure(new ObjectDisposedException("KafkaConnection"));
+
+        var failure = await Assert.ThrowsAsync<GroupException>(async () =>
+            await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate { ProcessId = "process-2" }));
+
+        await Assert.That(failure!.ErrorCode).IsEqualTo(ErrorCode.StreamsInvalidTopology);
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(2);
+        await Assert.That(fixture.Member.Snapshot.IsJoined).IsTrue();
+        await Assert.That(fixture.Member.Snapshot.MemberEpoch).IsEqualTo(1);
     }
 
     [Test]
@@ -1441,9 +1477,8 @@ public sealed class StreamsGroupMemberTests
         for (var index = 0; index < queued.Length; index++)
             _ = await Assert.ThrowsAsync<OperationCanceledException>(() => queued[index]);
         var close = fixture.Member.CloseAsync().AsTask();
-        blockedUpdate.SetResult(Success(epoch: 2));
 
-        await activeUpdate.WaitAsync(TimeSpan.FromSeconds(5));
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => activeUpdate);
         await close.WaitAsync(TimeSpan.FromSeconds(5));
         await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(3);
     }
@@ -1472,6 +1507,28 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(3);
         await Assert.That(connection.HeartbeatRequests[2].MemberEpoch).IsEqualTo(-1);
         await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
+    }
+
+    [Test]
+    public async Task CloseAsync_CancelsInFlightForegroundHeartbeat()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously).Task);
+        connection.EnqueueHeartbeat(Success(epoch: -1));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        var update = fixture.Member.UpdateAsync(
+            new StreamsGroupMemberUpdate { ProcessId = "blocked" }).AsTask();
+        await connection.SecondHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await fixture.Member.CloseAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => update);
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(3);
+        await Assert.That(connection.HeartbeatRequests[2].MemberEpoch).IsEqualTo(-1);
     }
 
     private static Fixture CreateFixture(ScriptedConnection connection, string? instanceId = null)
@@ -1617,10 +1674,11 @@ public sealed class StreamsGroupMemberTests
         }
     }
 
-    private sealed class ScriptedConnection : IKafkaConnection
+    private sealed class ScriptedConnection : IKafkaConnection, IKafkaRequestWriteObserverConnection
     {
         private readonly Queue<Task<FindCoordinatorResponse>> _findCoordinatorResponses = new();
         private readonly Queue<Task<StreamsGroupHeartbeatResponse>> _heartbeatResponses = new();
+        private readonly Queue<Exception> _preWriteHeartbeatFailures = new();
 
         public int BrokerId => 1;
         public string Host => "localhost";
@@ -1648,6 +1706,33 @@ public sealed class StreamsGroupMemberTests
 
         public void EnqueueHeartbeat(Task<StreamsGroupHeartbeatResponse> response) =>
             _heartbeatResponses.Enqueue(response);
+
+        public void EnqueuePreWriteHeartbeatFailure(Exception exception) =>
+            _preWriteHeartbeatFailures.Enqueue(exception);
+
+        public ValueTask<TResponse> SendWithWriteObservationAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            Action requestWriteStarted,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            if (request is StreamsGroupHeartbeatRequest && _preWriteHeartbeatFailures.TryDequeue(out var exception))
+                return ValueTask.FromException<TResponse>(exception);
+
+            requestWriteStarted();
+            return SendAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+        }
+
+        public ValueTask<PipelinedResponse<TResponse>> SendPipelinedWithWriteObservationAfterWriteAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            Action requestWriteStarted,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            throw new NotSupportedException();
 
         public async ValueTask<TResponse> SendAsync<TRequest, TResponse>(
             TRequest request,

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -83,7 +83,7 @@ public sealed class StreamsGroupMemberTests
     public async Task UpdateAsync_WhenMemberFenced_RejoinsWithCompleteState()
     {
         var connection = new ScriptedConnection();
-        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Success(epoch: 1, active: [TaskIds("topology", 0)]));
         connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
         {
             ErrorCode = ErrorCode.FencedMemberEpoch,
@@ -97,14 +97,24 @@ public sealed class StreamsGroupMemberTests
         var result = await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
         {
             EndpointInformationEpoch = 6,
-            ProcessId = "process-2"
+            ProcessId = "process-2",
+            ActiveTasks =
+            [
+                new StreamsGroupTaskSet { SubtopologyId = "topology", Partitions = [0] }
+            ]
         });
 
         var rejoin = connection.HeartbeatRequests[2];
         await Assert.That(rejoin.MemberEpoch).IsEqualTo(0);
         await Assert.That(rejoin.Topology!.Epoch).IsEqualTo(5);
         await Assert.That(rejoin.ProcessId).IsEqualTo("process-2");
+        await Assert.That(rejoin.ActiveTasks).IsEmpty();
+        await Assert.That(rejoin.StandbyTasks).IsEmpty();
+        await Assert.That(rejoin.WarmupTasks).IsEmpty();
         await Assert.That(result.MemberEpoch).IsEqualTo(2);
+        await Assert.That(fixture.Member.Snapshot.Assignment.ActiveTasks).IsEmpty();
+        await Assert.That(fixture.Member.Snapshot.Assignment.StandbyTasks).IsEmpty();
+        await Assert.That(fixture.Member.Snapshot.Assignment.WarmupTasks).IsEmpty();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -829,6 +829,7 @@ public sealed class StreamsGroupMemberTests
         }).AsTask();
         await connection.SecondHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         using var cancellation = new CancellationTokenSource();
+        // Matches StreamsGroupMember.CommandCapacity so the bounded queue is exactly full.
         var queued = new Task[64];
         for (var index = 0; index < queued.Length; index++)
         {
@@ -1319,6 +1320,35 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(connection.FindCoordinatorRequestCount).IsEqualTo(2);
         await Assert.That(result.MemberEpoch).IsEqualTo(3);
         await Assert.That(fixture.Member.Snapshot.IsJoined).IsTrue();
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task BackgroundHeartbeat_FinalRetriableFailureRemainsRecoverable(bool wrappedTransportFailure)
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            Exception failure = wrappedTransportFailure
+                ? new InvalidOperationException("wrapped transport failure", new IOException("connection failed"))
+                : new ObjectDisposedException("KafkaConnection");
+            connection.EnqueueHeartbeat(Task.FromException<StreamsGroupHeartbeatResponse>(failure));
+        }
+
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        StopHeartbeatTimer(fixture.Member);
+
+        await InvokeBackgroundHeartbeatAsync(fixture.Member);
+
+        await Assert.That(GetWorkerTask(fixture.Member).IsCompleted).IsFalse();
+        await Assert.That(fixture.Member.Snapshot.IsJoined).IsTrue();
+        StopHeartbeatTimer(fixture.Member);
+        await InvokeBackgroundHeartbeatAsync(fixture.Member);
+        await Assert.That(fixture.Member.Snapshot.MemberEpoch).IsEqualTo(2);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -221,6 +221,35 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task JoinAsync_FinalCoordinatorErrorPreservesBrokerResponse()
+    {
+        var connection = new ScriptedConnection();
+        for (var attempt = 0; attempt < 4; attempt++)
+        {
+            connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+            {
+                ErrorCode = ErrorCode.CoordinatorLoadInProgress,
+                MemberId = "member-1"
+            });
+        }
+
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.NotCoordinator,
+            ErrorMessage = "final coordinator response",
+            MemberId = "member-1"
+        });
+        await using var fixture = CreateFixture(connection);
+
+        var exception = await Assert.ThrowsAsync<GroupException>(
+            async () => await fixture.Member.JoinAsync(CreateInitialUpdate()));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.NotCoordinator);
+        await Assert.That(exception.Message).Contains("final coordinator response");
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(5);
+    }
+
+    [Test]
     public async Task JoinAsync_WhenCoordinatorDiscoveryTransportFails_RetriesDiscovery()
     {
         var connection = new ScriptedConnection();

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -251,11 +251,13 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(2);
     }
 
-    [Arguments(null, -1, false)]
-    [Arguments("instance-1", -2, true)]
+    [Arguments(null, StreamsGroupMembershipOperation.Default, -1, false)]
+    [Arguments("instance-1", StreamsGroupMembershipOperation.Default, -2, true)]
+    [Arguments("instance-1", StreamsGroupMembershipOperation.LeaveGroup, -1, false)]
     [Test]
-    public async Task CloseAsync_DefaultUsesMembershipSpecificTerminalEpoch(
+    public async Task CloseAsync_UsesMembershipSpecificTerminalEpoch(
         string? instanceId,
+        StreamsGroupMembershipOperation operation,
         int expectedEpoch,
         bool expectedJoined)
     {
@@ -265,11 +267,18 @@ public sealed class StreamsGroupMemberTests
         await using var fixture = CreateFixture(connection, instanceId);
         await fixture.Member.JoinAsync(CreateInitialUpdate());
 
-        await fixture.Member.CloseAsync();
+        await fixture.Member.CloseAsync(new StreamsGroupCloseOptions
+        {
+            GroupMembershipOperation = operation
+        });
 
         await Assert.That(connection.HeartbeatRequests[1].MemberEpoch).IsEqualTo(expectedEpoch);
         await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
         await Assert.That(fixture.Member.Snapshot.IsJoined).IsEqualTo(expectedJoined);
+        await Assert.That(fixture.Member.Snapshot.MemberId)
+            .IsEqualTo(expectedJoined ? "member-1" : null);
+        await Assert.That(fixture.Member.Snapshot.MemberEpoch)
+            .IsEqualTo(expectedJoined ? 1 : 0);
     }
 
     [Arguments(false)]
@@ -317,6 +326,30 @@ public sealed class StreamsGroupMemberTests
 
         await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(1);
         await Assert.That(fixture.Member.Snapshot.IsJoined).IsTrue();
+    }
+
+    [Test]
+    public async Task CloseAsync_RemainInGroupWithShutdownSendsCurrentEpochHeartbeat()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        await using var fixture = CreateFixture(connection, instanceId: "instance-1");
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.CloseAsync(new StreamsGroupCloseOptions
+        {
+            GroupMembershipOperation = StreamsGroupMembershipOperation.RemainInGroup,
+            ShutdownApplication = true
+        });
+
+        var shutdown = connection.HeartbeatRequests[1];
+        await Assert.That(shutdown.MemberEpoch).IsEqualTo(1);
+        await Assert.That(shutdown.ShutdownApplication).IsTrue();
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
+        await Assert.That(fixture.Member.Snapshot.IsJoined).IsTrue();
+        await Assert.That(fixture.Member.Snapshot.MemberId).IsEqualTo("member-1");
+        await Assert.That(fixture.Member.Snapshot.MemberEpoch).IsEqualTo(1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -696,11 +696,38 @@ public sealed class StreamsGroupMemberTests
 
             await Assert.That(failure!.InnerException).IsSameReferenceAs(unexpectedFailure);
             await Assert.That(failure.GroupId).IsEqualTo("streams-group");
+            await Assert.That(fixture.Member.Snapshot.IsJoined).IsFalse();
+            await Assert.That(fixture.Member.Snapshot.Assignment.ActiveTasks).IsEmpty();
         }
         finally
         {
             await fixture.DisposeMemberAndMetadataAsync();
         }
+    }
+
+    [Test]
+    public async Task BackgroundHeartbeat_NoBrokerMetadataRemainsRecoverable()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        StopHeartbeatTimer(fixture.Member);
+        CoordinatorIdField.SetValue(fixture.Member, -1);
+        fixture.SetBrokers(available: false);
+
+        await InvokeBackgroundHeartbeatAsync(fixture.Member);
+
+        await Assert.That(fixture.Member.Snapshot.IsJoined).IsTrue();
+        await Assert.That(GetWorkerTask(fixture.Member).IsCompleted).IsFalse();
+
+        fixture.SetBrokers(available: true);
+        StopHeartbeatTimer(fixture.Member);
+        await InvokeBackgroundHeartbeatAsync(fixture.Member);
+
+        await Assert.That(connection.FindCoordinatorRequestCount).IsEqualTo(2);
+        await Assert.That(fixture.Member.Snapshot.MemberEpoch).IsEqualTo(2);
     }
 
     [Test]
@@ -870,6 +897,26 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(recovery.ActiveTasks).IsEmpty();
         await Assert.That(recovery.StandbyTasks).IsEmpty();
         await Assert.That(recovery.WarmupTasks).IsEmpty();
+    }
+
+    [Test]
+    public async Task UpdateAsync_TopologyRejoinClearsOmittedResponseAssignment()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1, active: [TaskIds("old-active", 0)]));
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            Topology = CreateInitialUpdate(topologyEpoch: 2).Topology
+        });
+
+        var snapshot = fixture.Member.Snapshot;
+        await Assert.That(snapshot.Assignment.ActiveTasks).IsEmpty();
+        await Assert.That(snapshot.Assignment.StandbyTasks).IsEmpty();
+        await Assert.That(snapshot.Assignment.WarmupTasks).IsEmpty();
     }
 
     [Test]
@@ -1292,8 +1339,12 @@ public sealed class StreamsGroupMemberTests
 
     private static readonly FieldInfo HeartbeatTimerField = GetMemberField("_heartbeatTimer");
     private static readonly FieldInfo HeartbeatIntervalMsField = GetMemberField("_heartbeatIntervalMs");
+    private static readonly FieldInfo CoordinatorIdField = GetMemberField("_coordinatorId");
     private static readonly FieldInfo CommandsField = GetMemberField("_commands");
     private static readonly FieldInfo WorkerTaskField = GetMemberField("_workerTask");
+    private static readonly MethodInfo ProcessBackgroundHeartbeatMethod = typeof(StreamsGroupMember).GetMethod(
+        "ProcessBackgroundHeartbeatAsync",
+        BindingFlags.Instance | BindingFlags.NonPublic)!;
     private static readonly MethodInfo QueueHeartbeatMethod = typeof(StreamsGroupMember).GetMethod(
         "QueueHeartbeat",
         BindingFlags.Instance | BindingFlags.NonPublic)!;
@@ -1309,6 +1360,9 @@ public sealed class StreamsGroupMemberTests
 
     private static Task GetWorkerTask(StreamsGroupMember member) =>
         (Task)WorkerTaskField.GetValue(member)!;
+
+    private static ValueTask InvokeBackgroundHeartbeatAsync(StreamsGroupMember member) =>
+        (ValueTask)ProcessBackgroundHeartbeatMethod.Invoke(member, null)!;
 
     private static bool CompleteCommandWriter(StreamsGroupMember member)
     {
@@ -1328,6 +1382,14 @@ public sealed class StreamsGroupMemberTests
         MetadataManager metadataManager) : IAsyncDisposable
     {
         public StreamsGroupMember Member { get; } = member;
+
+        public void SetBrokers(bool available) => metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers = available
+                ? [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }]
+                : [],
+            Topics = []
+        });
 
         public async ValueTask DisposeAsync()
         {

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -579,6 +579,50 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(fixture.Member.Snapshot.MemberEpoch).IsEqualTo(1);
     }
 
+    [Arguments(false)]
+    [Arguments(true)]
+    [Test]
+    public async Task CloseAsync_RemainInGroupWithShutdownRejectsAmbiguousMembership(bool ambiguousUpdate)
+    {
+        var connection = new ScriptedConnection();
+        if (ambiguousUpdate)
+            connection.EnqueueHeartbeat(Success(epoch: 1));
+        var pendingHeartbeat = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(pendingHeartbeat.Task);
+        await using var fixture = CreateFixture(connection, instanceId: "instance-1");
+        using var cancellation = new CancellationTokenSource();
+
+        Task operation;
+        if (ambiguousUpdate)
+        {
+            await fixture.Member.JoinAsync(CreateInitialUpdate());
+            operation = fixture.Member.UpdateAsync(
+                new StreamsGroupMemberUpdate { ProcessId = "process-2" },
+                cancellation.Token).AsTask();
+        }
+        else
+        {
+            operation = fixture.Member.JoinAsync(CreateInitialUpdate(), cancellation.Token).AsTask();
+        }
+
+        await (ambiguousUpdate ? connection.SecondHeartbeatStarted.Task : connection.FirstHeartbeatStarted.Task)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => operation);
+
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await fixture.Member.CloseAsync(new StreamsGroupCloseOptions
+            {
+                GroupMembershipOperation = StreamsGroupMembershipOperation.RemainInGroup,
+                ShutdownApplication = true
+            }));
+
+        await Assert.That(failure!.Message).Contains("member epoch is unknown");
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(ambiguousUpdate ? 2 : 1);
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
+    }
+
     [Arguments(StreamsGroupMembershipOperation.Default, false, ErrorCode.FencedMemberEpoch)]
     [Arguments(StreamsGroupMembershipOperation.Default, false, ErrorCode.UnknownMemberId)]
     [Arguments(StreamsGroupMembershipOperation.RemainInGroup, true, ErrorCode.FencedMemberEpoch)]

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -983,6 +983,31 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task BackgroundHeartbeat_RetiredConnectionRediscoversAndRetries()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1, heartbeatIntervalMs: 1));
+        connection.EnqueueHeartbeat(Task.FromException<StreamsGroupHeartbeatResponse>(
+            new ObjectDisposedException("KafkaConnection")));
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        connection.EnqueueHeartbeat(Success(epoch: 3));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await connection.ThirdHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(() => fixture.Member.Snapshot.MemberEpoch)
+            .Eventually(epoch => epoch.IsEqualTo(2), TimeSpan.FromSeconds(5));
+        var result = await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            ProcessId = "process-2"
+        });
+
+        await Assert.That(connection.FindCoordinatorRequestCount).IsEqualTo(2);
+        await Assert.That(result.MemberEpoch).IsEqualTo(3);
+        await Assert.That(fixture.Member.Snapshot.IsJoined).IsTrue();
+    }
+
+    [Test]
     public async Task UpdateAsync_RejectedTopologyIsNotUsedForLaterFencedRecovery()
     {
         var connection = new ScriptedConnection();

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -107,6 +107,25 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task UpdateAsync_WhenStaticMemberFenced_RejoinsWithStaticEpoch()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.FencedMemberEpoch,
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection, instanceId: "instance-1");
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate { ProcessId = "process-2" });
+
+        await Assert.That(connection.HeartbeatRequests[2].MemberEpoch).IsEqualTo(-2);
+    }
+
+    [Test]
     public async Task ReportTaskOffsetsAsync_SendsCurrentAndEndOffsets()
     {
         var connection = new ScriptedConnection();
@@ -251,6 +270,36 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
     }
 
+    [Arguments(false)]
+    [Arguments(true)]
+    [Test]
+    public async Task CloseAsync_RetryPreservesTerminalEpoch(bool transportFailure)
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        if (transportFailure)
+        {
+            connection.EnqueueHeartbeat(Task.FromException<StreamsGroupHeartbeatResponse>(
+                new IOException("connection lost")));
+        }
+        else
+        {
+            connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+            {
+                ErrorCode = ErrorCode.NotCoordinator,
+                MemberId = "member-1"
+            });
+        }
+        connection.EnqueueHeartbeat(Success(epoch: -1));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.CloseAsync();
+
+        await Assert.That(connection.HeartbeatRequests[1].MemberEpoch).IsEqualTo(-1);
+        await Assert.That(connection.HeartbeatRequests[2].MemberEpoch).IsEqualTo(-1);
+    }
+
     [Test]
     public async Task CloseAsync_RemainInGroupSendsNoTerminalHeartbeat()
     {
@@ -310,12 +359,15 @@ public sealed class StreamsGroupMemberTests
     {
         var connection = new ScriptedConnection();
         connection.EnqueueHeartbeat(Success(epoch: 1, heartbeatIntervalMs: 1));
-        connection.EnqueueHeartbeat(Success(epoch: 1, heartbeatIntervalMs: 60_000));
+        var pendingHeartbeat = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(pendingHeartbeat.Task);
         await using var fixture = CreateFixture(connection);
         await fixture.Member.JoinAsync(CreateInitialUpdate());
         var joinedSnapshot = fixture.Member.Snapshot;
 
-        await connection.SecondHeartbeatCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.SecondHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        pendingHeartbeat.SetResult(Success(epoch: 1, heartbeatIntervalMs: 60_000));
         await Assert.That(() => fixture.Member.Snapshot.HeartbeatInterval)
             .Eventually(interval => interval.IsEqualTo(TimeSpan.FromSeconds(60)), TimeSpan.FromSeconds(5));
 
@@ -366,6 +418,86 @@ public sealed class StreamsGroupMemberTests
         var result = await update;
 
         await Assert.That(result.MemberEpoch).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task BackgroundHeartbeat_PermanentProtocolFailureBlocksForegroundOperation()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1, heartbeatIntervalMs: 1));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.GroupAuthorizationFailed,
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        await connection.SecondHeartbeatCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        GroupException? failure = null;
+        for (var attempt = 0; attempt < 2 && failure is null; attempt++)
+        {
+            try
+            {
+                await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate { ProcessId = "process-2" });
+            }
+            catch (GroupException exception)
+            {
+                failure = exception;
+            }
+        }
+
+        await Assert.That(failure).IsNotNull();
+        await Assert.That(failure!.ErrorCode).IsEqualTo(ErrorCode.GroupAuthorizationFailed);
+    }
+
+    [Test]
+    public async Task UpdateAsync_FailedTopologyChangePreservesJoinedEpoch()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.StreamsInvalidTopology,
+            ErrorMessage = "topology rejected",
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await Assert.ThrowsAsync<GroupException>(async () =>
+            await fixture.Member.UpdateAsync(CreateInitialUpdate(topologyEpoch: 2)));
+
+        await Assert.That(fixture.Member.Snapshot.MemberEpoch).IsEqualTo(1);
+        var result = await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            ProcessId = "process-2"
+        });
+        await Assert.That(connection.HeartbeatRequests[2].MemberEpoch).IsEqualTo(1);
+        await Assert.That(result.MemberEpoch).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task UpdateAsync_TopologyChangeRetryRemainsJoinShaped()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.NotCoordinator,
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.UpdateAsync(CreateInitialUpdate(topologyEpoch: 2));
+
+        var retry = connection.HeartbeatRequests[2];
+        await Assert.That(retry.MemberEpoch).IsEqualTo(0);
+        await Assert.That(retry.Topology!.Epoch).IsEqualTo(2);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -251,12 +251,13 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(2);
     }
 
-    [Arguments(null, -1)]
-    [Arguments("instance-1", -2)]
+    [Arguments(null, -1, false)]
+    [Arguments("instance-1", -2, true)]
     [Test]
     public async Task CloseAsync_DefaultUsesMembershipSpecificTerminalEpoch(
         string? instanceId,
-        int expectedEpoch)
+        int expectedEpoch,
+        bool expectedJoined)
     {
         var connection = new ScriptedConnection();
         connection.EnqueueHeartbeat(Success(epoch: 1));
@@ -268,6 +269,7 @@ public sealed class StreamsGroupMemberTests
 
         await Assert.That(connection.HeartbeatRequests[1].MemberEpoch).IsEqualTo(expectedEpoch);
         await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
+        await Assert.That(fixture.Member.Snapshot.IsJoined).IsEqualTo(expectedJoined);
     }
 
     [Arguments(false)]
@@ -314,6 +316,27 @@ public sealed class StreamsGroupMemberTests
         });
 
         await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(1);
+        await Assert.That(fixture.Member.Snapshot.IsJoined).IsTrue();
+    }
+
+    [Test]
+    public async Task CloseAsync_InvalidMembershipOperationDoesNotLeaveOrClose()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Success(epoch: -1));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            await fixture.Member.CloseAsync(new StreamsGroupCloseOptions
+            {
+                GroupMembershipOperation = (StreamsGroupMembershipOperation)int.MaxValue
+            }));
+
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(1);
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsFalse();
+        await Assert.That(fixture.Member.Snapshot.IsJoined).IsTrue();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -946,7 +946,11 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
-    public async Task UpdateAsync_AmbiguousCancellationRetainsStateForExplicitRejoin()
+    [Arguments(null, 0)]
+    [Arguments("instance-1", -2)]
+    public async Task UpdateAsync_AmbiguousCancellationRejoinUsesMembershipEpoch(
+        string? instanceId,
+        int expectedEpoch)
     {
         var connection = new ScriptedConnection();
         connection.EnqueueHeartbeat(Success(epoch: 1));
@@ -954,7 +958,7 @@ public sealed class StreamsGroupMemberTests
             TaskCreationOptions.RunContinuationsAsynchronously);
         connection.EnqueueHeartbeat(pendingUpdate.Task);
         connection.EnqueueHeartbeat(Success(epoch: 2));
-        await using var fixture = CreateFixture(connection);
+        await using var fixture = CreateFixture(connection, instanceId);
         await fixture.Member.JoinAsync(CreateInitialUpdate());
         using var cancellation = new CancellationTokenSource();
 
@@ -973,7 +977,7 @@ public sealed class StreamsGroupMemberTests
         });
 
         var recovery = connection.HeartbeatRequests[2];
-        await Assert.That(recovery.MemberEpoch).IsEqualTo(0);
+        await Assert.That(recovery.MemberEpoch).IsEqualTo(expectedEpoch);
         await Assert.That(recovery.ProcessId).IsEqualTo("process-2");
         await Assert.That(result.MemberEpoch).IsEqualTo(2);
     }

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -383,6 +383,128 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(connection.HeartbeatRequests[2].MemberEpoch).IsEqualTo(-1);
     }
 
+    [Arguments(null, StreamsGroupMembershipOperation.Default, -1)]
+    [Arguments("instance-1", StreamsGroupMembershipOperation.Default, -2)]
+    [Arguments("instance-1", StreamsGroupMembershipOperation.LeaveGroup, -1)]
+    [Test]
+    public async Task CloseAsync_AmbiguousMembershipStillSendsTerminalHeartbeat(
+        string? instanceId,
+        StreamsGroupMembershipOperation operation,
+        int expectedEpoch)
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        var pendingUpdate = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(pendingUpdate.Task);
+        connection.EnqueueHeartbeat(Success(epoch: expectedEpoch));
+        await using var fixture = CreateFixture(connection, instanceId);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        using var cancellation = new CancellationTokenSource();
+
+        var update = fixture.Member.UpdateAsync(
+            new StreamsGroupMemberUpdate { ProcessId = "process-2" },
+            cancellation.Token).AsTask();
+        await connection.SecondHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => update);
+
+        await fixture.Member.CloseAsync(new StreamsGroupCloseOptions
+        {
+            GroupMembershipOperation = operation
+        });
+
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(3);
+        await Assert.That(connection.HeartbeatRequests[2].MemberEpoch).IsEqualTo(expectedEpoch);
+    }
+
+    [Test]
+    public async Task CloseAsync_AmbiguousJoinStillSendsTerminalHeartbeat()
+    {
+        var connection = new ScriptedConnection();
+        var pendingJoin = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(pendingJoin.Task);
+        connection.EnqueueHeartbeat(Success(epoch: -1));
+        await using var fixture = CreateFixture(connection);
+        using var cancellation = new CancellationTokenSource();
+
+        var join = fixture.Member.JoinAsync(CreateInitialUpdate(), cancellation.Token).AsTask();
+        await connection.FirstHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => join);
+
+        await fixture.Member.CloseAsync();
+
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(2);
+        await Assert.That(connection.HeartbeatRequests[1].MemberEpoch).IsEqualTo(-1);
+    }
+
+    [Arguments(null, StreamsGroupMembershipOperation.Default, ErrorCode.UnknownMemberId)]
+    [Arguments(null, StreamsGroupMembershipOperation.Default, ErrorCode.FencedMemberEpoch)]
+    [Arguments("instance-1", StreamsGroupMembershipOperation.LeaveGroup, ErrorCode.UnknownMemberId)]
+    [Arguments("instance-1", StreamsGroupMembershipOperation.LeaveGroup, ErrorCode.FencedMemberEpoch)]
+    [Test]
+    public async Task CloseAsync_AmbiguousLeaveMembershipLossCompletesSuccessfully(
+        string? instanceId,
+        StreamsGroupMembershipOperation operation,
+        ErrorCode errorCode)
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Task.FromException<StreamsGroupHeartbeatResponse>(
+            new IOException("response lost")));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = errorCode,
+            MemberId = "member-1"
+        });
+        await using var fixture = CreateFixture(connection, instanceId);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.CloseAsync(new StreamsGroupCloseOptions
+        {
+            GroupMembershipOperation = operation
+        });
+
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(3);
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
+        await Assert.That(fixture.Member.Snapshot.IsJoined).IsFalse();
+    }
+
+    [Arguments(StreamsGroupMembershipOperation.Default, false, -2, ErrorCode.FencedMemberEpoch)]
+    [Arguments(StreamsGroupMembershipOperation.RemainInGroup, true, 1, ErrorCode.UnknownMemberId)]
+    [Test]
+    public async Task CloseAsync_RetainedMembershipLossStillThrowsAfterRetry(
+        StreamsGroupMembershipOperation operation,
+        bool shutdownApplication,
+        int expectedEpoch,
+        ErrorCode errorCode)
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Task.FromException<StreamsGroupHeartbeatResponse>(
+            new IOException("response lost")));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = errorCode,
+            MemberId = "member-1"
+        });
+        await using var fixture = CreateFixture(connection, instanceId: "instance-1");
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        var failure = await Assert.ThrowsAsync<GroupException>(async () =>
+            await fixture.Member.CloseAsync(new StreamsGroupCloseOptions
+            {
+                GroupMembershipOperation = operation,
+                ShutdownApplication = shutdownApplication
+            }));
+
+        await Assert.That(failure!.ErrorCode).IsEqualTo(errorCode);
+        await Assert.That(connection.HeartbeatRequests[1].MemberEpoch).IsEqualTo(expectedEpoch);
+        await Assert.That(connection.HeartbeatRequests[2].MemberEpoch).IsEqualTo(expectedEpoch);
+    }
+
     [Test]
     public async Task CloseAsync_RetiredConnectionRediscoversAndRetries()
     {
@@ -1347,7 +1469,8 @@ public sealed class StreamsGroupMemberTests
 
         _ = await Assert.ThrowsAsync<OperationCanceledException>(() => update);
         await fixture.Member.CloseAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
-        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(2);
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(3);
+        await Assert.That(connection.HeartbeatRequests[2].MemberEpoch).IsEqualTo(-1);
         await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
     }
 
@@ -1505,6 +1628,8 @@ public sealed class StreamsGroupMemberTests
         public bool IsConnected => true;
         public int FindCoordinatorRequestCount { get; private set; }
         public List<StreamsGroupHeartbeatRequest> HeartbeatRequests { get; } = [];
+        public TaskCompletionSource FirstHeartbeatStarted { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         public TaskCompletionSource SecondHeartbeatStarted { get; } = new(
             TaskCreationOptions.RunContinuationsAsynchronously);
         public TaskCompletionSource SecondHeartbeatCompleted { get; } = new(
@@ -1543,6 +1668,8 @@ public sealed class StreamsGroupMemberTests
             if (request is StreamsGroupHeartbeatRequest heartbeat)
             {
                 HeartbeatRequests.Add(heartbeat);
+                if (HeartbeatRequests.Count == 1)
+                    FirstHeartbeatStarted.TrySetResult();
                 if (HeartbeatRequests.Count == 2)
                     SecondHeartbeatStarted.TrySetResult();
                 if (HeartbeatRequests.Count == 3)

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -501,6 +501,113 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task UpdateAsync_WhenFencedRejoinFails_PreservesJoinedEpoch()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.FencedMemberEpoch,
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.StreamsInvalidTopology,
+            ErrorMessage = "topology rejected",
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await Assert.ThrowsAsync<GroupException>(async () =>
+            await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate { ProcessId = "process-2" }));
+        var result = await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate { ProcessId = "process-3" });
+
+        await Assert.That(connection.HeartbeatRequests[3].MemberEpoch).IsEqualTo(1);
+        await Assert.That(result.MemberEpoch).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task UpdateAsync_RejectedTopologyIsNotUsedForLaterFencedRecovery()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.StreamsInvalidTopology,
+            ErrorMessage = "topology rejected",
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.FencedMemberEpoch,
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate(topologyEpoch: 1));
+
+        await Assert.ThrowsAsync<GroupException>(async () =>
+            await fixture.Member.UpdateAsync(CreateInitialUpdate(topologyEpoch: 2)));
+        await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate { ProcessId = "process-2" });
+
+        await Assert.That(connection.HeartbeatRequests[3].Topology!.Epoch).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task UpdateAsync_TopologyChangePreservesShutdownApplication()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            Topology = CreateInitialUpdate(topologyEpoch: 2).Topology,
+            ShutdownApplication = true
+        });
+
+        await Assert.That(connection.HeartbeatRequests[1].ShutdownApplication).IsTrue();
+    }
+
+    [Arguments(false)]
+    [Arguments(true)]
+    [Test]
+    public async Task UpdateAsync_RetryPreservesShutdownApplication(bool transportFailure)
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        if (transportFailure)
+        {
+            connection.EnqueueHeartbeat(Task.FromException<StreamsGroupHeartbeatResponse>(
+                new IOException("connection lost")));
+        }
+        else
+        {
+            connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+            {
+                ErrorCode = ErrorCode.NotCoordinator,
+                MemberId = "member-1"
+            });
+        }
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            ProcessId = "process-2",
+            ShutdownApplication = true
+        });
+
+        await Assert.That(connection.HeartbeatRequests[1].ShutdownApplication).IsTrue();
+        await Assert.That(connection.HeartbeatRequests[2].ShutdownApplication).IsTrue();
+    }
+
+    [Test]
     public async Task SteadyRequestCache_RebuildsWhenIdentityChanges()
     {
         var cache = new StreamsGroupHeartbeatRequestCache();

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -214,6 +214,24 @@ public sealed class StreamsGroupMemberTests
         await Assert.That(exception.Message).Contains("group.coordinator.rebalance.protocols");
     }
 
+    [Test]
+    public async Task JoinAsync_StaticMemberRetriesUnreleasedInstanceId()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.UnreleasedInstanceId,
+            MemberId = "member-1"
+        });
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        await using var fixture = CreateFixture(connection, instanceId: "instance-1");
+
+        var result = await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await Assert.That(result.MemberEpoch).IsEqualTo(1);
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(2);
+    }
+
     [Arguments(null, -1)]
     [Arguments("instance-1", -2)]
     [Test]
@@ -272,6 +290,22 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task DisposeAsync_WhenTerminalHeartbeatFailsStillCompletes()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Task.FromException<StreamsGroupHeartbeatResponse>(
+            new NotSupportedException("terminal heartbeat failed")));
+        var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+
+        await fixture.Member.DisposeAsync();
+
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
+        await fixture.DisposeAsync();
+    }
+
+    [Test]
     public async Task BackgroundHeartbeat_AppliesIntervalChangeWithoutRace()
     {
         var connection = new ScriptedConnection();
@@ -307,17 +341,86 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task BackgroundHeartbeat_TransientFailureDoesNotBlockForegroundOperation()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1, heartbeatIntervalMs: 1));
+        connection.EnqueueHeartbeat(new StreamsGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.UnknownServerError,
+            MemberId = "member-1"
+        });
+        var pendingHeartbeat = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(pendingHeartbeat.Task);
+        connection.EnqueueHeartbeat(Success(epoch: 2));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        await connection.ThirdHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var update = fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            EndpointInformationEpoch = 1
+        }).AsTask();
+        pendingHeartbeat.SetResult(Success(epoch: 1, heartbeatIntervalMs: 60_000));
+        var result = await update;
+
+        await Assert.That(result.MemberEpoch).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task SteadyRequestCache_RebuildsWhenIdentityChanges()
+    {
+        var cache = new StreamsGroupHeartbeatRequestCache();
+        var initial = cache.Get("group", "member-1", 1, 2, "instance-1");
+
+        var unchanged = cache.Get("group", "member-1", 1, 2, "instance-1");
+        var changed = cache.Get("group", "member-2", 2, 3, "instance-2");
+
+        await Assert.That(unchanged).IsSameReferenceAs(initial);
+        await Assert.That(changed).IsNotSameReferenceAs(initial);
+        await Assert.That(changed.MemberId).IsEqualTo("member-2");
+        await Assert.That(changed.MemberEpoch).IsEqualTo(2);
+        await Assert.That(changed.EndpointInformationEpoch).IsEqualTo(3);
+        await Assert.That(changed.InstanceId).IsEqualTo("instance-2");
+    }
+
+    [Test]
     public async Task CloseAsync_WhenTerminalHeartbeatFailsStillStopsWorker()
     {
         var connection = new ScriptedConnection();
         connection.EnqueueHeartbeat(Success(epoch: 1));
+        connection.EnqueueHeartbeat(Task.FromException<StreamsGroupHeartbeatResponse>(
+            new NotSupportedException("terminal heartbeat failed")));
         await using var fixture = CreateFixture(connection);
         await fixture.Member.JoinAsync(CreateInitialUpdate());
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NotSupportedException>(
             async () => await fixture.Member.CloseAsync());
         await fixture.Member.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
 
+        await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
+    }
+
+    [Test]
+    public async Task CloseAsync_WhenCallerCancelsObservesLaterTerminalFailure()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        var terminalHeartbeat = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(terminalHeartbeat.Task);
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        using var cancellation = new CancellationTokenSource();
+
+        var close = fixture.Member.CloseAsync(cancellation.Token).AsTask();
+        await connection.SecondHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => close);
+        terminalHeartbeat.SetException(new NotSupportedException("terminal heartbeat failed"));
+
+        await fixture.Member.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
         await Assert.That(fixture.Member.Snapshot.IsClosed).IsTrue();
     }
 
@@ -422,6 +525,8 @@ public sealed class StreamsGroupMemberTests
             TaskCreationOptions.RunContinuationsAsynchronously);
         public TaskCompletionSource SecondHeartbeatCompleted { get; } = new(
             TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource ThirdHeartbeatStarted { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
 
         public void EnqueueFindCoordinator(FindCoordinatorResponse response) =>
             _findCoordinatorResponses.Enqueue(Task.FromResult(response));
@@ -456,10 +561,18 @@ public sealed class StreamsGroupMemberTests
                 HeartbeatRequests.Add(heartbeat);
                 if (HeartbeatRequests.Count == 2)
                     SecondHeartbeatStarted.TrySetResult();
-                var response = await _heartbeatResponses.Dequeue().WaitAsync(cancellationToken);
-                if (HeartbeatRequests.Count == 2)
-                    SecondHeartbeatCompleted.TrySetResult();
-                return (TResponse)(IKafkaResponse)response;
+                if (HeartbeatRequests.Count == 3)
+                    ThirdHeartbeatStarted.TrySetResult();
+                try
+                {
+                    var response = await _heartbeatResponses.Dequeue().WaitAsync(cancellationToken);
+                    return (TResponse)(IKafkaResponse)response;
+                }
+                finally
+                {
+                    if (HeartbeatRequests.Count == 2)
+                        SecondHeartbeatCompleted.TrySetResult();
+                }
             }
 
             throw new NotSupportedException(typeof(TRequest).Name);

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -656,6 +656,29 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task BackgroundHeartbeat_SecurityFailureBlocksForegroundOperation(bool authentication)
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1, heartbeatIntervalMs: 1));
+        Exception securityFailure = authentication
+            ? new AuthenticationException("authentication failed")
+            : new AuthorizationException("authorization failed");
+        connection.EnqueueHeartbeat(Task.FromException<StreamsGroupHeartbeatResponse>(securityFailure));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        await Assert.That(() => fixture.Member.Snapshot.IsJoined)
+            .Eventually(joined => joined.IsFalse(), TimeSpan.FromSeconds(5));
+
+        var failure = await Assert.ThrowsAsync<GroupException>(async () =>
+            await fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate { ProcessId = "process-2" }));
+
+        await Assert.That(failure!.InnerException).IsSameReferenceAs(securityFailure);
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(2);
+    }
+
+    [Test]
     public async Task BackgroundHeartbeat_PermanentProtocolFailureAllowsExplicitRejoin()
     {
         var connection = new ScriptedConnection();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
@@ -89,6 +89,31 @@ public sealed class InMemoryStreamsGroupMemberTests
     }
 
     [Test]
+    public async Task UpdateAsync_TopologyRejoinClearsOmittedAssignment()
+    {
+        await using var member = CreateMember();
+        await member.JoinAsync(new StreamsGroupMemberUpdate
+        {
+            Topology = CreateTopology(),
+            ActiveTasks = [new StreamsGroupTaskSet { SubtopologyId = "active", Partitions = [0] }],
+            StandbyTasks = [new StreamsGroupTaskSet { SubtopologyId = "standby", Partitions = [1] }],
+            WarmupTasks = [new StreamsGroupTaskSet { SubtopologyId = "warmup", Partitions = [2] }]
+        });
+
+        var result = await member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            Topology = CreateTopology()
+        });
+
+        await Assert.That(result.ActiveTasks).IsNull();
+        await Assert.That(result.StandbyTasks).IsNull();
+        await Assert.That(result.WarmupTasks).IsNull();
+        await Assert.That(member.Snapshot.Assignment.ActiveTasks).IsEmpty();
+        await Assert.That(member.Snapshot.Assignment.StandbyTasks).IsEmpty();
+        await Assert.That(member.Snapshot.Assignment.WarmupTasks).IsEmpty();
+    }
+
+    [Test]
     public async Task JoinAndUpdateAsync_DeepCopyPublishedTaskSets()
     {
         await using var member = CreateMember();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
@@ -6,6 +6,18 @@ namespace Dekaf.Tests.Unit.Testing;
 public sealed class InMemoryStreamsGroupMemberTests
 {
     [Test]
+    public async Task JoinAsync_WithoutTopologyThrowsArgumentException()
+    {
+        await using var member = CreateMember();
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            member.JoinAsync(new StreamsGroupMemberUpdate()));
+
+        await Assert.That(exception.ParamName).IsEqualTo("initialState");
+        await Assert.That(member.Snapshot.IsJoined).IsFalse();
+    }
+
+    [Test]
     public async Task JoinAsync_PublishesInitialAssignmentAndSnapshot()
     {
         await using var member = new InMemoryStreamsGroupMember(new StreamsGroupMemberOptions
@@ -51,6 +63,7 @@ public sealed class InMemoryStreamsGroupMemberTests
         await using var member = CreateMember();
         await member.JoinAsync(new StreamsGroupMemberUpdate
         {
+            Topology = CreateTopology(),
             ActiveTasks = [new StreamsGroupTaskSet { SubtopologyId = "sub-0", Partitions = [2] }],
             StandbyTasks = [],
             WarmupTasks = []
@@ -87,6 +100,7 @@ public sealed class InMemoryStreamsGroupMemberTests
 
         var joinResult = await member.JoinAsync(new StreamsGroupMemberUpdate
         {
+            Topology = CreateTopology(),
             ActiveTasks = joinTasks
         });
 
@@ -127,7 +141,7 @@ public sealed class InMemoryStreamsGroupMemberTests
             GroupId = "streams-group",
             InstanceId = instanceId
         });
-        await member.JoinAsync(new StreamsGroupMemberUpdate());
+        await member.JoinAsync(new StreamsGroupMemberUpdate { Topology = CreateTopology() });
         var closeOptions = new StreamsGroupCloseOptions
         {
             GroupMembershipOperation = operation,

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
@@ -24,6 +24,7 @@ public sealed class InMemoryStreamsGroupMemberTests
     public async Task JoinAsync_WithoutTopologyThrowsArgumentException()
     {
         await using var member = CreateMember();
+        await member.InitializeAsync();
 
         var exception = Assert.Throws<ArgumentException>(() =>
             member.JoinAsync(new StreamsGroupMemberUpdate()));
@@ -41,6 +42,7 @@ public sealed class InMemoryStreamsGroupMemberTests
             InstanceId = "instance-a",
             RackId = "rack-a"
         });
+        await member.InitializeAsync();
         var activeTasks = new[]
         {
             new StreamsGroupTaskSet { SubtopologyId = "sub-0", Partitions = [0, 1] }
@@ -80,6 +82,7 @@ public sealed class InMemoryStreamsGroupMemberTests
     public async Task UpdateAndReportOffsets_PreserveUnchangedAssignment()
     {
         await using var member = CreateMember();
+        await member.InitializeAsync();
         await member.JoinAsync(new StreamsGroupMemberUpdate
         {
             Topology = CreateTopology()
@@ -114,6 +117,7 @@ public sealed class InMemoryStreamsGroupMemberTests
     public async Task UpdateAsync_TopologyRejoinClearsOmittedAssignment()
     {
         await using var member = CreateMember();
+        await member.InitializeAsync();
         await member.JoinAsync(new StreamsGroupMemberUpdate
         {
             Topology = CreateTopology()
@@ -143,6 +147,7 @@ public sealed class InMemoryStreamsGroupMemberTests
     public async Task UpdateAsync_TopologyRejoinIgnoresSuppliedAssignment()
     {
         await using var member = CreateMember();
+        await member.InitializeAsync();
         await member.JoinAsync(new StreamsGroupMemberUpdate
         {
             Topology = CreateTopology(),
@@ -169,6 +174,7 @@ public sealed class InMemoryStreamsGroupMemberTests
     public async Task UpdateAsync_DeepCopiesPublishedTaskSets()
     {
         await using var member = CreateMember();
+        await member.InitializeAsync();
         await member.JoinAsync(new StreamsGroupMemberUpdate { Topology = CreateTopology() });
         var activePartitions = new List<int> { 0, 1 };
         var activeTasks = new List<StreamsGroupTaskSet>
@@ -212,6 +218,7 @@ public sealed class InMemoryStreamsGroupMemberTests
             GroupId = "streams-group",
             InstanceId = instanceId
         });
+        await member.InitializeAsync();
         await member.JoinAsync(new StreamsGroupMemberUpdate { Topology = CreateTopology() });
         var closeOptions = new StreamsGroupCloseOptions
         {
@@ -231,10 +238,34 @@ public sealed class InMemoryStreamsGroupMemberTests
     public async Task UpdateAsync_BeforeJoin_Throws()
     {
         await using var member = CreateMember();
+        await member.InitializeAsync();
 
         var action = async () => await member.UpdateAsync(new StreamsGroupMemberUpdate());
 
         await Assert.That(action).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Operations_BeforeInitialize_Throw()
+    {
+        await using var member = CreateMember();
+        var update = new StreamsGroupMemberUpdate { Topology = CreateTopology() };
+
+        var joinException = Assert.Throws<InvalidOperationException>(() => member.JoinAsync(update));
+        var updateException = Assert.Throws<InvalidOperationException>(() =>
+            member.UpdateAsync(new StreamsGroupMemberUpdate()));
+        var reportException = Assert.Throws<InvalidOperationException>(() =>
+            member.ReportTaskOffsetsAsync(new StreamsGroupTaskOffsetReport
+            {
+                TaskOffsets = [],
+                TaskEndOffsets = []
+            }));
+
+        const string message =
+            "The Streams group member is not initialized. Call InitializeAsync() before joining.";
+        await Assert.That(joinException.Message).IsEqualTo(message);
+        await Assert.That(updateException.Message).IsEqualTo(message);
+        await Assert.That(reportException.Message).IsEqualTo(message);
     }
 
     private static InMemoryStreamsGroupMember CreateMember() =>

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
@@ -6,6 +6,21 @@ namespace Dekaf.Tests.Unit.Testing;
 public sealed class InMemoryStreamsGroupMemberTests
 {
     [Test]
+    [Arguments(1L)]
+    [Arguments(21_474_836_480_000L)]
+    public async Task Constructor_RejectsUnrepresentableRebalanceTimeout(long ticks)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            _ = new InMemoryStreamsGroupMember(new StreamsGroupMemberOptions
+            {
+                GroupId = "streams-group",
+                RebalanceTimeout = TimeSpan.FromTicks(ticks)
+            }));
+
+        await Assert.That(exception.ParamName).IsEqualTo("options");
+    }
+
+    [Test]
     public async Task JoinAsync_WithoutTopologyThrowsArgumentException()
     {
         await using var member = CreateMember();
@@ -101,11 +116,15 @@ public sealed class InMemoryStreamsGroupMemberTests
         await using var member = CreateMember();
         await member.JoinAsync(new StreamsGroupMemberUpdate
         {
-            Topology = CreateTopology(),
+            Topology = CreateTopology()
+        });
+        await member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
             ActiveTasks = [new StreamsGroupTaskSet { SubtopologyId = "active", Partitions = [0] }],
             StandbyTasks = [new StreamsGroupTaskSet { SubtopologyId = "standby", Partitions = [1] }],
             WarmupTasks = [new StreamsGroupTaskSet { SubtopologyId = "warmup", Partitions = [2] }]
         });
+        await Assert.That(member.Snapshot.Assignment.ActiveTasks).IsNotEmpty();
 
         var result = await member.UpdateAsync(new StreamsGroupMemberUpdate
         {

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
@@ -18,7 +18,7 @@ public sealed class InMemoryStreamsGroupMemberTests
     }
 
     [Test]
-    public async Task JoinAsync_PublishesInitialAssignmentAndSnapshot()
+    public async Task JoinAsync_IgnoresCallerAssignment()
     {
         await using var member = new InMemoryStreamsGroupMember(new StreamsGroupMemberOptions
         {
@@ -50,11 +50,15 @@ public sealed class InMemoryStreamsGroupMemberTests
         await Assert.That(member.InstanceId).IsEqualTo("instance-a");
         await Assert.That(member.LastUpdate).IsSameReferenceAs(update);
         await Assert.That(result.MemberEpoch).IsEqualTo(1);
-        await Assert.That(result.ActiveTasks![0].SubtopologyId).IsEqualTo("sub-0");
+        await Assert.That(result.ActiveTasks).IsNull();
+        await Assert.That(result.StandbyTasks).IsNull();
+        await Assert.That(result.WarmupTasks).IsNull();
         await Assert.That(member.Snapshot.IsJoined).IsTrue();
         await Assert.That(member.Snapshot.IsClosed).IsFalse();
         await Assert.That(member.Snapshot.EndpointInformationEpoch).IsEqualTo(7);
-        await Assert.That(member.Snapshot.Assignment.ActiveTasks[0].Partitions).IsEquivalentTo([0, 1]);
+        await Assert.That(member.Snapshot.Assignment.ActiveTasks).IsEmpty();
+        await Assert.That(member.Snapshot.Assignment.StandbyTasks).IsEmpty();
+        await Assert.That(member.Snapshot.Assignment.WarmupTasks).IsEmpty();
     }
 
     [Test]
@@ -63,7 +67,10 @@ public sealed class InMemoryStreamsGroupMemberTests
         await using var member = CreateMember();
         await member.JoinAsync(new StreamsGroupMemberUpdate
         {
-            Topology = CreateTopology(),
+            Topology = CreateTopology()
+        });
+        await member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
             ActiveTasks = [new StreamsGroupTaskSet { SubtopologyId = "sub-0", Partitions = [2] }],
             StandbyTasks = [],
             WarmupTasks = []
@@ -140,39 +147,33 @@ public sealed class InMemoryStreamsGroupMemberTests
     }
 
     [Test]
-    public async Task JoinAndUpdateAsync_DeepCopyPublishedTaskSets()
+    public async Task UpdateAsync_DeepCopiesPublishedTaskSets()
     {
         await using var member = CreateMember();
-        var joinPartitions = new List<int> { 0, 1 };
-        var joinTasks = new List<StreamsGroupTaskSet>
+        await member.JoinAsync(new StreamsGroupMemberUpdate { Topology = CreateTopology() });
+        var activePartitions = new List<int> { 0, 1 };
+        var activeTasks = new List<StreamsGroupTaskSet>
         {
-            new() { SubtopologyId = "join", Partitions = joinPartitions }
+            new() { SubtopologyId = "active", Partitions = activePartitions }
         };
-
-        var joinResult = await member.JoinAsync(new StreamsGroupMemberUpdate
+        var standbyPartitions = new List<int> { 2, 3 };
+        var standbyTasks = new List<StreamsGroupTaskSet>
         {
-            Topology = CreateTopology(),
-            ActiveTasks = joinTasks
-        });
-
-        joinPartitions[0] = 99;
-        joinTasks.Clear();
-        await Assert.That(joinResult.ActiveTasks![0].Partitions).IsEquivalentTo([0, 1]);
-        await Assert.That(member.Snapshot.Assignment.ActiveTasks[0].Partitions).IsEquivalentTo([0, 1]);
-
-        var updatePartitions = new List<int> { 2, 3 };
-        var updateTasks = new List<StreamsGroupTaskSet>
-        {
-            new() { SubtopologyId = "update", Partitions = updatePartitions }
+            new() { SubtopologyId = "standby", Partitions = standbyPartitions }
         };
 
         var updateResult = await member.UpdateAsync(new StreamsGroupMemberUpdate
         {
-            StandbyTasks = updateTasks
+            ActiveTasks = activeTasks,
+            StandbyTasks = standbyTasks
         });
 
-        updatePartitions.Add(4);
-        updateTasks[0] = new StreamsGroupTaskSet { SubtopologyId = "replacement", Partitions = [9] };
+        activePartitions[0] = 99;
+        activeTasks.Clear();
+        standbyPartitions.Add(4);
+        standbyTasks[0] = new StreamsGroupTaskSet { SubtopologyId = "replacement", Partitions = [9] };
+        await Assert.That(updateResult.ActiveTasks![0].Partitions).IsEquivalentTo([0, 1]);
+        await Assert.That(member.Snapshot.Assignment.ActiveTasks[0].Partitions).IsEquivalentTo([0, 1]);
         await Assert.That(updateResult.StandbyTasks![0].Partitions).IsEquivalentTo([2, 3]);
         await Assert.That(member.Snapshot.Assignment.StandbyTasks[0].Partitions).IsEquivalentTo([2, 3]);
     }

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryStreamsGroupMemberTests.cs
@@ -114,6 +114,32 @@ public sealed class InMemoryStreamsGroupMemberTests
     }
 
     [Test]
+    public async Task UpdateAsync_TopologyRejoinIgnoresSuppliedAssignment()
+    {
+        await using var member = CreateMember();
+        await member.JoinAsync(new StreamsGroupMemberUpdate
+        {
+            Topology = CreateTopology(),
+            ActiveTasks = [new StreamsGroupTaskSet { SubtopologyId = "initial", Partitions = [0] }]
+        });
+
+        var result = await member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            Topology = CreateTopology(),
+            ActiveTasks = [new StreamsGroupTaskSet { SubtopologyId = "active", Partitions = [1] }],
+            StandbyTasks = [new StreamsGroupTaskSet { SubtopologyId = "standby", Partitions = [2] }],
+            WarmupTasks = [new StreamsGroupTaskSet { SubtopologyId = "warmup", Partitions = [3] }]
+        });
+
+        await Assert.That(result.ActiveTasks).IsNull();
+        await Assert.That(result.StandbyTasks).IsNull();
+        await Assert.That(result.WarmupTasks).IsNull();
+        await Assert.That(member.Snapshot.Assignment.ActiveTasks).IsEmpty();
+        await Assert.That(member.Snapshot.Assignment.StandbyTasks).IsEmpty();
+        await Assert.That(member.Snapshot.Assignment.WarmupTasks).IsEmpty();
+    }
+
+    [Test]
     public async Task JoinAndUpdateAsync_DeepCopyPublishedTaskSets()
     {
         await using var member = CreateMember();

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/StreamsGroupHeartbeatProtocolBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/StreamsGroupHeartbeatProtocolBenchmarks.cs
@@ -3,6 +3,7 @@ using BenchmarkDotNet.Attributes;
 using Dekaf.Benchmarks.Infrastructure;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Dekaf.Streams;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
@@ -31,6 +32,10 @@ public class StreamsGroupHeartbeatProtocolBenchmarks
             new StreamsGroupHeartbeatTaskOffset { SubtopologyId = "0", Partition = 0, Offset = 42 }
         ]
     };
+    private readonly StreamsGroupHeartbeatRequestCache _requestCache = new();
+
+    [GlobalSetup]
+    public void Setup() => GetCachedSteadyStateHeartbeat();
 
     [Benchmark]
     public int WriteStreamsGroupHeartbeatV0()
@@ -40,4 +45,13 @@ public class StreamsGroupHeartbeatProtocolBenchmarks
         _request.Write(ref writer, version: 0);
         return _buffer.WrittenCount;
     }
+
+    [Benchmark]
+    public object GetCachedSteadyStateHeartbeat() =>
+        _requestCache.Get(
+            _request.GroupId,
+            _request.MemberId,
+            _request.MemberEpoch,
+            _request.EndpointInformationEpoch,
+            _request.InstanceId);
 }


### PR DESCRIPTION
Closes #2787

## Summary

- add a public Streams group member backed by the root client's shared connections and metadata
- implement coordinator discovery, heartbeats, join/rejoin/leave, static membership, topology negotiation, assignment reconciliation, and task-offset reports
- keep steady-state heartbeat request creation allocation-free and surface actionable broker feature-gate errors

## Validation

- `dotnet build --configuration Release` — 0 warnings, 0 errors
- full net10 unit suite — 7,561 passed
- focused Streams coordinator unit suite — 22 passed
- Kafka 4.3.1 integration join/leave — passed
- Kafka 4.1.2 compatibility gate — skipped as expected (requires 4.2+ API 88 support)
- BenchmarkDotNet `GetCachedSteadyStateHeartbeat` — 0.8882 ns mean, 0 B allocated (previous PR head: 1.140 ns, 0 B)

## Performance

The recurring heartbeat uses a cached immutable protocol request. No per-heartbeat lock, LINQ, delegate, task, or request-object allocation is introduced. The channel worker serializes membership state transitions; the timer only queues a cached singleton command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct creation and management of Kafka Streams group members, including joining, assignments, task-offset reporting, heartbeats, snapshots, and graceful closure.
  * Added replica log-directory inspection APIs.
  * Added consumer record filtering and header-based deserialization.
  * Added support for asynchronous deserializer preparation.
  * Added protocol-version helpers for metadata, produce, and fetch requests.

* **Bug Fixes**
  * Improved recovery from fencing, heartbeat failures, coordinator issues, and unsupported broker capabilities.

* **Tests**
  * Expanded coverage for Streams membership, retries, assignments, offsets, heartbeats, cancellation, and shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
