### PR TITLE
feat(admin): delete Share groups

### DIFF
--- a/docs/docs/consumer/share-consumers.md
+++ b/docs/docs/consumer/share-consumers.md
@@ -169,7 +169,19 @@ await consumer.CloseAsync();
 
 ## Administration
 
-`IAdminClient` covers share group operations: `ListShareGroupsAsync`, `DescribeShareGroupsAsync`, `DescribeShareGroupOffsetsAsync`, `AlterShareGroupOffsetsAsync`, and `DeleteShareGroupOffsetsAsync`.
+`IAdminClient` covers share group operations: `ListShareGroupsAsync`, `DescribeShareGroupsAsync`, `DeleteShareGroupsAsync`, `DescribeShareGroupOffsetsAsync`, `AlterShareGroupOffsetsAsync`, and `DeleteShareGroupOffsetsAsync`.
+
+Group deletion returns one result per requested ID, so a batch preserves partial failures instead of throwing away successful results:
+
+```csharp
+var results = await admin.DeleteShareGroupsAsync(["jobs-a", "jobs-b"]);
+foreach (var (groupId, result) in results)
+{
+    Console.WriteLine($"{groupId}: {result.ErrorCode}");
+}
+```
+
+The operation uses the group coordinator and Kafka's `DeleteGroups` API, matching Kafka 4.3's `deleteShareGroups` implementation. Active groups normally return `NonEmptyGroup`; close their consumers before deletion.
 
 ## Testing
 

--- a/docs/docs/consumer/share-consumers.md
+++ b/docs/docs/consumer/share-consumers.md
@@ -183,6 +183,8 @@ foreach (var (groupId, result) in results)
 
 The operation uses the group coordinator and Kafka's `DeleteGroups` API, matching Kafka 4.3's `deleteShareGroups` implementation. Active groups normally return `NonEmptyGroup`; close their consumers before deletion.
 
+Per-group results cover terminal error codes only. If a request keeps failing with a retriable error, the call throws after retries are exhausted and returns no results. Duplicate group IDs raise `ArgumentException` before any request is sent. Dekaf's built-in and in-memory admin clients expose deletion through `IShareGroupDeletionAdminClient`; the `IAdminClient` extension preserves the same call syntax for binary compatibility.
+
 ## Testing
 
 `Dekaf.Testing` provides `InMemoryShareConsumer<TKey, TValue>` for broker-free unit tests, and `AddDekafInMemory()` swaps DI registrations for in-memory doubles. See [Testing](../testing).

--- a/src/Dekaf.Testing/Dekaf.Testing.csproj
+++ b/src/Dekaf.Testing/Dekaf.Testing.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Dekaf.Benchmarks" />
     <InternalsVisibleTo Include="Dekaf.Tests.Unit" />
   </ItemGroup>
 

--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -1156,7 +1156,7 @@ public sealed class InMemoryAdminClient :
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
 
