### PR TITLE
docs(consumer): decide classic protocol support

### DIFF
--- a/docs/docs/configuration/confluent-migration.md
+++ b/docs/docs/configuration/confluent-migration.md
@@ -195,6 +195,10 @@ partitioner values are `Random`, `Consistent`, `ConsistentRandom`, `Murmur2`, `M
 librdkafka delivery semantics, the adapter selects `OffsetStoreTiming.OnDelivery`. Configure
 Dekaf natively instead when you want its safer processing-completion semantics.
 
+`GroupProtocol=Classic` is rejected by design, not silently translated. See the
+[Classic protocol support decision](../consumer/consumer-groups.md#classic-protocol-support-decision)
+for the Kafka roadmap, migration alternatives, and reopen gates.
+
 ## CoreWCF Kafka migration
 
 CoreWCF's [Kafka transport binding](https://corewcf.github.io/blog/2023/10/21/kafkabinding)

--- a/docs/docs/consumer/consumer-groups.md
+++ b/docs/docs/consumer/consumer-groups.md
@@ -303,8 +303,9 @@ compatibility boundary, not a missing configuration switch:
   [KIP-1274](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/406619710/KIP-1274%2BDeprecate%2Band%2Bremove%2Bsupport%2Bfor%2BClassic%2Brebalance%2Bprotocol%2Bin%2BKafkaConsumer)
   recommends the Consumer protocol in Kafka 4.3, changes the Java consumer default and
   deprecates Classic in Kafka 5.0, and removes public KafkaConsumer Classic support in Kafka
-  6.0. Adding a second coordinator now would target an upstream client protocol scheduled for
-  removal.
+  6.0. These are planned milestones under the accepted KIP-1274 roadmap, not fixed release
+  commitments. Adding a second coordinator now would target an upstream client protocol planned
+  for removal.
 - Kafka supports online upgrade and downgrade between compatible Classic and Consumer group
   members. Dekaf tests both directions, so rolling migration does not require a permanent
   Classic implementation in Dekaf.
@@ -315,8 +316,11 @@ compatibility boundary, not a missing configuration switch:
 Applications that require Kafka 3.x, custom client-side assignor metadata, or a broker with
 Consumer groups disabled should use a Classic-compatible client while migrating. Manual
 assignment bypasses group membership, but it does not lower Dekaf's supported Kafka 4.0 broker
-floor. `enforceRebalance` is also intentionally absent: KIP-848 reconciles assignment
-incrementally, so update the subscription/remote assignor or recreate the member instead.
+floor. `enforceRebalance` is also intentionally absent and has no direct KIP-848 equivalent.
+`Subscribe`, `SubscribePattern`, and `Unsubscribe` update the subscription and trigger normal
+broker reconciliation. `GroupRemoteAssignor` is configured when creating the consumer; recreate
+the consumer to change it. Recreating a member changes group membership but does not guarantee
+an assignment change, so it is not a force-rebalance replacement.
 
 Reconsider this decision only with explicit maintainer approval and concrete evidence that all
 of these are true:

--- a/docs/docs/consumer/consumer-groups.md
+++ b/docs/docs/consumer/consumer-groups.md
@@ -291,6 +291,47 @@ revoke/lost/shutdown commits for you.
 
 Dekaf group subscriptions use Kafka's KIP-848 `consumer` group protocol, which requires Kafka 4.0 or later. KIP-848 assignment is server-side and every rebalance is incremental/cooperative: only partitions that move are revoked, while unaffected partitions continue processing.
 
+#### Classic protocol support decision
+
+Dekaf will not add Classic `JoinGroup` / `SyncGroup` membership. This is an intentional
+compatibility boundary, not a missing configuration switch:
+
+- KIP-848 has been generally available since Kafka 4.0, which is already Dekaf's broker
+  compatibility floor. It removes the group-wide synchronization barrier and moves assignment
+  state to the broker.
+- Apache Kafka's accepted
+  [KIP-1274](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/406619710/KIP-1274%2BDeprecate%2Band%2Bremove%2Bsupport%2Bfor%2BClassic%2Brebalance%2Bprotocol%2Bin%2BKafkaConsumer)
+  recommends the Consumer protocol in Kafka 4.3, changes the Java consumer default and
+  deprecates Classic in Kafka 5.0, and removes public KafkaConsumer Classic support in Kafka
+  6.0. Adding a second coordinator now would target an upstream client protocol scheduled for
+  removal.
+- Kafka supports online upgrade and downgrade between compatible Classic and Consumer group
+  members. Dekaf tests both directions, so rolling migration does not require a permanent
+  Classic implementation in Dekaf.
+- One membership state machine avoids duplicating fencing, static-membership, commit,
+  rebalance-listener, and shutdown semantics. This keeps the supported path easier to audit and
+  optimize.
+
+Applications that require Kafka 3.x, custom client-side assignor metadata, or a broker with
+Consumer groups disabled should use a Classic-compatible client while migrating. Manual
+assignment bypasses group membership, but it does not lower Dekaf's supported Kafka 4.0 broker
+floor. `enforceRebalance` is also intentionally absent: KIP-848 reconciles assignment
+incrementally, so update the subscription/remote assignor or recreate the member instead.
+
+Reconsider this decision only with explicit maintainer approval and concrete evidence that all
+of these are true:
+
+1. A supported deployment cannot use Kafka 4.0+ Consumer groups or Kafka's online migration.
+2. A broker-side assignor or temporary Classic-compatible client cannot cover the requirement.
+3. The demand justifies a second coordinator implementation and its full integration matrix.
+4. Apache Kafka's Classic removal roadmap has materially changed, or Dekaf intentionally adopts
+   a different long-term compatibility policy.
+
+See Apache Kafka's current
+[consumer rebalance protocol guide](https://kafka.apache.org/43/operations/consumer-rebalance-protocol/)
+for server settings, migration constraints, and configurations that no longer apply under
+KIP-848.
+
 Choose one of the broker's configured remote assignors with `WithGroupRemoteAssignor`:
 
 ```csharp


### PR DESCRIPTION
## Summary

- record the decision to keep Dekaf consumer subscriptions KIP-848-only
- tie the decision to Kafka 4.0 GA and accepted KIP-1274 phases
- document migration alternatives, `enforceRebalance` behavior, and explicit reopen gates
- link Confluent configuration rejection to the support decision

## Rationale

Apache Kafka's accepted KIP-1274 recommends the Consumer protocol in 4.3, changes the Java consumer default and deprecates Classic in 5.0, then removes public KafkaConsumer Classic support in 6.0. Dekaf already supports Kafka 4.0+ and tests online migration in both directions, so a second membership coordinator would add a large correctness/maintenance surface for a protocol on an upstream removal path.

## Validation

- `npm run build --prefix docs` — pass; 47 documents processed
- Docusaurus links/anchors and production static generation — pass
- required simplify pass — clean
- explicit pre-push self-review — clean

`npm ci` reported the repository's existing 21 audit findings (18 high, 3 moderate); no dependency or lock files changed.

Closes #2747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that only Kafka’s KIP-848 consumer group protocol is supported.
  - Documented that Classic `JoinGroup`/`SyncGroup` membership and `GroupProtocol=Classic` are not supported.
  - Added guidance on Kafka version compatibility, migration alternatives, unsupported scenarios, and conditions for future reconsideration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->