### PR TITLE
testing: inject consumer and group faults

### DIFF
--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -29,12 +29,16 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         long Position,
         bool ResumePartition,
         TaskCompletionSource<CapturedAutoCommitProof> Completion,
-        TopicPartitionOffset[] CapturedOffsets);
+        CapturedCommitOffsets CapturedCommit);
+
+    private readonly record struct CapturedCommitOffsets(
+        TopicPartitionOffset[] Offsets,
+        int ConsumerGroupGeneration);
 
     private readonly record struct CapturedAutoCommitProof(
         TopicPartition Partition,
         long Position,
-        TopicPartitionOffset[] Offsets,
+        CapturedCommitOffsets Commit,
         bool SharedWaiter,
         TaskCompletionSource<CapturedAutoCommitProof>? SharedWaiterCompletion);
 
@@ -474,9 +478,16 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                         cancellationToken).ConfigureAwait(false);
                     continue;
                 }
-                lock (_gate)
+                try
                 {
-                    ProveInDoubtRecordUnderLock(capturedProof);
+                    lock (_gate)
+                    {
+                        ProveInDoubtRecordUnderLock(capturedProof);
+                    }
+                }
+                finally
+                {
+                    CompleteSharedAutoCommitWaiters(capturedProof);
                 }
             }
         }
@@ -552,27 +563,34 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 long position;
                 bool complete;
                 bool pendingAutoCommitAdvancement;
-                lock (_gate)
+                try
                 {
-                    ThrowIfSnapshotStateChangedUnderLock(
-                        consumerStateVersion,
-                        consumerGroupGeneration);
+                    lock (_gate)
+                    {
+                        ThrowIfSnapshotStateChangedUnderLock(
+                            consumerStateVersion,
+                            consumerGroupGeneration);
 
-                    ProveInDoubtRecordUnderLock(capturedProof);
-                    if (!TrySelectSnapshotRecordUnderLock(
-                            partitions,
-                            ref activePartitionIndex,
-                            out partition,
-                            out record,
-                            out position,
-                            out pendingAutoCommitAdvancement))
-                    {
-                        complete = !pendingAutoCommitAdvancement;
+                        ProveInDoubtRecordUnderLock(capturedProof);
+                        if (!TrySelectSnapshotRecordUnderLock(
+                                partitions,
+                                ref activePartitionIndex,
+                                out partition,
+                                out record,
+                                out position,
+                                out pendingAutoCommitAdvancement))
+                        {
+                            complete = !pendingAutoCommitAdvancement;
+                        }
+                        else
+                        {
+                            complete = false;
+                        }
                     }
-                    else
-                    {
-                        complete = false;
-                    }
+                }
+                finally
+                {
+                    CompleteSharedAutoCommitWaiters(capturedProof);
                 }
 
                 if (pendingAutoCommitAdvancement)
@@ -588,7 +606,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
                 if (complete)
                 {
-                    TopicPartitionOffset[] completionOffsets;
+                    CapturedCommitOffsets completionOffsets;
                     ValueTask commitFaultApplication;
                     lock (_gate)
                     {
@@ -606,7 +624,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                         ThrowIfSnapshotStateChangedUnderLock(
                             consumerStateVersion,
                             consumerGroupGeneration);
-                        CommitCapturedOffsetsUnderLock(completionOffsets);
+                        CommitCapturedOffsetsUnderLock(in completionOffsets);
                     }
 
                     yield break;
@@ -820,7 +838,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         var groupId = GetCommitGroupId();
 
         TopicPartitionOffset? inDoubtRecord;
-        TopicPartitionOffset[] offsets;
+        CapturedCommitOffsets capturedCommit;
         int consumerStateVersion;
         bool hasFaultApplication;
         ValueTask faultApplication;
@@ -836,10 +854,10 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             var inDoubtCommitOffset = _options.EnableAutoOffsetStore
                 ? inDoubtRecord
                 : null;
-            offsets = CaptureCommitOffsetsUnderLock(inDoubtCommitOffset);
+            capturedCommit = CaptureCommitOffsetsUnderLock(inDoubtCommitOffset);
             hasFaultApplication = TryApplyMatchingCapturedCommitFault(
                 groupId,
-                offsets,
+                capturedCommit.Offsets,
                 cancellationToken,
                 out faultApplication);
         }
@@ -854,6 +872,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         {
             ThrowIfDisposed();
             if (_consumerStateVersion == consumerStateVersion &&
+                IsCapturedCommitCurrentUnderLock(in capturedCommit) &&
                 inDoubtRecord is { } capturedInDoubt &&
                 _inDoubtNextOffset == capturedInDoubt.Offset &&
                 _inDoubtPartition.Topic == capturedInDoubt.Topic &&
@@ -865,8 +884,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 ClearInDoubtRecordUnderLock();
             }
 
-            if (_consumerStateVersion == consumerStateVersion && offsets.Length != 0)
-                _cluster.CommitOffsets(groupId, offsets);
+            if (_consumerStateVersion == consumerStateVersion)
+                CommitCapturedOffsetsUnderLock(in capturedCommit);
         }
     }
 
@@ -1117,14 +1136,14 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         TaskCompletionSource completion,
         CancellationToken cancellationToken)
     {
-        TopicPartitionOffset[]? capturedOffsets = null;
+        CapturedCommitOffsets? capturedCommit = null;
         Exception? failure = null;
         try
         {
             ValueTask commitFaultApplication;
             lock (_gate)
             {
-                capturedOffsets = CaptureStoredAutoCommitOffsetsUnderLock(
+                capturedCommit = CaptureStoredAutoCommitOffsetsUnderLock(
                     cancellationToken,
                     out commitFaultApplication);
             }
@@ -1134,12 +1153,12 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         catch (Exception ex)
         {
             failure = ex;
-            capturedOffsets = null;
+            capturedCommit = null;
         }
 
         try
         {
-            await CompleteClose(capturedOffsets).ConfigureAwait(false);
+            await CompleteClose(capturedCommit).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -1156,15 +1175,15 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             completion.TrySetException(failure);
     }
 
-    private ValueTask CompleteClose(TopicPartitionOffset[]? capturedOffsets)
+    private ValueTask CompleteClose(CapturedCommitOffsets? capturedCommit)
     {
         lock (_gate)
         {
             if (_disposed)
                 return ValueTask.CompletedTask;
 
-            if (capturedOffsets is not null)
-                CommitCapturedOffsetsUnderLock(capturedOffsets);
+            if (capturedCommit is { } captured)
+                CommitCapturedOffsetsUnderLock(in captured);
 
             // The in-memory cluster has no broker session timer. Always unregister on close so
             // RemainInGroup cannot create an immortal member that permanently owns partitions.
@@ -1181,7 +1200,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                     pending.Completion.TrySetResult(new CapturedAutoCommitProof(
                         partition,
                         pending.Position,
-                        pending.CapturedOffsets,
+                        pending.CapturedCommit,
                         SharedWaiter: true,
                         SharedWaiterCompletion: null));
                 }
@@ -1726,6 +1745,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                         partition,
                         position,
                         record.Offset + 1,
+                        in selectionVersion,
                         cancellationToken,
                         out var hasAutoCommitReservation,
                         out var autoCommitFaultApplication))
@@ -1867,13 +1887,14 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
             try
             {
-                if (!IsRecordSelectionCurrentUnderLock(
+                if (!IsReservedRecordSelectionCurrentUnderLock(
                         partition,
                         expectedPosition,
+                        pending.ResumePartition,
                         in selectionVersion))
                     return false;
 
-                AdvancePositionUnderLock(partition, record, pending.CapturedOffsets);
+                AdvancePositionUnderLock(partition, record, pending.CapturedCommit);
                 return true;
             }
             finally
@@ -1915,10 +1936,30 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                currentPosition == expectedPosition;
     }
 
+    private bool IsReservedRecordSelectionCurrentUnderLock(
+        TopicPartition partition,
+        long expectedPosition,
+        bool resumePartition,
+        in ConsumerSelectionVersion selectionVersion)
+    {
+        ThrowIfDisposed();
+        if (!resumePartition ||
+            !_assignment.Contains(partition) ||
+            selectionVersion.ConsumerGroupGeneration >= 0 &&
+            _groupId is not null &&
+            _cluster.GetConsumerGroupGeneration(_groupId) != selectionVersion.ConsumerGroupGeneration)
+        {
+            return false;
+        }
+
+        return _positions.TryGetValue(partition, out var currentPosition) &&
+               currentPosition == expectedPosition;
+    }
+
     private void AdvancePositionUnderLock(
         TopicPartition partition,
         InMemoryRecord record,
-        TopicPartitionOffset[]? capturedOffsets = null)
+        CapturedCommitOffsets? capturedCommit = null)
     {
         _positions[partition] = record.Offset + 1;
         if (_options.OffsetStoreTiming == OffsetStoreTiming.OnDelivery)
@@ -1927,10 +1968,13 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 StoreOffsetUnderLock(partition, record.Offset + 1);
             if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
             {
-                if (capturedOffsets is null)
+                if (capturedCommit is null)
                     CommitStoredOffsets();
                 else
-                    CommitCapturedOffsetsUnderLock(capturedOffsets);
+                {
+                    var captured = capturedCommit.Value;
+                    CommitCapturedOffsetsUnderLock(in captured);
+                }
             }
         }
         else
@@ -1990,7 +2034,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                     return false;
                 }
 
-                AdvancePositionUnderLock(partition, record, pending.CapturedOffsets);
+                AdvancePositionUnderLock(partition, record, pending.CapturedCommit);
                 return true;
             }
             finally
@@ -2046,6 +2090,13 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             return;
         }
 
+        if (capturedProof is { } captured)
+        {
+            var capturedCommit = captured.Commit;
+            if (!IsCapturedCommitCurrentUnderLock(in capturedCommit))
+                return;
+        }
+
         if (IsInDoubtAutoCommitAdvancementPendingUnderLock())
             return;
 
@@ -2059,7 +2110,10 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             if (capturedProof is null)
                 CommitStoredOffsets();
             else
-                CommitCapturedOffsetsUnderLock(capturedProof.Value.Offsets);
+            {
+                var capturedCommit = capturedProof.Value.Commit;
+                CommitCapturedOffsetsUnderLock(in capturedCommit);
+            }
         }
     }
 
@@ -2276,10 +2330,10 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private void CommitStoredOffsets()
         => CommitOffsetsFrom(_storedOffsets);
 
-    private TopicPartitionOffset[] CaptureCommitOffsetsUnderLock(
+    private CapturedCommitOffsets CaptureCommitOffsetsUnderLock(
         TopicPartitionOffset? inDoubtOffset)
     {
-        var assignment = GetCurrentAssignmentUnderLock();
+        var assignment = GetCurrentAssignmentUnderLock(out var consumerGroupGeneration);
         var inDoubtPartition = inDoubtOffset is { } pending
             ? new TopicPartition(pending.Topic, pending.Partition)
             : (TopicPartition?)null;
@@ -2293,7 +2347,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         }
 
         if (count == 0)
-            return [];
+            return new CapturedCommitOffsets([], consumerGroupGeneration);
 
         var offsets = new TopicPartitionOffset[count];
         var index = 0;
@@ -2305,7 +2359,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 offsets[index++] = offset;
         }
 
-        return offsets;
+        return new CapturedCommitOffsets(offsets, consumerGroupGeneration);
     }
 
     private bool TryApplyMatchingCapturedCommitFault(
@@ -2371,18 +2425,32 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         TopicPartition partition,
         long expectedPosition,
         long nextOffset,
+        in ConsumerSelectionVersion selectionVersion,
         CancellationToken cancellationToken,
         out bool hasReservation,
         out ValueTask faultApplication)
     {
         lock (_gate)
+        {
+            if (!IsRecordSelectionCurrentUnderLock(
+                    partition,
+                    expectedPosition,
+                    in selectionVersion))
+            {
+                hasReservation = false;
+                faultApplication = ValueTask.CompletedTask;
+                return false;
+            }
+
             return TryPrepareOnDeliveryAutoCommitFaultUnderLock(
                 partition,
                 expectedPosition,
                 nextOffset,
+                in selectionVersion,
                 cancellationToken,
                 out hasReservation,
                 out faultApplication);
+        }
     }
 
     private bool TryPrepareSnapshotOnDeliveryAutoCommitFault(
@@ -2400,10 +2468,14 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             ThrowIfSnapshotStateChangedUnderLock(
                 consumerStateVersion,
                 consumerGroupGeneration);
+            var selectionVersion = new ConsumerSelectionVersion(
+                consumerStateVersion,
+                consumerGroupGeneration);
             return TryPrepareOnDeliveryAutoCommitFaultUnderLock(
                 partition,
                 expectedPosition,
                 nextOffset,
+                in selectionVersion,
                 cancellationToken,
                 out hasReservation,
                 out faultApplication);
@@ -2414,6 +2486,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         TopicPartition partition,
         long expectedPosition,
         long nextOffset,
+        in ConsumerSelectionVersion selectionVersion,
         CancellationToken cancellationToken,
         out bool hasReservation,
         out ValueTask faultApplication)
@@ -2451,6 +2524,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 partition,
                 expectedPosition,
                 pendingOffset,
+                in selectionVersion,
                 cancellationToken,
                 out _,
                 out faultApplication))
@@ -2465,11 +2539,12 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         TopicPartition reservationPartition,
         long reservationPosition,
         TopicPartitionOffset? pendingOffset,
+        in ConsumerSelectionVersion selectionVersion,
         CancellationToken cancellationToken,
-        out TopicPartitionOffset[] capturedOffsets,
+        out CapturedCommitOffsets capturedCommit,
         out ValueTask faultApplication)
     {
-        capturedOffsets = [];
+        capturedCommit = default;
         faultApplication = ValueTask.CompletedTask;
         if (_groupId is null)
             return false;
@@ -2483,12 +2558,16 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             hasMatchingCommitFault = HasMatchingCommitFaultUnderLock(faultPlan, pendingOffset);
         }
         while (faultPlanVersion != faultPlan.Version);
-        if (!hasMatchingCommitFault)
+        if (!hasMatchingCommitFault ||
+            !IsRecordSelectionCurrentUnderLock(
+                reservationPartition,
+                reservationPosition,
+                in selectionVersion))
         {
             return false;
         }
 
-        capturedOffsets = CaptureCommitOffsetsUnderLock(pendingOffset);
+        capturedCommit = CaptureCommitOffsetsUnderLock(pendingOffset);
         var resumePartition = _paused.Add(reservationPartition);
         if (resumePartition)
             InvalidatePotentialFaultActiveResourcesUnderLock();
@@ -2497,13 +2576,13 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             resumePartition,
             new TaskCompletionSource<CapturedAutoCommitProof>(
                 TaskCreationOptions.RunContinuationsAsynchronously),
-            capturedOffsets);
+            capturedCommit);
 
         try
         {
             if (TryApplyMatchingCapturedCommitFault(
                     _groupId,
-                    capturedOffsets,
+                    capturedCommit.Offsets,
                     cancellationToken,
                     out faultApplication))
             {
@@ -2519,7 +2598,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         }
 
         ClearPendingAutoCommitAdvancementUnderLock(reservationPartition, reservationPosition);
-        capturedOffsets = [];
+        capturedCommit = default;
         return false;
     }
 
@@ -2637,7 +2716,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             pending.Completion.TrySetResult(new CapturedAutoCommitProof(
                 partition,
                 pending.Position,
-                pending.CapturedOffsets,
+                pending.CapturedCommit,
                 SharedWaiter: true,
                 SharedWaiterCompletion: null));
         }
@@ -2664,7 +2743,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         TopicPartition inDoubtPartition;
         long inDoubtNextOffset;
-        TopicPartitionOffset[] capturedOffsets;
+        CapturedCommitOffsets capturedCommit;
         ValueTask faultApplication;
         lock (_gate)
         {
@@ -2689,12 +2768,19 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                     inDoubtPartition.Partition,
                     inDoubtNextOffset)
                 : (TopicPartitionOffset?)null;
+            var assignment = GetCurrentAssignmentUnderLock(out var consumerGroupGeneration);
+            if (!assignment.Contains(inDoubtPartition))
+                return default;
+            var selectionVersion = new ConsumerSelectionVersion(
+                _consumerStateVersion,
+                consumerGroupGeneration);
             if (!TryCaptureAndApplyMatchingCommitFaultUnderLock(
                     inDoubtPartition,
                     inDoubtNextOffset,
                     inDoubtOffset,
+                    in selectionVersion,
                     cancellationToken,
-                    out capturedOffsets,
+                    out capturedCommit,
                     out faultApplication))
             {
                 return default;
@@ -2705,7 +2791,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             faultApplication,
             inDoubtPartition,
             inDoubtNextOffset,
-            capturedOffsets);
+            capturedCommit);
     }
 
     private static async ValueTask<CapturedAutoCommitProof?> AwaitPendingAutoCommitProofAsync(
@@ -2717,7 +2803,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         ValueTask faultApplication,
         TopicPartition partition,
         long expectedPosition,
-        TopicPartitionOffset[] capturedOffsets)
+        CapturedCommitOffsets capturedCommit)
     {
         try
         {
@@ -2736,7 +2822,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         return new CapturedAutoCommitProof(
             partition,
             expectedPosition,
-            capturedOffsets,
+            capturedCommit,
             SharedWaiter: false,
             completion);
     }
@@ -2755,7 +2841,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         completion.TrySetResult(new CapturedAutoCommitProof(
             proof.Partition,
             proof.Position,
-            proof.Offsets,
+            proof.Commit,
             SharedWaiter: true,
             SharedWaiterCompletion: null));
         _cluster.SignalRecordsChanged();
@@ -2783,28 +2869,39 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         }
     }
 
-    private TopicPartitionOffset[] CaptureStoredAutoCommitOffsetsUnderLock(
+    private CapturedCommitOffsets CaptureStoredAutoCommitOffsetsUnderLock(
         CancellationToken cancellationToken,
         out ValueTask faultApplication)
     {
         faultApplication = ValueTask.CompletedTask;
         if (_options.OffsetCommitMode != OffsetCommitMode.Auto || _groupId is null)
-            return [];
+            return new CapturedCommitOffsets([], -1);
 
-        var offsets = CaptureCommitOffsetsUnderLock(inDoubtOffset: null);
+        var capturedCommit = CaptureCommitOffsetsUnderLock(inDoubtOffset: null);
         _ = TryApplyMatchingCapturedCommitFault(
             _groupId,
-            offsets,
+            capturedCommit.Offsets,
             cancellationToken,
             out faultApplication);
-        return offsets;
+        return capturedCommit;
     }
 
-    private void CommitCapturedOffsetsUnderLock(TopicPartitionOffset[] offsets)
+    private void CommitCapturedOffsetsUnderLock(in CapturedCommitOffsets capturedCommit)
     {
-        if (_groupId is not null && offsets.Length != 0)
-            _cluster.CommitOffsets(_groupId, offsets);
+        if (_groupId is null ||
+            capturedCommit.Offsets.Length == 0 ||
+            !IsCapturedCommitCurrentUnderLock(in capturedCommit))
+        {
+            return;
+        }
+
+        _cluster.CommitOffsets(_groupId, capturedCommit.Offsets);
     }
+
+    private bool IsCapturedCommitCurrentUnderLock(in CapturedCommitOffsets capturedCommit) =>
+        capturedCommit.ConsumerGroupGeneration < 0 ||
+        _groupId is not null &&
+        _cluster.GetConsumerGroupGeneration(_groupId) == capturedCommit.ConsumerGroupGeneration;
 
     private bool HasPotentialConsumerFault() =>
         HasPotentialConsumerFault(expectedConsumerStateVersion: -1, expectedConsumerGroupGeneration: -1);
@@ -2819,7 +2916,12 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         var consumerStateVersion = Volatile.Read(ref _consumerStateVersion);
         var autoCommitEnabled = _groupId is not null &&
                                 _options.OffsetCommitMode == OffsetCommitMode.Auto;
-        var requiresStoredOffset = autoCommitEnabled &&
+        var commitFaultEligible = autoCommitEnabled &&
+                                  (indexedPlan is null ||
+                                   indexedPlan.HasPotentialMatch(
+                                       KafkaFaultOperation.Commit,
+                                       _groupId!));
+        var requiresStoredOffset = commitFaultEligible &&
                                    !_options.EnableAutoOffsetStore;
         var storedOffsetsVersion = requiresStoredOffset
             ? Volatile.Read(ref _storedOffsetsVersion)
@@ -2853,7 +2955,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 out var activeResources,
                 out consumerGroupGeneration);
 
-            var includeCommit = autoCommitEnabled &&
+            var includeCommit = commitFaultEligible &&
                                 (_options.EnableAutoOffsetStore ||
                                  HasCommittableStoredOffsetUnderLock(
                                      assignment,

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -25,8 +25,30 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         TopicPartition Partition,
         long EndOffset);
 
+    private readonly record struct PendingAutoCommitAdvancement(
+        long Position,
+        bool ResumePartition,
+        TaskCompletionSource<CapturedAutoCommitProof> Completion,
+        TopicPartitionOffset[] CapturedOffsets);
+
+    private readonly record struct CapturedAutoCommitProof(
+        TopicPartition Partition,
+        long Position,
+        TopicPartitionOffset[] Offsets,
+        bool SharedWaiter,
+        TaskCompletionSource<CapturedAutoCommitProof>? SharedWaiterCompletion);
+
+    private readonly record struct ConsumeAttemptResult(
+        ConsumeResult<TKey, TValue>? Result,
+        bool StopPolling);
+
+    private readonly record struct ConsumerSelectionVersion(
+        int ConsumerState,
+        int ConsumerGroupGeneration);
+
     private readonly object _gate = new();
     private readonly InMemoryKafkaCluster _cluster;
+    private readonly KafkaFaultPlan? _indexedFaultPlan;
     private readonly IDeserializer<TKey> _keyDeserializer;
     private readonly IDeserializer<TValue> _valueDeserializer;
     // Non-null when the caller configured an IAsyncDeserializer for that component. The matching
@@ -41,6 +63,25 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private readonly HashSet<TopicPartition> _paused = [];
     private readonly Dictionary<TopicPartition, long> _positions = [];
     private readonly Dictionary<TopicPartition, TopicPartitionOffset> _storedOffsets = [];
+    private KafkaFaultScope[] _commitFaultScopes = new KafkaFaultScope[4];
+    private Dictionary<TopicPartition, PendingAutoCommitAdvancement>? _pendingAutoCommitAdvancements;
+    private int _storedOffsetsVersion;
+    private long _potentialFaultPlanVersion = -1;
+    private int _potentialFaultConsumerStateVersion = -1;
+    private int _potentialFaultConsumerGroupGeneration = -1;
+    private int _potentialFaultStoredOffsetsVersion = -1;
+    private bool _hasPotentialConsumerFault;
+    private IReadOnlySet<TopicPartition>? _potentialFaultAssignment;
+    private IReadOnlySet<TopicPartition>? _potentialFaultActiveResources;
+    private int _potentialFaultAssignmentConsumerStateVersion = -1;
+    private int _potentialFaultAssignmentConsumerGroupGeneration = -1;
+    private TopicPartition[] _orderedAssignment = [];
+    private int _orderedAssignmentConsumerStateVersion = -1;
+    private int _orderedAssignmentConsumerGroupGeneration = -1;
+    private int _committableOffsetConsumerStateVersion = -1;
+    private int _committableOffsetConsumerGroupGeneration = -1;
+    private int _committableOffsetStoredOffsetsVersion = -1;
+    private bool _hasCommittableStoredOffset;
     // In-doubt record under OffsetStoreTiming.AfterProcessing: delivered but not yet proven
     // processed. Staged for commit only when the next consume call or an explicit commit
     // proves it; an unwind (or close) leaves it unstaged so it is redelivered.
@@ -53,6 +94,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private int _consumerGroupGeneration = -1;
     private long _consumerGroupRegistrationId;
     private string? _subscriptionPattern;
+    private TaskCompletionSource? _autoCommitAdvancementWaiterEntered;
+    private Task? _closeTask;
     private bool _disposed;
 
     public InMemoryConsumer(InMemoryKafkaCluster cluster)
@@ -194,6 +237,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         InMemoryConsumerOptions options)
     {
         _cluster = cluster ?? throw new ArgumentNullException(nameof(cluster));
+        _indexedFaultPlan = _cluster.FaultPlan as KafkaFaultPlan;
         _asyncKeyDeserializer = asyncKeyDeserializer;
         _asyncValueDeserializer = asyncValueDeserializer;
         _keyDeserializer = asyncKeyDeserializer is null
@@ -243,7 +287,19 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         get
         {
             lock (_gate)
-                return _paused.ToHashSet();
+            {
+                var paused = _paused.ToHashSet();
+                if (_pendingAutoCommitAdvancements is not null)
+                {
+                    foreach (var (partition, pending) in _pendingAutoCommitAdvancements)
+                    {
+                        if (pending.ResumePartition)
+                            paused.Remove(partition);
+                    }
+                }
+
+                return paused;
+            }
         }
     }
 
@@ -308,18 +364,22 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     {
         ArgumentNullException.ThrowIfNull(topics);
         ThrowIfDisposed();
-
-        var topicPartitions = topics
+        var subscription = topics
             .Where(topic => !string.IsNullOrWhiteSpace(topic))
             .Distinct(StringComparer.Ordinal)
-            .SelectMany(topic => _cluster.GetTopicPartitions(topic))
             .ToArray();
 
         lock (_gate)
         {
+            ThrowIfAutoCommitAdvancementPendingUnderLock();
+            ApplyGroupTransitionFaults();
+            ThrowIfDisposed();
+            var topicPartitions = subscription
+                .SelectMany(topic => _cluster.GetTopicPartitions(topic))
+                .ToArray();
             _subscriptionPattern = null;
             _subscription.Clear();
-            foreach (var topic in topics.Where(topic => !string.IsNullOrWhiteSpace(topic)).Distinct(StringComparer.Ordinal))
+            foreach (var topic in subscription)
                 _subscription.Add(topic);
 
             ReplaceAssignment(topicPartitions);
@@ -358,6 +418,9 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            ThrowIfAutoCommitAdvancementPendingUnderLock();
+            ApplyGroupTransitionFaults();
+            ThrowIfDisposed();
             _subscriptionPattern = pattern;
             _subscription.Clear();
             ReplaceAssignment(topicPartitions);
@@ -371,13 +434,18 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            ThrowIfAutoCommitAdvancementPendingUnderLock();
+            if (_groupId is not null)
+                ApplyGroupTransitionFaultUnderLock(KafkaFaultOperation.Rebalance);
+
             _subscriptionPattern = null;
             _subscription.Clear();
             _assignment.Clear();
             _paused.Clear();
             _positions.Clear();
             _storedOffsets.Clear();
-            _inDoubtNextOffset = -1;
+            _storedOffsetsVersion++;
+            ClearInDoubtRecordUnderLock();
             _consumerStateVersion++;
             UnregisterConsumerGroupMemberUnderLock();
         }
@@ -395,9 +463,20 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
                 // Resuming after the yield proves that the caller processed this record.
                 // Do this before the loop observes cancellation, matching KafkaConsumer.
+                ThrowIfDisposed();
+                var capturedProof = await ApplyInDoubtAutoCommitFaultAsync(
+                    CancellationToken.None).ConfigureAwait(false);
+                ThrowIfDisposed();
+                if (capturedProof is { SharedWaiter: true })
+                {
+                    await WaitForSharedAutoCommitDeliveryAsync(
+                        capturedProof.Value,
+                        cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
                 lock (_gate)
                 {
-                    ProveInDoubtRecordUnderLock();
+                    ProveInDoubtRecordUnderLock(capturedProof);
                 }
             }
         }
@@ -457,32 +536,38 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         try
         {
+            var applyRecordFaults = HasPotentialConsumerFault();
             var activePartitionIndex = 0;
             while (true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                var capturedProof = await ApplyInDoubtAutoCommitFaultAsync(
+                    cancellationToken).ConfigureAwait(false);
+                ThrowIfDisposed();
+                if (capturedProof is { SharedWaiter: true })
+                    ThrowSnapshotStateChanged();
 
                 TopicPartition partition;
                 InMemoryRecord record;
                 long position;
                 bool complete;
+                bool pendingAutoCommitAdvancement;
                 lock (_gate)
                 {
                     ThrowIfSnapshotStateChangedUnderLock(
                         consumerStateVersion,
                         consumerGroupGeneration);
 
-                    ProveInDoubtRecordUnderLock();
+                    ProveInDoubtRecordUnderLock(capturedProof);
                     if (!TrySelectSnapshotRecordUnderLock(
                             partitions,
                             ref activePartitionIndex,
                             out partition,
                             out record,
-                            out position))
+                            out position,
+                            out pendingAutoCommitAdvancement))
                     {
-                        if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
-                            CommitStoredOffsets();
-                        complete = true;
+                        complete = !pendingAutoCommitAdvancement;
                     }
                     else
                     {
@@ -490,22 +575,129 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                     }
                 }
 
+                if (pendingAutoCommitAdvancement)
+                {
+                    await WaitForAutoCommitAdvancementAsync(
+                        partition,
+                        cancellationToken).ConfigureAwait(false);
+                    applyRecordFaults = HasPotentialConsumerFault(
+                        consumerStateVersion,
+                        consumerGroupGeneration);
+                    continue;
+                }
+
                 if (complete)
+                {
+                    TopicPartitionOffset[] completionOffsets;
+                    ValueTask commitFaultApplication;
+                    lock (_gate)
+                    {
+                        ThrowIfSnapshotStateChangedUnderLock(
+                            consumerStateVersion,
+                            consumerGroupGeneration);
+                        completionOffsets = CaptureStoredAutoCommitOffsetsUnderLock(
+                            cancellationToken,
+                            out commitFaultApplication);
+                    }
+
+                    await commitFaultApplication.ConfigureAwait(false);
+                    lock (_gate)
+                    {
+                        ThrowIfSnapshotStateChangedUnderLock(
+                            consumerStateVersion,
+                            consumerGroupGeneration);
+                        CommitCapturedOffsetsUnderLock(completionOffsets);
+                    }
+
                     yield break;
+                }
+
+                var fetchScope = new KafkaFaultScope(
+                    KafkaFaultOperation.Fetch,
+                    partition.Topic,
+                    partition.Partition,
+                    _groupId);
+                if (applyRecordFaults && _cluster.FaultPlan.HasMatchingFault(fetchScope))
+                {
+                    await _cluster.FaultPlan.ApplyAsync(
+                        fetchScope,
+                        cancellationToken).ConfigureAwait(false);
+                    ThrowIfSnapshotStateChanged(
+                        consumerStateVersion,
+                        consumerGroupGeneration);
+                }
 
                 var result = _hasAsyncDeserializers
-                    ? await ToConsumeResultAsync(partition, record, cancellationToken).ConfigureAwait(false)
+                    ? await ToConsumeResultAsync(
+                        partition,
+                        record,
+                        cancellationToken).ConfigureAwait(false)
                     : ToConsumeResult(partition, record);
 
-                if (!TryAdvanceSnapshotPosition(
+                applyRecordFaults = HasPotentialConsumerFault(
+                    consumerStateVersion,
+                    consumerGroupGeneration);
+
+                var consumeScope = new KafkaFaultScope(
+                    KafkaFaultOperation.Consume,
+                    partition.Topic,
+                    partition.Partition,
+                    _groupId);
+                if (applyRecordFaults && _cluster.FaultPlan.HasMatchingFault(consumeScope))
+                {
+                    await _cluster.FaultPlan.ApplyAsync(
+                        consumeScope,
+                        cancellationToken).ConfigureAwait(false);
+                    ThrowIfSnapshotStateChanged(
+                        consumerStateVersion,
+                        consumerGroupGeneration);
+                }
+
+                if (!TryPrepareSnapshotOnDeliveryAutoCommitFault(
+                        partition,
+                        position,
+                        record.Offset + 1,
+                        consumerStateVersion,
+                        consumerGroupGeneration,
+                        cancellationToken,
+                        out var hasAutoCommitReservation,
+                        out var autoCommitFaultApplication))
+                {
+                    continue;
+                }
+
+                if (hasAutoCommitReservation)
+                {
+                    await ApplyOnDeliveryAutoCommitFaultAsync(
+                        autoCommitFaultApplication,
+                        partition,
+                        position,
+                        cancellationToken).ConfigureAwait(false);
+                }
+
+                var positionAdvanced = hasAutoCommitReservation
+                    ? TryAdvanceReservedSnapshotPosition(
                         partition,
                         record,
                         position,
                         consumerStateVersion,
-                        consumerGroupGeneration))
+                        consumerGroupGeneration)
+                    : TryAdvanceSnapshotPosition(
+                        partition,
+                        record,
+                        position,
+                        consumerStateVersion,
+                        consumerGroupGeneration);
+                if (!positionAdvanced)
                     continue;
 
                 yield return result;
+                // The caller can add fault rules while enumeration is suspended at the yield.
+                // Reuse the fault-cache state reads to validate the snapshot before a commit
+                // fault can be consumed on the next iteration.
+                applyRecordFaults = HasPotentialConsumerFault(
+                    consumerStateVersion,
+                    consumerGroupGeneration);
             }
         }
         finally