-        var groupOffsets = _cluster.GetGroupOffsets(groupId);
+        var groupOffsets = _cluster.GetShareGroupOffsets(groupId);
         var targetPartitions = partitions?.ToArray() ?? groupOffsets.Keys.ToArray();
         var result = targetPartitions
             .Select(partition =>
@@ -1187,7 +1187,7 @@ public sealed class InMemoryAdminClient :
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
 
-        _cluster.CommitOffsets(
+        _cluster.CommitShareOffsets(
             groupId,
             offsets.Select(offset => new TopicPartitionOffset(
                 offset.TopicPartition.Topic,
@@ -1208,12 +1208,12 @@ public sealed class InMemoryAdminClient :
         ThrowIfDisposed();
 
         var topicSet = topics.ToHashSet(StringComparer.Ordinal);
-        var partitions = _cluster.GetGroupOffsets(groupId)
+        var partitions = _cluster.GetShareGroupOffsets(groupId)
             .Keys
             .Where(partition => topicSet.Contains(partition.Topic))
             .ToArray();
 
-        _cluster.DeleteGroupOffsets(groupId, partitions);
+        _cluster.DeleteShareGroupOffsets(groupId, partitions);
         return ValueTask.CompletedTask;
     }
 

--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -1095,12 +1095,18 @@ public sealed class InMemoryAdminClient :
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
 
+        var listedGroups = _cluster.ListShareGroups().ToDictionary(
+            static group => group.GroupId,
+            static group => group.HasActiveMembers,
+            StringComparer.Ordinal);
         var result = groupIds.ToDictionary(
             groupId => groupId,
             groupId => new ShareGroupDescription
             {
                 GroupId = groupId,
-                GroupState = "Stable",
+                GroupState = listedGroups.TryGetValue(groupId, out var hasActiveMembers) && !hasActiveMembers
+                    ? "Empty"
+                    : "Stable",
                 Members = []
             },
             StringComparer.Ordinal);

--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -1115,22 +1115,26 @@ public sealed class InMemoryAdminClient :
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
 
-        if (options?.States is { Count: > 0 } states
-            && !states.Contains("Stable", StringComparer.OrdinalIgnoreCase))
+        var groups = _cluster.ListShareGroups();
+        var result = new List<GroupListing>(groups.Count);
+        foreach (var group in groups)
         {
-            return ValueTask.FromResult<IReadOnlyList<GroupListing>>([]);
+            var state = group.HasActiveMembers ? "Stable" : "Empty";
+            if (options?.States is { Count: > 0 } states &&
+                !states.Contains(state, StringComparer.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            result.Add(new GroupListing
+            {
+                GroupId = group.GroupId,
+                ProtocolType = "share",
+                State = state
+            });
         }
 
-        IReadOnlyList<GroupListing> result = _cluster.ListShareGroups()
-            .Select(groupId => new GroupListing
-            {
-                GroupId = groupId,
-                ProtocolType = "share",
-                State = "Stable"
-            })
-            .ToArray();
-
-        return ValueTask.FromResult(result);
+        return ValueTask.FromResult<IReadOnlyList<GroupListing>>(result);
     }
 
     public ValueTask<IReadOnlyDictionary<string, DeleteShareGroupResult>> DeleteShareGroupsAsync(

--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -1115,6 +1115,12 @@ public sealed class InMemoryAdminClient :
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
 
+        if (options?.States is { Count: > 0 } states
+            && !states.Contains("Stable", StringComparer.OrdinalIgnoreCase))
+        {
+            return ValueTask.FromResult<IReadOnlyList<GroupListing>>([]);
+        }
+
         IReadOnlyList<GroupListing> result = _cluster.ListShareGroups()
             .Select(groupId => new GroupListing
             {

--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -1150,9 +1150,7 @@ public sealed class InMemoryAdminClient :
             results[groupId] = new DeleteShareGroupResult
             {
                 GroupId = groupId,
-                ErrorCode = _cluster.TryDeleteShareGroup(groupId)
-                    ? ErrorCode.None
-                    : ErrorCode.NonEmptyGroup
+                ErrorCode = _cluster.DeleteShareGroup(groupId)
             };
         }
 

--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -13,7 +13,8 @@ public sealed class InMemoryAdminClient :
     IAdminClient,
     IReplicaLogDirAdminClient,
     ITopicIdAdminClient,
-    ITransactionRemediationAdminClient
+    ITransactionRemediationAdminClient,
+    IShareGroupDeletionAdminClient
 {
     private static readonly TimeSpan DefaultDelegationTokenLifetime = TimeSpan.FromHours(24);
 
@@ -1134,11 +1135,12 @@ public sealed class InMemoryAdminClient :
         var results = new Dictionary<string, DeleteShareGroupResult>(groupIdList.Length, StringComparer.Ordinal);
         foreach (var groupId in groupIdList)
         {
-            _cluster.DeleteGroup(groupId);
             results[groupId] = new DeleteShareGroupResult
             {
                 GroupId = groupId,
-                ErrorCode = ErrorCode.None
+                ErrorCode = _cluster.TryDeleteShareGroup(groupId)
+                    ? ErrorCode.None
+                    : ErrorCode.NonEmptyGroup
             };
         }
 

--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -1114,6 +1114,37 @@ public sealed class InMemoryAdminClient :
         return ListConsumerGroupsAsync(null, cancellationToken);
     }
 
+    public ValueTask<IReadOnlyDictionary<string, DeleteShareGroupResult>> DeleteShareGroupsAsync(
+        IEnumerable<string> groupIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(groupIds);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        var groupIdList = groupIds.ToArray();
+        var uniqueGroupIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var groupId in groupIdList)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+            if (!uniqueGroupIds.Add(groupId))
+                throw new ArgumentException($"Share group ID '{groupId}' is duplicated.", nameof(groupIds));
+        }
+
+        var results = new Dictionary<string, DeleteShareGroupResult>(groupIdList.Length, StringComparer.Ordinal);
+        foreach (var groupId in groupIdList)
+        {
+            _cluster.DeleteGroup(groupId);
+            results[groupId] = new DeleteShareGroupResult
+            {
+                GroupId = groupId,
+                ErrorCode = ErrorCode.None
+            };
+        }
+
+        return ValueTask.FromResult<IReadOnlyDictionary<string, DeleteShareGroupResult>>(results);
+    }
+
     public ValueTask<IReadOnlyList<ShareGroupOffsetDescription>> DescribeShareGroupOffsetsAsync(
         string groupId,
         IEnumerable<TopicPartition>? partitions = null,

--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -1112,7 +1112,19 @@ public sealed class InMemoryAdminClient :
         ListShareGroupsOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        return ListConsumerGroupsAsync(null, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        IReadOnlyList<GroupListing> result = _cluster.ListShareGroups()
+            .Select(groupId => new GroupListing
+            {
+                GroupId = groupId,
+                ProtocolType = "share",
+                State = "Stable"
+            })
+            .ToArray();
+
+        return ValueTask.FromResult(result);
     }
 
     public ValueTask<IReadOnlyDictionary<string, DeleteShareGroupResult>> DeleteShareGroupsAsync(

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -608,6 +608,14 @@ public sealed class InMemoryKafkaCluster
 
         lock (_gate)
         {
+            if (!_shareGroupMembers.TryGetValue(groupId, out var members) ||
+                !members.ContainsKey(memberId))
+            {
+                record = null!;
+                deliveryCount = 0;
+                return false;
+            }
+
             if (!TryReadRecordUnderLock(
                     topicPartition,
                     offset,

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -20,7 +20,7 @@ public sealed class InMemoryKafkaCluster
     private readonly Dictionary<string, Dictionary<TopicPartition, TopicPartitionOffset>> _shareGroupOffsets = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<string, ConsumerGroupMemberState>> _consumerGroupMembers = new(StringComparer.Ordinal);
     private readonly Dictionary<string, int> _consumerGroupGenerations = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, HashSet<string>> _shareGroupMembers = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dictionary<string, int>> _shareGroupMembers = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, ShareLeaseState>>> _shareLeases = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, int>>> _shareDeliveryCounts = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Exception> _produceFailures = new(StringComparer.Ordinal);
@@ -866,11 +866,11 @@ public sealed class InMemoryKafkaCluster
         {
             if (!_shareGroupMembers.TryGetValue(groupId, out var members))
             {
-                members = new HashSet<string>(StringComparer.Ordinal);
+                members = new Dictionary<string, int>(StringComparer.Ordinal);
                 _shareGroupMembers[groupId] = members;
             }
 
-            members.Add(memberId);
+            members[memberId] = members.GetValueOrDefault(memberId) + 1;
         }
     }
 
@@ -884,7 +884,14 @@ public sealed class InMemoryKafkaCluster
             if (!_shareGroupMembers.TryGetValue(groupId, out var members))
                 return;
 
-            members.Remove(memberId);
+            if (!members.TryGetValue(memberId, out var registrationCount))
+                return;
+
+            if (registrationCount > 1)
+                members[memberId] = registrationCount - 1;
+            else
+                members.Remove(memberId);
+
             if (members.Count == 0)
                 _shareGroupMembers.Remove(groupId);
         }

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -958,6 +958,9 @@ public sealed class InMemoryKafkaCluster
 
             foreach (var partition in partitions)
                 offsets.Remove(partition);
+
+            if (offsets.Count == 0)
+                _shareGroupOffsets.Remove(groupId);
         }
     }
 

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -839,6 +839,18 @@ public sealed class InMemoryKafkaCluster
             return _consumerGroupOffsets.Keys.Order(StringComparer.Ordinal).ToArray();
     }
 
+    internal IReadOnlyList<string> ListShareGroups()
+    {
+        lock (_gate)
+        {
+            var groupIds = new HashSet<string>(_shareGroupOffsets.Keys, StringComparer.Ordinal);
+            groupIds.UnionWith(_shareGroupMembers.Keys);
+            groupIds.UnionWith(_shareLeases.Keys);
+            groupIds.UnionWith(_shareDeliveryCounts.Keys);
+            return groupIds.Order(StringComparer.Ordinal).ToArray();
+        }
+    }
+
     internal void DeleteGroup(string groupId)
     {
         lock (_gate)

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -629,21 +629,30 @@ public sealed class InMemoryKafkaCluster
             }
 
             var partitionLeases = GetShareLeasePartition(groupId, topicPartition, create: true)!;
-            if (partitionLeases.TryGetValue(candidate.Offset, out var lease) &&
-                !StringComparer.Ordinal.Equals(lease.MemberId, memberId))
+            var hasLease = partitionLeases.TryGetValue(candidate.Offset, out var lease);
+            if (hasLease)
             {
-                record = null!;
-                deliveryCount = 0;
-                return false;
+                var existingLease = lease!;
+                if (!StringComparer.Ordinal.Equals(existingLease.MemberId, memberId) ||
+                    (!ReferenceEquals(existingLease.Registration, registration) &&
+                     existingLease.Registration.IsActive))
+                {
+                    record = null!;
+                    deliveryCount = 0;
+                    return false;
+                }
+
+                if (!ReferenceEquals(existingLease.Registration, registration))
+                    existingLease.Registration = registration;
             }
 
             var partitionDeliveryCounts = GetShareDeliveryCountPartition(groupId, topicPartition, create: true)!;
-            if (!partitionLeases.ContainsKey(candidate.Offset))
+            if (!hasLease)
             {
                 partitionDeliveryCounts.TryGetValue(candidate.Offset, out deliveryCount);
                 deliveryCount++;
                 partitionDeliveryCounts[candidate.Offset] = deliveryCount;
-                partitionLeases[candidate.Offset] = new ShareLeaseState(memberId);
+                partitionLeases[candidate.Offset] = new ShareLeaseState(memberId, registration);
             }
             else
             {
@@ -658,6 +667,7 @@ public sealed class InMemoryKafkaCluster
     internal void CompleteShareRecords(
         string groupId,
         string memberId,
+        ShareGroupMemberRegistration registration,
         IEnumerable<TopicPartitionOffset> completedRecords,
         IEnumerable<TopicPartitionOffset> commitOffsets)
     {
@@ -671,7 +681,7 @@ public sealed class InMemoryKafkaCluster
 
         lock (_gate)
         {
-            ReleaseShareLeasesUnderLock(groupId, memberId, completed);
+            ReleaseShareLeasesUnderLock(groupId, memberId, registration, completed);
             if (commits.Length > 0)
             {
                 CommitShareOffsetsUnderLock(groupId, commits);
@@ -684,6 +694,7 @@ public sealed class InMemoryKafkaCluster
     internal void ReleaseShareRecords(
         string groupId,
         string memberId,
+        ShareGroupMemberRegistration registration,
         IEnumerable<TopicPartitionOffset> records)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
@@ -691,7 +702,7 @@ public sealed class InMemoryKafkaCluster
         ArgumentNullException.ThrowIfNull(records);
 
         lock (_gate)
-            ReleaseShareLeasesUnderLock(groupId, memberId, records);
+            ReleaseShareLeasesUnderLock(groupId, memberId, registration, records);
     }
 
     internal async Task WaitForRecordsAsync(TimeSpan timeout, CancellationToken cancellationToken)
@@ -1264,6 +1275,7 @@ public sealed class InMemoryKafkaCluster
     private void ReleaseShareLeasesUnderLock(
         string groupId,
         string memberId,
+        ShareGroupMemberRegistration registration,
         IEnumerable<TopicPartitionOffset> records)
     {
         if (!_shareLeases.TryGetValue(groupId, out var groupLeases))
@@ -1274,7 +1286,8 @@ public sealed class InMemoryKafkaCluster
             var topicPartition = new TopicPartition(record.Topic, record.Partition);
             if (!groupLeases.TryGetValue(topicPartition, out var partitionLeases) ||
                 !partitionLeases.TryGetValue(record.Offset, out var lease) ||
-                !StringComparer.Ordinal.Equals(lease.MemberId, memberId))
+                !StringComparer.Ordinal.Equals(lease.MemberId, memberId) ||
+                !ReferenceEquals(lease.Registration, registration))
             {
                 continue;
             }
@@ -1477,12 +1490,14 @@ public sealed class InMemoryKafkaCluster
 
     private sealed class ShareLeaseState
     {
-        public ShareLeaseState(string memberId)
+        public ShareLeaseState(string memberId, ShareGroupMemberRegistration registration)
         {
             MemberId = memberId;
+            Registration = registration;
         }
 
         public string MemberId { get; }
+        public ShareGroupMemberRegistration Registration { get; set; }
     }
 
     private readonly record struct ConsumerGroupMemberState(

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -890,23 +890,27 @@ public sealed class InMemoryKafkaCluster
         }
     }
 
-    internal bool TryDeleteShareGroup(string groupId)
+    internal ErrorCode DeleteShareGroup(string groupId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
 
         lock (_gate)
         {
-            if ((_shareGroupMembers.TryGetValue(groupId, out var members) && members.Count > 0) ||
-                (_shareLeases.TryGetValue(groupId, out var leases) && leases.Count > 0))
-            {
-                return false;
-            }
+            var hasOffsets = _shareGroupOffsets.ContainsKey(groupId);
+            var hasMembers = _shareGroupMembers.TryGetValue(groupId, out var members);
+            var hasLeases = _shareLeases.TryGetValue(groupId, out var leases);
+            var hasDeliveryCounts = _shareDeliveryCounts.ContainsKey(groupId);
+            if (!hasOffsets && !hasMembers && !hasLeases && !hasDeliveryCounts)
+                return ErrorCode.GroupIdNotFound;
+
+            if (members is { Count: > 0 } || leases is { Count: > 0 })
+                return ErrorCode.NonEmptyGroup;
 
             _shareGroupOffsets.Remove(groupId);
             _shareGroupMembers.Remove(groupId);
             _shareLeases.Remove(groupId);
             _shareDeliveryCounts.Remove(groupId);
-            return true;
+            return ErrorCode.None;
         }
     }
 

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -10,6 +10,10 @@ using Dekaf.Serialization;
 
 namespace Dekaf.Testing;
 
+internal readonly record struct InMemoryShareGroupListing(
+    string GroupId,
+    bool HasActiveMembers);
+
 /// <summary>
 /// Shared in-memory topic, partition, offset, and group-offset store.
 /// </summary>
@@ -22,6 +26,7 @@ public sealed class InMemoryKafkaCluster
     private readonly Dictionary<string, Dictionary<string, ConsumerGroupMemberState>> _consumerGroupMembers = new(StringComparer.Ordinal);
     private readonly Dictionary<string, int> _consumerGroupGenerations = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<string, int>> _shareGroupMembers = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _shareGroupsWithMemberHistory = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, ShareGroupMemberRegistration>>> _shareLeases = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, int>>> _shareDeliveryCounts = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Exception> _produceFailures = new(StringComparer.Ordinal);
@@ -883,15 +888,25 @@ public sealed class InMemoryKafkaCluster
             return _consumerGroupOffsets.Keys.Order(StringComparer.Ordinal).ToArray();
     }
 
-    internal IReadOnlyList<string> ListShareGroups()
+    internal IReadOnlyList<InMemoryShareGroupListing> ListShareGroups()
     {
         lock (_gate)
         {
-            var groupIds = new HashSet<string>(_shareGroupOffsets.Keys, StringComparer.Ordinal);
+            var groupIds = new HashSet<string>(_shareGroupsWithMemberHistory, StringComparer.Ordinal);
+            groupIds.UnionWith(_shareGroupOffsets.Keys);
             groupIds.UnionWith(_shareGroupMembers.Keys);
             groupIds.UnionWith(_shareLeases.Keys);
             groupIds.UnionWith(_shareDeliveryCounts.Keys);
-            return groupIds.Order(StringComparer.Ordinal).ToArray();
+            var result = new InMemoryShareGroupListing[groupIds.Count];
+            var index = 0;
+            foreach (var groupId in groupIds.Order(StringComparer.Ordinal))
+            {
+                var hasActiveMembers = _shareGroupMembers.TryGetValue(groupId, out var members) &&
+                    members.Count > 0;
+                result[index++] = new InMemoryShareGroupListing(groupId, hasActiveMembers);
+            }
+
+            return result;
         }
     }
 
@@ -908,6 +923,7 @@ public sealed class InMemoryKafkaCluster
 
         lock (_gate)
         {
+            _shareGroupsWithMemberHistory.Add(groupId);
             if (!_shareGroupMembers.TryGetValue(groupId, out var members))
             {
                 members = new Dictionary<string, int>(StringComparer.Ordinal);
@@ -959,7 +975,8 @@ public sealed class InMemoryKafkaCluster
             var hasMembers = _shareGroupMembers.TryGetValue(groupId, out var members);
             var hasLeases = _shareLeases.TryGetValue(groupId, out var leases);
             var hasDeliveryCounts = _shareDeliveryCounts.ContainsKey(groupId);
-            if (!hasOffsets && !hasMembers && !hasLeases && !hasDeliveryCounts)
+            var hasMemberHistory = _shareGroupsWithMemberHistory.Contains(groupId);
+            if (!hasOffsets && !hasMembers && !hasLeases && !hasDeliveryCounts && !hasMemberHistory)
                 return ErrorCode.GroupIdNotFound;
 
             if (members is { Count: > 0 } || leases is { Count: > 0 })
@@ -969,6 +986,7 @@ public sealed class InMemoryKafkaCluster
             _shareGroupMembers.Remove(groupId);
             _shareLeases.Remove(groupId);
             _shareDeliveryCounts.Remove(groupId);
+            _shareGroupsWithMemberHistory.Remove(groupId);
             return ErrorCode.None;
         }
     }
@@ -1235,14 +1253,22 @@ public sealed class InMemoryKafkaCluster
 
     private void CommitShareOffsetsUnderLock(string groupId, IEnumerable<TopicPartitionOffset> offsets)
     {
+        using var enumerator = offsets.GetEnumerator();
+        if (!enumerator.MoveNext())
+            return;
+
         if (!_shareGroupOffsets.TryGetValue(groupId, out var groupOffsets))
         {
             groupOffsets = [];
             _shareGroupOffsets[groupId] = groupOffsets;
         }
 
-        foreach (var offset in offsets)
+        do
+        {
+            var offset = enumerator.Current;
             groupOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset;
+        }
+        while (enumerator.MoveNext());
     }
 
     private Dictionary<long, ShareGroupMemberRegistration>? GetShareLeasePartition(

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -598,6 +598,7 @@ public sealed class InMemoryKafkaCluster
     internal bool TryAcquireShareRecord(
         string groupId,
         string memberId,
+        ShareGroupMemberRegistration registration,
         TopicPartition topicPartition,
         long offset,
         out InMemoryRecord record,
@@ -608,8 +609,7 @@ public sealed class InMemoryKafkaCluster
 
         lock (_gate)
         {
-            if (!_shareGroupMembers.TryGetValue(groupId, out var members) ||
-                !members.ContainsKey(memberId))
+            if (!registration.IsActive)
             {
                 record = null!;
                 deliveryCount = 0;
@@ -865,7 +865,7 @@ public sealed class InMemoryKafkaCluster
             _consumerGroupOffsets.Remove(groupId);
     }
 
-    internal void RegisterShareGroupMember(string groupId, string memberId)
+    internal ShareGroupMemberRegistration RegisterShareGroupMember(string groupId, string memberId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
         ArgumentException.ThrowIfNullOrWhiteSpace(memberId);
@@ -879,16 +879,24 @@ public sealed class InMemoryKafkaCluster
             }
 
             members[memberId] = members.GetValueOrDefault(memberId) + 1;
+            return new ShareGroupMemberRegistration();
         }
     }
 
-    internal void UnregisterShareGroupMember(string groupId, string memberId)
+    internal void UnregisterShareGroupMember(
+        string groupId,
+        string memberId,
+        ShareGroupMemberRegistration registration)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
         ArgumentException.ThrowIfNullOrWhiteSpace(memberId);
 
         lock (_gate)
         {
+            if (!registration.IsActive)
+                return;
+
+            registration.IsActive = false;
             if (!_shareGroupMembers.TryGetValue(groupId, out var members))
                 return;
 
@@ -1477,4 +1485,9 @@ public sealed class InMemoryKafkaCluster
     private readonly record struct ConsumerGroupMemberState(
         long RegistrationId,
         HashSet<TopicPartition> SubscribedPartitions);
+}
+
+internal sealed class ShareGroupMemberRegistration
+{
+    internal bool IsActive { get; set; } = true;
 }

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -17,6 +17,7 @@ public sealed class InMemoryKafkaCluster
     private readonly object _gate = new();
     private readonly Dictionary<string, TopicState> _topics = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, TopicPartitionOffset>> _consumerGroupOffsets = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dictionary<TopicPartition, TopicPartitionOffset>> _shareGroupOffsets = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<string, ConsumerGroupMemberState>> _consumerGroupMembers = new(StringComparer.Ordinal);
     private readonly Dictionary<string, int> _consumerGroupGenerations = new(StringComparer.Ordinal);
     private readonly Dictionary<string, HashSet<string>> _shareGroupMembers = new(StringComparer.Ordinal);
@@ -665,7 +666,7 @@ public sealed class InMemoryKafkaCluster
             ReleaseShareLeasesUnderLock(groupId, memberId, completed);
             if (commits.Length > 0)
             {
-                CommitOffsetsUnderLock(groupId, commits);
+                CommitShareOffsetsUnderLock(groupId, commits);
                 foreach (var commitOffset in commits)
                     RemoveCommittedShareDeliveryCountsUnderLock(groupId, commitOffset);
             }
@@ -795,11 +796,38 @@ public sealed class InMemoryKafkaCluster
             CommitOffsetsUnderLock(groupId, offsets);
     }
 
+    internal long? GetCommittedShareOffset(string groupId, TopicPartition topicPartition)
+    {
+        lock (_gate)
+        {
+            return _shareGroupOffsets.TryGetValue(groupId, out var offsets) &&
+                   offsets.TryGetValue(topicPartition, out var offset)
+                ? offset.Offset
+                : null;
+        }
+    }
+
+    internal void CommitShareOffsets(string groupId, IEnumerable<TopicPartitionOffset> offsets)
+    {
+        lock (_gate)
+            CommitShareOffsetsUnderLock(groupId, offsets);
+    }
+
     internal IReadOnlyDictionary<TopicPartition, long> GetGroupOffsets(string groupId)
     {
         lock (_gate)
         {
             return _consumerGroupOffsets.TryGetValue(groupId, out var offsets)
+                ? offsets.ToDictionary(static item => item.Key, static item => item.Value.Offset)
+                : new Dictionary<TopicPartition, long>();
+        }
+    }
+
+    internal IReadOnlyDictionary<TopicPartition, long> GetShareGroupOffsets(string groupId)
+    {
+        lock (_gate)
+        {
+            return _shareGroupOffsets.TryGetValue(groupId, out var offsets)
                 ? offsets.ToDictionary(static item => item.Key, static item => item.Value.Offset)
                 : new Dictionary<TopicPartition, long>();
         }
@@ -862,7 +890,7 @@ public sealed class InMemoryKafkaCluster
                 return false;
             }
 
-            _consumerGroupOffsets.Remove(groupId);
+            _shareGroupOffsets.Remove(groupId);
             _shareGroupMembers.Remove(groupId);
             _shareLeases.Remove(groupId);
             _shareDeliveryCounts.Remove(groupId);
@@ -875,6 +903,18 @@ public sealed class InMemoryKafkaCluster
         lock (_gate)
         {
             if (!_consumerGroupOffsets.TryGetValue(groupId, out var offsets))
+                return;
+
+            foreach (var partition in partitions)
+                offsets.Remove(partition);
+        }
+    }
+
+    internal void DeleteShareGroupOffsets(string groupId, IEnumerable<TopicPartition> partitions)
+    {
+        lock (_gate)
+        {
+            if (!_shareGroupOffsets.TryGetValue(groupId, out var offsets))
                 return;
 
             foreach (var partition in partitions)
@@ -1109,6 +1149,18 @@ public sealed class InMemoryKafkaCluster
         {
             groupOffsets = [];
             _consumerGroupOffsets[groupId] = groupOffsets;
+        }
+
+        foreach (var offset in offsets)
+            groupOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset;
+    }
+
+    private void CommitShareOffsetsUnderLock(string groupId, IEnumerable<TopicPartitionOffset> offsets)
+    {
+        if (!_shareGroupOffsets.TryGetValue(groupId, out var groupOffsets))
+        {
+            groupOffsets = [];
+            _shareGroupOffsets[groupId] = groupOffsets;
         }
 
         foreach (var offset in offsets)

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -21,7 +21,7 @@ public sealed class InMemoryKafkaCluster
     private readonly Dictionary<string, Dictionary<string, ConsumerGroupMemberState>> _consumerGroupMembers = new(StringComparer.Ordinal);
     private readonly Dictionary<string, int> _consumerGroupGenerations = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<string, int>> _shareGroupMembers = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, ShareLeaseState>>> _shareLeases = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, ShareGroupMemberRegistration>>> _shareLeases = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, int>>> _shareDeliveryCounts = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Exception> _produceFailures = new(StringComparer.Ordinal);
     private readonly Dictionary<PreparedTransactionState, IInMemoryPreparedTransaction> _preparedTransactions = [];
@@ -629,21 +629,21 @@ public sealed class InMemoryKafkaCluster
             }
 
             var partitionLeases = GetShareLeasePartition(groupId, topicPartition, create: true)!;
-            var hasLease = partitionLeases.TryGetValue(candidate.Offset, out var lease);
+            var hasLease = partitionLeases.TryGetValue(candidate.Offset, out var leaseRegistration);
             if (hasLease)
             {
-                var existingLease = lease!;
-                if (!StringComparer.Ordinal.Equals(existingLease.MemberId, memberId) ||
-                    (!ReferenceEquals(existingLease.Registration, registration) &&
-                     existingLease.Registration.IsActive))
+                var existingRegistration = leaseRegistration!;
+                if (!StringComparer.Ordinal.Equals(existingRegistration.MemberId, memberId) ||
+                    (!ReferenceEquals(existingRegistration, registration) &&
+                     existingRegistration.IsActive))
                 {
                     record = null!;
                     deliveryCount = 0;
                     return false;
                 }
 
-                if (!ReferenceEquals(existingLease.Registration, registration))
-                    existingLease.Registration = registration;
+                if (!ReferenceEquals(existingRegistration, registration))
+                    partitionLeases[candidate.Offset] = registration;
             }
 
             var partitionDeliveryCounts = GetShareDeliveryCountPartition(groupId, topicPartition, create: true)!;
@@ -652,7 +652,7 @@ public sealed class InMemoryKafkaCluster
                 partitionDeliveryCounts.TryGetValue(candidate.Offset, out deliveryCount);
                 deliveryCount++;
                 partitionDeliveryCounts[candidate.Offset] = deliveryCount;
-                partitionLeases[candidate.Offset] = new ShareLeaseState(memberId, registration);
+                partitionLeases[candidate.Offset] = registration;
             }
             else
             {
@@ -890,7 +890,7 @@ public sealed class InMemoryKafkaCluster
             }
 
             members[memberId] = members.GetValueOrDefault(memberId) + 1;
-            return new ShareGroupMemberRegistration();
+            return new ShareGroupMemberRegistration(memberId);
         }
     }
 
@@ -1220,7 +1220,7 @@ public sealed class InMemoryKafkaCluster
             groupOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset;
     }
 
-    private Dictionary<long, ShareLeaseState>? GetShareLeasePartition(
+    private Dictionary<long, ShareGroupMemberRegistration>? GetShareLeasePartition(
         string groupId,
         TopicPartition topicPartition,
         bool create)
@@ -1287,7 +1287,7 @@ public sealed class InMemoryKafkaCluster
             if (!groupLeases.TryGetValue(topicPartition, out var partitionLeases) ||
                 !partitionLeases.TryGetValue(record.Offset, out var lease) ||
                 !StringComparer.Ordinal.Equals(lease.MemberId, memberId) ||
-                !ReferenceEquals(lease.Registration, registration))
+                !ReferenceEquals(lease, registration))
             {
                 continue;
             }
@@ -1488,18 +1488,6 @@ public sealed class InMemoryKafkaCluster
         }
     }
 
