### PR TITLE
Make bootstrap throttle reconnect test deadline-relative

### DIFF
--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionBrokerThrottleTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionBrokerThrottleTests.cs
@@ -209,18 +209,22 @@ public sealed class KafkaConnectionBrokerThrottleTests
             cancellationToken);
         await Assert.That(await pool.ReapIdleConnectionsAsync()).IsEqualTo(1);
 
+        var bootstrapThrottleState = pool.GetBrokerThrottleStateForTest(-1, "127.0.0.1", port);
         pool.RegisterBroker(1, "127.0.0.1", port);
+        var brokerThrottleState = pool.GetBrokerThrottleStateForTest(1, "127.0.0.1", port);
+        await Assert.That(brokerThrottleState).IsSameReferenceAs(bootstrapThrottleState);
+
         var reconnectStarted = Stopwatch.GetTimestamp();
+        var remainingThrottleMs = brokerThrottleState.GetRemainingMilliseconds();
         var leaseTask = pool.LeaseConnectionAsync(1, cancellationToken).AsTask();
-        var earlyProgress = await Task.WhenAny(
-            secondConnectionAccepted.Task,
-            Task.Delay(100, cancellationToken));
-        await Assert.That(earlyProgress).IsNotSameReferenceAs(secondConnectionAccepted.Task);
+        await Assert.That(remainingThrottleMs).IsGreaterThan(0);
 
         using var lease = await leaseTask;
         var acceptedAt = await secondConnectionAccepted.Task;
         var elapsedMs = (acceptedAt - reconnectStarted) * 1000d / Stopwatch.Frequency;
-        await Assert.That(elapsedMs).IsGreaterThanOrEqualTo(200);
+        const double clockResolutionToleranceMs = 2;
+        await Assert.That(elapsedMs + clockResolutionToleranceMs)
+            .IsGreaterThanOrEqualTo(remainingThrottleMs);
         releaseSecondConnection.TrySetResult();
         await serverTask;
     }


### PR DESCRIPTION
Fixes #2822

## Summary
- assert bootstrap-to-broker throttle state identity across broker registration
- sample the shared state remaining deadline immediately before reconnect
- compare acceptance time against that deadline with 2 ms clock-resolution tolerance
- remove the arbitrary 100 ms early-progress race

## Validation
- Release build: 0 warnings, 0 errors
- focused regression: net10.0 20/20, net8.0 20/20
- full unit suite: net10.0 7,579/7,579; net8.0 7,443/7,443

## Performance
Test-only change; no src or hot-path impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of connection throttling during broker registration and reconnection.
  * Reconnection timing checks now account for the remaining throttle duration and clock-resolution differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->