@@ -548,19 +740,26 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (_hasAsyncDeserializers)
+            if (!_hasAsyncDeserializers && !HasPotentialConsumerFault())
             {
-                if (await TryConsumeOneAsync(cancellationToken).ConfigureAwait(false) is { } asyncResult)
-                    return asyncResult;
+                if (TryConsumeOne(out var result, out var retryWithFaults))
+                    return result;
+                if (retryWithFaults)
+                    continue;
             }
-            else if (TryConsumeOne(out var result))
+            else
             {
-                return result;
+                var attempt = await TryConsumeOneAsync(cancellationToken).ConfigureAwait(false);
+                if (attempt.Result is { } asyncResult)
+                    return asyncResult;
+                if (attempt.StopPolling)
+                    return null;
             }
 
             if (deadline is null)
             {
                 await _cluster.WaitForRecordsAsync(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+                ThrowIfDisposed();
                 continue;
             }
 
@@ -571,6 +770,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             try
             {
                 await _cluster.WaitForRecordsAsync(remaining, cancellationToken).ConfigureAwait(false);
+                ThrowIfDisposed();
             }
             catch (TimeoutException)
             {
@@ -613,24 +813,64 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         ThrowIfDisposed();
     }
 
-    public ValueTask CommitAsync(CancellationToken cancellationToken = default)
+    public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
-        _ = GetCommitGroupId();
+        var groupId = GetCommitGroupId();
+
+        TopicPartitionOffset? inDoubtRecord;
+        TopicPartitionOffset[] offsets;
+        int consumerStateVersion;
+        bool hasFaultApplication;
+        ValueTask faultApplication;
+        lock (_gate)
+        {
+            consumerStateVersion = _consumerStateVersion;
+            inDoubtRecord = _inDoubtNextOffset >= 0
+                ? new TopicPartitionOffset(
+                    _inDoubtPartition.Topic,
+                    _inDoubtPartition.Partition,
+                    _inDoubtNextOffset)
+                : null;
+            var inDoubtCommitOffset = _options.EnableAutoOffsetStore
+                ? inDoubtRecord
+                : null;
+            offsets = CaptureCommitOffsetsUnderLock(inDoubtCommitOffset);
+            hasFaultApplication = TryApplyMatchingCapturedCommitFault(
+                groupId,
+                offsets,
+                cancellationToken,
+                out faultApplication);
+        }
+
+        if (hasFaultApplication)
+        {
+            await faultApplication.ConfigureAwait(false);
+            ThrowIfDisposed();
+        }
 
         lock (_gate)
         {
-            // Explicit commit: the caller vouches for everything delivered so far,
-            // including the in-doubt record still being processed.
-            ProveInDoubtRecordUnderLock();
-            CommitStoredOffsets();
-        }
+            ThrowIfDisposed();
+            if (_consumerStateVersion == consumerStateVersion &&
+                inDoubtRecord is { } capturedInDoubt &&
+                _inDoubtNextOffset == capturedInDoubt.Offset &&
+                _inDoubtPartition.Topic == capturedInDoubt.Topic &&
+                _inDoubtPartition.Partition == capturedInDoubt.Partition)
+            {
+                // Explicit commit proves the record that was in doubt when this call began.
+                if (_options.EnableAutoOffsetStore)
+                    StoreOffsetUnderLock(capturedInDoubt);
+                ClearInDoubtRecordUnderLock();
+            }
 
-        return ValueTask.CompletedTask;
+            if (_consumerStateVersion == consumerStateVersion && offsets.Length != 0)
+                _cluster.CommitOffsets(groupId, offsets);
+        }
     }
 
-    public ValueTask CommitAsync(
+    public async ValueTask CommitAsync(
         IEnumerable<TopicPartitionOffset> offsets,
         CancellationToken cancellationToken = default)
     {
@@ -638,10 +878,93 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
         var groupId = GetCommitGroupId();
+        var faultPlan = _cluster.FaultPlan;
+        IReadOnlyList<TopicPartitionOffset>? offsetList = offsets as IReadOnlyList<TopicPartitionOffset>;
+        if (faultPlan.Count == 0)
+        {
+            offsetList ??= offsets.ToArray();
+            _cluster.CommitOffsets(groupId, offsetList);
+            return;
+        }
 
-        _cluster.CommitOffsets(groupId, offsets);
+        var faultApplied = false;
+        if (faultPlan is KafkaFaultPlan indexedPlan &&
+            offsetList is null &&
+            indexedPlan.HasPotentialMatch(KafkaFaultOperation.Commit, groupId))
+        {
+            offsetList = offsets.ToArray();
+            if (indexedPlan.TryApplyLeadingUnconditionalCommitFault(
+                    groupId,
+                    out var unconditionalApplication,
+                    cancellationToken))
+            {
+                await unconditionalApplication.ConfigureAwait(false);
+                ThrowIfDisposed();
+                faultApplied = true;
+            }
+        }
 
-        return ValueTask.CompletedTask;
+        offsetList ??= offsets.ToArray();
+        if (!faultApplied &&
+            offsetList.Count == 0 &&
+            faultPlan is KafkaFaultPlan emptyInputPlan &&
+            emptyInputPlan.HasPotentialMatch(KafkaFaultOperation.Commit, groupId) &&
+            emptyInputPlan.TryApplyUnconditionalCommitFault(
+                groupId,
+                out var emptyInputApplication,
+                cancellationToken))
+        {
+            await emptyInputApplication.ConfigureAwait(false);
+            ThrowIfDisposed();
+            faultApplied = true;
+        }
+
+        if (!faultApplied && faultPlan is KafkaFaultPlan orderedPlan)
+        {
+            if (orderedPlan.HasPotentialMatch(KafkaFaultOperation.Commit, groupId))
+            {
+                if (ReferenceEquals(offsetList, offsets))
+                    offsetList = offsetList.ToArray();
+
+                if (orderedPlan.TryApplyFirstMatchingCommitFault(
+                        groupId,
+                        offsetList,
+                        out var faultApplication,
+                        cancellationToken))
+                {
+                    await faultApplication.ConfigureAwait(false);
+                    ThrowIfDisposed();
+                }
+            }
+        }
+        else if (!faultApplied && faultPlan.Count != 0)
+        {
+            if (ReferenceEquals(offsetList, offsets))
+                offsetList = offsetList.ToArray();
+
+            var candidateScopes = new KafkaFaultScope[offsetList.Count + 1];
+            candidateScopes[0] = new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: groupId);
+            for (var index = 0; index < offsetList.Count; index++)
+            {
+                var offset = offsetList[index];
+                candidateScopes[index + 1] = new KafkaFaultScope(
+                    KafkaFaultOperation.Commit,
+                    offset.Topic,
+                    offset.Partition,
+                    groupId);
+            }
+
+            if (faultPlan.TryApplyFirstMatchingFault(
+                    candidateScopes,
+                    out var faultApplication,
+                    cancellationToken))
+            {
+                await faultApplication.ConfigureAwait(false);
+                ThrowIfDisposed();
+            }
+        }
+
+        _cluster.CommitOffsets(groupId, offsetList);
     }
 
     private string GetCommitGroupId() => _groupId
@@ -665,9 +988,18 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     {
         ThrowIfDisposed();
         TopicPartitionOffsetValidator.Validate(offset, nameof(offset));
+        ApplySynchronousFaultIfMatching(new KafkaFaultScope(
+            KafkaFaultOperation.StoreOffset,
+            offset.Topic,
+            offset.Partition,
+            _groupId));
+        ThrowIfDisposed();
 
         lock (_gate)
+        {
+            ThrowIfDisposed();
             StoreOffsetUnderLock(offset);
+        }
     }
 
     public void StoreOffsets<TOffsets>(TOffsets offsets)
@@ -678,13 +1010,30 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         ThrowIfDisposed();
 
         var count = offsets.Count;
+        var snapshot = new TopicPartitionOffset[count];
         for (var index = 0; index < count; index++)
-            TopicPartitionOffsetValidator.Validate(offsets[index], nameof(offsets));
+        {
+            var offset = offsets[index];
+            TopicPartitionOffsetValidator.Validate(offset, nameof(offsets));
+            snapshot[index] = offset;
+        }
+
+        for (var index = 0; index < count; index++)
+        {
+            var offset = snapshot[index];
+            ApplySynchronousFaultIfMatching(new KafkaFaultScope(
+                KafkaFaultOperation.StoreOffset,
+                offset.Topic,
+                offset.Partition,
+                _groupId));
+            ThrowIfDisposed();
+        }
 
         lock (_gate)
         {
+            ThrowIfDisposed();
             for (var index = 0; index < count; index++)
-                StoreOffsetUnderLock(offsets[index]);
+                StoreOffsetUnderLock(snapshot[index]);
         }
     }
 
@@ -692,13 +1041,26 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     {
         ThrowIfDisposed();
 
+        var snapshot = offsets.ToArray();
         for (var index = 0; index < offsets.Length; index++)
-            TopicPartitionOffsetValidator.Validate(offsets[index], nameof(offsets));
+            TopicPartitionOffsetValidator.Validate(snapshot[index], nameof(offsets));
+
+        for (var index = 0; index < snapshot.Length; index++)
+        {
+            var offset = snapshot[index];
+            ApplySynchronousFaultIfMatching(new KafkaFaultScope(
+                KafkaFaultOperation.StoreOffset,
+                offset.Topic,
+                offset.Partition,
+                _groupId));
+            ThrowIfDisposed();
+        }
 
         lock (_gate)
         {
-            for (var index = 0; index < offsets.Length; index++)
-                StoreOffsetUnderLock(offsets[index]);
+            ThrowIfDisposed();
+            for (var index = 0; index < snapshot.Length; index++)
+                StoreOffsetUnderLock(snapshot[index]);
         }
     }
 
@@ -720,24 +1082,115 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (_disposed)
-            return ValueTask.CompletedTask;
+        Task closeTask;
+        TaskCompletionSource? closeCompletion = null;
+        lock (_gate)
+        {
+            if (_closeTask is { IsCompleted: false } activeClose)
+            {
+                closeTask = activeClose;
+            }
+            else
+            {
+                if (_disposed)
+                    return ValueTask.CompletedTask;
 
+                closeCompletion = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                closeTask = closeCompletion.Task;
+                _closeTask = closeTask;
+            }
+        }
+
+        if (closeCompletion is not null)
+        {
+            _ = RunCloseAsync(closeCompletion, cancellationToken);
+            return new ValueTask(closeTask);
+        }
+
+        return cancellationToken.CanBeCanceled
+            ? new ValueTask(closeTask.WaitAsync(cancellationToken))
+            : new ValueTask(closeTask);
+    }
+
+    private async ValueTask RunCloseAsync(
+        TaskCompletionSource completion,
+        CancellationToken cancellationToken)
+    {
+        TopicPartitionOffset[]? capturedOffsets = null;
+        Exception? failure = null;
+        try
+        {
+            ValueTask commitFaultApplication;
+            lock (_gate)
+            {
+                capturedOffsets = CaptureStoredAutoCommitOffsetsUnderLock(
+                    cancellationToken,
+                    out commitFaultApplication);
+            }
+
+            await commitFaultApplication.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            failure = ex;
+            capturedOffsets = null;
+        }
+
+        try
+        {
+            await CompleteClose(capturedOffsets).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            failure = failure is null
+                ? ex
+                : new AggregateException(failure, ex);
+        }
+
+        if (failure is null)
+            completion.TrySetResult();
+        else if (failure is OperationCanceledException canceled)
+            completion.TrySetCanceled(canceled.CancellationToken);
+        else
+            completion.TrySetException(failure);
+    }
+
+    private ValueTask CompleteClose(TopicPartitionOffset[]? capturedOffsets)
+    {
         lock (_gate)
         {
             if (_disposed)
                 return ValueTask.CompletedTask;
 
-            if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
-                CommitStoredOffsets();
+            if (capturedOffsets is not null)
+                CommitCapturedOffsetsUnderLock(capturedOffsets);
 
             // The in-memory cluster has no broker session timer. Always unregister on close so
             // RemainInGroup cannot create an immortal member that permanently owns partitions.
             UnregisterConsumerGroupMemberUnderLock();
             _consumerStateVersion++;
             _disposed = true;
+            _autoCommitAdvancementWaiterEntered?.TrySetResult();
+            _autoCommitAdvancementWaiterEntered = null;
+            if (_pendingAutoCommitAdvancements is not null)
+            {
+                foreach (var (partition, pending) in _pendingAutoCommitAdvancements)
+                {
+                    _paused.Remove(partition);
+                    pending.Completion.TrySetResult(new CapturedAutoCommitProof(
+                        partition,
+                        pending.Position,
+                        pending.CapturedOffsets,
+                        SharedWaiter: true,
+                        SharedWaiterCompletion: null));
+                }
+
+                _pendingAutoCommitAdvancements = null;
+            }
         }
 
+        _cluster.SignalRecordsChanged();
         return ValueTask.CompletedTask;
     }
 
@@ -843,6 +1296,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            ThrowIfAutoCommitAdvancementPendingUnderLock();
             _subscriptionPattern = null;
             _subscription.Clear();
             ReplaceAssignment(partitions);
@@ -856,11 +1310,13 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            ThrowIfAutoCommitAdvancementPendingUnderLock();
             _assignment.Clear();
             _paused.Clear();
             _positions.Clear();
             _storedOffsets.Clear();
-            _inDoubtNextOffset = -1;
+            _storedOffsetsVersion++;
+            ClearInDoubtRecordUnderLock();
             _consumerStateVersion++;
             UnregisterConsumerGroupMemberUnderLock();
         }
@@ -873,6 +1329,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            ThrowIfAutoCommitAdvancementPendingUnderLock();
             var changed = false;
             foreach (var offset in partitions)
             {
@@ -898,6 +1355,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            ThrowIfAutoCommitAdvancementPendingUnderLock();
             var changed = false;
             foreach (var partition in partitions)
             {
@@ -905,7 +1363,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 _assignment.Remove(partition);
                 _paused.Remove(partition);
                 _positions.Remove(partition);
-                _storedOffsets.Remove(partition);
+                if (_storedOffsets.Remove(partition))
+                    _storedOffsetsVersion++;
                 DiscardInDoubtRecordUnderLock(partition);
             }
 
@@ -923,10 +1382,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
-            var changed = false;
-            foreach (var partition in partitions)
-                changed |= _paused.Add(partition);
-            if (changed)
+            if (SetPauseStateUnderLock(partitions, pause: true))
                 _consumerStateVersion++;
         }
     }
@@ -938,12 +1394,37 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
-            var changed = false;
-            foreach (var partition in partitions)
-                changed |= _paused.Remove(partition);
-            if (changed)
+            if (SetPauseStateUnderLock(partitions, pause: false))
                 _consumerStateVersion++;
         }
+    }
+
+    private bool SetPauseStateUnderLock(IReadOnlyList<TopicPartition> partitions, bool pause)
+    {
+        var changed = false;
+        for (var index = 0; index < partitions.Count; index++)
+        {
+            var partition = partitions[index];
+            if (_pendingAutoCommitAdvancements is not null &&
+                _pendingAutoCommitAdvancements.TryGetValue(partition, out var pending))
+            {
+                var resumePartition = !pause;
+                if (pending.ResumePartition != resumePartition)
+                {
+                    _pendingAutoCommitAdvancements[partition] = pending with
+                    {
+                        ResumePartition = resumePartition
+                    };
+                    changed = true;
+                }
+            }
+            else
+            {
+                changed |= pause ? _paused.Add(partition) : _paused.Remove(partition);
+            }
+        }
+
+        return changed;
     }
 
     public ValueTask<IReadOnlyDictionary<TopicPartition, long>> GetOffsetsForTimesAsync(
@@ -976,12 +1457,21 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         return ValueTask.FromResult(_cluster.GetWatermarks(topicPartition));
     }
 
-    private bool TryConsumeOne(out ConsumeResult<TKey, TValue> result)
+    private bool TryConsumeOne(
+        out ConsumeResult<TKey, TValue> result,
+        out bool retryWithFaults)
     {
+        retryWithFaults = false;
         var previousRecordProven = false;
         while (true)
         {
-            if (!TrySelectRecord(ref previousRecordProven, out var partition, out var record, out var position))
+            if (!TrySelectRecordWithVersion(
+                    ref previousRecordProven,
+                    capturedProof: null,
+                    out var partition,
+                    out var record,
+                    out var position,
+                    out var selectionVersion))
             {
                 result = default;
                 return false;
@@ -991,7 +1481,15 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             // leaves the selected offset untouched so the next consume retries the record.
             var selectedResult = ToConsumeResult(partition, record);
 
-            if (!TryAdvancePosition(partition, record, position))
+            if (Volatile.Read(ref _potentialFaultPlanVersion) != GetFaultPlanVersion() &&
+                HasPotentialConsumerFault())
+            {
+                retryWithFaults = true;
+                result = default;
+                return false;
+            }
+
+            if (!TryAdvancePosition(partition, record, position, in selectionVersion))
                 continue;
 
             result = selectedResult;
@@ -1004,11 +1502,31 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         ref int activePartitionIndex,
         out TopicPartition selectedPartition,
         out InMemoryRecord selectedRecord,
-        out long selectedPosition)
+        out long selectedPosition,
+        out bool pendingAutoCommitAdvancement)
     {
+        if (IsInDoubtAutoCommitAdvancementPendingUnderLock())
+        {
+            selectedPartition = _inDoubtPartition;
+            selectedRecord = null!;
+            selectedPosition = -1;
+            pendingAutoCommitAdvancement = true;
+            return false;
+        }
+
         while (activePartitionIndex < partitions.Length)
         {
             var bound = partitions[activePartitionIndex];
+            if (_pendingAutoCommitAdvancements is not null &&
+                _pendingAutoCommitAdvancements.ContainsKey(bound.Partition))
+            {
+                selectedPartition = bound.Partition;
+                selectedRecord = null!;
+                selectedPosition = -1;
+                pendingAutoCommitAdvancement = true;
+                return false;
+            }
+
             if (_positions.TryGetValue(bound.Partition, out var position) &&
                 position < bound.EndOffset)
             {
@@ -1023,6 +1541,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                     selectedPartition = bound.Partition;
                     selectedRecord = record;
                     selectedPosition = position;
+                    pendingAutoCommitAdvancement = false;
                     return true;
                 }
 
@@ -1046,7 +1565,47 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         selectedPartition = default;
         selectedRecord = null!;
         selectedPosition = -1;
+        pendingAutoCommitAdvancement = false;
         return false;
+    }
+
+    private ValueTask WaitForAutoCommitAdvancementAsync(
+        TopicPartition partition,
+        CancellationToken cancellationToken)
+    {
+        Task? advancementChanged;
+        lock (_gate)
+        {
+            advancementChanged = _pendingAutoCommitAdvancements is not null &&
+                                 _pendingAutoCommitAdvancements.TryGetValue(partition, out var pending)
+                ? pending.Completion.Task
+                : null;
+            if (advancementChanged is not null)
+            {
+                _autoCommitAdvancementWaiterEntered?.TrySetResult();
+                _autoCommitAdvancementWaiterEntered = null;
+            }
+        }
+
+        return advancementChanged is null
+            ? ValueTask.CompletedTask
+            : new ValueTask(advancementChanged.WaitAsync(cancellationToken));
+    }
+
+    internal Task WaitUntilAutoCommitAdvancementWaiterEnteredAsync()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+                return Task.CompletedTask;
+
+            if (_autoCommitAdvancementWaiterEntered is { Task.IsCompleted: false } existing)
+                return existing.Task;
+
+            _autoCommitAdvancementWaiterEntered = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            return _autoCommitAdvancementWaiterEntered.Task;
+        }
     }
 
     private void ThrowIfSnapshotActiveUnderLock()
@@ -1056,6 +1615,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             throw new InvalidOperationException(
                 "Cannot change consumer position while a snapshot enumeration is active.");
         }
+
+        ThrowIfAutoCommitAdvancementPendingUnderLock();
     }
 
     private void ThrowIfSnapshotStateChangedUnderLock(
@@ -1078,38 +1639,131 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         ThrowSnapshotStateChanged();
     }
 
+    private void ThrowIfSnapshotStateChanged(
+        int consumerStateVersion,
+        int consumerGroupGeneration)
+    {
+        lock (_gate)
+        {
+            ThrowIfSnapshotStateChangedUnderLock(
+                consumerStateVersion,
+                consumerGroupGeneration);
+        }
+    }
+
     [DoesNotReturn]
     private static void ThrowSnapshotStateChanged() =>
         throw new InvalidOperationException(
             "The consumer assignment or pause state changed while a snapshot enumeration was active.");
 
     /// <summary>
-    /// Consume path used when at least one component has an <see cref="IAsyncDeserializer{T}"/>.
-    /// Deliberate mirror of <see cref="TryConsumeOne"/>: both drive the same selection and
-    /// delivery bookkeeping helpers so their offset semantics cannot drift apart.
+    /// Consume path used when fault injection is active or a component has an
+    /// <see cref="IAsyncDeserializer{T}"/>. Faults run before position advancement so a retry
+    /// sees the same record.
     /// </summary>
-    private async ValueTask<ConsumeResult<TKey, TValue>?> TryConsumeOneAsync(CancellationToken cancellationToken)
+    private async ValueTask<ConsumeAttemptResult> TryConsumeOneAsync(
+        CancellationToken cancellationToken)
     {
-        var previousRecordProven = false;
-        while (true)
+        var capturedProof = await ApplyInDoubtAutoCommitFaultAsync(
+            cancellationToken).ConfigureAwait(false);
+        ThrowIfDisposed();
+        if (capturedProof is { SharedWaiter: true })
+            return new ConsumeAttemptResult(Result: null, StopPolling: true);
+
+        try
         {
-            if (!TrySelectRecord(ref previousRecordProven, out var partition, out var record, out var position))
-                return null;
+            var previousRecordProven = false;
+            while (true)
+            {
+                if (!TrySelectRecordWithVersion(
+                        ref previousRecordProven,
+                        capturedProof,
+                        out var partition,
+                        out var record,
+                        out var position,
+                        out var selectionVersion))
+                    return new ConsumeAttemptResult(Result: null, StopPolling: false);
 
-            var selectedResult = await ToConsumeResultAsync(partition, record, cancellationToken).ConfigureAwait(false);
+                var fetchScope = new KafkaFaultScope(
+                    KafkaFaultOperation.Fetch,
+                    partition.Topic,
+                    partition.Partition,
+                    _groupId);
+                if (HasMatchingFault(fetchScope))
+                {
+                    await _cluster.FaultPlan.ApplyAsync(
+                        fetchScope,
+                        cancellationToken).ConfigureAwait(false);
+                    ThrowIfDisposed();
+                    if (!IsRecordSelectionCurrent(partition, position, in selectionVersion))
+                        continue;
+                }
 
-            if (!TryAdvancePosition(partition, record, position))
-                continue;
+                var selectedResult = _hasAsyncDeserializers
+                    ? await ToConsumeResultAsync(partition, record, cancellationToken).ConfigureAwait(false)
+                    : ToConsumeResult(partition, record);
 
-            return selectedResult;
+                ThrowIfDisposed();
+                if (!IsRecordSelectionCurrent(partition, position, in selectionVersion))
+                    continue;
+
+                var consumeScope = new KafkaFaultScope(
+                    KafkaFaultOperation.Consume,
+                    partition.Topic,
+                    partition.Partition,
+                    _groupId);
+                if (HasMatchingFault(consumeScope))
+                {
+                    await _cluster.FaultPlan.ApplyAsync(
+                        consumeScope,
+                        cancellationToken).ConfigureAwait(false);
+                    ThrowIfDisposed();
+                    if (!IsRecordSelectionCurrent(partition, position, in selectionVersion))
+                        continue;
+                }
+
+                if (!TryPrepareOnDeliveryAutoCommitFault(
+                        partition,
+                        position,
+                        record.Offset + 1,
+                        cancellationToken,
+                        out var hasAutoCommitReservation,
+                        out var autoCommitFaultApplication))
+                {
+                    continue;
+                }
+
+                if (hasAutoCommitReservation)
+                {
+                    await ApplyOnDeliveryAutoCommitFaultAsync(
+                        autoCommitFaultApplication,
+                        partition,
+                        position,
+                        cancellationToken).ConfigureAwait(false);
+                }
+
+                var positionAdvanced = hasAutoCommitReservation
+                    ? TryAdvanceReservedPosition(partition, record, position, in selectionVersion)
+                    : TryAdvancePosition(partition, record, position, in selectionVersion);
+                if (!positionAdvanced)
+                    continue;
+
+                return new ConsumeAttemptResult(selectedResult, StopPolling: false);
+            }
+        }
+        finally
+        {
+            CompleteSharedAutoCommitWaiters(capturedProof);
         }
     }
 