-    private sealed class ShareLeaseState
-    {
-        public ShareLeaseState(string memberId, ShareGroupMemberRegistration registration)
-        {
-            MemberId = memberId;
-            Registration = registration;
-        }
-
-        public string MemberId { get; }
-        public ShareGroupMemberRegistration Registration { get; set; }
-    }
-
     private readonly record struct ConsumerGroupMemberState(
         long RegistrationId,
         HashSet<TopicPartition> SubscribedPartitions);
@@ -1507,5 +1495,11 @@ public sealed class InMemoryKafkaCluster
 
 internal sealed class ShareGroupMemberRegistration
 {
+    internal ShareGroupMemberRegistration(string memberId)
+    {
+        MemberId = memberId;
+    }
+
+    internal string MemberId { get; }
     internal bool IsActive { get; set; } = true;
 }

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Errors;
@@ -643,7 +644,15 @@ public sealed class InMemoryKafkaCluster
                 }
 
                 if (!ReferenceEquals(existingRegistration, registration))
+                {
                     partitionLeases[candidate.Offset] = registration;
+                    deliveryCount = RecordShareRedeliveryUnderLock(
+                        groupId,
+                        topicPartition,
+                        candidate.Offset);
+                    record = CloneRecord(candidate);
+                    return true;
+                }
             }
 
             var partitionDeliveryCounts = GetShareDeliveryCountPartition(groupId, topicPartition, create: true)!;
@@ -662,6 +671,22 @@ public sealed class InMemoryKafkaCluster
             record = CloneRecord(candidate);
             return true;
         }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private int RecordShareRedeliveryUnderLock(
+        string groupId,
+        TopicPartition topicPartition,
+        long offset)
+    {
+        var partitionDeliveryCounts = GetShareDeliveryCountPartition(
+            groupId,
+            topicPartition,
+            create: true)!;
+        partitionDeliveryCounts.TryGetValue(offset, out var deliveryCount);
+        deliveryCount++;
+        partitionDeliveryCounts[offset] = deliveryCount;
+        return deliveryCount;
     }
 
     internal void CompleteShareRecords(

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -19,6 +19,7 @@ public sealed class InMemoryKafkaCluster
     private readonly Dictionary<string, Dictionary<TopicPartition, TopicPartitionOffset>> _consumerGroupOffsets = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<string, ConsumerGroupMemberState>> _consumerGroupMembers = new(StringComparer.Ordinal);
     private readonly Dictionary<string, int> _consumerGroupGenerations = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, HashSet<string>> _shareGroupMembers = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, ShareLeaseState>>> _shareLeases = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, int>>> _shareDeliveryCounts = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Exception> _produceFailures = new(StringComparer.Ordinal);
@@ -814,6 +815,59 @@ public sealed class InMemoryKafkaCluster
     {
         lock (_gate)
             _consumerGroupOffsets.Remove(groupId);
+    }
+
+    internal void RegisterShareGroupMember(string groupId, string memberId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(memberId);
+
+        lock (_gate)
+        {
+            if (!_shareGroupMembers.TryGetValue(groupId, out var members))
+            {
+                members = new HashSet<string>(StringComparer.Ordinal);
+                _shareGroupMembers[groupId] = members;
+            }
+
+            members.Add(memberId);
+        }
+    }
+
+    internal void UnregisterShareGroupMember(string groupId, string memberId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(memberId);
+
+        lock (_gate)
+        {
+            if (!_shareGroupMembers.TryGetValue(groupId, out var members))
+                return;
+
+            members.Remove(memberId);
+            if (members.Count == 0)
+                _shareGroupMembers.Remove(groupId);
+        }
+    }
+
+    internal bool TryDeleteShareGroup(string groupId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+
+        lock (_gate)
+        {
+            if ((_shareGroupMembers.TryGetValue(groupId, out var members) && members.Count > 0) ||
+                (_shareLeases.TryGetValue(groupId, out var leases) && leases.Count > 0))
+            {
+                return false;
+            }
+
+            _consumerGroupOffsets.Remove(groupId);
+            _shareGroupMembers.Remove(groupId);
+            _shareLeases.Remove(groupId);
+            _shareDeliveryCounts.Remove(groupId);
+            return true;
+        }
     }
 
     internal void DeleteGroupOffsets(string groupId, IEnumerable<TopicPartition> partitions)

--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -304,35 +304,30 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
     public ValueTask CommitAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        ThrowIfDisposed();
 
         lock (_gate)
         {
-            if (_pending.Count == 0)
-                return ValueTask.CompletedTask;
-
-            var pending = _pending.Values.ToArray();
-            var offsets = BuildCommitOffsets(pending);
-            var completedRecords = BuildCompletedRecords(pending);
-
-            _cluster.CompleteShareRecords(_options.GroupId, _memberId, completedRecords, offsets);
-            _pending.Clear();
+            ThrowIfDisposed();
+            CompletePendingUnderLock();
         }
 
         return ValueTask.CompletedTask;
     }
 
-    public async ValueTask CloseAsync(CancellationToken cancellationToken = default)
+    public ValueTask CloseAsync(CancellationToken cancellationToken = default)
     {
-        if (_disposed)
-            return;
-
-        await CommitAsync(cancellationToken).ConfigureAwait(false);
         lock (_gate)
         {
+            if (_disposed)
+                return ValueTask.CompletedTask;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            CompletePendingUnderLock();
             UnregisterShareGroupMemberUnderLock();
             _disposed = true;
         }
+
+        return ValueTask.CompletedTask;
     }
 
     public async ValueTask DisposeAsync()
@@ -443,9 +438,16 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
         var pending = new PendingShareRecord(partition, record.Offset, record.Offset + 1);
 
         lock (_gate)
-            _pending[result] = pending;
+        {
+            if (!_disposed)
+            {
+                _pending[result] = pending;
+                return result;
+            }
+        }
 
-        return result;
+        ReleaseAcquiredRecord(partition, record);
+        throw new ObjectDisposedException(GetType().FullName);
     }
 
     private async ValueTask<ShareConsumeResult<TKey, TValue>> ToShareResultAsync(
@@ -559,6 +561,19 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             return;
 
         _cluster.ReleaseShareRecords(_options.GroupId, _memberId, BuildCompletedRecords(_pending.Values));
+        _pending.Clear();
+    }
+
+    private void CompletePendingUnderLock()
+    {
+        if (_pending.Count == 0)
+            return;
+
+        var pending = _pending.Values.ToArray();
+        var offsets = BuildCommitOffsets(pending);
+        var completedRecords = BuildCompletedRecords(pending);
+
+        _cluster.CompleteShareRecords(_options.GroupId, _memberId, completedRecords, offsets);
         _pending.Clear();
     }
 

--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -541,7 +541,7 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
 
     private long GetNextOffsetUnderLock(TopicPartition partition)
     {
-        var offset = _cluster.GetCommittedOffset(_options.GroupId, partition) ??
+        var offset = _cluster.GetCommittedShareOffset(_options.GroupId, partition) ??
                      _cluster.GetWatermarks(partition).Low;
 
         foreach (var pending in _pending.Values)

--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -24,7 +24,7 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
     private readonly HashSet<TopicPartition> _assignment = [];
     private readonly Dictionary<ShareConsumeResult<TKey, TValue>, PendingShareRecord> _pending = [];
     private readonly string _memberId;
-    private bool _registered;
+    private ShareGroupMemberRegistration? _registration;
     private bool _disposed;
 
     public InMemoryShareConsumer(InMemoryKafkaCluster cluster)
@@ -242,10 +242,9 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             {
                 UnregisterShareGroupMemberUnderLock();
             }
-            else if (!_registered)
+            else if (_registration is null)
             {
-                _cluster.RegisterShareGroupMember(_options.GroupId, _memberId);
-                _registered = true;
+                _registration = _cluster.RegisterShareGroupMember(_options.GroupId, _memberId);
             }
         }
 
