### PR TITLE
testing: inject producer and transaction faults

### DIFF
--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -252,7 +252,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         : new ConsumerGroupMetadata
         {
             GroupId = _groupId,
-            GenerationId = 1,
+            GenerationId = _cluster.GetConsumerGroupGeneration(_groupId),
             MemberId = _memberId
         };
 

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -51,6 +51,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private readonly string? _groupId;
     private readonly string? _memberId;
     private int _consumerGroupGeneration = -1;
+    private long _consumerGroupRegistrationId;
     private string? _subscriptionPattern;
     private bool _disposed;
 
@@ -1014,6 +1015,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 if (_cluster.TryRead(
                         bound.Partition,
                         position,
+                        _options.IsolationLevel,
                         out var record,
                         out var blockedByOngoingTransaction) &&
                     record.Offset < bound.EndOffset)
@@ -1127,7 +1129,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 if (!_positions.TryGetValue(partition, out var position))
                     continue;
 
-                if (!_cluster.TryRead(partition, position, out var record))
+                if (!_cluster.TryRead(partition, position, _options.IsolationLevel, out var record))
                     continue;
 
                 selectedPartition = partition;
@@ -1435,15 +1437,22 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     private IReadOnlySet<TopicPartition> GetCurrentAssignmentUnderLock(out int consumerGroupGeneration)
     {
-        if (_groupId is null || _memberId is null || _consumerGroupGeneration < 0)
+        if (_groupId is null || _memberId is null)
         {
             consumerGroupGeneration = -1;
             return _assignment;
         }
 
+        if (_consumerGroupGeneration < 0 || _consumerGroupRegistrationId == 0)
+        {
+            consumerGroupGeneration = -1;
+            return new HashSet<TopicPartition>();
+        }
+
         var owned = _cluster.GetConsumerGroupAssignment(
             _groupId,
             _memberId,
+            _consumerGroupRegistrationId,
             out consumerGroupGeneration);
         _consumerGroupGeneration = consumerGroupGeneration;
         return owned.Where(_assignment.Contains).ToHashSet();
@@ -1457,7 +1466,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         _consumerGroupGeneration = _cluster.RegisterConsumerGroupMember(
             _groupId,
             _memberId,
-            _assignment);
+            _assignment,
+            out _consumerGroupRegistrationId);
     }
 
     private void UnregisterConsumerGroupMemberUnderLock()
@@ -1465,8 +1475,12 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         if (_groupId is null || _memberId is null)
             return;
 
-        _cluster.UnregisterConsumerGroupMember(_groupId, _memberId);
+        _cluster.UnregisterConsumerGroupMember(
+            _groupId,
+            _memberId,
+            _consumerGroupRegistrationId);
         _consumerGroupGeneration = -1;
+        _consumerGroupRegistrationId = 0;
     }
 
     private void ThrowIfDisposed()

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -998,15 +998,27 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         while (activePartitionIndex < partitions.Length)
         {
             var bound = partitions[activePartitionIndex];
-            if (_positions.TryGetValue(bound.Partition, out var position)
-                && position < bound.EndOffset
-                && _cluster.TryRead(bound.Partition, position, out var record)
-                && record.Offset < bound.EndOffset)
+            if (_positions.TryGetValue(bound.Partition, out var position) &&
+                position < bound.EndOffset)
             {
-                selectedPartition = bound.Partition;
-                selectedRecord = record;
-                selectedPosition = position;
-                return true;
+                if (_cluster.TryRead(
+                        bound.Partition,
+                        position,
+                        out var record,
+                        out var blockedByOngoingTransaction) &&
+                    record.Offset < bound.EndOffset)
+                {
+                    selectedPartition = bound.Partition;
+                    selectedRecord = record;
+                    selectedPosition = position;
+                    return true;
+                }
+
+                if (blockedByOngoingTransaction)
+                {
+                    activePartitionIndex++;
+                    continue;
+                }
             }
 
             if (!_positions.TryGetValue(bound.Partition, out position)

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -50,6 +50,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private bool _snapshotActive;
     private readonly string? _groupId;
     private readonly string? _memberId;
+    private int _consumerGroupGeneration = -1;
     private string? _subscriptionPattern;
     private bool _disposed;
 
@@ -247,14 +248,23 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     public string? MemberId => _memberId;
 
-    public ConsumerGroupMetadata? ConsumerGroupMetadata => _groupId is null || _memberId is null
-        ? null
-        : new ConsumerGroupMetadata
+    public ConsumerGroupMetadata? ConsumerGroupMetadata
+    {
+        get
         {
-            GroupId = _groupId,
-            GenerationId = _cluster.GetConsumerGroupGeneration(_groupId),
-            MemberId = _memberId
-        };
+            lock (_gate)
+            {
+                return _groupId is null || _memberId is null || _consumerGroupGeneration < 0
+                    ? null
+                    : new ConsumerGroupMetadata
+                    {
+                        GroupId = _groupId,
+                        GenerationId = _consumerGroupGeneration,
+                        MemberId = _memberId
+                    };
+            }
+        }
+    }
 
     public IConsumerPositions Positions => this;
 
@@ -1425,7 +1435,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     private IReadOnlySet<TopicPartition> GetCurrentAssignmentUnderLock(out int consumerGroupGeneration)
     {
-        if (_groupId is null || _memberId is null)
+        if (_groupId is null || _memberId is null || _consumerGroupGeneration < 0)
         {
             consumerGroupGeneration = -1;
             return _assignment;
@@ -1435,6 +1445,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             _groupId,
             _memberId,
             out consumerGroupGeneration);
+        _consumerGroupGeneration = consumerGroupGeneration;
         return owned.Where(_assignment.Contains).ToHashSet();
     }
 
@@ -1443,7 +1454,10 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         if (_groupId is null || _memberId is null)
             return;
 
-        _cluster.RegisterConsumerGroupMember(_groupId, _memberId, _assignment);
+        _consumerGroupGeneration = _cluster.RegisterConsumerGroupMember(
+            _groupId,
+            _memberId,
+            _assignment);
     }
 
     private void UnregisterConsumerGroupMemberUnderLock()
@@ -1452,6 +1466,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             return;
 
         _cluster.UnregisterConsumerGroupMember(_groupId, _memberId);
+        _consumerGroupGeneration = -1;
     }
 
     private void ThrowIfDisposed()

--- a/src/Dekaf.Testing/InMemoryConsumerOptions.cs
+++ b/src/Dekaf.Testing/InMemoryConsumerOptions.cs
@@ -1,4 +1,5 @@
 using Dekaf.Consumer;
+using Dekaf.Protocol.Messages;
 
 namespace Dekaf.Testing;
 
@@ -41,6 +42,11 @@ public sealed class InMemoryConsumerOptions
     /// stages it immediately at delivery.
     /// </summary>
     public OffsetStoreTiming OffsetStoreTiming { get; init; } = OffsetStoreTiming.AfterProcessing;
+
+    /// <summary>
+    /// Isolation level for transactional reads.
+    /// </summary>
+    public IsolationLevel IsolationLevel { get; init; } = IsolationLevel.ReadUncommitted;
 
     /// <summary>
     /// Member ID reported by the fake consumer.

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -24,19 +24,36 @@ public sealed class InMemoryKafkaCluster
     private TimeSpan _produceLatency;
 
     public InMemoryKafkaCluster()
-        : this(new InMemoryKafkaClusterOptions())
+        : this(new InMemoryKafkaClusterOptions(), new KafkaFaultPlan())
     {
     }
 
     public InMemoryKafkaCluster(InMemoryKafkaClusterOptions options)
+        : this(options, new KafkaFaultPlan())
+    {
+    }
+
+    public InMemoryKafkaCluster(IKafkaFaultPlan faultPlan)
+        : this(new InMemoryKafkaClusterOptions(), faultPlan)
+    {
+    }
+
+    public InMemoryKafkaCluster(InMemoryKafkaClusterOptions options, IKafkaFaultPlan faultPlan)
     {
         ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(faultPlan);
         ArgumentNullException.ThrowIfNull(options.SupportedFeatures);
         ArgumentOutOfRangeException.ThrowIfLessThan(options.DefaultPartitionCount, 1);
         _options = options;
+        FaultPlan = faultPlan;
     }
 
     public InMemoryKafkaClusterOptions Options => _options;
+
+    /// <summary>
+    /// Gets the deterministic fault plan consumed by in-memory client operations.
+    /// </summary>
+    public IKafkaFaultPlan FaultPlan { get; }
 
     public TimeSpan ProduceLatency
     {
@@ -199,7 +216,8 @@ public sealed class InMemoryKafkaCluster
         bool isValueNull,
         IReadOnlyList<Header>? headers,
         DateTimeOffset timestamp,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        KafkaFaultOperation faultOperation = KafkaFaultOperation.Produce)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(topic);
         ArgumentNullException.ThrowIfNull(key);
@@ -213,6 +231,10 @@ public sealed class InMemoryKafkaCluster
 
         if (failure is not null)
             throw failure;
+
+        await FaultPlan.ApplyAsync(
+            new KafkaFaultScope(faultOperation, topic, partition),
+            cancellationToken).ConfigureAwait(false);
 
         TaskCompletionSource signal;
         RecordMetadata metadata;

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -22,6 +22,7 @@ public sealed class InMemoryKafkaCluster
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, int>>> _shareDeliveryCounts = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Exception> _produceFailures = new(StringComparer.Ordinal);
     private readonly Dictionary<PreparedTransactionState, object> _preparedTransactions = [];
+    private readonly Dictionary<InMemoryTransactionMarker, List<PartitionState>> _transactionPartitions = [];
     private readonly InMemoryKafkaClusterOptions _options;
     private TaskCompletionSource _recordsChanged = NewRecordsChangedSource();
     private long _nextProducerId;
@@ -210,7 +211,7 @@ public sealed class InMemoryKafkaCluster
             var visible = new List<InMemoryRecord>(partitionState.Records.Count);
             foreach (var record in partitionState.Records)
             {
-                if (IsOngoingTransaction(record))
+                if (record.Offset >= partitionState.FirstUnstableOffset)
                     break;
                 if (IsRecordVisibleUnderLock(record))
                     visible.Add(CloneRecord(record));
@@ -266,6 +267,12 @@ public sealed class InMemoryKafkaCluster
             transactionMarker.State = committed
                 ? InMemoryTransactionState.Committed
                 : InMemoryTransactionState.Aborted;
+
+            if (_transactionPartitions.Remove(transactionMarker, out var transactionPartitions))
+            {
+                foreach (var partition in transactionPartitions)
+                    partition.CompleteTransaction(transactionMarker);
+            }
 
             if (preparedState.HasTransaction &&
                 _preparedTransactions.TryGetValue(preparedState, out var registered) &&
@@ -360,6 +367,17 @@ public sealed class InMemoryKafkaCluster
             };
 
             partitionState.Records.Add(record);
+            if (transactionMarker is not null &&
+                partitionState.RegisterTransaction(transactionMarker, offset))
+            {
+                if (!_transactionPartitions.TryGetValue(transactionMarker, out var transactionPartitions))
+                {
+                    transactionPartitions = [];
+                    _transactionPartitions.Add(transactionMarker, transactionPartitions);
+                }
+
+                transactionPartitions.Add(partitionState);
+            }
 
             metadata = new RecordMetadata
             {
@@ -743,7 +761,7 @@ public sealed class InMemoryKafkaCluster
         var partition = topic.Partitions[topicPartition.Partition];
         foreach (var candidate in partition.Records)
         {
-            if (IsOngoingTransaction(candidate))
+            if (candidate.Offset >= partition.FirstUnstableOffset)
             {
                 record = null!;
                 blockedByOngoingTransaction = true;
@@ -760,16 +778,13 @@ public sealed class InMemoryKafkaCluster
         }
 
         record = null!;
-        blockedByOngoingTransaction = false;
+        blockedByOngoingTransaction = partition.FirstUnstableOffset != long.MaxValue;
         return false;
     }
 
     private static bool IsRecordVisibleUnderLock(InMemoryRecord record) =>
         record.Transaction is not { } transaction ||
         transaction.State == InMemoryTransactionState.Committed;
-
-    private static bool IsOngoingTransaction(InMemoryRecord record) =>
-        record.Transaction?.State == InMemoryTransactionState.Ongoing;
 
     private void ValidateConsumerGroupMetadataUnderLock(
         string groupId,
@@ -783,7 +798,7 @@ public sealed class InMemoryKafkaCluster
             !_consumerGroupMembers.TryGetValue(groupId, out var members) ||
             !members.ContainsKey(metadata.MemberId))
         {
-            throw new TransactionException(
+            throw new FatalTransactionException(
                 ErrorCode.IllegalGeneration,
                 $"Consumer group metadata for '{groupId}' is no longer current.");
         }
@@ -1073,9 +1088,34 @@ public sealed class InMemoryKafkaCluster
 
     private sealed class PartitionState
     {
+        private readonly Dictionary<InMemoryTransactionMarker, long> _transactionOffsets = [];
+
         public List<InMemoryRecord> Records { get; } = [];
         public long LogStartOffset { get; set; }
         public long HighWatermark => Records.Count == 0 ? LogStartOffset : Records[^1].Offset + 1;
+        public long FirstUnstableOffset { get; private set; } = long.MaxValue;
+
+        public bool RegisterTransaction(InMemoryTransactionMarker transaction, long offset)
+        {
+            if (!_transactionOffsets.TryAdd(transaction, offset))
+                return false;
+
+            FirstUnstableOffset = Math.Min(FirstUnstableOffset, offset);
+            return true;
+        }
+
+        public void CompleteTransaction(InMemoryTransactionMarker transaction)
+        {
+            if (!_transactionOffsets.Remove(transaction, out var offset) ||
+                offset != FirstUnstableOffset)
+            {
+                return;
+            }
+
+            FirstUnstableOffset = long.MaxValue;
+            foreach (var remainingOffset in _transactionOffsets.Values)
+                FirstUnstableOffset = Math.Min(FirstUnstableOffset, remainingOffset);
+        }
     }
 
     private sealed class ShareLeaseState

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -3,6 +3,7 @@ using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
 using Dekaf.Producer;
 using Dekaf.Serialization;
 
@@ -16,7 +17,7 @@ public sealed class InMemoryKafkaCluster
     private readonly object _gate = new();
     private readonly Dictionary<string, TopicState> _topics = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, TopicPartitionOffset>> _consumerGroupOffsets = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, Dictionary<string, HashSet<TopicPartition>>> _consumerGroupMembers = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dictionary<string, ConsumerGroupMemberState>> _consumerGroupMembers = new(StringComparer.Ordinal);
     private readonly Dictionary<string, int> _consumerGroupGenerations = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, ShareLeaseState>>> _shareLeases = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, int>>> _shareDeliveryCounts = new(StringComparer.Ordinal);
@@ -26,6 +27,7 @@ public sealed class InMemoryKafkaCluster
     private readonly InMemoryKafkaClusterOptions _options;
     private TaskCompletionSource _recordsChanged = NewRecordsChangedSource();
     private long _nextProducerId;
+    private long _nextConsumerGroupRegistrationId;
     private TimeSpan _produceLatency;
 
     public InMemoryKafkaCluster()
@@ -130,7 +132,8 @@ public sealed class InMemoryKafkaCluster
     internal int RegisterConsumerGroupMember(
         string groupId,
         string memberId,
-        IEnumerable<TopicPartition> subscribedPartitions)
+        IEnumerable<TopicPartition> subscribedPartitions,
+        out long registrationId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
         ArgumentException.ThrowIfNullOrWhiteSpace(memberId);
@@ -142,18 +145,22 @@ public sealed class InMemoryKafkaCluster
         {
             if (!_consumerGroupMembers.TryGetValue(groupId, out var members))
             {
-                members = new Dictionary<string, HashSet<TopicPartition>>(StringComparer.Ordinal);
+                members = new Dictionary<string, ConsumerGroupMemberState>(StringComparer.Ordinal);
                 _consumerGroupMembers[groupId] = members;
             }
 
-            members[memberId] = partitions;
+            registrationId = ++_nextConsumerGroupRegistrationId;
+            members[memberId] = new ConsumerGroupMemberState(registrationId, partitions);
             var generation = _consumerGroupGenerations.GetValueOrDefault(groupId) + 1;
             _consumerGroupGenerations[groupId] = generation;
             return generation;
         }
     }
 
-    internal void UnregisterConsumerGroupMember(string groupId, string memberId)
+    internal void UnregisterConsumerGroupMember(
+        string groupId,
+        string memberId,
+        long registrationId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
         ArgumentException.ThrowIfNullOrWhiteSpace(memberId);
@@ -163,8 +170,13 @@ public sealed class InMemoryKafkaCluster
             if (!_consumerGroupMembers.TryGetValue(groupId, out var members))
                 return;
 
-            if (!members.Remove(memberId))
+            if (!members.TryGetValue(memberId, out var member) ||
+                member.RegistrationId != registrationId)
+            {
                 return;
+            }
+
+            members.Remove(memberId);
 
             _consumerGroupGenerations[groupId] = _consumerGroupGenerations.GetValueOrDefault(groupId) + 1;
             if (members.Count == 0)
@@ -175,6 +187,7 @@ public sealed class InMemoryKafkaCluster
     internal IReadOnlySet<TopicPartition> GetConsumerGroupAssignment(
         string groupId,
         string memberId,
+        long registrationId,
         out int generation)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
@@ -182,6 +195,14 @@ public sealed class InMemoryKafkaCluster
 
         lock (_gate)
         {
+            if (!_consumerGroupMembers.TryGetValue(groupId, out var members) ||
+                !members.TryGetValue(memberId, out var member) ||
+                member.RegistrationId != registrationId)
+            {
+                generation = -1;
+                return new HashSet<TopicPartition>();
+            }
+
             generation = _consumerGroupGenerations.GetValueOrDefault(groupId);
             var assignments = BuildConsumerGroupAssignments(groupId);
             return assignments.TryGetValue(memberId, out var partitions)
@@ -496,11 +517,31 @@ public sealed class InMemoryKafkaCluster
     }
 
     internal bool TryRead(TopicPartition topicPartition, long offset, out InMemoryRecord record) =>
-        TryRead(topicPartition, offset, out record, out _);
+        TryRead(topicPartition, offset, IsolationLevel.ReadCommitted, out record, out _);
 
     internal bool TryRead(
         TopicPartition topicPartition,
         long offset,
+        IsolationLevel isolationLevel,
+        out InMemoryRecord record) =>
+        TryRead(topicPartition, offset, isolationLevel, out record, out _);
+
+    internal bool TryRead(
+        TopicPartition topicPartition,
+        long offset,
+        out InMemoryRecord record,
+        out bool blockedByOngoingTransaction) =>
+        TryRead(
+            topicPartition,
+            offset,
+            IsolationLevel.ReadCommitted,
+            out record,
+            out blockedByOngoingTransaction);
+
+    internal bool TryRead(
+        TopicPartition topicPartition,
+        long offset,
+        IsolationLevel isolationLevel,
         out InMemoryRecord record,
         out bool blockedByOngoingTransaction)
     {
@@ -509,6 +550,7 @@ public sealed class InMemoryKafkaCluster
             if (!TryReadRecordUnderLock(
                     topicPartition,
                     offset,
+                    isolationLevel,
                     out var candidate,
                     out blockedByOngoingTransaction))
             {
@@ -534,7 +576,12 @@ public sealed class InMemoryKafkaCluster
 
         lock (_gate)
         {
-            if (!TryReadRecordUnderLock(topicPartition, offset, out var candidate, out _))
+            if (!TryReadRecordUnderLock(
+                    topicPartition,
+                    offset,
+                    IsolationLevel.ReadCommitted,
+                    out var candidate,
+                    out _))
             {
                 record = null!;
                 deliveryCount = 0;
@@ -837,6 +884,7 @@ public sealed class InMemoryKafkaCluster
     private bool TryReadRecordUnderLock(
         TopicPartition topicPartition,
         long offset,
+        IsolationLevel isolationLevel,
         out InMemoryRecord record,
         out bool blockedByOngoingTransaction)
     {
@@ -851,7 +899,8 @@ public sealed class InMemoryKafkaCluster
         var partition = topic.Partitions[topicPartition.Partition];
         foreach (var candidate in partition.Records)
         {
-            if (candidate.Offset >= partition.FirstUnstableOffset)
+            if (isolationLevel == IsolationLevel.ReadCommitted &&
+                candidate.Offset >= partition.FirstUnstableOffset)
             {
                 record = null!;
                 blockedByOngoingTransaction = true;
@@ -859,7 +908,8 @@ public sealed class InMemoryKafkaCluster
             }
             if (candidate.Offset < offset)
                 continue;
-            if (IsRecordVisibleUnderLock(candidate))
+            if (isolationLevel == IsolationLevel.ReadUncommitted ||
+                IsRecordVisibleUnderLock(candidate))
             {
                 record = candidate;
                 blockedByOngoingTransaction = false;
@@ -868,7 +918,8 @@ public sealed class InMemoryKafkaCluster
         }
 
         record = null!;
-        blockedByOngoingTransaction = partition.FirstUnstableOffset != long.MaxValue;
+        blockedByOngoingTransaction = isolationLevel == IsolationLevel.ReadCommitted &&
+            partition.FirstUnstableOffset != long.MaxValue;
         return false;
     }
 
@@ -905,7 +956,7 @@ public sealed class InMemoryKafkaCluster
 
         var partitions = members
             .Values
-            .SelectMany(static item => item)
+            .SelectMany(static item => item.SubscribedPartitions)
             .Distinct()
             .OrderBy(static item => item.Topic, StringComparer.Ordinal)
             .ThenBy(static item => item.Partition)
@@ -915,7 +966,7 @@ public sealed class InMemoryKafkaCluster
         {
             var partition = partitions[i];
             var eligibleMembers = members
-                .Where(member => member.Value.Contains(partition))
+                .Where(member => member.Value.SubscribedPartitions.Contains(partition))
                 .Select(static member => member.Key)
                 .Order(StringComparer.Ordinal)
                 .ToArray();
@@ -1217,4 +1268,8 @@ public sealed class InMemoryKafkaCluster
 
         public string MemberId { get; }
     }
+
+    private readonly record struct ConsumerGroupMemberState(
+        long RegistrationId,
+        HashSet<TopicPartition> SubscribedPartitions);
 }

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -21,7 +21,7 @@ public sealed class InMemoryKafkaCluster
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, ShareLeaseState>>> _shareLeases = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, int>>> _shareDeliveryCounts = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Exception> _produceFailures = new(StringComparer.Ordinal);
-    private readonly Dictionary<PreparedTransactionState, object> _preparedTransactions = [];
+    private readonly Dictionary<PreparedTransactionState, IInMemoryPreparedTransaction> _preparedTransactions = [];
     private readonly Dictionary<InMemoryTransactionMarker, List<PartitionState>> _transactionPartitions = [];
     private readonly InMemoryKafkaClusterOptions _options;
     private TaskCompletionSource _recordsChanged = NewRecordsChangedSource();
@@ -224,14 +224,16 @@ public sealed class InMemoryKafkaCluster
 
     internal long AllocateProducerId() => Interlocked.Increment(ref _nextProducerId);
 
-    internal void RegisterPreparedTransaction(PreparedTransactionState state, object transaction)
+    internal void RegisterPreparedTransaction(
+        PreparedTransactionState state,
+        IInMemoryPreparedTransaction transaction)
     {
         ArgumentNullException.ThrowIfNull(transaction);
         lock (_gate)
             _preparedTransactions[state] = transaction;
     }
 
-    internal object? GetPreparedTransaction(PreparedTransactionState state)
+    internal IInMemoryPreparedTransaction? GetPreparedTransaction(PreparedTransactionState state)
     {
         lock (_gate)
             return _preparedTransactions.GetValueOrDefault(state);
@@ -245,7 +247,7 @@ public sealed class InMemoryKafkaCluster
             IReadOnlyList<ConsumerGroupMetadata> MetadataSnapshots,
             IReadOnlyList<TopicPartitionOffset> Offsets)> pendingOffsets,
         PreparedTransactionState preparedState,
-        object transaction)
+        IInMemoryPreparedTransaction transaction)
     {
         ArgumentNullException.ThrowIfNull(pendingOffsets);
         ArgumentNullException.ThrowIfNull(transactionMarker);

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -24,6 +24,7 @@ public sealed class InMemoryKafkaCluster
     private readonly Dictionary<PreparedTransactionState, object> _preparedTransactions = [];
     private readonly InMemoryKafkaClusterOptions _options;
     private TaskCompletionSource _recordsChanged = NewRecordsChangedSource();
+    private long _nextProducerId;
     private TimeSpan _produceLatency;
 
     public InMemoryKafkaCluster()
@@ -206,14 +207,22 @@ public sealed class InMemoryKafkaCluster
         {
             var state = GetTopicForRead(topic);
             var partitionState = GetPartitionForRead(state, partition);
-            return partitionState.Records
-                .Where(IsRecordVisibleUnderLock)
-                .Select(CloneRecord)
-                .ToArray();
+            var visible = new List<InMemoryRecord>(partitionState.Records.Count);
+            foreach (var record in partitionState.Records)
+            {
+                if (IsOngoingTransaction(record))
+                    break;
+                if (IsRecordVisibleUnderLock(record))
+                    visible.Add(CloneRecord(record));
+            }
+
+            return visible;
         }
     }
 
     internal static InMemoryTransactionMarker CreateTransactionMarker() => new();
+
+    internal long AllocateProducerId() => Interlocked.Increment(ref _nextProducerId);
 
     internal void RegisterPreparedTransaction(PreparedTransactionState state, object transaction)
     {
@@ -297,11 +306,12 @@ public sealed class InMemoryKafkaCluster
         if (failure is not null)
             throw failure;
 
+        TopicState selectedTopic;
         int selectedPartition;
         lock (_gate)
         {
-            var state = GetOrAutoCreateTopic(topic);
-            selectedPartition = SelectPartition(state, partition, key, isKeyNull);
+            selectedTopic = GetOrAutoCreateTopic(topic);
+            selectedPartition = SelectPartition(selectedTopic, partition, key, isKeyNull);
         }
 
         await FaultPlan.ApplyAsync(
@@ -312,7 +322,19 @@ public sealed class InMemoryKafkaCluster
         RecordMetadata metadata;
         lock (_gate)
         {
-            var state = GetOrAutoCreateTopic(topic);
+            if (!_topics.TryGetValue(topic, out var state) ||
+                !ReferenceEquals(state, selectedTopic) ||
+                (uint)selectedPartition >= (uint)state.Partitions.Count)
+            {
+                throw new ProduceException(
+                    ErrorCode.UnknownTopicOrPartition,
+                    $"Topic '{topic}' changed while the produce operation was paused.")
+                {
+                    Topic = topic,
+                    Partition = selectedPartition
+                };
+            }
+
             var partitionState = state.Partitions[selectedPartition];
             var offset = partitionState.HighWatermark;
             var timestampMs = timestamp.ToUnixTimeMilliseconds();
@@ -706,7 +728,7 @@ public sealed class InMemoryKafkaCluster
                 record = candidate;
                 return true;
             }
-            if (candidate.Transaction?.State == InMemoryTransactionState.Ongoing)
+            if (IsOngoingTransaction(candidate))
                 break;
         }
 
@@ -714,9 +736,12 @@ public sealed class InMemoryKafkaCluster
         return false;
     }
 
-    private bool IsRecordVisibleUnderLock(InMemoryRecord record) =>
+    private static bool IsRecordVisibleUnderLock(InMemoryRecord record) =>
         record.Transaction is not { } transaction ||
         transaction.State == InMemoryTransactionState.Committed;
+
+    private static bool IsOngoingTransaction(InMemoryRecord record) =>
+        record.Transaction?.State == InMemoryTransactionState.Ongoing;
 
     private void ValidateConsumerGroupMetadataUnderLock(
         string groupId,
@@ -727,7 +752,6 @@ public sealed class InMemoryKafkaCluster
 
         var generation = _consumerGroupGenerations.GetValueOrDefault(groupId);
         if (generation != metadata.GenerationId ||
-            metadata.GroupInstanceId is not null ||
             !_consumerGroupMembers.TryGetValue(groupId, out var members) ||
             !members.ContainsKey(metadata.MemberId))
         {

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -1,4 +1,6 @@
 using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Protocol;
 using Dekaf.Producer;
@@ -19,6 +21,7 @@ public sealed class InMemoryKafkaCluster
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, ShareLeaseState>>> _shareLeases = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, int>>> _shareDeliveryCounts = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Exception> _produceFailures = new(StringComparer.Ordinal);
+    private readonly Dictionary<PreparedTransactionState, object> _preparedTransactions = [];
     private readonly InMemoryKafkaClusterOptions _options;
     private TaskCompletionSource _recordsChanged = NewRecordsChangedSource();
     private TimeSpan _produceLatency;
@@ -203,8 +206,69 @@ public sealed class InMemoryKafkaCluster
         {
             var state = GetTopicForRead(topic);
             var partitionState = GetPartitionForRead(state, partition);
-            return partitionState.Records.Select(CloneRecord).ToArray();
+            return partitionState.Records
+                .Where(IsRecordVisibleUnderLock)
+                .Select(CloneRecord)
+                .ToArray();
         }
+    }
+
+    internal static InMemoryTransactionMarker CreateTransactionMarker() => new();
+
+    internal void RegisterPreparedTransaction(PreparedTransactionState state, object transaction)
+    {
+        ArgumentNullException.ThrowIfNull(transaction);
+        lock (_gate)
+            _preparedTransactions[state] = transaction;
+    }
+
+    internal object? GetPreparedTransaction(PreparedTransactionState state)
+    {
+        lock (_gate)
+            return _preparedTransactions.GetValueOrDefault(state);
+    }
+
+    internal void CompleteTransaction(
+        InMemoryTransactionMarker transactionMarker,
+        bool committed,
+        IEnumerable<(string GroupId, ConsumerGroupMetadata? Metadata, IReadOnlyList<TopicPartitionOffset> Offsets)> pendingOffsets,
+        PreparedTransactionState preparedState,
+        object transaction)
+    {
+        ArgumentNullException.ThrowIfNull(pendingOffsets);
+        ArgumentNullException.ThrowIfNull(transactionMarker);
+        ArgumentNullException.ThrowIfNull(transaction);
+
+        TaskCompletionSource signal;
+        lock (_gate)
+        {
+            if (transactionMarker.State != InMemoryTransactionState.Ongoing)
+                throw new InvalidOperationException("The in-memory transaction is no longer active.");
+
+            if (committed)
+            {
+                foreach (var (groupId, metadata, _) in pendingOffsets)
+                    ValidateConsumerGroupMetadataUnderLock(groupId, metadata);
+
+                foreach (var (groupId, _, offsets) in pendingOffsets)
+                    CommitOffsetsUnderLock(groupId, offsets);
+            }
+
+            transactionMarker.State = committed
+                ? InMemoryTransactionState.Committed
+                : InMemoryTransactionState.Aborted;
+
+            if (preparedState.HasTransaction &&
+                _preparedTransactions.TryGetValue(preparedState, out var registered) &&
+                ReferenceEquals(registered, transaction))
+            {
+                _preparedTransactions.Remove(preparedState);
+            }
+
+            signal = _recordsChanged;
+        }
+
+        signal.TrySetResult();
     }
 
     internal async ValueTask<RecordMetadata> AppendAsync(
@@ -217,7 +281,8 @@ public sealed class InMemoryKafkaCluster
         IReadOnlyList<Header>? headers,
         DateTimeOffset timestamp,
         CancellationToken cancellationToken,
-        KafkaFaultOperation faultOperation = KafkaFaultOperation.Produce)
+        KafkaFaultOperation faultOperation = KafkaFaultOperation.Produce,
+        InMemoryTransactionMarker? transactionMarker = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(topic);
         ArgumentNullException.ThrowIfNull(key);
@@ -232,8 +297,15 @@ public sealed class InMemoryKafkaCluster
         if (failure is not null)
             throw failure;
 
+        int selectedPartition;
+        lock (_gate)
+        {
+            var state = GetOrAutoCreateTopic(topic);
+            selectedPartition = SelectPartition(state, partition, key, isKeyNull);
+        }
+
         await FaultPlan.ApplyAsync(
-            new KafkaFaultScope(faultOperation, topic, partition),
+            new KafkaFaultScope(faultOperation, topic, selectedPartition),
             cancellationToken).ConfigureAwait(false);
 
         TaskCompletionSource signal;
@@ -241,7 +313,6 @@ public sealed class InMemoryKafkaCluster
         lock (_gate)
         {
             var state = GetOrAutoCreateTopic(topic);
-            var selectedPartition = SelectPartition(state, partition, key, isKeyNull);
             var partitionState = state.Partitions[selectedPartition];
             var offset = partitionState.HighWatermark;
             var timestampMs = timestamp.ToUnixTimeMilliseconds();
@@ -256,7 +327,8 @@ public sealed class InMemoryKafkaCluster
                 Value = value,
                 IsValueNull = isValueNull,
                 Headers = CopyHeaders(headers),
-                TimestampMs = timestampMs
+                TimestampMs = timestampMs,
+                Transaction = transactionMarker
             };
 
             partitionState.Records.Add(record);
@@ -627,15 +699,42 @@ public sealed class InMemoryKafkaCluster
         var partition = topic.Partitions[topicPartition.Partition];
         foreach (var candidate in partition.Records)
         {
-            if (candidate.Offset >= offset)
+            if (candidate.Offset < offset)
+                continue;
+            if (IsRecordVisibleUnderLock(candidate))
             {
                 record = candidate;
                 return true;
             }
+            if (candidate.Transaction?.State == InMemoryTransactionState.Ongoing)
+                break;
         }
 
         record = null!;
         return false;
+    }
+
+    private bool IsRecordVisibleUnderLock(InMemoryRecord record) =>
+        record.Transaction is not { } transaction ||
+        transaction.State == InMemoryTransactionState.Committed;
+
+    private void ValidateConsumerGroupMetadataUnderLock(
+        string groupId,
+        ConsumerGroupMetadata? metadata)
+    {
+        if (metadata is null)
+            return;
+
+        var generation = _consumerGroupGenerations.GetValueOrDefault(groupId);
+        if (generation != metadata.GenerationId ||
+            metadata.GroupInstanceId is not null ||
+            !_consumerGroupMembers.TryGetValue(groupId, out var members) ||
+            !members.ContainsKey(metadata.MemberId))
+        {
+            throw new TransactionException(
+                ErrorCode.IllegalGeneration,
+                $"Consumer group metadata for '{groupId}' is no longer current.");
+        }
     }
 
     private Dictionary<string, HashSet<TopicPartition>> BuildConsumerGroupAssignments(string groupId)

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -127,7 +127,7 @@ public sealed class InMemoryKafkaCluster
         }
     }
 
-    internal void RegisterConsumerGroupMember(
+    internal int RegisterConsumerGroupMember(
         string groupId,
         string memberId,
         IEnumerable<TopicPartition> subscribedPartitions)
@@ -147,7 +147,9 @@ public sealed class InMemoryKafkaCluster
             }
 
             members[memberId] = partitions;
-            _consumerGroupGenerations[groupId] = _consumerGroupGenerations.GetValueOrDefault(groupId) + 1;
+            var generation = _consumerGroupGenerations.GetValueOrDefault(groupId) + 1;
+            _consumerGroupGenerations[groupId] = generation;
+            return generation;
         }
     }
 

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -166,10 +166,7 @@ public sealed class InMemoryKafkaCluster
 
             _consumerGroupGenerations[groupId] = _consumerGroupGenerations.GetValueOrDefault(groupId) + 1;
             if (members.Count == 0)
-            {
                 _consumerGroupMembers.Remove(groupId);
-                _consumerGroupGenerations.Remove(groupId);
-            }
         }
     }
 