-    private bool TrySelectRecord(
+    private bool TrySelectRecordWithVersion(
         ref bool previousRecordProven,
+        CapturedAutoCommitProof? capturedProof,
         out TopicPartition selectedPartition,
         out InMemoryRecord selectedRecord,
-        out long selectedPosition)
+        out long selectedPosition,
+        out ConsumerSelectionVersion selectionVersion)
     {
         lock (_gate)
         {
@@ -1117,19 +1771,37 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             {
                 // A new consume call proves the previously delivered record was processed
                 // (poll contract) — stage it before selecting the next one.
-                ProveInDoubtRecordUnderLock();
+                ProveInDoubtRecordUnderLock(capturedProof);
+                if (IsInDoubtAutoCommitAdvancementPendingUnderLock())
+                {
+                    selectedPartition = default;
+                    selectedRecord = null!;
+                    selectedPosition = -1;
+                    selectionVersion = default;
+                    return false;
+                }
+
                 previousRecordProven = true;
             }
 
-            foreach (var partition in GetCurrentAssignmentUnderLock().OrderBy(item => item.Topic, StringComparer.Ordinal).ThenBy(item => item.Partition))
+            var assignment = GetOrderedCurrentAssignmentUnderLock(out var consumerGroupGeneration);
+            selectionVersion = new ConsumerSelectionVersion(
+                _consumerStateVersion,
+                consumerGroupGeneration);
+            for (var partitionIndex = 0; partitionIndex < assignment.Length; partitionIndex++)
             {
+                var partition = assignment[partitionIndex];
                 if (_paused.Contains(partition))
                     continue;
 
                 if (!_positions.TryGetValue(partition, out var position))
                     continue;
 
-                if (!_cluster.TryRead(partition, position, _options.IsolationLevel, out var record))
+                if (!_cluster.TryRead(
+                        partition,
+                        position,
+                        _options.IsolationLevel,
+                        out var record))
                     continue;
 
                 selectedPartition = partition;
@@ -1142,6 +1814,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         selectedPartition = default;
         selectedRecord = null!;
         selectedPosition = -1;
+        selectionVersion = default;
         return false;
     }
 
@@ -1150,28 +1823,119 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     /// user deserializers ran, in which case the caller must reselect instead of publishing a
     /// stale result.
     /// </summary>
-    private bool TryAdvancePosition(TopicPartition partition, InMemoryRecord record, long expectedPosition)
+    private bool TryAdvancePosition(
+        TopicPartition partition,
+        InMemoryRecord record,
+        long expectedPosition,
+        in ConsumerSelectionVersion selectionVersion)
     {
         lock (_gate)
         {
-            if (!_positions.TryGetValue(partition, out var currentPosition) || currentPosition != expectedPosition)
+            if (_pendingAutoCommitAdvancements is not null &&
+                _pendingAutoCommitAdvancements.ContainsKey(partition))
+            {
                 return false;
-
-            _positions[partition] = record.Offset + 1;
-            if (_options.OffsetStoreTiming == OffsetStoreTiming.OnDelivery)
-            {
-                if (_options.EnableAutoOffsetStore)
-                    StoreOffsetUnderLock(partition, record.Offset + 1);
-                if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
-                    CommitStoredOffsets();
-            }
-            else
-            {
-                _inDoubtPartition = partition;
-                _inDoubtNextOffset = record.Offset + 1;
             }
 
+            if (!IsRecordSelectionCurrentUnderLock(
+                    partition,
+                    expectedPosition,
+                    in selectionVersion))
+            {
+                return false;
+            }
+
+            AdvancePositionUnderLock(partition, record);
             return true;
+        }
+    }
+
+    private bool TryAdvanceReservedPosition(
+        TopicPartition partition,
+        InMemoryRecord record,
+        long expectedPosition,
+        in ConsumerSelectionVersion selectionVersion)
+    {
+        lock (_gate)
+        {
+            if (_pendingAutoCommitAdvancements is null ||
+                !_pendingAutoCommitAdvancements.TryGetValue(partition, out var pending) ||
+                pending.Position != expectedPosition)
+            {
+                return false;
+            }
+
+            try
+            {
+                if (!IsRecordSelectionCurrentUnderLock(
+                        partition,
+                        expectedPosition,
+                        in selectionVersion))
+                    return false;
+
+                AdvancePositionUnderLock(partition, record, pending.CapturedOffsets);
+                return true;
+            }
+            finally
+            {
+                ClearPendingAutoCommitAdvancementUnderLock(partition, expectedPosition);
+            }
+        }
+    }
+
+    private bool IsRecordSelectionCurrent(
+        TopicPartition partition,
+        long expectedPosition,
+        in ConsumerSelectionVersion selectionVersion)
+    {
+        lock (_gate)
+        {
+            return IsRecordSelectionCurrentUnderLock(
+                partition,
+                expectedPosition,
+                in selectionVersion);
+        }
+    }
+
+    private bool IsRecordSelectionCurrentUnderLock(
+        TopicPartition partition,
+        long expectedPosition,
+        in ConsumerSelectionVersion selectionVersion)
+    {
+        ThrowIfDisposed();
+        if (_consumerStateVersion != selectionVersion.ConsumerState ||
+            selectionVersion.ConsumerGroupGeneration >= 0 &&
+            _groupId is not null &&
+            _cluster.GetConsumerGroupGeneration(_groupId) != selectionVersion.ConsumerGroupGeneration)
+        {
+            return false;
+        }
+
+        return _positions.TryGetValue(partition, out var currentPosition) &&
+               currentPosition == expectedPosition;
+    }
+
+    private void AdvancePositionUnderLock(
+        TopicPartition partition,
+        InMemoryRecord record,
+        TopicPartitionOffset[]? capturedOffsets = null)
+    {
+        _positions[partition] = record.Offset + 1;
+        if (_options.OffsetStoreTiming == OffsetStoreTiming.OnDelivery)
+        {
+            if (_options.EnableAutoOffsetStore)
+                StoreOffsetUnderLock(partition, record.Offset + 1);
+            if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
+            {
+                if (capturedOffsets is null)
+                    CommitStoredOffsets();
+                else
+                    CommitCapturedOffsetsUnderLock(capturedOffsets);
+            }
+        }
+        else
+        {
+            SetInDoubtRecordUnderLock(partition, record.Offset + 1);
         }
     }
 
@@ -1184,52 +1948,146 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     {
         lock (_gate)
         {
-            ThrowIfSnapshotStateChangedUnderLock(
+            if (_pendingAutoCommitAdvancements is not null &&
+                _pendingAutoCommitAdvancements.ContainsKey(partition))
+            {
+                return false;
+            }
+
+            return TryAdvanceSnapshotPositionUnderLock(
+                partition,
+                record,
+                expectedPosition,
                 consumerStateVersion,
                 consumerGroupGeneration);
-            if (!_positions.TryGetValue(partition, out var currentPosition) || currentPosition != expectedPosition)
-                return false;
-
-            _positions[partition] = record.Offset + 1;
-            if (_options.OffsetStoreTiming == OffsetStoreTiming.OnDelivery)
-            {
-                if (_options.EnableAutoOffsetStore)
-                    StoreOffsetUnderLock(partition, record.Offset + 1);
-                if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
-                    CommitStoredOffsets();
-            }
-            else
-            {
-                _inDoubtPartition = partition;
-                _inDoubtNextOffset = record.Offset + 1;
-            }
-
-            return true;
         }
+    }
+
+    private bool TryAdvanceReservedSnapshotPosition(
+        TopicPartition partition,
+        InMemoryRecord record,
+        long expectedPosition,
+        int consumerStateVersion,
+        int consumerGroupGeneration)
+    {
+        lock (_gate)
+        {
+            if (_pendingAutoCommitAdvancements is null ||
+                !_pendingAutoCommitAdvancements.TryGetValue(partition, out var pending) ||
+                pending.Position != expectedPosition)
+            {
+                return false;
+            }
+
+            try
+            {
+                ThrowIfSnapshotStateChangedUnderLock(
+                    consumerStateVersion,
+                    consumerGroupGeneration);
+                if (!_positions.TryGetValue(partition, out var currentPosition) ||
+                    currentPosition != expectedPosition)
+                {
+                    return false;
+                }
+
+                AdvancePositionUnderLock(partition, record, pending.CapturedOffsets);
+                return true;
+            }
+            finally
+            {
+                ClearPendingAutoCommitAdvancementUnderLock(partition, expectedPosition);
+            }
+        }
+    }
+
+    private bool TryAdvanceSnapshotPositionUnderLock(
+        TopicPartition partition,
+        InMemoryRecord record,
+        long expectedPosition,
+        int consumerStateVersion,
+        int consumerGroupGeneration)
+    {
+        ThrowIfSnapshotStateChangedUnderLock(
+            consumerStateVersion,
+            consumerGroupGeneration);
+        if (!_positions.TryGetValue(partition, out var currentPosition) || currentPosition != expectedPosition)
+            return false;
+
+        _positions[partition] = record.Offset + 1;
+        if (_options.OffsetStoreTiming == OffsetStoreTiming.OnDelivery)
+        {
+            if (_options.EnableAutoOffsetStore)
+                StoreOffsetUnderLock(partition, record.Offset + 1);
+            if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
+                CommitStoredOffsets();
+        }
+        else
+        {
+            SetInDoubtRecordUnderLock(partition, record.Offset + 1);
+        }
+
+        return true;
     }
 
     /// <summary>
     /// Stages (and under Auto mode commits) the in-doubt record's offset. Called when the
     /// application demonstrably moved past it: a subsequent consume call or explicit commit.
     /// </summary>
-    private void ProveInDoubtRecordUnderLock()
+    private void ProveInDoubtRecordUnderLock(
+        CapturedAutoCommitProof? capturedProof = null,
+        bool commitAutomatically = true)
     {
         if (_inDoubtNextOffset < 0)
+            return;
+
+        if (capturedProof is { } proof &&
+            (_inDoubtNextOffset != proof.Position || !_inDoubtPartition.Equals(proof.Partition)))
+        {
+            return;
+        }
+
+        if (IsInDoubtAutoCommitAdvancementPendingUnderLock())
             return;
 
         if (_options.EnableAutoOffsetStore)
             StoreOffsetUnderLock(_inDoubtPartition, _inDoubtNextOffset);
 
-        _inDoubtNextOffset = -1;
+        ClearInDoubtRecordUnderLock();
 
-        if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
-            CommitStoredOffsets();
+        if (commitAutomatically && _options.OffsetCommitMode == OffsetCommitMode.Auto)
+        {
+            if (capturedProof is null)
+                CommitStoredOffsets();
+            else
+                CommitCapturedOffsetsUnderLock(capturedProof.Value.Offsets);
+        }
     }
+
+    private bool IsInDoubtAutoCommitAdvancementPendingUnderLock() =>
+        _inDoubtNextOffset >= 0 &&
+        _pendingAutoCommitAdvancements is not null &&
+        _pendingAutoCommitAdvancements.TryGetValue(_inDoubtPartition, out var pending) &&
+        pending.Position == _inDoubtNextOffset;
 
     private void DiscardInDoubtRecordUnderLock(TopicPartition partition)
     {
         if (_inDoubtNextOffset >= 0 && _inDoubtPartition.Equals(partition))
-            _inDoubtNextOffset = -1;
+            ClearInDoubtRecordUnderLock();
+    }
+
+    private void SetInDoubtRecordUnderLock(TopicPartition partition, long nextOffset)
+    {
+        _inDoubtPartition = partition;
+        _inDoubtNextOffset = nextOffset;
+    }
+
+    private void ClearInDoubtRecordUnderLock()
+    {
+        if (_inDoubtNextOffset < 0)
+            return;
+
+        _inDoubtNextOffset = -1;
+        _cluster.SignalRecordsChanged();
     }
 
     private ConsumeResult<TKey, TValue> ToConsumeResult(TopicPartition topicPartition, InMemoryRecord record)
@@ -1372,7 +2230,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         _paused.Clear();
         _positions.Clear();
         _storedOffsets.Clear();
-        _inDoubtNextOffset = -1;
+        _storedOffsetsVersion++;
+        ClearInDoubtRecordUnderLock();
 
         foreach (var (partition, position) in nextPositions)
         {
@@ -1417,6 +2276,80 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private void CommitStoredOffsets()
         => CommitOffsetsFrom(_storedOffsets);
 
+    private TopicPartitionOffset[] CaptureCommitOffsetsUnderLock(
+        TopicPartitionOffset? inDoubtOffset)
+    {
+        var assignment = GetCurrentAssignmentUnderLock();
+        var inDoubtPartition = inDoubtOffset is { } pending
+            ? new TopicPartition(pending.Topic, pending.Partition)
+            : (TopicPartition?)null;
+        var includeInDoubt = inDoubtPartition is { } pendingPartition &&
+                             assignment.Contains(pendingPartition);
+        var count = includeInDoubt ? 1 : 0;
+        foreach (var partition in _storedOffsets.Keys)
+        {
+            if (partition != inDoubtPartition && assignment.Contains(partition))
+                count++;
+        }
+
+        if (count == 0)
+            return [];
+
+        var offsets = new TopicPartitionOffset[count];
+        var index = 0;
+        if (includeInDoubt && inDoubtOffset is { } capturedInDoubt)
+            offsets[index++] = capturedInDoubt;
+        foreach (var (partition, offset) in _storedOffsets)
+        {
+            if (partition != inDoubtPartition && assignment.Contains(partition))
+                offsets[index++] = offset;
+        }
+
+        return offsets;
+    }
+
+    private bool TryApplyMatchingCapturedCommitFault(
+        string groupId,
+        IReadOnlyList<TopicPartitionOffset> offsets,
+        CancellationToken cancellationToken,
+        out ValueTask faultApplication)
+    {
+        faultApplication = ValueTask.CompletedTask;
+        if (offsets.Count == 0)
+            return false;
+
+        var faultPlan = _cluster.FaultPlan;
+        if (faultPlan is KafkaFaultPlan indexedPlan)
+        {
+            return indexedPlan.HasPotentialMatch(KafkaFaultOperation.Commit, groupId) &&
+                   indexedPlan.TryApplyFirstMatchingCommitFault(
+                       groupId,
+                       offsets,
+                       out faultApplication,
+                       cancellationToken);
+        }
+
+        if (faultPlan.Count == 0)
+            return false;
+
+        var candidateScopes = new KafkaFaultScope[offsets.Count + 1];
+        candidateScopes[0] = new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: groupId);
+        for (var index = 0; index < offsets.Count; index++)
+        {
+            var offset = offsets[index];
+            candidateScopes[index + 1] = new KafkaFaultScope(
+                KafkaFaultOperation.Commit,
+                offset.Topic,
+                offset.Partition,
+                groupId);
+        }
+
+        return faultPlan.TryApplyFirstMatchingFault(
+            candidateScopes,
+            out faultApplication,
+            cancellationToken);
+    }
+
     private void CommitOffsetsFrom(Dictionary<TopicPartition, TopicPartitionOffset> positions)
     {
         if (_groupId is null)
@@ -1428,24 +2361,672 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             .Select(static item => item.Value)
             .ToArray();
 
-        if (offsets.Length > 0)
+        if (offsets.Length == 0)
+            return;
+
+        _cluster.CommitOffsets(_groupId, offsets);
+    }
+
+    private bool TryPrepareOnDeliveryAutoCommitFault(
+        TopicPartition partition,
+        long expectedPosition,
+        long nextOffset,
+        CancellationToken cancellationToken,
+        out bool hasReservation,
+        out ValueTask faultApplication)
+    {
+        lock (_gate)
+            return TryPrepareOnDeliveryAutoCommitFaultUnderLock(
+                partition,
+                expectedPosition,
+                nextOffset,
+                cancellationToken,
+                out hasReservation,
+                out faultApplication);
+    }
+
+    private bool TryPrepareSnapshotOnDeliveryAutoCommitFault(
+        TopicPartition partition,
+        long expectedPosition,
+        long nextOffset,
+        int consumerStateVersion,
+        int consumerGroupGeneration,
+        CancellationToken cancellationToken,
+        out bool hasReservation,
+        out ValueTask faultApplication)
+    {
+        lock (_gate)
+        {
+            ThrowIfSnapshotStateChangedUnderLock(
+                consumerStateVersion,
+                consumerGroupGeneration);
+            return TryPrepareOnDeliveryAutoCommitFaultUnderLock(
+                partition,
+                expectedPosition,
+                nextOffset,
+                cancellationToken,
+                out hasReservation,
+                out faultApplication);
+        }
+    }
+
+    private bool TryPrepareOnDeliveryAutoCommitFaultUnderLock(
+        TopicPartition partition,
+        long expectedPosition,
+        long nextOffset,
+        CancellationToken cancellationToken,
+        out bool hasReservation,
+        out ValueTask faultApplication)
+    {
+        ThrowIfDisposed();
+        hasReservation = false;
+        faultApplication = ValueTask.CompletedTask;
+        if (!_positions.TryGetValue(partition, out var currentPosition) ||
+            currentPosition != expectedPosition)
+        {
+            return false;
+        }
+
+        if (_options.OffsetCommitMode != OffsetCommitMode.Auto ||
+            _options.OffsetStoreTiming != OffsetStoreTiming.OnDelivery)
+        {
+            return true;
+        }
+
+        if (_pendingAutoCommitAdvancements is not null &&
+            _pendingAutoCommitAdvancements.ContainsKey(partition))
+        {
+            return false;
+        }
+
+        // The partition can be paused while an async deserializer runs. Do not consume
+        // its commit fault until this delivery can reserve the partition.
+        if (_paused.Contains(partition))
+            return false;
+
+        var pendingOffset = _options.EnableAutoOffsetStore
+            ? new TopicPartitionOffset(partition.Topic, partition.Partition, nextOffset)
+            : (TopicPartitionOffset?)null;
+        if (TryCaptureAndApplyMatchingCommitFaultUnderLock(
+                partition,
+                expectedPosition,
+                pendingOffset,
+                cancellationToken,
+                out _,
+                out faultApplication))
+        {
+            hasReservation = true;
+        }
+
+        return true;
+    }
+
+    private bool TryCaptureAndApplyMatchingCommitFaultUnderLock(
+        TopicPartition reservationPartition,
+        long reservationPosition,
+        TopicPartitionOffset? pendingOffset,
+        CancellationToken cancellationToken,
+        out TopicPartitionOffset[] capturedOffsets,
+        out ValueTask faultApplication)
+    {
+        capturedOffsets = [];
+        faultApplication = ValueTask.CompletedTask;
+        if (_groupId is null)
+            return false;
+
+        var faultPlan = _cluster.FaultPlan;
+        bool hasMatchingCommitFault;
+        long faultPlanVersion;
+        do
+        {
+            faultPlanVersion = faultPlan.Version;
+            hasMatchingCommitFault = HasMatchingCommitFaultUnderLock(faultPlan, pendingOffset);
+        }
+        while (faultPlanVersion != faultPlan.Version);
+        if (!hasMatchingCommitFault)
+        {
+            return false;
+        }
+
+        capturedOffsets = CaptureCommitOffsetsUnderLock(pendingOffset);
+        var resumePartition = _paused.Add(reservationPartition);
+        if (resumePartition)
+            InvalidatePotentialFaultActiveResourcesUnderLock();
+        (_pendingAutoCommitAdvancements ??= [])[reservationPartition] = new PendingAutoCommitAdvancement(
+            reservationPosition,
+            resumePartition,
+            new TaskCompletionSource<CapturedAutoCommitProof>(
+                TaskCreationOptions.RunContinuationsAsynchronously),
+            capturedOffsets);
+
+        try
+        {
+            if (TryApplyMatchingCapturedCommitFault(
+                    _groupId,
+                    capturedOffsets,
+                    cancellationToken,
+                    out faultApplication))
+            {
+                // Fault observers run synchronously and may re-enter this consumer.
+                ThrowIfDisposed();
+                return true;
+            }
+        }
+        catch
+        {
+            ClearPendingAutoCommitAdvancementUnderLock(reservationPartition, reservationPosition);
+            throw;
+        }
+
+        ClearPendingAutoCommitAdvancementUnderLock(reservationPartition, reservationPosition);
+        capturedOffsets = [];
+        return false;
+    }
+
+    private bool HasMatchingCommitFaultUnderLock(
+        IKafkaFaultPlan faultPlan,
+        TopicPartitionOffset? pendingOffset)
+    {
+        var groupId = _groupId!;
+        var assignment = GetPotentialFaultAssignmentUnderLock(out _, out _);
+        if (!faultPlan.HasPotentialFault(
+                KafkaFaultOperation.Commit,
+                groupId,
+                assignment))
+        {
+            return false;
+        }
+
+        var scopeCount = 0;
+        AddCommitFaultScopeUnderLock(
+            ref scopeCount,
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: groupId));
+        TopicPartition? pendingPartition = null;
+        if (pendingOffset is { } pending)
+        {
+            pendingPartition = new TopicPartition(pending.Topic, pending.Partition);
+            if (assignment.Contains(pendingPartition.Value))
+            {
+                AddCommitFaultScopeUnderLock(
+                    ref scopeCount,
+                    new KafkaFaultScope(
+                        KafkaFaultOperation.Commit,
+                        pending.Topic,
+                        pending.Partition,
+                        groupId));
+            }
+        }
+
+        foreach (var partition in _storedOffsets.Keys)
+        {
+            if (partition == pendingPartition || !assignment.Contains(partition))
+                continue;
+
+            AddCommitFaultScopeUnderLock(
+                ref scopeCount,
+                new KafkaFaultScope(
+                    KafkaFaultOperation.Commit,
+                    partition.Topic,
+                    partition.Partition,
+                    groupId));
+        }
+
+        return scopeCount > 1 && faultPlan.TryGetFirstMatchingFaultScope(
+            _commitFaultScopes.AsSpan(0, scopeCount),
+            out _);
+    }
+
+    private void AddCommitFaultScopeUnderLock(ref int scopeCount, KafkaFaultScope scope)
+    {
+        if (scopeCount == _commitFaultScopes.Length)
+            Array.Resize(ref _commitFaultScopes, _commitFaultScopes.Length * 2);
+
+        _commitFaultScopes[scopeCount++] = scope;
+    }
+
+    private async ValueTask ApplyOnDeliveryAutoCommitFaultAsync(
+        ValueTask faultApplication,
+        TopicPartition partition,
+        long expectedPosition,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await faultApplication.ConfigureAwait(false);
+            ThrowIfDisposed();
+        }
+        catch
+        {
+            ClearPendingAutoCommitAdvancement(partition, expectedPosition);
+            throw;
+        }
+    }
+
+    private TaskCompletionSource<CapturedAutoCommitProof>? ClearPendingAutoCommitAdvancement(
+        TopicPartition partition,
+        long expectedPosition,
+        bool completeWaiters = true)
+    {
+        lock (_gate)
+            return ClearPendingAutoCommitAdvancementUnderLock(
+                partition,
+                expectedPosition,
+                completeWaiters);
+    }
+
+    private TaskCompletionSource<CapturedAutoCommitProof>? ClearPendingAutoCommitAdvancementUnderLock(
+        TopicPartition partition,
+        long expectedPosition,
+        bool completeWaiters = true)
+    {
+        if (_pendingAutoCommitAdvancements is null ||
+            !_pendingAutoCommitAdvancements.TryGetValue(partition, out var pending) ||
+            pending.Position != expectedPosition)
+        {
+            return null;
+        }
+
+        _pendingAutoCommitAdvancements.Remove(partition);
+        if (pending.ResumePartition && _paused.Remove(partition))
+            InvalidatePotentialFaultActiveResourcesUnderLock();
+        if (_pendingAutoCommitAdvancements.Count == 0)
+            _pendingAutoCommitAdvancements = null;
+
+        if (completeWaiters)
+        {
+            pending.Completion.TrySetResult(new CapturedAutoCommitProof(
+                partition,
+                pending.Position,
+                pending.CapturedOffsets,
+                SharedWaiter: true,
+                SharedWaiterCompletion: null));
+        }
+        _cluster.SignalRecordsChanged();
+        return pending.Completion;
+    }
+
+    private void ThrowIfAutoCommitAdvancementPendingUnderLock()
+    {
+        if (_pendingAutoCommitAdvancements is not null)
+            ThrowAutoCommitAdvancementPending();
+    }
+
+    [DoesNotReturn]
+    private static void ThrowAutoCommitAdvancementPending() =>
+        throw new InvalidOperationException(
+            "Cannot change consumer assignment or position while an automatic commit fault is pending.");
+
+    private ValueTask<CapturedAutoCommitProof?> ApplyInDoubtAutoCommitFaultAsync(
+        CancellationToken cancellationToken)
+    {
+        if (_options.OffsetCommitMode != OffsetCommitMode.Auto)
+            return default;
+
+        TopicPartition inDoubtPartition;
+        long inDoubtNextOffset;
+        TopicPartitionOffset[] capturedOffsets;
+        ValueTask faultApplication;
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            if (_inDoubtNextOffset < 0)
+                return default;
+
+            inDoubtPartition = _inDoubtPartition;
+            inDoubtNextOffset = _inDoubtNextOffset;
+            if (_pendingAutoCommitAdvancements is not null &&
+                _pendingAutoCommitAdvancements.TryGetValue(inDoubtPartition, out var pending) &&
+                pending.Position == inDoubtNextOffset)
+            {
+                return AwaitPendingAutoCommitProofAsync(
+                    pending.Completion.Task,
+                    cancellationToken);
+            }
+
+            var inDoubtOffset = _options.EnableAutoOffsetStore
+                ? new TopicPartitionOffset(
+                    inDoubtPartition.Topic,
+                    inDoubtPartition.Partition,
+                    inDoubtNextOffset)
+                : (TopicPartitionOffset?)null;
+            if (!TryCaptureAndApplyMatchingCommitFaultUnderLock(
+                    inDoubtPartition,
+                    inDoubtNextOffset,
+                    inDoubtOffset,
+                    cancellationToken,
+                    out capturedOffsets,
+                    out faultApplication))
+            {
+                return default;
+            }
+        }
+
+        return ApplyInDoubtAutoCommitFaultAndClearAsync(
+            faultApplication,
+            inDoubtPartition,
+            inDoubtNextOffset,
+            capturedOffsets);
+    }
+
+    private static async ValueTask<CapturedAutoCommitProof?> AwaitPendingAutoCommitProofAsync(
+        Task<CapturedAutoCommitProof> completion,
+        CancellationToken cancellationToken) =>
+        await completion.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+    private async ValueTask<CapturedAutoCommitProof?> ApplyInDoubtAutoCommitFaultAndClearAsync(
+        ValueTask faultApplication,
+        TopicPartition partition,
+        long expectedPosition,
+        TopicPartitionOffset[] capturedOffsets)
+    {
+        try
+        {
+            await faultApplication.ConfigureAwait(false);
+        }
+        catch
+        {
+            ClearPendingAutoCommitAdvancement(partition, expectedPosition);
+            throw;
+        }
+
+        var completion = ClearPendingAutoCommitAdvancement(
+            partition,
+            expectedPosition,
+            completeWaiters: false);
+        return new CapturedAutoCommitProof(
+            partition,
+            expectedPosition,
+            capturedOffsets,
+            SharedWaiter: false,
+            completion);
+    }
+
+    private void CompleteSharedAutoCommitWaiters(CapturedAutoCommitProof? capturedProof)
+    {
+        if (capturedProof is not
+            {
+                SharedWaiter: false,
+                SharedWaiterCompletion: { } completion
+            } proof)
+        {
+            return;
+        }
+
+        completion.TrySetResult(new CapturedAutoCommitProof(
+            proof.Partition,
+            proof.Position,
+            proof.Offsets,
+            SharedWaiter: true,
+            SharedWaiterCompletion: null));
+        _cluster.SignalRecordsChanged();
+    }
+
+    private async ValueTask WaitForSharedAutoCommitDeliveryAsync(
+        CapturedAutoCommitProof sharedProof,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var recordsChanged = _cluster.ObserveRecordsChanged();
+            lock (_gate)
+            {
+                ThrowIfDisposed();
+                if (_inDoubtNextOffset < 0 ||
+                    _inDoubtPartition.Equals(sharedProof.Partition) &&
+                    _inDoubtNextOffset == sharedProof.Position)
+                {
+                    return;
+                }
+            }
+
+            await recordsChanged.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private TopicPartitionOffset[] CaptureStoredAutoCommitOffsetsUnderLock(
+        CancellationToken cancellationToken,
+        out ValueTask faultApplication)
+    {
+        faultApplication = ValueTask.CompletedTask;
+        if (_options.OffsetCommitMode != OffsetCommitMode.Auto || _groupId is null)
+            return [];
+
+        var offsets = CaptureCommitOffsetsUnderLock(inDoubtOffset: null);
+        _ = TryApplyMatchingCapturedCommitFault(
+            _groupId,
+            offsets,
+            cancellationToken,
+            out faultApplication);
+        return offsets;
+    }
+
+    private void CommitCapturedOffsetsUnderLock(TopicPartitionOffset[] offsets)
+    {
+        if (_groupId is not null && offsets.Length != 0)
             _cluster.CommitOffsets(_groupId, offsets);
     }
+
+    private bool HasPotentialConsumerFault() =>
+        HasPotentialConsumerFault(expectedConsumerStateVersion: -1, expectedConsumerGroupGeneration: -1);
+
+    private bool HasPotentialConsumerFault(
+        int expectedConsumerStateVersion,
+        int expectedConsumerGroupGeneration)
+    {
+        var faultPlan = _cluster.FaultPlan;
+        var indexedPlan = _indexedFaultPlan;
+        var planVersion = indexedPlan is null ? faultPlan.Version : indexedPlan.Version;
+        var consumerStateVersion = Volatile.Read(ref _consumerStateVersion);
+        var autoCommitEnabled = _groupId is not null &&
+                                _options.OffsetCommitMode == OffsetCommitMode.Auto;
+        var requiresStoredOffset = autoCommitEnabled &&
+                                   !_options.EnableAutoOffsetStore;
+        var storedOffsetsVersion = requiresStoredOffset
+            ? Volatile.Read(ref _storedOffsetsVersion)
+            : -1;
+        var consumerGroupGeneration = _groupId is null
+            ? -1
+            : _cluster.GetConsumerGroupGeneration(_groupId);
+        if (expectedConsumerStateVersion >= 0)
+        {
+            ThrowIfDisposed();
+            if (consumerStateVersion != expectedConsumerStateVersion ||
+                consumerGroupGeneration != expectedConsumerGroupGeneration)
+            {
+                ThrowSnapshotStateChanged();
+            }
+        }
+
+        if (Volatile.Read(ref _potentialFaultPlanVersion) == planVersion &&
+            Volatile.Read(ref _potentialFaultConsumerStateVersion) == consumerStateVersion &&
+            Volatile.Read(ref _potentialFaultConsumerGroupGeneration) == consumerGroupGeneration &&
+            Volatile.Read(ref _potentialFaultStoredOffsetsVersion) == storedOffsetsVersion)
+        {
+            return Volatile.Read(ref _hasPotentialConsumerFault);
+        }
+
+        lock (_gate)
+        {
+            consumerStateVersion = _consumerStateVersion;
+            storedOffsetsVersion = requiresStoredOffset ? _storedOffsetsVersion : -1;
+            var assignment = GetPotentialFaultAssignmentUnderLock(
+                out var activeResources,
+                out consumerGroupGeneration);
+
+            var includeCommit = autoCommitEnabled &&
+                                (_options.EnableAutoOffsetStore ||
+                                 HasCommittableStoredOffsetUnderLock(
+                                     assignment,
+                                     consumerGroupGeneration));
+            bool hasPotentialFault;
+            if (indexedPlan is not null)
+            {
+                hasPotentialFault = indexedPlan.HasPotentialConsumerMatch(
+                    _groupId,
+                    activeResources,
+                    assignment,
+                    includeCommit,
+                    out planVersion);
+            }
+            else
+            {
+                do
+                {
+                    planVersion = faultPlan.Version;
+                    hasPotentialFault =
+                        faultPlan.HasPotentialFault(KafkaFaultOperation.Fetch, _groupId, activeResources) ||
+                        faultPlan.HasPotentialFault(KafkaFaultOperation.Consume, _groupId, activeResources) ||
+                        includeCommit &&
+                        faultPlan.HasPotentialFault(KafkaFaultOperation.Commit, _groupId, assignment);
+                }
+                while (planVersion != faultPlan.Version);
+            }
+
+            Volatile.Write(ref _hasPotentialConsumerFault, hasPotentialFault);
+            Volatile.Write(ref _potentialFaultConsumerStateVersion, consumerStateVersion);
+            Volatile.Write(ref _potentialFaultConsumerGroupGeneration, consumerGroupGeneration);
+            Volatile.Write(ref _potentialFaultStoredOffsetsVersion, storedOffsetsVersion);
+            Volatile.Write(ref _potentialFaultPlanVersion, planVersion);
+            return hasPotentialFault;
+        }
+    }
+
+    private IReadOnlySet<TopicPartition> GetPotentialFaultAssignmentUnderLock(
+        out IReadOnlySet<TopicPartition> activeResources,
+        out int consumerGroupGeneration)
+    {
+        while (true)
+        {
+            consumerGroupGeneration = _groupId is null
+                ? -1
+                : _cluster.GetConsumerGroupGeneration(_groupId);
+            if (_potentialFaultAssignment is not null &&
+                _potentialFaultAssignmentConsumerStateVersion == _consumerStateVersion &&
+                _potentialFaultAssignmentConsumerGroupGeneration == consumerGroupGeneration)
+            {
+                activeResources = _potentialFaultActiveResources!;
+                return _potentialFaultAssignment;
+            }
+
+            var assignment = GetCurrentAssignmentUnderLock(out var assignmentGeneration);
+            if (_groupId is not null &&
+                assignmentGeneration >= 0 &&
+                assignmentGeneration != _cluster.GetConsumerGroupGeneration(_groupId))
+            {
+                continue;
+            }
+
+            consumerGroupGeneration = assignmentGeneration;
+            _potentialFaultAssignment = assignment;
+            if (_paused.Count == 0)
+            {
+                activeResources = assignment;
+            }
+            else
+            {
+                var unpaused = new HashSet<TopicPartition>(assignment.Count);
+                foreach (var partition in assignment)
+                {
+                    if (!_paused.Contains(partition))
+                        unpaused.Add(partition);
+                }
+
+                activeResources = unpaused;
+            }
+
+            _potentialFaultActiveResources = activeResources;
+            _potentialFaultAssignmentConsumerStateVersion = _consumerStateVersion;
+            _potentialFaultAssignmentConsumerGroupGeneration = consumerGroupGeneration;
+            return assignment;
+        }
+    }
+
+    private void InvalidatePotentialFaultActiveResourcesUnderLock()
+    {
+        Volatile.Write(ref _potentialFaultConsumerStateVersion, -1);
+        _potentialFaultAssignmentConsumerStateVersion = -1;
+    }
+
+    private bool HasCommittableStoredOffsetUnderLock(
+        IReadOnlySet<TopicPartition> assignment,
+        int consumerGroupGeneration)
+    {
+        if (_committableOffsetConsumerStateVersion == _consumerStateVersion &&
+            _committableOffsetConsumerGroupGeneration == consumerGroupGeneration &&
+            _committableOffsetStoredOffsetsVersion == _storedOffsetsVersion)
+        {
+            return _hasCommittableStoredOffset;
+        }
+
+        var hasCommittableStoredOffset = false;
+        foreach (var partition in _storedOffsets.Keys)
+        {
+            if (!assignment.Contains(partition))
+                continue;
+
+            hasCommittableStoredOffset = true;
+            break;
+        }
+
+        _hasCommittableStoredOffset = hasCommittableStoredOffset;
+        _committableOffsetConsumerStateVersion = _consumerStateVersion;
+        _committableOffsetConsumerGroupGeneration = consumerGroupGeneration;
+        _committableOffsetStoredOffsetsVersion = _storedOffsetsVersion;
+        return hasCommittableStoredOffset;
+    }
+
+    private bool HasMatchingFault(in KafkaFaultScope operationScope)
+        => _cluster.FaultPlan.HasMatchingFault(operationScope);
 
     private void StoreOffsetUnderLock(TopicPartitionOffset offset)
     {
         var partition = new TopicPartition(offset.Topic, offset.Partition);
         _storedOffsets[partition] = offset;
+        _storedOffsetsVersion++;
     }
 
     private void StoreOffsetUnderLock(TopicPartition partition, long offset)
-        => _storedOffsets[partition] = new TopicPartitionOffset(
+    {
+        _storedOffsets[partition] = new TopicPartitionOffset(
             partition.Topic,
             partition.Partition,
             offset);
+        _storedOffsetsVersion++;
+    }
 
     private IReadOnlySet<TopicPartition> GetCurrentAssignmentUnderLock() =>
         GetCurrentAssignmentUnderLock(out _);
+
+    private TopicPartition[] GetOrderedCurrentAssignmentUnderLock(
+        out int consumerGroupGeneration)
+    {
+        var assignment = GetPotentialFaultAssignmentUnderLock(
+            out _,
+            out consumerGroupGeneration);
+        if (_orderedAssignmentConsumerStateVersion == _consumerStateVersion &&
+            _orderedAssignmentConsumerGroupGeneration == consumerGroupGeneration)
+        {
+            return _orderedAssignment;
+        }
+
+        var orderedAssignment = new TopicPartition[assignment.Count];
+        var partitionIndex = 0;
+        foreach (var partition in assignment)
+            orderedAssignment[partitionIndex++] = partition;
+
+        Array.Sort(orderedAssignment, static (left, right) =>
+        {
+            var topicComparison = string.CompareOrdinal(left.Topic, right.Topic);
+            return topicComparison != 0
+                ? topicComparison
+                : left.Partition.CompareTo(right.Partition);
+        });
+
+        _orderedAssignment = orderedAssignment;
+        _orderedAssignmentConsumerStateVersion = _consumerStateVersion;
+        _orderedAssignmentConsumerGroupGeneration = consumerGroupGeneration;
+        return orderedAssignment;
+    }
 
     private IReadOnlySet<TopicPartition> GetCurrentAssignmentUnderLock(out int consumerGroupGeneration)
     {
@@ -1493,6 +3074,50 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             _consumerGroupRegistrationId);
         _consumerGroupGeneration = -1;
         _consumerGroupRegistrationId = 0;
+    }
+
+    private void ApplyGroupTransitionFaults()
+    {
+        if (_groupId is null)
+            return;
+
+        ApplyGroupTransitionFaultUnderLock(KafkaFaultOperation.JoinGroup);
+        ApplyGroupTransitionFaultUnderLock(KafkaFaultOperation.SyncGroup);
+        ApplyGroupTransitionFaultUnderLock(KafkaFaultOperation.Rebalance);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private long GetFaultPlanVersion()
+    {
+        var indexedPlan = _indexedFaultPlan;
+        return indexedPlan is null
+            ? _cluster.FaultPlan.Version
+            : indexedPlan.Version;
+    }
+
+    private void ApplyGroupTransitionFaultUnderLock(KafkaFaultOperation operation)
+    {
+        ApplySynchronousFault(new KafkaFaultScope(operation, groupId: _groupId));
+        ThrowIfDisposed();
+        ThrowIfAutoCommitAdvancementPendingUnderLock();
+    }
+
+    private void ApplySynchronousFault(KafkaFaultScope scope)
+    {
+        var operation = _cluster.FaultPlan.ApplyAsync(scope);
+        if (!operation.IsCompleted)
+        {
+            throw new InvalidOperationException(
+                "Pause barriers require an asynchronous in-memory consumer operation.");
+        }
+
+        operation.GetAwaiter().GetResult();
+    }
+
+    private void ApplySynchronousFaultIfMatching(KafkaFaultScope scope)
+    {
+        if (HasMatchingFault(scope))
+            ApplySynchronousFault(scope);
     }
 
     private void ThrowIfDisposed()

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -239,11 +239,14 @@ public sealed class InMemoryKafkaCluster
 
             members.Remove(memberId);
 
-            _consumerGroupGenerations[groupId] = ++_nextConsumerGroupGeneration;
             if (members.Count == 0)
             {
                 _consumerGroupMembers.Remove(groupId);
-                _consumerGroupGenerations.TryRemove(groupId, out _);
+                _consumerGroupGenerations[groupId] = 0;
+            }
+            else
+            {
+                _consumerGroupGenerations[groupId] = ++_nextConsumerGroupGeneration;
             }
         }
     }
@@ -1069,7 +1072,7 @@ public sealed class InMemoryKafkaCluster
     {
         lock (_gate)
         {
-            var groupOffsets = GetOrCreateGroupOffsetsUnderLock(groupId);
+            var groupOffsets = GetOrCreateConsumerGroupOffsetsUnderLock(groupId);
             for (var index = 0; index < offsets.Count; index++)
             {
                 var offset = offsets[index];
@@ -1642,7 +1645,8 @@ public sealed class InMemoryKafkaCluster
     private bool RemoveConsumerGroupUnderLock(string groupId)
     {
         var existed = _consumerGroupOffsets.Remove(groupId);
-        return _consumerGroupGenerations.Remove(groupId) || existed;
+        var hadGeneration = _consumerGroupGenerations.TryRemove(groupId, out _);
+        return hadGeneration || existed;
     }
 
     private Dictionary<long, ShareGroupMemberRegistration>? GetShareLeasePartition(

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using Dekaf.Admin;
 using Dekaf.Consumer;
@@ -24,7 +25,7 @@ public sealed class InMemoryKafkaCluster
     private readonly Dictionary<string, Dictionary<TopicPartition, TopicPartitionOffset>> _consumerGroupOffsets = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, TopicPartitionOffset>> _shareGroupOffsets = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<string, ConsumerGroupMemberState>> _consumerGroupMembers = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, int> _consumerGroupGenerations = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, int> _consumerGroupGenerations = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<string, int>> _shareGroupMembers = new(StringComparer.Ordinal);
     private readonly HashSet<string> _shareGroupsWithMemberHistory = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, ShareGroupMemberRegistration>>> _shareLeases = new(StringComparer.Ordinal);
@@ -38,6 +39,7 @@ public sealed class InMemoryKafkaCluster
     private long _nextProducerId;
     private long _nextConsumerGroupRegistrationId;
     private TimeSpan _produceLatency;
+    private int _nextConsumerGroupGeneration;
 
     public InMemoryKafkaCluster()
         : this(new InMemoryKafkaClusterOptions(), new KafkaFaultPlan())
@@ -210,7 +212,7 @@ public sealed class InMemoryKafkaCluster
 
             registrationId = ++_nextConsumerGroupRegistrationId;
             members[memberId] = new ConsumerGroupMemberState(registrationId, partitions);
-            var generation = _consumerGroupGenerations.GetValueOrDefault(groupId) + 1;
+            var generation = ++_nextConsumerGroupGeneration;
             _consumerGroupGenerations[groupId] = generation;
             return generation;
         }
@@ -237,9 +239,12 @@ public sealed class InMemoryKafkaCluster
 
             members.Remove(memberId);
 
-            _consumerGroupGenerations[groupId] = _consumerGroupGenerations.GetValueOrDefault(groupId) + 1;
+            _consumerGroupGenerations[groupId] = ++_nextConsumerGroupGeneration;
             if (members.Count == 0)
+            {
                 _consumerGroupMembers.Remove(groupId);
+                _consumerGroupGenerations.TryRemove(groupId, out _);
+            }
         }
     }
 
@@ -274,8 +279,9 @@ public sealed class InMemoryKafkaCluster
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
 
-        lock (_gate)
-            return _consumerGroupGenerations.GetValueOrDefault(groupId);
+        return _consumerGroupGenerations.TryGetValue(groupId, out var generation)
+            ? generation
+            : 0;
     }
 
     public IReadOnlyList<InMemoryRecord> ReadRecords(string topic, int partition = 0)
@@ -931,6 +937,26 @@ public sealed class InMemoryKafkaCluster
         await task.WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
     }
 