@@ -406,12 +405,24 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
     private bool TryAcquireRecord(TopicPartition partition, out InMemoryRecord record, out int deliveryCount)
     {
         long offset;
+        ShareGroupMemberRegistration? registration;
         lock (_gate)
+        {
             offset = GetNextOffsetUnderLock(partition);
+            registration = _registration;
+        }
+
+        if (registration is null)
+        {
+            record = null!;
+            deliveryCount = 0;
+            return false;
+        }
 
         return _cluster.TryAcquireShareRecord(
             _options.GroupId,
             _memberId,
+            registration,
             partition,
             offset,
             out record,
@@ -579,11 +590,11 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
 
     private void UnregisterShareGroupMemberUnderLock()
     {
-        if (!_registered)
+        if (_registration is not { } registration)
             return;
 
-        _cluster.UnregisterShareGroupMember(_options.GroupId, _memberId);
-        _registered = false;
+        _cluster.UnregisterShareGroupMember(_options.GroupId, _memberId, registration);
+        _registration = null;
     }
 
     private static TopicPartitionOffset[] BuildCommitOffsets(IEnumerable<PendingShareRecord> records)

--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -229,6 +229,7 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
 
         lock (_gate)
         {
+            ThrowIfDisposed();
             ReleasePendingUnderLock();
             _subscription.Clear();
             foreach (var topic in topics.Where(topic => !string.IsNullOrWhiteSpace(topic)).Distinct(StringComparer.Ordinal))
@@ -341,7 +342,7 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
     {
         foreach (var partition in OrderedAssignment())
         {
-            if (!TryAcquireRecord(partition, out var record, out var deliveryCount))
+            if (!TryAcquireRecord(partition, out var record, out var deliveryCount, out var registration))
                 continue;
 
             ShareConsumeResult<TKey, TValue> result;
@@ -355,7 +356,7 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
                 throw;
             }
 
-            return RegisterPending(partition, record, result);
+            return RegisterPending(partition, record, result, registration);
         }
 
         return null;
@@ -371,7 +372,7 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
     {
         foreach (var partition in OrderedAssignment())
         {
-            if (!TryAcquireRecord(partition, out var record, out var deliveryCount))
+            if (!TryAcquireRecord(partition, out var record, out var deliveryCount, out var registration))
                 continue;
 
             ShareConsumeResult<TKey, TValue> result;
@@ -385,7 +386,7 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
                 throw;
             }
 
-            return RegisterPending(partition, record, result);
+            return RegisterPending(partition, record, result, registration);
         }
 
         return null;
@@ -402,23 +403,29 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
         }
     }
 
-    private bool TryAcquireRecord(TopicPartition partition, out InMemoryRecord record, out int deliveryCount)
+    private bool TryAcquireRecord(
+        TopicPartition partition,
+        out InMemoryRecord record,
+        out int deliveryCount,
+        out ShareGroupMemberRegistration registration)
     {
         long offset;
-        ShareGroupMemberRegistration? registration;
+        ShareGroupMemberRegistration? currentRegistration;
         lock (_gate)
         {
             offset = GetNextOffsetUnderLock(partition);
-            registration = _registration;
+            currentRegistration = _registration;
         }
 
-        if (registration is null)
+        if (currentRegistration is null)
         {
             record = null!;
             deliveryCount = 0;
+            registration = null!;
             return false;
         }
 
+        registration = currentRegistration;
         return _cluster.TryAcquireShareRecord(
             _options.GroupId,
             _memberId,
@@ -441,16 +448,19 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             _memberId,
             [new TopicPartitionOffset(partition.Topic, partition.Partition, record.Offset)]);
 
-    private ShareConsumeResult<TKey, TValue> RegisterPending(
+    private ShareConsumeResult<TKey, TValue>? RegisterPending(
         TopicPartition partition,
         InMemoryRecord record,
-        ShareConsumeResult<TKey, TValue> result)
+        ShareConsumeResult<TKey, TValue> result,
+        ShareGroupMemberRegistration registration)
     {
         var pending = new PendingShareRecord(partition, record.Offset, record.Offset + 1);
+        bool disposed;
 
         lock (_gate)
         {
-            if (!_disposed)
+            disposed = _disposed;
+            if (!disposed && ReferenceEquals(_registration, registration))
             {
                 _pending[result] = pending;
                 return result;
@@ -458,7 +468,10 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
         }
 
         ReleaseAcquiredRecord(partition, record);
-        throw new ObjectDisposedException(GetType().FullName);
+        if (disposed)
+            throw new ObjectDisposedException(GetType().FullName);
+
+        return null;
     }
 
     private async ValueTask<ShareConsumeResult<TKey, TValue>> ToShareResultAsync(

--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -24,6 +24,7 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
     private readonly HashSet<TopicPartition> _assignment = [];
     private readonly Dictionary<ShareConsumeResult<TKey, TValue>, PendingShareRecord> _pending = [];
     private readonly string _memberId;
+    private bool _registered;
     private bool _disposed;
 
     public InMemoryShareConsumer(InMemoryKafkaCluster cluster)
@@ -236,6 +237,16 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             _assignment.Clear();
             foreach (var topicPartition in topicPartitions)
                 _assignment.Add(topicPartition);
+
+            if (_subscription.Count == 0)
+            {
+                UnregisterShareGroupMemberUnderLock();
+            }
+            else if (!_registered)
+            {
+                _cluster.RegisterShareGroupMember(_options.GroupId, _memberId);
+                _registered = true;
+            }
         }
 
         return this;
@@ -250,6 +261,7 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             ReleasePendingUnderLock();
             _subscription.Clear();
             _assignment.Clear();
+            UnregisterShareGroupMemberUnderLock();
         }
 
         return this;
@@ -316,7 +328,11 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             return;
 
         await CommitAsync(cancellationToken).ConfigureAwait(false);
-        _disposed = true;
+        lock (_gate)
+        {
+            UnregisterShareGroupMemberUnderLock();
+            _disposed = true;
+        }
     }
 
     public async ValueTask DisposeAsync()
@@ -544,6 +560,15 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
 
         _cluster.ReleaseShareRecords(_options.GroupId, _memberId, BuildCompletedRecords(_pending.Values));
         _pending.Clear();
+    }
+
+    private void UnregisterShareGroupMemberUnderLock()
+    {
+        if (!_registered)
+            return;
+
+        _cluster.UnregisterShareGroupMember(_options.GroupId, _memberId);
+        _registered = false;
     }
 
     private static TopicPartitionOffset[] BuildCommitOffsets(IEnumerable<PendingShareRecord> records)

--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -352,7 +352,7 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             }
             catch
             {
-                ReleaseAcquiredRecord(partition, record);
+                ReleaseAcquiredRecord(partition, record, registration);
                 throw;
             }
 
@@ -382,7 +382,7 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             }
             catch
             {
-                ReleaseAcquiredRecord(partition, record);
+                ReleaseAcquiredRecord(partition, record, registration);
                 throw;
             }
 
@@ -442,10 +442,14 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
     /// acknowledge, commit, unsubscribe or close path can ever release it and the record stays
     /// unavailable to the group's other members.
     /// </summary>
-    private void ReleaseAcquiredRecord(TopicPartition partition, InMemoryRecord record) =>
+    private void ReleaseAcquiredRecord(
+        TopicPartition partition,
+        InMemoryRecord record,
+        ShareGroupMemberRegistration registration) =>
         _cluster.ReleaseShareRecords(
             _options.GroupId,
             _memberId,
+            registration,
             [new TopicPartitionOffset(partition.Topic, partition.Partition, record.Offset)]);
 
     private ShareConsumeResult<TKey, TValue>? RegisterPending(
@@ -467,7 +471,7 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             }
         }
 
-        ReleaseAcquiredRecord(partition, record);
+        ReleaseAcquiredRecord(partition, record, registration);
         if (disposed)
             throw new ObjectDisposedException(GetType().FullName);
 
@@ -584,7 +588,11 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
         if (_pending.Count == 0)
             return;
 
-        _cluster.ReleaseShareRecords(_options.GroupId, _memberId, BuildCompletedRecords(_pending.Values));
+        _cluster.ReleaseShareRecords(
+            _options.GroupId,
+            _memberId,
+            _registration!,
+            BuildCompletedRecords(_pending.Values));
         _pending.Clear();
     }
 
@@ -597,7 +605,12 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
         var offsets = BuildCommitOffsets(pending);
         var completedRecords = BuildCompletedRecords(pending);
 
-        _cluster.CompleteShareRecords(_options.GroupId, _memberId, completedRecords, offsets);
+        _cluster.CompleteShareRecords(
+            _options.GroupId,
+            _memberId,
+            _registration!,
+            completedRecords,
+            offsets);
         _pending.Clear();
     }
 