@@ -241,7 +238,10 @@ public sealed class InMemoryKafkaCluster
     internal void CompleteTransaction(
         InMemoryTransactionMarker transactionMarker,
         bool committed,
-        IEnumerable<(string GroupId, ConsumerGroupMetadata? Metadata, IReadOnlyList<TopicPartitionOffset> Offsets)> pendingOffsets,
+        IEnumerable<(
+            string GroupId,
+            IReadOnlyList<ConsumerGroupMetadata> MetadataSnapshots,
+            IReadOnlyList<TopicPartitionOffset> Offsets)> pendingOffsets,
         PreparedTransactionState preparedState,
         object transaction)
     {
@@ -257,8 +257,11 @@ public sealed class InMemoryKafkaCluster
 
             if (committed)
             {
-                foreach (var (groupId, metadata, _) in pendingOffsets)
-                    ValidateConsumerGroupMetadataUnderLock(groupId, metadata);
+                foreach (var (groupId, metadataSnapshots, _) in pendingOffsets)
+                {
+                    for (var i = 0; i < metadataSnapshots.Count; i++)
+                        ValidateConsumerGroupMetadataUnderLock(groupId, metadataSnapshots[i]);
+                }
 
                 foreach (var (groupId, _, offsets) in pendingOffsets)
                     CommitOffsetsUnderLock(groupId, offsets);

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -372,11 +372,22 @@ public sealed class InMemoryKafkaCluster
         return metadata;
     }
 
-    internal bool TryRead(TopicPartition topicPartition, long offset, out InMemoryRecord record)
+    internal bool TryRead(TopicPartition topicPartition, long offset, out InMemoryRecord record) =>
+        TryRead(topicPartition, offset, out record, out _);
+
+    internal bool TryRead(
+        TopicPartition topicPartition,
+        long offset,
+        out InMemoryRecord record,
+        out bool blockedByOngoingTransaction)
     {
         lock (_gate)
         {
-            if (!TryReadRecordUnderLock(topicPartition, offset, out var candidate))
+            if (!TryReadRecordUnderLock(
+                    topicPartition,
+                    offset,
+                    out var candidate,
+                    out blockedByOngoingTransaction))
             {
                 record = null!;
                 return false;
@@ -400,7 +411,7 @@ public sealed class InMemoryKafkaCluster
 
         lock (_gate)
         {
-            if (!TryReadRecordUnderLock(topicPartition, offset, out var candidate))
+            if (!TryReadRecordUnderLock(topicPartition, offset, out var candidate, out _))
             {
                 record = null!;
                 deliveryCount = 0;
@@ -709,30 +720,41 @@ public sealed class InMemoryKafkaCluster
         return EnsureTopic(name, _options.DefaultPartitionCount, configs: null);
     }
 
-    private bool TryReadRecordUnderLock(TopicPartition topicPartition, long offset, out InMemoryRecord record)
+    private bool TryReadRecordUnderLock(
+        TopicPartition topicPartition,
+        long offset,
+        out InMemoryRecord record,
+        out bool blockedByOngoingTransaction)
     {
         if (!_topics.TryGetValue(topicPartition.Topic, out var topic) ||
             (uint)topicPartition.Partition >= (uint)topic.Partitions.Count)
         {
             record = null!;
+            blockedByOngoingTransaction = false;
             return false;
         }
 
         var partition = topic.Partitions[topicPartition.Partition];
         foreach (var candidate in partition.Records)
         {
+            if (IsOngoingTransaction(candidate))
+            {
+                record = null!;
+                blockedByOngoingTransaction = true;
+                return false;
+            }
             if (candidate.Offset < offset)
                 continue;
             if (IsRecordVisibleUnderLock(candidate))
             {
                 record = candidate;
+                blockedByOngoingTransaction = false;
                 return true;
             }
-            if (IsOngoingTransaction(candidate))
-                break;
         }
 
         record = null!;
+        blockedByOngoingTransaction = false;
         return false;
     }
 

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -316,12 +316,13 @@ public sealed class InMemoryKafkaCluster
         Exception? failure;
         TaskCompletionSource? signal = null;
         RecordMetadata metadata = default;
-        var hasFaults = FaultPlan is not KafkaFaultPlan { HasEntries: false };
+        var hasMatchingFault = FaultPlan is not KafkaFaultPlan indexedPlan ||
+                               indexedPlan.HasPotentialProduceMatch(faultOperation, topic);
         lock (_gate)
         {
             failure = _produceFailures.GetValueOrDefault(topic);
             latency = _produceLatency;
-            if (latency == TimeSpan.Zero && failure is null && !hasFaults)
+            if (latency == TimeSpan.Zero && failure is null && !hasMatchingFault)
             {
                 var state = GetOrAutoCreateTopic(topic);
                 var selectedPartition = SelectPartition(state, partition, key, isKeyNull);

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -322,6 +322,12 @@ public sealed class InMemoryKafkaCluster
         RecordMetadata metadata;
         lock (_gate)
         {
+            if (transactionMarker is { State: not InMemoryTransactionState.Ongoing })
+            {
+                throw new InvalidOperationException(
+                    "The in-memory transaction completed while the produce operation was paused.");
+            }
+
             if (!_topics.TryGetValue(topic, out var state) ||
                 !ReferenceEquals(state, selectedTopic) ||
                 (uint)selectedPartition >= (uint)state.Partitions.Count)

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -292,7 +292,7 @@ public sealed class InMemoryKafkaCluster
         signal.TrySetResult();
     }
 
-    internal async ValueTask<RecordMetadata> AppendAsync(
+    internal ValueTask<RecordMetadata> AppendAsync(
         string topic,
         int? partition,
         byte[] key,
@@ -308,8 +308,73 @@ public sealed class InMemoryKafkaCluster
         ArgumentException.ThrowIfNullOrWhiteSpace(topic);
         ArgumentNullException.ThrowIfNull(key);
         ArgumentNullException.ThrowIfNull(value);
+        cancellationToken.ThrowIfCancellationRequested();
 
-        var latency = GetProduceLatency(topic, out var failure);
+        TimeSpan latency;
+        Exception? failure;
+        TaskCompletionSource? signal = null;
+        RecordMetadata metadata = default;
+        var hasFaults = FaultPlan is not KafkaFaultPlan { HasEntries: false };
+        lock (_gate)
+        {
+            failure = _produceFailures.GetValueOrDefault(topic);
+            latency = _produceLatency;
+            if (latency == TimeSpan.Zero && failure is null && !hasFaults)
+            {
+                var state = GetOrAutoCreateTopic(topic);
+                var selectedPartition = SelectPartition(state, partition, key, isKeyNull);
+                metadata = AppendRecordUnderLock(
+                    topic,
+                    state,
+                    selectedPartition,
+                    key,
+                    isKeyNull,
+                    value,
+                    isValueNull,
+                    headers,
+                    timestamp,
+                    transactionMarker,
+                    out signal);
+            }
+        }
+
+        if (signal is not null)
+        {
+            signal.TrySetResult();
+            return new ValueTask<RecordMetadata>(metadata);
+        }
+
+        return AppendSlowAsync(
+            topic,
+            partition,
+            key,
+            isKeyNull,
+            value,
+            isValueNull,
+            headers,
+            timestamp,
+            faultOperation,
+            transactionMarker,
+            latency,
+            failure,
+            cancellationToken);
+    }
+
+    private async ValueTask<RecordMetadata> AppendSlowAsync(
+        string topic,
+        int? partition,
+        byte[] key,
+        bool isKeyNull,
+        byte[] value,
+        bool isValueNull,
+        IReadOnlyList<Header>? headers,
+        DateTimeOffset timestamp,
+        KafkaFaultOperation faultOperation,
+        InMemoryTransactionMarker? transactionMarker,
+        TimeSpan latency,
+        Exception? failure,
+        CancellationToken cancellationToken)
+    {
         if (latency > TimeSpan.Zero)
             await Task.Delay(latency, cancellationToken).ConfigureAwait(false);
 
@@ -334,12 +399,6 @@ public sealed class InMemoryKafkaCluster
         RecordMetadata metadata;
         lock (_gate)
         {
-            if (transactionMarker is { State: not InMemoryTransactionState.Ongoing })
-            {
-                throw new InvalidOperationException(
-                    "The in-memory transaction completed while the produce operation was paused.");
-            }
-
             if (!_topics.TryGetValue(topic, out var state) ||
                 !ReferenceEquals(state, selectedTopic) ||
                 (uint)selectedPartition >= (uint)state.Partitions.Count)
@@ -353,52 +412,84 @@ public sealed class InMemoryKafkaCluster
                 };
             }
 
-            var partitionState = state.Partitions[selectedPartition];
-            var offset = partitionState.HighWatermark;
-            var timestampMs = timestamp.ToUnixTimeMilliseconds();
-
-            var record = new InMemoryRecord
-            {
-                Topic = topic,
-                Partition = selectedPartition,
-                Offset = offset,
-                Key = key,
-                IsKeyNull = isKeyNull,
-                Value = value,
-                IsValueNull = isValueNull,
-                Headers = CopyHeaders(headers),
-                TimestampMs = timestampMs,
-                Transaction = transactionMarker
-            };
-
-            partitionState.Records.Add(record);
-            if (transactionMarker is not null &&
-                partitionState.RegisterTransaction(transactionMarker, offset))
-            {
-                if (!_transactionPartitions.TryGetValue(transactionMarker, out var transactionPartitions))
-                {
-                    transactionPartitions = [];
-                    _transactionPartitions.Add(transactionMarker, transactionPartitions);
-                }
-
-                transactionPartitions.Add(partitionState);
-            }
-
-            metadata = new RecordMetadata
-            {
-                Topic = topic,
-                Partition = selectedPartition,
-                Offset = offset,
-                Timestamp = timestamp,
-                KeySize = isKeyNull ? 0 : key.Length,
-                ValueSize = isValueNull ? 0 : value.Length
-            };
-
-            signal = _recordsChanged;
+            metadata = AppendRecordUnderLock(
+                topic,
+                state,
+                selectedPartition,
+                key,
+                isKeyNull,
+                value,
+                isValueNull,
+                headers,
+                timestamp,
+                transactionMarker,
+                out signal);
         }
 
         signal.TrySetResult();
         return metadata;
+    }
+
+    private RecordMetadata AppendRecordUnderLock(
+        string topic,
+        TopicState state,
+        int selectedPartition,
+        byte[] key,
+        bool isKeyNull,
+        byte[] value,
+        bool isValueNull,
+        IReadOnlyList<Header>? headers,
+        DateTimeOffset timestamp,
+        InMemoryTransactionMarker? transactionMarker,
+        out TaskCompletionSource signal)
+    {
+        if (transactionMarker is { State: not InMemoryTransactionState.Ongoing })
+        {
+            throw new InvalidOperationException(
+                "The in-memory transaction completed while the produce operation was paused.");
+        }
+
+        var partitionState = state.Partitions[selectedPartition];
+        var offset = partitionState.HighWatermark;
+        var timestampMs = timestamp.ToUnixTimeMilliseconds();
+
+        var record = new InMemoryRecord
+        {
+            Topic = topic,
+            Partition = selectedPartition,
+            Offset = offset,
+            Key = key,
+            IsKeyNull = isKeyNull,
+            Value = value,
+            IsValueNull = isValueNull,
+            Headers = CopyHeaders(headers),
+            TimestampMs = timestampMs,
+            Transaction = transactionMarker
+        };
+
+        partitionState.Records.Add(record);
+        if (transactionMarker is not null &&
+            partitionState.RegisterTransaction(transactionMarker, offset))
+        {
+            if (!_transactionPartitions.TryGetValue(transactionMarker, out var transactionPartitions))
+            {
+                transactionPartitions = [];
+                _transactionPartitions.Add(transactionMarker, transactionPartitions);
+            }
+
+            transactionPartitions.Add(partitionState);
+        }
+
+        signal = _recordsChanged;
+        return new RecordMetadata
+        {
+            Topic = topic,
+            Partition = selectedPartition,
+            Offset = offset,
+            Timestamp = timestamp,
+            KeySize = isKeyNull ? 0 : key.Length,
+            ValueSize = isValueNull ? 0 : value.Length
+        };
     }
 
     internal bool TryRead(TopicPartition topicPartition, long offset, out InMemoryRecord record) =>
@@ -726,15 +817,6 @@ public sealed class InMemoryKafkaCluster
                     IsInternal = topic.IsInternal
                 })
                 .ToArray();
-        }
-    }
-
-    private TimeSpan GetProduceLatency(string topic, out Exception? failure)
-    {
-        lock (_gate)
-        {
-            failure = _produceFailures.GetValueOrDefault(topic);
-            return _produceLatency;
         }
     }
 

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -34,7 +34,7 @@ public sealed class InMemoryProducer<TKey, TValue> :
     IKafkaProducer<TKey, TValue>,
     IInMemoryTransactionRecoveryContext
 {
-    internal static Action? TransactionCompletionPublishedTestHook;
+    internal Action? TransactionCompletionPublishedTestHook;
 
     private readonly InMemoryKafkaCluster _cluster;
     private readonly ISerializer<TKey> _keySerializer;

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -26,6 +26,8 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     private InMemoryTransaction? _activeTransaction;
     private FatalTransactionException? _fatalTransactionException;
     private bool _preparedRecoveryEnabled;
+    private bool _preparedRecoveryInProgress;
+    private bool _disposeStarted;
     private bool _disposed;
 
     public InMemoryProducer(InMemoryKafkaCluster cluster)
@@ -244,15 +246,19 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
 
     public ITransaction<TKey, TValue> BeginTransaction()
     {
-        ThrowIfDisposed();
         ThrowIfFatalTransactionError();
 
         lock (_transactionGate)
         {
+            ThrowIfDisposingOrDisposed();
+            if (_preparedRecoveryInProgress)
+                throw new InvalidOperationException("A prepared transaction recovery is already in progress.");
             if (_activeTransaction is { IsCompleted: false })
                 throw new InvalidOperationException("A transaction is already active.");
 
-            return _activeTransaction = new InMemoryTransaction(this);
+            var transaction = new InMemoryTransaction(this);
+            Volatile.Write(ref _activeTransaction, transaction);
+            return transaction;
         }
     }
 
@@ -267,7 +273,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         await ApplyFaultAsync(
             new KafkaFaultScope(KafkaFaultOperation.InitializeTransactions),
             cancellationToken).ConfigureAwait(false);
-        _preparedRecoveryEnabled = keepPreparedTransaction;
+        Volatile.Write(ref _preparedRecoveryEnabled, keepPreparedTransaction);
     }
 
     public async ValueTask CompletePreparedTransactionAsync(
@@ -279,33 +285,48 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         ThrowIfDisposed();
         ThrowIfFatalTransactionError();
 
-        InMemoryTransaction? transaction;
+        InMemoryTransaction transaction;
         lock (_transactionGate)
-            transaction = _activeTransaction;
-
-        if (transaction is { IsCompleted: false } &&
-            (!transaction.IsPrepared || transaction.PreparedState != preparedState))
         {
-            throw new InvalidOperationException(
-                "Cannot recover a prepared transaction while another transaction is active.");
-        }
+            ThrowIfDisposingOrDisposed();
+            if (_preparedRecoveryInProgress)
+                throw new InvalidOperationException("A prepared transaction recovery is already in progress.");
 
-        if (transaction is null || !transaction.IsPrepared || transaction.PreparedState != preparedState)
-        {
-            if (!_preparedRecoveryEnabled ||
-                _cluster.GetPreparedTransaction(preparedState) is not InMemoryTransaction recovered)
+            transaction = _activeTransaction!;
+            if (transaction is { IsCompleted: false } &&
+                (!transaction.IsPrepared || transaction.PreparedState != preparedState))
             {
                 throw new InvalidOperationException(
-                    "There is no matching active or recoverable prepared transaction.");
+                    "Cannot recover a prepared transaction while another transaction is active.");
             }
 
-            transaction = recovered;
+            if (transaction is null || !transaction.IsPrepared || transaction.PreparedState != preparedState)
+            {
+                if (!Volatile.Read(ref _preparedRecoveryEnabled) ||
+                    _cluster.GetPreparedTransaction(preparedState) is not InMemoryTransaction recovered)
+                {
+                    throw new InvalidOperationException(
+                        "There is no matching active or recoverable prepared transaction.");
+                }
+
+                transaction = recovered;
+            }
+
+            if (!transaction.IsPrepared || transaction.PreparedState != preparedState)
+                throw new InvalidOperationException("The prepared transaction state does not match the active transaction.");
+
+            Volatile.Write(ref _preparedRecoveryInProgress, true);
         }
 
-        if (!transaction.IsPrepared || transaction.PreparedState != preparedState)
-            throw new InvalidOperationException("The prepared transaction state does not match the active transaction.");
-
-        await transaction.CompletePreparedAsync(this, committed, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await transaction.CompletePreparedAsync(this, committed, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (_transactionGate)
+                Volatile.Write(ref _preparedRecoveryInProgress, false);
+        }
     }
 
     public ITopicProducer<TKey, TValue> ForTopic(string topic)
@@ -317,17 +338,20 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
 
     public async ValueTask DisposeAsync()
     {
-        if (_disposed)
-            return;
-
         InMemoryTransaction? transaction;
         lock (_transactionGate)
+        {
+            if (_disposeStarted)
+                return;
+
+            Volatile.Write(ref _disposeStarted, true);
             transaction = _activeTransaction;
+        }
 
         if (transaction is { IsCompleted: false, IsPrepared: false })
             await transaction.DisposeAsync().ConfigureAwait(false);
 
-        _disposed = true;
+        Volatile.Write(ref _disposed, true);
     }
 
     private ValueTask<RecordMetadata> ProduceCoreAsync(
@@ -362,6 +386,8 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(topic);
         ThrowIfFatalTransactionError();
+        if (transactionMarker is null)
+            ThrowIfTransactionActive();
 
         if (_hasAsyncSerializers)
         {
@@ -541,7 +567,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         lock (_transactionGate)
         {
             if (ReferenceEquals(_activeTransaction, transaction))
-                _activeTransaction = null;
+                Volatile.Write(ref _activeTransaction, null);
         }
     }
 
@@ -606,14 +632,34 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
 
     private void ThrowIfDisposed()
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed), this);
+    }
+
+    private void ThrowIfDisposingOrDisposed()
+    {
+        ObjectDisposedException.ThrowIf(
+            Volatile.Read(ref _disposeStarted) || Volatile.Read(ref _disposed),
+            this);
+    }
+
+    private void ThrowIfTransactionActive()
+    {
+        ThrowIfDisposingOrDisposed();
+        if (Volatile.Read(ref _activeTransaction) is { IsCompleted: false } ||
+            Volatile.Read(ref _preparedRecoveryInProgress))
+        {
+            throw new InvalidOperationException(
+                "Cannot produce outside the active transaction; use the transaction handle.");
+        }
     }
 
     private sealed class InMemoryTransaction : ITransaction<TKey, TValue>
     {
+        private const long MutationCountMask = uint.MaxValue;
         private readonly InMemoryProducer<TKey, TValue> _producer;
         private readonly Dictionary<string, PendingGroupOffsets> _pendingOffsets = new(StringComparer.Ordinal);
-        private bool _completed;
+        private long _lifecycle;
+        private AbortableTransactionException? _abortableException;
         private bool _prepared;
 
         public InMemoryTransaction(InMemoryProducer<TKey, TValue> producer)
@@ -624,11 +670,12 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
 
         public InMemoryTransactionMarker TransactionMarker { get; }
 
-        public bool IsCompleted => _completed;
+        public bool IsCompleted => GetState(Volatile.Read(ref _lifecycle)) == TransactionLifecycleState.Completed;
 
-        public bool IsPrepared => _prepared;
+        public bool IsPrepared => Volatile.Read(ref _prepared) ||
+            GetState(Volatile.Read(ref _lifecycle)) == TransactionLifecycleState.Preparing;
 
-        public PreparedTransactionState PreparedState => _prepared
+        public PreparedTransactionState PreparedState => Volatile.Read(ref _prepared)
             ? new PreparedTransactionState(_producer._producerId, 0)
             : PreparedTransactionState.Empty;
 
@@ -636,8 +683,20 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             ProducerMessage<TKey, TValue> message,
             CancellationToken cancellationToken = default)
         {
-            ThrowIfCannotMutate("Cannot produce");
-            return await _producer.ProduceTransactionAsync(this, message, cancellationToken).ConfigureAwait(false);
+            EnterMutation("Cannot produce");
+            try
+            {
+                return await _producer.ProduceTransactionAsync(this, message, cancellationToken).ConfigureAwait(false);
+            }
+            catch (AbortableTransactionException exception)
+            {
+                MarkAbortable(exception);
+                throw;
+            }
+            finally
+            {
+                ExitMutation();
+            }
         }
 
         public async ValueTask<RecordMetadata> ProduceAsync(
@@ -646,39 +705,87 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             TValue value,
             CancellationToken cancellationToken = default)
         {
-            ThrowIfCannotMutate("Cannot produce");
-            return await _producer.ProduceTransactionAsync(this, topic, key, value, cancellationToken).ConfigureAwait(false);
+            EnterMutation("Cannot produce");
+            try
+            {
+                return await _producer.ProduceTransactionAsync(this, topic, key, value, cancellationToken).ConfigureAwait(false);
+            }
+            catch (AbortableTransactionException exception)
+            {
+                MarkAbortable(exception);
+                throw;
+            }
+            finally
+            {
+                ExitMutation();
+            }
         }
 
         public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
         {
-            ThrowIfCompleted("Cannot commit transaction");
+            var previousState = EnterCompletion("Cannot commit transaction", allowAbortable: false);
+            try
+            {
+                await _producer.ApplyFaultAsync(
+                    new KafkaFaultScope(KafkaFaultOperation.CommitTransaction),
+                    cancellationToken).ConfigureAwait(false);
 
-            await _producer.ApplyFaultAsync(
-                new KafkaFaultScope(KafkaFaultOperation.CommitTransaction),
-                cancellationToken).ConfigureAwait(false);
-
-            Complete(committed: true);
+                Complete(committed: true);
+            }
+            catch (AbortableTransactionException exception)
+            {
+                _abortableException = exception;
+                Volatile.Write(ref _lifecycle, Pack(TransactionLifecycleState.Abortable));
+                throw;
+            }
+            catch
+            {
+                RestoreAfterFailedCompletion(previousState);
+                throw;
+            }
         }
 
         public ValueTask<PreparedTransactionState> PrepareAsync(CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            ThrowIfCannotMutate("Cannot prepare transaction");
-            _prepared = true;
-            _producer._cluster.RegisterPreparedTransaction(PreparedState, this);
-            return ValueTask.FromResult(PreparedState);
+            TransitionToPrepared();
+            try
+            {
+                Volatile.Write(ref _prepared, true);
+                _producer._cluster.RegisterPreparedTransaction(PreparedState, this);
+                Volatile.Write(ref _lifecycle, Pack(TransactionLifecycleState.Prepared));
+                return ValueTask.FromResult(PreparedState);
+            }
+            catch
+            {
+                Volatile.Write(ref _prepared, false);
+                Volatile.Write(ref _lifecycle, Pack(TransactionLifecycleState.Active));
+                throw;
+            }
         }
 
         public async ValueTask AbortAsync(CancellationToken cancellationToken = default)
         {
-            ThrowIfCompleted("Cannot abort transaction");
+            var previousState = EnterCompletion("Cannot abort transaction", allowAbortable: true);
+            try
+            {
+                await _producer.ApplyFaultAsync(
+                    new KafkaFaultScope(KafkaFaultOperation.AbortTransaction),
+                    cancellationToken).ConfigureAwait(false);
 
-            await _producer.ApplyFaultAsync(
-                new KafkaFaultScope(KafkaFaultOperation.AbortTransaction),
-                cancellationToken).ConfigureAwait(false);
-
-            Complete(committed: false);
+                Complete(committed: false);
+            }
+            catch (AbortableTransactionException exception)
+            {
+                _abortableException = exception;
+                Volatile.Write(ref _lifecycle, Pack(TransactionLifecycleState.Abortable));
+                throw;
+            }
+            catch
+            {
+                RestoreAfterFailedCompletion(previousState);
+                throw;
+            }
         }
 
         public async ValueTask SendOffsetsToTransactionAsync(
@@ -688,17 +795,29 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         {
             ArgumentNullException.ThrowIfNull(offsets);
             ArgumentException.ThrowIfNullOrWhiteSpace(consumerGroupId);
-            ThrowIfCannotMutate("Cannot send offsets to transaction");
             var snapshot = offsets.ToArray();
+            EnterMutation("Cannot send offsets to transaction");
+            try
+            {
+                await _producer.ApplyFaultAsync(
+                    new KafkaFaultScope(
+                        KafkaFaultOperation.SendOffsetsToTransaction,
+                        groupId: consumerGroupId),
+                    cancellationToken).ConfigureAwait(false);
 
-            await _producer.ApplyFaultAsync(
-                new KafkaFaultScope(
-                    KafkaFaultOperation.SendOffsetsToTransaction,
-                    groupId: consumerGroupId),
-                cancellationToken).ConfigureAwait(false);
-
-            var pending = GetOrAddPendingOffsets(consumerGroupId);
-            pending.Offsets.AddRange(snapshot);
+                EnsureMutationActive("Cannot send offsets to transaction");
+                var pending = GetOrAddPendingOffsets(consumerGroupId);
+                pending.Offsets.AddRange(snapshot);
+            }
+            catch (AbortableTransactionException exception)
+            {
+                MarkAbortable(exception);
+                throw;
+            }
+            finally
+            {
+                ExitMutation();
+            }
         }
 
         public async ValueTask SendOffsetsToTransactionAsync(
@@ -709,29 +828,41 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             ArgumentNullException.ThrowIfNull(offsets);
             ArgumentNullException.ThrowIfNull(consumerGroupMetadata);
             ArgumentException.ThrowIfNullOrWhiteSpace(consumerGroupMetadata.GroupId);
-            ThrowIfCannotMutate("Cannot send offsets to transaction");
             var snapshot = offsets.ToArray();
+            EnterMutation("Cannot send offsets to transaction");
+            try
+            {
+                await _producer.ApplyFaultAsync(
+                    new KafkaFaultScope(
+                        KafkaFaultOperation.SendOffsetsToTransaction,
+                        groupId: consumerGroupMetadata.GroupId),
+                    cancellationToken).ConfigureAwait(false);
 
-            await _producer.ApplyFaultAsync(
-                new KafkaFaultScope(
-                    KafkaFaultOperation.SendOffsetsToTransaction,
-                    groupId: consumerGroupMetadata.GroupId),
-                cancellationToken).ConfigureAwait(false);
-
-            var pending = GetOrAddPendingOffsets(consumerGroupMetadata.GroupId);
-            pending.Metadata = consumerGroupMetadata;
-            pending.Offsets.AddRange(snapshot);
+                EnsureMutationActive("Cannot send offsets to transaction");
+                var pending = GetOrAddPendingOffsets(consumerGroupMetadata.GroupId);
+                pending.Metadata = consumerGroupMetadata;
+                pending.Offsets.AddRange(snapshot);
+            }
+            catch (AbortableTransactionException exception)
+            {
+                MarkAbortable(exception);
+                throw;
+            }
+            finally
+            {
+                ExitMutation();
+            }
         }
 
         public async ValueTask DisposeAsync()
         {
-            if (_completed || _prepared || _producer._disposed)
+            if (IsCompleted || IsPrepared || Volatile.Read(ref _producer._disposed))
                 return;
 
             // Fault plans accept arbitrary exceptions. Disposal is best-effort and must release the
             // producer slot after any injected abort failure without a generic catch clause.
             await AbortAsync().AsTask().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
-            if (!_completed)
+            if (!IsCompleted)
                 Complete(committed: false);
         }
 
@@ -741,34 +872,39 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             CancellationToken cancellationToken)
         {
             recoveringProducer.ThrowIfFatalTransactionError();
-            if (_completed)
-                throw new InvalidOperationException("Cannot complete prepared transaction: transaction is already completed.");
-            if (!_prepared)
+            var previousState = EnterCompletion(
+                "Cannot complete prepared transaction",
+                allowAbortable: !committed,
+                recoveringProducer);
+            if (previousState != TransactionLifecycleState.Prepared &&
+                previousState != TransactionLifecycleState.Abortable)
+            {
+                RestoreAfterFailedCompletion(previousState);
                 throw new InvalidOperationException("Transaction is not prepared.");
+            }
 
-            await recoveringProducer.ApplyFaultAsync(
-                new KafkaFaultScope(
-                    committed
-                        ? KafkaFaultOperation.CommitTransaction
-                        : KafkaFaultOperation.AbortTransaction),
-                cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await recoveringProducer.ApplyFaultAsync(
+                    new KafkaFaultScope(
+                        committed
+                            ? KafkaFaultOperation.CommitTransaction
+                            : KafkaFaultOperation.AbortTransaction),
+                    cancellationToken).ConfigureAwait(false);
 
-            Complete(committed);
-        }
-
-        private void ThrowIfCannotMutate(string operation)
-        {
-            ThrowIfCompleted(operation);
-            if (_prepared)
-                throw new InvalidOperationException("Transaction is prepared; only commit or abort is permitted.");
-        }
-
-        private void ThrowIfCompleted(string operation)
-        {
-            _producer.ThrowIfDisposed();
-            _producer.ThrowIfFatalTransactionError();
-            if (_completed)
-                throw new InvalidOperationException($"{operation}: transaction is already completed.");
+                Complete(committed);
+            }
+            catch (AbortableTransactionException exception)
+            {
+                _abortableException = exception;
+                Volatile.Write(ref _lifecycle, Pack(TransactionLifecycleState.Abortable));
+                throw;
+            }
+            catch
+            {
+                RestoreAfterFailedCompletion(previousState);
+                throw;
+            }
         }
 
         private PendingGroupOffsets GetOrAddPendingOffsets(string groupId)