+    internal Task ObserveRecordsChanged()
+    {
+        lock (_gate)
+        {
+            var task = _recordsChanged.Task;
+            if (task.IsCompleted)
+                _recordsChanged = NewRecordsChangedSource();
+            return task;
+        }
+    }
+
+    internal void SignalRecordsChanged()
+    {
+        TaskCompletionSource signal;
+        lock (_gate)
+            signal = _recordsChanged;
+
+        signal.TrySetResult();
+    }
+
     internal WatermarkOffsets GetWatermarks(TopicPartition topicPartition)
     {
         lock (_gate)
@@ -1037,6 +1063,19 @@ public sealed class InMemoryKafkaCluster
     {
         lock (_gate)
             CommitShareOffsetsUnderLock(groupId, offsets);
+    }
+
+    internal void CommitOffsets(string groupId, IReadOnlyList<TopicPartitionOffset> offsets)
+    {
+        lock (_gate)
+        {
+            var groupOffsets = GetOrCreateGroupOffsetsUnderLock(groupId);
+            for (var index = 0; index < offsets.Count; index++)
+            {
+                var offset = offsets[index];
+                groupOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset;
+            }
+        }
     }
 
     internal IReadOnlyDictionary<TopicPartition, long> GetGroupOffsets(string groupId)

--- a/src/Dekaf.Testing/KafkaFaultPlan.cs
+++ b/src/Dekaf.Testing/KafkaFaultPlan.cs
@@ -76,6 +76,24 @@ public readonly struct KafkaFaultScope
             throw new ArgumentOutOfRangeException(nameof(partition), partition, "Partition cannot be negative.");
         if (groupId is not null)
             ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        if (operation is KafkaFaultOperation.JoinGroup or
+            KafkaFaultOperation.SyncGroup or
+            KafkaFaultOperation.Rebalance)
+        {
+            if (topic is not null)
+            {
+                throw new ArgumentException(
+                    "Consumer-group transition faults do not support topic selectors.",
+                    nameof(topic));
+            }
+
+            if (partition is not null)
+            {
+                throw new ArgumentException(
+                    "Consumer-group transition faults do not support partition selectors.",
+                    nameof(partition));
+            }
+        }
 
         Operation = operation;
         Topic = topic;
@@ -231,6 +249,45 @@ public interface IKafkaFaultPlan
     int Count { get; }
 
     /// <summary>
+    /// Gets a value that changes whenever the queued fault script changes.
+    /// </summary>
+    /// <remarks>
+    /// Implementations must expose this value thread-safely and change it whenever matching results can change.
+    /// </remarks>
+    long Version { get; }
+
+    /// <summary>
+    /// Returns whether the supplied concrete operation scope matches a queued entry.
+    /// </summary>
+    bool HasMatchingFault(in KafkaFaultScope operationScope);
+
+    /// <summary>
+    /// Returns whether an operation can match a queued entry for the supplied group and resources.
+    /// </summary>
+    bool HasPotentialFault(
+        KafkaFaultOperation operation,
+        string? groupId,
+        IReadOnlySet<TopicPartition> resources);
+
+    /// <summary>
+    /// Selects the supplied concrete operation scope matched by the earliest queued entry.
+    /// </summary>
+    bool TryGetFirstMatchingFaultScope(
+        ReadOnlySpan<KafkaFaultScope> operationScopes,
+        out KafkaFaultScope operationScope);
+
+    /// <summary>
+    /// Atomically consumes and applies the earliest entry matching any supplied operation scope.
+    /// </summary>
+    /// <returns>
+    /// True when an entry was consumed; when true, the caller must await <paramref name="application"/>.
+    /// </returns>
+    bool TryApplyFirstMatchingFault(
+        ReadOnlySpan<KafkaFaultScope> operationScopes,
+        out ValueTask application,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Appends a failure consumed by the next matching operations.
     /// </summary>
     void Fail(KafkaFaultScope scope, Exception exception, int occurrenceCount = 1);
@@ -272,6 +329,8 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
     private readonly List<FaultEntry> _entries = [];
     private ProduceFaultIndex _produceFaultIndex = ProduceFaultIndex.Empty;
     private ShareFaultIndex _shareFaultIndex = ShareFaultIndex.Empty;
+    private FaultScopeIndex _scopeIndex = FaultScopeIndex.Empty;
+    private int _count;
     private int _hasEntries;
     private int _shareFaultIndexVersion;
 
@@ -304,14 +363,7 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
     /// <summary>
     /// Gets the number of queued entries. A next-N failure is one entry.
     /// </summary>
-    public int Count
-    {
-        get
-        {
-            lock (_gate)
-                return _entries.Count;
-        }
-    }
+    public int Count => Volatile.Read(ref _count);
 
     /// <summary>
     /// Appends a failure consumed by the next matching operations.
@@ -325,8 +377,10 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
         lock (_gate)
         {
             _entries.Add(FaultEntry.Failure(scope, exception, occurrenceCount, isPersistent: false));
+            Volatile.Write(ref _count, _entries.Count);
             Volatile.Write(ref _hasEntries, 1);
             AddFaultIndexUnderLock(scope);
+            PublishScopeIndexUnderLock();
         }
     }
 
@@ -341,8 +395,10 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
         lock (_gate)
         {
             _entries.Add(FaultEntry.Failure(scope, exception, remainingOccurrences: 0, isPersistent: true));
+            Volatile.Write(ref _count, _entries.Count);
             Volatile.Write(ref _hasEntries, 1);
             AddFaultIndexUnderLock(scope);
+            PublishScopeIndexUnderLock();
         }
     }
 
@@ -356,8 +412,10 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
         lock (_gate)
         {
             _entries.Add(FaultEntry.Pause(scope, barrier));
+            Volatile.Write(ref _count, _entries.Count);
             Volatile.Write(ref _hasEntries, 1);
             AddFaultIndexUnderLock(scope);
+            PublishScopeIndexUnderLock();
         }
 
         return barrier;
@@ -375,50 +433,61 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
         if (Volatile.Read(ref _hasEntries) == 0)
             return ValueTask.CompletedTask;
 
+        if (!TryConsumeFirstMatchingEntry(
+                operationScope,
+                out var entry,
+                out var observation,
+                out var observer))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        return ApplyConsumedEntry(entry, observation, observer, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public bool TryApplyFirstMatchingFault(
+        ReadOnlySpan<KafkaFaultScope> operationScopes,
+        out ValueTask application,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        for (var i = 0; i < operationScopes.Length; i++)
+            operationScopes[i].Validate();
+
         FaultEntry? entry = null;
         KafkaFaultObservation observation = default;
         Action<KafkaFaultObservation>? observer = null;
         lock (_gate)
         {
-            for (var i = 0; i < _entries.Count; i++)
+            for (var entryIndex = 0; entryIndex < _entries.Count && entry is null; entryIndex++)
             {
-                var candidate = _entries[i];
-                if (!candidate.Scope.Matches(operationScope))
-                    continue;
-
-                entry = candidate;
-                if (!candidate.IsPersistent)
+                var candidate = _entries[entryIndex];
+                for (var scopeIndex = 0; scopeIndex < operationScopes.Length; scopeIndex++)
                 {
-                    candidate.RemainingOccurrences--;
-                    if (candidate.RemainingOccurrences == 0)
-                    {
-                        _entries.RemoveAt(i);
-                        if (_entries.Count == 0)
-                            Volatile.Write(ref _hasEntries, 0);
-                        RemoveFaultIndexUnderLock(candidate.Scope);
-                    }
-                }
+                    var operationScope = operationScopes[scopeIndex];
+                    if (!candidate.Scope.Matches(operationScope))
+                        continue;
 
-                observation = new KafkaFaultObservation(
-                    candidate.Scope,
-                    operationScope,
-                    candidate.Action,
-                    candidate.Exception,
-                    candidate.IsPersistent,
-                    candidate.IsPersistent ? null : candidate.RemainingOccurrences);
-                observer = FaultConsumed;
-                break;
+                    ConsumeEntryUnderLock(
+                        entryIndex,
+                        operationScope,
+                        out entry,
+                        out observation,
+                        out observer);
+                    break;
+                }
             }
         }
 
         if (entry is null)
-            return ValueTask.CompletedTask;
+        {
+            application = ValueTask.CompletedTask;
+            return false;
+        }
 
-        observer?.Invoke(observation);
-        if (entry.Exception is { } exception)
-            return ValueTask.FromException(exception);
-
-        return entry.Barrier!.EnterAsync(cancellationToken);
+        application = ApplyConsumedEntry(entry, observation, observer, cancellationToken);
+        return true;
     }
 
     /// <summary>
@@ -442,8 +511,11 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
                 removed++;
             }
 
+            Volatile.Write(ref _count, _entries.Count);
             if (_entries.Count == 0)
                 Volatile.Write(ref _hasEntries, 0);
+            if (removed != 0)
+                PublishScopeIndexUnderLock();
         }
 
         return removed;
@@ -461,6 +533,7 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
                 _entries[i].Barrier?.ClearBeforeEntry();
 
             _entries.Clear();
+            Volatile.Write(ref _count, 0);
             Volatile.Write(ref _hasEntries, 0);
             Volatile.Write(ref _produceFaultIndex, ProduceFaultIndex.Empty);
             if (!ReferenceEquals(Volatile.Read(ref _shareFaultIndex), ShareFaultIndex.Empty))
@@ -468,6 +541,7 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
                 Volatile.Write(ref _shareFaultIndex, ShareFaultIndex.Empty);
                 Interlocked.Increment(ref _shareFaultIndexVersion);
             }
+            PublishScopeIndexUnderLock();
             return removed;
         }
     }
@@ -920,6 +994,392 @@ public sealed class KafkaFaultPlan : IKafkaFaultPlan
     private readonly record struct PartitionGroupKey(int Partition, string GroupId);
 
     private readonly record struct ExactShareKey(string Topic, int Partition, string GroupId);