--- a/src/Dekaf.Testing/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.Testing/PublicAPI.Unshipped.txt
@@ -28,6 +28,7 @@ Dekaf.Testing.InMemoryStreamsGroupMember.LastUpdate.get -> Dekaf.Streams.Streams
 Dekaf.Testing.InMemoryStreamsGroupMember.ReportTaskOffsetsAsync(Dekaf.Streams.StreamsGroupTaskOffsetReport! report, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Streams.StreamsGroupHeartbeatResult!>
 Dekaf.Testing.InMemoryStreamsGroupMember.Snapshot.get -> Dekaf.Streams.StreamsGroupMemberSnapshot!
 Dekaf.Testing.InMemoryStreamsGroupMember.UpdateAsync(Dekaf.Streams.StreamsGroupMemberUpdate! update, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Streams.StreamsGroupHeartbeatResult!>
+Dekaf.Testing.InMemoryAdminClient.DeleteShareGroupsAsync(System.Collections.Generic.IEnumerable<string!>! groupIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.DeleteShareGroupResult!>!>
 Dekaf.Testing.KafkaFaultAction
 Dekaf.Testing.KafkaFaultAction.Pause = 1 -> Dekaf.Testing.KafkaFaultAction
 Dekaf.Testing.KafkaFaultAction.Throw = 0 -> Dekaf.Testing.KafkaFaultAction

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -5001,7 +5001,26 @@ public sealed class AdminClient :
                 if (results.ContainsKey(groupId))
                     continue;
 
-                var coordinatorId = await FindGroupCoordinatorAsync(groupId, cancellationToken).ConfigureAwait(false);
+                int coordinatorId;
+                try
+                {
+                    coordinatorId = await FindGroupCoordinatorAsync(
+                        groupId,
+                        cancellationToken).ConfigureAwait(false);
+                }
+                catch (Errors.GroupException exception) when (
+                    exception.ErrorCode is { } errorCode &&
+                    !errorCode.IsRetriable() &&
+                    !errorCode.RequiresMetadataRefresh())
+                {
+                    results[groupId] = new DeleteShareGroupResult
+                    {
+                        GroupId = groupId,
+                        ErrorCode = errorCode
+                    };
+                    continue;
+                }
+
                 if (!groupsByCoordinator.TryGetValue(coordinatorId, out var coordinatorGroups))
                 {
                     coordinatorGroups = [];

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -25,6 +25,7 @@ public sealed class AdminClient :
     IReplicaLogDirAdminClient,
     ITopicIdAdminClient,
     ITransactionRemediationAdminClient,
+    IShareGroupDeletionAdminClient,
     IKafkaClientStatusProvider
 {
     private const string MetadataQuorumTopic = "__cluster_metadata";
@@ -4987,6 +4988,8 @@ public sealed class AdminClient :
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
+        // Both collections intentionally survive retry attempts: terminal results prevent
+        // resending completed groups, while ambiguity turns a later not-found response into success.
         var results = new Dictionary<string, DeleteShareGroupResult>(groupIdList.Length, StringComparer.Ordinal);
         var ambiguousGroups = new HashSet<string>(StringComparer.Ordinal);
 
@@ -5074,9 +5077,11 @@ public sealed class AdminClient :
                 {
                     if (!responseGroupIds.Contains(groupId))
                     {
-                        retryFailure ??= new KafkaException(
-                            Protocol.ErrorCode.UnknownServerError,
-                            $"DeleteShareGroups returned no result for group '{groupId}'.");
+                        results[groupId] = new DeleteShareGroupResult
+                        {
+                            GroupId = groupId,
+                            ErrorCode = Protocol.ErrorCode.UnknownServerError
+                        };
                     }
                 }
             }

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -4966,6 +4966,132 @@ public sealed class AdminClient :
         }, cancellationToken).ConfigureAwait(false);
     }
 
+    public async ValueTask<IReadOnlyDictionary<string, DeleteShareGroupResult>> DeleteShareGroupsAsync(
+        IEnumerable<string> groupIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(groupIds);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var groupIdList = groupIds.ToArray();
+        var uniqueGroupIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var groupId in groupIdList)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+            if (!uniqueGroupIds.Add(groupId))
+                throw new ArgumentException($"Share group ID '{groupId}' is duplicated.", nameof(groupIds));
+        }
+
+        if (groupIdList.Length == 0)
+            return new Dictionary<string, DeleteShareGroupResult>(StringComparer.Ordinal);
+
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        var results = new Dictionary<string, DeleteShareGroupResult>(groupIdList.Length, StringComparer.Ordinal);
+        var ambiguousGroups = new HashSet<string>(StringComparer.Ordinal);
+
+        return await WithRetryAsync<IReadOnlyDictionary<string, DeleteShareGroupResult>>(async () =>
+        {
+            var groupsByCoordinator = new Dictionary<int, List<string>>();
+            foreach (var groupId in groupIdList)
+            {
+                if (results.ContainsKey(groupId))
+                    continue;
+
+                var coordinatorId = await FindGroupCoordinatorAsync(groupId, cancellationToken).ConfigureAwait(false);
+                if (!groupsByCoordinator.TryGetValue(coordinatorId, out var coordinatorGroups))
+                {
+                    coordinatorGroups = [];
+                    groupsByCoordinator[coordinatorId] = coordinatorGroups;
+                }
+                coordinatorGroups.Add(groupId);
+            }
+
+            Exception? retryFailure = null;
+            foreach (var (coordinatorId, coordinatorGroups) in groupsByCoordinator)
+            {
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(
+                    coordinatorId,
+                    cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    Protocol.ApiKey.DeleteGroups,
+                    DeleteGroupsRequest.LowestSupportedVersion,
+                    DeleteGroupsRequest.HighestSupportedVersion);
+
+                DeleteGroupsResponse response;
+                try
+                {
+                    response = await connection.SendAsync<DeleteGroupsRequest, DeleteGroupsResponse>(
+                        new DeleteGroupsRequest { GroupsNames = coordinatorGroups },
+                        apiVersion,
+                        cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception exception) when (
+                    RetryHelper.IsRetriableRequestFailure(exception) &&
+                    !cancellationToken.IsCancellationRequested)
+                {
+                    ambiguousGroups.UnionWith(coordinatorGroups);
+                    retryFailure ??= exception;
+                    continue;
+                }
+
+                var coordinatorGroupIds = new HashSet<string>(coordinatorGroups, StringComparer.Ordinal);
+                var responseGroupIds = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var groupResult in response.Results)
+                {
+                    if (!coordinatorGroupIds.Contains(groupResult.GroupId))
+                        continue;
+
+                    responseGroupIds.Add(groupResult.GroupId);
+                    var errorCode = groupResult.ErrorCode;
+                    if (errorCode.IsRetriable() || errorCode.RequiresMetadataRefresh())
+                    {
+                        retryFailure ??= new Errors.GroupException(
+                            errorCode,
+                            $"DeleteShareGroups failed for group '{groupResult.GroupId}': {errorCode}")
+                        {
+                            GroupId = groupResult.GroupId
+                        };
+                        continue;
+                    }
+
+                    if (errorCode == Protocol.ErrorCode.GroupIdNotFound &&
+                        ambiguousGroups.Contains(groupResult.GroupId))
+                    {
+                        errorCode = Protocol.ErrorCode.None;
+                    }
+
+                    results[groupResult.GroupId] = new DeleteShareGroupResult
+                    {
+                        GroupId = groupResult.GroupId,
+                        ErrorCode = errorCode
+                    };
+                }
+
+                foreach (var groupId in coordinatorGroups)
+                {
+                    if (!responseGroupIds.Contains(groupId))
+                    {
+                        retryFailure ??= new KafkaException(
+                            Protocol.ErrorCode.UnknownServerError,
+                            $"DeleteShareGroups returned no result for group '{groupId}'.");
+                    }
+                }
+            }
+
+            if (retryFailure is not null)
+                throw retryFailure;
+
+            var orderedResults = new Dictionary<string, DeleteShareGroupResult>(groupIdList.Length, StringComparer.Ordinal);
+            foreach (var groupId in groupIdList)
+                orderedResults[groupId] = results[groupId];
+
+            return orderedResults;
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
     public async ValueTask<IReadOnlyList<ShareGroupOffsetDescription>> DescribeShareGroupOffsetsAsync(
         string groupId,
         IEnumerable<TopicPartition>? partitions = null,

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -486,15 +486,6 @@ public interface IAdminClient : IAsyncDisposable
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Deletes share groups and returns the result for every requested group.
-    /// </summary>
-    /// <param name="groupIds">The share group IDs to delete.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    ValueTask<IReadOnlyDictionary<string, DeleteShareGroupResult>> DeleteShareGroupsAsync(
-        IEnumerable<string> groupIds,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Describes share group offsets.
     /// </summary>
     /// <param name="groupId">The share group ID.</param>

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -486,6 +486,15 @@ public interface IAdminClient : IAsyncDisposable
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Deletes share groups and returns the result for every requested group.
+    /// </summary>
+    /// <param name="groupIds">The share group IDs to delete.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    ValueTask<IReadOnlyDictionary<string, DeleteShareGroupResult>> DeleteShareGroupsAsync(
+        IEnumerable<string> groupIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Describes share group offsets.
     /// </summary>
     /// <param name="groupId">The share group ID.</param>

--- a/src/Dekaf/Admin/IShareGroupDeletionAdminClient.cs
+++ b/src/Dekaf/Admin/IShareGroupDeletionAdminClient.cs
@@ -1,0 +1,51 @@
+namespace Dekaf.Admin;
+
+/// <summary>
+/// Optional admin-client capability for deleting share groups.
+/// </summary>
+/// <remarks>
+/// Dekaf's built-in and in-memory admin clients implement this interface. Custom
+/// <see cref="IAdminClient"/> implementations can implement it to support
+/// <see cref="AdminClientShareGroupDeletionExtensions.DeleteShareGroupsAsync"/>.
+/// </remarks>
+public interface IShareGroupDeletionAdminClient
+{
+    /// <summary>
+    /// Deletes share groups and returns the result for every requested group.
+    /// </summary>
+    /// <param name="groupIds">The share group IDs to delete.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A dictionary containing one result per requested group ID.</returns>
+    ValueTask<IReadOnlyDictionary<string, DeleteShareGroupResult>> DeleteShareGroupsAsync(
+        IEnumerable<string> groupIds,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Share-group deletion operations for <see cref="IAdminClient"/>.
+/// </summary>
+public static class AdminClientShareGroupDeletionExtensions
+{
+    /// <summary>
+    /// Deletes share groups and returns the result for every requested group.
+    /// </summary>
+    /// <param name="adminClient">The admin client.</param>
+    /// <param name="groupIds">The share group IDs to delete.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A dictionary containing one result per requested group ID.</returns>
+    /// <exception cref="NotSupportedException">
+    /// The admin client does not implement <see cref="IShareGroupDeletionAdminClient"/>.
+    /// </exception>
+    public static ValueTask<IReadOnlyDictionary<string, DeleteShareGroupResult>> DeleteShareGroupsAsync(
+        this IAdminClient adminClient,
+        IEnumerable<string> groupIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(adminClient);
+
+        return adminClient is IShareGroupDeletionAdminClient shareGroupDeletionAdminClient
+            ? shareGroupDeletionAdminClient.DeleteShareGroupsAsync(groupIds, cancellationToken)
+            : throw new NotSupportedException(
+                $"Admin client type '{adminClient.GetType().FullName}' does not support share-group deletion.");
+    }
+}

--- a/src/Dekaf/Admin/ShareGroupTypes.cs
+++ b/src/Dekaf/Admin/ShareGroupTypes.cs
@@ -37,6 +37,15 @@ public sealed class ListShareGroupsOptions
 }
 
 /// <summary>
+/// Result of deleting a share group.
+/// </summary>
+public sealed class DeleteShareGroupResult
+{
+    public required string GroupId { get; init; }
+    public Protocol.ErrorCode ErrorCode { get; init; }
+}
+
+/// <summary>
 /// Description of a share group's offset for a partition.
 /// </summary>
 public sealed class ShareGroupOffsetDescription

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -428,3 +428,11 @@ static Dekaf.Protocol.Messages.ProduceRequest.IsFlexibleVersion(short version) -
 static Dekaf.Protocol.Messages.FetchRequest.GetRequestHeaderVersion(short version) -> short
 static Dekaf.Protocol.Messages.FetchRequest.GetResponseHeaderVersion(short version) -> short
 static Dekaf.Protocol.Messages.FetchRequest.IsFlexibleVersion(short version) -> bool
+Dekaf.Admin.AdminClient.DeleteShareGroupsAsync(System.Collections.Generic.IEnumerable<string!>! groupIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.DeleteShareGroupResult!>!>
+Dekaf.Admin.DeleteShareGroupResult
+Dekaf.Admin.DeleteShareGroupResult.DeleteShareGroupResult() -> void
+Dekaf.Admin.DeleteShareGroupResult.ErrorCode.get -> Dekaf.Protocol.ErrorCode
+Dekaf.Admin.DeleteShareGroupResult.ErrorCode.init -> void
+Dekaf.Admin.DeleteShareGroupResult.GroupId.get -> string!
+Dekaf.Admin.DeleteShareGroupResult.GroupId.init -> void
+Dekaf.Admin.IAdminClient.DeleteShareGroupsAsync(System.Collections.Generic.IEnumerable<string!>! groupIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.DeleteShareGroupResult!>!>

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -435,4 +435,7 @@ Dekaf.Admin.DeleteShareGroupResult.ErrorCode.get -> Dekaf.Protocol.ErrorCode
 Dekaf.Admin.DeleteShareGroupResult.ErrorCode.init -> void
 Dekaf.Admin.DeleteShareGroupResult.GroupId.get -> string!
 Dekaf.Admin.DeleteShareGroupResult.GroupId.init -> void
-Dekaf.Admin.IAdminClient.DeleteShareGroupsAsync(System.Collections.Generic.IEnumerable<string!>! groupIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.DeleteShareGroupResult!>!>
+Dekaf.Admin.AdminClientShareGroupDeletionExtensions
+Dekaf.Admin.IShareGroupDeletionAdminClient
+Dekaf.Admin.IShareGroupDeletionAdminClient.DeleteShareGroupsAsync(System.Collections.Generic.IEnumerable<string!>! groupIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.DeleteShareGroupResult!>!>
+static Dekaf.Admin.AdminClientShareGroupDeletionExtensions.DeleteShareGroupsAsync(this Dekaf.Admin.IAdminClient! adminClient, System.Collections.Generic.IEnumerable<string!>! groupIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.DeleteShareGroupResult!>!>

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -428,3 +428,11 @@ static Dekaf.Protocol.Messages.ProduceRequest.IsFlexibleVersion(short version) -
 static Dekaf.Protocol.Messages.FetchRequest.GetRequestHeaderVersion(short version) -> short
 static Dekaf.Protocol.Messages.FetchRequest.GetResponseHeaderVersion(short version) -> short
 static Dekaf.Protocol.Messages.FetchRequest.IsFlexibleVersion(short version) -> bool
+Dekaf.Admin.AdminClient.DeleteShareGroupsAsync(System.Collections.Generic.IEnumerable<string!>! groupIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.DeleteShareGroupResult!>!>
+Dekaf.Admin.DeleteShareGroupResult
+Dekaf.Admin.DeleteShareGroupResult.DeleteShareGroupResult() -> void
+Dekaf.Admin.DeleteShareGroupResult.ErrorCode.get -> Dekaf.Protocol.ErrorCode
+Dekaf.Admin.DeleteShareGroupResult.ErrorCode.init -> void
+Dekaf.Admin.DeleteShareGroupResult.GroupId.get -> string!
+Dekaf.Admin.DeleteShareGroupResult.GroupId.init -> void
+Dekaf.Admin.IAdminClient.DeleteShareGroupsAsync(System.Collections.Generic.IEnumerable<string!>! groupIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.DeleteShareGroupResult!>!>

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -435,4 +435,7 @@ Dekaf.Admin.DeleteShareGroupResult.ErrorCode.get -> Dekaf.Protocol.ErrorCode
 Dekaf.Admin.DeleteShareGroupResult.ErrorCode.init -> void
 Dekaf.Admin.DeleteShareGroupResult.GroupId.get -> string!
 Dekaf.Admin.DeleteShareGroupResult.GroupId.init -> void
-Dekaf.Admin.IAdminClient.DeleteShareGroupsAsync(System.Collections.Generic.IEnumerable<string!>! groupIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.DeleteShareGroupResult!>!>
+Dekaf.Admin.AdminClientShareGroupDeletionExtensions
+Dekaf.Admin.IShareGroupDeletionAdminClient
+Dekaf.Admin.IShareGroupDeletionAdminClient.DeleteShareGroupsAsync(System.Collections.Generic.IEnumerable<string!>! groupIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.DeleteShareGroupResult!>!>
+static Dekaf.Admin.AdminClientShareGroupDeletionExtensions.DeleteShareGroupsAsync(this Dekaf.Admin.IAdminClient! adminClient, System.Collections.Generic.IEnumerable<string!>! groupIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.DeleteShareGroupResult!>!>

--- a/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
@@ -454,6 +454,52 @@ public class ShareConsumerAdminTests(KafkaTestContainer kafka) : KafkaIntegratio
     }
 
     [Test]
+    [SupportsKafka(430)]
+    public async Task DeleteShareGroups_DeletesShareGroupWithoutAffectingConsumerGroup()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var shareGroupId = $"share-delete-{Guid.NewGuid():N}";
+        var consumerGroupId = $"consumer-preserve-{Guid.NewGuid():N}";
+        var partition = new TopicPartition(topic, 0);
+
+        await using (var consumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(shareGroupId)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync())
+        {
+            consumer.Subscribe(topic);
+            await ShareConsumerTestHelper.PrimeShareConsumerAsync(consumer);
+        }
+
+        await using var admin = KafkaContainer.CreateAdminClient();
+        await admin.AlterConsumerGroupOffsetsAsync(
+            consumerGroupId,
+            [new TopicPartitionOffset(topic, 0, 0)]);
+
+        var deletionResults = await WaitForConditionAsync(
+            () => admin.DeleteShareGroupsAsync([shareGroupId]).AsTask(),
+            results => results[shareGroupId].ErrorCode == Protocol.ErrorCode.None,
+            maxRetries: 12,
+            initialDelayMs: 250,
+            description: "share group to become empty and delete");
+
+        await Assert.That(deletionResults[shareGroupId].ErrorCode).IsEqualTo(Protocol.ErrorCode.None);
+
+        var shareGroups = await WaitForConditionAsync(
+            () => admin.ListShareGroupsAsync().AsTask(),
+            groups => groups.All(group => group.GroupId != shareGroupId),
+            maxRetries: 12,
+            initialDelayMs: 250,
+            description: "deleted share group to disappear");
+        await Assert.That(shareGroups.Any(group => group.GroupId == shareGroupId)).IsFalse();
+
+        var consumerOffsets = await admin.ListConsumerGroupOffsetsAsync(consumerGroupId);
+        await Assert.That(consumerOffsets).ContainsKey(partition);
+        await Assert.That(consumerOffsets[partition]).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task DescribeShareGroupOffsets_ReturnsStartOffsets()
     {
         // Arrange — create a share consumer and consume a record to establish offsets

--- a/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Dekaf.Admin;
 using Dekaf.Producer;
 using Dekaf.Serialization;
 using Dekaf.ShareConsumer;

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientDeleteShareGroupsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientDeleteShareGroupsTests.cs
@@ -1,0 +1,224 @@
+using Dekaf.Admin;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+public sealed class AdminClientDeleteShareGroupsTests
+{
+    private const string FirstGroupId = "share-a";
+    private const string SecondGroupId = "share-b";
+
+    [Test]
+    public async Task DeleteShareGroupsAsync_RejectsInvalidInput()
+    {
+        var (admin, _) = CreateAdmin();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await admin.DeleteShareGroupsAsync(null!));
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await admin.DeleteShareGroupsAsync([""]));
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await admin.DeleteShareGroupsAsync([FirstGroupId, FirstGroupId]));
+    }
+
+    [Test]
+    public async Task DeleteShareGroupsAsync_EmptyInputReturnsWithoutNetworkCall()
+    {
+        var (admin, connection) = CreateAdmin();
+
+        var results = await admin.DeleteShareGroupsAsync([]);
+
+        await Assert.That(results).IsEmpty();
+        await connection.DidNotReceive().SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+            Arg.Any<FindCoordinatorRequest>(),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task DeleteShareGroupsAsync_PreCancelledTokenStopsBeforeNetworkCall()
+    {
+        var (admin, connection) = CreateAdmin();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await admin.DeleteShareGroupsAsync([FirstGroupId], cancellation.Token));
+        await connection.DidNotReceive().SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+            Arg.Any<FindCoordinatorRequest>(),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task DeleteShareGroupsAsync_PreservesPerGroupResultsAndUsesGroupCoordinator()
+    {
+        var (admin, connection) = CreateAdmin();
+        SetupFindCoordinator(connection);
+        connection.SendAsync<DeleteGroupsRequest, DeleteGroupsResponse>(
+                Arg.Any<DeleteGroupsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new DeleteGroupsResponse
+            {
+                Results =
+                [
+                    Result(FirstGroupId, ErrorCode.None),
+                    Result(SecondGroupId, ErrorCode.NonEmptyGroup)
+                ]
+            }));
+
+        var results = await admin.DeleteShareGroupsAsync([FirstGroupId, SecondGroupId]);
+
+        await Assert.That(results[FirstGroupId].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(results[SecondGroupId].ErrorCode).IsEqualTo(ErrorCode.NonEmptyGroup);
+        await connection.Received(2).SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+            Arg.Is<FindCoordinatorRequest>(request =>
+                request != null && request.KeyType == CoordinatorType.Group),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+        await connection.Received(1).SendAsync<DeleteGroupsRequest, DeleteGroupsResponse>(
+            Arg.Is<DeleteGroupsRequest>(request =>
+                request != null &&
+                request.GroupsNames.Count == 2 &&
+                request.GroupsNames.Contains(FirstGroupId) &&
+                request.GroupsNames.Contains(SecondGroupId)),
+            2,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task DeleteShareGroupsAsync_TimeoutRetriesThenPropagates()
+    {
+        var (admin, connection) = CreateAdmin();
+        SetupFindCoordinator(connection);
+        connection.SendAsync<DeleteGroupsRequest, DeleteGroupsResponse>(
+                Arg.Any<DeleteGroupsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns<ValueTask<DeleteGroupsResponse>>(_ =>
+                throw new KafkaException(ErrorCode.RequestTimedOut, "simulated timeout"));
+
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await admin.DeleteShareGroupsAsync([FirstGroupId]));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RequestTimedOut);
+        await connection.Received(4).SendAsync<DeleteGroupsRequest, DeleteGroupsResponse>(
+            Arg.Any<DeleteGroupsRequest>(),
+            2,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task DeleteShareGroupsAsync_GroupNotFoundAfterAmbiguousSendIsSuccess()
+    {
+        var (admin, connection) = CreateAdmin();
+        SetupFindCoordinator(connection);
+        var calls = 0;
+        connection.SendAsync<DeleteGroupsRequest, DeleteGroupsResponse>(
+                Arg.Any<DeleteGroupsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (Interlocked.Increment(ref calls) == 1)
+                    throw new KafkaException(ErrorCode.RequestTimedOut, "simulated timeout");
+
+                return ValueTask.FromResult(new DeleteGroupsResponse
+                {
+                    Results = [Result(FirstGroupId, ErrorCode.GroupIdNotFound)]
+                });
+            });
+
+        var results = await admin.DeleteShareGroupsAsync([FirstGroupId]);
+
+        await Assert.That(results[FirstGroupId].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    private static DeleteGroupsResponseResult Result(string groupId, ErrorCode errorCode) => new()
+    {
+        GroupId = groupId,
+        ErrorCode = errorCode
+    };
+
+    private static void SetupFindCoordinator(IKafkaConnection connection)
+    {
+        connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<FindCoordinatorRequest>()!;
+                return ValueTask.FromResult(new FindCoordinatorResponse
+                {
+                    Coordinators =
+                    [
+                        new Coordinator
+                        {
+                            Key = request.Key,
+                            NodeId = 1,
+                            Host = "localhost",
+                            Port = 9092,
+                            ErrorCode = ErrorCode.None
+                        }
+                    ]
+                });
+            });
+    }
+
+    private static (AdminClient Admin, IKafkaConnection Connection) CreateAdmin()
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.BrokerId.Returns(1);
+        connection.Host.Returns("localhost");
+        connection.Port.Returns(9092);
+        connection.IsConnected.Returns(true);
+
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+        pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+
+        var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        metadataManager.Metadata.Update(CreateMetadataResponse());
+        metadataManager.SetApiVersion(ApiKey.Metadata, 9, 13);
+        metadataManager.SetApiVersion(ApiKey.FindCoordinator, 4, 6);
+        metadataManager.SetApiVersion(ApiKey.DeleteGroups, 2, 2);
+
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(CreateMetadataResponse()));
+
+        var admin = new AdminClient(
+            new AdminClientOptions { BootstrapServers = ["localhost:9092"] },
+            pool,
+            metadataManager);
+        return (admin, connection);
+    }
+
+    private static MetadataResponse CreateMetadataResponse() => new()
+    {
+        Brokers =
+        [
+            new BrokerMetadata
+            {
+                NodeId = 1,
+                Host = "localhost",
+                Port = 9092
+            }
+        ],
+        ClusterId = "test-cluster",
+        ControllerId = 1,
+        Topics = []
+    };
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientDeleteShareGroupsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientDeleteShareGroupsTests.cs
@@ -93,6 +93,57 @@ public sealed class AdminClientDeleteShareGroupsTests
     }
 
     [Test]
+    public async Task DeleteShareGroupsAsync_PreservesTerminalCoordinatorErrorPerGroup()
+    {
+        var (admin, connection) = CreateAdmin();
+        connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<FindCoordinatorRequest>()!;
+                return ValueTask.FromResult(new FindCoordinatorResponse
+                {
+                    Coordinators =
+                    [
+                        new Coordinator
+                        {
+                            Key = request.Key,
+                            NodeId = 1,
+                            Host = "localhost",
+                            Port = 9092,
+                            ErrorCode = request.Key == SecondGroupId
+                                ? ErrorCode.GroupAuthorizationFailed
+                                : ErrorCode.None
+                        }
+                    ]
+                });
+            });
+        connection.SendAsync<DeleteGroupsRequest, DeleteGroupsResponse>(
+                Arg.Any<DeleteGroupsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new DeleteGroupsResponse
+            {
+                Results = [Result(FirstGroupId, ErrorCode.None)]
+            }));
+
+        var results = await admin.DeleteShareGroupsAsync([FirstGroupId, SecondGroupId]);
+
+        await Assert.That(results[FirstGroupId].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(results[SecondGroupId].ErrorCode)
+            .IsEqualTo(ErrorCode.GroupAuthorizationFailed);
+        await connection.Received(1).SendAsync<DeleteGroupsRequest, DeleteGroupsResponse>(
+            Arg.Is<DeleteGroupsRequest>(request =>
+                request != null &&
+                request.GroupsNames.Count == 1 &&
+                request.GroupsNames[0] == FirstGroupId),
+            2,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     public async Task DeleteShareGroupsAsync_TimeoutRetriesThenPropagates()
     {
         var (admin, connection) = CreateAdmin();

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientDeleteShareGroupsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientDeleteShareGroupsTests.cs
@@ -141,6 +141,40 @@ public sealed class AdminClientDeleteShareGroupsTests
         await Assert.That(calls).IsEqualTo(2);
     }
 
+    [Test]
+    public async Task DeleteShareGroupsAsync_MissingResponseReturnsPerGroupError()
+    {
+        var (admin, connection) = CreateAdmin();
+        SetupFindCoordinator(connection);
+        connection.SendAsync<DeleteGroupsRequest, DeleteGroupsResponse>(
+                Arg.Any<DeleteGroupsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new DeleteGroupsResponse
+            {
+                Results = [Result(FirstGroupId, ErrorCode.None)]
+            }));
+
+        var results = await admin.DeleteShareGroupsAsync([FirstGroupId, SecondGroupId]);
+
+        await Assert.That(results[FirstGroupId].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(results[SecondGroupId].ErrorCode).IsEqualTo(ErrorCode.UnknownServerError);
+        await connection.Received(1).SendAsync<DeleteGroupsRequest, DeleteGroupsResponse>(
+            Arg.Any<DeleteGroupsRequest>(),
+            2,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task DeleteShareGroupsAsync_UnsupportedAdminClient_ThrowsNotSupportedException()
+    {
+        var admin = Substitute.For<IAdminClient>();
+
+        async Task Act() => await admin.DeleteShareGroupsAsync([FirstGroupId]);
+
+        await Assert.That(Act).Throws<NotSupportedException>();
+    }
+
     private static DeleteGroupsResponseResult Result(string groupId, ErrorCode errorCode) => new()
     {
         GroupId = groupId,

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryAsyncSerdeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryAsyncSerdeTests.cs
@@ -417,6 +417,49 @@ public sealed class InMemoryAsyncSerdeTests
     }
 
     [Test]
+    public async Task ShareConsumer_UnsubscribeDuringAsyncDeserializationRejectsStaleRecord()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var deserializer = new BlockingAsyncDeserializer();
+        await using var consumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            Serializers.String,
+            deserializer,
+            new InMemoryShareConsumerOptions { GroupId = "share-unsubscribe-race", MemberId = "first" });
+        var admin = new InMemoryAdminClient(cluster);
+
+        await producer.ProduceAsync("shared", "k", "v");
+        consumer.Subscribe("shared");
+        var poll = consumer.PollAsync().FirstAsync().AsTask();
+        try
+        {
+            await deserializer.Entered.WaitAsync(TimeSpan.FromSeconds(5));
+            consumer.Unsubscribe();
+        }
+        finally
+        {
+            deserializer.Release();
+        }
+
+        await Assert.That(async () => await poll).Throws<InvalidOperationException>();
+        await consumer.CommitAsync();
+        await Assert.That(await admin.DescribeShareGroupOffsetsAsync("share-unsubscribe-race")).IsEmpty();
+
+        await using var otherConsumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "share-unsubscribe-race", MemberId = "second" });
+        otherConsumer.Subscribe("shared");
+        var redelivery = await otherConsumer.PollAsync()
+            .FirstAsync()
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(redelivery.Offset).IsEqualTo(0);
+        await Assert.That(redelivery.DeliveryCount).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task ShareConsumer_SyncDeserializerFailure_ReleasesRecordForOtherMembers()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryAsyncSerdeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryAsyncSerdeTests.cs
@@ -4,6 +4,7 @@ using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Producer;
+using Dekaf.Protocol;
 using Dekaf.Serialization;
 using Dekaf.ShareConsumer;
 using Dekaf.Testing;
@@ -380,6 +381,42 @@ public sealed class InMemoryAsyncSerdeTests
     }
 
     [Test]
+    public async Task ShareConsumer_CloseDuringAsyncDeserialization_ReleasesAcquiredRecord()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var deserializer = new BlockingAsyncDeserializer();
+        var consumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            Serializers.String,
+            deserializer,
+            new InMemoryShareConsumerOptions { GroupId = "share-close-race" });
+        var admin = new InMemoryAdminClient(cluster);
+
+        await producer.ProduceAsync("shared", "k", "v");
+        consumer.Subscribe("shared");
+
+        var poll = consumer.PollAsync().FirstAsync().AsTask();
+        try
+        {
+            await deserializer.Entered.WaitAsync(TimeSpan.FromSeconds(5));
+            await consumer.CloseAsync();
+
+            var activeDeletion = await admin.DeleteShareGroupsAsync(["share-close-race"]);
+            await Assert.That(activeDeletion["share-close-race"].ErrorCode).IsEqualTo(ErrorCode.NonEmptyGroup);
+        }
+        finally
+        {
+            deserializer.Release();
+        }
+
+        await Assert.That(async () => await poll).Throws<ObjectDisposedException>();
+
+        var deletion = await admin.DeleteShareGroupsAsync(["share-close-race"]);
+        await Assert.That(deletion["share-close-race"].ErrorCode).IsEqualTo(ErrorCode.None);
+    }
+
+    [Test]
     public async Task ShareConsumer_SyncDeserializerFailure_ReleasesRecordForOtherMembers()
     {
         var cluster = new InMemoryKafkaCluster();
@@ -444,6 +481,28 @@ public sealed class InMemoryAsyncSerdeTests
             Context = context;
             return Encoding.UTF8.GetString(data.Span);
         }
+    }
+
+    private sealed class BlockingAsyncDeserializer : IAsyncDeserializer<string>
+    {
+        private readonly TaskCompletionSource _entered = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task Entered => _entered.Task;
+
+        public async ValueTask<string> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            _entered.TrySetResult();
+            await _release.Task.WaitAsync(cancellationToken);
+            return Encoding.UTF8.GetString(data.Span);
+        }
+
+        public void Release() => _release.TrySetResult();
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryAsyncSerdeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryAsyncSerdeTests.cs
@@ -297,13 +297,13 @@ public sealed class InMemoryAsyncSerdeTests
         shareConsumer.Acknowledge(record);
         await shareConsumer.CommitAsync();
 
-        var offsets = await admin.ListConsumerGroupOffsetsAsync("async-share");
+        var offsets = await admin.DescribeShareGroupOffsetsAsync("async-share");
 
         await Assert.That(record.Key).IsEqualTo("k");
         await Assert.That(record.Value).IsEqualTo("v");
         await Assert.That(Encoding.UTF8.GetString(serde.LastDeserializeContext.KeyData.Span)).IsEqualTo("v:k");
         await Assert.That(serde.LastDeserializeContext.IsKeyNull).IsFalse();
-        await Assert.That(offsets[new TopicPartition("shared", 0)]).IsEqualTo(1);
+        await Assert.That(offsets.Single().StartOffset).IsEqualTo(1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -836,6 +836,29 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task Admin_ListShareGroupsHonorsStateFilter()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("shared", 0);
+        await admin.AlterShareGroupOffsetsAsync(
+            "offset-only",
+            [new ShareGroupOffsetAlteration { TopicPartition = partition, StartOffset = 3 }]);
+
+        var excluded = await admin.ListShareGroupsAsync(new ListShareGroupsOptions
+        {
+            States = ["Empty"]
+        });
+        var included = await admin.ListShareGroupsAsync(new ListShareGroupsOptions
+        {
+            States = ["stable"]
+        });
+
+        await Assert.That(excluded).IsEmpty();
+        await Assert.That(included.Select(static group => group.GroupId)).IsEquivalentTo(["offset-only"]);
+    }
+
+    [Test]
     public async Task Admin_DeleteLastShareGroupOffsetRemovesGroupState()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -786,6 +786,42 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task Admin_DeleteShareGroupsDeletesOnlyRequestedGroups()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("shared", 0);
+        await admin.AlterShareGroupOffsetsAsync(
+            "share-delete",
+            [new ShareGroupOffsetAlteration { TopicPartition = partition, StartOffset = 3 }]);
+        await admin.AlterConsumerGroupOffsetsAsync(
+            "consumer-preserve",
+            [new TopicPartitionOffset(partition.Topic, partition.Partition, 7)]);
+
+        var results = await admin.DeleteShareGroupsAsync(["share-delete"]);
+
+        await Assert.That(results["share-delete"].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(await admin.ListConsumerGroupOffsetsAsync("share-delete")).IsEmpty();
+        await Assert.That((await admin.ListConsumerGroupOffsetsAsync("consumer-preserve"))[partition]).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task Admin_DeleteShareGroupsValidatesBatchBeforeDeleting()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("shared", 0);
+        await admin.AlterShareGroupOffsetsAsync(
+            "share-preserve",
+            [new ShareGroupOffsetAlteration { TopicPartition = partition, StartOffset = 3 }]);
+
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await admin.DeleteShareGroupsAsync(["share-preserve", "share-preserve"]));
+
+        await Assert.That((await admin.ListConsumerGroupOffsetsAsync("share-preserve"))[partition]).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task ShareConsumer_ReleaseGapStopsContiguousCommit()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -778,11 +778,11 @@ public sealed class InMemoryKafkaClusterTests
         shareConsumer.Acknowledge(second);
         await shareConsumer.CommitAsync();
         var admin = new InMemoryAdminClient(cluster);
-        var offsets = await admin.ListConsumerGroupOffsetsAsync("share-workers");
+        var offsets = await admin.DescribeShareGroupOffsetsAsync("share-workers");
 
         await Assert.That(first.Offset).IsEqualTo(0);
         await Assert.That(second.Offset).IsEqualTo(0);
-        await Assert.That(offsets[new TopicPartition("shared", 0)]).IsEqualTo(1);
+        await Assert.That(offsets.Single().StartOffset).IsEqualTo(1);
     }
 
     [Test]
@@ -792,17 +792,17 @@ public sealed class InMemoryKafkaClusterTests
         var admin = new InMemoryAdminClient(cluster);
         var partition = new TopicPartition("shared", 0);
         await admin.AlterShareGroupOffsetsAsync(
-            "share-delete",
+            "shared-id",
             [new ShareGroupOffsetAlteration { TopicPartition = partition, StartOffset = 3 }]);
         await admin.AlterConsumerGroupOffsetsAsync(
-            "consumer-preserve",
+            "shared-id",
             [new TopicPartitionOffset(partition.Topic, partition.Partition, 7)]);
 
-        var results = await admin.DeleteShareGroupsAsync(["share-delete"]);
+        var results = await admin.DeleteShareGroupsAsync(["shared-id"]);
 
-        await Assert.That(results["share-delete"].ErrorCode).IsEqualTo(ErrorCode.None);
-        await Assert.That(await admin.ListConsumerGroupOffsetsAsync("share-delete")).IsEmpty();
-        await Assert.That((await admin.ListConsumerGroupOffsetsAsync("consumer-preserve"))[partition]).IsEqualTo(7);
+        await Assert.That(results["shared-id"].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(await admin.DescribeShareGroupOffsetsAsync("shared-id")).IsEmpty();
+        await Assert.That((await admin.ListConsumerGroupOffsetsAsync("shared-id"))[partition]).IsEqualTo(7);
     }
 
     [Test]
@@ -818,7 +818,8 @@ public sealed class InMemoryKafkaClusterTests
         await Assert.ThrowsAsync<ArgumentException>(async () =>
             await admin.DeleteShareGroupsAsync(["share-preserve", "share-preserve"]));
 
-        await Assert.That((await admin.ListConsumerGroupOffsetsAsync("share-preserve"))[partition]).IsEqualTo(3);
+        await Assert.That((await admin.DescribeShareGroupOffsetsAsync("share-preserve")).Single().StartOffset)
+            .IsEqualTo(3);
     }
 
     [Test]
@@ -838,7 +839,8 @@ public sealed class InMemoryKafkaClusterTests
         var activeResult = await admin.DeleteShareGroupsAsync(["share-active"]);
 
         await Assert.That(activeResult["share-active"].ErrorCode).IsEqualTo(ErrorCode.NonEmptyGroup);
-        await Assert.That((await admin.ListConsumerGroupOffsetsAsync("share-active"))[partition]).IsEqualTo(3);
+        await Assert.That((await admin.DescribeShareGroupOffsetsAsync("share-active")).Single().StartOffset)
+            .IsEqualTo(3);
 
         await consumer.CloseAsync();
         var inactiveResult = await admin.DeleteShareGroupsAsync(["share-active"]);
@@ -909,10 +911,10 @@ public sealed class InMemoryKafkaClusterTests
 
         var redelivered = await shareConsumer.PollAsync().FirstAsync();
         var admin = new InMemoryAdminClient(cluster);
-        var offsets = await admin.ListConsumerGroupOffsetsAsync("share-gap");
+        var offsets = await admin.DescribeShareGroupOffsetsAsync("share-gap");
 
         await Assert.That(records.Select(record => record.Offset).ToArray()).IsEquivalentTo([0L, 1L, 2L]);
-        await Assert.That(offsets[new TopicPartition("shared", 0)]).IsEqualTo(1);
+        await Assert.That(offsets.Single().StartOffset).IsEqualTo(1);
         await Assert.That(redelivered.Offset).IsEqualTo(1);
     }
 

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -883,6 +883,37 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task Admin_DeleteShareGroupsWaitsForEverySharedMemberRegistration()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("shared", 0);
+        await admin.AlterShareGroupOffsetsAsync(
+            "shared-member-id",
+            [new ShareGroupOffsetAlteration { TopicPartition = partition, StartOffset = 3 }]);
+        await using var first = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "shared-member-id", MemberId = "worker" });
+        await using var second = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "shared-member-id", MemberId = "worker" });
+        first.Subscribe("shared");
+        second.Subscribe("shared");
+
+        await first.CloseAsync();
+        var activeResult = await admin.DeleteShareGroupsAsync(["shared-member-id"]);
+
+        await Assert.That(activeResult["shared-member-id"].ErrorCode).IsEqualTo(ErrorCode.NonEmptyGroup);
+        await Assert.That((await admin.DescribeShareGroupOffsetsAsync("shared-member-id")).Single().StartOffset)
+            .IsEqualTo(3);
+
+        await second.CloseAsync();
+        var inactiveResult = await admin.DeleteShareGroupsAsync(["shared-member-id"]);
+
+        await Assert.That(inactiveResult["shared-member-id"].ErrorCode).IsEqualTo(ErrorCode.None);
+    }
+
+    [Test]
     public async Task Admin_DeleteShareGroupsClearsShareDeliveryCounts()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -945,6 +945,46 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task ShareConsumer_ClosedMemberCannotRecreateDeletedGroupState()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("shared", 0);
