### PR TITLE
feat(schema): integrate Protobuf identity framing

### DIFF
--- a/src/Dekaf.Abstractions/Dekaf.Abstractions.csproj
+++ b/src/Dekaf.Abstractions/Dekaf.Abstractions.csproj
@@ -23,6 +23,7 @@
     <InternalsVisibleTo Include="Dekaf.Testing" />
     <InternalsVisibleTo Include="Dekaf.SchemaRegistry" />
     <InternalsVisibleTo Include="Dekaf.SchemaRegistry.Avro" />
+    <InternalsVisibleTo Include="Dekaf.SchemaRegistry.Protobuf" />
     <InternalsVisibleTo Include="Dekaf.Serialization.Routing" />
   </ItemGroup>
 

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufDeserializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufDeserializerConfig.cs
@@ -6,6 +6,11 @@ namespace Dekaf.SchemaRegistry.Protobuf;
 public sealed class ProtobufDeserializerConfig
 {
     /// <summary>
+    /// Strategy used to read the schema identity. The default accepts a GUID header and falls back to the payload prefix.
+    /// </summary>
+    public SchemaIdDeserializerStrategy SchemaIdStrategy { get; init; } = SchemaIdDeserializerStrategy.Dual;
+
+    /// <summary>
     /// Whether to use the latest registered subject version as the reader schema and execute
     /// any migration rules between the writer and reader versions.
     /// </summary>

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
@@ -80,17 +80,10 @@ public sealed class ProtobufSchemaRegistryDeserializer<T>
     {
         Header? identityHeader = null;
         if (_config.SchemaIdStrategy != SchemaIdDeserializerStrategy.Prefix
-            && context.Headers is { } callerHeaders)
+            && context.Headers is { } callerHeaders
+            && callerHeaders.TryGetLastSchemaIdentity(context.Component, out var header))
         {
-            var headerName = GetIdentityHeaderName(context.Component);
-            for (var index = callerHeaders.Count - 1; index >= 0; index--)
-            {
-                if (string.Equals(callerHeaders[index].Key, headerName, StringComparison.Ordinal))
-                {
-                    identityHeader = callerHeaders[index];
-                    break;
-                }
-            }
+            identityHeader = header;
         }
 
         return DeserializeCore(data, context, identityHeader);

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
@@ -293,6 +293,9 @@ public sealed class ProtobufSchemaRegistryDeserializer<T>
                 $"Schema with GUID {key.SchemaGuid:D} is not a Protobuf schema. Type: {unscopedSchema.SchemaType}");
         }
 