+
+    /// <inheritdoc />
+    public long Version => Volatile.Read(ref _scopeIndex).Version;
+
+    internal bool HasPotentialMatch(KafkaFaultOperation operation, string? groupId) =>
+        Volatile.Read(ref _scopeIndex).HasPotentialMatch(operation, groupId);
+
+    /// <inheritdoc />
+    public bool HasMatchingFault(in KafkaFaultScope operationScope) =>
+        Volatile.Read(ref _scopeIndex).HasMatchingFault(operationScope);
+
+    /// <inheritdoc />
+    public bool HasPotentialFault(
+        KafkaFaultOperation operation,
+        string? groupId,
+        IReadOnlySet<TopicPartition> resources)
+    {
+        ArgumentNullException.ThrowIfNull(resources);
+        return Volatile.Read(ref _scopeIndex).HasPotentialMatch(operation, groupId, resources);
+    }
+
+    /// <inheritdoc />
+    public bool TryGetFirstMatchingFaultScope(
+        ReadOnlySpan<KafkaFaultScope> operationScopes,
+        out KafkaFaultScope operationScope) =>
+        Volatile.Read(ref _scopeIndex).TryGetFirstMatchingFaultScope(
+            operationScopes,
+            out operationScope);
+
+    internal bool TryApplyUnconditionalCommitFault(
+        string groupId,
+        out ValueTask application,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var operationScope = new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: groupId);
+        if (!TryConsumeFirstMatchingEntry(
+                operationScope,
+                out var entry,
+                out var observation,
+                out var observer))
+        {
+            application = ValueTask.CompletedTask;
+            return false;
+        }
+
+        application = ApplyConsumedEntry(entry, observation, observer, cancellationToken);
+        return true;
+    }
+
+    internal bool TryApplyLeadingUnconditionalCommitFault(
+        string groupId,
+        out ValueTask application,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        FaultEntry? entry = null;
+        KafkaFaultObservation observation = default;
+        Action<KafkaFaultObservation>? observer = null;
+        var operationScope = new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: groupId);
+        lock (_gate)
+        {
+            for (var entryIndex = 0; entryIndex < _entries.Count; entryIndex++)
+            {
+                var scope = _entries[entryIndex].Scope;
+                if (scope.Operation != KafkaFaultOperation.Commit ||
+                    scope.GroupId is not null && scope.GroupId != groupId)
+                {
+                    continue;
+                }
+
+                if (scope.Topic is not null || scope.Partition is not null)
+                    break;
+
+                ConsumeEntryUnderLock(
+                    entryIndex,
+                    operationScope,
+                    out entry,
+                    out observation,
+                    out observer);
+                break;
+            }
+        }
+
+        if (entry is null)
+        {
+            application = ValueTask.CompletedTask;
+            return false;
+        }
+
+        application = ApplyConsumedEntry(entry, observation, observer, cancellationToken);
+        return true;
+    }
+
+    internal bool TryApplyFirstMatchingCommitFault(
+        string groupId,
+        IReadOnlyList<TopicPartitionOffset> offsets,
+        out ValueTask application,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        FaultEntry? entry = null;
+        KafkaFaultObservation observation = default;
+        Action<KafkaFaultObservation>? observer = null;
+        lock (_gate)
+        {
+            for (var entryIndex = 0; entryIndex < _entries.Count && entry is null; entryIndex++)
+            {
+                var candidate = _entries[entryIndex];
+                if (candidate.Scope.Operation != KafkaFaultOperation.Commit ||
+                    candidate.Scope.GroupId is not null && candidate.Scope.GroupId != groupId)
+                {
+                    continue;
+                }
+
+                for (var offsetIndex = 0; offsetIndex < offsets.Count; offsetIndex++)
+                {
+                    var offset = offsets[offsetIndex];
+                    var operationScope = new KafkaFaultScope(
+                        KafkaFaultOperation.Commit,
+                        offset.Topic,
+                        offset.Partition,
+                        groupId);
+                    if (!candidate.Scope.Matches(operationScope))
+                        continue;
+
+                    ConsumeEntryUnderLock(
+                        entryIndex,
+                        operationScope,
+                        out entry,
+                        out observation,
+                        out observer);
+                    break;
+                }
+            }
+        }
+
+        if (entry is null)
+        {
+            application = ValueTask.CompletedTask;
+            return false;
+        }
+
+        application = ApplyConsumedEntry(entry, observation, observer, cancellationToken);
+        return true;
+    }
+
+    internal bool HasPotentialConsumerMatch(
+        string? groupId,
+        IReadOnlySet<TopicPartition> activeResources,
+        IReadOnlySet<TopicPartition> ownedResources,
+        bool includeCommit,
+        out long scopeVersion)
+    {
+        var index = Volatile.Read(ref _scopeIndex);
+        scopeVersion = index.Version;
+        return index.HasPotentialMatch(KafkaFaultOperation.Fetch, groupId, activeResources) ||
+               index.HasPotentialMatch(KafkaFaultOperation.Consume, groupId, activeResources) ||
+               includeCommit &&
+               index.HasPotentialMatch(KafkaFaultOperation.Commit, groupId, ownedResources);
+    }
+
+    private void PublishScopeIndexUnderLock()
+    {
+        var version = unchecked(Volatile.Read(ref _scopeIndex).Version + 1);
+        Volatile.Write(ref _scopeIndex, new FaultScopeIndex(_entries, version));
+    }
+
+    private void ConsumeEntryUnderLock(
+        int entryIndex,
+        KafkaFaultScope operationScope,
+        out FaultEntry entry,
+        out KafkaFaultObservation observation,
+        out Action<KafkaFaultObservation>? observer)
+    {
+        entry = _entries[entryIndex];
+        if (!entry.IsPersistent)
+        {
+            entry.RemainingOccurrences--;
+            if (entry.RemainingOccurrences == 0)
+            {
+                _entries.RemoveAt(entryIndex);
+                Volatile.Write(ref _count, _entries.Count);
+                if (_entries.Count == 0)
+                    Volatile.Write(ref _hasEntries, 0);
+                RemoveFaultIndexUnderLock(entry.Scope);
+                PublishScopeIndexUnderLock();
+            }
+        }
+
+        observation = new KafkaFaultObservation(
+            entry.Scope,
+            operationScope,
+            entry.Action,
+            entry.Exception,
+            entry.IsPersistent,
+            entry.IsPersistent ? null : entry.RemainingOccurrences);
+        observer = FaultConsumed;
+    }
+
+    private bool TryConsumeFirstMatchingEntry(
+        KafkaFaultScope operationScope,
+        out FaultEntry entry,
+        out KafkaFaultObservation observation,
+        out Action<KafkaFaultObservation>? observer)
+    {
+        lock (_gate)
+        {
+            for (var entryIndex = 0; entryIndex < _entries.Count; entryIndex++)
+            {
+                if (!_entries[entryIndex].Scope.Matches(operationScope))
+                    continue;
+
+                ConsumeEntryUnderLock(
+                    entryIndex,
+                    operationScope,
+                    out entry,
+                    out observation,
+                    out observer);
+                return true;
+            }
+        }
+
+        entry = null!;
+        observation = default;
+        observer = null;
+        return false;
+    }
+
+    private static ValueTask ApplyConsumedEntry(
+        FaultEntry entry,
+        KafkaFaultObservation observation,
+        Action<KafkaFaultObservation>? observer,
+        CancellationToken cancellationToken)
+    {
+        observer?.Invoke(observation);
+        if (entry.Exception is { } exception)
+            return ValueTask.FromException(exception);
+
+        return entry.Barrier!.EnterAsync(cancellationToken);
+    }
+
+    private sealed class FaultScopeIndex
+    {
+        internal static readonly FaultScopeIndex Empty = new();
+
+        private readonly HashSet<OperationGroupKey> _operationGroups;
+        private readonly HashSet<ScopeKey> _scopes;
+        private readonly ScopeKey[] _orderedScopes;
+        private readonly ulong _operations;
+
+        private FaultScopeIndex()
+        {
+            _operationGroups = [];
+            _scopes = [];
+            _orderedScopes = [];
+        }
+
+        internal FaultScopeIndex(List<FaultEntry> entries, long version)
+        {
+            Version = version;
+            _operationGroups = new HashSet<OperationGroupKey>(entries.Count);
+            _scopes = new HashSet<ScopeKey>(entries.Count);
+            _orderedScopes = new ScopeKey[entries.Count];
+            for (var index = 0; index < entries.Count; index++)
+            {
+                var scope = entries[index].Scope;
+                _operations |= 1UL << (int)scope.Operation;
+                _operationGroups.Add(new OperationGroupKey(scope.Operation, scope.GroupId));
+                var key = new ScopeKey(
+                    scope.Operation,
+                    scope.Topic,
+                    scope.Partition,
+                    scope.GroupId);
+                _scopes.Add(key);
+                _orderedScopes[index] = key;
+            }
+        }
+
+        internal long Version { get; }
+
+        internal bool HasPotentialMatch(KafkaFaultOperation operation, string? groupId)
+        {
+            if ((_operations & (1UL << (int)operation)) == 0)
+                return false;
+
+            return _operationGroups.Contains(new OperationGroupKey(operation, null)) ||
+                   (groupId is not null &&
+                    _operationGroups.Contains(new OperationGroupKey(operation, groupId)));
+        }
+
+        internal bool HasPotentialMatch(
+            KafkaFaultOperation operation,
+            string? groupId,
+            IReadOnlySet<TopicPartition> assignment)
+        {
+            if (!HasPotentialMatch(operation, groupId))
+                return false;
+
+            foreach (var scope in _scopes)
+            {
+                if (scope.Operation != operation ||
+                    scope.GroupId is not null && scope.GroupId != groupId)
+                {
+                    continue;
+                }
+
+                if (scope.Topic is null && scope.Partition is null)
+                    return true;
+
+                foreach (var assigned in assignment)
+                {
+                    if ((scope.Topic is null || scope.Topic == assigned.Topic) &&
+                        (scope.Partition is null || scope.Partition == assigned.Partition))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        internal bool HasMatchingFault(in KafkaFaultScope operationScope)
+        {
+            if (!HasPotentialMatch(operationScope.Operation, operationScope.GroupId))
+                return false;
+
+            for (var selectors = 0; selectors < 8; selectors++)
+            {
+                var key = new ScopeKey(
+                    operationScope.Operation,
+                    (selectors & 1) == 0 ? null : operationScope.Topic,
+                    (selectors & 2) == 0 ? null : operationScope.Partition,
+                    (selectors & 4) == 0 ? null : operationScope.GroupId);
+                if (_scopes.Contains(key))
+                    return true;
+            }
+
+            return false;
+        }
+
+        internal bool TryGetFirstMatchingFaultScope(
+            ReadOnlySpan<KafkaFaultScope> operationScopes,
+            out KafkaFaultScope operationScope)
+        {
+            for (var scopeIndex = 0; scopeIndex < _orderedScopes.Length; scopeIndex++)
+            {
+                var ruleScope = _orderedScopes[scopeIndex];
+                for (var operationIndex = 0; operationIndex < operationScopes.Length; operationIndex++)
+                {
+                    var candidate = operationScopes[operationIndex];
+                    if (!Matches(ruleScope, candidate))
+                        continue;
+
+                    operationScope = candidate;
+                    return true;
+                }
+            }
+
+            operationScope = default;
+            return false;
+        }
+
+        private static bool Matches(ScopeKey ruleScope, KafkaFaultScope candidate)
+        {
+            if (ruleScope.Operation != candidate.Operation)
+                return false;
+            if (ruleScope.GroupId is not null && ruleScope.GroupId != candidate.GroupId)
+                return false;
+            if (ruleScope.Topic is not null && ruleScope.Topic != candidate.Topic)
+                return false;
+            return ruleScope.Partition is null || ruleScope.Partition == candidate.Partition;
+        }
+
+    }
+
+    private readonly record struct OperationGroupKey(
+        KafkaFaultOperation Operation,
+        string? GroupId);
+
+    private readonly record struct ScopeKey(
+        KafkaFaultOperation Operation,
+        string? Topic,
+        int? Partition,
+        string? GroupId);
 
     private sealed class FaultEntry
     {

--- a/src/Dekaf.Testing/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.Testing/PublicAPI.Unshipped.txt
@@ -73,6 +73,11 @@ Dekaf.Testing.IKafkaFaultPlan.Count.get -> int
 Dekaf.Testing.IKafkaFaultPlan.Fail(Dekaf.Testing.KafkaFaultScope scope, System.Exception! exception, int occurrenceCount = 1) -> void
 Dekaf.Testing.IKafkaFaultPlan.FailPersistently(Dekaf.Testing.KafkaFaultScope scope, System.Exception! exception) -> void
 Dekaf.Testing.IKafkaFaultPlan.FaultConsumed -> System.Action<Dekaf.Testing.KafkaFaultObservation>?
+Dekaf.Testing.IKafkaFaultPlan.HasMatchingFault(in Dekaf.Testing.KafkaFaultScope operationScope) -> bool
+Dekaf.Testing.IKafkaFaultPlan.HasPotentialFault(Dekaf.Testing.KafkaFaultOperation operation, string? groupId, System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>! resources) -> bool
+Dekaf.Testing.IKafkaFaultPlan.TryGetFirstMatchingFaultScope(System.ReadOnlySpan<Dekaf.Testing.KafkaFaultScope> operationScopes, out Dekaf.Testing.KafkaFaultScope operationScope) -> bool
+Dekaf.Testing.IKafkaFaultPlan.TryApplyFirstMatchingFault(System.ReadOnlySpan<Dekaf.Testing.KafkaFaultScope> operationScopes, out System.Threading.Tasks.ValueTask application, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> bool
+Dekaf.Testing.IKafkaFaultPlan.Version.get -> long
 Dekaf.Testing.IKafkaFaultPlan.PauseNext(Dekaf.Testing.KafkaFaultScope scope) -> Dekaf.Testing.KafkaFaultBarrier!
 Dekaf.Testing.InMemoryProducer<TKey, TValue>.GetPartitionsForAsync(string! topic, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Dekaf.Producer.ProducerPartitionMetadata!>!>
 Dekaf.Testing.KafkaFaultPlan
@@ -83,6 +88,11 @@ Dekaf.Testing.KafkaFaultPlan.Count.get -> int
 Dekaf.Testing.KafkaFaultPlan.Fail(Dekaf.Testing.KafkaFaultScope scope, System.Exception! exception, int occurrenceCount = 1) -> void
 Dekaf.Testing.KafkaFaultPlan.FailPersistently(Dekaf.Testing.KafkaFaultScope scope, System.Exception! exception) -> void
 Dekaf.Testing.KafkaFaultPlan.FaultConsumed -> System.Action<Dekaf.Testing.KafkaFaultObservation>?
+Dekaf.Testing.KafkaFaultPlan.HasMatchingFault(in Dekaf.Testing.KafkaFaultScope operationScope) -> bool
+Dekaf.Testing.KafkaFaultPlan.HasPotentialFault(Dekaf.Testing.KafkaFaultOperation operation, string? groupId, System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>! resources) -> bool
+Dekaf.Testing.KafkaFaultPlan.TryGetFirstMatchingFaultScope(System.ReadOnlySpan<Dekaf.Testing.KafkaFaultScope> operationScopes, out Dekaf.Testing.KafkaFaultScope operationScope) -> bool
+Dekaf.Testing.KafkaFaultPlan.TryApplyFirstMatchingFault(System.ReadOnlySpan<Dekaf.Testing.KafkaFaultScope> operationScopes, out System.Threading.Tasks.ValueTask application, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> bool
+Dekaf.Testing.KafkaFaultPlan.Version.get -> long
 Dekaf.Testing.KafkaFaultPlan.KafkaFaultPlan() -> void
 Dekaf.Testing.KafkaFaultPlan.PauseNext(Dekaf.Testing.KafkaFaultScope scope) -> Dekaf.Testing.KafkaFaultBarrier!
 Dekaf.Testing.KafkaFaultScope

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryAdminShareFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryAdminShareFaultTests.cs
@@ -1167,7 +1167,34 @@ public sealed class InMemoryAdminShareFaultTests
 
         public int Count => 0;
 
+        public long Version => 0;
+
         public int GetResultCount { get; private set; }
+
+        public bool HasMatchingFault(in KafkaFaultScope operationScope) => false;
+
+        public bool HasPotentialFault(
+            KafkaFaultOperation operation,
+            string? groupId,
+            IReadOnlySet<TopicPartition> resources) => false;
+
+        public bool TryGetFirstMatchingFaultScope(
+            ReadOnlySpan<KafkaFaultScope> operationScopes,
+            out KafkaFaultScope operationScope)
+        {
+            operationScope = default;
+            return false;
+        }
+
+        public bool TryApplyFirstMatchingFault(
+            ReadOnlySpan<KafkaFaultScope> operationScopes,
+            out ValueTask application,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            application = ValueTask.CompletedTask;
+            return false;
+        }
 
         public void Fail(KafkaFaultScope scope, Exception exception, int occurrenceCount = 1) =>
             throw new NotSupportedException();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryAsyncSerdeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryAsyncSerdeTests.cs
@@ -5,6 +5,7 @@ using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Producer;
 using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
 using Dekaf.Serialization;
 using Dekaf.ShareConsumer;
 using Dekaf.Testing;
@@ -244,6 +245,34 @@ public sealed class InMemoryAsyncSerdeTests
         await Assert.That(first!.Value.Value).IsEqualTo("one");
         await Assert.That(second!.Value.Value).IsEqualTo("two");
         await Assert.That(offsets[new TopicPartition("orders", 0)]).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task AsyncDeserializer_ReadUncommittedConsumesOngoingTransaction()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var serde = new AsyncPrefixSerde("v:");
+        await using var producer = new InMemoryProducer<string, string>(
+            cluster,
+            Serializers.String,
+            serde);
+        await using var transaction = producer.BeginTransaction();
+        _ = await transaction.ProduceAsync("orders", "key", "pending");
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            Serializers.String,
+            serde,
+            new InMemoryConsumerOptions
+            {
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                IsolationLevel = IsolationLevel.ReadUncommitted
+            });
+        consumer.Assign(new TopicPartition("orders", 0));
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Value).IsEqualTo("pending");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryConsumerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryConsumerFaultTests.cs
@@ -1,0 +1,2822 @@
+using System.Text;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+using Dekaf.Testing;
+
+namespace Dekaf.Tests.Unit.Testing;
+
+public sealed class InMemoryConsumerFaultTests
+{
+    private const string Topic = "orders";
+    private const string GroupId = "workers";
+    private static readonly TopicPartition Partition = new(Topic, 0);
+
+    [Test]
+    public async Task ConsumeOneAsync_FetchFailurePreservesPositionForRetry()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync();
+        var failure = new InvalidOperationException("fetch failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Fetch, Topic, 0, GroupId),
+            failure);
+
+        var actual = await Assert.ThrowsAsync<Exception>(
+            () => consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(0);
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Offset).IsEqualTo(0);
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_ConsumeFailurePreservesPositionAndStoredOffset()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync(enableAutoOffsetStore: true);
+        var failure = new InvalidOperationException("delivery failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Consume, Topic, 0, GroupId),
+            failure);
+
+        var actual = await Assert.ThrowsAsync<Exception>(
+            () => consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+        await consumer.CommitAsync();
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(0);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsNull();
+
+        _ = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        await consumer.CommitAsync();
+
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(1);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_ConsumesFetchAndConsumeFaultsInOperationOrder()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync();
+        var fetchFailure = new InvalidOperationException("fetch");
+        var consumeFailure = new InvalidOperationException("consume");
+        cluster.FaultPlan.Fail(new KafkaFaultScope(KafkaFaultOperation.Fetch), fetchFailure);
+        cluster.FaultPlan.Fail(new KafkaFaultScope(KafkaFaultOperation.Consume), consumeFailure);
+
+        var first = await Assert.ThrowsAsync<Exception>(
+            () => consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+        var second = await Assert.ThrowsAsync<Exception>(
+            () => consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+        var result = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(first).IsSameReferenceAs(fetchFailure);
+        await Assert.That(second).IsSameReferenceAs(consumeFailure);
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Offset).IsEqualTo(0);
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_UnrelatedSameGroupResourceCompletesSynchronously()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync();
+        cluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(
+                KafkaFaultOperation.Fetch,
+                topic: "payments",
+                partition: 0,
+                groupId: GroupId),
+            new InvalidOperationException("unrelated"));
+
+        var operation = consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(operation.IsCompletedSuccessfully).IsTrue();
+        await Assert.That(operation.Result).IsNotNull();
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_GroupMemberIgnoresFaultForForeignPartition()
+    {
+        var innerPlan = new KafkaFaultPlan();
+        var faultPlan = new DelegatingFaultPlan(innerPlan);
+        var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions(), faultPlan);
+        cluster.CreateTopic(Topic, partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 0,
+            Key = "key",
+            Value = "zero"
+        });
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 1,
+            Key = "key",
+            Value = "one"
+        });
+        await using var first = CreateConsumer(cluster);
+        await using var second = CreateConsumer(cluster);
+        first.Subscribe(Topic);
+        second.Subscribe(Topic);
+        var foreignPartition = second.Assignment.Single();
+        innerPlan.FailPersistently(
+            new KafkaFaultScope(
+                KafkaFaultOperation.Fetch,
+                foreignPartition.Topic,
+                foreignPartition.Partition,
+                GroupId),
+            new InvalidOperationException("foreign partition"));
+
+        var result = await first.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Partition).IsNotEqualTo(foreignPartition.Partition);
+        await Assert.That(faultPlan.MatchingProbeCount).IsEqualTo(0);
+        await Assert.That(innerPlan.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_CustomPlanCachesUnrelatedPersistentFault()
+    {
+        var innerPlan = new KafkaFaultPlan();
+        var faultPlan = new DelegatingFaultPlan(innerPlan);
+        var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions(), faultPlan);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "first");
+        await producer.ProduceAsync(Topic, "key", "second");
+        await using var consumer = CreateConsumer(cluster);
+        consumer.Subscribe(Topic);
+        innerPlan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.Produce, Topic, 0),
+            new InvalidOperationException("producer only"));
+
+        var first = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        var probeCount = faultPlan.PotentialProbeCount;
+        var second = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(first).IsNotNull();
+        await Assert.That(second).IsNotNull();
+        await Assert.That(probeCount).IsEqualTo(2);
+        await Assert.That(faultPlan.PotentialProbeCount).IsEqualTo(probeCount);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_PausedPartitionFaultDoesNotDivertActivePartition()
+    {
+        var innerPlan = new KafkaFaultPlan();
+        var faultPlan = new DelegatingFaultPlan(innerPlan);
+        var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions(), faultPlan);
+        cluster.CreateTopic(Topic, partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 0,
+            Key = "key",
+            Value = "paused"
+        });
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 1,
+            Key = "key",
+            Value = "active"
+        });
+        await using var consumer = CreateConsumer(cluster);
+        var pausedPartition = new TopicPartition(Topic, 0);
+        consumer.Assign(pausedPartition, new TopicPartition(Topic, 1));
+        consumer.Pause(pausedPartition);
+        var failure = new InvalidOperationException("paused partition");
+        innerPlan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.Consume, Topic, 0, GroupId),
+            failure);
+
+        var operation = consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(operation.IsCompletedSuccessfully).IsTrue();
+        await Assert.That(operation.Result).IsNotNull();
+        await Assert.That(operation.Result!.Value.Partition).IsEqualTo(1);
+        await Assert.That(faultPlan.MatchingProbeCount).IsEqualTo(0);
+
+        consumer.Resume(pausedPartition);
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_GroupOwnershipChangeInvalidatesFaultCache()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic, partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 0,
+            Key = "key",
+            Value = "zero"
+        });
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 1,
+            Key = "key",
+            Value = "one"
+        });
+        await using var first = CreateConsumer(cluster);
+        var second = CreateConsumer(cluster);
+        first.Subscribe(Topic);
+        second.Subscribe(Topic);
+        var foreignPartition = second.Assignment.Single();
+        var failure = new InvalidOperationException("newly owned partition");
+        cluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(
+                KafkaFaultOperation.Fetch,
+                foreignPartition.Topic,
+                foreignPartition.Partition,
+                GroupId),
+            failure);
+
+        var firstResult = await first.ConsumeOneAsync(TimeSpan.Zero);
+        await second.DisposeAsync();
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => first.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+
+        await Assert.That(firstResult).IsNotNull();
+        await Assert.That(firstResult!.Value.Partition).IsNotEqualTo(foreignPartition.Partition);
+        await Assert.That(actual).IsSameReferenceAs(failure);
+    }
+
+    [Test]
+    [Arguments(KafkaFaultOperation.Fetch)]
+    [Arguments(KafkaFaultOperation.Consume)]
+    public async Task ConsumeOneAsync_GroupOwnershipChangeDuringFaultBarrierReselectsRecord(
+        KafkaFaultOperation operation)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic, partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 0,
+            Key = "key",
+            Value = "zero"
+        });
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 1,
+            Key = "key",
+            Value = "one"
+        });
+        await using var first = CreateConsumer(cluster, memberId: "z-member");
+        first.Subscribe(Topic);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(operation, Topic, 0, GroupId));
+
+        var firstConsume = first.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        await using var second = CreateConsumer(cluster, memberId: "a-member");
+        second.Subscribe(Topic);
+        await Assert.That(barrier.Release()).IsTrue();
+
+        var firstResult = await firstConsume.WaitAsync(TimeSpan.FromSeconds(5));
+        var secondResult = await second.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(firstResult).IsNotNull();
+        await Assert.That(firstResult!.Value.Partition).IsEqualTo(1);
+        await Assert.That(secondResult).IsNotNull();
+        await Assert.That(secondResult!.Value.Partition).IsEqualTo(0);
+        await Assert.That(first.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ConsumeSnapshotAsync_EmptyCustomPlanSkipsRecordProbes()
+    {
+        var innerPlan = new KafkaFaultPlan();
+        var faultPlan = new DelegatingFaultPlan(innerPlan);
+        var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions(), faultPlan);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        await using var consumer = CreateConsumer(cluster);
+        consumer.Subscribe(Topic);
+
+        var records = new List<ConsumeResult<string, string>>();
+        await foreach (var record in consumer.ConsumeSnapshotAsync())
+            records.Add(record);
+
+        await Assert.That(records).Count().IsEqualTo(1);
+        await Assert.That(faultPlan.MatchingProbeCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_FetchBarrierCancellationPreservesPosition()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync();
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Fetch, Topic, 0, GroupId));
+        using var cancellation = new CancellationTokenSource();
+
+        var operation = consumer
+            .ConsumeOneAsync(Timeout.InfiniteTimeSpan, cancellation.Token)
+            .AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        cancellation.Cancel();
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => operation);
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(0);
+        await Assert.That(barrier.Release()).IsTrue();
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Offset).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_FetchBarrierDisposalDoesNotPublishSelectedRecord()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync();
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Fetch, Topic, 0, GroupId));
+
+        var operation = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        await consumer.DisposeAsync();
+        await Assert.That(barrier.Release()).IsTrue();
+
+        _ = await Assert.ThrowsAsync<ObjectDisposedException>(() => operation);
+    }
+
+    [Test]
+    public async Task CommitAsync_ResourceScopedFailurePreservesStoredOffsetForRetry()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync(enableAutoOffsetStore: false);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 1));
+        var failure = new InvalidOperationException("commit failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId),
+            failure);
+
+        var actual = await Assert.ThrowsAsync<Exception>(() => consumer.CommitAsync().AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsNull();
+
+        await consumer.CommitAsync();
+
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task CommitAsync_InjectedPlanMatchesConcreteStoredOffset()
+    {
+        var innerPlan = new KafkaFaultPlan();
+        IKafkaFaultPlan faultPlan = new DelegatingFaultPlan(innerPlan);
+        var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions(), faultPlan);
+        cluster.CreateTopic(Topic);
+        var consumer = CreateConsumer(cluster, enableAutoOffsetStore: false);
+        consumer.Assign(Partition);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 1));
+        var failure = new InvalidOperationException("resource commit failed");
+        innerPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId),
+            failure);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.CommitAsync().AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsNull();
+    }
+
+    [Test]
+    public async Task CommitAsync_InjectedPlanMatchesLaterExplicitOffset()
+    {
+        var innerPlan = new KafkaFaultPlan();
+        IKafkaFaultPlan faultPlan = new DelegatingFaultPlan(innerPlan);
+        var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions(), faultPlan);
+        var consumer = CreateConsumer(cluster, enableAutoOffsetStore: false);
+        var otherPartition = new TopicPartition(Topic, 1);
+        var failure = new InvalidOperationException("later resource commit failed");
+        innerPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 1, GroupId),
+            failure);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.CommitAsync(
+                [
+                    new TopicPartitionOffset(Topic, 0, 1),
+                    new TopicPartitionOffset(Topic, 1, 1)
+                ]).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(otherPartition)).IsNull();
+    }
+
+    [Test]
+    public async Task CommitAsync_InjectedPlanPreservesResourceBeforeGroupOrder()
+    {
+        var innerPlan = new KafkaFaultPlan();
+        IKafkaFaultPlan faultPlan = new DelegatingFaultPlan(innerPlan);
+        var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions(), faultPlan);
+        var consumer = CreateConsumer(cluster, enableAutoOffsetStore: false);
+        var resourceFailure = new InvalidOperationException("resource commit failed");
+        innerPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId),
+            resourceFailure);
+        innerPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            new InvalidOperationException("group commit failed"));
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.CommitAsync([new TopicPartitionOffset(Topic, 0, 1)]).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(resourceFailure);
+        await Assert.That(innerPlan.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task CommitAsync_ConcurrentCommitsReserveDistinctOrderedFaults()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        await using var firstConsumer = CreateConsumer(cluster, enableAutoOffsetStore: false);
+        await using var secondConsumer = CreateConsumer(cluster, enableAutoOffsetStore: false);
+        var firstPartition = new TopicPartitionOffset(Topic, 0, 1);
+        var secondPartition = new TopicPartitionOffset(Topic, 1, 1);
+        var firstBarrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId));
+        var secondFailure = new InvalidOperationException("second partition");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 1, GroupId),
+            secondFailure);
+
+        var firstCommit = firstConsumer.CommitAsync([firstPartition, secondPartition]).AsTask();
+        await firstBarrier.WaitUntilEnteredAsync();
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            secondConsumer.CommitAsync([secondPartition]).AsTask());
+        await Assert.That(firstBarrier.Release()).IsTrue();
+        await firstCommit;
+
+        await Assert.That(actual).IsSameReferenceAs(secondFailure);
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CommitAsync_ConcurrentStoredCommitsReserveDistinctOrderedFaults()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic, partitionCount: 2);
+        await using var firstConsumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: false,
+            groupId: "stored-a");
+        await using var secondConsumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: false,
+            groupId: "stored-b");
+        var secondPartition = new TopicPartition(Topic, 1);
+        var offsets = new[]
+        {
+            new TopicPartitionOffset(Topic, 0, 1),
+            new TopicPartitionOffset(Topic, 1, 1)
+        };
+        firstConsumer.Assign([Partition, secondPartition]);
+        secondConsumer.Assign([Partition, secondPartition]);
+        firstConsumer.StoreOffsets(offsets);
+        secondConsumer.StoreOffsets(offsets);
+        var firstBarrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0));
+        var secondFailure = new InvalidOperationException("second partition");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 1),
+            secondFailure);
+
+        var firstCommit = firstConsumer.CommitAsync().AsTask();
+        await firstBarrier.WaitUntilEnteredAsync();
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            secondConsumer.CommitAsync().AsTask());
+        await Assert.That(firstBarrier.Release()).IsTrue();
+        await firstCommit;
+
+        await Assert.That(actual).IsSameReferenceAs(secondFailure);
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CommitAsync_AssignmentChangeDuringBarrierSkipsCapturedOffsets()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic, partitionCount: 2);
+        await using var consumer = CreateConsumer(cluster, enableAutoOffsetStore: false);
+        var secondPartition = new TopicPartition(Topic, 1);
+        consumer.Assign(Partition, secondPartition);
+        consumer.StoreOffsets([
+            new TopicPartitionOffset(Topic, 0, 1),
+            new TopicPartitionOffset(Topic, 1, 1)
+        ]);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId));
+
+        var commit = consumer.CommitAsync().AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        consumer.IncrementalUnassign([Partition]);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 1, 9));
+        await Assert.That(barrier.Release()).IsTrue();
+        await commit;
+
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsNull();
+        await Assert.That(cluster.GetCommittedOffset(GroupId, secondPartition)).IsNull();
+
+        await consumer.CommitAsync();
+
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsNull();
+        await Assert.That(cluster.GetCommittedOffset(GroupId, secondPartition)).IsEqualTo(9);
+    }
+
+    [Test]
+    public async Task CommitAsync_BarrierCommitsExactCallerOffsets()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync();
+        TopicPartitionOffset[] offsets = [new(Topic, 0, 1)];
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId));
+        cluster.FaultPlan.FaultConsumed += _ =>
+            offsets[0] = new TopicPartitionOffset(Topic, 0, 9);
+
+        var commit = consumer.CommitAsync(offsets).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        offsets[0] = new TopicPartitionOffset(Topic, 0, 10);
+        await Assert.That(barrier.Release()).IsTrue();
+        await commit;
+
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task OnDeliveryAutoCommit_BarrierCommitsExactCapturedOffsets()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic, partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 0,
+            Key = "key",
+            Value = "value"
+        });
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        var secondPartition = new TopicPartition(Topic, 1);
+        consumer.Assign(Partition, secondPartition);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 1, 1));
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId));
+
+        var consume = consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 1, 9));
+        await Assert.That(barrier.Release()).IsTrue();
+        _ = await consume;
+
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsEqualTo(1);
+        await Assert.That(cluster.GetCommittedOffset(GroupId, secondPartition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task OnDeliveryAutoCommit_BarrierAllowsPausingUnrelatedPartition()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic, partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 0,
+            Key = "key",
+            Value = "value"
+        });
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        var secondPartition = new TopicPartition(Topic, 1);
+        consumer.Assign(Partition, secondPartition);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId));
+
+        var consume = consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        consumer.Pause(secondPartition);
+        await Assert.That(barrier.Release()).IsTrue();
+        _ = await consume;
+
+        await Assert.That(consumer.Paused).Contains(secondPartition);
+        await Assert.That(consumer.Paused).DoesNotContain(Partition);
+    }
+
+    [Test]
+    public async Task OnDeliveryAutoCommit_UnrelatedCommitFaultDoesNotReserve()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var deserializer = new AsyncStringDeserializer();
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            deserializer,
+            deserializer,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                EnableAutoOffsetStore = true,
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                OffsetStoreTiming = OffsetStoreTiming.OnDelivery
+            });
+        consumer.Subscribe(Topic);
+        cluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(
+                KafkaFaultOperation.Commit,
+                topic: "payments",
+                partition: 0,
+                groupId: GroupId),
+            new InvalidOperationException("unrelated"));
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task OnDeliveryAutoCommit_FaultObserverCannotReentrantlyCommitCurrentRecord()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var failure = new InvalidOperationException("commit failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            failure);
+        ConsumeResult<string, string>? reentrantResult = null;
+        cluster.FaultPlan.FaultConsumed += _ =>
+            reentrantResult = consumer.ConsumeOneAsync(TimeSpan.Zero).GetAwaiter().GetResult();
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(reentrantResult).IsNull();
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(0);
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsNull();
+    }
+
+    [Test]
+    public async Task OnDeliveryAutoCommit_FaultObserverCannotWidenCapturedOffsets()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic, partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 0,
+            Key = "key",
+            Value = "value"
+        });
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        var secondPartition = new TopicPartition(Topic, 1);
+        consumer.Assign(Partition, secondPartition);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 1, 1));
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId));
+        cluster.FaultPlan.FaultConsumed += _ =>
+            consumer.StoreOffset(new TopicPartitionOffset(Topic, 1, 9));
+
+        var consume = consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        await Assert.That(barrier.Release()).IsTrue();
+        _ = await consume;
+
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsEqualTo(1);
+        await Assert.That(cluster.GetCommittedOffset(GroupId, secondPartition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task OnDeliveryAutoCommit_FaultObserverPauseRemainsPaused()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var failure = new InvalidOperationException("commit failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            failure);
+        cluster.FaultPlan.FaultConsumed += _ => consumer.Pause(Partition);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(consumer.Paused).Contains(Partition);
+    }
+
+    [Test]
+    public async Task OnDeliveryAutoCommit_BarrierKeepsFaultObserverPauseVisible()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+        cluster.FaultPlan.FaultConsumed += _ => consumer.Pause(Partition);
+
+        var consume = consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+
+        await Assert.That(consumer.Paused).Contains(Partition);
+        await Assert.That(barrier.Release()).IsTrue();
+        _ = await consume;
+        await Assert.That(consumer.Paused).Contains(Partition);
+    }
+
+    [Test]
+    public async Task OnDeliveryAutoCommit_FaultObserverClosePreventsReservation()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Assign(Partition);
+        var failure = new InvalidOperationException("commit failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId),
+            failure);
+        Task? closeTask = null;
+        cluster.FaultPlan.FaultConsumed += _ => closeTask = consumer.CloseAsync().AsTask();
+
+        _ = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+
+        await Assert.That(closeTask).IsNotNull();
+        await closeTask!;
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CommitAsync_InjectedPlanPreservesStoredResourceBeforeGroupOrder()
+    {
+        var innerPlan = new KafkaFaultPlan();
+        IKafkaFaultPlan faultPlan = new DelegatingFaultPlan(innerPlan);
+        var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions(), faultPlan);
+        cluster.CreateTopic(Topic);
+        var consumer = CreateConsumer(cluster, enableAutoOffsetStore: false);
+        consumer.Assign(Partition);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 1));
+        var resourceFailure = new InvalidOperationException("stored resource commit failed");
+        innerPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId),
+            resourceFailure);
+        innerPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            new InvalidOperationException("stored group commit failed"));
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.CommitAsync().AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(resourceFailure);
+        await Assert.That(innerPlan.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task CommitAsync_EmptyListConsumesGroupFault()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var consumer = CreateConsumer(cluster, enableAutoOffsetStore: false);
+        var failure = new InvalidOperationException("empty commit failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            failure);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.CommitAsync(Array.Empty<TopicPartitionOffset>()).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+    }
+
+    [Test]
+    public async Task CommitAsync_EmptyListSkipsResourceFaultBeforeGroupFault()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var consumer = CreateConsumer(cluster, enableAutoOffsetStore: false);
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId),
+            new InvalidOperationException("resource commit failed"));
+        var groupFailure = new InvalidOperationException("group commit failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            groupFailure);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.CommitAsync(Array.Empty<TopicPartitionOffset>()).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(groupFailure);
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task CommitAsync_ExplicitOffsetsConsumeResourceScopedFailure()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync();
+        TopicPartitionOffset[] offsets = [new(Topic, 0, 1)];
+        var failure = new InvalidOperationException("commit failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId),
+            failure);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.CommitAsync(offsets).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsNull();
+
+        await consumer.CommitAsync(offsets);
+
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task CommitAsync_ExplicitOffsetsPreserveFaultScriptOrder()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync();
+        TopicPartitionOffset[] offsets =
+        [
+            new("payments", 0, 1),
+            new(Topic, 0, 1)
+        ];
+        var resourceFailure = new InvalidOperationException("resource first");
+        var groupFailure = new InvalidOperationException("group second");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId),
+            resourceFailure);
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            groupFailure);
+
+        var first = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.CommitAsync(offsets).AsTask());
+        var second = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.CommitAsync(offsets).AsTask());
+
+        await Assert.That(first).IsSameReferenceAs(resourceFailure);
+        await Assert.That(second).IsSameReferenceAs(groupFailure);
+    }
+
+    [Test]
+    public async Task CommitAsync_StoredOffsetsPreserveFaultScriptOrder()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic);
+        cluster.CreateTopic("payments");
+        var consumer = CreateConsumer(cluster, enableAutoOffsetStore: false);
+        consumer.Subscribe(["payments", Topic]);
+        consumer.StoreOffset(new TopicPartitionOffset("payments", 0, 1));
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 1));
+        var resourceFailure = new InvalidOperationException("resource first");
+        var groupFailure = new InvalidOperationException("group second");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId),
+            resourceFailure);
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            groupFailure);
+
+        var first = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.CommitAsync().AsTask());
+        var second = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.CommitAsync().AsTask());
+
+        await Assert.That(first).IsSameReferenceAs(resourceFailure);
+        await Assert.That(second).IsSameReferenceAs(groupFailure);
+    }
+
+    [Test]
+    public async Task CommitAsync_BarrierCancellationPreservesStoredOffsetForRetry()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync(enableAutoOffsetStore: false);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 1));
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+        using var cancellation = new CancellationTokenSource();
+
+        var operation = consumer.CommitAsync(cancellation.Token).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        cancellation.Cancel();
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => operation);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsNull();
+        await Assert.That(barrier.Release()).IsTrue();
+
+        await consumer.CommitAsync();
+
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task AutoCommit_FailurePreservesPositionAndOffsetForRetry()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var failure = new InvalidOperationException("auto commit failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            failure);
+
+        var actual = await Assert.ThrowsAsync<Exception>(
+            () => consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(0);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsNull();
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(1);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task AutoCommit_BarrierRunsBeforePositionMutation()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var operation = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(0);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsNull();
+        await Assert.That(barrier.Release()).IsTrue();
+
+        var result = await operation;
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(1);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Snapshot_WaitsForConcurrentAutoCommitReservation()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var snapshotFetchBarrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Fetch, Topic, 0, GroupId));
+        var concurrentCommitBarrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+
+        var snapshotMove = snapshot.MoveNextAsync().AsTask();
+        await snapshotFetchBarrier.WaitUntilEnteredAsync();
+        var concurrentConsume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await concurrentCommitBarrier.WaitUntilEnteredAsync();
+        await Assert.That(snapshotFetchBarrier.Release()).IsTrue();
+        await Assert.That(concurrentCommitBarrier.Release()).IsTrue();
+
+        await Assert.That(await concurrentConsume).IsNotNull();
+        await Assert.That(await snapshotMove).IsFalse();
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Snapshot_CloseReleasesConcurrentAutoCommitReservationWait()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var snapshotFetchBarrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Fetch, Topic, 0, GroupId));
+        var concurrentCommitBarrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+
+        var snapshotMove = snapshot.MoveNextAsync().AsTask();
+        await snapshotFetchBarrier.WaitUntilEnteredAsync();
+        var concurrentConsume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await concurrentCommitBarrier.WaitUntilEnteredAsync();
+        var snapshotWaitEntered = consumer.WaitUntilAutoCommitAdvancementWaiterEnteredAsync();
+        await Assert.That(snapshotFetchBarrier.Release()).IsTrue();
+        await snapshotWaitEntered;
+
+        await consumer.CloseAsync();
+        _ = await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            await snapshotMove.WaitAsync(TimeSpan.FromSeconds(5)));
+
+        await Assert.That(concurrentCommitBarrier.Release()).IsTrue();
+        _ = await Assert.ThrowsAsync<ObjectDisposedException>(() => concurrentConsume);
+    }
+
+    [Test]
+    public async Task CloseAsync_WakesInfiniteConsumeWaitingBehindAutoCommitReservation()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var reservedConsume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        var waitingConsume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await Assert.That(waitingConsume.IsCompleted).IsFalse();
+
+        await consumer.CloseAsync();
+
+        _ = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            waitingConsume.WaitAsync(TimeSpan.FromSeconds(5)));
+        await Assert.That(barrier.Release()).IsTrue();
+        _ = await Assert.ThrowsAsync<ObjectDisposedException>(() => reservedConsume);
+    }
+
+    [Test]
+    public async Task AutoCommitAdvancementWaitHook_IsReusableAndCloseCompletesIt()
+    {
+        var consumer = CreateConsumer(new InMemoryKafkaCluster());
+
+        var first = consumer.WaitUntilAutoCommitAdvancementWaiterEnteredAsync();
+        var second = consumer.WaitUntilAutoCommitAdvancementWaiterEnteredAsync();
+
+        await Assert.That(second).IsSameReferenceAs(first);
+        await consumer.CloseAsync();
+        await first;
+        await Assert.That(consumer.WaitUntilAutoCommitAdvancementWaiterEnteredAsync().IsCompletedSuccessfully)
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task AutoCommit_BarrierRejectsSeekUntilPositionAdvances()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var operation = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+
+        var actual = Assert.Throws<InvalidOperationException>(() =>
+            consumer.Seek(new TopicPartitionOffset(Topic, 0, 1)));
+
+        await Assert.That(actual.Message).Contains("automatic commit fault");
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(0);
+        await Assert.That(consumer.Paused).IsEmpty();
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsNull();
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.Zero)).IsNull();
+        await Assert.That(barrier.Release()).IsTrue();
+
+        var result = await operation;
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(1);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+
+        consumer.Seek(new TopicPartitionOffset(Topic, 0, 0));
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task AutoCommit_BarrierCancellationReleasesPositionReservation()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+        using var cancellation = new CancellationTokenSource();
+
+        var operation = consumer
+            .ConsumeOneAsync(Timeout.InfiniteTimeSpan, cancellation.Token)
+            .AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        cancellation.Cancel();
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => operation);
+        consumer.Seek(new TopicPartitionOffset(Topic, 0, 1));
+
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(1);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsNull();
+        await Assert.That(barrier.Release()).IsTrue();
+    }
+
+    [Test]
+    public async Task AutoCommit_BarrierCancellationWakesConcurrentInfiniteConsume()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+        using var cancellation = new CancellationTokenSource();
+
+        var reservedConsume = consumer
+            .ConsumeOneAsync(Timeout.InfiniteTimeSpan, cancellation.Token)
+            .AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        var waitingConsume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        cancellation.Cancel();
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => reservedConsume);
+        var result = await waitingConsume.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Key).IsEqualTo("key");
+        await Assert.That(barrier.Release()).IsTrue();
+    }
+
+    [Test]
+    public async Task AutoCommit_BarrierCancellationInvalidatesPausedFaultCache()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+        using var cancellation = new CancellationTokenSource();
+
+        var reservedConsume = consumer
+            .ConsumeOneAsync(Timeout.InfiniteTimeSpan, cancellation.Token)
+            .AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        var failure = new InvalidOperationException("fetch failed");
+        cluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.Fetch, Topic, 0, GroupId),
+            failure);
+
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.Zero)).IsNull();
+        cancellation.Cancel();
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => reservedConsume);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(barrier.Release()).IsTrue();
+    }
+
+    [Test]
+    public async Task AutoCommit_PositionChangeBeforeAdvancementPreservesFault()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var deserializer = new BlockingAsyncDeserializer();
+        var consumer = CreateAsyncConsumer(cluster, deserializer);
+        consumer.Subscribe(Topic);
+        var failure = new InvalidOperationException("commit failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            failure);
+
+        var operation = consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask();
+        await deserializer.WaitUntilEnteredAsync();
+        consumer.Seek(new TopicPartitionOffset(Topic, 0, 1));
+        deserializer.Release();
+
+        await Assert.That(await operation).IsNull();
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsNull();
+
+        consumer.Seek(new TopicPartitionOffset(Topic, 0, 0));
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+    }
+
+    [Test]
+    public async Task AutoCommit_PauseBeforeAdvancementPreservesFault()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var deserializer = new BlockingAsyncDeserializer();
+        await using var consumer = CreateAsyncConsumer(cluster, deserializer);
+        consumer.Subscribe(Topic);
+        var failure = new InvalidOperationException("commit failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            failure);
+
+        var operation = consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask();
+        await deserializer.WaitUntilEnteredAsync();
+        consumer.Pause(Partition);
+        deserializer.Release();
+
+        await Assert.That(await operation).IsNull();
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+        consumer.Resume(Partition);
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_GroupChangeAfterDeserializationPreservesConsumeFault()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var deserializer = new BlockingAsyncDeserializer();
+        await using var consumer = CreateAsyncConsumer(cluster, deserializer, "z-member");
+        consumer.Subscribe(Topic);
+        var failure = new InvalidOperationException("consume failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Consume, Topic, 0, GroupId),
+            failure);
+
+        var operation = consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask();
+        await deserializer.WaitUntilEnteredAsync();
+        await using var joiningConsumer = CreateConsumer(cluster, memberId: "a-member");
+        joiningConsumer.Subscribe(Topic);
+        deserializer.Release();
+
+        await Assert.That(await operation).IsNull();
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            joiningConsumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+        await Assert.That(actual).IsSameReferenceAs(failure);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_SynchronousDeserializerPausePreventsStaleDelivery()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        InMemoryConsumer<string, string>? consumer = null;
+        var deserializer = new CallbackOnceDeserializer(() => consumer!.Pause(Partition));
+        await using (consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            deserializer,
+            deserializer,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                EnableAutoOffsetStore = true,
+                OffsetStoreTiming = OffsetStoreTiming.OnDelivery
+            }))
+        {
+            consumer.Subscribe(Topic);
+
+            var result = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+            await Assert.That(result).IsNull();
+            await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(0);
+            await Assert.That(consumer.Paused).Contains(Partition);
+            await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsNull();
+        }
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_GroupChangeDuringCommitProbePreventsStaleAdvancement()
+    {
+        var innerPlan = new KafkaFaultPlan();
+        var faultPlan = new DelegatingFaultPlan(innerPlan);
+        var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions(), faultPlan);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var deserializer = new AsyncStringDeserializer();
+        await using var consumer = CreateAsyncConsumer(cluster, deserializer, "z-member");
+        consumer.Subscribe(Topic);
+        InMemoryConsumer<string, string>? joiningConsumer = null;
+        faultPlan.ObserveNextMatchingProbe(() =>
+        {
+            joiningConsumer = CreateConsumer(cluster, memberId: "a-member");
+            joiningConsumer.Subscribe(Topic);
+        });
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(result).IsNull();
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(0);
+        await Assert.That(joiningConsumer).IsNotNull();
+        var reassignedConsumer = joiningConsumer!;
+        await using (reassignedConsumer)
+        {
+            var reassignedResult = await reassignedConsumer.ConsumeOneAsync(TimeSpan.Zero);
+            await Assert.That(reassignedResult).IsNotNull();
+            await Assert.That(reassignedResult!.Value.Offset).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_DisposalDuringDeserializationPreservesConsumeFault()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var deserializer = new BlockingAsyncDeserializer();
+        var consumer = CreateAsyncConsumer(cluster, deserializer);
+        consumer.Subscribe(Topic);
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Consume, Topic, 0, GroupId),
+            new InvalidOperationException("consume failed"));
+
+        var operation = consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask();
+        await deserializer.WaitUntilEnteredAsync();
+        var disposal = consumer.DisposeAsync().AsTask();
+        deserializer.Release();
+
+        _ = await Assert.ThrowsAsync<ObjectDisposedException>(() => operation);
+        await disposal;
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(KafkaFaultOperation.Consume)]
+    [Arguments(KafkaFaultOperation.Commit)]
+    public async Task Snapshot_GroupChangeAfterAsyncDeserializationPreservesFault(
+        KafkaFaultOperation operation)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var deserializer = new BlockingAsyncDeserializer();
+        await using var consumer = CreateAsyncConsumer(cluster, deserializer);
+        consumer.Subscribe(Topic);
+        var failure = new InvalidOperationException("record fault failed");
+        cluster.FaultPlan.Fail(
+            operation == KafkaFaultOperation.Consume
+                ? new KafkaFaultScope(operation, Topic, 0, GroupId)
+                : new KafkaFaultScope(operation, groupId: GroupId),
+            failure);
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+
+        var moveNext = snapshot.MoveNextAsync().AsTask();
+        await deserializer.WaitUntilEnteredAsync();
+        await using var joiningConsumer = CreateConsumer(cluster);
+        joiningConsumer.Subscribe(Topic);
+        deserializer.Release();
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => moveNext);
+
+        await Assert.That(actual).IsNotSameReferenceAs(failure);
+        await Assert.That(actual!.Message).Contains("snapshot enumeration");
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Snapshot_GroupChangeDuringSynchronousDeserializationPreservesConsumeFault()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        await using var joiningConsumer = CreateConsumer(cluster);
+        var deserializer = new CallbackOnceDeserializer(() => joiningConsumer.Subscribe(Topic));
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            deserializer,
+            deserializer,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                EnableAutoOffsetStore = true,
+                OffsetStoreTiming = OffsetStoreTiming.OnDelivery
+            });
+        consumer.Subscribe(Topic);
+        var failure = new InvalidOperationException("record fault failed");
+        var faultScope = new KafkaFaultScope(
+            KafkaFaultOperation.Consume,
+            Topic,
+            0,
+            GroupId);
+        cluster.FaultPlan.Fail(faultScope, failure);
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            snapshot.MoveNextAsync().AsTask());
+
+        await Assert.That(actual).IsNotSameReferenceAs(failure);
+        await Assert.That(actual!.Message).Contains("snapshot enumeration");
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+        await Assert.That(cluster.FaultPlan.Clear(faultScope)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task SnapshotCompletion_BarrierCommitsExactCapturedOffsets()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic);
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: false,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 1));
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId));
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+
+        var completion = snapshot.MoveNextAsync().AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 9));
+        await Assert.That(barrier.Release()).IsTrue();
+
+        await Assert.That(await completion).IsFalse();
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Snapshot_GroupChangeDuringCommitBarrierThrowsBeforePublishingRecord()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+
+        var moveNext = snapshot.MoveNextAsync().AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        await using var joiningConsumer = CreateConsumer(cluster);
+        joiningConsumer.Subscribe(Topic);
+        await Assert.That(barrier.Release()).IsTrue();
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => moveNext);
+
+        await Assert.That(actual!.Message).Contains("snapshot enumeration");
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(0);
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Snapshot_GroupChangeAfterYieldPreservesCommitFault()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key-0", "value-0");
+        await producer.ProduceAsync(Topic, "key-1", "value-1");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+        var failure = new InvalidOperationException("commit failed");
+        var faultScope = new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId);
+        cluster.FaultPlan.Fail(faultScope, failure);
+        await using var joiningConsumer = CreateConsumer(cluster);
+        joiningConsumer.Subscribe(Topic);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            snapshot.MoveNextAsync().AsTask());
+
+        await Assert.That(actual).IsNotSameReferenceAs(failure);
+        await Assert.That(actual!.Message).Contains("snapshot enumeration");
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+        await Assert.That(cluster.FaultPlan.Clear(faultScope)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Snapshot_FaultAddedDuringAdvancementWaitAppliesToNextRecord()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key-0", "value-0");
+        await producer.ProduceAsync(Topic, "key-1", "value-1");
+        var deserializer = new FirstCallBlockingAsyncDeserializer();
+        await using var consumer = CreateAsyncConsumer(cluster, deserializer);
+        consumer.Subscribe(Topic);
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+        var snapshotMove = snapshot.MoveNextAsync().AsTask();
+        await deserializer.WaitUntilEnteredAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        var commitBarrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+        var concurrentConsume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await commitBarrier.WaitUntilEnteredAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        var waitEntered = consumer.WaitUntilAutoCommitAdvancementWaiterEnteredAsync();
+        deserializer.Release();
+        await waitEntered.WaitAsync(TimeSpan.FromSeconds(5));
+        var failure = new InvalidOperationException("consume failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Consume, Topic, 0, GroupId),
+            failure);
+        await Assert.That(commitBarrier.Release()).IsTrue();
+
+        await Assert.That(await concurrentConsume.WaitAsync(TimeSpan.FromSeconds(5))).IsNotNull();
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => snapshotMove);
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Snapshot_FaultAddedAfterFirstRecordAppliesToNextRecord()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key-0", "value-0");
+        await producer.ProduceAsync(Topic, "key-1", "value-1");
+        await using var consumer = CreateConsumer(cluster);
+        consumer.Subscribe(Topic);
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+        var failure = new InvalidOperationException("consume failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Consume, Topic, 0, GroupId),
+            failure);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            snapshot.MoveNextAsync().AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Snapshot_FaultAddedDuringDeserializationAppliesToCurrentRecord()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var deserializer = new BlockingAsyncDeserializer();
+        await using var consumer = CreateAsyncConsumer(cluster, deserializer);
+        consumer.Subscribe(Topic);
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+
+        var moveNext = snapshot.MoveNextAsync().AsTask();
+        await deserializer.WaitUntilEnteredAsync();
+        var failure = new InvalidOperationException("consume failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Consume, Topic, 0, GroupId),
+            failure);
+        deserializer.Release();
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => moveNext);
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(0);
+
+        var retry = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(retry).IsNotNull();
+        await Assert.That(retry!.Value.Offset).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Snapshot_StopsProbingAfterOneShotFaultIsConsumed()
+    {
+        var innerPlan = new KafkaFaultPlan();
+        var faultPlan = new DelegatingFaultPlan(innerPlan);
+        var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions(), faultPlan);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key-0", "value-0");
+        await producer.ProduceAsync(Topic, "key-1", "value-1");
+        await using var consumer = CreateConsumer(cluster);
+        consumer.Subscribe(Topic);
+        var barrier = innerPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Consume, Topic, 0, GroupId));
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+
+        var firstMove = snapshot.MoveNextAsync().AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        await Assert.That(barrier.Release()).IsTrue();
+        await Assert.That(await firstMove).IsTrue();
+        var probesAfterFault = faultPlan.MatchingProbeCount;
+
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+
+        await Assert.That(faultPlan.MatchingProbeCount).IsEqualTo(probesAfterFault);
+    }
+
+    [Test]
+    public async Task AutoCommit_DoesNotConsumeCommitFaultWithoutStoredOffset()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: false,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var failure = new InvalidOperationException("commit failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            failure);
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsNull();
+
+        consumer.StoreOffset(result!.Value);
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.CommitAsync().AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_FaultAddedDuringSynchronousDeserializationAppliesToCurrentRecord()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var failure = new InvalidOperationException("consume failed");
+        var deserializer = new CallbackOnceDeserializer(() => cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Consume, Topic, 0, GroupId),
+            failure));
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            deserializer,
+            deserializer,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                EnableAutoOffsetStore = false
+            });
+        consumer.Subscribe(Topic);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(0);
+        var result = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Offset).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ManualCommit_InjectedCommitFaultDoesNotEnterAsyncFaultPath()
+    {
+        var innerPlan = new KafkaFaultPlan();
+        var faultPlan = new DelegatingFaultPlan(innerPlan);
+        var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions(), faultPlan);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Manual);
+        consumer.Subscribe(Topic);
+        innerPlan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            new InvalidOperationException("commit failed"));
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(faultPlan.MatchingProbeCount).IsEqualTo(0);
+        await Assert.That(innerPlan.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task AutoCommit_WithoutCommittableOffsetStaysOnSynchronousPath()
+    {
+        var innerPlan = new KafkaFaultPlan();
+        var faultPlan = new DelegatingFaultPlan(innerPlan);
+        var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions(), faultPlan);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key-0", "value-0");
+        await producer.ProduceAsync(Topic, "key-1", "value-1");
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: false,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var failure = new InvalidOperationException("commit failed");
+        innerPlan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            failure);
+
+        var operation = consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(operation.IsCompletedSuccessfully).IsTrue();
+        var result = operation.Result;
+        await Assert.That(result).IsNotNull();
+        await Assert.That(faultPlan.MatchingProbeCount).IsEqualTo(0);
+
+        consumer.StoreOffset(result!.Value);
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+    }
+
+    [Test]
+    public async Task AutoCommit_AfterProcessingConsumesResourceFaultOnNextPoll()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto,
+            offsetStoreTiming: OffsetStoreTiming.AfterProcessing);
+        consumer.Subscribe(Topic);
+        var failure = new InvalidOperationException("commit failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId),
+            failure);
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsNull();
+
+        var next = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(next).IsNull();
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task AutoCommit_AfterProcessingBarrierReservesInDoubtAdvancement()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key-0", "value-0");
+        await producer.ProduceAsync(Topic, "key-1", "value-1");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto,
+            offsetStoreTiming: OffsetStoreTiming.AfterProcessing);
+        consumer.Subscribe(Topic);
+        _ = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var reservedConsume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        var concurrentResult = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(concurrentResult).IsNull();
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(1);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsNull();
+        await Assert.That(barrier.Release()).IsTrue();
+
+        var result = await reservedConsume;
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Key).IsEqualTo("key-1");
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(2);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task AutoCommit_AfterProcessingFaultObserverClosePreventsLateReservation()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key-0", "value-0");
+        await producer.ProduceAsync(Topic, "key-1", "value-1");
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto,
+            offsetStoreTiming: OffsetStoreTiming.AfterProcessing);
+        consumer.Subscribe(Topic);
+        _ = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+        Task? closeTask = null;
+        cluster.FaultPlan.FaultConsumed += observation =>
+        {
+            if (observation.OperationScope.Operation == KafkaFaultOperation.Commit)
+                closeTask = consumer.CloseAsync().AsTask();
+        };
+
+        var consume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+
+        try
+        {
+            await Assert.That(consume.IsCompleted).IsTrue();
+            _ = await Assert.ThrowsAsync<ObjectDisposedException>(() => consume);
+            await Assert.That(closeTask).IsNotNull();
+            await closeTask!;
+        }
+        finally
+        {
+            barrier.Release();
+        }
+    }
+
+    [Test]
+    public async Task AutoCommit_AfterProcessingFaultObserverCannotWidenCapturedOffsets()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic, partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto,
+            offsetStoreTiming: OffsetStoreTiming.AfterProcessing);
+        var secondPartition = new TopicPartition(Topic, 1);
+        consumer.Assign(Partition, secondPartition);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 1, 1));
+        _ = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId));
+        cluster.FaultPlan.FaultConsumed += _ =>
+            consumer.StoreOffset(new TopicPartitionOffset(Topic, 1, 9));
+
+        var consume = consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        await Assert.That(barrier.Release()).IsTrue();
+        _ = await consume;
+
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(secondPartition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task AutoCommit_AfterProcessingSharedWaiterCannotProveNextRecord()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key-0", "value-0");
+        await producer.ProduceAsync(Topic, "key-1", "value-1");
+        var deserializer = new AsyncStringDeserializer();
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            deserializer,
+            deserializer,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                EnableAutoOffsetStore = true,
+                OffsetStoreTiming = OffsetStoreTiming.AfterProcessing
+            });
+        consumer.Subscribe(Topic);
+        _ = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var provingConsume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        var sharedWaiter = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await Assert.That(sharedWaiter.IsCompleted).IsFalse();
+        await Assert.That(barrier.Release()).IsTrue();
+
+        var results = await Task.WhenAll(provingConsume, sharedWaiter);
+
+        await Assert.That(results.Count(static result => result is not null)).IsEqualTo(1);
+        await Assert.That(results.Single(static result => result is not null)!.Value.Key)
+            .IsEqualTo("key-1");
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+
+        var commitFault = new InvalidOperationException("commit failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            commitFault);
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(commitFault);
+    }
+
+    [Test]
+    public async Task ConsumeAsync_AfterProcessingSharedWaiterContinuesEnumeration()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key-0", "value-0");
+        await producer.ProduceAsync(Topic, "key-1", "value-1");
+        await producer.ProduceAsync(Topic, "key-2", "value-2");
+        var deserializer = new AsyncStringDeserializer();
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            deserializer,
+            deserializer,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                EnableAutoOffsetStore = true,
+                OffsetStoreTiming = OffsetStoreTiming.AfterProcessing
+            });
+        consumer.Subscribe(Topic);
+        await using var stream = consumer.ConsumeAsync().GetAsyncEnumerator();
+        await Assert.That(await stream.MoveNextAsync()).IsTrue();
+        await Assert.That(stream.Current.Key).IsEqualTo("key-0");
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var provingConsume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        var sharedMove = stream.MoveNextAsync().AsTask();
+        await Assert.That(sharedMove.IsCompleted).IsFalse();
+        await Assert.That(barrier.Release()).IsTrue();
+
+        var concurrent = await provingConsume;
+        await Assert.That(concurrent).IsNotNull();
+        await Assert.That(concurrent!.Value.Key).IsEqualTo("key-1");
+        await Assert.That(sharedMove.IsCompleted).IsFalse();
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+
+        await consumer.CommitAsync();
+
+        await Assert.That(await sharedMove).IsTrue();
+        await Assert.That(stream.Current.Key).IsEqualTo("key-2");
+    }
+
+    [Test]
+    public async Task Snapshot_AfterProcessingSharedWaiterFailsInsteadOfTruncating()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic, partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 0,
+            Key = "snapshot-0",
+            Value = "value-0"
+        });
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 1,
+            Key = "concurrent",
+            Value = "value-1"
+        });
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 1,
+            Key = "remaining",
+            Value = "value-2"
+        });
+        var deserializer = new AsyncStringDeserializer();
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            deserializer,
+            deserializer,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                EnableAutoOffsetStore = true,
+                OffsetStoreTiming = OffsetStoreTiming.AfterProcessing
+            });
+        consumer.Assign(Partition, new TopicPartition(Topic, 1));
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+        await Assert.That(snapshot.Current.Key).IsEqualTo("snapshot-0");
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var provingConsume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        var sharedMove = snapshot.MoveNextAsync().AsTask();
+        await Assert.That(sharedMove.IsCompleted).IsFalse();
+        await Assert.That(barrier.Release()).IsTrue();
+
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(() => sharedMove);
+        var concurrent = await provingConsume;
+
+        await Assert.That(failure!.Message).Contains("snapshot enumeration");
+        await Assert.That(concurrent).IsNotNull();
+        await Assert.That(concurrent!.Value.Key).IsEqualTo("concurrent");
+        await consumer.CommitAsync();
+        var remaining = new List<string>();
+        await foreach (var record in consumer.ConsumeSnapshotAsync())
+            remaining.Add(record.Key!);
+        await Assert.That(remaining).IsEquivalentTo(["remaining"]);
+    }
+
+    [Test]
+    public async Task AutoCommit_AfterProcessingBarrierPreservesCallerPause()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto,
+            offsetStoreTiming: OffsetStoreTiming.AfterProcessing);
+        consumer.Subscribe(Topic);
+        _ = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        consumer.Pause(Partition);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var operation = consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        await Assert.That(barrier.Release()).IsTrue();
+
+        await Assert.That(await operation).IsNull();
+        await Assert.That(consumer.Paused).Contains(Partition);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ConsumeAsync_DisposedAfterYieldPreservesCommitFault()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto,
+            offsetStoreTiming: OffsetStoreTiming.AfterProcessing);
+        consumer.Subscribe(Topic);
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            new InvalidOperationException("commit failed"));
+        await using var records = consumer.ConsumeAsync().GetAsyncEnumerator();
+
+        await Assert.That(await records.MoveNextAsync()).IsTrue();
+        await consumer.CloseAsync();
+        _ = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            records.MoveNextAsync().AsTask());
+
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task CloseAsync_AutoCommitFailureStillDisposesWithoutCommitting()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: false,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 1));
+        var failure = new InvalidOperationException("commit failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            failure);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.CloseAsync().AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsNull();
+        _ = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask());
+    }
+
+    [Test]
+    public async Task CloseAsync_ConcurrentCallersShareCommitBarrier()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: false,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 1));
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var firstClose = consumer.CloseAsync().AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        var secondClose = consumer.CloseAsync().AsTask();
+
+        await Assert.That(secondClose).IsSameReferenceAs(firstClose);
+        await Assert.That(secondClose.IsCompleted).IsFalse();
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsNull();
+        await Assert.That(barrier.Release()).IsTrue();
+        await Task.WhenAll(firstClose, secondClose);
+
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task CloseAsync_BarrierCommitsExactCapturedOffsets()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic);
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: false,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 1));
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId));
+
+        var close = consumer.CloseAsync().AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 9));
+        await Assert.That(barrier.Release()).IsTrue();
+        await close;
+
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task CommitAsync_SnapshotsLazyOffsetsBeforeFaultObserver()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync();
+        var offsets = new List<TopicPartitionOffset> { new(Topic, 0, 1) };
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+        cluster.FaultPlan.FaultConsumed += _ =>
+        {
+            offsets[0] = new TopicPartitionOffset(Topic, 0, 9);
+            barrier.Release();
+        };
+
+        await consumer.CommitAsync(offsets.Select(static offset => offset));
+
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task CommitAsync_LazyOffsetsPreserveResourceRuleOrder()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync();
+        var resourceFailure = new InvalidOperationException("resource failed");
+        var groupFailure = new InvalidOperationException("group failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId),
+            resourceFailure);
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            groupFailure);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.CommitAsync(YieldOffset(new TopicPartitionOffset(Topic, 0, 1))).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(resourceFailure);
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+
+        actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            consumer.CommitAsync(YieldOffset(new TopicPartitionOffset(Topic, 0, 1))).AsTask());
+
+        await Assert.That(actual).IsSameReferenceAs(groupFailure);
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CommitAsync_ReadOnlyListUsesIndexedCommitPath()
+    {
+        var (_, consumer) = await CreateConsumerWithRecordAsync();
+        var offsets = new IndexOnlyOffsets(new TopicPartitionOffset(Topic, 0, 1));
+
+        await consumer.CommitAsync(offsets);
+
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task StoreOffset_FailureDoesNotMutateStoredOffsets()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync(enableAutoOffsetStore: false);
+        var failure = new InvalidOperationException("store failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.StoreOffset, Topic, 0, GroupId),
+            failure);
+
+        var actual = Assert.Throws<InvalidOperationException>(
+            () => consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 1)));
+        await consumer.CommitAsync();
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsNull();
+
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 1));
+        await consumer.CommitAsync();
+
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task StoreOffset_UnrelatedRuleRemainsQueued()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync(enableAutoOffsetStore: false);
+        cluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(
+                KafkaFaultOperation.StoreOffset,
+                topic: "payments",
+                partition: 0,
+                groupId: GroupId),
+            new InvalidOperationException("unrelated"));
+
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 1));
+        await consumer.CommitAsync();
+
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task StoreOffsets_FaultObserverCannotMutateValidatedBatch()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync(enableAutoOffsetStore: false);
+        TopicPartitionOffset[] offsets = [new(Topic, 0, 1)];
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.StoreOffset, Topic, 0, GroupId));
+        cluster.FaultPlan.FaultConsumed += _ =>
+        {
+            offsets[0] = new TopicPartitionOffset(Topic, 0, 9);
+            barrier.Release();
+        };
+
+        consumer.StoreOffsets(offsets);
+        await consumer.CommitAsync();
+
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments("Single")]
+    [Arguments("List")]
+    [Arguments("Span")]
+    public async Task StoreOffsets_FaultObserverClosePreventsDisposedMutationAndLaterFaultConsumption(
+        string overload)
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync(enableAutoOffsetStore: false);
+        var firstOffset = new TopicPartitionOffset(Topic, 0, 1);
+        var secondOffset = new TopicPartitionOffset(Topic, 1, 2);
+        var firstBarrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.StoreOffset, Topic, 0, GroupId));
+        if (overload != "Single")
+        {
+            _ = cluster.FaultPlan.PauseNext(
+                new KafkaFaultScope(KafkaFaultOperation.StoreOffset, Topic, 1, GroupId));
+        }
+        await Assert.That(firstBarrier.Release()).IsTrue();
+        Task? closeTask = null;
+        cluster.FaultPlan.FaultConsumed += _ => closeTask ??= consumer.CloseAsync().AsTask();
+        Action store = overload switch
+        {
+            "Single" => () => consumer.StoreOffset(firstOffset),
+            "List" => () => consumer.StoreOffsets(new[] { firstOffset, secondOffset }),
+            "Span" => () => consumer.StoreOffsets(new[] { firstOffset, secondOffset }.AsSpan()),
+            _ => throw new ArgumentOutOfRangeException(nameof(overload), overload, null)
+        };
+
+        _ = Assert.Throws<ObjectDisposedException>(store);
+
+        await Assert.That(closeTask).IsNotNull();
+        await closeTask!;
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(overload == "Single" ? 0 : 1);
+    }
+
+    [Test]
+    [Arguments("Subscribe")]
+    [Arguments("SubscribePattern")]
+    [Arguments("Unsubscribe")]
+    public async Task GroupTransition_AutoCommitBarrierPreservesQueuedFault(string transition)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic);
+        cluster.CreateTopic("payments");
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var commitBarrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+        var consume = consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask();
+        await commitBarrier.WaitUntilEnteredAsync();
+        var groupOperation = transition == "Unsubscribe"
+            ? KafkaFaultOperation.Rebalance
+            : KafkaFaultOperation.JoinGroup;
+        var groupFailure = new InvalidOperationException("group transition failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(groupOperation, groupId: GroupId),
+            groupFailure);
+        Action transitionAction = transition switch
+        {
+            "Subscribe" => () => consumer.Subscribe("payments"),
+            "SubscribePattern" => () => consumer.SubscribePattern("^payments$"),
+            "Unsubscribe" => consumer.Unsubscribe,
+            _ => throw new ArgumentOutOfRangeException(nameof(transition))
+        };
+
+        var pending = Assert.Throws<InvalidOperationException>(transitionAction);
+
+        await Assert.That(pending.Message).Contains("automatic commit fault");
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+        await Assert.That(commitBarrier.Release()).IsTrue();
+        _ = await consume;
+
+        var actual = Assert.Throws<InvalidOperationException>(transitionAction);
+
+        await Assert.That(actual).IsSameReferenceAs(groupFailure);
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    [Arguments(KafkaFaultOperation.JoinGroup)]
+    [Arguments(KafkaFaultOperation.SyncGroup)]
+    [Arguments(KafkaFaultOperation.Rebalance)]
+    public async Task Subscribe_GroupTransitionObserverCannotCreateLateAutoCommitReservation(
+        KafkaFaultOperation operation)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic);
+        cluster.CreateTopic("payments");
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe(Topic);
+        var commitBarrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+        var transitionBarrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(operation, groupId: GroupId));
+        await Assert.That(transitionBarrier.Release()).IsTrue();
+        Task<ConsumeResult<string, string>?>? consume = null;
+        cluster.FaultPlan.FaultConsumed += observation =>
+        {
+            if (observation.OperationScope.Operation == operation)
+                consume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        };
+
+        var actual = Assert.Throws<InvalidOperationException>(() => consumer.Subscribe("payments"));
+
+        await Assert.That(actual.Message).Contains("automatic commit fault");
+        await Assert.That(consume is not null).IsTrue();
+        await Assert.That(consumer.Subscription).IsEquivalentTo([Topic]);
+        await Assert.That(consumer.Assignment).IsEquivalentTo([Partition]);
+        await Assert.That(commitBarrier.Release()).IsTrue();
+        await consume!;
+    }
+
+    [Test]
+    public async Task Subscribe_GroupTransitionObserverCannotMutateTopicSnapshot()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic);
+        cluster.CreateTopic("payments");
+        await using var consumer = CreateConsumer(cluster);
+        var topics = new[] { Topic };
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.JoinGroup, groupId: GroupId));
+        await Assert.That(barrier.Release()).IsTrue();
+        cluster.FaultPlan.FaultConsumed += observation =>
+        {
+            if (observation.OperationScope.Operation == KafkaFaultOperation.JoinGroup)
+                topics[0] = "payments";
+        };
+
+        consumer.Subscribe(topics);
+
+        await Assert.That(consumer.Subscription).IsEquivalentTo([Topic]);
+        await Assert.That(consumer.Assignment).IsEquivalentTo([Partition]);
+    }
+
+    [Arguments("Subscribe")]
+    [Arguments("SubscribePattern")]
+    [Test]
+    public async Task Subscribe_GroupTransitionObserverCloseCannotReregisterDisposedConsumer(
+        string transition)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic);
+        cluster.CreateTopic("payments");
+        var consumer = CreateConsumer(cluster);
+        consumer.Subscribe(Topic);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.JoinGroup, groupId: GroupId));
+        await Assert.That(barrier.Release()).IsTrue();
+        Task? closeTask = null;
+        cluster.FaultPlan.FaultConsumed += _ => closeTask = consumer.CloseAsync().AsTask();
+        Action subscribe = transition == "Subscribe"
+            ? () => consumer.Subscribe("payments")
+            : () => consumer.SubscribePattern("^payments$");
+
+        _ = Assert.Throws<ObjectDisposedException>(subscribe);
+
+        await Assert.That(closeTask).IsNotNull();
+        await closeTask!;
+        await Assert.That(consumer.Assignment).IsEmpty();
+        await using var replacement = CreateConsumer(cluster);
+        replacement.Subscribe("payments");
+        await Assert.That(replacement.Assignment)
+            .IsEquivalentTo([new TopicPartition("payments", 0)]);
+    }
+
+    [Test]
+    [Arguments(KafkaFaultOperation.JoinGroup)]
+    [Arguments(KafkaFaultOperation.SyncGroup)]
+    [Arguments(KafkaFaultOperation.Rebalance)]
+    public async Task Subscribe_GroupTransitionFailurePreservesExistingAssignment(
+        KafkaFaultOperation operation)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic, partitionCount: 1);
+        cluster.CreateTopic("payments", partitionCount: 1);
+        var consumer = CreateConsumer(cluster);
+        consumer.Subscribe(Topic);
+        var failure = new InvalidOperationException(operation.ToString());
+        cluster.FaultPlan.Fail(new KafkaFaultScope(operation, groupId: GroupId), failure);
+
+        var actual = Assert.Throws<InvalidOperationException>(() => consumer.Subscribe("payments"));
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(consumer.Subscription).IsEquivalentTo([Topic]);
+        await Assert.That(consumer.Assignment).IsEquivalentTo([Partition]);
+
+        consumer.Subscribe("payments");
+
+        await Assert.That(consumer.Subscription).IsEquivalentTo(["payments"]);
+        await Assert.That(consumer.Assignment)
+            .IsEquivalentTo([new TopicPartition("payments", 0)]);
+    }
+
+    [Test]
+    public async Task Subscribe_GroupTransitionFailureDoesNotAutoCreateTopic()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var consumer = CreateConsumer(cluster);
+        var failure = new InvalidOperationException("join failed");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.JoinGroup, groupId: GroupId),
+            failure);
+
+        var actual = Assert.Throws<InvalidOperationException>(() => consumer.Subscribe("missing"));
+
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(cluster.ListTopics()).IsEmpty();
+    }
+
+    [Test]
+    public async Task ManualAssignment_DoesNotConsumeGroupTransitionFaults()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic);
+        var consumer = CreateConsumer(cluster);
+        var failure = new InvalidOperationException("group transition");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.JoinGroup, groupId: GroupId),
+            failure);
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.SyncGroup, groupId: GroupId),
+            failure);
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Rebalance),
+            failure);
+
+        consumer.Assign(Partition);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
+        consumer.IncrementalUnassign([Partition]);
+        consumer.Unassign();
+
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task FaultSelectors_DoNotConsumeRuleForDifferentGroup()
+    {
+        var (cluster, consumer) = await CreateConsumerWithRecordAsync();
+        var failure = new InvalidOperationException("other group");
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Fetch, Topic, 0, "other-workers"),
+            failure);
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+    }
+
+    private static async Task<(InMemoryKafkaCluster Cluster, InMemoryConsumer<string, string> Consumer)>
+        CreateConsumerWithRecordAsync(bool enableAutoOffsetStore = true)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        var consumer = CreateConsumer(cluster, enableAutoOffsetStore);
+        consumer.Subscribe(Topic);
+        return (cluster, consumer);
+    }
+
+    private static InMemoryConsumer<string, string> CreateConsumer(
+        InMemoryKafkaCluster cluster,
+        bool enableAutoOffsetStore = true,
+        OffsetCommitMode offsetCommitMode = OffsetCommitMode.Manual,
+        OffsetStoreTiming offsetStoreTiming = OffsetStoreTiming.OnDelivery,
+        string groupId = GroupId,
+        string? memberId = null) =>
+        new(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = groupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = offsetCommitMode,
+                EnableAutoOffsetStore = enableAutoOffsetStore,
+                OffsetStoreTiming = offsetStoreTiming,
+                MemberId = memberId
+            });
+
+    private static InMemoryConsumer<string, string> CreateAsyncConsumer(
+        InMemoryKafkaCluster cluster,
+        IAsyncDeserializer<string> deserializer,
+        string? memberId = null) =>
+        new(
+            cluster,
+            deserializer,
+            deserializer,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                EnableAutoOffsetStore = true,
+                OffsetStoreTiming = OffsetStoreTiming.OnDelivery,
+                MemberId = memberId
+            });
+
+    private static IEnumerable<TopicPartitionOffset> YieldOffset(TopicPartitionOffset offset)
+    {
+        yield return offset;
+    }
+
+    private sealed class IndexOnlyOffsets(TopicPartitionOffset offset) : IReadOnlyList<TopicPartitionOffset>
+    {
+        public int Count => 1;
+
+        public TopicPartitionOffset this[int index] => index == 0
+            ? offset
+            : throw new ArgumentOutOfRangeException(nameof(index));
+
+        public IEnumerator<TopicPartitionOffset> GetEnumerator() =>
+            throw new InvalidOperationException("Indexed collection was enumerated.");
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class DelegatingFaultPlan(KafkaFaultPlan inner) : IKafkaFaultPlan
+    {
+        private Action? _countObserved;
+        private Action? _matchingObserved;
+
+        public int MatchingProbeCount { get; private set; }
+
+        public int PotentialProbeCount { get; private set; }
+
+        public event Action<KafkaFaultObservation>? FaultConsumed
+        {
+            add => inner.FaultConsumed += value;
+            remove => inner.FaultConsumed -= value;
+        }
+
+        public int Count
+        {
+            get
+            {
+                Interlocked.Exchange(ref _countObserved, null)?.Invoke();
+                return inner.Count;
+            }
+        }
+
+        public long Version => inner.Version;
+
+        public void ObserveNextCount(Action callback) =>
+            _countObserved = callback;
+
+        public void ObserveNextMatchingProbe(Action callback) =>
+            _matchingObserved = callback;
+
+        public bool HasMatchingFault(in KafkaFaultScope operationScope)
+        {
+            Interlocked.Exchange(ref _matchingObserved, null)?.Invoke();
+            MatchingProbeCount++;
+            return inner.HasMatchingFault(operationScope);
+        }
+
+        public bool HasPotentialFault(
+            KafkaFaultOperation operation,
+            string? groupId,
+            IReadOnlySet<TopicPartition> resources)
+        {
+            PotentialProbeCount++;
+            return inner.HasPotentialFault(operation, groupId, resources);
+        }
+
+        public bool TryGetFirstMatchingFaultScope(
+            ReadOnlySpan<KafkaFaultScope> operationScopes,
+            out KafkaFaultScope operationScope)
+        {
+            Interlocked.Exchange(ref _matchingObserved, null)?.Invoke();
+            return inner.TryGetFirstMatchingFaultScope(operationScopes, out operationScope);
+        }
+
+        public bool TryApplyFirstMatchingFault(
+            ReadOnlySpan<KafkaFaultScope> operationScopes,
+            out ValueTask application,
+            CancellationToken cancellationToken = default) =>
+            inner.TryApplyFirstMatchingFault(operationScopes, out application, cancellationToken);
+
+        public void Fail(KafkaFaultScope scope, Exception exception, int occurrenceCount = 1) =>
+            inner.Fail(scope, exception, occurrenceCount);
+
+        public void FailPersistently(KafkaFaultScope scope, Exception exception) =>
+            inner.FailPersistently(scope, exception);
+
+        public KafkaFaultBarrier PauseNext(KafkaFaultScope scope) => inner.PauseNext(scope);
+
+        public ValueTask ApplyAsync(
+            KafkaFaultScope operationScope,
+            CancellationToken cancellationToken = default) =>
+            inner.ApplyAsync(operationScope, cancellationToken);
+
+        public int Clear(KafkaFaultScope scope) => inner.Clear(scope);
+
+        public int Clear() => inner.Clear();
+    }
+
+    private sealed class BlockingAsyncDeserializer : IAsyncDeserializer<string>
+    {
+        private readonly TaskCompletionSource _entered = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async ValueTask<string> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            _entered.TrySetResult();
+            await _release.Task.WaitAsync(cancellationToken);
+            return Encoding.UTF8.GetString(data.Span);
+        }
+
+        public Task WaitUntilEnteredAsync() => _entered.Task;
+
+        public void Release() => _release.TrySetResult();
+    }
+
+    private sealed class AsyncStringDeserializer : IAsyncDeserializer<string>
+    {
+        public ValueTask<string> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(Encoding.UTF8.GetString(data.Span));
+    }
+
+    private sealed class CallbackOnceDeserializer(Action callback) : IDeserializer<string>
+    {
+        private int _invokeCallback = 1;
+
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            if (Interlocked.Exchange(ref _invokeCallback, 0) != 0)
+                callback();
+
+            return Encoding.UTF8.GetString(data.Span);
+        }
+    }
+
+    private sealed class FirstCallBlockingAsyncDeserializer : IAsyncDeserializer<string>
+    {
+        private readonly TaskCompletionSource _entered = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _blockNext = 1;
+
+        public async ValueTask<string> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Exchange(ref _blockNext, 0) != 0)
+            {
+                _entered.TrySetResult();
+                await _release.Task.WaitAsync(cancellationToken);
+            }
+
+            return Encoding.UTF8.GetString(data.Span);
+        }
+
+        public Task WaitUntilEnteredAsync() => _entered.Task;
+
+        public void Release() => _release.TrySetResult();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryConsumerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryConsumerFaultTests.cs
@@ -545,6 +545,34 @@ public sealed class InMemoryConsumerFaultTests
     }
 
     [Test]