+        await producer.ProduceAsync(partition.Topic, "k", "v");
+        await admin.AlterShareGroupOffsetsAsync(
+            "deleted-share",
+            [new ShareGroupOffsetAlteration { TopicPartition = partition, StartOffset = 0 }]);
+        await using var consumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "deleted-share" });
+        consumer.Subscribe(partition.Topic);
+        var memberId = consumer.MemberId!;
+
+        await consumer.CloseAsync();
+        var deletion = await admin.DeleteShareGroupsAsync(["deleted-share"]);
+        var acquired = cluster.TryAcquireShareRecord(
+            "deleted-share",
+            memberId,
+            partition,
+            offset: 0,
+            out _,
+            out _);
+
+        await Assert.That(deletion["deleted-share"].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(acquired).IsFalse();
+        await Assert.That(await admin.ListShareGroupsAsync()).IsEmpty();
+
+        await using var recreatedConsumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "deleted-share" });
+        recreatedConsumer.Subscribe(partition.Topic);
+        var delivery = await recreatedConsumer.PollAsync().FirstAsync();
+
+        await Assert.That(delivery.DeliveryCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ShareConsumer_ReleaseGapStopsContiguousCommit()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -822,6 +822,62 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task Admin_DeleteShareGroupsRejectsActiveGroup()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("shared", 0);
+        await admin.AlterShareGroupOffsetsAsync(
+            "share-active",
+            [new ShareGroupOffsetAlteration { TopicPartition = partition, StartOffset = 3 }]);
+        await using var consumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "share-active" });
+        consumer.Subscribe("shared");
+
+        var activeResult = await admin.DeleteShareGroupsAsync(["share-active"]);
+
+        await Assert.That(activeResult["share-active"].ErrorCode).IsEqualTo(ErrorCode.NonEmptyGroup);
+        await Assert.That((await admin.ListConsumerGroupOffsetsAsync("share-active"))[partition]).IsEqualTo(3);
+
+        await consumer.CloseAsync();
+        var inactiveResult = await admin.DeleteShareGroupsAsync(["share-active"]);
+
+        await Assert.That(inactiveResult["share-active"].ErrorCode).IsEqualTo(ErrorCode.None);
+    }
+
+    [Test]
+    public async Task Admin_DeleteShareGroupsClearsShareDeliveryCounts()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var admin = new InMemoryAdminClient(cluster);
+        await producer.ProduceAsync("shared", "k", "v");
+
+        await using (var firstConsumer = new InMemoryShareConsumer<string, string>(
+                         cluster,
+                         new InMemoryShareConsumerOptions { GroupId = "share-recreated" }))
+        {
+            firstConsumer.Subscribe("shared");
+            var firstDelivery = await firstConsumer.PollAsync().FirstAsync();
+            await Assert.That(firstDelivery.DeliveryCount).IsEqualTo(1);
+            firstConsumer.Acknowledge(firstDelivery, AcknowledgeType.Release);
+            await firstConsumer.CommitAsync();
+        }
+
+        var deletion = await admin.DeleteShareGroupsAsync(["share-recreated"]);
+        await Assert.That(deletion["share-recreated"].ErrorCode).IsEqualTo(ErrorCode.None);
+
+        await using var recreatedConsumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "share-recreated" });
+        recreatedConsumer.Subscribe("shared");
+        var recreatedDelivery = await recreatedConsumer.PollAsync().FirstAsync();
+
+        await Assert.That(recreatedDelivery.DeliveryCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ShareConsumer_ReleaseGapStopsContiguousCommit()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -1087,6 +1087,57 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task ShareConsumer_StaleRegistrationCannotReleaseReplacementLease()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var partition = new TopicPartition("shared", 0);
+        await producer.ProduceAsync(partition.Topic, "k", "v");
+        const string groupId = "shared-group";
+        const string memberId = "shared-member";
+        var staleRegistration = cluster.RegisterShareGroupMember(groupId, memberId);
+        var staleAcquired = cluster.TryAcquireShareRecord(
+            groupId,
+            memberId,
+            staleRegistration,
+            partition,
+            offset: 0,
+            out var record,
+            out _);
+        await Assert.That(staleAcquired).IsTrue();
+
+        var replacementRegistration = cluster.RegisterShareGroupMember(groupId, memberId);
+        cluster.UnregisterShareGroupMember(groupId, memberId, staleRegistration);
+        var replacementAcquired = cluster.TryAcquireShareRecord(
+            groupId,
+            memberId,
+            replacementRegistration,
+            partition,
+            offset: 0,
+            out _,
+            out _);
+        await Assert.That(replacementAcquired).IsTrue();
+
+        cluster.ReleaseShareRecords(
+            groupId,
+            memberId,
+            staleRegistration,
+            [new TopicPartitionOffset(partition.Topic, partition.Partition, record.Offset)]);
+        const string thirdMemberId = "third-member";
+        var thirdRegistration = cluster.RegisterShareGroupMember(groupId, thirdMemberId);
+        var thirdAcquired = cluster.TryAcquireShareRecord(
+            groupId,
+            thirdMemberId,
+            thirdRegistration,
+            partition,
+            offset: 0,
+            out _,
+            out _);
+
+        await Assert.That(thirdAcquired).IsFalse();
+    }
+
+    [Test]
     public async Task ShareConsumer_ReleaseGapStopsContiguousCommit()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -827,12 +827,20 @@ public sealed class InMemoryKafkaClusterTests
         await Assert.That(activeGroups.Select(static group => group.GroupId))
             .IsEquivalentTo(["member-only", "offset-only"]);
         await Assert.That(activeGroups.All(static group => group.ProtocolType == "share")).IsTrue();
