### PR TITLE
test: isolate KIP-1242 timeout case

### DIFF
--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
@@ -458,6 +458,7 @@ public class KafkaConnectionCapabilityHandshakeTests
     }
 
     [Test]
+    [NotInParallel]
     [Timeout(5_000)]
     public async Task ConnectAsync_Kip1242_WhenIdentityHandshakeTimesOut_ThrowsKafkaException(
         CancellationToken cancellationToken)


### PR DESCRIPTION
Closes #2826.

## Root cause

The KIP-1242 identity-handshake timeout test exercised a real 50 ms `CancellationTokenSource` timer while running in parallel with the full unit suite. On the net8 Linux CI lane, scheduler contention delayed the timer callback until TUnit's 5-second watchdog expired. The established negotiation-timeout test already uses `[NotInParallel]` for this reason.

## Change

- isolate the KIP-1242 timeout test with `[NotInParallel]`
- keep the 50 ms product timeout and 5-second test watchdog unchanged

## Validation

- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release -f net8.0 --no-restore` — 0 warnings/errors
- full net8 unit suite — 7,524 passed, 0 failed
- net10 unit build — 0 warnings/errors
- focused net10 test — 1 passed, 0 failed

Test-only scheduling change; no `src/` or performance-path changes.

#2828 was filed during CI triage before discovery of the earlier issue and is closed as a duplicate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the identity-handshake timeout test to run independently and avoid interference from parallel test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->