@@ -790,9 +926,160 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
                 PreparedState,
                 this);
             _pendingOffsets.Clear();
-            _completed = true;
+            SetStatePreservingMutationCount(TransactionLifecycleState.Completed);
             _producer.CompleteTransaction(this);
         }
+
+        private void EnterMutation(string operation)
+        {
+            _producer.ThrowIfDisposingOrDisposed();
+            _producer.ThrowIfFatalTransactionError();
+
+            while (true)
+            {
+                var lifecycle = Volatile.Read(ref _lifecycle);
+                var state = GetState(lifecycle);
+                if (state != TransactionLifecycleState.Active)
+                    ThrowForState(operation, state);
+                if ((uint)lifecycle == uint.MaxValue)
+                    throw new InvalidOperationException($"{operation}: too many concurrent transaction operations.");
+
+                if (Interlocked.CompareExchange(ref _lifecycle, lifecycle + 1, lifecycle) == lifecycle)
+                    return;
+            }
+        }
+
+        private void ExitMutation() => Interlocked.Decrement(ref _lifecycle);
+
+        private void TransitionToPrepared()
+        {
+            _producer.ThrowIfDisposingOrDisposed();
+            _producer.ThrowIfFatalTransactionError();
+
+            while (true)
+            {
+                var lifecycle = Volatile.Read(ref _lifecycle);
+                var state = GetState(lifecycle);
+                if (state != TransactionLifecycleState.Active)
+                    ThrowForState("Cannot prepare transaction", state);
+                if ((lifecycle & MutationCountMask) != 0)
+                {
+                    throw new InvalidOperationException(
+                        "Cannot prepare transaction while transaction operations are in progress.");
+                }
+
+                if (Interlocked.CompareExchange(
+                        ref _lifecycle,
+                        Pack(TransactionLifecycleState.Preparing),
+                        lifecycle) == lifecycle)
+                {
+                    return;
+                }
+            }
+        }
+
+        private void EnsureMutationActive(string operation)
+        {
+            var state = GetState(Volatile.Read(ref _lifecycle));
+            if (state != TransactionLifecycleState.Active)
+                ThrowForState(operation, state);
+        }
+
+        private TransactionLifecycleState EnterCompletion(
+            string operation,
+            bool allowAbortable,
+            InMemoryProducer<TKey, TValue>? operationProducer = null)
+        {
+            var producer = operationProducer ?? _producer;
+            producer.ThrowIfDisposed();
+            producer.ThrowIfFatalTransactionError();
+
+            while (true)
+            {
+                var lifecycle = Volatile.Read(ref _lifecycle);
+                var state = GetState(lifecycle);
+                if (state is not (TransactionLifecycleState.Active or TransactionLifecycleState.Prepared) &&
+                    !(allowAbortable && state == TransactionLifecycleState.Abortable))
+                {
+                    ThrowForState(operation, state);
+                }
+
+                if ((lifecycle & MutationCountMask) != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"{operation} while transaction operations are in progress.");
+                }
+
+                if (Interlocked.CompareExchange(
+                        ref _lifecycle,
+                        Pack(TransactionLifecycleState.Completing),
+                        lifecycle) == lifecycle)
+                {
+                    return state;
+                }
+            }
+        }
+
+        private void RestoreAfterFailedCompletion(TransactionLifecycleState state) =>
+            Interlocked.CompareExchange(
+                ref _lifecycle,
+                Pack(state),
+                Pack(TransactionLifecycleState.Completing));
+
+        private void MarkAbortable(AbortableTransactionException exception)
+        {
+            _abortableException = exception;
+            while (true)
+            {
+                var lifecycle = Volatile.Read(ref _lifecycle);
+                if (GetState(lifecycle) != TransactionLifecycleState.Active)
+                    return;
+
+                var abortable = Pack(TransactionLifecycleState.Abortable) | (lifecycle & MutationCountMask);
+                if (Interlocked.CompareExchange(ref _lifecycle, abortable, lifecycle) == lifecycle)
+                    return;
+            }
+        }
+
+        private void SetStatePreservingMutationCount(TransactionLifecycleState state)
+        {
+            while (true)
+            {
+                var lifecycle = Volatile.Read(ref _lifecycle);
+                if (GetState(lifecycle) == state)
+                    return;
+
+                var updated = Pack(state) | (lifecycle & MutationCountMask);
+                if (Interlocked.CompareExchange(ref _lifecycle, updated, lifecycle) == lifecycle)
+                    return;
+            }
+        }
+
+        private void ThrowForState(string operation, TransactionLifecycleState state)
+        {
+            if (state == TransactionLifecycleState.Abortable && _abortableException is { } exception)
+                throw exception;
+
+            throw new InvalidOperationException(state switch
+            {
+                TransactionLifecycleState.Prepared =>
+                    $"{operation}: transaction is prepared; only commit or abort is permitted.",
+                TransactionLifecycleState.Preparing =>
+                    $"{operation}: transaction preparation is already in progress.",
+                TransactionLifecycleState.Completing =>
+                    $"{operation}: transaction completion is already in progress.",
+                TransactionLifecycleState.Completed =>
+                    $"{operation}: transaction is already completed.",
+                TransactionLifecycleState.Abortable =>
+                    $"{operation}: transaction has an abortable error and must be aborted.",
+                _ => $"{operation}: transaction is not active."
+            });
+        }
+
+        private static long Pack(TransactionLifecycleState state) => (long)state << 32;
+
+        private static TransactionLifecycleState GetState(long lifecycle) =>
+            (TransactionLifecycleState)(lifecycle >> 32);
 
         private static (
             string GroupId,
@@ -805,6 +1092,16 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         {
             public List<TopicPartitionOffset> Offsets { get; } = [];
             public ConsumerGroupMetadata? Metadata { get; set; }
+        }
+
+        private enum TransactionLifecycleState : byte
+        {
+            Active,
+            Preparing,
+            Prepared,
+            Abortable,
+            Completing,
+            Completed
         }
     }
 

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Producer;
@@ -27,6 +28,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     private FatalTransactionException? _fatalTransactionException;
     private bool _preparedRecoveryEnabled;
     private bool _preparedRecoveryInProgress;
+    private TaskCompletionSource? _preparedRecoveryCompletion;
     private bool _disposeStarted;
     private bool _disposed;
 
@@ -286,6 +288,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         ThrowIfFatalTransactionError();
 
         InMemoryTransaction transaction;
+        TaskCompletionSource recoveryCompletion;
         lock (_transactionGate)
         {
             ThrowIfDisposingOrDisposed();
@@ -316,6 +319,8 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
                 throw new InvalidOperationException("The prepared transaction state does not match the active transaction.");
 
             Volatile.Write(ref _preparedRecoveryInProgress, true);
+            recoveryCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _preparedRecoveryCompletion = recoveryCompletion;
         }
 
         try
@@ -325,7 +330,11 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         finally
         {
             lock (_transactionGate)
+            {
                 Volatile.Write(ref _preparedRecoveryInProgress, false);
+                recoveryCompletion.TrySetResult();
+                _preparedRecoveryCompletion = null;
+            }
         }
     }
 
@@ -339,6 +348,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     public async ValueTask DisposeAsync()
     {
         InMemoryTransaction? transaction;
+        Task? preparedRecovery;
         lock (_transactionGate)
         {
             if (_disposeStarted)
@@ -346,7 +356,11 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
 
             Volatile.Write(ref _disposeStarted, true);
             transaction = _activeTransaction;
+            preparedRecovery = _preparedRecoveryCompletion?.Task;
         }
+
+        if (preparedRecovery is not null)
+            await preparedRecovery.ConfigureAwait(false);
 
         if (transaction is { IsCompleted: false, IsPrepared: false })
             await transaction.DisposeAsync().ConfigureAwait(false);
@@ -689,7 +703,9 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             ProducerMessage<TKey, TValue> message,
             CancellationToken cancellationToken = default)
         {
-            EnterMutation("Cannot produce");
+            if (!TryEnterMutation("Cannot produce", out var admissionException))
+                return ValueTask.FromException<RecordMetadata>(admissionException);
+
             try
             {
                 var operation = _producer.ProduceTransactionAsync(this, message, cancellationToken);
@@ -718,7 +734,9 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             TValue value,
             CancellationToken cancellationToken = default)
         {
-            EnterMutation("Cannot produce");
+            if (!TryEnterMutation("Cannot produce", out var admissionException))
+                return ValueTask.FromException<RecordMetadata>(admissionException);
+
             try
             {
                 var operation = _producer.ProduceTransactionAsync(this, topic, key, value, cancellationToken);
@@ -900,7 +918,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             // Fault plans accept arbitrary exceptions. Disposal is best-effort and must release the
             // producer slot after any injected abort failure without a generic catch clause.
             await AbortAsync().AsTask().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
-            if (!IsCompleted)
+            if (TryEnterDisposalCompletion())
                 Complete(committed: false);
         }
 
@@ -994,20 +1012,46 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
 
         private void EnterMutation(string operation)
         {
-            _producer.ThrowIfDisposingOrDisposed();
-            _producer.ThrowIfFatalTransactionError();
+            if (!TryEnterMutation(operation, out var exception))
+                throw exception;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool TryEnterMutation(string operation, out Exception exception)
+        {
+            if (Volatile.Read(ref _producer._disposeStarted) || Volatile.Read(ref _producer._disposed))
+            {
+                exception = new ObjectDisposedException(_producer.GetType().FullName);
+                return false;
+            }
+
+            if (Volatile.Read(ref _producer._fatalTransactionException) is { } fatalException)
+            {
+                exception = fatalException;
+                return false;
+            }
 
             while (true)
             {
                 var lifecycle = Volatile.Read(ref _lifecycle);
                 var state = GetState(lifecycle);
                 if (state != TransactionLifecycleState.Active)
-                    ThrowForState(operation, state);
+                {
+                    exception = ExceptionForState(operation, state);
+                    return false;
+                }
                 if ((uint)lifecycle == uint.MaxValue)
-                    throw new InvalidOperationException($"{operation}: too many concurrent transaction operations.");
+                {
+                    exception = new InvalidOperationException(
+                        $"{operation}: too many concurrent transaction operations.");
+                    return false;
+                }
 
                 if (Interlocked.CompareExchange(ref _lifecycle, lifecycle + 1, lifecycle) == lifecycle)
-                    return;
+                {
+                    exception = null!;
+                    return true;
+                }
             }
         }
 
@@ -1088,6 +1132,25 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
                 Pack(state),
                 Pack(TransactionLifecycleState.Completing));
 
+        private bool TryEnterDisposalCompletion()
+        {
+            while (true)
+            {
+                var lifecycle = Volatile.Read(ref _lifecycle);
+                var state = GetState(lifecycle);
+                if (state is not (TransactionLifecycleState.Active or TransactionLifecycleState.Abortable))
+                    return false;
+
+                if (Interlocked.CompareExchange(
+                        ref _lifecycle,
+                        Pack(TransactionLifecycleState.Completing) | (lifecycle & MutationCountMask),
+                        lifecycle) == lifecycle)
+                {
+                    return true;
+                }
+            }
+        }
+
         private void MarkAbortable(AbortableTransactionException exception)
         {
             _abortableException = exception;
@@ -1118,11 +1181,14 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         }
 
         private void ThrowForState(string operation, TransactionLifecycleState state)
+            => throw ExceptionForState(operation, state);
+
+        private Exception ExceptionForState(string operation, TransactionLifecycleState state)
         {
             if (state == TransactionLifecycleState.Abortable && _abortableException is { } exception)
-                throw exception;
+                return exception;
 
-            throw new InvalidOperationException(state switch
+            return new InvalidOperationException(state switch
             {
                 TransactionLifecycleState.Prepared =>
                     $"{operation}: transaction is prepared; only commit or abort is permitted.",

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -657,6 +657,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     {
         private const long MutationCountMask = uint.MaxValue;
         private readonly InMemoryProducer<TKey, TValue> _producer;
+        private readonly object _pendingOffsetsGate = new();
         private readonly Dictionary<string, PendingGroupOffsets> _pendingOffsets = new(StringComparer.Ordinal);
         private long _lifecycle;
         private AbortableTransactionException? _abortableException;
@@ -732,6 +733,11 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
 
                 Complete(committed: true);
             }
+            catch (FatalTransactionException exception)
+            {
+                RestoreAfterFailedCompletion(previousState);
+                throw _producer.CaptureFatalTransactionException(exception);
+            }
             catch (AbortableTransactionException exception)
             {
                 _abortableException = exception;
@@ -805,9 +811,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
                         groupId: consumerGroupId),
                     cancellationToken).ConfigureAwait(false);
 
-                EnsureMutationActive("Cannot send offsets to transaction");
-                var pending = GetOrAddPendingOffsets(consumerGroupId);
-                pending.Offsets.AddRange(snapshot);
+                StageOffsets(consumerGroupId, snapshot, metadata: null);
             }
             catch (AbortableTransactionException exception)
             {
@@ -838,10 +842,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
                         groupId: consumerGroupMetadata.GroupId),
                     cancellationToken).ConfigureAwait(false);
 
-                EnsureMutationActive("Cannot send offsets to transaction");
-                var pending = GetOrAddPendingOffsets(consumerGroupMetadata.GroupId);
-                pending.Metadata = consumerGroupMetadata;
-                pending.Offsets.AddRange(snapshot);
+                StageOffsets(consumerGroupMetadata.GroupId, snapshot, consumerGroupMetadata);
             }
             catch (AbortableTransactionException exception)
             {
@@ -894,6 +895,11 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
 
                 Complete(committed);
             }
+            catch (FatalTransactionException exception)
+            {
+                RestoreAfterFailedCompletion(previousState);
+                throw recoveringProducer.CaptureFatalTransactionException(exception);
+            }
             catch (AbortableTransactionException exception)
             {
                 _abortableException = exception;
@@ -917,16 +923,35 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             return pending;
         }
 
+        private void StageOffsets(
+            string groupId,
+            TopicPartitionOffset[] offsets,
+            ConsumerGroupMetadata? metadata)
+        {
+            lock (_pendingOffsetsGate)
+            {
+                EnsureMutationActive("Cannot send offsets to transaction");
+                var pending = GetOrAddPendingOffsets(groupId);
+                if (metadata is not null)
+                    pending.Metadata = metadata;
+                pending.Offsets.AddRange(offsets);
+            }
+        }
+
         private void Complete(bool committed)
         {
-            _producer._cluster.CompleteTransaction(
-                TransactionMarker,
-                committed,
-                _pendingOffsets.Select(static item => CreatePendingOffsets(item)),
-                PreparedState,
-                this);
-            _pendingOffsets.Clear();
-            SetStatePreservingMutationCount(TransactionLifecycleState.Completed);
+            lock (_pendingOffsetsGate)
+            {
+                _producer._cluster.CompleteTransaction(
+                    TransactionMarker,
+                    committed,
+                    _pendingOffsets.Select(static item => CreatePendingOffsets(item)),
+                    PreparedState,
+                    this);
+                _pendingOffsets.Clear();
+                SetStatePreservingMutationCount(TransactionLifecycleState.Completed);
+            }
+
             _producer.CompleteTransaction(this);
         }
 

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -541,7 +541,12 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         }
     }
 
-    private async ValueTask<T> ObserveFatalAsync<T>(ValueTask<T> operation)
+    private ValueTask<T> ObserveFatalAsync<T>(ValueTask<T> operation) =>
+        operation.IsCompletedSuccessfully
+            ? operation
+            : ObserveFatalSlowAsync(operation);
+
+    private async ValueTask<T> ObserveFatalSlowAsync<T>(ValueTask<T> operation)
     {
         try
         {

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -751,6 +751,7 @@ public sealed class InMemoryProducer<TKey, TValue> :
         private readonly object _pendingOffsetsGate = new();
         private readonly Dictionary<string, PendingGroupOffsets> _pendingOffsets = new(StringComparer.Ordinal);
         private TaskCompletionSource? _completionAttempt;
+        private TaskCompletionSource? _mutationCompletion;
         private long _lifecycle;
         private AbortableTransactionException? _abortableException;
         private bool _prepared;
@@ -1015,8 +1016,11 @@ public sealed class InMemoryProducer<TKey, TValue> :
                 // Fault plans accept arbitrary exceptions. Disposal is best-effort and must release the
                 // producer slot after any injected abort failure without a generic catch clause.
                 await AbortAsync().AsTask().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
-                if (TryEnterDisposalCompletion(out var ownedCompletion))
+                if (TryEnterDisposalCompletion(out var ownedCompletion, out var mutationCompletion))
                 {
+                    if (mutationCompletion is not null)
+                        await mutationCompletion.ConfigureAwait(false);
+
                     Complete(committed: false);
                     return;
                 }
@@ -1160,7 +1164,15 @@ public sealed class InMemoryProducer<TKey, TValue> :
             }
         }
 
-        private void ExitMutation() => Interlocked.Decrement(ref _lifecycle);
+        private void ExitMutation()
+        {
+            var lifecycle = Interlocked.Decrement(ref _lifecycle);
+            if (GetState(lifecycle) == TransactionLifecycleState.Completing &&
+                (lifecycle & MutationCountMask) == 0)
+            {
+                Volatile.Read(ref _mutationCompletion)?.TrySetResult();
+            }
+        }
 
         private void TransitionToPrepared()
         {
@@ -1191,9 +1203,16 @@ public sealed class InMemoryProducer<TKey, TValue> :
 
         private void EnsureMutationActive(string operation)
         {
-            var state = GetState(Volatile.Read(ref _lifecycle));
-            if (state != TransactionLifecycleState.Active)
-                ThrowForState(operation, state);
+            var lifecycle = Volatile.Read(ref _lifecycle);
+            var state = GetState(lifecycle);
+            if (state == TransactionLifecycleState.Active ||
+                (state == TransactionLifecycleState.Completing &&
+                 (lifecycle & MutationCountMask) != 0))
+            {
+                return;
+            }
+
+            ThrowForState(operation, state);
         }
 
         private TransactionLifecycleState EnterCompletion(
@@ -1255,7 +1274,9 @@ public sealed class InMemoryProducer<TKey, TValue> :
             completion?.TrySetResult();
         }
 
-        private bool TryEnterDisposalCompletion(out Task? ownedCompletion)
+        private bool TryEnterDisposalCompletion(
+            out Task? ownedCompletion,
+            out Task? mutationCompletion)
         {
             lock (_completionGate)
             {
@@ -1266,12 +1287,14 @@ public sealed class InMemoryProducer<TKey, TValue> :
                     if (state == TransactionLifecycleState.Completing)
                     {
                         ownedCompletion = _completionAttempt!.Task;
+                        mutationCompletion = null;
                         return false;
                     }
 
                     if (state is not (TransactionLifecycleState.Active or TransactionLifecycleState.Abortable))
                     {
                         ownedCompletion = null;
+                        mutationCompletion = null;
                         return false;
                     }
 
@@ -1283,10 +1306,27 @@ public sealed class InMemoryProducer<TKey, TValue> :
                         _completionAttempt = new TaskCompletionSource(
                             TaskCreationOptions.RunContinuationsAsynchronously);
                         ownedCompletion = null;
+                        mutationCompletion = CreateMutationCompletion(lifecycle);
                         return true;
                     }
                 }
             }
+        }
+
+        private Task? CreateMutationCompletion(long lifecycle)
+        {
+            if ((lifecycle & MutationCountMask) == 0)
+                return null;
+
+            var completion = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            Volatile.Write(ref _mutationCompletion, completion);
+
+            // The last mutation may have exited between the lifecycle transition and publication.
+            if ((Volatile.Read(ref _lifecycle) & MutationCountMask) == 0)
+                completion.TrySetResult();
+
+            return completion.Task;
         }
 
         internal void PublishCompleted()
@@ -1296,6 +1336,7 @@ public sealed class InMemoryProducer<TKey, TValue> :
                 SetStatePreservingMutationCount(TransactionLifecycleState.Completed);
                 var completion = _completionAttempt;
                 _completionAttempt = null;
+                Volatile.Write(ref _mutationCompletion, null);
                 completion?.TrySetResult();
             }
         }

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -1,4 +1,6 @@
 using System.Buffers;
+using Dekaf.Consumer;
+using Dekaf.Errors;
 using Dekaf.Producer;
 using Dekaf.Serialization;
 using Dekaf.Telemetry;