+    public async Task CommitAsync_GroupChangeDuringBarrierDoesNotOverwriteNewOwnerOffset()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic);
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: false,
+            memberId: "z-member");
+        consumer.Subscribe(Topic);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 1));
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var staleCommit = consumer.CommitAsync().AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        await using var newOwner = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: false,
+            memberId: "a-member");
+        newOwner.Subscribe(Topic);
+        await newOwner.CommitAsync([new TopicPartitionOffset(Topic, 0, 9)]);
+        await Assert.That(barrier.Release()).IsTrue();
+        await staleCommit;
+
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsEqualTo(9);
+    }
+
+    [Test]
     public async Task CommitAsync_BarrierCommitsExactCallerOffsets()
     {
         var (cluster, consumer) = await CreateConsumerWithRecordAsync();
@@ -597,6 +625,35 @@ public sealed class InMemoryConsumerFaultTests
     }
 
     [Test]
+    public async Task OnDeliveryAutoCommit_GroupChangeDuringBarrierDoesNotOverwriteNewOwnerOffset()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key", "value");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto,
+            memberId: "z-member");
+        consumer.Subscribe(Topic);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var staleConsume = consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        await using var newOwner = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: false,
+            memberId: "a-member");
+        newOwner.Subscribe(Topic);
+        await newOwner.CommitAsync([new TopicPartitionOffset(Topic, 0, 9)]);
+        await Assert.That(barrier.Release()).IsTrue();
+
+        await Assert.That(await staleConsume).IsNull();
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsEqualTo(9);
+    }
+
+    [Test]
     public async Task OnDeliveryAutoCommit_BarrierAllowsPausingUnrelatedPartition()
     {
         var cluster = new InMemoryKafkaCluster();
@@ -615,17 +672,21 @@ public sealed class InMemoryConsumerFaultTests
             offsetCommitMode: OffsetCommitMode.Auto);
         var secondPartition = new TopicPartition(Topic, 1);
         consumer.Assign(Partition, secondPartition);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 1, 1));
         var barrier = cluster.FaultPlan.PauseNext(
             new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId));
 
         var consume = consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask();
         await barrier.WaitUntilEnteredAsync();
         consumer.Pause(secondPartition);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 1, 9));
         await Assert.That(barrier.Release()).IsTrue();
         _ = await consume;
 
         await Assert.That(consumer.Paused).Contains(secondPartition);
         await Assert.That(consumer.Paused).DoesNotContain(Partition);
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsEqualTo(1);
+        await Assert.That(cluster.GetCommittedOffset(GroupId, secondPartition)).IsEqualTo(1);
     }
 
     [Test]