+        await Assert.That(activeGroups.Single(static group => group.GroupId == "member-only").State)
+            .IsEqualTo("Stable");
+        await Assert.That(activeGroups.Single(static group => group.GroupId == "offset-only").State)
+            .IsEqualTo("Empty");
 
         await consumer.CloseAsync();
         var inactiveGroups = await admin.ListShareGroupsAsync();
 
         await Assert.That(inactiveGroups.Select(static group => group.GroupId))
-            .IsEquivalentTo(["offset-only"]);
+            .IsEquivalentTo(["member-only", "offset-only"]);
+        await Assert.That(inactiveGroups.All(static group => group.State == "Empty")).IsTrue();
+
+        var deletion = await admin.DeleteShareGroupsAsync(["member-only"]);
+        await Assert.That(deletion["member-only"].ErrorCode).IsEqualTo(ErrorCode.None);
     }
 
     [Test]
@@ -844,18 +852,38 @@ public sealed class InMemoryKafkaClusterTests
         await admin.AlterShareGroupOffsetsAsync(
             "offset-only",
             [new ShareGroupOffsetAlteration { TopicPartition = partition, StartOffset = 3 }]);
+        await using var consumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "member-only" });
+        consumer.Subscribe(partition.Topic);
 
-        var excluded = await admin.ListShareGroupsAsync(new ListShareGroupsOptions
+        var emptyGroups = await admin.ListShareGroupsAsync(new ListShareGroupsOptions
         {
             States = ["Empty"]
         });
-        var included = await admin.ListShareGroupsAsync(new ListShareGroupsOptions
+        var stableGroups = await admin.ListShareGroupsAsync(new ListShareGroupsOptions
         {
             States = ["stable"]
         });
 
-        await Assert.That(excluded).IsEmpty();
-        await Assert.That(included.Select(static group => group.GroupId)).IsEquivalentTo(["offset-only"]);
+        await Assert.That(emptyGroups.Select(static group => group.GroupId))
+            .IsEquivalentTo(["offset-only"]);
+        await Assert.That(stableGroups.Select(static group => group.GroupId))
+            .IsEquivalentTo(["member-only"]);
+    }
+
+    [Test]
+    public async Task Admin_AlterEmptyShareGroupOffsetsDoesNotCreateGroup()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var admin = new InMemoryAdminClient(cluster);
+
+        await admin.AlterShareGroupOffsetsAsync("phantom", []);
+        var groups = await admin.ListShareGroupsAsync();
+        var deletion = await admin.DeleteShareGroupsAsync(["phantom"]);
+
+        await Assert.That(groups).IsEmpty();
+        await Assert.That(deletion["phantom"].ErrorCode).IsEqualTo(ErrorCode.GroupIdNotFound);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -876,6 +876,10 @@ public sealed class InMemoryKafkaClusterTests
         var inactiveResult = await admin.DeleteShareGroupsAsync(["share-active"]);
 
         await Assert.That(inactiveResult["share-active"].ErrorCode).IsEqualTo(ErrorCode.None);
+
+        var missingResult = await admin.DeleteShareGroupsAsync(["share-active"]);
+
+        await Assert.That(missingResult["share-active"].ErrorCode).IsEqualTo(ErrorCode.GroupIdNotFound);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -823,6 +823,7 @@ public sealed class InMemoryKafkaClusterTests
         consumer.Subscribe("shared");
 
         var activeGroups = await admin.ListShareGroupsAsync();
+        var activeDescriptions = await admin.DescribeShareGroupsAsync(["member-only", "offset-only"]);
 
         await Assert.That(activeGroups.Select(static group => group.GroupId))
             .IsEquivalentTo(["member-only", "offset-only"]);
@@ -831,13 +832,17 @@ public sealed class InMemoryKafkaClusterTests
             .IsEqualTo("Stable");
         await Assert.That(activeGroups.Single(static group => group.GroupId == "offset-only").State)
             .IsEqualTo("Empty");
+        await Assert.That(activeDescriptions["member-only"].GroupState).IsEqualTo("Stable");
+        await Assert.That(activeDescriptions["offset-only"].GroupState).IsEqualTo("Empty");
 
         await consumer.CloseAsync();
         var inactiveGroups = await admin.ListShareGroupsAsync();
+        var inactiveDescriptions = await admin.DescribeShareGroupsAsync(["member-only", "offset-only"]);
 
         await Assert.That(inactiveGroups.Select(static group => group.GroupId))
             .IsEquivalentTo(["member-only", "offset-only"]);
         await Assert.That(inactiveGroups.All(static group => group.State == "Empty")).IsTrue();
+        await Assert.That(inactiveDescriptions.Values.All(static group => group.GroupState == "Empty")).IsTrue();
 
         var deletion = await admin.DeleteShareGroupsAsync(["member-only"]);
         await Assert.That(deletion["member-only"].ErrorCode).IsEqualTo(ErrorCode.None);

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -955,17 +955,15 @@ public sealed class InMemoryKafkaClusterTests
         await admin.AlterShareGroupOffsetsAsync(
             "deleted-share",
             [new ShareGroupOffsetAlteration { TopicPartition = partition, StartOffset = 0 }]);
-        await using var consumer = new InMemoryShareConsumer<string, string>(
-            cluster,
-            new InMemoryShareConsumerOptions { GroupId = "deleted-share" });
-        consumer.Subscribe(partition.Topic);
-        var memberId = consumer.MemberId!;
+        const string memberId = "closed-member";
+        var registration = cluster.RegisterShareGroupMember("deleted-share", memberId);
 
-        await consumer.CloseAsync();
+        cluster.UnregisterShareGroupMember("deleted-share", memberId, registration);
         var deletion = await admin.DeleteShareGroupsAsync(["deleted-share"]);
         var acquired = cluster.TryAcquireShareRecord(
             "deleted-share",
             memberId,
+            registration,
             partition,
             offset: 0,
             out _,
@@ -982,6 +980,38 @@ public sealed class InMemoryKafkaClusterTests
         var delivery = await recreatedConsumer.PollAsync().FirstAsync();
 
         await Assert.That(delivery.DeliveryCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ShareConsumer_DuplicateMemberRegistrationsUseIndependentTokens()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var partition = new TopicPartition("shared", 0);
+        await producer.ProduceAsync(partition.Topic, "k", "v");
+        var closedRegistration = cluster.RegisterShareGroupMember("shared-group", "shared-member");
+        var activeRegistration = cluster.RegisterShareGroupMember("shared-group", "shared-member");
+
+        cluster.UnregisterShareGroupMember("shared-group", "shared-member", closedRegistration);
+        var closedAcquired = cluster.TryAcquireShareRecord(
+            "shared-group",
+            "shared-member",
+            closedRegistration,
+            partition,
+            offset: 0,
+            out _,
+            out _);
+        var activeAcquired = cluster.TryAcquireShareRecord(
+            "shared-group",
+            "shared-member",
+            activeRegistration,
+            partition,
+            offset: 0,
+            out _,
+            out _);
+
+        await Assert.That(closedAcquired).IsFalse();
+        await Assert.That(activeAcquired).IsTrue();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -836,6 +836,78 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task Admin_DeleteLastShareGroupOffsetRemovesGroupState()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("shared", 0);
+        await admin.AlterShareGroupOffsetsAsync(
+            "offset-only",
+            [new ShareGroupOffsetAlteration { TopicPartition = partition, StartOffset = 3 }]);
+
+        await admin.DeleteShareGroupOffsetsAsync("offset-only", [partition.Topic]);
+        var groups = await admin.ListShareGroupsAsync();
+        var deletion = await admin.DeleteShareGroupsAsync(["offset-only"]);
+
+        await Assert.That(groups).IsEmpty();
+        await Assert.That(deletion["offset-only"].ErrorCode).IsEqualTo(ErrorCode.GroupIdNotFound);
+    }
+
+    [Test]
+    public async Task ShareConsumer_SubscribeCannotRegisterAfterConcurrentClose()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var admin = new InMemoryAdminClient(cluster);
+        var consumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "subscribe-close-race" });
+        await producer.ProduceAsync("shared", "k", "v");
+        var gate = typeof(InMemoryShareConsumer<string, string>).GetField(
+            "_gate",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(consumer)!;
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                consumer.Subscribe("shared");
+                completion.SetResult();
+            }
+            catch (Exception exception)
+            {
+                completion.SetException(exception);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "in-memory-share-subscribe-test-worker"
+        };
+        var gateHeld = false;
+        bool subscribeReachedGate;
+        try
+        {
+            Monitor.Enter(gate, ref gateHeld);
+            thread.Start();
+            subscribeReachedGate = SpinWait.SpinUntil(
+                () => thread.ThreadState.HasFlag(System.Threading.ThreadState.WaitSleepJoin),
+                TimeSpan.FromSeconds(5));
+            consumer.CloseAsync().AsTask().GetAwaiter().GetResult();
+        }
+        finally
+        {
+            if (gateHeld)
+                Monitor.Exit(gate);
+        }
+
+        await Assert.That(subscribeReachedGate).IsTrue();
+        await Assert.That(async () => await completion.Task.WaitAsync(TimeSpan.FromSeconds(5)))
+            .Throws<ObjectDisposedException>();
+        var deletion = await admin.DeleteShareGroupsAsync(["subscribe-close-race"]);
+        await Assert.That(deletion["subscribe-close-race"].ErrorCode).IsEqualTo(ErrorCode.GroupIdNotFound);
+    }
+
+    [Test]
     public async Task Admin_DeleteShareGroupsValidatesBatchBeforeDeleting()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -806,6 +806,36 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task Admin_ListShareGroupsUsesOnlyShareState()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("shared", 0);