@@ -10,6 +12,7 @@ namespace Dekaf.Testing;
 /// </summary>
 public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue>
 {
+    private static long s_nextProducerId;
     private readonly InMemoryKafkaCluster _cluster;
     private readonly ISerializer<TKey> _keySerializer;
     private readonly ISerializer<TValue> _valueSerializer;
@@ -19,6 +22,10 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     private readonly IAsyncSerializer<TKey>? _asyncKeySerializer;
     private readonly IAsyncSerializer<TValue>? _asyncValueSerializer;
     private readonly bool _hasAsyncSerializers;
+    private readonly object _transactionGate = new();
+    private readonly long _producerId = Interlocked.Increment(ref s_nextProducerId);
+    private InMemoryTransaction? _activeTransaction;
+    private FatalTransactionException? _fatalTransactionException;
     private bool _disposed;
 
     public InMemoryProducer(InMemoryKafkaCluster cluster)
@@ -237,32 +244,54 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     public ITransaction<TKey, TValue> BeginTransaction()
     {
         ThrowIfDisposed();
-        throw new NotSupportedException("In-memory producer transactions are not supported.");
+        ThrowIfFatalTransactionError();
+
+        lock (_transactionGate)
+        {
+            if (_activeTransaction is { IsCompleted: false })
+                throw new InvalidOperationException("A transaction is already active.");
+
+            return _activeTransaction = new InMemoryTransaction(this);
+        }
     }
 
-    public ValueTask InitTransactionsAsync(CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        ThrowIfDisposed();
-        return ValueTask.CompletedTask;
-    }
+    public ValueTask InitTransactionsAsync(CancellationToken cancellationToken = default) =>
+        InitTransactionsAsync(keepPreparedTransaction: false, cancellationToken);
 
     public ValueTask InitTransactionsAsync(bool keepPreparedTransaction, CancellationToken cancellationToken = default)
     {
+        _ = keepPreparedTransaction;
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
-        return ValueTask.CompletedTask;
+        ThrowIfFatalTransactionError();
+        return ApplyFaultAsync(
+            new KafkaFaultScope(KafkaFaultOperation.InitializeTransactions),
+            cancellationToken);
     }
 
-    public ValueTask CompletePreparedTransactionAsync(
+    public async ValueTask CompletePreparedTransactionAsync(
         PreparedTransactionState preparedState,
         bool committed,
         CancellationToken cancellationToken = default)
     {
-        _ = committed;
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
-        throw new NotSupportedException("In-memory producer transactions are not supported.");
+        ThrowIfFatalTransactionError();
+
+        InMemoryTransaction transaction;
+        lock (_transactionGate)
+        {
+            transaction = _activeTransaction
+                ?? throw new InvalidOperationException("There is no active prepared transaction.");
+        }
+
+        if (!transaction.IsPrepared || transaction.PreparedState != preparedState)
+            throw new InvalidOperationException("The prepared transaction state does not match the active transaction.");
+
+        if (committed)
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        else
+            await transaction.AbortAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public ITopicProducer<TKey, TValue> ForTopic(string topic)
@@ -285,9 +314,29 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         TValue value,
         Headers? headers,
         DateTimeOffset timestamp,
+        CancellationToken cancellationToken) =>
+        ProduceCoreAsync(
+            topic,
+            partition,
+            key,
+            value,
+            headers,
+            timestamp,
+            KafkaFaultOperation.Produce,
+            cancellationToken);
+
+    private ValueTask<RecordMetadata> ProduceCoreAsync(
+        string topic,
+        int? partition,
+        TKey? key,
+        TValue value,
+        Headers? headers,
+        DateTimeOffset timestamp,
+        KafkaFaultOperation faultOperation,
         CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+        ThrowIfFatalTransactionError();
 
         if (_hasAsyncSerializers)
         {
@@ -298,13 +347,14 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
                 value,
                 headers,
                 timestamp,
+                faultOperation,
                 cancellationToken);
         }
 
         var keyBytes = Serialize(_keySerializer, key, topic, SerializationComponent.Key, headers, out var isKeyNull);
         var valueBytes = Serialize(_valueSerializer, value, topic, SerializationComponent.Value, headers, out var isValueNull);
 
-        return _cluster.AppendAsync(
+        return ObserveFatalAsync(_cluster.AppendAsync(
             topic,
             partition,
             keyBytes,
@@ -313,7 +363,8 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             isValueNull,
             headers?.ToList(),
             timestamp,
-            cancellationToken);
+            cancellationToken,
+            faultOperation));
     }
 
     private async ValueTask FireAndForgetCoreAsync(
@@ -347,6 +398,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         TValue value,
         Headers? headers,
         DateTimeOffset timestamp,
+        KafkaFaultOperation faultOperation,
         CancellationToken cancellationToken)
     {
         // Null components skip their serializer entirely, matching the synchronous path.
@@ -374,7 +426,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
                 headers,
                 cancellationToken).ConfigureAwait(false);
 
-        return await _cluster.AppendAsync(
+        return await ObserveFatalAsync(_cluster.AppendAsync(
             topic,
             partition,
             keyBytes,
@@ -383,7 +435,81 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             isValueNull,
             headers?.ToList(),
             timestamp,
-            cancellationToken).ConfigureAwait(false);
+            cancellationToken,
+            faultOperation)).ConfigureAwait(false);
+    }
+
+    private ValueTask<RecordMetadata> ProduceTransactionAsync(
+        ProducerMessage<TKey, TValue> message,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        return ProduceCoreAsync(
+            message.Topic,
+            message.Partition,
+            message.Key,
+            message.Value,
+            message.Headers,
+            message.Timestamp ?? DateTimeOffset.UtcNow,
+            KafkaFaultOperation.TransactionProduce,
+            cancellationToken);
+    }
+
+    private ValueTask<RecordMetadata> ProduceTransactionAsync(
+        string topic,
+        TKey? key,
+        TValue value,
+        CancellationToken cancellationToken) =>
+        ProduceCoreAsync(
+            topic,
+            partition: null,
+            key,
+            value,
+            headers: null,
+            DateTimeOffset.UtcNow,
+            KafkaFaultOperation.TransactionProduce,
+            cancellationToken);
+
+    private async ValueTask ApplyFaultAsync(KafkaFaultScope scope, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _cluster.FaultPlan.ApplyAsync(scope, cancellationToken).ConfigureAwait(false);
+        }
+        catch (FatalTransactionException exception)
+        {
+            throw CaptureFatalTransactionException(exception);
+        }
+    }
+
+    private async ValueTask<T> ObserveFatalAsync<T>(ValueTask<T> operation)
+    {
+        try
+        {
+            return await operation.ConfigureAwait(false);
+        }
+        catch (FatalTransactionException exception)
+        {
+            throw CaptureFatalTransactionException(exception);
+        }
+    }
+
+    private FatalTransactionException CaptureFatalTransactionException(FatalTransactionException exception) =>
+        Interlocked.CompareExchange(ref _fatalTransactionException, exception, null) ?? exception;
+
+    private void ThrowIfFatalTransactionError()
+    {
+        if (Volatile.Read(ref _fatalTransactionException) is { } exception)
+            throw exception;
+    }
+
+    private void CompleteTransaction(InMemoryTransaction transaction)
+    {
+        lock (_transactionGate)
+        {
+            if (ReferenceEquals(_activeTransaction, transaction))
+                _activeTransaction = null;
+        }
     }
 
     /// <summary>
@@ -448,6 +574,150 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     private void ThrowIfDisposed()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
+    private sealed class InMemoryTransaction : ITransaction<TKey, TValue>
+    {
+        private readonly InMemoryProducer<TKey, TValue> _producer;
+        private readonly Dictionary<string, List<TopicPartitionOffset>> _pendingOffsets = new(StringComparer.Ordinal);
+        private bool _completed;
+        private bool _prepared;
+
+        public InMemoryTransaction(InMemoryProducer<TKey, TValue> producer)
+        {
+            _producer = producer;
+        }
+
+        public bool IsCompleted => _completed;
+
+        public bool IsPrepared => _prepared;
+
+        public PreparedTransactionState PreparedState => _prepared
+            ? new PreparedTransactionState(_producer._producerId, 0)
+            : PreparedTransactionState.Empty;
+
+        public async ValueTask<RecordMetadata> ProduceAsync(
+            ProducerMessage<TKey, TValue> message,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfCannotMutate("Cannot produce");
+            return await _producer.ProduceTransactionAsync(message, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async ValueTask<RecordMetadata> ProduceAsync(
+            string topic,
+            TKey? key,
+            TValue value,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfCannotMutate("Cannot produce");
+            return await _producer.ProduceTransactionAsync(topic, key, value, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
+        {
+            ThrowIfIncomplete("Cannot commit transaction");
+
+            await _producer.ApplyFaultAsync(
+                new KafkaFaultScope(KafkaFaultOperation.CommitTransaction),
+                cancellationToken).ConfigureAwait(false);
+
+            foreach (var (groupId, offsets) in _pendingOffsets)
+                _producer._cluster.CommitOffsets(groupId, offsets);
+
+            Complete();
+        }
+
+        public ValueTask<PreparedTransactionState> PrepareAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfCannotMutate("Cannot prepare transaction");
+            _prepared = true;
+            return ValueTask.FromResult(PreparedState);
+        }
+
+        public async ValueTask AbortAsync(CancellationToken cancellationToken = default)
+        {
+            ThrowIfIncomplete("Cannot abort transaction");
+
+            await _producer.ApplyFaultAsync(
+                new KafkaFaultScope(KafkaFaultOperation.AbortTransaction),
+                cancellationToken).ConfigureAwait(false);
+
+            _pendingOffsets.Clear();
+            Complete();
+        }
+
+        public async ValueTask SendOffsetsToTransactionAsync(
+            IEnumerable<TopicPartitionOffset> offsets,
+            string consumerGroupId,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(offsets);
+            ArgumentException.ThrowIfNullOrWhiteSpace(consumerGroupId);
+            ThrowIfCannotMutate("Cannot send offsets to transaction");
+            var snapshot = offsets.ToArray();
+
+            await _producer.ApplyFaultAsync(
+                new KafkaFaultScope(
+                    KafkaFaultOperation.SendOffsetsToTransaction,
+                    groupId: consumerGroupId),
+                cancellationToken).ConfigureAwait(false);
+
+            if (!_pendingOffsets.TryGetValue(consumerGroupId, out var pending))
+            {
+                pending = [];
+                _pendingOffsets.Add(consumerGroupId, pending);
+            }
+
+            pending.AddRange(snapshot);
+        }
+
+        public ValueTask SendOffsetsToTransactionAsync(
+            IEnumerable<TopicPartitionOffset> offsets,
+            ConsumerGroupMetadata consumerGroupMetadata,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(consumerGroupMetadata);
+            return SendOffsetsToTransactionAsync(offsets, consumerGroupMetadata.GroupId, cancellationToken);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_completed || _producer._disposed)
+                return;
+
+            try
+            {
+                await AbortAsync().ConfigureAwait(false);
+            }
+            catch (TransactionException)
+            {
+                // Best-effort cleanup mirrors the production transaction adapter.
+                Complete();
+            }
+        }
+
+        private void ThrowIfCannotMutate(string operation)
+        {
+            ThrowIfIncomplete(operation);
+            if (_prepared)
+                throw new InvalidOperationException("Transaction is prepared; only commit or abort is permitted.");
+        }
+
+        private void ThrowIfIncomplete(string operation)
+        {
+            _producer.ThrowIfDisposed();
+            _producer.ThrowIfFatalTransactionError();
+            if (_completed)
+                throw new InvalidOperationException($"{operation}: transaction is already completed.");
+        }
+
+        private void Complete()
+        {
+            _completed = true;
+            _producer.CompleteTransaction(this);
+        }
     }
 
     private sealed class InMemoryTopicProducer : ITopicProducer<TKey, TValue>

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -26,6 +26,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     private readonly long _producerId = Interlocked.Increment(ref s_nextProducerId);
     private InMemoryTransaction? _activeTransaction;
     private FatalTransactionException? _fatalTransactionException;
+    private bool _preparedRecoveryEnabled;
     private bool _disposed;
 
     public InMemoryProducer(InMemoryKafkaCluster cluster)
@@ -258,15 +259,15 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     public ValueTask InitTransactionsAsync(CancellationToken cancellationToken = default) =>
         InitTransactionsAsync(keepPreparedTransaction: false, cancellationToken);
 
-    public ValueTask InitTransactionsAsync(bool keepPreparedTransaction, CancellationToken cancellationToken = default)
+    public async ValueTask InitTransactionsAsync(bool keepPreparedTransaction, CancellationToken cancellationToken = default)
     {
-        _ = keepPreparedTransaction;
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
         ThrowIfFatalTransactionError();
-        return ApplyFaultAsync(
+        await ApplyFaultAsync(
             new KafkaFaultScope(KafkaFaultOperation.InitializeTransactions),
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
+        _preparedRecoveryEnabled = keepPreparedTransaction;
     }
 
     public async ValueTask CompletePreparedTransactionAsync(
@@ -278,20 +279,26 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         ThrowIfDisposed();
         ThrowIfFatalTransactionError();
 
-        InMemoryTransaction transaction;
+        InMemoryTransaction? transaction;
         lock (_transactionGate)
+            transaction = _activeTransaction;
+
+        if (transaction is null || !transaction.IsPrepared || transaction.PreparedState != preparedState)
         {
-            transaction = _activeTransaction
-                ?? throw new InvalidOperationException("There is no active prepared transaction.");
+            if (!_preparedRecoveryEnabled ||
+                _cluster.GetPreparedTransaction(preparedState) is not InMemoryTransaction recovered)
+            {
+                throw new InvalidOperationException(
+                    "There is no matching active or recoverable prepared transaction.");
+            }
+
+            transaction = recovered;
         }
 
         if (!transaction.IsPrepared || transaction.PreparedState != preparedState)
             throw new InvalidOperationException("The prepared transaction state does not match the active transaction.");
 
-        if (committed)
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-        else
-            await transaction.AbortAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CompletePreparedAsync(this, committed, cancellationToken).ConfigureAwait(false);
     }
 
     public ITopicProducer<TKey, TValue> ForTopic(string topic)
@@ -301,10 +308,19 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         return new InMemoryTopicProducer(this, topic);
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
+        if (_disposed)
+            return;
+
+        InMemoryTransaction? transaction;
+        lock (_transactionGate)
+            transaction = _activeTransaction;
+
+        if (transaction is { IsCompleted: false, IsPrepared: false })
+            await transaction.DisposeAsync().ConfigureAwait(false);
+
         _disposed = true;
-        return ValueTask.CompletedTask;
     }
 
     private ValueTask<RecordMetadata> ProduceCoreAsync(
@@ -323,6 +339,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             headers,
             timestamp,
             KafkaFaultOperation.Produce,
+            transactionMarker: null,
             cancellationToken);
 
     private ValueTask<RecordMetadata> ProduceCoreAsync(
@@ -333,6 +350,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         Headers? headers,
         DateTimeOffset timestamp,
         KafkaFaultOperation faultOperation,
+        InMemoryTransactionMarker? transactionMarker,
         CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(topic);
@@ -348,6 +366,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
                 headers,
                 timestamp,
                 faultOperation,
+                transactionMarker,
                 cancellationToken);
         }
 
@@ -364,7 +383,8 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             headers?.ToList(),
             timestamp,
             cancellationToken,
-            faultOperation));
+            faultOperation,
+            transactionMarker));
     }
 
     private async ValueTask FireAndForgetCoreAsync(
@@ -399,6 +419,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         Headers? headers,
         DateTimeOffset timestamp,
         KafkaFaultOperation faultOperation,
+        InMemoryTransactionMarker? transactionMarker,
         CancellationToken cancellationToken)
     {
         // Null components skip their serializer entirely, matching the synchronous path.
@@ -436,10 +457,12 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             headers?.ToList(),
             timestamp,
             cancellationToken,
-            faultOperation)).ConfigureAwait(false);
+            faultOperation,
+            transactionMarker)).ConfigureAwait(false);
     }
 
     private ValueTask<RecordMetadata> ProduceTransactionAsync(
+        InMemoryTransaction transaction,
         ProducerMessage<TKey, TValue> message,
         CancellationToken cancellationToken)
     {
@@ -452,10 +475,12 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             message.Headers,
             message.Timestamp ?? DateTimeOffset.UtcNow,
             KafkaFaultOperation.TransactionProduce,
+            transaction.TransactionMarker,
             cancellationToken);
     }
 
     private ValueTask<RecordMetadata> ProduceTransactionAsync(
+        InMemoryTransaction transaction,
         string topic,
         TKey? key,
         TValue value,
@@ -468,6 +493,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             headers: null,
             DateTimeOffset.UtcNow,
             KafkaFaultOperation.TransactionProduce,
+            transaction.TransactionMarker,
             cancellationToken);
 
     private async ValueTask ApplyFaultAsync(KafkaFaultScope scope, CancellationToken cancellationToken)
@@ -579,14 +605,17 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     private sealed class InMemoryTransaction : ITransaction<TKey, TValue>
     {
         private readonly InMemoryProducer<TKey, TValue> _producer;
-        private readonly Dictionary<string, List<TopicPartitionOffset>> _pendingOffsets = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, PendingGroupOffsets> _pendingOffsets = new(StringComparer.Ordinal);
         private bool _completed;
         private bool _prepared;
 
         public InMemoryTransaction(InMemoryProducer<TKey, TValue> producer)
         {
             _producer = producer;
+            TransactionMarker = InMemoryKafkaCluster.CreateTransactionMarker();
         }
+
+        public InMemoryTransactionMarker TransactionMarker { get; }
 
         public bool IsCompleted => _completed;
 
@@ -601,7 +630,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             CancellationToken cancellationToken = default)
         {
             ThrowIfCannotMutate("Cannot produce");
-            return await _producer.ProduceTransactionAsync(message, cancellationToken).ConfigureAwait(false);
+            return await _producer.ProduceTransactionAsync(this, message, cancellationToken).ConfigureAwait(false);
         }
 
         public async ValueTask<RecordMetadata> ProduceAsync(
@@ -611,21 +640,18 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             CancellationToken cancellationToken = default)
         {
             ThrowIfCannotMutate("Cannot produce");
-            return await _producer.ProduceTransactionAsync(topic, key, value, cancellationToken).ConfigureAwait(false);
+            return await _producer.ProduceTransactionAsync(this, topic, key, value, cancellationToken).ConfigureAwait(false);
         }
 
         public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
         {
-            ThrowIfIncomplete("Cannot commit transaction");
+            ThrowIfCompleted("Cannot commit transaction");
 
             await _producer.ApplyFaultAsync(
                 new KafkaFaultScope(KafkaFaultOperation.CommitTransaction),
                 cancellationToken).ConfigureAwait(false);
 
-            foreach (var (groupId, offsets) in _pendingOffsets)
-                _producer._cluster.CommitOffsets(groupId, offsets);
-
-            Complete();
+            Complete(committed: true);
         }
 
         public ValueTask<PreparedTransactionState> PrepareAsync(CancellationToken cancellationToken = default)
@@ -633,19 +659,19 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfCannotMutate("Cannot prepare transaction");
             _prepared = true;
+            _producer._cluster.RegisterPreparedTransaction(PreparedState, this);
             return ValueTask.FromResult(PreparedState);
         }
 
         public async ValueTask AbortAsync(CancellationToken cancellationToken = default)
         {
-            ThrowIfIncomplete("Cannot abort transaction");
+            ThrowIfCompleted("Cannot abort transaction");
 
             await _producer.ApplyFaultAsync(
                 new KafkaFaultScope(KafkaFaultOperation.AbortTransaction),
                 cancellationToken).ConfigureAwait(false);
 
-            _pendingOffsets.Clear();
-            Complete();
+            Complete(committed: false);
         }
 
         public async ValueTask SendOffsetsToTransactionAsync(
@@ -664,22 +690,30 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
                     groupId: consumerGroupId),
                 cancellationToken).ConfigureAwait(false);
 
-            if (!_pendingOffsets.TryGetValue(consumerGroupId, out var pending))
-            {
-                pending = [];
-                _pendingOffsets.Add(consumerGroupId, pending);
-            }
-
-            pending.AddRange(snapshot);
+            var pending = GetOrAddPendingOffsets(consumerGroupId);
+            pending.Offsets.AddRange(snapshot);
         }
 
-        public ValueTask SendOffsetsToTransactionAsync(
+        public async ValueTask SendOffsetsToTransactionAsync(
             IEnumerable<TopicPartitionOffset> offsets,
             ConsumerGroupMetadata consumerGroupMetadata,
             CancellationToken cancellationToken = default)
         {
+            ArgumentNullException.ThrowIfNull(offsets);
             ArgumentNullException.ThrowIfNull(consumerGroupMetadata);
-            return SendOffsetsToTransactionAsync(offsets, consumerGroupMetadata.GroupId, cancellationToken);
+            ArgumentException.ThrowIfNullOrWhiteSpace(consumerGroupMetadata.GroupId);
+            ThrowIfCannotMutate("Cannot send offsets to transaction");
+            var snapshot = offsets.ToArray();
+
+            await _producer.ApplyFaultAsync(
+                new KafkaFaultScope(
+                    KafkaFaultOperation.SendOffsetsToTransaction,
+                    groupId: consumerGroupMetadata.GroupId),
+                cancellationToken).ConfigureAwait(false);
+
+            var pending = GetOrAddPendingOffsets(consumerGroupMetadata.GroupId);
+            pending.Metadata = consumerGroupMetadata;
+            pending.Offsets.AddRange(snapshot);
         }
 
         public async ValueTask DisposeAsync()
@@ -691,32 +725,76 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             {
                 await AbortAsync().ConfigureAwait(false);
             }
-            catch (TransactionException)
+            catch (Exception)
             {
                 // Best-effort cleanup mirrors the production transaction adapter.
-                Complete();
+                Complete(committed: false);
             }
+        }
+
+        public async ValueTask CompletePreparedAsync(
+            InMemoryProducer<TKey, TValue> recoveringProducer,
+            bool committed,
+            CancellationToken cancellationToken)
+        {
+            ThrowIfCompleted("Cannot complete prepared transaction", allowDisposedProducer: true);
+            if (!_prepared)
+                throw new InvalidOperationException("Transaction is not prepared.");
+
+            await recoveringProducer.ApplyFaultAsync(
+                new KafkaFaultScope(
+                    committed
+                        ? KafkaFaultOperation.CommitTransaction
+                        : KafkaFaultOperation.AbortTransaction),
+                cancellationToken).ConfigureAwait(false);
+
+            Complete(committed);
         }
 
         private void ThrowIfCannotMutate(string operation)
         {
-            ThrowIfIncomplete(operation);
+            ThrowIfCompleted(operation);
             if (_prepared)
                 throw new InvalidOperationException("Transaction is prepared; only commit or abort is permitted.");
         }
 
-        private void ThrowIfIncomplete(string operation)
+        private void ThrowIfCompleted(string operation, bool allowDisposedProducer = false)
         {
-            _producer.ThrowIfDisposed();
+            if (!allowDisposedProducer)
+                _producer.ThrowIfDisposed();
             _producer.ThrowIfFatalTransactionError();
             if (_completed)
                 throw new InvalidOperationException($"{operation}: transaction is already completed.");
         }
 
-        private void Complete()
+        private PendingGroupOffsets GetOrAddPendingOffsets(string groupId)
         {
+            if (_pendingOffsets.TryGetValue(groupId, out var pending))
+                return pending;
+
+            pending = new PendingGroupOffsets();
+            _pendingOffsets.Add(groupId, pending);
+            return pending;
+        }
+
+        private void Complete(bool committed)
+        {
+            _producer._cluster.CompleteTransaction(
+                TransactionMarker,
+                committed,
+                _pendingOffsets.Select(static item =>
+                    (item.Key, item.Value.Metadata, (IReadOnlyList<TopicPartitionOffset>)item.Value.Offsets)),
+                PreparedState,
+                this);
+            _pendingOffsets.Clear();
             _completed = true;
             _producer.CompleteTransaction(this);
+        }
+
+        private sealed class PendingGroupOffsets
+        {
+            public List<TopicPartitionOffset> Offsets { get; } = [];
+            public ConsumerGroupMetadata? Metadata { get; set; }
         }
     }
 

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -34,6 +34,8 @@ public sealed class InMemoryProducer<TKey, TValue> :
     IKafkaProducer<TKey, TValue>,
     IInMemoryTransactionRecoveryContext
 {
+    internal static Action? TransactionCompletionPublishedTestHook;
+
     private readonly InMemoryKafkaCluster _cluster;
     private readonly ISerializer<TKey> _keySerializer;
     private readonly ISerializer<TValue> _valueSerializer;
@@ -639,6 +641,8 @@ public sealed class InMemoryProducer<TKey, TValue> :
     {
         lock (_transactionGate)
         {
+            transaction.PublishCompleted();
+            Volatile.Read(ref TransactionCompletionPublishedTestHook)?.Invoke();
             if (ReferenceEquals(_activeTransaction, transaction))
                 Volatile.Write(ref _activeTransaction, null);
         }
@@ -1095,11 +1099,9 @@ public sealed class InMemoryProducer<TKey, TValue> :
                     PreparedState,
                     this);
                 _pendingOffsets.Clear();
-                SetStatePreservingMutationCount(TransactionLifecycleState.Completed);
             }
 
             _producer.CompleteTransaction(this);
-            SignalCompletionAttempt();
         }
 
         private void EnterMutation(string operation)
@@ -1276,16 +1278,15 @@ public sealed class InMemoryProducer<TKey, TValue> :
             }
         }
 
-        private void SignalCompletionAttempt()
+        internal void PublishCompleted()
         {
-            TaskCompletionSource? completion;
             lock (_completionGate)
             {
-                completion = _completionAttempt;
+                SetStatePreservingMutationCount(TransactionLifecycleState.Completed);
+                var completion = _completionAttempt;
                 _completionAttempt = null;
+                completion?.TrySetResult();
             }
-
-            completion?.TrySetResult();
         }
 
         private void MarkAbortable(AbortableTransactionException exception)

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -255,6 +255,17 @@ public sealed class InMemoryProducer<TKey, TValue> :
     {
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
+
+        if ((options & PurgeOptions.All) == PurgeOptions.None)
+            return ValueTask.CompletedTask;
+
+        if (Volatile.Read(ref _activeTransaction) is { IsCompleted: false } ||
+            Volatile.Read(ref _preparedRecoveryInProgress))
+        {
+            throw new InvalidOperationException(
+                "PurgeAsync cannot be called while a transaction is active. Commit or abort the transaction before purging buffered records.");
+        }
+
         return ValueTask.CompletedTask;
     }
 

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -933,7 +933,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
                 EnsureMutationActive("Cannot send offsets to transaction");
                 var pending = GetOrAddPendingOffsets(groupId);
                 if (metadata is not null)
-                    pending.Metadata = metadata;
+                    pending.MetadataSnapshots.Add(metadata);
                 pending.Offsets.AddRange(offsets);
             }
         }
@@ -1108,15 +1108,15 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
 
         private static (
             string GroupId,
-            ConsumerGroupMetadata? Metadata,
+            IReadOnlyList<ConsumerGroupMetadata> MetadataSnapshots,
             IReadOnlyList<TopicPartitionOffset> Offsets) CreatePendingOffsets(
                 KeyValuePair<string, PendingGroupOffsets> item) =>
-            (item.Key, item.Value.Metadata, item.Value.Offsets);
+            (item.Key, item.Value.MetadataSnapshots, item.Value.Offsets);
 
         private sealed class PendingGroupOffsets
         {
             public List<TopicPartitionOffset> Offsets { get; } = [];
-            public ConsumerGroupMetadata? Metadata { get; set; }
+            public List<ConsumerGroupMetadata> MetadataSnapshots { get; } = [];
         }
 
         private enum TransactionLifecycleState : byte

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -8,10 +8,31 @@ using Dekaf.Telemetry;
 
 namespace Dekaf.Testing;
 
+internal interface IInMemoryPreparedTransaction
+{
+    bool IsCompleted { get; }
+    bool IsPrepared { get; }
+    PreparedTransactionState PreparedState { get; }
+
+    ValueTask CompletePreparedAsync(
+        IInMemoryTransactionRecoveryContext recoveryContext,
+        bool committed,
+        CancellationToken cancellationToken);
+}
+
+internal interface IInMemoryTransactionRecoveryContext
+{
+    void ThrowIfFatalTransactionError();
+    ValueTask ApplyFaultAsync(KafkaFaultScope scope, CancellationToken cancellationToken);
+    FatalTransactionException CaptureFatalTransactionException(FatalTransactionException exception);
+}
+
 /// <summary>
 /// In-memory <see cref="IKafkaProducer{TKey,TValue}"/> backed by an <see cref="InMemoryKafkaCluster"/>.
 /// </summary>