+        if (_ruleExecutor is null && _migrationRunner is null)
+            return new GuidResolvedSchema(-1, null, unscopedSchema);
+
         var context = new SerializationContext
         {
             Topic = key.Topic,
@@ -348,7 +351,7 @@ public sealed class ProtobufSchemaRegistryDeserializer<T>
 
     private readonly record struct GuidTopicKey(Guid SchemaGuid, string Topic, bool IsKey);
 
-    private sealed record GuidResolvedSchema(int SchemaId, string Subject, Schema Schema);
+    private sealed record GuidResolvedSchema(int SchemaId, string? Subject, Schema Schema);
 
     private string GetSubjectName(int schemaId, Schema? schema, SerializationContext context)
     {

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
@@ -1,4 +1,4 @@
-using System.Buffers.Binary;
+using System.Collections.Concurrent;
 using Dekaf.Serialization;
 using Google.Protobuf;
 
@@ -6,7 +6,8 @@ namespace Dekaf.SchemaRegistry.Protobuf;
 
 /// <summary>
 /// Protobuf deserializer that integrates with Confluent Schema Registry.
-/// Wire format: [magic byte (0x00)] [schema ID (4 bytes)] [varint array indexes] [protobuf binary]
+/// Supports Confluent schema-ID prefix framing, GUID record-header framing, or dual detection.
+/// Protobuf message indexes remain adjacent to their selected identity frame.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -23,11 +24,13 @@ namespace Dekaf.SchemaRegistry.Protobuf;
 /// </para>
 /// </remarks>
 /// <typeparam name="T">The Protobuf message type to deserialize.</typeparam>
-public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisposable
+public sealed class ProtobufSchemaRegistryDeserializer<T>
+    : IDeserializer<T>, IRecordHeaderDeserializer<T>, ICallerOwnedHeaderDeserializer<T>,
+      IRecordHeaderRoutingProvider, IAsyncDisposable
     where T : IMessage<T>, IBufferMessage, new()
 {
-    private const byte MagicByte = 0x00;
     private static readonly TimeSpan SchemaRegistryTimeout = TimeSpan.FromSeconds(30);
+    private const int MaxCachedGuidSchemas = 1024;
     private static readonly string RecordName = new T().Descriptor.FullName;
 
     private readonly ISchemaRegistryClient _schemaRegistry;
@@ -37,6 +40,10 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
     private readonly MessageParser<T> _parser;
     private readonly DeserializerSubjectNameCache? _subjectNames;
     private readonly SchemaRegistryMigrationRunner? _migrationRunner;
+    private readonly ConcurrentDictionary<GuidTopicKey, Lazy<Task<GuidResolvedSchema>>> _guidSchemaCache = new();
+    private readonly ConcurrentQueue<KeyValuePair<GuidTopicKey, Lazy<Task<GuidResolvedSchema>>>>
+        _guidSchemaEvictionQueue = new();
+    private int _cachedGuidSchemaCount;
 
     /// <summary>
     /// Creates a new Protobuf Schema Registry deserializer.
@@ -51,6 +58,7 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _config = config ?? new ProtobufDeserializerConfig();
+        ValidateSchemaIdStrategy(_config.SchemaIdStrategy);
         _ruleExecutor = _config.RuleExecutor;
         _ownsClient = ownsClient;
         _parser = new MessageParser<T>(() => new T());
@@ -70,27 +78,74 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
     /// <inheritdoc />
     public T Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
     {
-        var span = data.Span;
-
-        if (span.Length < 5)
+        Header? identityHeader = null;
+        if (_config.SchemaIdStrategy != SchemaIdDeserializerStrategy.Prefix
+            && context.Headers is { } callerHeaders)
         {
-            if (context is { IsNull: true, Component: SerializationComponent.Value })
-                return default!;
-
-            throw new InvalidOperationException("Message too short to contain Schema Registry wire format");
+            var headerName = GetIdentityHeaderName(context.Component);
+            for (var index = callerHeaders.Count - 1; index >= 0; index--)
+            {
+                if (string.Equals(callerHeaders[index].Key, headerName, StringComparison.Ordinal))
+                {
+                    identityHeader = callerHeaders[index];
+                    break;
+                }
+            }
         }
 
-        // Verify magic byte
-        if (span[0] != MagicByte)
-            throw new InvalidOperationException($"Unknown magic byte: {span[0]}. Expected Schema Registry format (0x00).");
+        return DeserializeCore(data, context, identityHeader);
+    }
 
-        // Read schema ID (big-endian)
-        var schemaId = BinaryPrimitives.ReadInt32BigEndian(span.Slice(1, 4));
+    T ICallerOwnedHeaderDeserializer<T>.DeserializeCallerOwned(
+        ReadOnlyMemory<byte> data,
+        SerializationContext context) => Deserialize(data, context);
+
+    T IRecordHeaderDeserializer<T>.Deserialize(
+        ReadOnlyMemory<byte> data,
+        SerializationContext context,
+        in RecordHeaderRoutingLookup headers)
+    {
+        Header? identityHeader = headers.TryGetLast(GetIdentityHeaderName(context.Component), out var header)
+            ? header
+            : null;
+        return DeserializeCore(data, context, identityHeader);
+    }
+
+    void IRecordHeaderRoutingProvider.CollectHeaderNames(List<string> names)
+    {
+        AddHeaderName(names, SchemaIdentityHeaderNames.Key);
+        AddHeaderName(names, SchemaIdentityHeaderNames.Value);
+    }
+
+    private T DeserializeCore(
+        ReadOnlyMemory<byte> data,
+        SerializationContext context,
+        Header? identityHeader)
+    {
+        if (context is { IsNull: true, Component: SerializationComponent.Value })
+            return default!;
+
+        var identity = SchemaIdentityFraming.Read(
+            data.Span,
+            identityHeader,
+            _config.SchemaIdStrategy,
+            out var payloadOffset,
+            out var headerMessageIndexes);
+        var schemaId = identity.SchemaId ?? -1;
+        var needsSchema = !_config.SkipSchemaValidation
+                          || _config.RuleExecutor is SchemaRegistryRuleExecutor
+                          || _migrationRunner is not null;
+        var guidSchema = identity.SchemaGuid is { } schemaGuid
+                         && (needsSchema || _ruleExecutor is not null)
+            ? GetGuidSchemaCached(schemaGuid, context)
+            : null;
+        if (guidSchema is not null)
+            schemaId = guidSchema.SchemaId;
 
         // Optionally validate the schema exists (with timeout to prevent indefinite hang)
-        Schema? schema = null;
+        Schema? schema = guidSchema?.Schema;
         string? ruleSubject = null;
-        if (!_config.SkipSchemaValidation || _config.RuleExecutor is SchemaRegistryRuleExecutor || _migrationRunner is not null)
+        if (needsSchema && guidSchema is null)
         {
             if (_config.RuleExecutor is not null && _subjectNames is null)
             {
@@ -109,27 +164,44 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
         }
 
         // Read the message indexes (varints)
-        var payloadMemory = data.Slice(5);
-        var payload = payloadMemory.Span;
-        var (indexCount, bytesRead) = ReadVarint(payload, _config.UseDeprecatedFormat);
+        var indexesMemory = identity.SchemaGuid.HasValue
+            ? headerMessageIndexes
+            : data[payloadOffset..];
+        var indexes = indexesMemory.Span;
+        var (indexCount, bytesRead) = ReadVarint(indexes, _config.UseDeprecatedFormat);
         if (indexCount < 0)
             throw new InvalidOperationException("Message index array length cannot be negative");
 
         // Skip past the index array
         for (var i = 0; i < indexCount; i++)
         {
-            var (index, indexBytesRead) = ReadVarint(payload.Slice(bytesRead), _config.UseDeprecatedFormat);
+            var (index, indexBytesRead) = ReadVarint(indexes[bytesRead..], _config.UseDeprecatedFormat);
             if (index < 0)
                 throw new InvalidOperationException("Message index cannot be negative");
             bytesRead += indexBytesRead;
         }
 
         // The rest is the protobuf message
-        var protobufData = payloadMemory.Slice(bytesRead);
+        ReadOnlyMemory<byte> protobufData;
+        if (identity.SchemaGuid.HasValue)
+        {
+            if (bytesRead != headerMessageIndexes.Length)
+            {
+                throw new InvalidDataException(
+                    "The Protobuf schema identity header contains trailing message-index data.");
+            }
+
+            protobufData = data[payloadOffset..];
+        }
+        else
+        {
+            protobufData = data[(payloadOffset + bytesRead)..];
+        }
+
         if (_ruleExecutor is not null)
         {
-            var subject = ruleSubject ?? GetSubjectName(schemaId, schema, context);
-            if (schema is not null && ruleSubject is null)
+            var subject = guidSchema?.Subject ?? ruleSubject ?? GetSubjectName(schemaId, schema, context);
+            if (guidSchema is null && schema is not null && ruleSubject is null)
                 schema = _schemaRegistry.GetSchemaSync(schemaId, subject, SchemaRegistryTimeout);
             if (_migrationRunner is null)
             {
@@ -166,6 +238,113 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
         // IBufferMessage constraint is enforced at compile time.
         return _parser.ParseFrom(protobufData.Span);
     }
+
+    private GuidResolvedSchema GetGuidSchemaCached(Guid schemaGuid, SerializationContext context)
+    {
+        var key = new GuidTopicKey(
+            schemaGuid,
+            context.Topic,
+            context.Component == SerializationComponent.Key);
+        if (!_guidSchemaCache.TryGetValue(key, out var lazy))
+        {
+            lazy = _guidSchemaCache.GetOrAdd(
+                key,
+                static (cacheKey, deserializer) => deserializer.CreateGuidSchemaLazy(cacheKey),
+                this);
+        }
+
+        var task = lazy.Value;
+        return task.IsCompletedSuccessfully
+            ? task.Result
+            : task.WaitAsync(SchemaRegistryTimeout).ConfigureAwait(false).GetAwaiter().GetResult();
+    }
+
+    private Lazy<Task<GuidResolvedSchema>> CreateGuidSchemaLazy(GuidTopicKey key) =>
+        new(() => FetchGuidSchemaAsync(key));
+
+    private async Task<GuidResolvedSchema> FetchGuidSchemaAsync(GuidTopicKey key)
+    {
+        try
+        {
+            var unscopedSchema = await _schemaRegistry.GetSchemaByGuidAsync(
+                    key.SchemaGuid.ToString("D"),
+                    cancellationToken: CancellationToken.None)
+                .ConfigureAwait(false);
+            if (unscopedSchema.SchemaType != SchemaType.Protobuf)
+            {
+                throw new InvalidOperationException(
+                    $"Schema with GUID {key.SchemaGuid:D} is not a Protobuf schema. Type: {unscopedSchema.SchemaType}");
+            }
+
+            var context = new SerializationContext
+            {
+                Topic = key.Topic,
+                Component = key.IsKey ? SerializationComponent.Key : SerializationComponent.Value
+            };
+            var subject = GetSubjectName(0, unscopedSchema, context);
+            var registered = await _schemaRegistry.LookupSchemaAsync(
+                    subject,
+                    unscopedSchema,
+                    ignoreDeletedSchemas: true,
+                    cancellationToken: CancellationToken.None)
+                .ConfigureAwait(false);
+            if (registered.Schema.SchemaType != SchemaType.Protobuf)
+            {
+                throw new InvalidOperationException(
+                    $"Schema with GUID {key.SchemaGuid:D} resolved to type {registered.Schema.SchemaType}; expected {SchemaType.Protobuf}.");
+            }
+            if (!Guid.TryParse(registered.Guid, out var registeredGuid) || registeredGuid != key.SchemaGuid)
+            {
+                throw new InvalidDataException(
+                    $"Schema Registry returned a conflicting GUID for subject '{subject}'.");
+            }
+
+            var resolved = new GuidResolvedSchema(
+                registered.Id,
+                subject,
+                registered.Schema);
+            BoundedSchemaIdentityCache.RecordSuccessfulResolution(
+                _guidSchemaCache,
+                _guidSchemaEvictionQueue,
+                key,
+                ref _cachedGuidSchemaCount,
+                MaxCachedGuidSchemas);
+            return resolved;
+        }
+        catch
+        {
+            _guidSchemaCache.TryRemove(key, out _);
+            throw;
+        }
+    }
+
+    private static void ValidateSchemaIdStrategy(SchemaIdDeserializerStrategy strategy)
+    {
+        if (strategy is not (
+            SchemaIdDeserializerStrategy.Dual
+            or SchemaIdDeserializerStrategy.Prefix
+            or SchemaIdDeserializerStrategy.Header))
+        {
+            throw new ArgumentOutOfRangeException(nameof(strategy), strategy, "Unknown schema identity strategy.");
+        }
+    }
+
+    private static void AddHeaderName(List<string> names, string name)
+    {
+        if (!names.Contains(name))
+            names.Add(name);
+    }
+
+    private static string GetIdentityHeaderName(SerializationComponent component) => component switch
+    {
+        SerializationComponent.Key => SchemaIdentityHeaderNames.Key,
+        SerializationComponent.Value => SchemaIdentityHeaderNames.Value,
+        _ => throw new ArgumentOutOfRangeException(nameof(component), component, "Unknown serialization component.")
+    };
+
+    private readonly record struct GuidTopicKey(Guid SchemaGuid, string Topic, bool IsKey);
+
+    private sealed record GuidResolvedSchema(int SchemaId, string Subject, Schema Schema);
 
     private string GetSubjectName(int schemaId, Schema? schema, SerializationContext context)
     {

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
@@ -259,43 +259,11 @@ public sealed class ProtobufSchemaRegistryDeserializer<T>
     {
         try
         {
-            var unscopedSchema = await _schemaRegistry.GetSchemaByGuidAsync(
-                    key.SchemaGuid.ToString("D"),
-                    cancellationToken: CancellationToken.None)
+            var resolved = await SchemaRegistryOperationTimeout.ExecuteAsync(
+                    cancellationToken => FetchGuidSchemaCoreAsync(key, cancellationToken),
+                    SchemaRegistryTimeout,
+                    $"Schema GUID {key.SchemaGuid:D} resolution timed out.")
                 .ConfigureAwait(false);
-            if (unscopedSchema.SchemaType != SchemaType.Protobuf)
-            {
-                throw new InvalidOperationException(
-                    $"Schema with GUID {key.SchemaGuid:D} is not a Protobuf schema. Type: {unscopedSchema.SchemaType}");
-            }
-
-            var context = new SerializationContext
-            {
-                Topic = key.Topic,
-                Component = key.IsKey ? SerializationComponent.Key : SerializationComponent.Value
-            };
-            var subject = GetSubjectName(0, unscopedSchema, context);
-            var registered = await _schemaRegistry.LookupSchemaAsync(
-                    subject,
-                    unscopedSchema,
-                    ignoreDeletedSchemas: true,
-                    cancellationToken: CancellationToken.None)
-                .ConfigureAwait(false);
-            if (registered.Schema.SchemaType != SchemaType.Protobuf)
-            {
-                throw new InvalidOperationException(
-                    $"Schema with GUID {key.SchemaGuid:D} resolved to type {registered.Schema.SchemaType}; expected {SchemaType.Protobuf}.");
-            }
-            if (!Guid.TryParse(registered.Guid, out var registeredGuid) || registeredGuid != key.SchemaGuid)
-            {
-                throw new InvalidDataException(
-                    $"Schema Registry returned a conflicting GUID for subject '{subject}'.");
-            }
-
-            var resolved = new GuidResolvedSchema(
-                registered.Id,
-                subject,
-                registered.Schema);
             BoundedSchemaIdentityCache.RecordSuccessfulResolution(
                 _guidSchemaCache,
                 _guidSchemaEvictionQueue,
@@ -309,6 +277,49 @@ public sealed class ProtobufSchemaRegistryDeserializer<T>
             _guidSchemaCache.TryRemove(key, out _);
             throw;
         }
+    }
+
+    private async Task<GuidResolvedSchema> FetchGuidSchemaCoreAsync(
+        GuidTopicKey key,
+        CancellationToken cancellationToken)
+    {
+        var unscopedSchema = await _schemaRegistry.GetSchemaByGuidAsync(
+                key.SchemaGuid.ToString("D"),
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        if (unscopedSchema.SchemaType != SchemaType.Protobuf)
+        {
+            throw new InvalidOperationException(
+                $"Schema with GUID {key.SchemaGuid:D} is not a Protobuf schema. Type: {unscopedSchema.SchemaType}");
+        }
+
+        var context = new SerializationContext
+        {
+            Topic = key.Topic,
+            Component = key.IsKey ? SerializationComponent.Key : SerializationComponent.Value
+        };
+        var subject = GetSubjectName(0, unscopedSchema, context);
+        var registered = await _schemaRegistry.LookupSchemaAsync(
+                subject,
+                unscopedSchema,
+                ignoreDeletedSchemas: true,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        if (registered.Schema.SchemaType != SchemaType.Protobuf)
+        {
+            throw new InvalidOperationException(
+                $"Schema with GUID {key.SchemaGuid:D} resolved to type {registered.Schema.SchemaType}; expected {SchemaType.Protobuf}.");
+        }
+        if (!Guid.TryParse(registered.Guid, out var registeredGuid) || registeredGuid != key.SchemaGuid)
+        {
+            throw new InvalidDataException(
+                $"Schema Registry returned a conflicting GUID for subject '{subject}'.");
+        }
+
+        return new GuidResolvedSchema(
+            registered.Id,
+            subject,
+            registered.Schema);
     }
 
     private static void ValidateSchemaIdStrategy(SchemaIdDeserializerStrategy strategy)

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -432,29 +432,16 @@ public sealed class ProtobufSchemaRegistrySerializer<
         CancellationToken cancellationToken)
     {
         var references = schema.References;
-        var expectedCount = 0;
-        for (var dependencyIndex = 0; dependencyIndex < descriptor.Dependencies.Count; dependencyIndex++)
-        {
-            if (!_config.SkipKnownTypes || !IsKnownType(descriptor.Dependencies[dependencyIndex].Name))
-                expectedCount++;
-        }
-
-        if ((references?.Count ?? 0) != expectedCount)
-        {
-            throw new InvalidOperationException(
-                $"Schema ID {schemaId} does not match the Protobuf reference graph for '{_descriptor.FullName}'.");
-        }
+        var referenceCount = references?.Count ?? 0;
+        var matchedReferenceCount = 0;
 
         for (var dependencyIndex = 0; dependencyIndex < descriptor.Dependencies.Count; dependencyIndex++)
         {
             var dependency = descriptor.Dependencies[dependencyIndex];
-            if (_config.SkipKnownTypes && IsKnownType(dependency.Name))
-                continue;
-
             SchemaReference? matchingReference = null;
-            for (var referenceIndex = 0; referenceIndex < references!.Count; referenceIndex++)
+            for (var referenceIndex = 0; referenceIndex < referenceCount; referenceIndex++)
             {
-                var candidate = references[referenceIndex];
+                var candidate = references![referenceIndex];
                 if (!string.Equals(candidate.Name, dependency.Name, StringComparison.Ordinal))
                     continue;
                 if (matchingReference is not null)
@@ -468,10 +455,14 @@ public sealed class ProtobufSchemaRegistrySerializer<
 
             if (matchingReference is null)
             {
+                if (IsKnownType(dependency.Name))
+                    continue;
+
                 throw new InvalidOperationException(
                     $"Schema ID {schemaId} is missing Protobuf reference '{dependency.Name}'.");
             }
 
+            matchedReferenceCount++;
             var key = new SchemaReferenceKey(matchingReference.Subject, matchingReference.Version);
             if (!resolvedReferences.TryGetValue(key, out var resolvedSchema))
             {
@@ -492,6 +483,12 @@ public sealed class ProtobufSchemaRegistrySerializer<
                     resolvedReferences,
                     cancellationToken)
                 .ConfigureAwait(false);
+        }
+
+        if (matchedReferenceCount != referenceCount)
+        {
+            throw new InvalidOperationException(
+                $"Schema ID {schemaId} does not match the Protobuf reference graph for '{_descriptor.FullName}'.");
         }
     }
 

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -411,6 +411,9 @@ public sealed class ProtobufSchemaRegistrySerializer<
         CancellationToken cancellationToken)
     {
         ValidateDescriptor(schemaId, _descriptor.File, schema);
+        if (!_config.UseSchemaReferences)
+            return;
+
         var resolvedReferences = new Dictionary<SchemaReferenceKey, Schema>();
         await ValidateReferencesAsync(
                 schemaId,

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using Dekaf.Serialization;
 using Google.Protobuf;
@@ -313,7 +314,11 @@ public sealed class ProtobufSchemaRegistrySerializer<
                     subject,
                     cancellationToken)
                 .ConfigureAwait(false);
-            ValidateExplicitSchema(schemaId, explicitSchema);
+            await ValidateExplicitSchemaAsync(
+                    schemaId,
+                    explicitSchema,
+                    cancellationToken)
+                .ConfigureAwait(false);
 
             return await CreateResolvedValueAsync(
                     subject,
@@ -400,7 +405,94 @@ public sealed class ProtobufSchemaRegistrySerializer<
             .ConfigureAwait(false);
     }
 
-    private void ValidateExplicitSchema(int schemaId, Schema schema)
+    private async Task ValidateExplicitSchemaAsync(
+        int schemaId,
+        Schema schema,
+        CancellationToken cancellationToken)
+    {
+        ValidateDescriptor(schemaId, _descriptor.File, schema);
+        var resolvedReferences = new Dictionary<SchemaReferenceKey, Schema>();
+        await ValidateReferencesAsync(
+                schemaId,
+                _descriptor.File,
+                schema,
+                resolvedReferences,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task ValidateReferencesAsync(
+        int schemaId,
+        FileDescriptor descriptor,
+        Schema schema,
+        Dictionary<SchemaReferenceKey, Schema> resolvedReferences,
+        CancellationToken cancellationToken)
+    {
+        var references = schema.References;
+        var expectedCount = 0;
+        for (var dependencyIndex = 0; dependencyIndex < descriptor.Dependencies.Count; dependencyIndex++)
+        {
+            if (!_config.SkipKnownTypes || !IsKnownType(descriptor.Dependencies[dependencyIndex].Name))
+                expectedCount++;
+        }
+
+        if ((references?.Count ?? 0) != expectedCount)
+        {
+            throw new InvalidOperationException(
+                $"Schema ID {schemaId} does not match the Protobuf reference graph for '{_descriptor.FullName}'.");
+        }
+
+        for (var dependencyIndex = 0; dependencyIndex < descriptor.Dependencies.Count; dependencyIndex++)
+        {
+            var dependency = descriptor.Dependencies[dependencyIndex];
+            if (_config.SkipKnownTypes && IsKnownType(dependency.Name))
+                continue;
+
+            SchemaReference? matchingReference = null;
+            for (var referenceIndex = 0; referenceIndex < references!.Count; referenceIndex++)
+            {
+                var candidate = references[referenceIndex];
+                if (!string.Equals(candidate.Name, dependency.Name, StringComparison.Ordinal))
+                    continue;
+                if (matchingReference is not null)
+                {
+                    throw new InvalidOperationException(
+                        $"Schema ID {schemaId} contains duplicate Protobuf reference '{dependency.Name}'.");
+                }
+
+                matchingReference = candidate;
+            }
+
+            if (matchingReference is null)
+            {
+                throw new InvalidOperationException(
+                    $"Schema ID {schemaId} is missing Protobuf reference '{dependency.Name}'.");
+            }
+
+            var key = new SchemaReferenceKey(matchingReference.Subject, matchingReference.Version);
+            if (!resolvedReferences.TryGetValue(key, out var resolvedSchema))
+            {
+                var registered = await _schemaRegistry.GetSchemaBySubjectAsync(
+                        matchingReference.Subject,
+                        matchingReference.Version.ToString(CultureInfo.InvariantCulture),
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                resolvedSchema = registered.Schema;
+                resolvedReferences.Add(key, resolvedSchema);
+            }
+
+            ValidateDescriptor(schemaId, dependency, resolvedSchema);
+            await ValidateReferencesAsync(
+                    schemaId,
+                    dependency,
+                    resolvedSchema,
+                    resolvedReferences,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private void ValidateDescriptor(int schemaId, FileDescriptor descriptor, Schema schema)
     {
         if (schema.SchemaType != SchemaType.Protobuf)
         {
@@ -408,7 +500,7 @@ public sealed class ProtobufSchemaRegistrySerializer<
                 $"Schema ID {schemaId} has format {schema.SchemaType}; expected {SchemaType.Protobuf}.");
         }
 
-        if (!string.Equals(schema.SchemaString, _schemaString, StringComparison.Ordinal))
+        if (!string.Equals(schema.SchemaString, descriptor.SerializedData.ToBase64(), StringComparison.Ordinal))
         {
             throw new InvalidOperationException(
                 $"Schema ID {schemaId} does not match Protobuf message type '{_descriptor.FullName}'.");
@@ -681,6 +773,8 @@ public sealed class ProtobufSchemaRegistrySerializer<
         ProtobufSchemaRegistrySerializer<T> Serializer,
         string Topic,
         bool IsKey);
+
+    private readonly record struct SchemaReferenceKey(string Subject, int Version);
 
     private sealed class ReferenceRegistrationState(string topic, bool isKey)
     {

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -313,11 +313,7 @@ public sealed class ProtobufSchemaRegistrySerializer<
                     subject,
                     cancellationToken)
                 .ConfigureAwait(false);
-            if (explicitSchema.SchemaType != SchemaType.Protobuf)
-            {
-                throw new InvalidOperationException(
-                    $"Schema ID {schemaId} has format {explicitSchema.SchemaType}; expected {SchemaType.Protobuf}.");
-            }
+            ValidateExplicitSchema(schemaId, explicitSchema);
 
             return await CreateResolvedValueAsync(
                     subject,
@@ -402,6 +398,21 @@ public sealed class ProtobufSchemaRegistrySerializer<
                 registered,
                 cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    private void ValidateExplicitSchema(int schemaId, Schema schema)
+    {
+        if (schema.SchemaType != SchemaType.Protobuf)
+        {
+            throw new InvalidOperationException(
+                $"Schema ID {schemaId} has format {schema.SchemaType}; expected {SchemaType.Protobuf}.");
+        }
+
+        if (!string.Equals(schema.SchemaString, _schemaString, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Schema ID {schemaId} does not match Protobuf message type '{_descriptor.FullName}'.");
+        }
     }
 
     private async Task<SubjectSchemaIdCache.SubjectSchemaIdCacheValue> CreateResolvedValueAsync(

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -1,6 +1,6 @@
 using System.Buffers;
-using System.Buffers.Binary;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Dekaf.Serialization;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
@@ -9,7 +9,9 @@ namespace Dekaf.SchemaRegistry.Protobuf;
 
 /// <summary>
 /// Protobuf serializer that integrates with Confluent Schema Registry.
-/// Wire format: [magic byte (0x00)] [schema ID (4 bytes)] [varint array indexes] [protobuf binary]
+/// Prefix framing writes [magic byte (0x00)] [schema ID (4 bytes)] [varint array indexes]
+/// [protobuf binary]. Header framing writes the GUID and message indexes to the schema-identity
+/// record header and leaves the payload as raw Protobuf binary.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -24,14 +26,15 @@ namespace Dekaf.SchemaRegistry.Protobuf;
 /// <typeparam name="T">The Protobuf message type to serialize.</typeparam>
 public sealed class ProtobufSchemaRegistrySerializer<
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
-    : ISerializer<T>, IAsyncSerializerPreparer<T>, IAsyncDisposable
+    : ISerializer<T>, IAsyncSerializerPreparer<T>, IRecordHeaderSerializer, IAsyncDisposable
     where T : IMessage<T>
 {
-    private const byte MagicByte = 0x00;
     private static readonly TimeSpan SchemaRegistryTimeout = TimeSpan.FromSeconds(30);
 
     private readonly ISchemaRegistryClient _schemaRegistry;
     private readonly ProtobufSerializerConfig _config;
+    private readonly SchemaIdSerializerStrategy _schemaIdStrategy;
+    private readonly SchemaSelectionMode _schemaSelectionMode;
     private readonly bool _ownsClient;
     private readonly MessageDescriptor _descriptor;
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
@@ -40,6 +43,10 @@ public sealed class ProtobufSchemaRegistrySerializer<
     private readonly SchemaResolutionCache<SubjectSchemaIdCache.SubjectSchemaIdCacheValue> _schemaResolutionCache = new();
     private readonly SchemaResolutionCache<RegisteredDependency> _referenceResolutionCache = new();
     private readonly Schema _resolutionIdentitySchema;
+    private readonly ConditionalWeakTable<Schema, IdentityHeaderFrame> _identityHeaderFrames = new();
+
+    bool IRecordHeaderSerializer.ProducesRecordHeaders =>
+        _schemaIdStrategy == SchemaIdSerializerStrategy.Header;
 
     /// <summary>
     /// Creates a new Protobuf Schema Registry serializer.
@@ -54,6 +61,13 @@ public sealed class ProtobufSchemaRegistrySerializer<
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _config = config ?? new ProtobufSerializerConfig();
+        _schemaIdStrategy = _config.SchemaIdStrategy;
+        _schemaSelectionMode = SchemaRegistrySerializerConfigValidator.ValidateAndResolve(
+            _config.UseSchemaId,
+            _config.UseLatestVersion,
+            _config.AutoRegisterSchemas);
+        if (_schemaIdStrategy is not (SchemaIdSerializerStrategy.Prefix or SchemaIdSerializerStrategy.Header))
+            throw new ArgumentOutOfRangeException(nameof(config), _schemaIdStrategy, "Unknown schema identity strategy.");
         _ownsClient = ownsClient;
 
         // Get the message descriptor from the type
@@ -146,26 +160,27 @@ public sealed class ProtobufSchemaRegistrySerializer<
             }
         }
 
-        // Total size: magic byte + schema ID + indexes + message
         var protobufPayloadLength = _config.RuleExecutor is null ? protoSize : transformedPayload.Length;
-        var totalSize = 1 + 4 + _encodedMessageIndexes.Length + protobufPayloadLength;
+        var payloadOffset = _schemaIdStrategy == SchemaIdSerializerStrategy.Prefix
+            ? SchemaIdentityFraming.SchemaIdFrameSize + _encodedMessageIndexes.Length
+            : 0;
+        var totalSize = payloadOffset + protobufPayloadLength;
         var span = destination.GetSpan(totalSize);
 
-        // Write magic byte
-        span[0] = MagicByte;
-
-        // Write schema ID (big-endian)
-        BinaryPrimitives.WriteInt32BigEndian(span.Slice(1, 4), schemaId);
-
-        var offset = 5;
-        _encodedMessageIndexes.CopyTo(span.Slice(offset));
-        offset += _encodedMessageIndexes.Length;
+        if (_schemaIdStrategy == SchemaIdSerializerStrategy.Prefix)
+        {
+            SchemaIdentityFraming.WriteSchemaId(span, schemaId);
+            _encodedMessageIndexes.CopyTo(span[SchemaIdentityFraming.SchemaIdFrameSize..]);
+        }
 
         // Write the protobuf message
         if (_config.RuleExecutor is null)
-            value.WriteTo(span.Slice(offset, protoSize));
+            value.WriteTo(span.Slice(payloadOffset, protoSize));
         else
-            transformedPayload.Span.CopyTo(span.Slice(offset, transformedPayload.Length));
+            transformedPayload.Span.CopyTo(span.Slice(payloadOffset, transformedPayload.Length));
+
+        if (_schemaIdStrategy == SchemaIdSerializerStrategy.Header)
+            WriteIdentityHeader(context, in schemaEntry);
 
         destination.Advance(totalSize);
     }
@@ -270,7 +285,7 @@ public sealed class ProtobufSchemaRegistrySerializer<
 
     private SchemaResolutionScope GetSchemaResolutionScope(string topic, bool isKey) =>
         _config.UseSchemaReferences &&
-        !_config.UseLatestVersion &&
+        _schemaSelectionMode is SchemaSelectionMode.AutoRegister or SchemaSelectionMode.Lookup &&
         _config.CustomReferenceSubjectNameStrategy is not null
             ? new SchemaResolutionScope(topic, isKey)
             : default;
@@ -290,12 +305,47 @@ public sealed class ProtobufSchemaRegistrySerializer<
         bool isKey,
         CancellationToken cancellationToken)
     {
-        if (_config.UseLatestVersion)
+        if (_schemaSelectionMode == SchemaSelectionMode.ExplicitId)
+        {
+            var schemaId = _config.UseSchemaId!.Value;
+            var explicitSchema = await _schemaRegistry.GetSchemaAsync(
+                    schemaId,
+                    subject,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (explicitSchema.SchemaType != SchemaType.Protobuf)
+            {
+                throw new InvalidOperationException(
+                    $"Schema ID {schemaId} has format {explicitSchema.SchemaType}; expected {SchemaType.Protobuf}.");
+            }
+
+            return await CreateResolvedValueAsync(
+                    subject,
+                    schemaId,
+                    explicitSchema,
+                    registeredSchema: null,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (_schemaSelectionMode == SchemaSelectionMode.Latest)
         {
             var latest = await _schemaRegistry.GetSchemaBySubjectAsync(
                 subject,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
-            return new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(latest.Id, latest.Schema);
+            if (latest.Schema.SchemaType != SchemaType.Protobuf)
+            {
+                throw new InvalidOperationException(
+                    $"Schema ID {latest.Id} has format {latest.Schema.SchemaType}; expected {SchemaType.Protobuf}.");
+            }
+
+            return await CreateResolvedValueAsync(
+                    subject,
+                    latest.Id,
+                    latest.Schema,
+                    latest,
+                    cancellationToken)
+                .ConfigureAwait(false);
         }
 
         IReadOnlyList<SchemaReference>? references = null;
@@ -315,7 +365,7 @@ public sealed class ProtobufSchemaRegistrySerializer<
             References = references
         };
 
-        if (_config.AutoRegisterSchemas)
+        if (_schemaSelectionMode == SchemaSelectionMode.AutoRegister)
         {
             var id = _config.NormalizeSchemas
                 ? await _schemaRegistry.GetOrRegisterSchemaAsync(
@@ -330,7 +380,13 @@ public sealed class ProtobufSchemaRegistrySerializer<
             var executionSchema = _config.RuleExecutor is SchemaRegistryRuleExecutor
                 ? await _schemaRegistry.GetSchemaAsync(id, subject, cancellationToken).ConfigureAwait(false)
                 : schema;
-            return new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(id, executionSchema);
+            return await CreateResolvedValueAsync(
+                    subject,
+                    id,
+                    executionSchema,
+                    registeredSchema: null,
+                    cancellationToken)
+                .ConfigureAwait(false);
         }
 
         var registered = await _schemaRegistry.LookupSchemaAsync(
@@ -339,7 +395,65 @@ public sealed class ProtobufSchemaRegistrySerializer<
             ignoreDeletedSchemas: true,
             normalize: _config.NormalizeSchemas,
             cancellationToken).ConfigureAwait(false);
-        return new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(registered.Id, registered.Schema);
+        return await CreateResolvedValueAsync(
+                subject,
+                registered.Id,
+                registered.Schema,
+                registered,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<SubjectSchemaIdCache.SubjectSchemaIdCacheValue> CreateResolvedValueAsync(
+        string subject,
+        int schemaId,
+        Schema schema,
+        RegisteredSchema? registeredSchema,
+        CancellationToken cancellationToken)
+    {
+        var resolved = await SchemaIdentityResolution.CreateSerializerValueAsync(
+                _schemaRegistry,
+                subject,
+                schemaId,
+                schema,
+                _schemaIdStrategy,
+                _config.NormalizeSchemas,
+                registeredSchema,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (_schemaIdStrategy == SchemaIdSerializerStrategy.Header)
+            CacheIdentityHeaderFrame(resolved.Schema!, resolved.SchemaId);
+
+        return resolved;
+    }
+
+    private void CacheIdentityHeaderFrame(Schema schema, int schemaId)
+    {
+        var encodedGuid = SchemaGuidFrameCache.Get(schema, schemaId);
+        var frame = GC.AllocateUninitializedArray<byte>(encodedGuid.Length + _encodedMessageIndexes.Length);
+        encodedGuid.Span.CopyTo(frame);
+        _encodedMessageIndexes.CopyTo(frame.AsSpan(encodedGuid.Length));
+        _identityHeaderFrames.AddOrUpdate(schema, new IdentityHeaderFrame(frame));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void WriteIdentityHeader(
+        SerializationContext context,
+        in SubjectSchemaIdCache.SubjectSchemaIdCacheEntry schemaEntry)
+    {
+        if (context.Headers is not { } headers)
+        {
+            throw new InvalidOperationException(
+                "Header schema identity framing requires a record Headers collection.");
+        }
+
+        if (!_identityHeaderFrames.TryGetValue(schemaEntry.Schema!, out var frame))
+        {
+            throw new InvalidDataException(
+                $"Schema Registry GUID framing is unavailable for schema ID {schemaEntry.SchemaId}.");
+        }
+
+        headers.Add(SchemaIdentityFraming.CreateSchemaGuidHeader(context.Component, frame.Value));
     }
 
     private string GetSubjectName(string topic, bool isKey)
@@ -566,6 +680,11 @@ public sealed class ProtobufSchemaRegistrySerializer<
     }
 
     private readonly record struct RegisteredDependency(string Subject, int Version);
+
+    private sealed class IdentityHeaderFrame(ReadOnlyMemory<byte> value)
+    {
+        internal ReadOnlyMemory<byte> Value { get; } = value;
+    }
 
     private static int[] CalculateMessageIndexes(MessageDescriptor descriptor)
     {

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
@@ -42,6 +42,16 @@ public sealed class ProtobufSerializerConfig
     public bool UseLatestVersion { get; init; }
 
     /// <summary>
+    /// Global Schema Registry ID to use instead of registering, looking up, or selecting the latest schema.
+    /// </summary>
+    public int? UseSchemaId { get; init; }
+
+    /// <summary>
+    /// Strategy used to carry the selected schema identity. The default writes the Confluent payload prefix.
+    /// </summary>
+    public SchemaIdSerializerStrategy SchemaIdStrategy { get; init; } = SchemaIdSerializerStrategy.Prefix;
+
+    /// <summary>
     /// Whether schema registration and lookup requests should include normalize=true.
     /// Default is false.
     /// </summary>

--- a/src/Dekaf.SchemaRegistry.Protobuf/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry.Protobuf/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 Dekaf.SchemaRegistry.Protobuf.ProtobufDeserializerConfig.CustomSubjectNameStrategy.get -> Dekaf.SchemaRegistry.ISubjectNameStrategy?
 Dekaf.SchemaRegistry.Protobuf.ProtobufDeserializerConfig.CustomSubjectNameStrategy.init -> void
+Dekaf.SchemaRegistry.Protobuf.ProtobufDeserializerConfig.SchemaIdStrategy.get -> Dekaf.SchemaRegistry.SchemaIdDeserializerStrategy
+Dekaf.SchemaRegistry.Protobuf.ProtobufDeserializerConfig.SchemaIdStrategy.init -> void
 Dekaf.SchemaRegistry.Protobuf.ProtobufDeserializerConfig.SubjectNameStrategy.get -> Dekaf.SchemaRegistry.SubjectNameStrategy
 Dekaf.SchemaRegistry.Protobuf.ProtobufDeserializerConfig.SubjectNameStrategy.init -> void
 Dekaf.SchemaRegistry.Protobuf.ProtobufDeserializerConfig.UseLegacySubjectNames.get -> bool
@@ -13,4 +15,8 @@ Dekaf.SchemaRegistry.Protobuf.ProtobufSchemaRegistrySerializer<T>.PrepareAsync(s
 Dekaf.SchemaRegistry.Protobuf.ProtobufSchemaRegistrySerializer<T>.PrepareAsync(T value, Dekaf.Serialization.SerializationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Dekaf.SchemaRegistry.Protobuf.ProtobufSerializerConfig.CustomReferenceSubjectNameStrategy.get -> Dekaf.SchemaRegistry.Protobuf.IReferenceSubjectNameStrategy?
 Dekaf.SchemaRegistry.Protobuf.ProtobufSerializerConfig.CustomReferenceSubjectNameStrategy.init -> void
+Dekaf.SchemaRegistry.Protobuf.ProtobufSerializerConfig.SchemaIdStrategy.get -> Dekaf.SchemaRegistry.SchemaIdSerializerStrategy
+Dekaf.SchemaRegistry.Protobuf.ProtobufSerializerConfig.SchemaIdStrategy.init -> void
+Dekaf.SchemaRegistry.Protobuf.ProtobufSerializerConfig.UseSchemaId.get -> int?
+Dekaf.SchemaRegistry.Protobuf.ProtobufSerializerConfig.UseSchemaId.init -> void
 Dekaf.SchemaRegistry.Protobuf.ReferenceSubjectNameStrategy.Qualified = 1 -> Dekaf.SchemaRegistry.Protobuf.ReferenceSubjectNameStrategy

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -184,9 +184,16 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         out bool usesWorkspace)
     {
         usesWorkspace = false;
-        if (!_producesRecordHeaders || headers is not null)
+        if (!_producesRecordHeaders)
         {
             checkpoint = headers?.CaptureCheckpoint() ?? default;
+            return headers;
+        }
+
+        if (headers is not null)
+        {
+            checkpoint = headers.CaptureCheckpoint();
+            headers.BeginRecordHeaderStaging();
             return headers;
         }
 
@@ -218,9 +225,16 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         out bool usesPooledWorkspace)
     {
         usesPooledWorkspace = false;
-        if (!_producesRecordHeaders || headers is not null)
+        if (!_producesRecordHeaders)
         {
             checkpoint = headers?.CaptureCheckpoint() ?? default;
+            return headers;
+        }
+
+        if (headers is not null)
+        {
+            checkpoint = headers.CaptureCheckpoint();
+            headers.BeginRecordHeaderStaging();
             return headers;
         }
 
@@ -236,9 +250,13 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         in Headers.Checkpoint checkpoint,
         bool usesPooledWorkspace)
     {
-        headers?.Restore(in checkpoint);
         if (usesPooledWorkspace)
+        {
             _asyncSerializationHeadersPool!.Return(headers!);
+            return;
+        }
+
+        headers?.Restore(in checkpoint);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -248,9 +266,14 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         ProducerThreadCache cache,
         bool usesWorkspace)
     {
-        headers?.Restore(in checkpoint);
         if (usesWorkspace)
+        {
+            headers!.Clear();
             cache.SerializationHeaderWorkspaceDepth--;
+            return;
+        }
+
+        headers?.Restore(in checkpoint);
     }
 
     /// <summary>
@@ -299,7 +322,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
 
         protected override Headers Create() => new(2);
 
-        protected override void Reset(Headers item) { }
+        protected override void Reset(Headers item) => item.Clear();
     }
 
     private const string TransactionVersionFeature = "transaction.version";
@@ -1643,7 +1666,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             var timestampMs = timestamp?.ToUnixTimeMilliseconds() ?? GetFastTimestampMs();
 
             // Convert headers
-            if (headers is not null && headers.Count > 0)
+            if (headers is not null && headers.SerializationCount > 0)
             {
                 RentAndFillHeaders(headers, out pooledHeaderArray, out headerCount);
             }
@@ -1971,7 +1994,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             var timestampMs = timestamp.ToUnixTimeMilliseconds();
 
             // Convert headers with minimal allocations
-            if (serializationHeaders is { Count: > 0 })
+            if (serializationHeaders is not null && serializationHeaders.SerializationCount > 0)
             {
                 RentAndFillHeaders(serializationHeaders, out pooledHeaderArray, out headerCount);
             }
@@ -4829,7 +4852,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
 
             Header[]? pooledHeaderArray = null;
             var headerCount = 0;
-            if (serializationHeaders is { Count: > 0 })
+            if (serializationHeaders is not null && serializationHeaders.SerializationCount > 0)
             {
                 RentAndFillHeaders(serializationHeaders, out pooledHeaderArray, out headerCount);
             }
@@ -5398,7 +5421,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
 
         Header[]? pooledHeaderArray = null;
         var headerCount = 0;
-        if (headers is not null && headers.Count > 0)
+        if (headers is not null && headers.SerializationCount > 0)
         {
             RentAndFillHeaders(headers, out pooledHeaderArray, out headerCount);
         }
@@ -5459,7 +5482,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void RentAndFillHeaders(Headers headers, out Header[] pooledArray, out int headerCount)
     {
-        var count = headers.Count;
+        var count = headers.SerializationCount;
         headerCount = count;
 
         // Use dedicated pool to prevent TLS accumulation from cross-thread return
@@ -5467,9 +5490,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         var result = ProducerContainerPools.Headers.Rent(count);
         pooledArray = result;
 
-        // Use index-based iteration to avoid enumerator boxing allocation
-        for (var i = 0; i < count; i++)
-            result[i] = headers[i];
+        headers.CopySerializationHeadersTo(result);
 
         headers.RemoveDeferredTraceContext();
     }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -178,13 +178,15 @@ public sealed partial class KafkaProducer<TKey, TValue> :
     private Headers? PrepareSerializationHeaders(
         Headers? headers,
         ProducerThreadCache cache,
-        out int originalCount,
+        out Headers.Checkpoint checkpoint,
         out bool usesWorkspace)
     {
-        originalCount = headers?.CountWithoutDeferredTraceContext ?? 0;
         usesWorkspace = false;
         if (!_producesRecordHeaders || headers is not null)
+        {
+            checkpoint = headers?.CaptureCheckpoint() ?? default;
             return headers;
+        }
 
         var depth = cache.SerializationHeaderWorkspaceDepth;
         var workspaces = cache.SerializationHeaderWorkspaces;
@@ -203,23 +205,24 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         workspace.Clear();
         cache.SerializationHeaderWorkspaceDepth = depth + 1;
         usesWorkspace = true;
+        checkpoint = workspace.CaptureCheckpoint();
         return workspace;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void RestoreSerializationHeaders(Headers? headers, int originalCount)
+    private static void RestoreSerializationHeaders(Headers? headers, in Headers.Checkpoint checkpoint)
     {
-        headers?.Truncate(originalCount);
+        headers?.Restore(in checkpoint);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void RestoreSerializationHeaders(
         Headers? headers,
-        int originalCount,
+        in Headers.Checkpoint checkpoint,
         ProducerThreadCache cache,
         bool usesWorkspace)
     {
-        headers?.Truncate(originalCount);
+        headers?.Restore(in checkpoint);
         if (usesWorkspace)
             cache.SerializationHeaderWorkspaceDepth--;
     }
@@ -1517,7 +1520,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         {
             var headerCache = GetOrCreateCache();
             var serializationHeaders = PrepareSerializationHeaders(
-                headers, headerCache, out var originalHeaderCount, out var usesHeaderWorkspace);
+                headers, headerCache, out var headerCheckpoint, out var usesHeaderWorkspace);
             try
             {
                 TryProduceSyncCore(
@@ -1527,7 +1530,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             finally
             {
                 RestoreSerializationHeaders(
-                    serializationHeaders, originalHeaderCount, headerCache, usesHeaderWorkspace);
+                    serializationHeaders, in headerCheckpoint, headerCache, usesHeaderWorkspace);
             }
 
             return;
@@ -1897,10 +1900,10 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         var value = PooledMemory.Null;
         Header[]? pooledHeaderArray = null;
         var headerCount = 0;
-        var originalHeaderCount = headers?.CountWithoutDeferredTraceContext ?? 0;
         var serializationHeaders = headers;
         if (_producesRecordHeaders && serializationHeaders is null)
             serializationHeaders = new Headers(2);
+        var headerCheckpoint = serializationHeaders?.CaptureCheckpoint() ?? default;
         try
         {
             if (!keyIsNull)
@@ -1963,7 +1966,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         }
         finally
         {
-            RestoreSerializationHeaders(serializationHeaders, originalHeaderCount);
+            RestoreSerializationHeaders(serializationHeaders, in headerCheckpoint);
         }
     }
 
@@ -4748,7 +4751,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
     {
         var cache = GetOrCreateCache();
         var serializationHeaders = PrepareSerializationHeaders(
-            headers, cache, out var originalHeaderCount, out var usesHeaderWorkspace);
+            headers, cache, out var headerCheckpoint, out var usesHeaderWorkspace);
         try
         {
             var keyIsNull = key is null;
@@ -4807,7 +4810,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         finally
         {
             RestoreSerializationHeaders(
-                serializationHeaders, originalHeaderCount, cache, usesHeaderWorkspace);
+                serializationHeaders, in headerCheckpoint, cache, usesHeaderWorkspace);
         }
     }
 
@@ -5223,10 +5226,10 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         Activity? activity,
         Action<RecordMetadata, Exception?>? deliveryHandler)
     {
-        var originalHeaderCount = headers?.CountWithoutDeferredTraceContext ?? 0;
         var serializationHeaders = headers;
         if (_producesRecordHeaders && serializationHeaders is null)
             serializationHeaders = new Headers(2);
+        var headerCheckpoint = serializationHeaders?.CaptureCheckpoint() ?? default;
         try
         {
             // Metadata: thread-local cache, then manager cache, then bounded fetch
@@ -5326,7 +5329,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
         }
         finally
         {
-            RestoreSerializationHeaders(serializationHeaders, originalHeaderCount);
+            RestoreSerializationHeaders(serializationHeaders, in headerCheckpoint);
             headers?.RemoveDeferredTraceContext();
             activity?.Dispose();
         }

--- a/src/Dekaf/Serialization/Headers.cs
+++ b/src/Dekaf/Serialization/Headers.cs
@@ -20,6 +20,12 @@ public sealed class Headers : IEnumerable<Header>
     private int _deferredTracestateIndex = -1;
     private int _keySchemaIdentityIndex = -1;
     private int _valueSchemaIdentityIndex = -1;
+    private Header _stagedHeader0;
+    private Header _stagedHeader1;
+    private int _stagedHeaderCount;
+    private int _stagedKeySchemaIdentityIndex = -1;
+    private int _stagedValueSchemaIdentityIndex = -1;
+    private bool _stagingRecordHeaders;
 
     /// <summary>
     /// Creates an empty headers collection.
@@ -73,6 +79,8 @@ public sealed class Headers : IEnumerable<Header>
     /// </summary>
     public int Count => _headers.Count;
 
+    internal int SerializationCount => _headers.Count + _stagedHeaderCount;
+
     internal int CountWithoutDeferredTraceContext
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -92,6 +100,48 @@ public sealed class Headers : IEnumerable<Header>
     /// Gets the header at the specified index.
     /// </summary>
     public Header this[int index] => _headers[index];
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal Header GetSerializationHeader(int index)
+    {
+        var stagedCount = _stagedHeaderCount;
+        if (stagedCount == 0)
+            return _headers[index];
+
+        var insertionIndex = _deferredTraceparentIndex >= 0
+            ? _deferredTraceparentIndex
+            : _headers.Count;
+        if (index < insertionIndex)
+            return _headers[index];
+        if (index < insertionIndex + stagedCount)
+            return index == insertionIndex ? _stagedHeader0 : _stagedHeader1;
+        return _headers[index - stagedCount];
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void CopySerializationHeadersTo(Header[] destination)
+    {
+        var stagedCount = _stagedHeaderCount;
+        if (stagedCount == 0)
+        {
+            for (var i = 0; i < _headers.Count; i++)
+                destination[i] = _headers[i];
+            return;
+        }
+
+        var insertionIndex = _deferredTraceparentIndex >= 0
+            ? _deferredTraceparentIndex
+            : _headers.Count;
+        for (var i = 0; i < insertionIndex; i++)
+            destination[i] = _headers[i];
+
+        destination[insertionIndex] = _stagedHeader0;
+        if (stagedCount == 2)
+            destination[insertionIndex + 1] = _stagedHeader1;
+
+        for (var i = insertionIndex; i < _headers.Count; i++)
+            destination[stagedCount + i] = _headers[i];
+    }
 
     /// <summary>
     /// Adds a header with a string value.
@@ -182,6 +232,14 @@ public sealed class Headers : IEnumerable<Header>
         _deferredTracestateIndex = -1;
         _keySchemaIdentityIndex = -1;
         _valueSchemaIdentityIndex = -1;
+        EndRecordHeaderStaging();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void BeginRecordHeaderStaging()
+    {
+        EndRecordHeaderStaging();
+        _stagingRecordHeaders = true;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -193,6 +251,7 @@ public sealed class Headers : IEnumerable<Header>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void Restore(in Checkpoint checkpoint)
     {
+        EndRecordHeaderStaging();
         if ((uint)checkpoint.Count > (uint)_headers.Count)
             throw new ArgumentOutOfRangeException(nameof(checkpoint));
 
@@ -279,6 +338,12 @@ public sealed class Headers : IEnumerable<Header>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void AddHeader(Header header)
     {
+        if (_stagingRecordHeaders)
+        {
+            AddStagedRecordHeader(header);
+            return;
+        }
+
         var traceparentIndex = _deferredTraceparentIndex;
         if (traceparentIndex < 0)
         {
@@ -319,19 +384,62 @@ public sealed class Headers : IEnumerable<Header>
     {
         var index = component switch
         {
-            SerializationComponent.Key => _keySchemaIdentityIndex,
-            SerializationComponent.Value => _valueSchemaIdentityIndex,
+            SerializationComponent.Key => _stagedKeySchemaIdentityIndex >= 0
+                ? _stagedKeySchemaIdentityIndex
+                : _keySchemaIdentityIndex,
+            SerializationComponent.Value => _stagedValueSchemaIdentityIndex >= 0
+                ? _stagedValueSchemaIdentityIndex
+                : _valueSchemaIdentityIndex,
             _ => throw new ArgumentOutOfRangeException(nameof(component), component, "Unknown serialization component.")
         };
 
-        if ((uint)index < (uint)_headers.Count)
+        if ((uint)index < (uint)SerializationCount)
         {
-            header = _headers[index];
+            header = GetSerializationHeader(index);
             return true;
         }
 
         header = default;
         return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void AddStagedRecordHeader(Header header)
+    {
+        var stagedIndex = _stagedHeaderCount;
+        if (stagedIndex == 0)
+            _stagedHeader0 = header;
+        else if (stagedIndex == 1)
+            _stagedHeader1 = header;
+        else
+            throw new InvalidOperationException("A producer can stage at most one record header per key and value serializer.");
+
+        var insertionIndex = _deferredTraceparentIndex >= 0
+            ? _deferredTraceparentIndex
+            : _headers.Count;
+        var logicalIndex = insertionIndex + stagedIndex;
+        _stagedHeaderCount = stagedIndex + 1;
+        var key = header.Key;
+        if (key.Length == KeySchemaIdentityHeader.Length
+            && string.Equals(key, KeySchemaIdentityHeader, StringComparison.Ordinal))
+            _stagedKeySchemaIdentityIndex = logicalIndex;
+        else if (key.Length == ValueSchemaIdentityHeader.Length
+                 && string.Equals(key, ValueSchemaIdentityHeader, StringComparison.Ordinal))
+            _stagedValueSchemaIdentityIndex = logicalIndex;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void EndRecordHeaderStaging()
+    {
+        if (!_stagingRecordHeaders)
+            return;
+
+        _stagingRecordHeaders = false;
+        _stagedHeaderCount = 0;
+        _stagedHeader0 = default;
+        _stagedHeader1 = default;
+        _stagedKeySchemaIdentityIndex = -1;
+        _stagedValueSchemaIdentityIndex = -1;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Serialization/Headers.cs
+++ b/src/Dekaf/Serialization/Headers.cs
@@ -12,9 +12,14 @@ namespace Dekaf.Serialization;
 /// </summary>
 public sealed class Headers : IEnumerable<Header>
 {
+    // Keep synchronized with SchemaIdentityHeaderNames in Dekaf.SchemaRegistry.
+    private const string KeySchemaIdentityHeader = "__key_schema_id";
+    private const string ValueSchemaIdentityHeader = "__value_schema_id";
     private readonly List<Header> _headers;
     private int _deferredTraceparentIndex = -1;
     private int _deferredTracestateIndex = -1;
+    private int _keySchemaIdentityIndex = -1;
+    private int _valueSchemaIdentityIndex = -1;
 
     /// <summary>
     /// Creates an empty headers collection.
@@ -38,6 +43,7 @@ public sealed class Headers : IEnumerable<Header>
     public Headers(IEnumerable<Header> headers)
     {
         _headers = [.. headers];
+        InitializeSchemaIdentityIndexes();
     }
 
     /// <summary>
@@ -174,6 +180,8 @@ public sealed class Headers : IEnumerable<Header>
         _headers.Clear();
         _deferredTraceparentIndex = -1;
         _deferredTracestateIndex = -1;
+        _keySchemaIdentityIndex = -1;
+        _valueSchemaIdentityIndex = -1;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -188,6 +196,14 @@ public sealed class Headers : IEnumerable<Header>
         _headers.RemoveRange(count, _headers.Count - count);
         _deferredTraceparentIndex = _deferredTraceparentIndex < count ? _deferredTraceparentIndex : -1;
         _deferredTracestateIndex = _deferredTracestateIndex < count ? _deferredTracestateIndex : -1;
+        _keySchemaIdentityIndex = GetRetainedSchemaIdentityIndex(
+            _keySchemaIdentityIndex,
+            count,
+            KeySchemaIdentityHeader);
+        _valueSchemaIdentityIndex = GetRetainedSchemaIdentityIndex(
+            _valueSchemaIdentityIndex,
+            count,
+            ValueSchemaIdentityHeader);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -217,11 +233,11 @@ public sealed class Headers : IEnumerable<Header>
         _deferredTracestateIndex = -1;
 
         if ((uint)tracestateIndex < (uint)_headers.Count)
-            _headers.RemoveAt(tracestateIndex);
+            RemoveAt(tracestateIndex);
 
         if ((uint)traceparentIndex < (uint)_headers.Count
             && _headers[traceparentIndex].HasDeferredTraceparent)
-            _headers.RemoveAt(traceparentIndex);
+            RemoveAt(traceparentIndex);
     }
 
     private void RemoveAt(int index)
@@ -229,6 +245,14 @@ public sealed class Headers : IEnumerable<Header>
         _headers.RemoveAt(index);
         _deferredTraceparentIndex = AdjustTrackedIndex(_deferredTraceparentIndex, index);
         _deferredTracestateIndex = AdjustTrackedIndex(_deferredTracestateIndex, index);
+        _keySchemaIdentityIndex = AdjustSchemaIdentityIndex(
+            _keySchemaIdentityIndex,
+            index,
+            KeySchemaIdentityHeader);
+        _valueSchemaIdentityIndex = AdjustSchemaIdentityIndex(
+            _valueSchemaIdentityIndex,
+            index,
+            ValueSchemaIdentityHeader);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -238,9 +262,16 @@ public sealed class Headers : IEnumerable<Header>
         if (traceparentIndex < 0)
         {
             _headers.Add(header);
+            TrackSchemaIdentityCandidate(header.Key, _headers.Count - 1);
             return;
         }
 
+        AddHeaderBeforeDeferredTraceContext(header, traceparentIndex);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void AddHeaderBeforeDeferredTraceContext(Header header, int traceparentIndex)
+    {
         var traceparent = _headers[traceparentIndex];
         var tracestateIndex = _deferredTracestateIndex;
         if (tracestateIndex < 0)
@@ -248,15 +279,99 @@ public sealed class Headers : IEnumerable<Header>
             _headers.Add(traceparent);
             _headers[traceparentIndex] = header;
             _deferredTraceparentIndex = traceparentIndex + 1;
-            return;
+        }
+        else
+        {
+            var tracestate = _headers[tracestateIndex];
+            _headers.Add(tracestate);
+            _headers[traceparentIndex] = header;
+            _headers[tracestateIndex] = traceparent;
+            _deferredTraceparentIndex = traceparentIndex + 1;
+            _deferredTracestateIndex = tracestateIndex + 1;
         }
 
-        var tracestate = _headers[tracestateIndex];
-        _headers.Add(tracestate);
-        _headers[traceparentIndex] = header;
-        _headers[tracestateIndex] = traceparent;
-        _deferredTraceparentIndex = traceparentIndex + 1;
-        _deferredTracestateIndex = tracestateIndex + 1;
+        TrackSchemaIdentityCandidate(header.Key, traceparentIndex);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryGetLastSchemaIdentity(SerializationComponent component, out Header header)
+    {
+        var index = component switch
+        {
+            SerializationComponent.Key => _keySchemaIdentityIndex,
+            SerializationComponent.Value => _valueSchemaIdentityIndex,
+            _ => throw new ArgumentOutOfRangeException(nameof(component), component, "Unknown serialization component.")
+        };
+
+        if ((uint)index < (uint)_headers.Count)
+        {
+            header = _headers[index];
+            return true;
+        }
+
+        header = default;
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void TrackSchemaIdentityCandidate(string? key, int index)
+    {
+        if (key is null)
+            return;
+
+        if (key.Length == KeySchemaIdentityHeader.Length
+            && string.Equals(key, KeySchemaIdentityHeader, StringComparison.Ordinal))
+        {
+            _keySchemaIdentityIndex = index;
+        }
+        else if (key.Length == ValueSchemaIdentityHeader.Length
+                 && string.Equals(key, ValueSchemaIdentityHeader, StringComparison.Ordinal))
+        {
+            _valueSchemaIdentityIndex = index;
+        }
+    }
+
+    private void InitializeSchemaIdentityIndexes()
+    {
+        for (var index = _headers.Count - 1; index >= 0; index--)
+        {
+            var key = _headers[index].Key;
+            if (_keySchemaIdentityIndex < 0
+                && string.Equals(key, KeySchemaIdentityHeader, StringComparison.Ordinal))
+            {
+                _keySchemaIdentityIndex = index;
+            }
+            else if (_valueSchemaIdentityIndex < 0
+                     && string.Equals(key, ValueSchemaIdentityHeader, StringComparison.Ordinal))
+            {
+                _valueSchemaIdentityIndex = index;
+            }
+
+            if (_keySchemaIdentityIndex >= 0 && _valueSchemaIdentityIndex >= 0)
+                return;
+        }
+    }
+
+    private int AdjustSchemaIdentityIndex(int trackedIndex, int removedIndex, string key)
+    {
+        if (trackedIndex != removedIndex)
+            return trackedIndex > removedIndex ? trackedIndex - 1 : trackedIndex;
+
+        return FindLastSchemaIdentityIndex(key, _headers.Count);
+    }
+
+    private int GetRetainedSchemaIdentityIndex(int trackedIndex, int count, string key) =>
+        trackedIndex < count ? trackedIndex : FindLastSchemaIdentityIndex(key, count);
+
+    private int FindLastSchemaIdentityIndex(string key, int count)
+    {
+        for (var index = count - 1; index >= 0; index--)
+        {
+            if (string.Equals(_headers[index].Key, key, StringComparison.Ordinal))
+                return index;
+        }
+
+        return -1;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Serialization/Headers.cs
+++ b/src/Dekaf/Serialization/Headers.cs
@@ -185,6 +185,27 @@ public sealed class Headers : IEnumerable<Header>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal Checkpoint CaptureCheckpoint() => new(
+        CountWithoutDeferredTraceContext,
+        _keySchemaIdentityIndex,
+        _valueSchemaIdentityIndex);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void Restore(in Checkpoint checkpoint)
+    {
+        if ((uint)checkpoint.Count > (uint)_headers.Count)
+            throw new ArgumentOutOfRangeException(nameof(checkpoint));
+
+        if (checkpoint.Count != _headers.Count)
+            _headers.RemoveRange(checkpoint.Count, _headers.Count - checkpoint.Count);
+
+        _deferredTraceparentIndex = -1;
+        _deferredTracestateIndex = -1;
+        _keySchemaIdentityIndex = checkpoint.KeySchemaIdentityIndex;
+        _valueSchemaIdentityIndex = checkpoint.ValueSchemaIdentityIndex;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void Truncate(int count)
     {
         if ((uint)count > (uint)_headers.Count)
@@ -377,6 +398,11 @@ public sealed class Headers : IEnumerable<Header>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int AdjustTrackedIndex(int trackedIndex, int removedIndex) =>
         trackedIndex == removedIndex ? -1 : trackedIndex > removedIndex ? trackedIndex - 1 : trackedIndex;
+
+    internal readonly record struct Checkpoint(
+        int Count,
+        int KeySchemaIdentityIndex,
+        int ValueSchemaIdentityIndex);
 
     /// <summary>
     /// Adds multiple headers from a collection of key-value pairs.

--- a/tests/Dekaf.Tests.Integration/ProtobufSerializerIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProtobufSerializerIntegrationTests.cs
@@ -3,6 +3,7 @@ using Dekaf.Producer;
 using Dekaf.SchemaRegistry;
 using Dekaf.SchemaRegistry.Protobuf;
 using Dekaf.Tests.Integration.Protos;
+using Google.Protobuf;
 
 namespace Dekaf.Tests.Integration;
 
@@ -13,6 +14,63 @@ namespace Dekaf.Tests.Integration;
 [ClassDataSource<KafkaWithSchemaRegistryContainer>(Shared = SharedType.PerTestSession)]
 public sealed class ProtobufSerializerIntegrationTests(KafkaWithSchemaRegistryContainer testInfra)
 {
+    [Test]
+    public async Task ProtobufSerializer_ExplicitSchemaId_RoundTrips()
+    {
+        var topic = await testInfra.CreateTestTopicAsync();
+        using var registryClient = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = testInfra.RegistryUrl
+        });
+        var schemaId = await registryClient.RegisterSchemaAsync($"{topic}-value", new Schema
+        {
+            SchemaType = SchemaType.Protobuf,
+            SchemaString = TestPerson.Descriptor.File.SerializedData.ToBase64()
+        });
+        var person = new TestPerson { Id = 71, Name = "Explicit ID", Email = "id@example.com" };
+
+        await using var producer = await Kafka.CreateProducer<string, TestPerson>()
+            .WithBootstrapServers(testInfra.BootstrapServers)
+            .UseProtobufSchemaRegistry(registryClient, new ProtobufSerializerConfig
+            {
+                UseSchemaId = schemaId
+            })
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+        await producer.ProduceAsync(topic, "explicit", person);
+
+        var consumed = await ConsumeOneAsync(topic, registryClient);
+
+        await Assert.That(consumed.Id).IsEqualTo(person.Id);
+        await Assert.That(consumed.Name).IsEqualTo(person.Name);
+    }
+
+    [Test]
+    public async Task ProtobufSerializer_GuidHeader_RoundTrips()
+    {
+        var topic = await testInfra.CreateTestTopicAsync();
+        using var registryClient = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = testInfra.RegistryUrl
+        });
+        var person = new TestPerson { Id = 72, Name = "GUID", Email = "guid@example.com" };
+
+        await using var producer = await Kafka.CreateProducer<string, TestPerson>()
+            .WithBootstrapServers(testInfra.BootstrapServers)
+            .UseProtobufSchemaRegistry(registryClient, new ProtobufSerializerConfig
+            {
+                SchemaIdStrategy = SchemaIdSerializerStrategy.Header
+            })
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+        await producer.ProduceAsync(topic, "guid", person);
+
+        var consumed = await ConsumeOneAsync(topic, registryClient);
+
+        await Assert.That(consumed.Id).IsEqualTo(person.Id);
+        await Assert.That(consumed.Name).IsEqualTo(person.Name);
+    }
+
     [Test]
     public async Task ProtobufSerializer_ProduceAndConsume_RoundTrips()
     {
@@ -210,5 +268,23 @@ public sealed class ProtobufSerializerIntegrationTests(KafkaWithSchemaRegistryCo
         await Assert.That(consumed!.Id).IsEqualTo(0);
         await Assert.That(consumed.Name).IsEqualTo("");
         await Assert.That(consumed.Email).IsEqualTo("");
+    }
+
+    private async Task<TestPerson> ConsumeOneAsync(string topic, ISchemaRegistryClient registryClient)
+    {
+        await using var consumer = await Kafka.CreateConsumer<string, TestPerson>()
+            .WithBootstrapServers(testInfra.BootstrapServers)
+            .WithGroupId($"proto-identity-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .UseProtobufSchemaRegistry(registryClient)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await foreach (var message in consumer.ConsumeAsync(cts.Token))
+            return message.Value!;
+
+        throw new InvalidOperationException("The produced Protobuf message was not consumed.");
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -166,6 +166,58 @@ public class KafkaProducerFastPathTests
     }
 
     [Test]
+    public async Task ProduceAsync_RecordHeaderSerializer_DoesNotMutateCallerHeaders()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == DekafDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-record-header-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 4096,
+            LingerMs = 10,
+            RequestTimeoutMs = 500,
+            DeliveryTimeoutMs = 1000,
+            CloseTimeoutMs = 1000
+        };
+
+        await using var producer = new KafkaProducer<string, string>(
+            options,
+            Serializers.String,
+            new RecordHeaderStringSerializer());
+        await StopProducerBackgroundLoopsAsync(producer);
+        SeedProducerMetadata(producer);
+        SetInstanceField(producer, "_initialized", true);
+        var headers = new Headers(1).Add("caller", "owned");
+
+        var produceTask = producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Key = "key",
+            Value = "identity-value",
+            Headers = headers
+        });
+
+        await Assert.That(headers.Count).IsEqualTo(1);
+        await Assert.That(headers[0].Key).IsEqualTo("caller");
+        var readyBatch = CompleteCurrentBatch(producer.RecordAccumulator, new TopicPartition(Topic, 0));
+        var record = readyBatch.RecordBatch.Records[0];
+        await Assert.That(record.HeaderCount).IsEqualTo(3);
+        await Assert.That(record.Headers![0].Key).IsEqualTo("caller");
+        await Assert.That(record.Headers[1].Key).IsEqualTo("identity");
+        await Assert.That(record.Headers[2].Key).IsEqualTo("traceparent");
+
+        readyBatch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow);
+        _ = await produceTask;
+        await Assert.That(headers.Count).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ProduceAsync_AsyncSerializerTracing_RestoresCallerOwnedHeadersAfterAppend()
     {
         using var listener = new ActivityListener

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaIdentityTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaIdentityTests.cs
@@ -109,6 +109,74 @@ public class ProtobufSchemaIdentityTests
     }
 
     [Test]
+    public async Task Serialize_ExplicitId_AcceptsMatchingProtobufReferenceGraph()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var registered = await RegisterReferenceGraphAsync(registry);
+        var schemaId = await registry.RegisterSchemaAsync("identity-value", registered.Schema);
+        var config = new ProtobufSerializerConfig { UseSchemaId = schemaId };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<ReferenceGraphMessage>(registry, config);
+        var destination = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(new ReferenceGraphMessage(), ref destination, CreateContext());
+
+        await Assert.That(BinaryPrimitives.ReadInt32BigEndian(destination.WrittenSpan[1..5]))
+            .IsEqualTo(schemaId);
+    }
+
+    [Test]
+    public async Task Serialize_ExplicitId_RejectsDifferentNestedProtobufReferenceVersion()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var registered = await RegisterReferenceGraphAsync(registry);
+        var registeredLeft = await registry.GetSchemaBySubjectAsync("deps/left.proto", "1");
+        _ = await registry.RegisterSchemaAsync("shared/base.proto", new Schema
+        {
+            SchemaType = SchemaType.Protobuf,
+            SchemaString = Google.Protobuf.WellKnownTypes.StringValue.Descriptor.File.SerializedData.ToBase64()
+        });
+        _ = await registry.RegisterSchemaAsync("deps/left.proto", new Schema
+        {
+            SchemaType = SchemaType.Protobuf,
+            SchemaString = registeredLeft.Schema.SchemaString,
+            References = registeredLeft.Schema.References!
+                .Select(static reference => new SchemaReference
+                {
+                    Name = reference.Name,
+                    Subject = reference.Subject,
+                    Version = reference.Name == "shared/base.proto" ? 2 : reference.Version
+                })
+                .ToArray()
+        });
+        var references = registered.Schema.References!
+            .Select(static reference => new SchemaReference
+            {
+                Name = reference.Name,
+                Subject = reference.Subject,
+                Version = reference.Name == "deps/left.proto" ? 2 : reference.Version
+            })
+            .ToArray();
+        var schemaId = await registry.RegisterSchemaAsync("identity-value", new Schema
+        {
+            SchemaType = SchemaType.Protobuf,
+            SchemaString = registered.Schema.SchemaString,
+            References = references
+        });
+        var config = new ProtobufSerializerConfig { UseSchemaId = schemaId };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<ReferenceGraphMessage>(registry, config);
+        var destination = new ArrayBufferWriter<byte>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        {
+            serializer.Serialize(new ReferenceGraphMessage(), ref destination, CreateContext());
+            return Task.CompletedTask;
+        });
+
+        await Assert.That(exception!.Message).Contains("does not match Protobuf message type");
+        await Assert.That(destination.WrittenCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Serialize_Header_RequiresHeadersCollection()
     {
         var registry = new MockSchemaRegistryClient();
@@ -395,6 +463,18 @@ public class ProtobufSchemaIdentityTests
         SchemaType = SchemaType.Protobuf,
         SchemaString = TestMessage.Descriptor.File.SerializedData.ToBase64()
     };
+
+    private static async Task<RegisteredSchema> RegisterReferenceGraphAsync(MockSchemaRegistryClient registry)
+    {
+        await using var serializer = new ProtobufSchemaRegistrySerializer<ReferenceGraphMessage>(registry);
+        var destination = new ArrayBufferWriter<byte>();
+        serializer.Serialize(new ReferenceGraphMessage(), ref destination, new SerializationContext
+        {
+            Topic = "graph",
+            Component = SerializationComponent.Value
+        });
+        return await registry.GetSchemaBySubjectAsync("graph-value");
+    }
 
     private static SerializationContext CreateContext(Headers? headers = null) => new()
     {

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaIdentityTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaIdentityTests.cs
@@ -85,6 +85,30 @@ public class ProtobufSchemaIdentityTests
     }
 
     [Test]
+    public async Task Serialize_ExplicitId_RejectsDifferentProtobufDescriptor()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var schemaId = await registry.RegisterSchemaAsync("identity-value", new Schema
+        {
+            SchemaType = SchemaType.Protobuf,
+            SchemaString = Google.Protobuf.WellKnownTypes.StringValue.Descriptor.File.SerializedData.ToBase64()
+        });
+        var config = new ProtobufSerializerConfig { UseSchemaId = schemaId };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<TestMessage>(registry, config);
+        var destination = new ArrayBufferWriter<byte>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        {
+            serializer.Serialize(new TestMessage(), ref destination, CreateContext());
+            return Task.CompletedTask;
+        });
+
+        await Assert.That(exception!.Message).Contains("does not match Protobuf message type");
+        await Assert.That(exception.Message).Contains(TestMessage.Descriptor.FullName);
+        await Assert.That(destination.WrittenCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Serialize_Header_RequiresHeadersCollection()
     {
         var registry = new MockSchemaRegistryClient();

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaIdentityTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaIdentityTests.cs
@@ -148,6 +148,47 @@ public class ProtobufSchemaIdentityTests
     }
 
     [Test]
+    public async Task Serialize_ExplicitId_AcceptsKnownTypeReferencesFromDifferentSkipSetting()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var descriptor = Google.Protobuf.WellKnownTypes.Api.Descriptor.File;
+        var references = new SchemaReference[descriptor.Dependencies.Count];
+        for (var index = 0; index < descriptor.Dependencies.Count; index++)
+        {
+            var dependency = descriptor.Dependencies[index];
+            _ = await registry.RegisterSchemaAsync(dependency.Name, new Schema
+            {
+                SchemaType = SchemaType.Protobuf,
+                SchemaString = dependency.SerializedData.ToBase64()
+            });
+            references[index] = new SchemaReference
+            {
+                Name = dependency.Name,
+                Subject = dependency.Name,
+                Version = 1
+            };
+        }
+
+        var schemaId = await registry.RegisterSchemaAsync("identity-value", new Schema
+        {
+            SchemaType = SchemaType.Protobuf,
+            SchemaString = descriptor.SerializedData.ToBase64(),
+            References = references
+        });
+        var config = new ProtobufSerializerConfig { UseSchemaId = schemaId };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<Google.Protobuf.WellKnownTypes.Api>(
+            registry,
+            config);
+        var destination = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(new Google.Protobuf.WellKnownTypes.Api(), ref destination, CreateContext());
+
+        await Assert.That(descriptor.Dependencies.Count).IsGreaterThan(0);
+        await Assert.That(BinaryPrimitives.ReadInt32BigEndian(destination.WrittenSpan[1..5]))
+            .IsEqualTo(schemaId);
+    }
+
+    [Test]
     public async Task Serialize_ExplicitId_RejectsDifferentNestedProtobufReferenceVersion()
     {
         var registry = new MockSchemaRegistryClient();
@@ -240,6 +281,7 @@ public class ProtobufSchemaIdentityTests
         await Assert.That(result.Id).IsEqualTo(message.Id);
         await Assert.That(result.Name).IsEqualTo(message.Name);
         await Assert.That(schemaId).IsEqualTo(registered.Id);
+        await Assert.That(registry.LastGetSchemaByGuidCancellationToken.CanBeCanceled).IsTrue();
     }
 
     [Test]
@@ -372,14 +414,14 @@ public class ProtobufSchemaIdentityTests
         registry.GetSchemaByGuidAsync(
                 identityGuid.ToString("D"),
                 null,
-                Arg.Any<CancellationToken>())
+                Arg.Is<CancellationToken>(static token => token.CanBeCanceled))
             .Returns(schema);
         registry.LookupSchemaAsync(
                 "identity-value",
                 schema,
                 true,
                 false,
-                Arg.Any<CancellationToken>())
+                Arg.Is<CancellationToken>(static token => token.CanBeCanceled))
             .Returns(new RegisteredSchema
             {
                 Id = 7,

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaIdentityTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaIdentityTests.cs
@@ -1,0 +1,418 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Protobuf;
+using Dekaf.Serialization;
+using Google.Protobuf;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public class ProtobufSchemaIdentityTests
+{
+    [Test]
+    public async Task Serialize_Header_WritesGuidAndMessageIndexesOutsidePayload()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var schema = CreateSchema();
+        var schemaId = await registry.RegisterSchemaAsync("identity-value", schema);
+        var registered = await registry.GetSchemaBySubjectAsync("identity-value");
+        var context = CreateContext(headers: new Headers());
+        var config = new ProtobufSerializerConfig
+        {
+            AutoRegisterSchemas = false,
+            SchemaIdStrategy = SchemaIdSerializerStrategy.Header
+        };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<TestMessage>(registry, config);
+        var message = new TestMessage { Id = 42, Name = "header", Value = 1.25 };
+        var destination = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(message, ref destination, context);
+
+        await Assert.That(destination.WrittenSpan.ToArray()).IsEquivalentTo(message.ToByteArray());
+        var header = context.Headers!.GetFirst(SchemaIdentityHeaderNames.Value);
+        await Assert.That(header).IsNotNull();
+        var headerValue = header!.Value.Value;
+        await Assert.That(headerValue.Length).IsEqualTo(18);
+        await Assert.That(headerValue.Span[0]).IsEqualTo((byte)1);
+        await Assert.That(new Guid(headerValue.Span[1..17], bigEndian: true))
+            .IsEqualTo(Guid.Parse(registered.Guid!));
+        await Assert.That(headerValue.Span[17]).IsEqualTo((byte)0);
+        await Assert.That(schemaId).IsEqualTo(registered.Id);
+    }
+
+    [Test]
+    public async Task Serialize_ExplicitId_WinsOverLatestAndRegistration()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var schemaId = await registry.RegisterSchemaAsync("identity-value", CreateSchema());
+        var config = new ProtobufSerializerConfig
+        {
+            UseSchemaId = schemaId,
+            UseLatestVersion = true,
+            AutoRegisterSchemas = true
+        };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<TestMessage>(registry, config);
+        var destination = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(new TestMessage { Id = 7 }, ref destination, CreateContext());
+
+        await Assert.That(BinaryPrimitives.ReadInt32BigEndian(destination.WrittenSpan[1..5]))
+            .IsEqualTo(schemaId);
+        await Assert.That(registry.GetOrRegisterSchemaCallCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Serialize_ExplicitId_RejectsNonProtobufSchema()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var schemaId = await registry.RegisterSchemaAsync("identity-value", new Schema
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = "{}"
+        });
+        var config = new ProtobufSerializerConfig { UseSchemaId = schemaId };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<TestMessage>(registry, config);
+        var destination = new ArrayBufferWriter<byte>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        {
+            serializer.Serialize(new TestMessage(), ref destination, CreateContext());
+            return Task.CompletedTask;
+        });
+
+        await Assert.That(exception!.Message).Contains("expected Protobuf");
+    }
+
+    [Test]
+    public async Task Serialize_Header_RequiresHeadersCollection()
+    {
+        var registry = new MockSchemaRegistryClient();
+        await registry.RegisterSchemaAsync("identity-value", CreateSchema());
+        var config = new ProtobufSerializerConfig
+        {
+            AutoRegisterSchemas = false,
+            SchemaIdStrategy = SchemaIdSerializerStrategy.Header
+        };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<TestMessage>(registry, config);
+        var destination = new ArrayBufferWriter<byte>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        {
+            serializer.Serialize(new TestMessage(), ref destination, CreateContext());
+            return Task.CompletedTask;
+        });
+
+        await Assert.That(exception!.Message).Contains("Headers collection");
+        await Assert.That(destination.WrittenCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [Arguments(SchemaIdDeserializerStrategy.Dual)]
+    [Arguments(SchemaIdDeserializerStrategy.Header)]
+    public async Task Deserialize_Header_RoundTripsGuidIdentity(SchemaIdDeserializerStrategy strategy)
+    {
+        var registry = new MockSchemaRegistryClient();
+        var schemaId = await registry.RegisterSchemaAsync("identity-value", CreateSchema());
+        var registered = await registry.GetSchemaBySubjectAsync("identity-value");
+        var message = new TestMessage { Id = 91, Name = "guid", Value = 9.5 };
+        var context = CreateContext(headers: CreateIdentityHeaders(Guid.Parse(registered.Guid!), [0]));
+        var config = new ProtobufDeserializerConfig { SchemaIdStrategy = strategy };
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry, config);
+
+        var result = deserializer.Deserialize(message.ToByteArray(), context);
+
+        await Assert.That(result.Id).IsEqualTo(message.Id);
+        await Assert.That(result.Name).IsEqualTo(message.Name);
+        await Assert.That(schemaId).IsEqualTo(registered.Id);
+    }
+
+    [Test]
+    [Arguments(false, new byte[] { 4, 2, 0 })]
+    [Arguments(true, new byte[] { 2, 1, 0 })]
+    public async Task Deserialize_Header_PreservesEveryMessageIndexEncoding(
+        bool deprecated,
+        byte[] messageIndexes)
+    {
+        var registry = new MockSchemaRegistryClient();
+        await registry.RegisterSchemaAsync("identity-value", CreateSchema());
+        var registered = await registry.GetSchemaBySubjectAsync("identity-value");
+        var message = new TestMessage { Id = 17, Name = "nested" };
+        var context = CreateContext(
+            headers: CreateIdentityHeaders(Guid.Parse(registered.Guid!), messageIndexes));
+        var config = new ProtobufDeserializerConfig
+        {
+            SchemaIdStrategy = SchemaIdDeserializerStrategy.Header,
+            UseDeprecatedFormat = deprecated
+        };
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry, config);
+
+        var result = deserializer.Deserialize(message.ToByteArray(), context);
+
+        await Assert.That(result.Id).IsEqualTo(message.Id);
+        await Assert.That(result.Name).IsEqualTo(message.Name);
+    }
+
+    [Test]
+    public async Task Deserialize_Dual_FallsBackToPrefix()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var schemaId = await registry.RegisterSchemaAsync("identity-value", CreateSchema());
+        var message = new TestMessage { Id = 22 };
+        var payload = CreatePrefixPayload(schemaId, message);
+        var config = new ProtobufDeserializerConfig { SchemaIdStrategy = SchemaIdDeserializerStrategy.Dual };
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry, config);
+
+        var result = deserializer.Deserialize(payload, CreateContext(headers: new Headers()));
+
+        await Assert.That(result.Id).IsEqualTo(message.Id);
+    }
+
+    [Test]
+    public async Task Deserialize_Header_UseLatestVersion_PreservesMigrationContext()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var subject = "identity-value";
+        var writerId = await registry.RegisterSchemaAsync(subject, CreateSchema());
+        var readerId = await registry.RegisterSchemaAsync(subject, CreateSchema());
+        var writer = await registry.GetSchemaBySubjectAsync(subject, "1");
+        var replacement = new TestMessage { Id = 88, Name = "migrated" };
+        var executor = new CapturingRuleExecutor(replacement.ToByteArray());
+        var context = CreateContext(
+            headers: CreateIdentityHeaders(Guid.Parse(writer.Guid!), [0]));
+        var config = new ProtobufDeserializerConfig
+        {
+            SchemaIdStrategy = SchemaIdDeserializerStrategy.Header,
+            UseLatestVersion = true,
+            RuleExecutor = executor
+        };
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry, config);
+
+        var result = deserializer.Deserialize(new TestMessage { Id = 1 }.ToByteArray(), context);
+
+        await Assert.That(result.Id).IsEqualTo(replacement.Id);
+        await Assert.That(result.Name).IsEqualTo(replacement.Name);
+        await Assert.That(executor.Context).IsNotNull();
+        await Assert.That(executor.Context!.SchemaId).IsEqualTo(readerId);
+        await Assert.That(executor.Context.Subject).IsEqualTo(subject);
+        await Assert.That(writerId).IsNotEqualTo(readerId);
+    }
+
+    [Test]
+    public async Task Deserialize_Prefix_IgnoresIdentityHeader()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var schemaId = await registry.RegisterSchemaAsync("identity-value", CreateSchema());
+        var message = new TestMessage { Id = 23 };
+        var headers = CreateIdentityHeaders(Guid.NewGuid(), [0]);
+        var config = new ProtobufDeserializerConfig { SchemaIdStrategy = SchemaIdDeserializerStrategy.Prefix };
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry, config);
+
+        var result = deserializer.Deserialize(CreatePrefixPayload(schemaId, message), CreateContext(headers: headers));
+
+        await Assert.That(result.Id).IsEqualTo(message.Id);
+    }
+
+    [Test]
+    public async Task Deserialize_Header_RejectsMissingIdentity()
+    {
+        var registry = Substitute.For<ISchemaRegistryClient>();
+        var config = new ProtobufDeserializerConfig { SchemaIdStrategy = SchemaIdDeserializerStrategy.Header };
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry, config);
+
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(() =>
+            Task.FromResult(deserializer.Deserialize(new TestMessage().ToByteArray(), CreateContext())));
+
+        await Assert.That(exception!.Message).Contains("identity header is missing");
+    }
+
+    [Test]
+    public async Task Deserialize_Header_RejectsNonProtobufGuidSchema()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var schemaId = await registry.RegisterSchemaAsync("identity-value", new Schema
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = "{}"
+        });
+        var registered = await registry.GetSchemaBySubjectAsync("identity-value");
+        var headers = CreateIdentityHeaders(Guid.Parse(registered.Guid!), [0]);
+        var config = new ProtobufDeserializerConfig { SchemaIdStrategy = SchemaIdDeserializerStrategy.Header };
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry, config);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Task.FromResult(deserializer.Deserialize(new TestMessage().ToByteArray(), CreateContext(headers: headers))));
+
+        await Assert.That(exception!.Message).Contains("is not a Protobuf schema");
+        await Assert.That(exception.Message).Contains(registered.Guid!);
+        await Assert.That(schemaId).IsEqualTo(registered.Id);
+    }
+
+    [Test]
+    public async Task Deserialize_Header_RejectsConflictingRegisteredGuid()
+    {
+        var identityGuid = Guid.NewGuid();
+        var schema = CreateSchema();
+        var registry = Substitute.For<ISchemaRegistryClient>();
+        registry.GetSchemaByGuidAsync(
+                identityGuid.ToString("D"),
+                null,
+                Arg.Any<CancellationToken>())
+            .Returns(schema);
+        registry.LookupSchemaAsync(
+                "identity-value",
+                schema,
+                true,
+                false,
+                Arg.Any<CancellationToken>())
+            .Returns(new RegisteredSchema
+            {
+                Id = 7,
+                Guid = Guid.NewGuid().ToString("D"),
+                Subject = "identity-value",
+                Version = 1,
+                Schema = schema
+            });
+        var headers = CreateIdentityHeaders(identityGuid, [0]);
+        var config = new ProtobufDeserializerConfig { SchemaIdStrategy = SchemaIdDeserializerStrategy.Header };
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry, config);
+
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(() =>
+            Task.FromResult(deserializer.Deserialize(new TestMessage().ToByteArray(), CreateContext(headers: headers))));
+
+        await Assert.That(exception!.Message).Contains("conflicting GUID");
+        await Assert.That(exception.Message).Contains("identity-value");
+    }
+
+    [Test]
+    public async Task Deserialize_Header_RejectsTrailingMessageIndexData()
+    {
+        var registry = new MockSchemaRegistryClient();
+        await registry.RegisterSchemaAsync("identity-value", CreateSchema());
+        var registered = await registry.GetSchemaBySubjectAsync("identity-value");
+        var headers = CreateIdentityHeaders(Guid.Parse(registered.Guid!), [0, 42]);
+        var config = new ProtobufDeserializerConfig { SchemaIdStrategy = SchemaIdDeserializerStrategy.Header };
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry, config);
+
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(() =>
+            Task.FromResult(deserializer.Deserialize(new TestMessage().ToByteArray(), CreateContext(headers: headers))));
+
+        await Assert.That(exception!.Message).Contains("trailing message-index data");
+    }
+
+    [Test]
+    public async Task Deserialize_LiveHeaderRouting_UsesReservedSlotWithManyHeaders()
+    {
+        var registry = Substitute.For<ISchemaRegistryClient>();
+        var config = new ProtobufDeserializerConfig
+        {
+            SchemaIdStrategy = SchemaIdDeserializerStrategy.Header,
+            SkipSchemaValidation = true
+        };
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry, config);
+        var message = new TestMessage { Id = 31, Name = "routed" };
+        var identity = CreateIdentityHeaders(Guid.NewGuid(), [0])[0];
+        var headers = new Header[33];
+        for (var index = 0; index < 32; index++)
+            headers[index] = new Header($"noise-{index}", ReadOnlyMemory<byte>.Empty);
+        headers[32] = identity;
+        var plan = RecordHeaderRoutingPlan.Create<string, TestMessage>(null, deserializer)!;
+        var lookup = new RecordHeaderRoutingLookup(
+            plan,
+            headers,
+            headers.Length,
+            firstIndex: 0,
+            secondIndex: 33,
+            routedHeaderTailOffset: RecordHeaderRoutingPlan.FullyIndexedWithoutTail);
+
+        var result = RecordHeaderDeserializer.Deserialize(
+            deserializer,
+            message.ToByteArray(),
+            CreateContext(),
+            in lookup);
+
+        await Assert.That(result.Id).IsEqualTo(message.Id);
+        await Assert.That(result.Name).IsEqualTo(message.Name);
+    }
+
+    [Test]
+    public async Task Constructors_RejectUnknownIdentityStrategies()
+    {
+        var registry = Substitute.For<ISchemaRegistryClient>();
+
+        _ = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => Task.FromResult(
+            new ProtobufSchemaRegistrySerializer<TestMessage>(registry, new ProtobufSerializerConfig
+            {
+                SchemaIdStrategy = (SchemaIdSerializerStrategy)99
+            })));
+        _ = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => Task.FromResult(
+            new ProtobufSchemaRegistryDeserializer<TestMessage>(registry, new ProtobufDeserializerConfig
+            {
+                SchemaIdStrategy = (SchemaIdDeserializerStrategy)99
+            })));
+    }
+
+    [Test]
+    public async Task Serializer_RejectsNegativeExplicitId()
+    {
+        var registry = Substitute.For<ISchemaRegistryClient>();
+
+        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => Task.FromResult(
+            new ProtobufSchemaRegistrySerializer<TestMessage>(registry, new ProtobufSerializerConfig
+            {
+                UseSchemaId = -1
+            })));
+
+        await Assert.That(exception!.ParamName).IsEqualTo("useSchemaId");
+    }
+
+    private static Schema CreateSchema() => new()
+    {
+        SchemaType = SchemaType.Protobuf,
+        SchemaString = TestMessage.Descriptor.File.SerializedData.ToBase64()
+    };
+
+    private static SerializationContext CreateContext(Headers? headers = null) => new()
+    {
+        Topic = "identity",
+        Component = SerializationComponent.Value,
+        Headers = headers
+    };
+
+    private static Headers CreateIdentityHeaders(Guid schemaGuid, ReadOnlySpan<byte> messageIndexes)
+    {
+        var frame = new byte[17 + messageIndexes.Length];
+        frame[0] = 1;
+        _ = schemaGuid.TryWriteBytes(frame.AsSpan(1, 16), bigEndian: true, out _);
+        messageIndexes.CopyTo(frame.AsSpan(17));
+        return new Headers().Add(SchemaIdentityHeaderNames.Value, frame);
+    }
+
+    private static byte[] CreatePrefixPayload(int schemaId, TestMessage message)
+    {
+        var protobuf = message.ToByteArray();
+        var payload = new byte[6 + protobuf.Length];
+        payload[0] = 0;
+        BinaryPrimitives.WriteInt32BigEndian(payload.AsSpan(1, 4), schemaId);
+        payload[5] = 0;
+        protobuf.CopyTo(payload.AsSpan(6));
+        return payload;
+    }
+
+    private sealed class CapturingRuleExecutor(byte[] replacement) : ISchemaRegistryRuleExecutor
+    {
+        internal SchemaRegistryRuleContext? Context { get; private set; }
+
+        public ReadOnlyMemory<byte> TransformSerializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleContext context) => payload;
+
+        public ReadOnlyMemory<byte> TransformDeserializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleContext context)
+        {
+            Context = SchemaRegistryRuleContextSnapshot.Capture(context);
+            return replacement;
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaIdentityTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaIdentityTests.cs
@@ -125,6 +125,29 @@ public class ProtobufSchemaIdentityTests
     }
 
     [Test]
+    public async Task Serialize_ExplicitId_WithoutSchemaReferences_AcceptsMatchingRootDescriptor()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var schemaId = await registry.RegisterSchemaAsync("identity-value", new Schema
+        {
+            SchemaType = SchemaType.Protobuf,
+            SchemaString = ReferenceGraphMessage.Descriptor.File.SerializedData.ToBase64()
+        });
+        var config = new ProtobufSerializerConfig
+        {
+            UseSchemaId = schemaId,
+            UseSchemaReferences = false
+        };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<ReferenceGraphMessage>(registry, config);
+        var destination = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(new ReferenceGraphMessage(), ref destination, CreateContext());
+
+        await Assert.That(BinaryPrimitives.ReadInt32BigEndian(destination.WrittenSpan[1..5]))
+            .IsEqualTo(schemaId);
+    }
+
+    [Test]
     public async Task Serialize_ExplicitId_RejectsDifferentNestedProtobufReferenceVersion()
     {
         var registry = new MockSchemaRegistryClient();

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaIdentityTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaIdentityTests.cs
@@ -285,6 +285,37 @@ public class ProtobufSchemaIdentityTests
     }
 
     [Test]
+    public async Task Deserialize_Header_ValidationOnly_DoesNotRequireConsumerSubject()
+    {
+        var identityGuid = Guid.NewGuid();
+        var schema = CreateSchema();
+        var registry = Substitute.For<ISchemaRegistryClient>();
+        registry.GetSchemaByGuidAsync(
+                identityGuid.ToString("D"),
+                null,
+                Arg.Is<CancellationToken>(static token => token.CanBeCanceled))
+            .Returns(schema);
+        var message = new TestMessage { Id = 92, Name = "record-name-subject" };
+        var headers = CreateIdentityHeaders(identityGuid, [0]);
+        var config = new ProtobufDeserializerConfig
+        {
+            SchemaIdStrategy = SchemaIdDeserializerStrategy.Header
+        };
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry, config);
+
+        var result = deserializer.Deserialize(message.ToByteArray(), CreateContext(headers: headers));
+
+        await Assert.That(result.Id).IsEqualTo(message.Id);
+        await Assert.That(result.Name).IsEqualTo(message.Name);
+        await registry.DidNotReceive().LookupSchemaAsync(
+            Arg.Any<string>(),
+            Arg.Any<Schema>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     [Arguments(false, new byte[] { 4, 2, 0 })]
     [Arguments(true, new byte[] { 2, 1, 0 })]
     public async Task Deserialize_Header_PreservesEveryMessageIndexEncoding(
@@ -431,7 +462,11 @@ public class ProtobufSchemaIdentityTests
                 Schema = schema
             });
         var headers = CreateIdentityHeaders(identityGuid, [0]);
-        var config = new ProtobufDeserializerConfig { SchemaIdStrategy = SchemaIdDeserializerStrategy.Header };
+        var config = new ProtobufDeserializerConfig
+        {
+            SchemaIdStrategy = SchemaIdDeserializerStrategy.Header,
+            RuleExecutor = new CapturingRuleExecutor(new TestMessage().ToByteArray())
+        };
         await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(registry, config);
 
         var exception = await Assert.ThrowsAsync<InvalidDataException>(() =>

--- a/tests/Dekaf.Tests.Unit/Serialization/HeadersTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/HeadersTests.cs
@@ -28,6 +28,21 @@ public class HeadersTests
         await Assert.That(headers.Count).IsEqualTo(2);
     }
 
+    [Test]
+    public async Task Constructor_FromCollection_IndexesLastSchemaIdentity()
+    {
+        var headers = new Headers([
+            new Header("__value_schema_id", "first"u8.ToArray()),
+            new Header("noise", ReadOnlyMemory<byte>.Empty),
+            new Header("__value_schema_id", "last"u8.ToArray())
+        ]);
+
+        var found = headers.TryGetLastSchemaIdentity(SerializationComponent.Value, out var header);
+
+        await Assert.That(found).IsTrue();
+        await Assert.That(header.GetValueAsString()).IsEqualTo("last");
+    }
+
     #endregion
 
     #region Factory Tests
@@ -89,6 +104,71 @@ public class HeadersTests
 
         await Assert.That(headers.Count).IsEqualTo(traceState is null ? 2 : 3);
         await Assert.That(headers.CountWithoutDeferredTraceContext).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TryGetLastSchemaIdentity_DuplicateHeaders_ReturnsLastPerComponent()
+    {
+        var headers = new Headers()
+            .Add("__key_schema_id", "old-key")
+            .Add("__value_schema_id", "value")
+            .Add("__key_schema_id", "new-key");
+
+        var foundKey = headers.TryGetLastSchemaIdentity(SerializationComponent.Key, out var keyHeader);
+        var foundValue = headers.TryGetLastSchemaIdentity(SerializationComponent.Value, out var valueHeader);
+
+        await Assert.That(foundKey).IsTrue();
+        await Assert.That(keyHeader.GetValueAsString()).IsEqualTo("new-key");
+        await Assert.That(foundValue).IsTrue();
+        await Assert.That(valueHeader.GetValueAsString()).IsEqualTo("value");
+    }
+
+    [Test]
+    public async Task TryGetLastSchemaIdentity_AfterOrdinaryRemoval_PreservesShiftedIndex()
+    {
+        var headers = new Headers()
+            .Add("noise", "value")
+            .Add("__value_schema_id", "identity");
+
+        headers.Remove("noise");
+
+        var found = headers.TryGetLastSchemaIdentity(SerializationComponent.Value, out var header);
+        await Assert.That(found).IsTrue();
+        await Assert.That(header.GetValueAsString()).IsEqualTo("identity");
+    }
+
+    [Test]
+    public async Task TryGetLastSchemaIdentity_AfterTruncate_FallsBackToPreviousIdentity()
+    {
+        var headers = new Headers()
+            .Add("__value_schema_id", "first")
+            .Add("noise", "value")
+            .Add("__value_schema_id", "last");
+
+        headers.Truncate(2);
+
+        var found = headers.TryGetLastSchemaIdentity(SerializationComponent.Value, out var header);
+        await Assert.That(found).IsTrue();
+        await Assert.That(header.GetValueAsString()).IsEqualTo("first");
+    }
+
+    [Arguments(null)]
+    [Arguments("vendor=value")]
+    [Test]
+    public async Task TryGetLastSchemaIdentity_AddedAfterDeferredTraceContext_UsesInsertedIndex(string? traceState)
+    {
+        var headers = new Headers();
+        headers.AddDeferredTraceContext(new object(), traceState);
+        headers.Add("__value_schema_id", "identity");
+
+        var foundBeforeRemoval = headers.TryGetLastSchemaIdentity(SerializationComponent.Value, out var beforeRemoval);
+        headers.RemoveDeferredTraceContext();
+        var foundAfterRemoval = headers.TryGetLastSchemaIdentity(SerializationComponent.Value, out var afterRemoval);
+
+        await Assert.That(foundBeforeRemoval).IsTrue();
+        await Assert.That(beforeRemoval.GetValueAsString()).IsEqualTo("identity");
+        await Assert.That(foundAfterRemoval).IsTrue();
+        await Assert.That(afterRemoval.GetValueAsString()).IsEqualTo("identity");
     }
 
     [Test]
@@ -273,6 +353,18 @@ public class HeadersTests
     }
 
     [Test]
+    public async Task Remove_SchemaIdentity_RemovesTrackedHeader()
+    {
+        var headers = new Headers()
+            .Add("__value_schema_id", "first")
+            .Add("__value_schema_id", "last");
+
+        headers.Remove("__value_schema_id");
+
+        await Assert.That(headers.TryGetLastSchemaIdentity(SerializationComponent.Value, out _)).IsFalse();
+    }
+
+    [Test]
     public async Task Remove_NonExistentKey_DoesNothing()
     {
         var headers = new Headers();
@@ -301,6 +393,7 @@ public class HeadersTests
         headers.Add("key2", "value2");
         headers.Clear();
         await Assert.That(headers.Count).IsEqualTo(0);
+        await Assert.That(headers.TryGetLastSchemaIdentity(SerializationComponent.Value, out _)).IsFalse();
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Serialization/HeadersTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/HeadersTests.cs
@@ -171,6 +171,30 @@ public class HeadersTests
         await Assert.That(afterRemoval.GetValueAsString()).IsEqualTo("identity");
     }
 
+    [Arguments(null)]
+    [Arguments("vendor=value")]
+    [Test]
+    public async Task Restore_CheckpointRestoresIdentityIndexesWithoutDeferredTraceContext(string? traceState)
+    {
+        var headers = new Headers()
+            .Add("__key_schema_id", "original-key")
+            .Add("__value_schema_id", "original-value");
+        headers.AddDeferredTraceContext(new object(), traceState);
+        var checkpoint = headers.CaptureCheckpoint();
+        headers.Add("__key_schema_id", "temporary-key");
+        headers.Add("__value_schema_id", "temporary-value");
+
+        headers.Restore(in checkpoint);
+
+        var foundKey = headers.TryGetLastSchemaIdentity(SerializationComponent.Key, out var keyHeader);
+        var foundValue = headers.TryGetLastSchemaIdentity(SerializationComponent.Value, out var valueHeader);
+        await Assert.That(headers.Count).IsEqualTo(2);
+        await Assert.That(foundKey).IsTrue();
+        await Assert.That(keyHeader.GetValueAsString()).IsEqualTo("original-key");
+        await Assert.That(foundValue).IsTrue();
+        await Assert.That(valueHeader.GetValueAsString()).IsEqualTo("original-value");
+    }
+
     [Test]
     public async Task Indexer_ReturnsCorrectHeader()
     {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/AsyncProducerSerdePoolingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/AsyncProducerSerdePoolingBenchmarks.cs
@@ -33,6 +33,7 @@ public class AsyncProducerSerdePoolingBenchmarks
     private Thread _drainerThread = null!;
     private DekafProducer.ProducerMessage<string, string> _messageWithoutHeaders = null!;
     private DekafProducer.ProducerMessage<string, string> _messageWithHeaders = null!;
+    private DekafProducer.ProducerMessage<string, string> _messageWithCapacityTightHeaders = null!;
     private string _value = null!;
 
     [GlobalSetup]
@@ -107,6 +108,22 @@ public class AsyncProducerSerdePoolingBenchmarks
                 .ConfigureAwait(false);
         }
     }
+
+    [IterationSetup(Target = nameof(FireAsync_CompletedSerializerWithCapacityTightHeaders))]
+    public void ResetCapacityTightHeaders()
+    {
+        _messageWithCapacityTightHeaders = new DekafProducer.ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Key = Keys[0],
+            Value = _value,
+            Headers = new Headers(1).Add("caller", "value")
+        };
+    }
+
+    [Benchmark]
+    public ValueTask FireAsync_CompletedSerializerWithCapacityTightHeaders() =>
+        _producer.FireAsync(_messageWithCapacityTightHeaders);
 
     [Benchmark(OperationsPerInvoke = Operations)]
     public async Task FireAsync_YieldingSerializer()

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtobufSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtobufSchemaRegistrySerializerBenchmarks.cs
@@ -17,26 +17,44 @@ public class ProtobufSchemaRegistrySerializerBenchmarks
 {
     private readonly ArrayBufferWriter<byte> _destination = new(256);
     private ProtobufSchemaRegistrySerializer<StringValue> _serializer = null!;
+    private ProtobufSchemaRegistrySerializer<StringValue> _headerSerializer = null!;
     private StringValue _value = null!;
     private SerializationContext _context;
+    private SerializationContext _headerContext;
 
     [GlobalSetup]
     public void Setup()
     {
         _serializer = new ProtobufSchemaRegistrySerializer<StringValue>(new BenchmarkSchemaRegistryClient());
+        _headerSerializer = new ProtobufSchemaRegistrySerializer<StringValue>(
+            new BenchmarkSchemaRegistryClient(),
+            new ProtobufSerializerConfig { SchemaIdStrategy = SchemaIdSerializerStrategy.Header });
         _value = new StringValue { Value = "protobuf-benchmark" };
         _context = new SerializationContext
         {
             Topic = "protobuf-benchmark",
             Component = SerializationComponent.Value
         };
+        _headerContext = new SerializationContext
+        {
+            Topic = "protobuf-benchmark",
+            Component = SerializationComponent.Value,
+            Headers = new Headers(1)
+        };
 
         var destination = _destination;
         _serializer.Serialize(_value, ref destination, _context);
+        destination.Clear();
+        _headerSerializer.Serialize(_value, ref destination, _headerContext);
+        _headerContext.Headers!.Clear();
     }
 
     [GlobalCleanup]
-    public ValueTask Cleanup() => _serializer.DisposeAsync();
+    public async ValueTask Cleanup()
+    {
+        await _serializer.DisposeAsync().ConfigureAwait(false);
+        await _headerSerializer.DisposeAsync().ConfigureAwait(false);
+    }
 
     [Benchmark]
     public void SerializeCached()
@@ -44,6 +62,15 @@ public class ProtobufSchemaRegistrySerializerBenchmarks
         _destination.Clear();
         var destination = _destination;
         _serializer.Serialize(_value, ref destination, _context);
+    }
+
+    [Benchmark]
+    public void SerializeCachedHeader()
+    {
+        _destination.Clear();
+        _headerContext.Headers!.Clear();
+        var destination = _destination;
+        _headerSerializer.Serialize(_value, ref destination, _headerContext);
     }
 
     [Benchmark]
@@ -63,6 +90,20 @@ public class ProtobufSchemaRegistrySerializerBenchmarks
             string subject,
             string version = "latest",
             CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<RegisteredSchema> LookupSchemaAsync(
+            string subject,
+            Schema schema,
+            bool ignoreDeletedSchemas = true,
+            bool normalize = false,
+            CancellationToken cancellationToken = default) => Task.FromResult(new RegisteredSchema
+            {
+                Id = 1,
+                Guid = "89791762-2336-4186-9674-299b90a802e2",
+                Subject = subject,
+                Version = 1,
+                Schema = schema
+            });
 
         public Task<int> GetOrRegisterSchemaAsync(
             string subject,

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaIdentityFramingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaIdentityFramingBenchmarks.cs
@@ -21,6 +21,8 @@ public class SchemaIdentityFramingBenchmarks
     private byte[] _guidFrame = null!;
     private Header _identityHeader;
     private RecordHeaderRoutingLookup _routingLookup;
+    private readonly Headers _ordinaryHeaders = new(1);
+    private Headers _callerOwnedHeaders = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -34,6 +36,7 @@ public class SchemaIdentityFramingBenchmarks
         multiHeaders[32] = new Header(
             SchemaIdentityHeaderNames.Value,
             [.. _guidFrame, 0]);
+        _callerOwnedHeaders = new Headers(multiHeaders);
 
         var routingPlan = RecordHeaderRoutingPlan.Create<byte, byte>(
             null,
@@ -89,9 +92,30 @@ public class SchemaIdentityFramingBenchmarks
     }
 
     [Benchmark]
+    public SchemaIdentity CallerOwnedProtobufHeaderReadWith32NoiseHeaders()
+    {
+        if (!_callerOwnedHeaders.TryGetLastSchemaIdentity(SerializationComponent.Value, out var identityHeader))
+            throw new InvalidOperationException("The caller-owned schema identity header was not found.");
+
+        var identity = SchemaIdentityFraming.ReadHeader(in identityHeader, out var messageIndexes);
+        if (messageIndexes.Length != 1 || messageIndexes.Span[0] != 0)
+            throw new InvalidDataException("The Protobuf message-index vector is invalid.");
+
+        return identity;
+    }
+
+    [Benchmark]
     public Header CreateHeader() => SchemaIdentityFraming.CreateSchemaGuidHeader(
         SerializationComponent.Value,
         _guidFrame);
+
+    [Benchmark]
+    public int AddAndClearOrdinaryHeader()
+    {
+        _ordinaryHeaders.Clear();
+        _ordinaryHeaders.Add(new Header("ordinary", _guidFrame));
+        return _ordinaryHeaders.Count;
+    }
 
     private sealed class IdentityRoutingDeserializer : IDeserializer<byte>, IRecordHeaderRoutingProvider
     {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaIdentityFramingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaIdentityFramingBenchmarks.cs
@@ -23,6 +23,8 @@ public class SchemaIdentityFramingBenchmarks
     private RecordHeaderRoutingLookup _routingLookup;
     private readonly Headers _ordinaryHeaders = new(1);
     private Headers _callerOwnedHeaders = null!;
+    private Headers _restoredHeaders = null!;
+    private Headers _truncatedHeaders = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -31,12 +33,19 @@ public class SchemaIdentityFramingBenchmarks
         _identityHeader = new Header(SchemaIdentityHeaderNames.Value, _guidFrame);
 
         var multiHeaders = new Header[33];
+        var noiseHeaders = new Header[32];
         for (var index = 0; index < 32; index++)
-            multiHeaders[index] = new Header($"noise-{index}", ReadOnlyMemory<byte>.Empty);
+        {
+            var noiseHeader = new Header($"noise-{index}", ReadOnlyMemory<byte>.Empty);
+            multiHeaders[index] = noiseHeader;
+            noiseHeaders[index] = noiseHeader;
+        }
         multiHeaders[32] = new Header(
             SchemaIdentityHeaderNames.Value,
             [.. _guidFrame, 0]);
         _callerOwnedHeaders = new Headers(multiHeaders);
+        _restoredHeaders = new Headers(noiseHeaders);
+        _truncatedHeaders = new Headers(noiseHeaders);
 
         var routingPlan = RecordHeaderRoutingPlan.Create<byte, byte>(
             null,
@@ -115,6 +124,24 @@ public class SchemaIdentityFramingBenchmarks
         _ordinaryHeaders.Clear();
         _ordinaryHeaders.Add(new Header("ordinary", _guidFrame));
         return _ordinaryHeaders.Count;
+    }
+
+    [Benchmark]
+    public int AddAndRestoreIdentityHeaderWith32NoiseHeaders()
+    {
+        var checkpoint = _restoredHeaders.CaptureCheckpoint();
+        _restoredHeaders.Add(_identityHeader);
+        _restoredHeaders.Restore(in checkpoint);
+        return _restoredHeaders.Count;
+    }
+
+    [Benchmark]
+    public int AddAndTruncateIdentityHeaderWith32NoiseHeaders()
+    {
+        var count = _truncatedHeaders.CountWithoutDeferredTraceContext;
+        _truncatedHeaders.Add(_identityHeader);
+        _truncatedHeaders.Truncate(count);
+        return _truncatedHeaders.Count;
     }
 
     private sealed class IdentityRoutingDeserializer : IDeserializer<byte>, IRecordHeaderRoutingProvider

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaIdentityFramingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaIdentityFramingBenchmarks.cs
@@ -20,12 +20,31 @@ public class SchemaIdentityFramingBenchmarks
     private readonly byte[] _idPrefix = [0, 0, 0, 0, 42, 7, 8];
     private byte[] _guidFrame = null!;
     private Header _identityHeader;
+    private RecordHeaderRoutingLookup _routingLookup;
 
     [GlobalSetup]
     public void Setup()
     {
         _guidFrame = SchemaIdentityFraming.CreateSchemaGuidFrame(SchemaGuid);
         _identityHeader = new Header(SchemaIdentityHeaderNames.Value, _guidFrame);
+
+        var multiHeaders = new Header[33];
+        for (var index = 0; index < 32; index++)
+            multiHeaders[index] = new Header($"noise-{index}", ReadOnlyMemory<byte>.Empty);
+        multiHeaders[32] = new Header(
+            SchemaIdentityHeaderNames.Value,
+            [.. _guidFrame, 0]);
+
+        var routingPlan = RecordHeaderRoutingPlan.Create<byte, byte>(
+            null,
+            IdentityRoutingDeserializer.Instance)!;
+        _routingLookup = new RecordHeaderRoutingLookup(
+            routingPlan,
+            multiHeaders,
+            multiHeaders.Length,
+            firstIndex: 0,
+            secondIndex: 33,
+            routedHeaderTailOffset: RecordHeaderRoutingPlan.FullyIndexedWithoutTail);
     }
 
     [Benchmark(Baseline = true)]
@@ -57,9 +76,35 @@ public class SchemaIdentityFramingBenchmarks
         out _);
 
     [Benchmark]
+    public SchemaIdentity RoutedProtobufHeaderReadWith32NoiseHeaders()
+    {
+        if (!_routingLookup.TryGetLast(SchemaIdentityHeaderNames.Value, out var identityHeader))
+            throw new InvalidOperationException("The routed schema identity header was not found.");
+
+        var identity = SchemaIdentityFraming.ReadHeader(in identityHeader, out var messageIndexes);
+        if (messageIndexes.Length != 1 || messageIndexes.Span[0] != 0)
+            throw new InvalidDataException("The Protobuf message-index vector is invalid.");
+
+        return identity;
+    }
+
+    [Benchmark]
     public Header CreateHeader() => SchemaIdentityFraming.CreateSchemaGuidHeader(
         SerializationComponent.Value,
         _guidFrame);
+
+    private sealed class IdentityRoutingDeserializer : IDeserializer<byte>, IRecordHeaderRoutingProvider
+    {
+        internal static readonly IdentityRoutingDeserializer Instance = new();
+
+        public byte Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) => 0;
+
+        public void CollectHeaderNames(List<string> names)
+        {
+            names.Add(SchemaIdentityHeaderNames.Key);
+            names.Add(SchemaIdentityHeaderNames.Value);
+        }
+    }
 
     private sealed class FramingConfig : ManualConfig
     {


### PR DESCRIPTION
Closes #2781.

Stacked on #2830; merge that PR first.

## Summary
- add Protobuf UseSchemaId precedence plus prefix/header serializer framing
- add prefix/header/dual deserialization while preserving standard and deprecated message-index vectors
- resolve GUID identities through exact subject lookup so metadata, migrations, rules, and validation retain their registered context
- use reserved record-header routing for O(1) live lookup and bounded GUID resolution caching
- add public API baselines, unit/integration coverage, and MemoryDiagnoser benchmarks

## Verification
- net10 full unit suite: 7689/7689 passed before the final two rejection cases; final Protobuf identity class: 18/18 passed
- net8 Protobuf identity class: 18/18 passed
- net8 full suite: 7551 passed, 2 unrelated timing tests failed after runner starvation; not rerun per flaky-test policy
- integration project builds; local execution unavailable because Docker named pipe is absent
- NativeAOT C# compilation and analysis reached native link; local Visual Studio C++ linker is absent

## Performance
Exact parent bbb600ea2 to candidate:
- cached prefix serialization: 25.041 ns -> 21.796 ns (-12.96%), 0 B -> 0 B
- cached header serialization: 32.702 ns, 0 B
- cached prepare: 2.786 ns, 0 B

Hard-gate benchmark on a routed Protobuf GUID header with 32 noise headers:
- 23.277 ns mean, p50 23.242 ns, p99 23.373 ns, max 23.376 ns, 0 B