### PR TITLE
test(networking): coordinate identity-timeout cleanup

### DIFF
--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
@@ -488,6 +488,7 @@ public class KafkaConnectionCapabilityHandshakeTests
                 var buffer = new byte[1];
                 while (await stream.ReadAsync(buffer, cancellationToken) != 0)
                 {
+                    // Drain until the client closes or aborts the socket.
                 }
             }
             catch (IOException exception) when (exception.InnerException is SocketException)

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
@@ -467,7 +467,6 @@ public class KafkaConnectionCapabilityHandshakeTests
         listener.Start();
         var port = ((IPEndPoint)listener.LocalEndpoint).Port;
         var identityRequestReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var releaseServer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var serverTask = StartServerEagerly(async () =>
         {
@@ -484,10 +483,20 @@ public class KafkaConnectionCapabilityHandshakeTests
 
             _ = await ReadFrameAsync(stream, cancellationToken);
             identityRequestReceived.TrySetResult();
-            await releaseServer.Task.WaitAsync(cancellationToken);
+            try
+            {
+                var buffer = new byte[1];
+                while (await stream.ReadAsync(buffer, cancellationToken) != 0)
+                {
+                }
+            }
+            catch (IOException exception) when (exception.InnerException is SocketException)
+            {
+                // KafkaConnection disposal aborts its socket, which can surface as a reset.
+            }
         });
 
-        await using var connection = new KafkaConnection(
+        var connection = new KafkaConnection(
             7,
             "127.0.0.1",
             port,
@@ -509,7 +518,7 @@ public class KafkaConnectionCapabilityHandshakeTests
         }
         finally
         {
-            releaseServer.TrySetResult();
+            await connection.DisposeAsync();
         }
 
         await serverTask;


### PR DESCRIPTION
## Summary
- make client disposal the sole KIP-1242 timeout-test shutdown trigger
- have the fake broker wait for the real client EOF/reset instead of a ThreadPool-scheduled release continuation
- preserve the 50 ms product timeout and 5-second watchdog while making cleanup causally ordered

## Test plan
- [x] Release build, 0 warnings/errors
- [x] focused test net8.0: 1/1
- [x] focused test net10.0: 1/1
- [x] concurrent full suites: net8.0 7,653/7,653; net10.0 7,789/7,789
- [x] `/simplify` and explicit pre-push self-review

The observed concurrent net8 failure is the red evidence; reproducing the old failure deterministically would require manufacturing external ThreadPool starvation. The regression instead removes that scheduler continuation from correctness and verifies the peer observes the disposal-driven close.

Closes #2842


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of mock-server connection and identity-handshake timeout tests.
  * Updated test cleanup to handle client disconnects and socket-reset scenarios more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->