-public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue>
+public sealed class InMemoryProducer<TKey, TValue> :
+    IKafkaProducer<TKey, TValue>,
+    IInMemoryTransactionRecoveryContext
 {
     private readonly InMemoryKafkaCluster _cluster;
     private readonly ISerializer<TKey> _keySerializer;
@@ -288,7 +309,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         ThrowIfDisposed();
         ThrowIfFatalTransactionError();
 
-        InMemoryTransaction transaction;
+        IInMemoryPreparedTransaction transaction;
         TaskCompletionSource recoveryCompletion;
         lock (_transactionGate)
         {
@@ -307,7 +328,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             if (transaction is null || !transaction.IsPrepared || transaction.PreparedState != preparedState)
             {
                 if (!Volatile.Read(ref _preparedRecoveryEnabled) ||
-                    _cluster.GetPreparedTransaction(preparedState) is not InMemoryTransaction recovered)
+                    _cluster.GetPreparedTransaction(preparedState) is not { } recovered)
                 {
                     throw new InvalidOperationException(
                         "There is no matching active or recoverable prepared transaction.");
@@ -596,6 +617,18 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     private FatalTransactionException CaptureFatalTransactionException(FatalTransactionException exception) =>
         Interlocked.CompareExchange(ref _fatalTransactionException, exception, null) ?? exception;
 
+    void IInMemoryTransactionRecoveryContext.ThrowIfFatalTransactionError() =>
+        ThrowIfFatalTransactionError();
+
+    ValueTask IInMemoryTransactionRecoveryContext.ApplyFaultAsync(
+        KafkaFaultScope scope,
+        CancellationToken cancellationToken) =>
+        ApplyFaultAsync(scope, cancellationToken);
+
+    FatalTransactionException IInMemoryTransactionRecoveryContext.CaptureFatalTransactionException(
+        FatalTransactionException exception) =>
+        CaptureFatalTransactionException(exception);
+
     private void ThrowIfFatalTransactionError()
     {
         if (Volatile.Read(ref _fatalTransactionException) is { } exception)
@@ -693,12 +726,16 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         }
     }
 
-    private sealed class InMemoryTransaction : ITransaction<TKey, TValue>
+    private sealed class InMemoryTransaction :
+        ITransaction<TKey, TValue>,
+        IInMemoryPreparedTransaction
     {
         private const long MutationCountMask = uint.MaxValue;
         private readonly InMemoryProducer<TKey, TValue> _producer;
+        private readonly object _completionGate = new();
         private readonly object _pendingOffsetsGate = new();
         private readonly Dictionary<string, PendingGroupOffsets> _pendingOffsets = new(StringComparer.Ordinal);
+        private TaskCompletionSource? _completionAttempt;
         private long _lifecycle;
         private AbortableTransactionException? _abortableException;
         private bool _prepared;
@@ -740,12 +777,17 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             {
                 MarkAbortable(exception);
                 ExitMutation();
-                throw;
+                return FaultedProduce(exception);
             }
-            catch
+            catch (OperationCanceledException exception)
             {
                 ExitMutation();
-                throw;
+                return CanceledProduce(exception, cancellationToken);
+            }
+            catch (Exception exception)
+            {
+                ExitMutation();
+                return FaultedProduce(exception);
             }
         }
 
@@ -771,14 +813,34 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             {
                 MarkAbortable(exception);
                 ExitMutation();
-                throw;
+                return FaultedProduce(exception);
             }
-            catch
+            catch (OperationCanceledException exception)
             {
                 ExitMutation();
-                throw;
+                return CanceledProduce(exception, cancellationToken);
+            }
+            catch (Exception exception)
+            {
+                ExitMutation();
+                return FaultedProduce(exception);
             }
         }
+
+        private static ValueTask<RecordMetadata> CanceledProduce(
+            OperationCanceledException exception,
+            CancellationToken cancellationToken)
+        {
+            var canceledToken = exception.CancellationToken.IsCancellationRequested
+                ? exception.CancellationToken
+                : cancellationToken.IsCancellationRequested
+                    ? cancellationToken
+                    : new CancellationToken(canceled: true);
+            return new ValueTask<RecordMetadata>(Task.FromCanceled<RecordMetadata>(canceledToken));
+        }
+
+        private static ValueTask<RecordMetadata> FaultedProduce(Exception exception) =>
+            new(Task.FromException<RecordMetadata>(exception));
 
         private async ValueTask<RecordMetadata> CompleteProduceAsync(
             ValueTask<RecordMetadata> operation)
@@ -817,7 +879,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             catch (AbortableTransactionException exception)
             {
                 _abortableException = exception;
-                Volatile.Write(ref _lifecycle, Pack(TransactionLifecycleState.Abortable));
+                RestoreAfterFailedCompletion(TransactionLifecycleState.Abortable);
                 throw;
             }
             catch
@@ -860,7 +922,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             catch (AbortableTransactionException exception)
             {
                 _abortableException = exception;
-                Volatile.Write(ref _lifecycle, Pack(TransactionLifecycleState.Abortable));
+                RestoreAfterFailedCompletion(TransactionLifecycleState.Abortable);
                 throw;
             }
             catch
@@ -933,26 +995,34 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
 
         public async ValueTask DisposeAsync()
         {
-            if (IsCompleted || IsPrepared || Volatile.Read(ref _producer._disposed))
-                return;
+            while (!IsCompleted && !IsPrepared && !Volatile.Read(ref _producer._disposed))
+            {
+                // Fault plans accept arbitrary exceptions. Disposal is best-effort and must release the
+                // producer slot after any injected abort failure without a generic catch clause.
+                await AbortAsync().AsTask().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+                if (TryEnterDisposalCompletion(out var ownedCompletion))
+                {
+                    Complete(committed: false);
+                    return;
+                }
 
-            // Fault plans accept arbitrary exceptions. Disposal is best-effort and must release the
-            // producer slot after any injected abort failure without a generic catch clause.
-            await AbortAsync().AsTask().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
-            if (TryEnterDisposalCompletion())
-                Complete(committed: false);
+                if (ownedCompletion is null)
+                    return;
+
+                await ownedCompletion.ConfigureAwait(false);
+            }
         }
 
         public async ValueTask CompletePreparedAsync(
-            InMemoryProducer<TKey, TValue> recoveringProducer,
+            IInMemoryTransactionRecoveryContext recoveryContext,
             bool committed,
             CancellationToken cancellationToken)
         {
-            recoveringProducer.ThrowIfFatalTransactionError();
+            recoveryContext.ThrowIfFatalTransactionError();
             var previousState = EnterCompletion(
                 "Cannot complete prepared transaction",
                 allowAbortable: !committed,
-                recoveringProducer);
+                recoveryContext);
             if (previousState != TransactionLifecycleState.Prepared &&
                 previousState != TransactionLifecycleState.Abortable)
             {
@@ -962,7 +1032,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
 
             try
             {
-                await recoveringProducer.ApplyFaultAsync(
+                await recoveryContext.ApplyFaultAsync(
                     new KafkaFaultScope(
                         committed
                             ? KafkaFaultOperation.CommitTransaction
@@ -974,12 +1044,12 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             catch (FatalTransactionException exception)
             {
                 RestoreAfterFailedCompletion(previousState);
-                throw recoveringProducer.CaptureFatalTransactionException(exception);
+                throw recoveryContext.CaptureFatalTransactionException(exception);
             }
             catch (AbortableTransactionException exception)
             {
                 _abortableException = exception;
-                Volatile.Write(ref _lifecycle, Pack(TransactionLifecycleState.Abortable));
+                RestoreAfterFailedCompletion(TransactionLifecycleState.Abortable);
                 throw;
             }
             catch
@@ -1029,6 +1099,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             }
 
             _producer.CompleteTransaction(this);
+            SignalCompletionAttempt();
         }
 
         private void EnterMutation(string operation)
@@ -1115,61 +1186,106 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         private TransactionLifecycleState EnterCompletion(
             string operation,
             bool allowAbortable,
-            InMemoryProducer<TKey, TValue>? operationProducer = null)
+            IInMemoryTransactionRecoveryContext? recoveryContext = null)
         {
-            var producer = operationProducer ?? _producer;
-            producer.ThrowIfDisposed();
-            producer.ThrowIfFatalTransactionError();
-
-            while (true)
+            if (recoveryContext is null)
             {
-                var lifecycle = Volatile.Read(ref _lifecycle);
-                var state = GetState(lifecycle);
-                if (state is not (TransactionLifecycleState.Active or TransactionLifecycleState.Prepared) &&
-                    !(allowAbortable && state == TransactionLifecycleState.Abortable))
-                {
-                    ThrowForState(operation, state);
-                }
+                _producer.ThrowIfDisposed();
+                _producer.ThrowIfFatalTransactionError();
+            }
+            else
+            {
+                recoveryContext.ThrowIfFatalTransactionError();
+            }
 
-                if ((lifecycle & MutationCountMask) != 0)
+            lock (_completionGate)
+            {
+                while (true)
                 {
-                    throw new InvalidOperationException(
-                        $"{operation} while transaction operations are in progress.");
-                }
+                    var lifecycle = Volatile.Read(ref _lifecycle);
+                    var state = GetState(lifecycle);
+                    if (state is not (TransactionLifecycleState.Active or TransactionLifecycleState.Prepared) &&
+                        !(allowAbortable && state == TransactionLifecycleState.Abortable))
+                    {
+                        ThrowForState(operation, state);
+                    }
 
-                if (Interlocked.CompareExchange(
-                        ref _lifecycle,
-                        Pack(TransactionLifecycleState.Completing),
-                        lifecycle) == lifecycle)
-                {
-                    return state;
+                    if ((lifecycle & MutationCountMask) != 0)
+                    {
+                        throw new InvalidOperationException(
+                            $"{operation} while transaction operations are in progress.");
+                    }
+
+                    if (Interlocked.CompareExchange(
+                            ref _lifecycle,
+                            Pack(TransactionLifecycleState.Completing),
+                            lifecycle) == lifecycle)
+                    {
+                        _completionAttempt = new TaskCompletionSource(
+                            TaskCreationOptions.RunContinuationsAsynchronously);
+                        return state;
+                    }
                 }
             }
         }
 
-        private void RestoreAfterFailedCompletion(TransactionLifecycleState state) =>
-            Interlocked.CompareExchange(
-                ref _lifecycle,
-                Pack(state),
-                Pack(TransactionLifecycleState.Completing));
-
-        private bool TryEnterDisposalCompletion()
+        private void RestoreAfterFailedCompletion(TransactionLifecycleState state)
         {
-            while (true)
+            TaskCompletionSource? completion;
+            lock (_completionGate)
             {
-                var lifecycle = Volatile.Read(ref _lifecycle);
-                var state = GetState(lifecycle);
-                if (state is not (TransactionLifecycleState.Active or TransactionLifecycleState.Abortable))
-                    return false;
+                Volatile.Write(ref _lifecycle, Pack(state));
+                completion = _completionAttempt;
+                _completionAttempt = null;
+            }
 
-                if (Interlocked.CompareExchange(
-                        ref _lifecycle,
-                        Pack(TransactionLifecycleState.Completing) | (lifecycle & MutationCountMask),
-                        lifecycle) == lifecycle)
+            completion?.TrySetResult();
+        }
+
+        private bool TryEnterDisposalCompletion(out Task? ownedCompletion)
+        {
+            lock (_completionGate)
+            {
+                while (true)
                 {
-                    return true;
+                    var lifecycle = Volatile.Read(ref _lifecycle);
+                    var state = GetState(lifecycle);
+                    if (state == TransactionLifecycleState.Completing)
+                    {
+                        ownedCompletion = _completionAttempt!.Task;
+                        return false;
+                    }
+
+                    if (state is not (TransactionLifecycleState.Active or TransactionLifecycleState.Abortable))
+                    {
+                        ownedCompletion = null;
+                        return false;
+                    }
+
+                    if (Interlocked.CompareExchange(
+                            ref _lifecycle,
+                            Pack(TransactionLifecycleState.Completing) | (lifecycle & MutationCountMask),
+                            lifecycle) == lifecycle)
+                    {
+                        _completionAttempt = new TaskCompletionSource(
+                            TaskCreationOptions.RunContinuationsAsynchronously);
+                        ownedCompletion = null;
+                        return true;
+                    }
                 }
             }
+        }
+
+        private void SignalCompletionAttempt()
+        {
+            TaskCompletionSource? completion;
+            lock (_completionGate)
+            {
+                completion = _completionAttempt;
+                _completionAttempt = null;
+            }
+
+            completion?.TrySetResult();
         }
 
         private void MarkAbortable(AbortableTransactionException exception)

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -29,6 +29,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     private bool _preparedRecoveryEnabled;
     private bool _preparedRecoveryInProgress;
     private TaskCompletionSource? _preparedRecoveryCompletion;
+    private TaskCompletionSource? _disposeCompletion;
     private bool _disposeStarted;
     private bool _disposed;
 
@@ -345,27 +346,47 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         return new InMemoryTopicProducer(this, topic);
     }
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         InMemoryTransaction? transaction;
         Task? preparedRecovery;
+        TaskCompletionSource disposeCompletion;
         lock (_transactionGate)
         {
-            if (_disposeStarted)
-                return;
+            if (_disposeCompletion is not null)
+                return new ValueTask(_disposeCompletion.Task);
 
             Volatile.Write(ref _disposeStarted, true);
+            disposeCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _disposeCompletion = disposeCompletion;
             transaction = _activeTransaction;
             preparedRecovery = _preparedRecoveryCompletion?.Task;
         }
 
-        if (preparedRecovery is not null)
-            await preparedRecovery.ConfigureAwait(false);
+        _ = DisposeCoreAsync(transaction, preparedRecovery, disposeCompletion);
+        return new ValueTask(disposeCompletion.Task);
+    }
 
-        if (transaction is { IsCompleted: false, IsPrepared: false })
-            await transaction.DisposeAsync().ConfigureAwait(false);
+    private async Task DisposeCoreAsync(
+        InMemoryTransaction? transaction,
+        Task? preparedRecovery,
+        TaskCompletionSource disposeCompletion)
+    {
+        try
+        {
+            if (preparedRecovery is not null)
+                await preparedRecovery.ConfigureAwait(false);
 
-        Volatile.Write(ref _disposed, true);
+            if (transaction is { IsCompleted: false, IsPrepared: false })
+                await transaction.DisposeAsync().ConfigureAwait(false);
+
+            Volatile.Write(ref _disposed, true);
+            disposeCompletion.TrySetResult();
+        }
+        catch (Exception exception)
+        {
+            disposeCompletion.TrySetException(exception);
+        }
     }
 
     private ValueTask<RecordMetadata> ProduceCoreAsync(

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -12,7 +12,6 @@ namespace Dekaf.Testing;
 /// </summary>
 public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue>
 {
-    private static long s_nextProducerId;
     private readonly InMemoryKafkaCluster _cluster;
     private readonly ISerializer<TKey> _keySerializer;
     private readonly ISerializer<TValue> _valueSerializer;
@@ -23,7 +22,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     private readonly IAsyncSerializer<TValue>? _asyncValueSerializer;
     private readonly bool _hasAsyncSerializers;
     private readonly object _transactionGate = new();
-    private readonly long _producerId = Interlocked.Increment(ref s_nextProducerId);
+    private readonly long _producerId;
     private InMemoryTransaction? _activeTransaction;
     private FatalTransactionException? _fatalTransactionException;
     private bool _preparedRecoveryEnabled;
@@ -106,6 +105,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         IAsyncSerializer<TValue>? asyncValueSerializer)
     {
         _cluster = cluster ?? throw new ArgumentNullException(nameof(cluster));
+        _producerId = _cluster.AllocateProducerId();
         _asyncKeySerializer = asyncKeySerializer;
         _asyncValueSerializer = asyncValueSerializer;
         _keySerializer = asyncKeySerializer is null
@@ -727,7 +727,7 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             }
             catch (Exception)
             {
-                // Best-effort cleanup mirrors the production transaction adapter.
+                // Fault plans accept arbitrary exceptions; disposal must release the slot for all of them.
                 Complete(committed: false);
             }
         }
@@ -737,7 +737,9 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             bool committed,
             CancellationToken cancellationToken)
         {
-            ThrowIfCompleted("Cannot complete prepared transaction", allowDisposedProducer: true);
+            recoveringProducer.ThrowIfFatalTransactionError();
+            if (_completed)
+                throw new InvalidOperationException("Cannot complete prepared transaction: transaction is already completed.");
             if (!_prepared)
                 throw new InvalidOperationException("Transaction is not prepared.");
 
@@ -758,10 +760,9 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
                 throw new InvalidOperationException("Transaction is prepared; only commit or abort is permitted.");
         }
 
-        private void ThrowIfCompleted(string operation, bool allowDisposedProducer = false)
+        private void ThrowIfCompleted(string operation)
         {
-            if (!allowDisposedProducer)
-                _producer.ThrowIfDisposed();
+            _producer.ThrowIfDisposed();
             _producer.ThrowIfFatalTransactionError();
             if (_completed)
                 throw new InvalidOperationException($"{operation}: transaction is already completed.");
@@ -782,14 +783,20 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             _producer._cluster.CompleteTransaction(
                 TransactionMarker,
                 committed,
-                _pendingOffsets.Select(static item =>
-                    (item.Key, item.Value.Metadata, (IReadOnlyList<TopicPartitionOffset>)item.Value.Offsets)),
+                _pendingOffsets.Select(static item => CreatePendingOffsets(item)),
                 PreparedState,
                 this);
             _pendingOffsets.Clear();
             _completed = true;
             _producer.CompleteTransaction(this);
         }
+
+        private static (
+            string GroupId,
+            ConsumerGroupMetadata? Metadata,
+            IReadOnlyList<TopicPartitionOffset> Offsets) CreatePendingOffsets(
+                KeyValuePair<string, PendingGroupOffsets> item) =>
+            (item.Key, item.Value.Metadata, item.Value.Offsets);
 
         private sealed class PendingGroupOffsets
         {

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -685,27 +685,34 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             ? new PreparedTransactionState(_producer._producerId, 0)
             : PreparedTransactionState.Empty;
 
-        public async ValueTask<RecordMetadata> ProduceAsync(
+        public ValueTask<RecordMetadata> ProduceAsync(
             ProducerMessage<TKey, TValue> message,
             CancellationToken cancellationToken = default)
         {
             EnterMutation("Cannot produce");
             try
             {
-                return await _producer.ProduceTransactionAsync(this, message, cancellationToken).ConfigureAwait(false);
+                var operation = _producer.ProduceTransactionAsync(this, message, cancellationToken);
+                if (!operation.IsCompletedSuccessfully)
+                    return CompleteProduceAsync(operation);
+
+                ExitMutation();
+                return operation;
             }
             catch (AbortableTransactionException exception)
             {
                 MarkAbortable(exception);
+                ExitMutation();
                 throw;
             }
-            finally
+            catch
             {
                 ExitMutation();
+                throw;
             }
         }
 
-        public async ValueTask<RecordMetadata> ProduceAsync(
+        public ValueTask<RecordMetadata> ProduceAsync(
             string topic,
             TKey? key,
             TValue value,
@@ -714,7 +721,32 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             EnterMutation("Cannot produce");
             try
             {
-                return await _producer.ProduceTransactionAsync(this, topic, key, value, cancellationToken).ConfigureAwait(false);
+                var operation = _producer.ProduceTransactionAsync(this, topic, key, value, cancellationToken);
+                if (!operation.IsCompletedSuccessfully)
+                    return CompleteProduceAsync(operation);
+
+                ExitMutation();
+                return operation;
+            }
+            catch (AbortableTransactionException exception)
+            {
+                MarkAbortable(exception);
+                ExitMutation();
+                throw;
+            }
+            catch
+            {
+                ExitMutation();
+                throw;
+            }
+        }
+
+        private async ValueTask<RecordMetadata> CompleteProduceAsync(
+            ValueTask<RecordMetadata> operation)
+        {
+            try
+            {
+                return await operation.ConfigureAwait(false);
             }
             catch (AbortableTransactionException exception)
             {

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -283,6 +283,13 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         lock (_transactionGate)
             transaction = _activeTransaction;
 
+        if (transaction is { IsCompleted: false } &&
+            (!transaction.IsPrepared || transaction.PreparedState != preparedState))
+        {
+            throw new InvalidOperationException(
+                "Cannot recover a prepared transaction while another transaction is active.");
+        }
+
         if (transaction is null || !transaction.IsPrepared || transaction.PreparedState != preparedState)
         {
             if (!_preparedRecoveryEnabled ||
@@ -718,18 +725,14 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
 
         public async ValueTask DisposeAsync()
         {
-            if (_completed || _producer._disposed)
+            if (_completed || _prepared || _producer._disposed)
                 return;
 
-            try
-            {
-                await AbortAsync().ConfigureAwait(false);
-            }
-            catch (Exception)
-            {
-                // Fault plans accept arbitrary exceptions; disposal must release the slot for all of them.
+            // Fault plans accept arbitrary exceptions. Disposal is best-effort and must release the
+            // producer slot after any injected abort failure without a generic catch clause.
+            await AbortAsync().AsTask().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+            if (!_completed)
                 Complete(committed: false);
-            }
         }
 
         public async ValueTask CompletePreparedAsync(

--- a/src/Dekaf.Testing/InMemoryRecord.cs
+++ b/src/Dekaf.Testing/InMemoryRecord.cs
@@ -17,4 +17,17 @@ public sealed record InMemoryRecord
     public IReadOnlyList<Header> Headers { get; init; } = Array.Empty<Header>();
     public required long TimestampMs { get; init; }
     public DateTimeOffset Timestamp => DateTimeOffset.FromUnixTimeMilliseconds(TimestampMs);
+    internal InMemoryTransactionMarker? Transaction { get; init; }
+}
+
+internal sealed class InMemoryTransactionMarker
+{
+    public InMemoryTransactionState State { get; set; } = InMemoryTransactionState.Ongoing;
+}
+
+internal enum InMemoryTransactionState : byte
+{
+    Ongoing,
+    Committed,
+    Aborted
 }

--- a/src/Dekaf.Testing/KafkaFaultPlan.cs
+++ b/src/Dekaf.Testing/KafkaFaultPlan.cs
@@ -447,12 +447,8 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
 
     private void PublishProduceFaultIndexUnderLock()
     {
-        var allProduceTopics = false;
-        var allTransactionProduceTopics = false;
-        string? produceTopic = null;
-        string? transactionProduceTopic = null;
-        HashSet<string>? produceTopics = null;
-        HashSet<string>? transactionProduceTopics = null;
+        var produceScopes = new ProduceScopeBuilder();
+        var transactionProduceScopes = new ProduceScopeBuilder();
         for (var entryIndex = 0; entryIndex < _entries.Count; entryIndex++)
         {
             var scope = _entries[entryIndex].Scope;
@@ -462,18 +458,10 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
             switch (scope.Operation)
             {
                 case KafkaFaultOperation.Produce:
-                    AddProduceScope(
-                        scope.Topic,
-                        ref allProduceTopics,
-                        ref produceTopic,
-                        ref produceTopics);
+                    produceScopes.Add(scope.Topic);
                     break;
                 case KafkaFaultOperation.TransactionProduce:
-                    AddProduceScope(
-                        scope.Topic,
-                        ref allTransactionProduceTopics,
-                        ref transactionProduceTopic,
-                        ref transactionProduceTopics);
+                    transactionProduceScopes.Add(scope.Topic);
                     break;
             }
         }
@@ -481,43 +469,46 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
         Volatile.Write(
             ref _produceFaultIndex,
             new ProduceFaultIndex(
-                allProduceTopics,
-                produceTopic,
-                produceTopics,
-                allTransactionProduceTopics,
-                transactionProduceTopic,
-                transactionProduceTopics));
+                produceScopes.AllTopics,
+                produceScopes.SingleTopic,
+                produceScopes.Topics,
+                transactionProduceScopes.AllTopics,
+                transactionProduceScopes.SingleTopic,
+                transactionProduceScopes.Topics));
     }
 
-    private static void AddProduceScope(
-        string? topic,
-        ref bool allTopics,
-        ref string? singleTopic,
-        ref HashSet<string>? topics)
+    private struct ProduceScopeBuilder
     {
-        if (topic is null)
+        internal bool AllTopics;
+        internal string? SingleTopic;
+        internal HashSet<string>? Topics;
+
+        internal void Add(string? topic)
         {
-            allTopics = true;
-            return;
+            if (topic is null)
+            {
+                AllTopics = true;
+                return;
+            }
+
+            if (Topics is not null)
+            {
+                Topics.Add(topic);
+                return;
+            }
+
+            if (SingleTopic is null)
+            {
+                SingleTopic = topic;
+                return;
+            }
+
+            if (string.Equals(SingleTopic, topic, StringComparison.Ordinal))
+                return;
+
+            Topics = new HashSet<string>(StringComparer.Ordinal) { SingleTopic, topic };
+            SingleTopic = null;
         }
-
-        if (topics is not null)
-        {
-            topics.Add(topic);
-            return;
-        }
-
-        if (singleTopic is null)
-        {
-            singleTopic = topic;
-            return;
-        }
-
-        if (string.Equals(singleTopic, topic, StringComparison.Ordinal))
-            return;
-
-        topics = new HashSet<string>(StringComparer.Ordinal) { singleTopic, topic };
-        singleTopic = null;
     }
 
     private sealed class ProduceFaultIndex(

--- a/src/Dekaf.Testing/KafkaFaultPlan.cs
+++ b/src/Dekaf.Testing/KafkaFaultPlan.cs
@@ -267,9 +267,11 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
 {
     private readonly object _gate = new();
     private readonly List<FaultEntry> _entries = [];
+    private ProduceFaultIndex _produceFaultIndex = ProduceFaultIndex.Empty;
     private int _hasEntries;
 
-    internal bool HasEntries => Volatile.Read(ref _hasEntries) != 0;
+    internal bool HasPotentialProduceMatch(KafkaFaultOperation operation, string topic) =>
+        Volatile.Read(ref _produceFaultIndex).Matches(operation, topic);
 
     /// <summary>
     /// Raised synchronously after a matching entry is consumed and before its action runs.
@@ -301,6 +303,7 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
         {
             _entries.Add(FaultEntry.Failure(scope, exception, occurrenceCount, isPersistent: false));
             Volatile.Write(ref _hasEntries, 1);
+            PublishProduceFaultIndexUnderLock();
         }
     }
 
@@ -316,6 +319,7 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
         {
             _entries.Add(FaultEntry.Failure(scope, exception, remainingOccurrences: 0, isPersistent: true));
             Volatile.Write(ref _hasEntries, 1);
+            PublishProduceFaultIndexUnderLock();
         }
     }
 
@@ -330,6 +334,7 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
         {
             _entries.Add(FaultEntry.Pause(scope, barrier));
             Volatile.Write(ref _hasEntries, 1);
+            PublishProduceFaultIndexUnderLock();
         }
 
         return barrier;
@@ -367,6 +372,7 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
                         _entries.RemoveAt(i);
                         if (_entries.Count == 0)
                             Volatile.Write(ref _hasEntries, 0);
+                        PublishProduceFaultIndexUnderLock();
                     }
                 }
 
@@ -414,6 +420,8 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
 
             if (_entries.Count == 0)
                 Volatile.Write(ref _hasEntries, 0);
+            if (removed != 0)
+                PublishProduceFaultIndexUnderLock();
         }
 
         return removed;
@@ -432,8 +440,108 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
 
             _entries.Clear();
             Volatile.Write(ref _hasEntries, 0);
+            Volatile.Write(ref _produceFaultIndex, ProduceFaultIndex.Empty);
             return removed;
         }
+    }
+
+    private void PublishProduceFaultIndexUnderLock()
+    {
+        var allProduceTopics = false;
+        var allTransactionProduceTopics = false;
+        string? produceTopic = null;
+        string? transactionProduceTopic = null;
+        HashSet<string>? produceTopics = null;
+        HashSet<string>? transactionProduceTopics = null;
+        for (var entryIndex = 0; entryIndex < _entries.Count; entryIndex++)
+        {
+            var scope = _entries[entryIndex].Scope;
+            if (scope.GroupId is not null)
+                continue;
+
+            switch (scope.Operation)
+            {
+                case KafkaFaultOperation.Produce:
+                    AddProduceScope(
+                        scope.Topic,
+                        ref allProduceTopics,
+                        ref produceTopic,
+                        ref produceTopics);
+                    break;
+                case KafkaFaultOperation.TransactionProduce:
+                    AddProduceScope(
+                        scope.Topic,
+                        ref allTransactionProduceTopics,
+                        ref transactionProduceTopic,
+                        ref transactionProduceTopics);
+                    break;
+            }
+        }
+
+        Volatile.Write(
+            ref _produceFaultIndex,
+            new ProduceFaultIndex(
+                allProduceTopics,
+                produceTopic,
+                produceTopics,
+                allTransactionProduceTopics,
+                transactionProduceTopic,
+                transactionProduceTopics));
+    }
+
+    private static void AddProduceScope(
+        string? topic,
+        ref bool allTopics,
+        ref string? singleTopic,
+        ref HashSet<string>? topics)
+    {
+        if (topic is null)
+        {
+            allTopics = true;
+            return;
+        }
+
+        if (topics is not null)
+        {
+            topics.Add(topic);
+            return;
+        }
+
+        if (singleTopic is null)
+        {
+            singleTopic = topic;
+            return;
+        }
+
+        if (string.Equals(singleTopic, topic, StringComparison.Ordinal))
+            return;
+
+        topics = new HashSet<string>(StringComparer.Ordinal) { singleTopic, topic };
+        singleTopic = null;
+    }
+
+    private sealed class ProduceFaultIndex(
+        bool allProduceTopics,
+        string? produceTopic,
+        HashSet<string>? produceTopics,
+        bool allTransactionProduceTopics,
+        string? transactionProduceTopic,
+        HashSet<string>? transactionProduceTopics)
+    {
+        public static ProduceFaultIndex Empty { get; } = new(false, null, null, false, null, null);
+
+        public bool Matches(KafkaFaultOperation operation, string topic) => operation switch
+        {
+            KafkaFaultOperation.Produce =>
+                allProduceTopics ||
+                string.Equals(produceTopic, topic, StringComparison.Ordinal) ||
+                produceTopics is not null && produceTopics.Contains(topic),
+            KafkaFaultOperation.TransactionProduce =>
+                allTransactionProduceTopics ||
+                string.Equals(transactionProduceTopic, topic, StringComparison.Ordinal) ||
+                transactionProduceTopics is not null && transactionProduceTopics.Contains(topic),
+            _ => false
+        };
     }
 
     private sealed class FaultEntry