@@ -1369,7 +1430,7 @@ public sealed class InMemoryConsumerFaultTests
     }
 
     [Test]
-    public async Task ConsumeOneAsync_GroupChangeDuringCommitProbePreventsStaleAdvancement()
+    public async Task ConsumeOneAsync_GroupChangeDuringCommitProbePreservesFault()
     {
         var innerPlan = new KafkaFaultPlan();
         var faultPlan = new DelegatingFaultPlan(innerPlan);
@@ -1379,8 +1440,13 @@ public sealed class InMemoryConsumerFaultTests
         var deserializer = new AsyncStringDeserializer();
         await using var consumer = CreateAsyncConsumer(cluster, deserializer, "z-member");
         consumer.Subscribe(Topic);
+        var commitFailure = new InvalidOperationException("commit failed");
+        var commitScope = new KafkaFaultScope(
+            KafkaFaultOperation.Commit,
+            groupId: GroupId);
+        innerPlan.Fail(commitScope, commitFailure);
         InMemoryConsumer<string, string>? joiningConsumer = null;
-        faultPlan.ObserveNextMatchingProbe(() =>
+        faultPlan.ObserveNextCommitProbe(() =>
         {
             joiningConsumer = CreateConsumer(cluster, memberId: "a-member");
             joiningConsumer.Subscribe(Topic);
@@ -1391,6 +1457,8 @@ public sealed class InMemoryConsumerFaultTests
         await Assert.That(result).IsNull();
         await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(0);
         await Assert.That(joiningConsumer).IsNotNull();
+        await Assert.That(innerPlan.Count).IsEqualTo(1);
+        await Assert.That(innerPlan.Clear(commitScope)).IsEqualTo(1);
         var reassignedConsumer = joiningConsumer!;
         await using (reassignedConsumer)
         {
@@ -1876,6 +1944,38 @@ public sealed class InMemoryConsumerFaultTests
     }
 
     [Test]
+    public async Task AutoCommit_AfterProcessingGroupChangeDoesNotOverwriteNewOwnerOffset()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key-0", "value-0");
+        await producer.ProduceAsync(Topic, "key-1", "value-1");
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto,
+            offsetStoreTiming: OffsetStoreTiming.AfterProcessing,
+            memberId: "z-member");
+        consumer.Subscribe(Topic);
+        _ = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var staleConsume = consumer.ConsumeOneAsync(TimeSpan.Zero).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        await using var newOwner = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: false,
+            memberId: "a-member");
+        newOwner.Subscribe(Topic);
+        await newOwner.CommitAsync([new TopicPartitionOffset(Topic, 0, 9)]);
+        await Assert.That(barrier.Release()).IsTrue();
+
+        await Assert.That(await staleConsume).IsNull();
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsEqualTo(9);
+    }
+
+    [Test]
     public async Task AutoCommit_AfterProcessingFaultObserverClosePreventsLateReservation()
     {
         var cluster = new InMemoryKafkaCluster();
@@ -2035,6 +2135,80 @@ public sealed class InMemoryConsumerFaultTests
 
         await Assert.That(await sharedMove).IsTrue();
         await Assert.That(stream.Current.Key).IsEqualTo("key-2");
+    }
+
+    [Test]
+    public async Task ConsumeAsync_AfterProcessingOwnerCompletesSharedWaiter()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key-0", "value-0");
+        await producer.ProduceAsync(Topic, "key-1", "value-1");
+        var deserializer = new AsyncStringDeserializer();
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            deserializer,
+            deserializer,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                EnableAutoOffsetStore = true,
+                OffsetStoreTiming = OffsetStoreTiming.AfterProcessing
+            });
+        consumer.Subscribe(Topic);
+        await using var stream = consumer.ConsumeAsync().GetAsyncEnumerator();
+        await Assert.That(await stream.MoveNextAsync()).IsTrue();
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var ownerMove = stream.MoveNextAsync().AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        var sharedConsume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await Assert.That(sharedConsume.IsCompleted).IsFalse();
+        await Assert.That(barrier.Release()).IsTrue();
+
+        await Assert.That(await ownerMove.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+        await Assert.That(stream.Current.Key).IsEqualTo("key-1");
+        await Assert.That(await sharedConsume.WaitAsync(TimeSpan.FromSeconds(5))).IsNull();
+    }
+
+    [Test]
+    public async Task Snapshot_AfterProcessingOwnerCompletesSharedWaiter()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key-0", "value-0");
+        await producer.ProduceAsync(Topic, "key-1", "value-1");
+        var deserializer = new AsyncStringDeserializer();
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            deserializer,
+            deserializer,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                EnableAutoOffsetStore = true,
+                OffsetStoreTiming = OffsetStoreTiming.AfterProcessing
+            });
+        consumer.Subscribe(Topic);
+        await using var snapshot = consumer.ConsumeSnapshotAsync().GetAsyncEnumerator();
+        await Assert.That(await snapshot.MoveNextAsync()).IsTrue();
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var ownerMove = snapshot.MoveNextAsync().AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        var sharedConsume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await Assert.That(sharedConsume.IsCompleted).IsFalse();
+        await Assert.That(barrier.Release()).IsTrue();
+
+        await Assert.That(await ownerMove.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+        await Assert.That(snapshot.Current.Key).IsEqualTo("key-1");
+        await Assert.That(await sharedConsume.WaitAsync(TimeSpan.FromSeconds(5))).IsNull();
     }
 
     [Test]
@@ -2225,6 +2399,35 @@ public sealed class InMemoryConsumerFaultTests
         await close;
 
         await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task CloseAsync_GroupChangeDuringBarrierDoesNotOverwriteNewOwnerOffset()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic);
+        var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: false,
+            offsetCommitMode: OffsetCommitMode.Auto,
+            memberId: "z-member");
+        consumer.Subscribe(Topic);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 0, 1));
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var staleClose = consumer.CloseAsync().AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        await using var newOwner = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: false,
+            memberId: "a-member");
+        newOwner.Subscribe(Topic);
+        await newOwner.CommitAsync([new TopicPartitionOffset(Topic, 0, 9)]);
+        await Assert.That(barrier.Release()).IsTrue();
+        await staleClose;
+
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsEqualTo(9);
     }
 
     [Test]
