### PR TITLE
test: isolate reserved-slot producer thread

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using Dekaf.Consumer;
 using Dekaf.Protocol.Records;
 
@@ -870,6 +871,8 @@ public class MpscFetchBufferTests
         var firstWrite = StartDedicatedWrite(buffer, first);
         Task<bool>? secondWrite = null;
         Task<bool>? waitForReadable = null;
+        Exception? firstWriteFailure = null;
+        Exception? secondWriteFailure = null;
         var firstWritten = false;
         try
         {
@@ -887,10 +890,32 @@ public class MpscFetchBufferTests
         finally
         {
             allowFirstCommit.Set();
-            firstWritten = await firstWrite.WaitAsync(TimeSpan.FromSeconds(5));
+            try
+            {
+                firstWritten = await firstWrite.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (Exception exception)
+            {
+                firstWriteFailure = exception;
+            }
+
             if (secondWrite is not null)
-                _ = await secondWrite.WaitAsync(TimeSpan.FromSeconds(5));
+            {
+                try
+                {
+                    _ = await secondWrite.WaitAsync(TimeSpan.FromSeconds(5));
+                }
+                catch (Exception exception)
+                {
+                    secondWriteFailure = exception;
+                }
+            }
         }
+
+        if (firstWriteFailure is not null)
+            ExceptionDispatchInfo.Capture(firstWriteFailure).Throw();
+        if (secondWriteFailure is not null)
+            ExceptionDispatchInfo.Capture(secondWriteFailure).Throw();
 
         await Assert.That(firstWritten).IsTrue();
         await Assert.That(await waitForReadable!).IsTrue();

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -850,7 +850,8 @@ public class MpscFetchBufferTests
     [Test]
     public async Task LaterProducer_DoesNotWaitForEarlierReservedSlotToCommit()
     {
-        using var firstReserved = new ManualResetEventSlim();
+        var firstReserved = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         using var allowFirstCommit = new ManualResetEventSlim();
         var buffer = new MpscFetchBuffer(
             capacity: 2,
@@ -859,24 +860,26 @@ public class MpscFetchBufferTests
             {
                 if (sequence == 0)
                 {
-                    firstReserved.Set();
+                    firstReserved.TrySetResult();
                     allowFirstCommit.Wait();
                 }
             });
         var first = CreateDummy("topic", 1);
         var second = CreateDummy("topic", 2);
 
-        var firstWrite = Task.Run(() => buffer.TryWrite(first));
+        var firstWrite = StartDedicatedWrite(buffer, first);
+        Task<bool>? secondWrite = null;
         Task<bool>? waitForReadable = null;
+        var firstWritten = false;
         try
         {
-            await Assert.That(firstReserved.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await firstReserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
             waitForReadable = buffer.WaitToReadAsync(30_000, CancellationToken.None).AsTask();
             await TestWait.UntilAsync(
                 () => GetConsumerWaiting(buffer) == 1 && IsReadWaiterActive(buffer),
                 TimeSpan.FromSeconds(5));
 
-            var secondWrite = Task.Run(() => buffer.TryWrite(second));
+            secondWrite = StartDedicatedWrite(buffer, second);
             await Assert.That(await secondWrite.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
             await Assert.That(buffer.Count).IsEqualTo(2);
             await Assert.That(waitForReadable.IsCompleted).IsFalse();
@@ -884,9 +887,12 @@ public class MpscFetchBufferTests
         finally
         {
             allowFirstCommit.Set();
+            firstWritten = await firstWrite.WaitAsync(TimeSpan.FromSeconds(5));
+            if (secondWrite is not null)
+                _ = await secondWrite.WaitAsync(TimeSpan.FromSeconds(5));
         }
 
-        await Assert.That(await firstWrite).IsTrue();
+        await Assert.That(firstWritten).IsTrue();
         await Assert.That(await waitForReadable!).IsTrue();
         await Assert.That(buffer.TryRead(out var firstRead)).IsTrue();
         await Assert.That(firstRead!.PartitionIndex).IsEqualTo(1);
@@ -895,6 +901,15 @@ public class MpscFetchBufferTests
         await Assert.That(secondRead!.PartitionIndex).IsEqualTo(2);
         secondRead.Dispose();
     }
+
+    private static Task<bool> StartDedicatedWrite(
+        MpscFetchBuffer buffer,
+        PendingFetchData item) =>
+        Task.Factory.StartNew(
+            () => buffer.TryWrite(item),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
 
     #endregion
 

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -890,26 +890,10 @@ public class MpscFetchBufferTests
         finally
         {
             allowFirstCommit.Set();
-            try
-            {
-                firstWritten = await firstWrite.WaitAsync(TimeSpan.FromSeconds(5));
-            }
-            catch (Exception exception)
-            {
-                firstWriteFailure = exception;
-            }
+            (firstWritten, firstWriteFailure) = await ObserveDedicatedWriteAsync(firstWrite);
 
             if (secondWrite is not null)
-            {
-                try
-                {
-                    _ = await secondWrite.WaitAsync(TimeSpan.FromSeconds(5));
-                }
-                catch (Exception exception)
-                {
-                    secondWriteFailure = exception;
-                }
-            }
+                (_, secondWriteFailure) = await ObserveDedicatedWriteAsync(secondWrite);
         }
 
         if (firstWriteFailure is not null)
@@ -935,6 +919,18 @@ public class MpscFetchBufferTests
             CancellationToken.None,
             TaskCreationOptions.LongRunning,
             TaskScheduler.Default);
+
+    private static async Task<(bool Result, Exception? Failure)> ObserveDedicatedWriteAsync(
+        Task<bool> write)
+    {
+        var wait = write.WaitAsync(TimeSpan.FromSeconds(5));
+        Task observation = wait;
+        await observation.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+
+        return wait.IsCompletedSuccessfully
+            ? (wait.GetAwaiter().GetResult(), null)
+            : (false, wait.Exception?.InnerException ?? new TaskCanceledException(wait));
+    }
 
     #endregion
 


### PR DESCRIPTION
Closes #2827\n\n## Summary\n\n- run both reserved-slot producers on dedicated LongRunning threads\n- replace the ThreadPool-blocking readiness event with an asynchronous TaskCompletionSource\n- release and observe producer tasks during cleanup\n\n## Validation\n\n- dotnet build tests/Dekaf.Tests.Unit --configuration Release (net8.0 + net10.0, 0 warnings)\n- focused test: 20/20 passes on net8.0 and 20/20 passes on net10.0\n- focused test after cleanup hardening: pass on net8.0 and net10.0\n- full unit suite: 7,524/7,524 net8.0; 7,660/7,660 net10.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for concurrent producer writes and ordering behavior.
  * Added bounded waits and clearer validation of write results to make test outcomes more reliable.
  * Improved handling and reporting of producer errors during concurrent write tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->