--- a/src/Dekaf.Testing/KafkaFaultPlan.cs
+++ b/src/Dekaf.Testing/KafkaFaultPlan.cs
@@ -269,6 +269,8 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
     private readonly List<FaultEntry> _entries = [];
     private int _hasEntries;
 
+    internal bool HasEntries => Volatile.Read(ref _hasEntries) != 0;
+
     /// <summary>
     /// Raised synchronously after a matching entry is consumed and before its action runs.
     /// </summary>

--- a/src/Dekaf.Testing/KafkaFaultPlan.cs
+++ b/src/Dekaf.Testing/KafkaFaultPlan.cs
@@ -267,6 +267,7 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
 {
     private readonly object _gate = new();
     private readonly List<FaultEntry> _entries = [];
+    private int _hasEntries;
 
     /// <summary>
     /// Raised synchronously after a matching entry is consumed and before its action runs.
@@ -295,7 +296,10 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
         ArgumentOutOfRangeException.ThrowIfLessThan(occurrenceCount, 1);
 
         lock (_gate)
+        {
             _entries.Add(FaultEntry.Failure(scope, exception, occurrenceCount, isPersistent: false));
+            Volatile.Write(ref _hasEntries, 1);
+        }
     }
 
     /// <summary>
@@ -307,7 +311,10 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
         ArgumentNullException.ThrowIfNull(exception);
 
         lock (_gate)
+        {
             _entries.Add(FaultEntry.Failure(scope, exception, remainingOccurrences: 0, isPersistent: true));
+            Volatile.Write(ref _hasEntries, 1);
+        }
     }
 
     /// <summary>
@@ -318,7 +325,10 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
         scope.Validate();
         var barrier = new KafkaFaultBarrier();
         lock (_gate)
+        {
             _entries.Add(FaultEntry.Pause(scope, barrier));
+            Volatile.Write(ref _hasEntries, 1);
+        }
 
         return barrier;
     }
@@ -332,6 +342,8 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
     {
         operationScope.Validate();
         cancellationToken.ThrowIfCancellationRequested();
+        if (Volatile.Read(ref _hasEntries) == 0)
+            return ValueTask.CompletedTask;
 
         FaultEntry? entry = null;
         KafkaFaultObservation observation = default;
@@ -349,7 +361,11 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
                 {
                     candidate.RemainingOccurrences--;
                     if (candidate.RemainingOccurrences == 0)
+                    {
                         _entries.RemoveAt(i);
+                        if (_entries.Count == 0)
+                            Volatile.Write(ref _hasEntries, 0);
+                    }
                 }
 
                 observation = new KafkaFaultObservation(
@@ -393,6 +409,9 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
                 entry.Barrier?.ClearBeforeEntry();
                 removed++;
             }
+
+            if (_entries.Count == 0)
+                Volatile.Write(ref _hasEntries, 0);
         }
 
         return removed;
@@ -410,6 +429,7 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
                 _entries[i].Barrier?.ClearBeforeEntry();
 
             _entries.Clear();
+            Volatile.Write(ref _hasEntries, 0);
             return removed;
         }
     }

--- a/src/Dekaf.Testing/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.Testing/PublicAPI.Unshipped.txt
@@ -4,6 +4,9 @@ Dekaf.Testing.InMemoryConsumer<TKey, TValue>.ConsumeSnapshotAsync(System.Threadi
 Dekaf.Testing.InMemoryConsumer<TKey, TValue>.SeekToTailAsync(Dekaf.TopicPartition partition, int offsetCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.TopicPartitionOffset>
 Dekaf.Testing.InMemoryConsumer<TKey, TValue>.StoreOffsets(System.ReadOnlySpan<Dekaf.TopicPartitionOffset> offsets) -> void
 Dekaf.Testing.InMemoryConsumer<TKey, TValue>.StoreOffsets<TOffsets>(TOffsets offsets) -> void
+Dekaf.Testing.InMemoryKafkaCluster.FaultPlan.get -> Dekaf.Testing.IKafkaFaultPlan!
+Dekaf.Testing.InMemoryKafkaCluster.InMemoryKafkaCluster(Dekaf.Testing.IKafkaFaultPlan! faultPlan) -> void
+Dekaf.Testing.InMemoryKafkaCluster.InMemoryKafkaCluster(Dekaf.Testing.InMemoryKafkaClusterOptions! options, Dekaf.Testing.IKafkaFaultPlan! faultPlan) -> void
 Dekaf.Testing.InMemoryStreamsGroupMember
 Dekaf.Testing.InMemoryStreamsGroupMember.CloseAsync(Dekaf.Streams.StreamsGroupCloseOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Dekaf.Testing.InMemoryStreamsGroupMember.CloseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask

--- a/src/Dekaf.Testing/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.Testing/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ Dekaf.Testing.InMemoryConsumer<TKey, TValue>.ConsumeSnapshotAsync(System.Threadi
 Dekaf.Testing.InMemoryConsumer<TKey, TValue>.SeekToTailAsync(Dekaf.TopicPartition partition, int offsetCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.TopicPartitionOffset>
 Dekaf.Testing.InMemoryConsumer<TKey, TValue>.StoreOffsets(System.ReadOnlySpan<Dekaf.TopicPartitionOffset> offsets) -> void
 Dekaf.Testing.InMemoryConsumer<TKey, TValue>.StoreOffsets<TOffsets>(TOffsets offsets) -> void
+Dekaf.Testing.InMemoryConsumerOptions.IsolationLevel.get -> Dekaf.Protocol.Messages.IsolationLevel
+Dekaf.Testing.InMemoryConsumerOptions.IsolationLevel.init -> void
 Dekaf.Testing.InMemoryKafkaCluster.FaultPlan.get -> Dekaf.Testing.IKafkaFaultPlan!
 Dekaf.Testing.InMemoryKafkaCluster.InMemoryKafkaCluster(Dekaf.Testing.IKafkaFaultPlan! faultPlan) -> void
 Dekaf.Testing.InMemoryKafkaCluster.InMemoryKafkaCluster(Dekaf.Testing.InMemoryKafkaClusterOptions! options, Dekaf.Testing.IKafkaFaultPlan! faultPlan) -> void

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
@@ -106,7 +106,7 @@ public sealed class ConsumerPartitionStopListenerTests
     public async Task CloseAsync_PartitionStopTimeout_CancelsListenerAndContinuesCleanup()
     {
         var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var releaseListener = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseListener = new TaskCompletionSource();
         var listenerCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var listener = new TrackingPartitionStopListener
         {

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -90,9 +90,13 @@ public sealed class ConsumerPauseResumeCacheTests
         consumer.Assign(partition0, partition1);
         var paused = (ConcurrentDictionary<TopicPartition, byte>)GetField("_paused").GetValue(consumer)!;
         var epoch = (BatchIterationEpoch)GetField("_batchIterationEpoch").GetValue(consumer)!;
+        using var publisherReady = new ManualResetEventSlim();
+        using var startPublisher = new ManualResetEventSlim();
         Exception? publisherFailure = null;
         var publisher = new Thread(() =>
         {
+            publisherReady.Set();
+            startPublisher.Wait();
             try
             {
                 consumer.Pause(partition0);
@@ -107,10 +111,12 @@ public sealed class ConsumerPauseResumeCacheTests
         };
 
         bool publisherMutated;
+        publisher.Start();
+        var publisherWasReady = publisherReady.Wait(TimeSpan.FromSeconds(5));
         epoch.BeginPublication();
         try
         {
-            publisher.Start();
+            startPublisher.Set();
             publisherMutated = SpinWait.SpinUntil(
                 () => paused.ContainsKey(partition0),
                 TimeSpan.FromSeconds(5));
@@ -118,12 +124,14 @@ public sealed class ConsumerPauseResumeCacheTests
         }
         finally
         {
+            startPublisher.Set();
             epoch.EndPublication();
         }
 
         var publisherCompleted = publisher.Join(TimeSpan.FromSeconds(5));
         var snapshot = (HashSet<TopicPartition>)GetField("_pausedSnapshot").GetValue(consumer)!;
 
+        await Assert.That(publisherWasReady).IsTrue();
         await Assert.That(publisherMutated).IsTrue();
         await Assert.That(publisherCompleted).IsTrue();
         await Assert.That(publisherFailure).IsNull();
@@ -499,21 +507,29 @@ public sealed class ConsumerPauseResumeCacheTests
         await using var consumer = CreatePrefetchedConsumer(CreatePendingFetch(partition, 10, 1));
         consumer.Pause(partition);
 
-        using var cancellationSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var cancellationSource = new CancellationTokenSource();
         var consume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan, cancellationSource.Token).AsTask();
         var pausedDirectFetchCancellationSource = GetField("_pausedDirectFetchCancellationSource");
-        await Assert.That(SpinWait.SpinUntil(
-            () => pausedDirectFetchCancellationSource.GetValue(consumer) is not null,
-            TimeSpan.FromSeconds(5))).IsTrue();
+        try
+        {
+            await Assert.That(SpinWait.SpinUntil(
+                () => pausedDirectFetchCancellationSource.GetValue(consumer) is not null,
+                TimeSpan.FromSeconds(5))).IsTrue();
 
-        consumer.Resume(partition);
+            consumer.Resume(partition);
 
-        var resumed = await consume;
-        await Assert.That(resumed).IsNotNull();
-        await Assert.That(resumed!.Value.Topic).IsEqualTo(partition.Topic);
-        await Assert.That(resumed.Value.Partition).IsEqualTo(partition.Partition);
-        await Assert.That(resumed.Value.Offset).IsEqualTo(10);
-        await Assert.That(pausedDirectFetchCancellationSource.GetValue(consumer)).IsNull();
+            var resumed = await consume.WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(resumed).IsNotNull();
+            await Assert.That(resumed!.Value.Topic).IsEqualTo(partition.Topic);
+            await Assert.That(resumed.Value.Partition).IsEqualTo(partition.Partition);
+            await Assert.That(resumed.Value.Offset).IsEqualTo(10);
+            await Assert.That(pausedDirectFetchCancellationSource.GetValue(consumer)).IsNull();
+        }
+        finally
+        {
+            cancellationSource.Cancel();
+            await ((Task)consume).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+        }
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -528,7 +528,8 @@ public sealed class ConsumerPauseResumeCacheTests
         finally
         {
             cancellationSource.Cancel();
-            await ((Task)consume).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+            Task consumeCleanup = consume;
+            await consumeCleanup.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Producer;
+using Dekaf.Protocol.Messages;
 using Dekaf.Serialization;
 using Dekaf.Testing;
 
@@ -333,7 +334,11 @@ public sealed class InMemoryBoundedConsumerTests
         _ = await producer.ProduceAsync("events", "key-1", "after");
         await using var consumer = new InMemoryConsumer<string, string>(
             cluster,
-            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+            new InMemoryConsumerOptions
+            {
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                IsolationLevel = IsolationLevel.ReadCommitted
+            });
         var partition = new TopicPartition("events", 0);
         consumer.Assign(partition);
         consumer.Seek(new TopicPartitionOffset("events", 0, 1));

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryBoundedConsumerTests.cs
@@ -323,6 +323,32 @@ public sealed class InMemoryBoundedConsumerTests
     }
 
     [Test]
+    public async Task ConsumeSnapshotAsync_OngoingTransactionBeforePositionPreservesPosition()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var transactionalProducer = new InMemoryProducer<string, string>(cluster);
+        await using var transaction = transactionalProducer.BeginTransaction();
+        _ = await transaction.ProduceAsync("events", "key-0", "pending");
+        var producer = new InMemoryProducer<string, string>(cluster);
+        _ = await producer.ProduceAsync("events", "key-1", "after");
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+        var partition = new TopicPartition("events", 0);
+        consumer.Assign(partition);
+        consumer.Seek(new TopicPartitionOffset("events", 0, 1));
+
+        var snapshot = await CollectValuesAsync(consumer.ConsumeSnapshotAsync());
+
+        await Assert.That(snapshot).IsEmpty();
+        await Assert.That(consumer.GetPosition(partition)).IsEqualTo(1L);
+
+        await transaction.CommitAsync();
+        var resumed = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        await Assert.That(resumed!.Value.Value).IsEqualTo("after");
+    }
+
+    [Test]
     public async Task BoundedExtensions_ReachBuiltInCapabilityThroughInterface()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -591,6 +591,22 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    [Arguments(PurgeOptions.Queue)]
+    [Arguments(PurgeOptions.InFlight)]
+    [Arguments(PurgeOptions.All)]
+    public async Task Producer_PurgeAsync_RejectsActiveTransaction(PurgeOptions options)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await using var transaction = producer.BeginTransaction();
+
+        await producer.PurgeAsync(PurgeOptions.None);
+        var action = async () => await producer.PurgeAsync(options);
+
+        await Assert.That(action).Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task ShareConsumer_ReleaseDoesNotAdvanceOffset_AcceptDoes()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -490,6 +490,48 @@ public sealed class InMemoryProducerFaultTests
     }
 
     [Test]
+    public async Task ProducerDispose_DoesNotAbortTransactionWhileCommitOwnsLifecycle()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var transaction = producer.BeginTransaction();
+        _ = await transaction.ProduceAsync("orders", "k", "committed");
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.CommitTransaction));
+        var pendingCommit = transaction.CommitAsync().AsTask();
+
+        await barrier.WaitUntilEnteredAsync();
+        await producer.DisposeAsync();
+        await Assert.That(barrier.Release()).IsTrue();
+        await pendingCommit;
+
+        var visible = cluster.ReadRecords("orders");
+        await Assert.That(visible).Count().IsEqualTo(1);
+        await Assert.That(Encoding.UTF8.GetString(visible[0].Value)).IsEqualTo("committed");
+    }
+
+    [Test]
+    public async Task TransactionProduce_AfterCompletion_ReturnsFaultedValueTask()
+    {
+        var producer = new InMemoryProducer<string, string>(new InMemoryKafkaCluster());
+        var transaction = producer.BeginTransaction();
+        await transaction.AbortAsync();
+
+        var componentwiseOperation = transaction.ProduceAsync("orders", "k", "v");
+        var messageOperation = transaction.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = "orders",
+            Key = "k",
+            Value = "v"
+        });
+
+        await Assert.That(componentwiseOperation.IsCompleted).IsTrue();
+        await Assert.That(messageOperation.IsCompleted).IsTrue();
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(() => componentwiseOperation.AsTask());
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(() => messageOperation.AsTask());
+    }
+
+    [Test]
     public async Task TransactionCommit_RejectsStaleConsumerGroupMetadataWithoutCommittingOffsets()
     {
         var cluster = new InMemoryKafkaCluster();
@@ -863,6 +905,36 @@ public sealed class InMemoryProducerFaultTests
         await using var recovered = replacement.BeginTransaction();
         await recovered.AbortAsync();
         await Assert.That(cluster.ReadRecords("orders")).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task PreparedTransaction_ProducerDisposeWaitsForRecoveryCompletion()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var original = new InMemoryProducer<string, string>(cluster);
+        var transaction = original.BeginTransaction();
+        _ = await transaction.ProduceAsync("orders", "k", "prepared");
+        var prepared = await transaction.PrepareAsync();
+        await original.DisposeAsync();
+
+        var replacement = new InMemoryProducer<string, string>(cluster);
+        await replacement.InitTransactionsAsync(keepPreparedTransaction: true);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.CommitTransaction));
+        var pendingRecovery = replacement
+            .CompletePreparedTransactionAsync(prepared, committed: true)
+            .AsTask();
+        await barrier.WaitUntilEnteredAsync();
+
+        var pendingDispose = replacement.DisposeAsync().AsTask();
+        await Assert.That(pendingDispose.IsCompleted).IsFalse();
+        await Assert.That(barrier.Release()).IsTrue();
+        await pendingRecovery;
+        await pendingDispose;
+
+        await Assert.That(cluster.ReadRecords("orders")).Count().IsEqualTo(1);
+        await Assert.That(() => replacement.BeginTransaction()).Throws<ObjectDisposedException>();
+        await transaction.DisposeAsync();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -513,6 +513,52 @@ public sealed class InMemoryProducerFaultTests
     }
 
     [Test]
+    [NotInParallel]
+    public async Task ProducerDispose_WaitsUntilCompletedTransactionIsUnpublished()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var transaction = producer.BeginTransaction();
+        var completionPublished = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseCompletion = new ManualResetEventSlim();
+        Volatile.Write(
+            ref InMemoryProducer<string, string>.TransactionCompletionPublishedTestHook,
+            () =>
+            {
+                completionPublished.TrySetResult();
+                releaseCompletion.Wait();
+            });
+
+        try
+        {
+            var pendingCommit = Task.Run(() => transaction.CommitAsync().AsTask());
+            await completionPublished.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var disposeStarted = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var pendingDispose = Task.Run(() =>
+            {
+                disposeStarted.TrySetResult();
+                return producer.DisposeAsync().AsTask();
+            });
+            await disposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(pendingDispose.IsCompleted).IsFalse();
+            releaseCompletion.Set();
+            await pendingCommit.WaitAsync(TimeSpan.FromSeconds(5));
+            await pendingDispose.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            Volatile.Write(
+                ref InMemoryProducer<string, string>.TransactionCompletionPublishedTestHook,
+                null);
+            releaseCompletion.Set();
+            await producer.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task TransactionProduce_AfterCompletion_ReturnsFaultedValueTask()
     {
         var producer = new InMemoryProducer<string, string>(new InMemoryKafkaCluster());

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -314,7 +314,7 @@ public sealed class InMemoryProducerFaultTests
         var transaction = producer.BeginTransaction();
         cluster.FaultPlan.Fail(
             new KafkaFaultScope(KafkaFaultOperation.AbortTransaction),
-            new KafkaTimeoutException("abort timed out"));
+            new InvalidOperationException("injected abort failure"));
 
         await transaction.DisposeAsync();
 
@@ -430,6 +430,44 @@ public sealed class InMemoryProducerFaultTests
         await Assert.That(Encoding.UTF8.GetString(visible[0].Value)).IsEqualTo("committed");
         await committedTransaction.DisposeAsync();
         await abortedTransaction.DisposeAsync();
+    }
+
+    [Test]
+    public async Task PreparedTransaction_DisposingHandlePreservesRecoveryState()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var transaction = producer.BeginTransaction();
+        _ = await transaction.ProduceAsync("orders", "k", "prepared");
+        var prepared = await transaction.PrepareAsync();
+
+        await transaction.DisposeAsync();
+        await producer.CompletePreparedTransactionAsync(prepared, committed: true);
+
+        await Assert.That(cluster.ReadRecords("orders")).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task PreparedTransaction_RecoveryRejectsAnotherActiveTransaction()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var original = new InMemoryProducer<string, string>(cluster);
+        var preparedTransaction = original.BeginTransaction();
+        _ = await preparedTransaction.ProduceAsync("orders", "k", "prepared");
+        var prepared = await preparedTransaction.PrepareAsync();
+        await original.DisposeAsync();
+
+        var replacement = new InMemoryProducer<string, string>(cluster);
+        await replacement.InitTransactionsAsync(keepPreparedTransaction: true);
+        var activeTransaction = replacement.BeginTransaction();
+
+        await Assert.That(async () =>
+                await replacement.CompletePreparedTransactionAsync(prepared, committed: true))
+            .Throws<InvalidOperationException>();
+
+        await activeTransaction.AbortAsync();
+        await replacement.CompletePreparedTransactionAsync(prepared, committed: true);
+        await Assert.That(cluster.ReadRecords("orders")).Count().IsEqualTo(1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -204,6 +204,85 @@ public sealed class InMemoryProducerFaultTests
     }
 
     [Test]
+    public async Task TransactionProduce_AbortableFailureRequiresAbortBeforeReuse()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var abortable = new AbortableTransactionException(
+            ErrorCode.TransactionAbortable,
+            "abort required");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.TransactionProduce, "orders"),
+            abortable);
+        var transaction = producer.BeginTransaction();
+
+        var initial = await Assert.ThrowsAsync<AbortableTransactionException>(() =>
+            transaction.ProduceAsync("orders", "k", "v").AsTask());
+        var produce = await Assert.ThrowsAsync<AbortableTransactionException>(() =>
+            transaction.ProduceAsync("orders", "k", "retry").AsTask());
+        var offsets = await Assert.ThrowsAsync<AbortableTransactionException>(() =>
+            transaction.SendOffsetsToTransactionAsync(
+                [new TopicPartitionOffset("orders", 0, 1)],
+                "billing").AsTask());
+        var prepare = await Assert.ThrowsAsync<AbortableTransactionException>(() =>
+            transaction.PrepareAsync().AsTask());
+        var commit = await Assert.ThrowsAsync<AbortableTransactionException>(() =>
+            transaction.CommitAsync().AsTask());
+
+        await Assert.That(initial).IsSameReferenceAs(abortable);
+        await Assert.That(produce).IsSameReferenceAs(abortable);
+        await Assert.That(offsets).IsSameReferenceAs(abortable);
+        await Assert.That(prepare).IsSameReferenceAs(abortable);
+        await Assert.That(commit).IsSameReferenceAs(abortable);
+
+        await transaction.AbortAsync();
+        await using var recovered = producer.BeginTransaction();
+        await recovered.AbortAsync();
+    }
+
+    [Test]
+    public async Task TransactionProduce_PausedMutationRejectsCommitUntilAppendCompletes()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var transaction = producer.BeginTransaction();
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.TransactionProduce, "orders"));
+
+        var pendingProduce = transaction.ProduceAsync("orders", "k", "v").AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            transaction.CommitAsync().AsTask());
+        await Assert.That(barrier.Release()).IsTrue();
+        _ = await pendingProduce;
+        await transaction.CommitAsync();
+
+        await Assert.That(cluster.ReadRecords("orders")).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TransactionOffsets_PausedMutationRejectsAbortUntilMutationCompletes()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var transaction = producer.BeginTransaction();
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.SendOffsetsToTransaction, groupId: "billing"));
+
+        var pendingOffsets = transaction.SendOffsetsToTransactionAsync(
+            [new TopicPartitionOffset("orders", 0, 17)],
+            "billing").AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            transaction.AbortAsync().AsTask());
+        await Assert.That(barrier.Release()).IsTrue();
+        await pendingOffsets;
+        await transaction.AbortAsync();
+
+        await Assert.That(cluster.GetCommittedOffset("billing", new TopicPartition("orders", 0))).IsNull();
+    }
+
+    [Test]
     public async Task TransactionOperations_FailBeforeMutationAndRecoverWithoutDelays()
     {
         var plan = new KafkaFaultPlan();
@@ -287,6 +366,21 @@ public sealed class InMemoryProducerFaultTests
     }
 
     [Test]
+    public async Task ProducerProduce_RejectsSendOutsideActiveTransaction()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var transaction = producer.BeginTransaction();
+
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            producer.ProduceAsync("orders", "k", "outside").AsTask());
+        await transaction.AbortAsync();
+        var metadata = await producer.ProduceAsync("orders", "k", "after");
+
+        await Assert.That(metadata.Offset).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ReadRecords_StopsAtOngoingTransactionBoundary()
     {
         var cluster = new InMemoryKafkaCluster();
@@ -320,6 +414,62 @@ public sealed class InMemoryProducerFaultTests
 
         await using var recovered = producer.BeginTransaction();
         await recovered.AbortAsync();
+    }
+
+    [Test]
+    public async Task ProducerDispose_ClaimsLifecycleBeforeAwaitingTransactionAbort()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        _ = producer.BeginTransaction();
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.AbortTransaction));
+
+        var pendingDispose = producer.DisposeAsync().AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        await Assert.That(() => producer.BeginTransaction()).Throws<ObjectDisposedException>();
+        await Assert.That(barrier.Release()).IsTrue();
+        await pendingDispose;
+        _ = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            producer.ProduceAsync("orders", "k", "v").AsTask());
+    }
+
+    [Test]
+    public async Task ProducerDispose_PreventsPausedOffsetsFromMutatingCompletedTransaction()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var transaction = producer.BeginTransaction();
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.SendOffsetsToTransaction, groupId: "billing"));
+        var pendingOffsets = transaction.SendOffsetsToTransactionAsync(
+            [new TopicPartitionOffset("orders", 0, 17)],
+            "billing").AsTask();
+
+        await barrier.WaitUntilEnteredAsync();
+        await producer.DisposeAsync();
+        await Assert.That(barrier.Release()).IsTrue();
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(() => pendingOffsets);
+
+        await Assert.That(cluster.GetCommittedOffset("billing", new TopicPartition("orders", 0))).IsNull();
+    }
+
+    [Test]
+    public async Task ProducerDispose_PreventsPausedProduceFromAppendingAfterAbort()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var transaction = producer.BeginTransaction();
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.TransactionProduce, "orders"));
+        var pendingProduce = transaction.ProduceAsync("orders", "k", "v").AsTask();
+
+        await barrier.WaitUntilEnteredAsync();
+        await producer.DisposeAsync();
+        await Assert.That(barrier.Release()).IsTrue();
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(() => pendingProduce);
+
+        await Assert.That(cluster.ReadRecords("orders")).IsEmpty();
     }
 
     [Test]
@@ -467,6 +617,34 @@ public sealed class InMemoryProducerFaultTests
 
         await activeTransaction.AbortAsync();
         await replacement.CompletePreparedTransactionAsync(prepared, committed: true);
+        await Assert.That(cluster.ReadRecords("orders")).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task PreparedTransaction_RecoveryClaimsLifecycleBeforeAwaitingCompletion()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var original = new InMemoryProducer<string, string>(cluster);
+        var transaction = original.BeginTransaction();
+        _ = await transaction.ProduceAsync("orders", "k", "prepared");
+        var prepared = await transaction.PrepareAsync();
+        await original.DisposeAsync();
+
+        var replacement = new InMemoryProducer<string, string>(cluster);
+        await replacement.InitTransactionsAsync(keepPreparedTransaction: true);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.CommitTransaction));
+        var pendingRecovery = replacement
+            .CompletePreparedTransactionAsync(prepared, committed: true)
+            .AsTask();
+
+        await barrier.WaitUntilEnteredAsync();
+        await Assert.That(() => replacement.BeginTransaction()).Throws<InvalidOperationException>();
+        await Assert.That(barrier.Release()).IsTrue();
+        await pendingRecovery;
+
+        await using var recovered = replacement.BeginTransaction();
+        await recovered.AbortAsync();
         await Assert.That(cluster.ReadRecords("orders")).Count().IsEqualTo(1);
     }
 

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -926,11 +926,14 @@ public sealed class InMemoryProducerFaultTests
             .AsTask();
         await barrier.WaitUntilEnteredAsync();
 
-        var pendingDispose = replacement.DisposeAsync().AsTask();
-        await Assert.That(pendingDispose.IsCompleted).IsFalse();
+        var firstDispose = replacement.DisposeAsync().AsTask();
+        var concurrentDispose = replacement.DisposeAsync().AsTask();
+        await Assert.That(firstDispose.IsCompleted).IsFalse();
+        await Assert.That(concurrentDispose.IsCompleted).IsFalse();
         await Assert.That(barrier.Release()).IsTrue();
         await pendingRecovery;
-        await pendingDispose;
+        await firstDispose;
+        await concurrentDispose;
 
         await Assert.That(cluster.ReadRecords("orders")).Count().IsEqualTo(1);
         await Assert.That(() => replacement.BeginTransaction()).Throws<ObjectDisposedException>();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -1,8 +1,10 @@
+using System.Buffers;
 using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Producer;
 using Dekaf.Protocol;
+using Dekaf.Serialization;
 using Dekaf.Testing;
 
 namespace Dekaf.Tests.Unit.Testing;
@@ -59,6 +61,36 @@ public sealed class InMemoryProducerFaultTests
 
         await Assert.That(actual).IsSameReferenceAs(failure);
         await Assert.That(recovered.Partition).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Produce_TopicDeletedDuringPartitionFaultPauseFailsAsUnknownPartition()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders", partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Produce, "orders", partition: 1));