@@ -2673,6 +2876,7 @@ public sealed class InMemoryConsumerFaultTests
     {
         private Action? _countObserved;
         private Action? _matchingObserved;
+        private Action? _commitProbeObserved;
 
         public int MatchingProbeCount { get; private set; }
 
@@ -2701,6 +2905,9 @@ public sealed class InMemoryConsumerFaultTests
         public void ObserveNextMatchingProbe(Action callback) =>
             _matchingObserved = callback;
 
+        public void ObserveNextCommitProbe(Action callback) =>
+            _commitProbeObserved = callback;
+
         public bool HasMatchingFault(in KafkaFaultScope operationScope)
         {
             Interlocked.Exchange(ref _matchingObserved, null)?.Invoke();
@@ -2721,6 +2928,7 @@ public sealed class InMemoryConsumerFaultTests
             ReadOnlySpan<KafkaFaultScope> operationScopes,
             out KafkaFaultScope operationScope)
         {
+            Interlocked.Exchange(ref _commitProbeObserved, null)?.Invoke();
             Interlocked.Exchange(ref _matchingObserved, null)?.Invoke();
             return inner.TryGetFirstMatchingFaultScope(operationScopes, out operationScope);
         }

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -16,6 +16,15 @@ namespace Dekaf.Tests.Unit.Testing;
 public sealed class InMemoryKafkaClusterTests
 {
     [Test]
+    public async Task Constructor_NullOptionsUsesOptionsOverload()
+    {
+        var actual = Assert.Throws<ArgumentNullException>(() =>
+            _ = new InMemoryKafkaCluster((InMemoryKafkaClusterOptions)null!));
+
+        await Assert.That(actual.ParamName).IsEqualTo("options");
+    }
+
+    [Test]
     public async Task AdminFeatures_KeepSupportedAndFinalizedRangesIndependent()
     {
         var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions
@@ -1766,6 +1775,59 @@ public sealed class InMemoryKafkaClusterTests
             .IsEquivalentTo([0, 1]);
         await Assert.That(new[] { first!.Value.Partition, second!.Value.Partition })
             .IsEquivalentTo([0, 1]);
+    }
+
+    [Test]
+    public async Task ConsumerGroupGeneration_IsScopedAndMonotonic()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.RegisterConsumerGroupMember("tracked", "a", [], out var trackedRegistrationId);
+        var initialGeneration = cluster.GetConsumerGroupGeneration("tracked");
+
+        cluster.RegisterConsumerGroupMember("unrelated", "b", [], out var unrelatedRegistrationId);
+        cluster.UnregisterConsumerGroupMember("unrelated", "b", unrelatedRegistrationId);
+
+        await Assert.That(cluster.GetConsumerGroupGeneration("tracked"))
+            .IsEqualTo(initialGeneration);
+
+        cluster.UnregisterConsumerGroupMember("tracked", "a", trackedRegistrationId);
+        await Assert.That(cluster.GetConsumerGroupGeneration("tracked")).IsEqualTo(0);
+        cluster.RegisterConsumerGroupMember("tracked", "c", [], out _);
+
+        await Assert.That(cluster.GetConsumerGroupGeneration("tracked"))
+            .IsGreaterThan(initialGeneration);
+    }
+
+    [Test]
+    public async Task ConsumerGroup_DuplicateMemberIdFencesStaleRegistrationWithoutSpinning()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("duplicate-member-topic");
+        await using var first = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "duplicate-members",
+                MemberId = "member",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        await using var replacement = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "duplicate-members",
+                MemberId = "member",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        first.Subscribe("duplicate-member-topic");
+        replacement.Subscribe("duplicate-member-topic");
+
+        // Keep a generation-loop regression bounded instead of hanging the test process.
+        var result = await Task.Run(() => first.ConsumeOneAsync(TimeSpan.Zero).AsTask())
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(result).IsNull();
+        await Assert.That(first.Assignment).IsEmpty();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Testing/KafkaFaultPlanTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/KafkaFaultPlanTests.cs
@@ -55,11 +55,113 @@ public sealed class KafkaFaultPlanTests
         var plan = new KafkaFaultPlan();
         var failure = new InvalidOperationException("wildcard");
         plan.Fail(new KafkaFaultScope(KafkaFaultOperation.Fetch), failure);
+        var concreteScope = new KafkaFaultScope(
+            KafkaFaultOperation.Fetch,
+            "orders",
+            4,
+            "billing");
 
-        await AssertFaultAsync(
-            plan,
-            new KafkaFaultScope(KafkaFaultOperation.Fetch, "orders", 4, "billing"),
-            failure);
+        await Assert.That(plan.HasMatchingFault(concreteScope)).IsTrue();
+        await AssertFaultAsync(plan, concreteScope, failure);
+        await Assert.That(plan.HasMatchingFault(concreteScope)).IsFalse();
+    }
+
+    [Test]
+    [Arguments(KafkaFaultOperation.JoinGroup)]
+    [Arguments(KafkaFaultOperation.SyncGroup)]
+    [Arguments(KafkaFaultOperation.Rebalance)]
+    public async Task GroupTransitionScope_RejectsResourceSelectors(
+        KafkaFaultOperation operation)
+    {
+        var topicError = Assert.Throws<ArgumentException>(() =>
+            _ = new KafkaFaultScope(operation, topic: "orders", groupId: "workers"));
+        var partitionError = Assert.Throws<ArgumentException>(() =>
+            _ = new KafkaFaultScope(operation, partition: 0, groupId: "workers"));
+
+        await Assert.That(topicError!.ParamName).IsEqualTo("topic");
+        await Assert.That(partitionError!.ParamName).IsEqualTo("partition");
+    }
+
+    [Test]
+    public async Task ScopeIndex_FiltersUnrelatedOperationsAndGroups()
+    {
+        var plan = new KafkaFaultPlan();
+        plan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.Fetch, topic: "orders", groupId: "billing"),
+            new InvalidOperationException("fetch"));
+
+        await Assert.That(plan.HasPotentialMatch(KafkaFaultOperation.Admin, "billing")).IsFalse();
+        await Assert.That(plan.HasPotentialMatch(KafkaFaultOperation.Fetch, "other")).IsFalse();
+        await Assert.That(plan.HasPotentialMatch(KafkaFaultOperation.Fetch, "billing")).IsTrue();
+        await Assert.That(plan.HasMatchingFault(
+            new KafkaFaultScope(KafkaFaultOperation.Fetch, "payments", 0, "billing"))).IsFalse();
+        await Assert.That(plan.HasMatchingFault(
+            new KafkaFaultScope(KafkaFaultOperation.Fetch, "orders", 0, "billing"))).IsTrue();
+    }
+
+    [Test]
+    public async Task ScopeIndex_FiltersUnassignedResourcesAndPublishesVersion()
+    {
+        var plan = new KafkaFaultPlan();
+        var assignment = new HashSet<TopicPartition> { new("orders", 0) };
+        plan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.Fetch, "payments", 0, "billing"),
+            new InvalidOperationException("fetch"));
+
+        var matched = plan.HasPotentialConsumerMatch(
+            "billing",
+            assignment,
+            assignment,
+            includeCommit: true,
+            out var version);
+
+        await Assert.That(matched).IsFalse();
+        await Assert.That(version).IsEqualTo(plan.Version);
+
+        plan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.Consume, "orders", 0, "billing"),
+            new InvalidOperationException("consume"));
+
+        await Assert.That(plan.Version).IsGreaterThan(version);
+        await Assert.That(plan.HasPotentialConsumerMatch(
+            "billing",
+            assignment,
+            assignment,
+            includeCommit: true,
+            out _)).IsTrue();
+    }
+
+    [Test]
+    [Arguments(KafkaFaultOperation.JoinGroup)]
+    [Arguments(KafkaFaultOperation.SyncGroup)]
+    [Arguments(KafkaFaultOperation.Rebalance)]
+    public async Task HasPotentialFault_EmptyResourcesMatchesResourceFreeRule(
+        KafkaFaultOperation operation)
+    {
+        var plan = new KafkaFaultPlan();
+        var resources = new HashSet<TopicPartition>();
+        plan.FailPersistently(
+            new KafkaFaultScope(operation, groupId: "billing"),
+            new InvalidOperationException("group transition"));
+
+        await Assert.That(plan.HasPotentialFault(operation, "billing", resources)).IsTrue();
+        await Assert.That(plan.HasPotentialFault(operation, "other", resources)).IsFalse();
+    }
+
+    [Test]
+    public async Task ScopeIndex_RemovesConsumedAndClearedRules()
+    {
+        var plan = new KafkaFaultPlan();
+        var scope = new KafkaFaultScope(KafkaFaultOperation.Fetch, groupId: "billing");
+        plan.Fail(scope, new InvalidOperationException("fetch"));
+
+        await Assert.That(plan.HasPotentialMatch(KafkaFaultOperation.Fetch, "billing")).IsTrue();
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(() => plan.ApplyAsync(scope).AsTask());
+        await Assert.That(plan.HasPotentialMatch(KafkaFaultOperation.Fetch, "billing")).IsFalse();
+
+        plan.FailPersistently(scope, new InvalidOperationException("fetch"));
+        plan.Clear(scope);
+        await Assert.That(plan.HasMatchingFault(scope)).IsFalse();
     }
 
     [Test]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryConsumerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryConsumerBenchmarks.cs
@@ -1,0 +1,370 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Consumer;
+using Dekaf.Serialization;
+using Dekaf.Testing;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class InMemoryConsumerBenchmarks
+{
+    private const string Topic = "in-memory-consumer";
+    private const string GroupId = "benchmark-group";
+    private const int SnapshotRecordCount = 256;
+    private static readonly TopicPartitionOffset StoredOffset = new(Topic, 0, 1);
+    private static readonly IReadOnlyList<TopicPartitionOffset> ExplicitOffsets = [StoredOffset];
+    private InMemoryConsumer<Ignore, Ignore> _consumer = null!;
+    private InMemoryConsumer<Ignore, Ignore> _manualCommitFaultConsumer = null!;
+    private InMemoryConsumer<Ignore, Ignore> _unrelatedFaultConsumer = null!;
+    private InMemoryConsumer<Ignore, Ignore> _asyncAutoCommitConsumer = null!;
+    private InMemoryConsumer<Ignore, Ignore> _asyncAutoCommitUnrelatedFaultConsumer = null!;
+    private InMemoryConsumer<Ignore, Ignore> _noStoreCommitFaultConsumer = null!;
+    private InMemoryConsumer<Ignore, Ignore> _customPlanStoredOffsetConsumer = null!;
+    private InMemoryConsumer<Ignore, Ignore> _snapshotConsumer = null!;
+    private ConsumeResult<Ignore, Ignore>? _result;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<Ignore, Ignore>(cluster);
+        producer.ProduceAsync(Topic, default, default).GetAwaiter().GetResult();
+        _consumer = new InMemoryConsumer<Ignore, Ignore>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                EnableAutoOffsetStore = false,
+                OffsetCommitMode = OffsetCommitMode.Manual
+            });
+        _consumer.Subscribe(Topic);
+
+        var manualCommitFaultCluster = new InMemoryKafkaCluster();
+        var manualCommitFaultProducer = new InMemoryProducer<Ignore, Ignore>(manualCommitFaultCluster);
+        manualCommitFaultProducer.ProduceAsync(Topic, default, default).GetAwaiter().GetResult();
+        manualCommitFaultCluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            new InvalidOperationException("commit-only"));
+        _manualCommitFaultConsumer = new InMemoryConsumer<Ignore, Ignore>(
+            manualCommitFaultCluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Manual
+            });
+        _manualCommitFaultConsumer.Subscribe(Topic);
+
+        var unrelatedFaultCluster = new InMemoryKafkaCluster();
+        var unrelatedFaultProducer = new InMemoryProducer<Ignore, Ignore>(unrelatedFaultCluster);
+        unrelatedFaultProducer.ProduceAsync(Topic, default, default).GetAwaiter().GetResult();
+        unrelatedFaultCluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(
+                KafkaFaultOperation.Fetch,
+                topic: "other-topic",
+                partition: 0,
+                groupId: GroupId),
+            new InvalidOperationException("unrelated"));
+        _unrelatedFaultConsumer = new InMemoryConsumer<Ignore, Ignore>(
+            unrelatedFaultCluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                EnableAutoOffsetStore = false,
+                OffsetCommitMode = OffsetCommitMode.Manual
+            });
+        _unrelatedFaultConsumer.Subscribe(Topic);
+
+        _consumer.StoreOffset(StoredOffset);
+        _unrelatedFaultConsumer.StoreOffset(StoredOffset);
+
+        var asyncAutoCommitCluster = new InMemoryKafkaCluster();
+        var asyncAutoCommitProducer = new InMemoryProducer<Ignore, Ignore>(asyncAutoCommitCluster);
+        asyncAutoCommitProducer.ProduceAsync(Topic, default, default).GetAwaiter().GetResult();
+        var completedDeserializer = new CompletedIgnoreDeserializer();
+        _asyncAutoCommitConsumer = new InMemoryConsumer<Ignore, Ignore>(
+            asyncAutoCommitCluster,
+            completedDeserializer,
+            completedDeserializer,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                EnableAutoOffsetStore = true,
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                OffsetStoreTiming = OffsetStoreTiming.OnDelivery
+            });
+        _asyncAutoCommitConsumer.Subscribe(Topic);
+
+        var asyncAutoCommitUnrelatedFaultCluster = new InMemoryKafkaCluster();
+        var asyncAutoCommitUnrelatedFaultProducer =
+            new InMemoryProducer<Ignore, Ignore>(asyncAutoCommitUnrelatedFaultCluster);
+        asyncAutoCommitUnrelatedFaultProducer.ProduceAsync(Topic, default, default).GetAwaiter().GetResult();
+        asyncAutoCommitUnrelatedFaultCluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(
+                KafkaFaultOperation.Commit,
+                topic: "other-topic",
+                partition: 0,
+                groupId: GroupId),
+            new InvalidOperationException("unrelated commit"));
+        _asyncAutoCommitUnrelatedFaultConsumer = new InMemoryConsumer<Ignore, Ignore>(
+            asyncAutoCommitUnrelatedFaultCluster,
+            completedDeserializer,
+            completedDeserializer,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                EnableAutoOffsetStore = true,
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                OffsetStoreTiming = OffsetStoreTiming.OnDelivery
+            });
+        _asyncAutoCommitUnrelatedFaultConsumer.Subscribe(Topic);
+
+        var noStoreCommitFaultCluster = new InMemoryKafkaCluster();
+        var noStoreCommitFaultProducer = new InMemoryProducer<Ignore, Ignore>(noStoreCommitFaultCluster);
+        noStoreCommitFaultProducer.ProduceAsync(Topic, default, default).GetAwaiter().GetResult();
+        noStoreCommitFaultCluster.FaultPlan.FailPersistently(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            new InvalidOperationException("commit-only"));
+        _noStoreCommitFaultConsumer = new InMemoryConsumer<Ignore, Ignore>(
+            noStoreCommitFaultCluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                EnableAutoOffsetStore = false,
+                OffsetCommitMode = OffsetCommitMode.Auto
+            });
+        _noStoreCommitFaultConsumer.Subscribe(Topic);
+
+        var customInnerPlan = new KafkaFaultPlan();
+        var customPlanCluster = new InMemoryKafkaCluster(
+            new InMemoryKafkaClusterOptions(),
+            new DelegatingFaultPlan(customInnerPlan));
+        var customPlanProducer = new InMemoryProducer<Ignore, Ignore>(customPlanCluster);
+        customPlanProducer.ProduceAsync(Topic, default, default).GetAwaiter().GetResult();
+        customInnerPlan.FailPersistently(
+            new KafkaFaultScope(
+                KafkaFaultOperation.Commit,
+                topic: "other-topic",
+                partition: 0,
+                groupId: GroupId),
+            new InvalidOperationException("unrelated commit"));
+        _customPlanStoredOffsetConsumer = new InMemoryConsumer<Ignore, Ignore>(
+            customPlanCluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                EnableAutoOffsetStore = false,
+                OffsetCommitMode = OffsetCommitMode.Auto
+            });
+        _customPlanStoredOffsetConsumer.Subscribe(Topic);
+        for (var partition = 1; partition <= 1024; partition++)
+        {
+            _customPlanStoredOffsetConsumer.StoreOffset(
+                new TopicPartitionOffset("other-topic", partition, 1));
+        }
+        _customPlanStoredOffsetConsumer.StoreOffset(StoredOffset);
+
+        var snapshotCluster = new InMemoryKafkaCluster();
+        var snapshotProducer = new InMemoryProducer<Ignore, Ignore>(snapshotCluster);
+        for (var i = 0; i < SnapshotRecordCount; i++)
+            snapshotProducer.ProduceAsync(Topic, default, default).GetAwaiter().GetResult();
+
+        _snapshotConsumer = new InMemoryConsumer<Ignore, Ignore>(
+            snapshotCluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                EnableAutoOffsetStore = false,
+                OffsetCommitMode = OffsetCommitMode.Manual
+            });
+        _snapshotConsumer.Subscribe(Topic);
+    }
+
+    [Benchmark]
+    [InvocationCount(131072)]
+    public void ConsumeOneNoFault()
+    {
+        _consumer.Seek(new TopicPartitionOffset(Topic, 0, 0));
+        var operation = _consumer.ConsumeOneAsync(TimeSpan.Zero);
+        if (!operation.IsCompletedSuccessfully)
+            throw new InvalidOperationException("No-fault consume did not complete synchronously.");
+
+        _result = operation.Result;
+    }
+
+    [Benchmark]
+    [InvocationCount(131072)]
+    public void ConsumeOneUnrelatedFault()
+    {
+        _unrelatedFaultConsumer.Seek(new TopicPartitionOffset(Topic, 0, 0));
+        var operation = _unrelatedFaultConsumer.ConsumeOneAsync(TimeSpan.Zero);
+        if (!operation.IsCompletedSuccessfully)
+            throw new InvalidOperationException("Unrelated-fault consume did not complete synchronously.");
+
+        _result = operation.Result;
+    }
+
+    [Benchmark]
+    [InvocationCount(262144)]
+    public void ConsumeOneManualCommitFault()
+    {
+        _manualCommitFaultConsumer.Seek(new TopicPartitionOffset(Topic, 0, 0));
+        var operation = _manualCommitFaultConsumer.ConsumeOneAsync(TimeSpan.Zero);
+        if (!operation.IsCompletedSuccessfully)
+            throw new InvalidOperationException("Manual commit fault consume did not complete synchronously.");
+
+        _result = operation.Result;
+    }
+
+    [Benchmark]
+    [InvocationCount(131072)]
+    public void ConsumeOneAsyncAutoCommitNoFault()
+    {
+        _asyncAutoCommitConsumer.Seek(new TopicPartitionOffset(Topic, 0, 0));
+        var operation = _asyncAutoCommitConsumer.ConsumeOneAsync(TimeSpan.Zero);
+        if (!operation.IsCompletedSuccessfully)
+            throw new InvalidOperationException("Async auto-commit consume did not complete synchronously.");
+
+        _result = operation.Result;
+    }
+
+    [Benchmark]
+    [InvocationCount(131072)]
+    public void ConsumeOneAsyncAutoCommitUnrelatedFault()
+    {
+        _asyncAutoCommitUnrelatedFaultConsumer.Seek(new TopicPartitionOffset(Topic, 0, 0));
+        var operation = _asyncAutoCommitUnrelatedFaultConsumer.ConsumeOneAsync(TimeSpan.Zero);
+        if (!operation.IsCompletedSuccessfully)
+            throw new InvalidOperationException("Async auto-commit unrelated-fault consume did not complete synchronously.");
+
+        _result = operation.Result;
+    }
+
+    [Benchmark]
+    [InvocationCount(131072)]
+    public void ConsumeOneAutoCommitNoStoredOffset()
+    {
+        _noStoreCommitFaultConsumer.Seek(new TopicPartitionOffset(Topic, 0, 0));
+        var operation = _noStoreCommitFaultConsumer.ConsumeOneAsync(TimeSpan.Zero);
+        if (!operation.IsCompletedSuccessfully)
+            throw new InvalidOperationException("No-stored-offset consume did not complete synchronously.");
+
+        _result = operation.Result;
+    }
+
+    [Benchmark]
+    [InvocationCount(131072)]
+    public void ConsumeOneCustomPlanStoredOffset()
+    {
+        _customPlanStoredOffsetConsumer.Seek(new TopicPartitionOffset(Topic, 0, 0));
+        var operation = _customPlanStoredOffsetConsumer.ConsumeOneAsync(TimeSpan.Zero);
+        if (!operation.IsCompletedSuccessfully)
+            throw new InvalidOperationException("Custom-plan consume did not complete synchronously.");
+
+        _result = operation.Result;
+    }
+
+    [Benchmark]
+    public async Task<int> ConsumeSnapshotNoFault()
+    {
+        _snapshotConsumer.Seek(new TopicPartitionOffset(Topic, 0, 0));
+        var count = 0;
+        await foreach (var result in _snapshotConsumer.ConsumeSnapshotAsync().ConfigureAwait(false))
+        {
+            _result = result;
+            count++;
+        }
+
+        if (count != SnapshotRecordCount)
+            throw new InvalidOperationException("Snapshot benchmark consumed an unexpected record count.");
+
+        return count;
+    }
+
+    [Benchmark]
+    [InvocationCount(4194304)]
+    public void StoreOffsetNoFault() => _consumer.StoreOffset(StoredOffset);
+
+    [Benchmark]
+    [InvocationCount(4194304)]
+    public void StoreOffsetUnrelatedFault() =>
+        _unrelatedFaultConsumer.StoreOffset(StoredOffset);
+
+    [Benchmark]
+    [InvocationCount(131072)]
+    public void CommitExplicitNoFault()
+    {
+        var operation = _consumer.CommitAsync(ExplicitOffsets);
+        if (!operation.IsCompletedSuccessfully)
+            throw new InvalidOperationException("No-fault commit did not complete synchronously.");
+
+        operation.GetAwaiter().GetResult();
+    }
+
+    private sealed class CompletedIgnoreDeserializer : IAsyncDeserializer<Ignore>
+    {
+        public ValueTask<Ignore> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(default(Ignore));
+    }
+
+    private sealed class DelegatingFaultPlan(KafkaFaultPlan inner) : IKafkaFaultPlan
+    {
+        public event Action<KafkaFaultObservation>? FaultConsumed
+        {
+            add => inner.FaultConsumed += value;
+            remove => inner.FaultConsumed -= value;
+        }
+
+        public int Count => inner.Count;
+
+        public long Version => inner.Version;
+
+        public bool HasMatchingFault(in KafkaFaultScope operationScope) =>
+            inner.HasMatchingFault(operationScope);
+
+        public bool HasPotentialFault(
+            KafkaFaultOperation operation,
+            string? groupId,
+            IReadOnlySet<TopicPartition> resources) =>
+            inner.HasPotentialFault(operation, groupId, resources);
+
+        public bool TryGetFirstMatchingFaultScope(
+            ReadOnlySpan<KafkaFaultScope> operationScopes,
+            out KafkaFaultScope operationScope) =>
+            inner.TryGetFirstMatchingFaultScope(operationScopes, out operationScope);
+
+        public bool TryApplyFirstMatchingFault(
+            ReadOnlySpan<KafkaFaultScope> operationScopes,
+            out ValueTask application,
+            CancellationToken cancellationToken = default) =>
+            inner.TryApplyFirstMatchingFault(operationScopes, out application, cancellationToken);
+
+        public void Fail(KafkaFaultScope scope, Exception exception, int occurrenceCount = 1) =>
+            inner.Fail(scope, exception, occurrenceCount);
+
+        public void FailPersistently(KafkaFaultScope scope, Exception exception) =>
+            inner.FailPersistently(scope, exception);
+
+        public KafkaFaultBarrier PauseNext(KafkaFaultScope scope) => inner.PauseNext(scope);
+
+        public ValueTask ApplyAsync(
+            KafkaFaultScope operationScope,
+            CancellationToken cancellationToken = default) =>
+            inner.ApplyAsync(operationScope, cancellationToken);
+
+        public int Clear(KafkaFaultScope scope) => inner.Clear(scope);
+
+        public int Clear() => inner.Clear();
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryConsumerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryConsumerBenchmarks.cs
@@ -20,6 +20,7 @@ public class InMemoryConsumerBenchmarks
     private InMemoryConsumer<Ignore, Ignore> _asyncAutoCommitConsumer = null!;
     private InMemoryConsumer<Ignore, Ignore> _asyncAutoCommitUnrelatedFaultConsumer = null!;
     private InMemoryConsumer<Ignore, Ignore> _noStoreCommitFaultConsumer = null!;
+    private InMemoryConsumer<Ignore, Ignore> _manualStoreNoFaultConsumer = null!;
     private InMemoryConsumer<Ignore, Ignore> _customPlanStoredOffsetConsumer = null!;
     private InMemoryConsumer<Ignore, Ignore> _snapshotConsumer = null!;
     private ConsumeResult<Ignore, Ignore>? _result;
@@ -141,6 +142,25 @@ public class InMemoryConsumerBenchmarks
             });
         _noStoreCommitFaultConsumer.Subscribe(Topic);
 
+        var manualStoreNoFaultCluster = new InMemoryKafkaCluster();
+        var manualStoreNoFaultProducer = new InMemoryProducer<Ignore, Ignore>(manualStoreNoFaultCluster);
+        manualStoreNoFaultProducer.ProduceAsync(Topic, default, default).GetAwaiter().GetResult();
+        _manualStoreNoFaultConsumer = new InMemoryConsumer<Ignore, Ignore>(
+            manualStoreNoFaultCluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                EnableAutoOffsetStore = false,
+                OffsetCommitMode = OffsetCommitMode.Auto
+            });
+        _manualStoreNoFaultConsumer.Subscribe(Topic);
+        for (var partition = 1; partition <= 1024; partition++)
+        {
+            _manualStoreNoFaultConsumer.StoreOffset(
+                new TopicPartitionOffset("other-topic", partition, 1));
+        }
+
         var customInnerPlan = new KafkaFaultPlan();
         var customPlanCluster = new InMemoryKafkaCluster(
             new InMemoryKafkaClusterOptions(),
@@ -256,6 +276,19 @@ public class InMemoryConsumerBenchmarks
         var operation = _noStoreCommitFaultConsumer.ConsumeOneAsync(TimeSpan.Zero);
         if (!operation.IsCompletedSuccessfully)
             throw new InvalidOperationException("No-stored-offset consume did not complete synchronously.");
+
+        _result = operation.Result;
+    }
+
+    [Benchmark]
+    [InvocationCount(131072)]
+    public void ConsumeOneAutoCommitManualStoreNoFault()
+    {
+        _manualStoreNoFaultConsumer.StoreOffset(StoredOffset);
+        _manualStoreNoFaultConsumer.Seek(new TopicPartitionOffset(Topic, 0, 0));
+        var operation = _manualStoreNoFaultConsumer.ConsumeOneAsync(TimeSpan.Zero);
+        if (!operation.IsCompletedSuccessfully)
+            throw new InvalidOperationException("Manual-store no-fault consume did not complete synchronously.");
 
         _result = operation.Result;
     }


### PR DESCRIPTION
## Summary

- apply deterministic fetch and consume faults before position advancement
- inject offset store/commit and join/sync/rebalance failures before state mutation
- preserve positions, stored offsets, assignments, and retry state across failures
- support cancellation/disposal races with fault barriers and concrete topic/partition/group scopes

## Verification

- Release unit build: net8.0 + net10.0, 0 warnings/errors
- focused consumer fault tests: 12/12 on net8.0 and net10.0
- in-memory Testing namespace: 99/99 on net8.0 and net10.0 before final disposal-race addition; final focused class remains 12/12
- full net8.0 unit suite: 7,455/7,455
- full net10.0 unit run: 7,589 passed; one unrelated pre-existing deadline-relative throttle test defect identified and filed as #2822
- /simplify: complete
- mandatory pre-push self-review: clean

No production Dekaf hot path changed. The rebase integration in `Dekaf.Testing` was benchmarked because it combines Consumer and Share fault indexes.

Closes #2800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded fault simulation across consumption, commits, snapshots, offset storage, and consumer-group transitions.
  - Improved fault matching for operations, groups, topics, partitions, assignments, and selectors.
  - Added more reliable handling for consumer closure, pending operations, retries, cancellation, and disposal.
  - Improved support for missing group IDs, committable offsets, and asynchronous deserialization.
  - Exposed additional fault-plan inspection and matching capabilities.

- **Tests**
  - Added comprehensive coverage for fault behavior, consumer lifecycle scenarios, and group-generation handling.
  - Added performance benchmarks for consumption and offset-related scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Rebase integration verification (2026-08-26)

- rebased onto `b1f684873` (`testing: inject admin and share-consumer faults`)
- preserved the specialized zero-allocation Share fault index and the Consumer scope index; both update on add/remove/consume/clear
- Release build: 0 warnings/errors
- focused merged fault suites: 227/227 on net8.0 and 227/227 on net10.0
- full unit suites: 8,110/8,110 on net8.0 and 8,246/8,246 on net10.0
- `Dekaf.Testing` package and symbols package created successfully
- `/simplify`: no safe reduction; merging the indexes would add interface enumeration/scans

### Same-machine MemoryDiagnoser comparison

Pre-rebase `2602a584f` -> rebased `dc0941a25`, seven `ConsumeOne*` methods:

| Method | Baseline | Candidate | Allocation |
|---|---:|---:|---:|
| ConsumeOneNoFault | 576.8 ns | 609.7 ns | 80 B -> 80 B |
| ConsumeOneUnrelatedFault | 622.7 ns | 585.6 ns | 80 B -> 80 B |
| ConsumeOneAsyncAutoCommitNoFault | 1,599.9 ns | 1,243.2 ns | 2,576 B -> 2,576 B |
| ConsumeOneAsyncAutoCommitUnrelatedFault | 1,551.3 ns | 1,359.3 ns | 2,624 B -> 2,624 B |
| ConsumeOneAutoCommitNoStoredOffset | 581.6 ns | 563.3 ns | 80 B -> 80 B |
| ConsumeOneCustomPlanStoredOffset | 542.9 ns | 588.7 ns | 80 B -> 80 B |
| ConsumeOneManualCommitFault | 276.1 ns | 268.6 ns | 80 B -> 80 B |

The short run was noisy, so `ConsumeOneNoFault` was repeated with 10 warmups and 10 measured iterations. Baseline: 242.4 ns, 99.9% CI [234.9, 249.9], 80 B. Candidate: 258.8 ns, 99.9% CI [234.0, 283.6], 80 B. Candidate measurements were bimodal and the confidence intervals overlap. Decision: allocation is unchanged; timing is inconclusive with no demonstrated material regression. No further identical repeat was dispatched.


### Current-main rebase verification (`a11b7af70`)
- rebased onto `b302a7546` (`Manage Streams group offsets and deletion`)
- reconciled the PR's lock-free/global generation tracking with main's known-empty-group lifecycle: empty groups retain generation `0`; explicit deletion removes the marker
- full Release solution build: 0 warnings/errors
- affected fault/testing classes: 272/272 on net8.0 and 272/272 on net10.0
- deterministic merge-conflict regressions reproduced on both TFMs, root cause fixed, and targeted lifecycle tests pass 3/3 on both TFMs
- `/simplify` and `git diff --check`: passed