+        await admin.AlterShareGroupOffsetsAsync(
+            "offset-only",
+            [new ShareGroupOffsetAlteration { TopicPartition = partition, StartOffset = 3 }]);
+        await admin.AlterConsumerGroupOffsetsAsync(
+            "consumer-only",
+            [new TopicPartitionOffset(partition.Topic, partition.Partition, 7)]);
+        await using var consumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "member-only" });
+        consumer.Subscribe("shared");
+
+        var activeGroups = await admin.ListShareGroupsAsync();
+
+        await Assert.That(activeGroups.Select(static group => group.GroupId))
+            .IsEquivalentTo(["member-only", "offset-only"]);
+        await Assert.That(activeGroups.All(static group => group.ProtocolType == "share")).IsTrue();
+
+        await consumer.CloseAsync();
+        var inactiveGroups = await admin.ListShareGroupsAsync();
+
+        await Assert.That(inactiveGroups.Select(static group => group.GroupId))
+            .IsEquivalentTo(["offset-only"]);
+    }
+
+    [Test]
     public async Task Admin_DeleteShareGroupsValidatesBatchBeforeDeleting()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -1103,8 +1103,9 @@ public sealed class InMemoryKafkaClusterTests
             partition,
             offset: 0,
             out var record,
-            out _);
+            out var staleDeliveryCount);
         await Assert.That(staleAcquired).IsTrue();
+        await Assert.That(staleDeliveryCount).IsEqualTo(1);
 
         var replacementRegistration = cluster.RegisterShareGroupMember(groupId, memberId);
         cluster.UnregisterShareGroupMember(groupId, memberId, staleRegistration);
@@ -1115,8 +1116,9 @@ public sealed class InMemoryKafkaClusterTests
             partition,
             offset: 0,
             out _,
-            out _);
+            out var replacementDeliveryCount);
         await Assert.That(replacementAcquired).IsTrue();
+        await Assert.That(replacementDeliveryCount).IsEqualTo(2);
 
         cluster.ReleaseShareRecords(
             groupId,

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryShareRecordAcquisitionBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryShareRecordAcquisitionBenchmarks.cs
@@ -5,7 +5,8 @@ using Dekaf.Testing;
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
 [MemoryDiagnoser]
-[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+[MinIterationTime(500)]
+[SimpleJob(RunStrategy.Throughput, launchCount: 3, warmupCount: 8, iterationCount: 12)]
 public class InMemoryShareRecordAcquisitionBenchmarks
 {
     private const int OperationsPerInvoke = 1024;

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryShareRecordAcquisitionBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryShareRecordAcquisitionBenchmarks.cs
@@ -1,0 +1,46 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Testing;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class InMemoryShareRecordAcquisitionBenchmarks
+{
+    private const int OperationsPerInvoke = 1024;
+    private const string GroupId = "benchmark-group";
+    private const string MemberId = "benchmark-member";
+    private readonly InMemoryKafkaCluster _cluster = new();
+    private readonly TopicPartition _topicPartition = new("benchmark-topic", 0);
+    private ShareGroupMemberRegistration _registration = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _cluster.CreateTopic(_topicPartition.Topic);
+        _registration = _cluster.RegisterShareGroupMember(GroupId, MemberId);
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public int ActiveMemberMissingRecord()
+    {
+        var acquired = 0;
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            if (_cluster.TryAcquireShareRecord(
+                    GroupId,
+                    MemberId,
+                    _registration,
+                    _topicPartition,
+                    offset: 0,
+                    out _,
+                    out _))
+            {
+                acquired++;
+            }
+        }
+
+        return acquired;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryShareRecordAcquisitionBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryShareRecordAcquisitionBenchmarks.cs
@@ -14,17 +14,42 @@ public class InMemoryShareRecordAcquisitionBenchmarks
     private const string MemberId = "benchmark-member";
     private readonly InMemoryKafkaCluster _cluster = new();
     private readonly TopicPartition _topicPartition = new("benchmark-topic", 0);
+    private TopicPartitionOffset[] _benchmarkLeases = null!;
     private ShareGroupMemberRegistration _registration = null!;
 
     [GlobalSetup]
-    public void Setup()
+    public async Task Setup()
     {
         _cluster.CreateTopic(_topicPartition.Topic);
         _registration = _cluster.RegisterShareGroupMember(GroupId, MemberId);
+        _benchmarkLeases = new TopicPartitionOffset[OperationsPerInvoke];
+        await using var producer = new InMemoryProducer<byte[], byte[]>(_cluster);
+        await producer.ProduceAsync(_topicPartition.Topic, [], []).ConfigureAwait(false);
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            await producer.ProduceAsync(_topicPartition.Topic, [], []).ConfigureAwait(false);
+            _benchmarkLeases[i] = new TopicPartitionOffset(
+                _topicPartition.Topic,
+                _topicPartition.Partition,
+                i + 1);
+        }
+
+        _cluster.TryAcquireShareRecord(
+            GroupId,
+            MemberId,
+            _registration,
+            _topicPartition,
+            offset: 0,
+            out _,
+            out _);
     }
 
+    [IterationSetup]
+    public void ResetBenchmarkLease() =>
+        _cluster.ReleaseShareRecords(GroupId, MemberId, _registration, _benchmarkLeases);
+
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public int ActiveMemberMissingRecord()
+    public int ActiveMemberSuccessfulAcquisition()
     {
         var acquired = 0;
         for (var i = 0; i < OperationsPerInvoke; i++)
@@ -34,7 +59,7 @@ public class InMemoryShareRecordAcquisitionBenchmarks
                     MemberId,
                     _registration,
                     _topicPartition,
-                    offset: 0,
+                    offset: i + 1,
                     out _,
                     out _))
             {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryShareRecordAcquisitionBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryShareRecordAcquisitionBenchmarks.cs
@@ -5,11 +5,10 @@ using Dekaf.Testing;
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
 [MemoryDiagnoser]
-[MinIterationTime(500)]
-[SimpleJob(RunStrategy.Throughput, launchCount: 3, warmupCount: 8, iterationCount: 12)]
+[SimpleJob(RunStrategy.Throughput, launchCount: 5, warmupCount: 8, iterationCount: 20)]
 public class InMemoryShareRecordAcquisitionBenchmarks
 {
-    private const int OperationsPerInvoke = 1024;
+    private const int OperationsPerInvoke = 8192;
     private const string GroupId = "benchmark-group";
     private const string MemberId = "benchmark-member";
     private readonly InMemoryKafkaCluster _cluster = new();


### PR DESCRIPTION
Closes #2839

## Summary
- add interface-first batch DeleteShareGroupsAsync with cancellation
- route by Group coordinator and send DeleteGroups v2
- preserve per-group success/failure results across retries
- add InMemoryAdminClient parity, public API baselines, and docs

## Validation
- unit build: net10.0 + net8.0, 0 warnings/errors
- full unit: net10.0 7797 passed; net8.0 7661 passed
- focused delete tests: 6 passed on each TFM
- Kafka 4.3.1 integration: 1 passed
- git diff --check: clean

## Performance
No benchmark: Admin control-plane operation only; no serialization, production, consumption, batch, channel, or receive hot path changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added share-group deletion with per-group results, validation, retries, and error reporting.
  - Added topic description and deletion by ID.
  - Added transaction force-termination support.
  - Added safe deletion of inactive share groups while preserving consumer-group offsets.
  - Added membership tracking and delivery-count reset when groups are recreated.
- **Documentation**
  - Documented deletion errors, retry exhaustion, duplicate-ID validation, and administration access.
- **Tests**
  - Added coverage for administration operations, deletion behavior, retries, validation, offsets, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->