+        var message = new ProducerMessage<string, string>
+        {
+            Topic = "orders",
+            Partition = 1,
+            Key = "k",
+            Value = "v"
+        };
+
+        var pending = producer.ProduceAsync(message).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        await Assert.That(cluster.DeleteTopic("orders")).IsTrue();
+        await Assert.That(barrier.Release()).IsTrue();
+
+        var failure = await Assert.ThrowsAsync<ProduceException>(() => pending);
+        await Assert.That(failure!.ErrorCode).IsEqualTo(ErrorCode.UnknownTopicOrPartition);
+        await Assert.That(failure.Topic).IsEqualTo("orders");
+        await Assert.That(failure.Partition).IsEqualTo(1);
+
+        var recovered = await producer.ProduceAsync("orders", "k", "recovered");
+        await Assert.That(recovered.Offset).IsEqualTo(0);
     }
 
     [Test]
@@ -243,7 +275,7 @@ public sealed class InMemoryProducerFaultTests
         await Assert.That(visible.Select(static record => record.Offset))
             .IsEquivalentTo([0L, 2L]);
 
-        var consumer = new InMemoryConsumer<string, string>(
+        await using var consumer = new InMemoryConsumer<string, string>(
             cluster,
             new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
         consumer.Subscribe("orders");
@@ -252,6 +284,26 @@ public sealed class InMemoryProducerFaultTests
 
         await Assert.That(first!.Value.Offset).IsEqualTo(0);
         await Assert.That(second!.Value.Offset).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ReadRecords_StopsAtOngoingTransactionBoundary()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        _ = await producer.ProduceAsync("orders", "k", "before");
+        await using var transaction = producer.BeginTransaction();
+        _ = await transaction.ProduceAsync("orders", "k", "pending");
+        var otherProducer = new InMemoryProducer<string, string>(cluster);
+        _ = await otherProducer.ProduceAsync("orders", "k", "after");
+
+        var blocked = cluster.ReadRecords("orders");
+        await Assert.That(blocked.Select(static record => record.Offset)).IsEquivalentTo([0L]);
+
+        await transaction.CommitAsync();
+        var committed = cluster.ReadRecords("orders");
+        await Assert.That(committed.Select(static record => record.Offset))
+            .IsEquivalentTo([0L, 1L, 2L]);
     }
 
     [Test]
@@ -275,7 +327,7 @@ public sealed class InMemoryProducerFaultTests
     {
         var cluster = new InMemoryKafkaCluster();
         cluster.CreateTopic("orders");
-        var consumer = new InMemoryConsumer<string, string>(
+        await using var consumer = new InMemoryConsumer<string, string>(
             cluster,
             new InMemoryConsumerOptions { GroupId = "billing" });
         consumer.Subscribe("orders");
@@ -286,7 +338,7 @@ public sealed class InMemoryProducerFaultTests
             [new TopicPartitionOffset("orders", 0, 17)],
             metadata);
 
-        var replacement = new InMemoryConsumer<string, string>(
+        await using var replacement = new InMemoryConsumer<string, string>(
             cluster,
             new InMemoryConsumerOptions { GroupId = "billing" });
         replacement.Subscribe("orders");
@@ -297,6 +349,35 @@ public sealed class InMemoryProducerFaultTests
         await Assert.That(failure!.ErrorCode).IsEqualTo(ErrorCode.IllegalGeneration);
         await Assert.That(cluster.GetCommittedOffset("billing", new TopicPartition("orders", 0))).IsNull();
         await transaction.AbortAsync();
+    }
+
+    [Test]
+    public async Task TransactionCommit_AcceptsCurrentStaticConsumerGroupMetadata()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { GroupId = "billing" });
+        consumer.Subscribe("orders");
+        var current = consumer.ConsumerGroupMetadata!;
+        var staticMetadata = new ConsumerGroupMetadata
+        {
+            GroupId = current.GroupId,
+            GenerationId = current.GenerationId,
+            MemberId = current.MemberId,
+            GroupInstanceId = "billing-worker-1"
+        };
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await using var transaction = producer.BeginTransaction();
+        await transaction.SendOffsetsToTransactionAsync(
+            [new TopicPartitionOffset("orders", 0, 17)],
+            staticMetadata);
+
+        await transaction.CommitAsync();
+
+        await Assert.That(cluster.GetCommittedOffset("billing", new TopicPartition("orders", 0)))
+            .IsEqualTo(17);
     }
 
     [Test]
@@ -352,6 +433,72 @@ public sealed class InMemoryProducerFaultTests
     }
 
     [Test]
+    public async Task PreparedTransaction_StatesAreUniqueAcrossProducerGenericTypes()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var firstProducer = new InMemoryProducer<ProducerKeyA, string>(
+            cluster,
+            ProducerKeySerializer<ProducerKeyA>.Instance,
+            Serializers.String);
+        var secondProducer = new InMemoryProducer<ProducerKeyB, string>(
+            cluster,
+            ProducerKeySerializer<ProducerKeyB>.Instance,
+            Serializers.String);
+        var firstTransaction = firstProducer.BeginTransaction();
+        var secondTransaction = secondProducer.BeginTransaction();
+        _ = await firstTransaction.ProduceAsync("strings", new ProducerKeyA(), "value");
+        _ = await secondTransaction.ProduceAsync("ints", new ProducerKeyB(), "value");
+        var firstState = await firstTransaction.PrepareAsync();
+        var secondState = await secondTransaction.PrepareAsync();
+        await firstProducer.DisposeAsync();
+        await secondProducer.DisposeAsync();
+
+        await Assert.That(firstState).IsNotEqualTo(secondState);
+
+        var firstReplacement = new InMemoryProducer<ProducerKeyA, string>(
+            cluster,
+            ProducerKeySerializer<ProducerKeyA>.Instance,
+            Serializers.String);
+        await firstReplacement.InitTransactionsAsync(keepPreparedTransaction: true);
+        await firstReplacement.CompletePreparedTransactionAsync(firstState, committed: true);
+        var secondReplacement = new InMemoryProducer<ProducerKeyB, string>(
+            cluster,
+            ProducerKeySerializer<ProducerKeyB>.Instance,
+            Serializers.String);
+        await secondReplacement.InitTransactionsAsync(keepPreparedTransaction: true);
+        await secondReplacement.CompletePreparedTransactionAsync(secondState, committed: true);
+
+        await Assert.That(cluster.ReadRecords("strings")).Count().IsEqualTo(1);
+        await Assert.That(cluster.ReadRecords("ints")).Count().IsEqualTo(1);
+        await firstTransaction.DisposeAsync();
+        await secondTransaction.DisposeAsync();
+    }
+
+    [Test]
+    public async Task PreparedTransaction_RecoveryUsesReplacementProducerFatalState()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var original = new InMemoryProducer<string, string>(cluster);
+        var transaction = original.BeginTransaction();
+        _ = await transaction.ProduceAsync("orders", "k", "v");
+        var prepared = await transaction.PrepareAsync();
+        var fenced = new FatalTransactionException(ErrorCode.ProducerFenced, "original fenced");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.CommitTransaction),
+            fenced);
+        _ = await Assert.ThrowsAsync<FatalTransactionException>(() =>
+            original.CompletePreparedTransactionAsync(prepared, committed: true).AsTask());
+        await original.DisposeAsync();
+
+        var replacement = new InMemoryProducer<string, string>(cluster);
+        await replacement.InitTransactionsAsync(keepPreparedTransaction: true);
+        await replacement.CompletePreparedTransactionAsync(prepared, committed: true);
+
+        await Assert.That(cluster.ReadRecords("orders")).Count().IsEqualTo(1);
+        await transaction.DisposeAsync();
+    }
+
+    [Test]
     public async Task ProducerFencing_CapturesOneFatalInstanceAndPoisonsOnlyProducer()
     {
         var cluster = new InMemoryKafkaCluster();
@@ -392,4 +539,26 @@ public sealed class InMemoryProducerFaultTests
             Key = "k",
             Value = "v"
         }).AsTask();
+
+    private readonly struct ProducerKeyA;
+
+    private readonly struct ProducerKeyB;
+
+    private sealed class ProducerKeySerializer<T> : ISerializer<T>
+    {
+        public static readonly ProducerKeySerializer<T> Instance = new();
+
+        public void Serialize<TWriter>(
+            T value,
+            ref TWriter destination,
+            SerializationContext context)
+            where TWriter : IBufferWriter<byte>
+#if NET10_0_OR_GREATER
+            , allows ref struct
+#endif
+        {
+            destination.GetSpan(1)[0] = 1;
+            destination.Advance(1);
+        }
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -501,9 +501,11 @@ public sealed class InMemoryProducerFaultTests
         var pendingCommit = transaction.CommitAsync().AsTask();
 
         await barrier.WaitUntilEnteredAsync();
-        await producer.DisposeAsync();
+        var pendingDispose = producer.DisposeAsync().AsTask();
+        await Assert.That(pendingDispose.IsCompleted).IsFalse();
         await Assert.That(barrier.Release()).IsTrue();
         await pendingCommit;
+        await pendingDispose;
 
         var visible = cluster.ReadRecords("orders");
         await Assert.That(visible).Count().IsEqualTo(1);
@@ -516,6 +518,55 @@ public sealed class InMemoryProducerFaultTests
         var producer = new InMemoryProducer<string, string>(new InMemoryKafkaCluster());
         var transaction = producer.BeginTransaction();
         await transaction.AbortAsync();
+
+        var componentwiseOperation = transaction.ProduceAsync("orders", "k", "v");
+        var messageOperation = transaction.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = "orders",
+            Key = "k",
+            Value = "v"
+        });
+
+        await Assert.That(componentwiseOperation.IsCompleted).IsTrue();
+        await Assert.That(messageOperation.IsCompleted).IsTrue();
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(() => componentwiseOperation.AsTask());
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(() => messageOperation.AsTask());
+    }
+
+    [Test]
+    public async Task TransactionProduce_SynchronousCancellation_ReturnsCanceledValueTask()
+    {
+        var producer = new InMemoryProducer<string, string>(new InMemoryKafkaCluster());
+        await using var transaction = producer.BeginTransaction();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var componentwiseOperation = transaction.ProduceAsync(
+            "orders",
+            "k",
+            "v",
+            cancellation.Token);
+        var messageOperation = transaction.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = "orders",
+            Key = "k",
+            Value = "v"
+        }, cancellation.Token);
+
+        await Assert.That(componentwiseOperation.IsCompleted).IsTrue();
+        await Assert.That(messageOperation.IsCompleted).IsTrue();
+        await Assert.That(componentwiseOperation.AsTask().IsCanceled).IsTrue();
+        await Assert.That(messageOperation.AsTask().IsCanceled).IsTrue();
+    }
+
+    [Test]
+    public async Task TransactionProduce_SynchronousSerializationFailure_ReturnsFaultedValueTask()
+    {
+        var producer = new InMemoryProducer<string, string>(
+            new InMemoryKafkaCluster(),
+            Serializers.String,
+            ThrowingSerializer<string>.Instance);
+        await using var transaction = producer.BeginTransaction();
 
         var componentwiseOperation = transaction.ProduceAsync("orders", "k", "v");
         var messageOperation = transaction.ProduceAsync(new ProducerMessage<string, string>
@@ -983,6 +1034,26 @@ public sealed class InMemoryProducerFaultTests
     }
 
     [Test]
+    public async Task PreparedTransaction_ReplacementProducerSupportsDifferentGenericTypes()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var original = new InMemoryProducer<string, string>(cluster);
+        var transaction = original.BeginTransaction();
+        _ = await transaction.ProduceAsync("orders", "k", "committed");
+        var prepared = await transaction.PrepareAsync();
+        await original.DisposeAsync();
+
+        var replacement = new InMemoryProducer<int, int>(cluster);
+        await replacement.InitTransactionsAsync(keepPreparedTransaction: true);
+        await replacement.CompletePreparedTransactionAsync(prepared, committed: true);
+
+        var visible = cluster.ReadRecords("orders");
+        await Assert.That(visible).Count().IsEqualTo(1);
+        await Assert.That(Encoding.UTF8.GetString(visible[0].Value)).IsEqualTo("committed");
+        await transaction.DisposeAsync();
+    }
+
+    [Test]
     public async Task PreparedTransaction_RecoveryUsesReplacementProducerFatalState()
     {
         var cluster = new InMemoryKafkaCluster();
@@ -1068,5 +1139,20 @@ public sealed class InMemoryProducerFaultTests
             destination.GetSpan(1)[0] = 1;
             destination.Advance(1);
         }
+    }
+
+    private sealed class ThrowingSerializer<T> : ISerializer<T>
+    {
+        public static readonly ThrowingSerializer<T> Instance = new();
+
+        public void Serialize<TWriter>(
+            T value,
+            ref TWriter destination,
+            SerializationContext context)
+            where TWriter : IBufferWriter<byte>
+#if NET10_0_OR_GREATER
+            , allows ref struct
+#endif
+            => throw new InvalidOperationException("Injected serialization failure.");
     }
 }

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Producer;
@@ -39,6 +40,25 @@ public sealed class InMemoryProducerFaultTests
         await Assert.That(otherPartition.Partition).IsEqualTo(0);
         await Assert.That(recovered.Partition).IsEqualTo(1);
         await Assert.That(cluster.ReadRecords("orders", 1)).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Produce_PartitionScopedFaultMatchesResolvedRoundRobinPartition()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders", partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var failure = new InvalidOperationException("partition zero");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Produce, "orders", partition: 0),
+            failure);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            producer.ProduceAsync("orders", key: null, "first").AsTask());
+        var recovered = await producer.ProduceAsync("orders", key: null, "second");
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(recovered.Partition).IsEqualTo(1);
     }
 
     [Test]
@@ -196,6 +216,90 @@ public sealed class InMemoryProducerFaultTests
     }
 
     [Test]
+    public async Task TransactionalRecords_AreVisibleOnlyAfterCommitAndNeverAfterAbort()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+
+        await using (var committed = producer.BeginTransaction())
+        {
+            _ = await committed.ProduceAsync("orders", "k", "committed");
+            await Assert.That(cluster.ReadRecords("orders")).IsEmpty();
+            await committed.CommitAsync();
+        }
+
+        await using (var aborted = producer.BeginTransaction())
+        {
+            _ = await aborted.ProduceAsync("orders", "k", "aborted");
+            await Assert.That(cluster.ReadRecords("orders")).Count().IsEqualTo(1);
+            await aborted.AbortAsync();
+        }
+
+        _ = await producer.ProduceAsync("orders", "k", "ordinary");
+        var visible = cluster.ReadRecords("orders");
+
+        await Assert.That(visible.Select(static record => Encoding.UTF8.GetString(record.Value)))
+            .IsEquivalentTo(["committed", "ordinary"]);
+        await Assert.That(visible.Select(static record => record.Offset))
+            .IsEquivalentTo([0L, 2L]);
+
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+        consumer.Subscribe("orders");
+        var first = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        var second = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(first!.Value.Offset).IsEqualTo(0);
+        await Assert.That(second!.Value.Offset).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task TransactionDispose_AbortFaultIsBestEffortAndReleasesProducerSlot()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var transaction = producer.BeginTransaction();
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.AbortTransaction),
+            new KafkaTimeoutException("abort timed out"));
+
+        await transaction.DisposeAsync();
+
+        await using var recovered = producer.BeginTransaction();
+        await recovered.AbortAsync();
+    }
+
+    [Test]
+    public async Task TransactionCommit_RejectsStaleConsumerGroupMetadataWithoutCommittingOffsets()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { GroupId = "billing" });
+        consumer.Subscribe("orders");
+        var metadata = consumer.ConsumerGroupMetadata!;
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await using var transaction = producer.BeginTransaction();
+        await transaction.SendOffsetsToTransactionAsync(
+            [new TopicPartitionOffset("orders", 0, 17)],
+            metadata);
+
+        var replacement = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { GroupId = "billing" });
+        replacement.Subscribe("orders");
+
+        var failure = await Assert.ThrowsAsync<TransactionException>(
+            () => transaction.CommitAsync().AsTask());
+
+        await Assert.That(failure!.ErrorCode).IsEqualTo(ErrorCode.IllegalGeneration);
+        await Assert.That(cluster.GetCommittedOffset("billing", new TopicPartition("orders", 0))).IsNull();
+        await transaction.AbortAsync();
+    }
+
+    [Test]
     public async Task PreparedTransaction_ProducerCompletionSupportsCommitAndAbort()
     {
         var producer = new InMemoryProducer<string, string>(new InMemoryKafkaCluster());
@@ -215,6 +319,36 @@ public sealed class InMemoryProducerFaultTests
 
         await using var recovered = producer.BeginTransaction();
         await recovered.AbortAsync();
+    }
+
+    [Test]
+    public async Task PreparedTransaction_ReplacementProducerRecoversCommitAndAbort()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var original = new InMemoryProducer<string, string>(cluster);
+        var committedTransaction = original.BeginTransaction();
+        _ = await committedTransaction.ProduceAsync("orders", "k", "committed");
+        var committedState = await committedTransaction.PrepareAsync();
+        await original.DisposeAsync();
+
+        var replacement = new InMemoryProducer<string, string>(cluster);
+        await replacement.InitTransactionsAsync(keepPreparedTransaction: true);
+        await replacement.CompletePreparedTransactionAsync(committedState, committed: true);
+
+        var abortedTransaction = replacement.BeginTransaction();
+        _ = await abortedTransaction.ProduceAsync("orders", "k", "aborted");
+        var abortedState = await abortedTransaction.PrepareAsync();
+        await replacement.DisposeAsync();
+
+        var secondReplacement = new InMemoryProducer<string, string>(cluster);
+        await secondReplacement.InitTransactionsAsync(keepPreparedTransaction: true);
+        await secondReplacement.CompletePreparedTransactionAsync(abortedState, committed: false);
+
+        var visible = cluster.ReadRecords("orders");
+        await Assert.That(visible).Count().IsEqualTo(1);
+        await Assert.That(Encoding.UTF8.GetString(visible[0].Value)).IsEqualTo("committed");
+        await committedTransaction.DisposeAsync();
+        await abortedTransaction.DisposeAsync();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -4,6 +4,7 @@ using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Producer;
 using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
 using Dekaf.Serialization;
 using Dekaf.Testing;
 
@@ -400,7 +401,11 @@ public sealed class InMemoryProducerFaultTests
 
         await using var consumer = new InMemoryConsumer<string, string>(
             cluster,
-            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+            new InMemoryConsumerOptions
+            {
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                IsolationLevel = IsolationLevel.ReadCommitted
+            });
         consumer.Subscribe("orders");
         var first = await consumer.ConsumeOneAsync(TimeSpan.Zero);
         var second = await consumer.ConsumeOneAsync(TimeSpan.Zero);
@@ -442,6 +447,61 @@ public sealed class InMemoryProducerFaultTests
         var committed = cluster.ReadRecords("orders");
         await Assert.That(committed.Select(static record => record.Offset))
             .IsEquivalentTo([0L, 1L, 2L]);
+    }
+
+    [Test]
+    public async Task Consumer_DefaultIsolationReadsOngoingTransactionAndFollowingRecords()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        await using var transactionalProducer = new InMemoryProducer<string, string>(cluster);
+        await using var transaction = transactionalProducer.BeginTransaction();
+        _ = await transaction.ProduceAsync("orders", "k", "pending");
+        await using var ordinaryProducer = new InMemoryProducer<string, string>(cluster);
+        _ = await ordinaryProducer.ProduceAsync("orders", "k", "following");
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.Earliest });
+        consumer.Assign(new TopicPartition("orders", 0));
+
+        var pending = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        var following = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(pending).IsNotNull();
+        await Assert.That(pending!.Value.Value).IsEqualTo("pending");
+        await Assert.That(following).IsNotNull();
+        await Assert.That(following!.Value.Value).IsEqualTo("following");
+    }
+
+    [Test]
+    public async Task Consumer_ReadCommittedStopsUntilTransactionCompletes()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        await using var transactionalProducer = new InMemoryProducer<string, string>(cluster);
+        await using var transaction = transactionalProducer.BeginTransaction();
+        _ = await transaction.ProduceAsync("orders", "k", "pending");
+        await using var ordinaryProducer = new InMemoryProducer<string, string>(cluster);
+        _ = await ordinaryProducer.ProduceAsync("orders", "k", "following");
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                IsolationLevel = IsolationLevel.ReadCommitted
+            });
+        consumer.Assign(new TopicPartition("orders", 0));
+
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.Zero)).IsNull();
+
+        await transaction.CommitAsync();
+
+        var pending = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        var following = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        await Assert.That(pending).IsNotNull();
+        await Assert.That(pending!.Value.Value).IsEqualTo("pending");
+        await Assert.That(following).IsNotNull();
+        await Assert.That(following!.Value.Value).IsEqualTo("following");
     }
 
     [Test]
@@ -773,6 +833,37 @@ public sealed class InMemoryProducerFaultTests
 
         await Assert.That(staleConsumer.ConsumerGroupMetadata).IsNull();
         await Assert.That(replacement.ConsumerGroupMetadata!.GenerationId).IsGreaterThan(staleGeneration);
+    }
+
+    [Test]
+    public async Task ConsumerGroupRegistration_DoesNotTransferAcrossDuplicateMemberIds()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        var options = new InMemoryConsumerOptions
+        {
+            GroupId = "billing",
+            MemberId = "billing-worker"
+        };
+        var displaced = new InMemoryConsumer<string, string>(cluster, options);
+        displaced.Subscribe("orders");
+        var displacedGeneration = displaced.ConsumerGroupMetadata!.GenerationId;
+        await using var replacement = new InMemoryConsumer<string, string>(cluster, options);
+        replacement.Subscribe("orders");
+        var replacementGeneration = replacement.ConsumerGroupMetadata!.GenerationId;
+
+        _ = displaced.Assignment;
+
+        await Assert.That(displaced.ConsumerGroupMetadata).IsNull();
+        await Assert.That(displaced.Assignment).IsEmpty();
+        await Assert.That(replacementGeneration).IsGreaterThan(displacedGeneration);
+
+        await displaced.DisposeAsync();
+        var replacementAssignment = replacement.Assignment;
+
+        await Assert.That(replacementAssignment).Contains(new TopicPartition("orders", 0));
+        await Assert.That(replacement.ConsumerGroupMetadata!.GenerationId)
+            .IsEqualTo(replacementGeneration);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -479,7 +479,7 @@ public sealed class InMemoryProducerFaultTests
     }
 
     [Test]
-    public async Task ProducerDispose_PreventsPausedOffsetsFromMutatingCompletedTransaction()
+    public async Task ProducerDispose_WaitsForPausedOffsetsBeforeAbortingTransaction()
     {
         var cluster = new InMemoryKafkaCluster();
         var producer = new InMemoryProducer<string, string>(cluster);
@@ -491,15 +491,17 @@ public sealed class InMemoryProducerFaultTests
             "billing").AsTask();
 
         await barrier.WaitUntilEnteredAsync();
-        await producer.DisposeAsync();
+        var pendingDispose = producer.DisposeAsync().AsTask();
+        await Assert.That(pendingDispose.IsCompleted).IsFalse();
         await Assert.That(barrier.Release()).IsTrue();
-        _ = await Assert.ThrowsAsync<InvalidOperationException>(() => pendingOffsets);
+        await pendingOffsets;
+        await pendingDispose;
 
         await Assert.That(cluster.GetCommittedOffset("billing", new TopicPartition("orders", 0))).IsNull();
     }
 
     [Test]
-    public async Task ProducerDispose_PreventsPausedProduceFromAppendingAfterAbort()
+    public async Task ProducerDispose_WaitsForPausedProduceBeforeAbortingTransaction()
     {
         var cluster = new InMemoryKafkaCluster();
         var producer = new InMemoryProducer<string, string>(cluster);
@@ -509,9 +511,11 @@ public sealed class InMemoryProducerFaultTests
         var pendingProduce = transaction.ProduceAsync("orders", "k", "v").AsTask();
 
         await barrier.WaitUntilEnteredAsync();
-        await producer.DisposeAsync();
+        var pendingDispose = producer.DisposeAsync().AsTask();
+        await Assert.That(pendingDispose.IsCompleted).IsFalse();
         await Assert.That(barrier.Release()).IsTrue();
-        _ = await Assert.ThrowsAsync<InvalidOperationException>(() => pendingProduce);
+        _ = await pendingProduce;
+        await pendingDispose;
 
         await Assert.That(cluster.ReadRecords("orders")).IsEmpty();
     }

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -505,6 +505,69 @@ public sealed class InMemoryProducerFaultTests
     }
 
     [Test]
+    public async Task TransactionCommit_ValidatesMetadataFromEveryStagedOffsetSend()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        await using var firstConsumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { GroupId = "billing" });
+        firstConsumer.Subscribe("orders");
+        var staleMetadata = firstConsumer.ConsumerGroupMetadata!;
+        await using var producer = new InMemoryProducer<string, string>(cluster);
+        await using var transaction = producer.BeginTransaction();
+        await transaction.SendOffsetsToTransactionAsync(
+            [new TopicPartitionOffset("orders", 0, 17)],
+            staleMetadata);
+        await using var secondConsumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { GroupId = "billing" });
+        secondConsumer.Subscribe("orders");
+        await transaction.SendOffsetsToTransactionAsync(
+            [new TopicPartitionOffset("orders", 1, 23)],
+            secondConsumer.ConsumerGroupMetadata!);
+
+        var failure = await Assert.ThrowsAsync<FatalTransactionException>(
+            () => transaction.CommitAsync().AsTask());
+
+        await Assert.That(failure!.ErrorCode).IsEqualTo(ErrorCode.IllegalGeneration);
+        await Assert.That(cluster.GetCommittedOffset("billing", new TopicPartition("orders", 0))).IsNull();
+        await Assert.That(cluster.GetCommittedOffset("billing", new TopicPartition("orders", 1))).IsNull();
+    }
+
+    [Test]
+    public async Task TransactionCommit_RejectsMetadataFromRecreatedGroupWithReusedMemberId()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        var options = new InMemoryConsumerOptions
+        {
+            GroupId = "billing",
+            MemberId = "billing-worker"
+        };
+        var firstConsumer = new InMemoryConsumer<string, string>(cluster, options);
+        firstConsumer.Subscribe("orders");
+        var staleMetadata = firstConsumer.ConsumerGroupMetadata!;
+        await firstConsumer.DisposeAsync();
+        await using var replacement = new InMemoryConsumer<string, string>(cluster, options);
+        replacement.Subscribe("orders");
+        var currentMetadata = replacement.ConsumerGroupMetadata!;
+        await using var producer = new InMemoryProducer<string, string>(cluster);
+        await using var transaction = producer.BeginTransaction();
+        await transaction.SendOffsetsToTransactionAsync(
+            [new TopicPartitionOffset("orders", 0, 17)],
+            staleMetadata);
+
+        var failure = await Assert.ThrowsAsync<FatalTransactionException>(
+            () => transaction.CommitAsync().AsTask());
+
+        await Assert.That(currentMetadata.MemberId).IsEqualTo(staleMetadata.MemberId);
+        await Assert.That(currentMetadata.GenerationId).IsGreaterThan(staleMetadata.GenerationId);
+        await Assert.That(failure!.ErrorCode).IsEqualTo(ErrorCode.IllegalGeneration);
+        await Assert.That(cluster.GetCommittedOffset("billing", new TopicPartition("orders", 0))).IsNull();
+    }
+
+    [Test]
     public async Task TransactionOffsets_ConcurrentStagingCommitsEveryOffset()
     {
         const int operationCount = 32;

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -568,6 +568,28 @@ public sealed class InMemoryProducerFaultTests
     }
 
     [Test]
+    public async Task ConsumerGroupMetadata_DoesNotAdoptReplacementGenerationWithReusedMemberId()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        var options = new InMemoryConsumerOptions
+        {
+            GroupId = "billing",
+            MemberId = "billing-worker"
+        };
+        var staleConsumer = new InMemoryConsumer<string, string>(cluster, options);
+        staleConsumer.Subscribe("orders");
+        var staleGeneration = staleConsumer.ConsumerGroupMetadata!.GenerationId;
+        await staleConsumer.DisposeAsync();
+
+        await using var replacement = new InMemoryConsumer<string, string>(cluster, options);
+        replacement.Subscribe("orders");
+
+        await Assert.That(staleConsumer.ConsumerGroupMetadata).IsNull();
+        await Assert.That(replacement.ConsumerGroupMetadata!.GenerationId).IsGreaterThan(staleGeneration);
+    }
+
+    [Test]
     public async Task TransactionOffsets_ConcurrentStagingCommitsEveryOffset()
     {
         const int operationCount = 32;

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -1,0 +1,261 @@
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Testing;
+
+namespace Dekaf.Tests.Unit.Testing;
+
+public sealed class InMemoryProducerFaultTests
+{
+    [Test]
+    public async Task Produce_FaultsHonorScopeOccurrenceAndRetryBoundaries()
+    {
+        var plan = new KafkaFaultPlan();
+        var cluster = new InMemoryKafkaCluster(plan);
+        cluster.CreateTopic("orders", partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var retriable = new ProduceException(ErrorCode.NotLeaderOrFollower, "retry");
+        var nonRetriable = new ProduceException(ErrorCode.MessageTooLarge, "reject");
+        var scope = new KafkaFaultScope(KafkaFaultOperation.Produce, "orders", partition: 1);
+        plan.Fail(scope, retriable);
+        plan.Fail(scope, nonRetriable);
+
+        var first = await Assert.ThrowsAsync<ProduceException>(() => ProduceToPartitionAsync(producer, 1));
+        var second = await Assert.ThrowsAsync<ProduceException>(() => ProduceToPartitionAsync(producer, 1));
+        var otherPartition = await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = "orders",
+            Partition = 0,
+            Key = "k",
+            Value = "other"
+        });
+        var recovered = await ProduceToPartitionAsync(producer, 1);
+
+        await Assert.That(first).IsSameReferenceAs(retriable);
+        await Assert.That(first!.IsRetriable).IsTrue();
+        await Assert.That(second).IsSameReferenceAs(nonRetriable);
+        await Assert.That(second!.IsRetriable).IsFalse();
+        await Assert.That(otherPartition.Partition).IsEqualTo(0);
+        await Assert.That(recovered.Partition).IsEqualTo(1);
+        await Assert.That(cluster.ReadRecords("orders", 1)).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Produce_LegacyFailureTakesPriorityWithoutConsumingScript()
+    {
+        var plan = new KafkaFaultPlan();
+        var cluster = new InMemoryKafkaCluster(plan);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var legacy = new InvalidOperationException("legacy");
+        var scripted = new TimeoutException("scripted");
+        cluster.FailProduces("orders", legacy);
+        plan.Fail(new KafkaFaultScope(KafkaFaultOperation.Produce, "orders"), scripted);
+
+        var first = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => producer.ProduceAsync("orders", "k", "v").AsTask());
+        cluster.ClearProduceFailure("orders");
+        var second = await Assert.ThrowsAsync<TimeoutException>(
+            () => producer.ProduceAsync("orders", "k", "v").AsTask());
+
+        await Assert.That(first).IsSameReferenceAs(legacy);
+        await Assert.That(second).IsSameReferenceAs(scripted);
+    }
+
+    [Test]
+    public async Task FireAsync_ConsumesFaultWithoutSurfacingDeliveryFailure()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Produce, "events"),
+            new InvalidOperationException("delivery failed"));
+
+        await producer.FireAsync("events", "k", "first");
+        var metadata = await producer.ProduceAsync("events", "k", "second");
+
+        await Assert.That(metadata.Offset).IsEqualTo(0);
+        await Assert.That(cluster.ReadRecords("events")).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ProduceBarrier_CancellationDoesNotAppendAndRetryRecovers()
+    {
+        var plan = new KafkaFaultPlan();
+        var cluster = new InMemoryKafkaCluster(plan);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var barrier = plan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Produce, "orders", partition: 0));
+        using var cancellation = new CancellationTokenSource();
+        var message = new ProducerMessage<string, string>
+        {
+            Topic = "orders",
+            Partition = 0,
+            Key = "k",
+            Value = "v"
+        };
+
+        var pending = producer.ProduceAsync(message, cancellation.Token).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        cancellation.Cancel();
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => pending);
+        await Assert.That(barrier.Release()).IsTrue();
+        await Assert.That(cluster.ReadRecords("orders")).IsEmpty();
+        var recovered = await producer.ProduceAsync(message);
+        await Assert.That(recovered.Offset).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task InitTransactions_OneShotFailureAllowsRetry()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var failure = new KafkaTimeoutException("coordinator unavailable");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.InitializeTransactions),
+            failure);
+
+        var actual = await Assert.ThrowsAsync<KafkaTimeoutException>(
+            () => producer.InitTransactionsAsync().AsTask());
+        await producer.InitTransactionsAsync();
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+    }
+
+    [Test]
+    public async Task TransactionProduce_FailureIsScopedAndRetryable()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders", partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var failure = new ProduceException(ErrorCode.NotLeaderOrFollower, "retry transaction produce");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.TransactionProduce, "orders", partition: 1),
+            failure);
+        await using var transaction = producer.BeginTransaction();
+        var message = new ProducerMessage<string, string>
+        {
+            Topic = "orders",
+            Partition = 1,
+            Key = "k",
+            Value = "v"
+        };
+
+        var actual = await Assert.ThrowsAsync<ProduceException>(
+            () => transaction.ProduceAsync(message).AsTask());
+        var recovered = await transaction.ProduceAsync(message);
+        await transaction.CommitAsync();
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(recovered.Partition).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TransactionOperations_FailBeforeMutationAndRecoverWithoutDelays()
+    {
+        var plan = new KafkaFaultPlan();
+        var cluster = new InMemoryKafkaCluster(plan);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var offsetFailure = new KafkaTimeoutException("offset send failed");
+        var commitFailure = new KafkaTimeoutException("commit failed");
+        var abortFailure = new KafkaTimeoutException("abort failed");
+        plan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.SendOffsetsToTransaction, groupId: "billing"),
+            offsetFailure);
+        plan.Fail(new KafkaFaultScope(KafkaFaultOperation.CommitTransaction), commitFailure);
+        plan.Fail(new KafkaFaultScope(KafkaFaultOperation.AbortTransaction), abortFailure);
+
+        await using (var transaction = producer.BeginTransaction())
+        {
+            var offsets = new[] { new TopicPartitionOffset("orders", 0, 17) };
+            var actualOffsetFailure = await Assert.ThrowsAsync<KafkaTimeoutException>(
+                () => transaction.SendOffsetsToTransactionAsync(offsets, "billing").AsTask());
+            await transaction.SendOffsetsToTransactionAsync(offsets, "billing");
+            var actualCommitFailure = await Assert.ThrowsAsync<KafkaTimeoutException>(
+                () => transaction.CommitAsync().AsTask());
+
+            await Assert.That(actualOffsetFailure).IsSameReferenceAs(offsetFailure);
+            await Assert.That(actualCommitFailure).IsSameReferenceAs(commitFailure);
+            await Assert.That(cluster.GetCommittedOffset("billing", new TopicPartition("orders", 0))).IsNull();
+            await transaction.CommitAsync();
+        }
+
+        await Assert.That(cluster.GetCommittedOffset("billing", new TopicPartition("orders", 0))).IsEqualTo(17);
+
+        await using (var transaction = producer.BeginTransaction())
+        {
+            var actualAbortFailure = await Assert.ThrowsAsync<KafkaTimeoutException>(
+                () => transaction.AbortAsync().AsTask());
+            await Assert.That(actualAbortFailure).IsSameReferenceAs(abortFailure);
+            await transaction.AbortAsync();
+        }
+
+        await using var recoveredTransaction = producer.BeginTransaction();
+        await recoveredTransaction.AbortAsync();
+    }
+
+    [Test]
+    public async Task PreparedTransaction_ProducerCompletionSupportsCommitAndAbort()
+    {
+        var producer = new InMemoryProducer<string, string>(new InMemoryKafkaCluster());
+
+        await using (var transaction = producer.BeginTransaction())
+        {
+            var prepared = await transaction.PrepareAsync();
+            await Assert.That(prepared.HasTransaction).IsTrue();
+            await producer.CompletePreparedTransactionAsync(prepared, committed: true);
+        }
+
+        await using (var transaction = producer.BeginTransaction())
+        {
+            var prepared = await transaction.PrepareAsync();
+            await producer.CompletePreparedTransactionAsync(prepared, committed: false);
+        }
+
+        await using var recovered = producer.BeginTransaction();
+        await recovered.AbortAsync();
+    }
+
+    [Test]
+    public async Task ProducerFencing_CapturesOneFatalInstanceAndPoisonsOnlyProducer()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var fenced = new FatalTransactionException(ErrorCode.ProducerFenced, "producer fenced");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.TransactionProduce, "orders"),
+            fenced);
+        await using var transaction = producer.BeginTransaction();
+
+        var initial = await Assert.ThrowsAsync<FatalTransactionException>(
+            () => transaction.ProduceAsync("orders", "k", "v").AsTask());
+        var commit = await Assert.ThrowsAsync<FatalTransactionException>(
+            () => transaction.CommitAsync().AsTask());
+        var initialize = await Assert.ThrowsAsync<FatalTransactionException>(
+            () => producer.InitTransactionsAsync().AsTask());
+        var produce = await Assert.ThrowsAsync<FatalTransactionException>(
+            () => producer.ProduceAsync("orders", "k", "v").AsTask());
+
+        await Assert.That(initial).IsSameReferenceAs(fenced);
+        await Assert.That(commit).IsSameReferenceAs(fenced);
+        await Assert.That(initialize).IsSameReferenceAs(fenced);
+        await Assert.That(produce).IsSameReferenceAs(fenced);
+        await Assert.That(() => producer.BeginTransaction()).Throws<FatalTransactionException>();
+
+        var replacement = new InMemoryProducer<string, string>(cluster);
+        var metadata = await replacement.ProduceAsync("orders", "k", "recovered");
+        await Assert.That(metadata.Offset).IsEqualTo(0);
+    }
+
+    private static Task<RecordMetadata> ProduceToPartitionAsync(
+        InMemoryProducer<string, string> producer,
+        int partition) =>
+        producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = "orders",
+            Partition = partition,
+            Key = "k",
+            Value = "v"
+        }).AsTask();
+}

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -482,7 +482,7 @@ public sealed class InMemoryProducerFaultTests
             new InMemoryConsumerOptions { GroupId = "billing" });
         consumer.Subscribe("orders");
         var metadata = consumer.ConsumerGroupMetadata!;
-        var producer = new InMemoryProducer<string, string>(cluster);
+        await using var producer = new InMemoryProducer<string, string>(cluster);
         await using var transaction = producer.BeginTransaction();
         await transaction.SendOffsetsToTransactionAsync(
             [new TopicPartitionOffset("orders", 0, 17)],
@@ -493,12 +493,127 @@ public sealed class InMemoryProducerFaultTests
             new InMemoryConsumerOptions { GroupId = "billing" });
         replacement.Subscribe("orders");
 
-        var failure = await Assert.ThrowsAsync<TransactionException>(
+        var failure = await Assert.ThrowsAsync<FatalTransactionException>(
             () => transaction.CommitAsync().AsTask());
+        var poisoned = await Assert.ThrowsAsync<FatalTransactionException>(
+            () => producer.ProduceAsync("orders", "k", "v").AsTask());
 
         await Assert.That(failure!.ErrorCode).IsEqualTo(ErrorCode.IllegalGeneration);
+        await Assert.That(poisoned).IsSameReferenceAs(failure);
+        await Assert.That(() => producer.BeginTransaction()).Throws<FatalTransactionException>();
         await Assert.That(cluster.GetCommittedOffset("billing", new TopicPartition("orders", 0))).IsNull();
-        await transaction.AbortAsync();
+    }
+
+    [Test]
+    public async Task TransactionOffsets_ConcurrentStagingCommitsEveryOffset()
+    {
+        const int operationCount = 32;
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await using var transaction = producer.BeginTransaction();
+        var scope = new KafkaFaultScope(
+            KafkaFaultOperation.SendOffsetsToTransaction,
+            groupId: "billing");
+        var barriers = CreateOffsetBarriers(cluster, scope, operationCount);
+        var operations = StageOffsets(transaction, operationCount);
+        await WaitUntilEnteredAsync(barriers);
+        await ReleaseAsync(barriers);
+        await Task.WhenAll(operations);
+        await transaction.CommitAsync();
+        await AssertOffsetsCommittedAsync(cluster, operationCount);
+    }
+
+    private static KafkaFaultBarrier[] CreateOffsetBarriers(
+        InMemoryKafkaCluster cluster,
+        KafkaFaultScope scope,
+        int operationCount)
+    {
+        var barriers = new KafkaFaultBarrier[operationCount];
+        for (var index = 0; index < barriers.Length; index++)
+            barriers[index] = cluster.FaultPlan.PauseNext(scope);
+        return barriers;
+    }
+
+    private static Task[] StageOffsets(
+        ITransaction<string, string> transaction,
+        int operationCount)
+    {
+        var operations = new Task[operationCount];
+        for (var index = 0; index < operations.Length; index++)
+        {
+            operations[index] = transaction.SendOffsetsToTransactionAsync(
+                [new TopicPartitionOffset($"orders-{index}", 0, index + 1)],
+                "billing").AsTask();
+        }
+        return operations;
+    }
+
+    private static async Task WaitUntilEnteredAsync(KafkaFaultBarrier[] barriers)
+    {
+        for (var index = 0; index < barriers.Length; index++)
+            await barriers[index].WaitUntilEnteredAsync();
+    }
+
+    private static async Task ReleaseAsync(KafkaFaultBarrier[] barriers)
+    {
+        for (var index = 0; index < barriers.Length; index++)
+            await Assert.That(barriers[index].Release()).IsTrue();
+    }
+
+    private static async Task AssertOffsetsCommittedAsync(
+        InMemoryKafkaCluster cluster,
+        int operationCount)
+    {
+        for (var index = 0; index < operationCount; index++)
+        {
+            await Assert.That(cluster.GetCommittedOffset(
+                    "billing",
+                    new TopicPartition($"orders-{index}", 0)))
+                .IsEqualTo(index + 1);
+        }
+    }
+
+    [Test]
+    public async Task DeleteRecords_PreservesOpenTransactionBoundary()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        var firstTransactionalProducer = new InMemoryProducer<string, string>(cluster);
+        var secondTransactionalProducer = new InMemoryProducer<string, string>(cluster);
+        var ordinaryProducer = new InMemoryProducer<string, string>(cluster);
+        await using var firstTransaction = firstTransactionalProducer.BeginTransaction();
+        await using var secondTransaction = secondTransactionalProducer.BeginTransaction();
+        _ = await firstTransaction.ProduceAsync("orders", "k", "first-pending");
+        _ = await secondTransaction.ProduceAsync("orders", "k", "second-pending");
+        _ = await ordinaryProducer.ProduceAsync("orders", "k", "later");
+        await using var admin = new InMemoryAdminClient(cluster);
+        var topicPartition = new TopicPartition("orders", 0);
+
+        _ = await admin.DeleteRecordsAsync(new Dictionary<TopicPartition, long>
+        {
+            [topicPartition] = 2
+        });
+
+        await Assert.That(cluster.TryRead(
+            topicPartition,
+            2,
+            out _,
+            out var blockedByOngoingTransaction)).IsFalse();
+        await Assert.That(blockedByOngoingTransaction).IsTrue();
+
+        await firstTransaction.CommitAsync();
+
+        await Assert.That(cluster.TryRead(
+            topicPartition,
+            2,
+            out _,
+            out blockedByOngoingTransaction)).IsFalse();
+        await Assert.That(blockedByOngoingTransaction).IsTrue();
+
+        await secondTransaction.CommitAsync();
+
+        await Assert.That(cluster.TryRead(topicPartition, 2, out var visible)).IsTrue();
+        await Assert.That(Encoding.UTF8.GetString(visible.Value)).IsEqualTo("later");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -12,6 +12,23 @@ namespace Dekaf.Tests.Unit.Testing;
 public sealed class InMemoryProducerFaultTests
 {
     [Test]
+    public async Task Produce_EmptyPlanCompletesSynchronously()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        await using var producer = new InMemoryProducer<string, string>(cluster);
+
+        var produce = producer.ProduceAsync("orders", "k", "v");
+        await Assert.That(produce.IsCompletedSuccessfully).IsTrue();
+        _ = await produce;
+
+        await using var transaction = producer.BeginTransaction();
+        var transactionProduce = transaction.ProduceAsync("orders", "k", "v");
+        await Assert.That(transactionProduce.IsCompletedSuccessfully).IsTrue();
+        _ = await transactionProduce;
+    }
+
+    [Test]
     public async Task Produce_FaultsHonorScopeOccurrenceAndRetryBoundaries()
     {
         var plan = new KafkaFaultPlan();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryProducerFaultTests.cs
@@ -29,6 +29,33 @@ public sealed class InMemoryProducerFaultTests
     }
 
     [Test]
+    public async Task Produce_UnrelatedPersistentFaultsRemainOnFastPath()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        cluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.Fetch, "orders", partition: 0),
+            new InvalidOperationException("consumer only"));
+        cluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.Produce, "other-topic"),
+            new InvalidOperationException("other topic"));
+        cluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.TransactionProduce, "other-topic"),
+            new InvalidOperationException("other transaction topic"));
+        await using var producer = new InMemoryProducer<string, string>(cluster);
+
+        var produce = producer.ProduceAsync("orders", "k", "v");
+        await using var transaction = producer.BeginTransaction();
+        var transactionProduce = transaction.ProduceAsync("orders", "k", "v");
+
+        await Assert.That(produce.IsCompletedSuccessfully).IsTrue();
+        await Assert.That(transactionProduce.IsCompletedSuccessfully).IsTrue();
+        await Assert.That((await produce).Offset).IsEqualTo(0);
+        await Assert.That((await transactionProduce).Offset).IsEqualTo(1);
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task Produce_FaultsHonorScopeOccurrenceAndRetryBoundaries()
     {
         var plan = new KafkaFaultPlan();
@@ -513,7 +540,6 @@ public sealed class InMemoryProducerFaultTests
     }
 
     [Test]
-    [NotInParallel]
     public async Task ProducerDispose_WaitsUntilCompletedTransactionIsUnpublished()
     {
         var cluster = new InMemoryKafkaCluster();
@@ -523,7 +549,7 @@ public sealed class InMemoryProducerFaultTests
             TaskCreationOptions.RunContinuationsAsynchronously);
         using var releaseCompletion = new ManualResetEventSlim();
         Volatile.Write(
-            ref InMemoryProducer<string, string>.TransactionCompletionPublishedTestHook,
+            ref producer.TransactionCompletionPublishedTestHook,
             () =>
             {
                 completionPublished.TrySetResult();
@@ -551,7 +577,7 @@ public sealed class InMemoryProducerFaultTests
         finally
         {
             Volatile.Write(
-                ref InMemoryProducer<string, string>.TransactionCompletionPublishedTestHook,
+                ref producer.TransactionCompletionPublishedTestHook,
                 null);
             releaseCompletion.Set();
             await producer.DisposeAsync();

--- a/tests/Dekaf.Tests.Unit/Testing/KafkaFaultPlanTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/KafkaFaultPlanTests.cs
@@ -117,6 +117,17 @@ public sealed class KafkaFaultPlanTests
     }
 
     [Test]
+    public async Task ApplyAsync_EmptyPlanCompletesSynchronously()
+    {
+        var plan = new KafkaFaultPlan();
+
+        var application = plan.ApplyAsync(ProduceOrders);
+
+        await Assert.That(application.IsCompletedSuccessfully).IsTrue();
+        await application;
+    }
+
+    [Test]
     public async Task Clear_ExactScopeLeavesOtherRulesQueued()
     {
         var plan = new KafkaFaultPlan();

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaFaultPlanBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaFaultPlanBenchmarks.cs
@@ -1,0 +1,15 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Testing;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser(displayGenColumns: false)]
+[ShortRunJob]
+public class KafkaFaultPlanBenchmarks
+{
+    private readonly KafkaFaultPlan _emptyPlan = new();
+    private readonly KafkaFaultScope _scope = new(KafkaFaultOperation.Produce, "orders", 0);
+
+    [Benchmark]
+    public ValueTask ApplyEmptyPlan() => _emptyPlan.ApplyAsync(_scope);
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaFaultPlanBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaFaultPlanBenchmarks.cs
@@ -13,6 +13,8 @@ public class KafkaFaultPlanBenchmarks
     private readonly KafkaFaultPlan _emptyPlan = new();
     private readonly KafkaFaultScope _scope = new(KafkaFaultOperation.Produce, "orders", 0);
     private InMemoryProducer<byte[], byte[]> _producer = null!;
+    private InMemoryProducer<byte[], byte[]> _transactionProducer = null!;
+    private ITransaction<byte[], byte[]> _transaction = null!;
 
     [IterationSetup(Target = nameof(ProduceEmptyPlan))]
     public void SetupProducer()
@@ -25,6 +27,22 @@ public class KafkaFaultPlanBenchmarks
     [IterationCleanup(Target = nameof(ProduceEmptyPlan))]
     public void CleanupProducer() => _producer.DisposeAsync().GetAwaiter().GetResult();
 
+    [IterationSetup(Target = nameof(ProduceTransactionEmptyPlan))]
+    public void SetupTransactionProducer()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        _transactionProducer = new InMemoryProducer<byte[], byte[]>(cluster);
+        _transaction = _transactionProducer.BeginTransaction();
+    }
+
+    [IterationCleanup(Target = nameof(ProduceTransactionEmptyPlan))]
+    public void CleanupTransactionProducer()
+    {
+        _transaction.DisposeAsync().GetAwaiter().GetResult();
+        _transactionProducer.DisposeAsync().GetAwaiter().GetResult();
+    }
+
     [Benchmark]
     public ValueTask ApplyEmptyPlan() => _emptyPlan.ApplyAsync(_scope);
 
@@ -32,4 +50,9 @@ public class KafkaFaultPlanBenchmarks
     [InvocationCount(131072)]
     public ValueTask<RecordMetadata> ProduceEmptyPlan() =>
         _producer.ProduceAsync("orders", Key, Value);
+
+    [Benchmark]
+    [InvocationCount(131072)]
+    public ValueTask<RecordMetadata> ProduceTransactionEmptyPlan() =>
+        _transaction.ProduceAsync("orders", Key, Value);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaFaultPlanBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaFaultPlanBenchmarks.cs
@@ -13,8 +13,11 @@ public class KafkaFaultPlanBenchmarks
     private readonly KafkaFaultPlan _emptyPlan = new();
     private readonly KafkaFaultScope _scope = new(KafkaFaultOperation.Produce, "orders", 0);
     private InMemoryProducer<byte[], byte[]> _producer = null!;
+    private InMemoryProducer<byte[], byte[]> _unrelatedFaultProducer = null!;
     private InMemoryProducer<byte[], byte[]> _transactionProducer = null!;
     private ITransaction<byte[], byte[]> _transaction = null!;
+    private InMemoryProducer<byte[], byte[]> _unrelatedTransactionProducer = null!;
+    private ITransaction<byte[], byte[]> _unrelatedTransaction = null!;
 
     [IterationSetup(Target = nameof(ProduceEmptyPlan))]
     public void SetupProducer()
@@ -26,6 +29,24 @@ public class KafkaFaultPlanBenchmarks
 
     [IterationCleanup(Target = nameof(ProduceEmptyPlan))]
     public void CleanupProducer() => _producer.DisposeAsync().GetAwaiter().GetResult();
+
+    [IterationSetup(Target = nameof(ProduceUnrelatedFaultPlan))]
+    public void SetupUnrelatedFaultProducer()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        cluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.Fetch, "orders", partition: 0),
+            new InvalidOperationException("consumer only"));
+        cluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.Produce, "other-topic"),
+            new InvalidOperationException("other topic"));
+        _unrelatedFaultProducer = new InMemoryProducer<byte[], byte[]>(cluster);
+    }
+
+    [IterationCleanup(Target = nameof(ProduceUnrelatedFaultPlan))]
+    public void CleanupUnrelatedFaultProducer() =>
+        _unrelatedFaultProducer.DisposeAsync().GetAwaiter().GetResult();
 
     [IterationSetup(Target = nameof(ProduceTransactionEmptyPlan))]
     public void SetupTransactionProducer()
@@ -43,6 +64,28 @@ public class KafkaFaultPlanBenchmarks
         _transactionProducer.DisposeAsync().GetAwaiter().GetResult();
     }
 
+    [IterationSetup(Target = nameof(ProduceTransactionUnrelatedFaultPlan))]
+    public void SetupUnrelatedTransactionProducer()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        cluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.Fetch, "orders", partition: 0),
+            new InvalidOperationException("consumer only"));
+        cluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.TransactionProduce, "other-topic"),
+            new InvalidOperationException("other transaction topic"));
+        _unrelatedTransactionProducer = new InMemoryProducer<byte[], byte[]>(cluster);
+        _unrelatedTransaction = _unrelatedTransactionProducer.BeginTransaction();
+    }
+
+    [IterationCleanup(Target = nameof(ProduceTransactionUnrelatedFaultPlan))]
+    public void CleanupUnrelatedTransactionProducer()
+    {
+        _unrelatedTransaction.DisposeAsync().GetAwaiter().GetResult();
+        _unrelatedTransactionProducer.DisposeAsync().GetAwaiter().GetResult();
+    }
+
     [Benchmark]
     public ValueTask ApplyEmptyPlan() => _emptyPlan.ApplyAsync(_scope);
 
@@ -52,7 +95,17 @@ public class KafkaFaultPlanBenchmarks
         _producer.ProduceAsync("orders", Key, Value);
 
     [Benchmark]
+    [InvocationCount(131072)]
+    public ValueTask<RecordMetadata> ProduceUnrelatedFaultPlan() =>
+        _unrelatedFaultProducer.ProduceAsync("orders", Key, Value);
+
+    [Benchmark]
     [InvocationCount(1048576)]
     public ValueTask<RecordMetadata> ProduceTransactionEmptyPlan() =>
         _transaction.ProduceAsync("orders", Key, Value);
+
+    [Benchmark]
+    [InvocationCount(1048576)]
+    public ValueTask<RecordMetadata> ProduceTransactionUnrelatedFaultPlan() =>
+        _unrelatedTransaction.ProduceAsync("orders", Key, Value);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaFaultPlanBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaFaultPlanBenchmarks.cs
@@ -1,4 +1,5 @@
 using BenchmarkDotNet.Attributes;
+using Dekaf.Producer;
 using Dekaf.Testing;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
@@ -7,9 +8,28 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [ShortRunJob]
 public class KafkaFaultPlanBenchmarks
 {
+    private static readonly byte[] Key = [1];
+    private static readonly byte[] Value = [2];
     private readonly KafkaFaultPlan _emptyPlan = new();
     private readonly KafkaFaultScope _scope = new(KafkaFaultOperation.Produce, "orders", 0);
+    private InMemoryProducer<byte[], byte[]> _producer = null!;
+
+    [IterationSetup(Target = nameof(ProduceEmptyPlan))]
+    public void SetupProducer()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        _producer = new InMemoryProducer<byte[], byte[]>(cluster);
+    }
+
+    [IterationCleanup(Target = nameof(ProduceEmptyPlan))]
+    public void CleanupProducer() => _producer.DisposeAsync().GetAwaiter().GetResult();
 
     [Benchmark]
     public ValueTask ApplyEmptyPlan() => _emptyPlan.ApplyAsync(_scope);
+
+    [Benchmark]
+    [InvocationCount(131072)]
+    public ValueTask<RecordMetadata> ProduceEmptyPlan() =>
+        _producer.ProduceAsync("orders", Key, Value);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaFaultPlanBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaFaultPlanBenchmarks.cs
@@ -52,7 +52,7 @@ public class KafkaFaultPlanBenchmarks
         _producer.ProduceAsync("orders", Key, Value);
 
     [Benchmark]
-    [InvocationCount(131072)]
+    [InvocationCount(1048576)]
     public ValueTask<RecordMetadata> ProduceTransactionEmptyPlan() =>
         _transaction.ProduceAsync("orders", Key, Value);
 }

--- a/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
+++ b/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\..\src\Dekaf.Compression.Zstd\Dekaf.Compression.Zstd.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Serialization.Json\Dekaf.Serialization.Json.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Serialization.Routing\Dekaf.Serialization.Routing.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Testing\Dekaf.Testing.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Avro\Dekaf.SchemaRegistry.Avro.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Avro.Poco.Generator\Dekaf.SchemaRegistry.Avro.Poco.Generator.csproj"
                       OutputItemType="Analyzer"


### PR DESCRIPTION
## Summary
- expose an injectable `IKafkaFaultPlan` from `InMemoryKafkaCluster`
- consume scoped faults from producer acknowledgement and transaction operations
- preserve legacy `FailProduces` priority and fire-and-forget failure swallowing
- model retryable commit/abort/offset state and sticky producer-local fatal fencing
- add deterministic barrier, ordering, recovery, prepared transaction, and singleton fatal coverage

## Verification
- `dotnet build --configuration Release --no-restore` — 0 warnings/errors
- in-memory unit tests — 83/83 passed on net10.0 and 83/83 on net8.0
- full unit suite — 7,588/7,588 passed on net10.0 and 7,452/7,452 on net8.0
- `/simplify` and pre-push self-review — clear

No benchmark is required: changes are isolated to `Dekaf.Testing`; no production `Dekaf` hot path is modified.

Part of #2757.

Closes #2799

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable fault injection for in-memory Kafka clusters.
  - Added producer transaction support, including commit, abort, offset staging, recovery, and completion.
  - Added transaction-aware record visibility, producer fencing, and accurate consumer-group generation metadata.

- **Bug Fixes**
  - Improved transaction and consumer metadata validation.
  - Ensured consistent fault handling, cancellation, retries, producer isolation, and consumer positions when transactions are pending.

- **Tests**
  - Added comprehensive coverage for faults, transactions, recovery, fencing, visibility, retries, committed offsets, and consumer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->