### PR TITLE
test(avro): isolate pooled allocation gate

### DIFF
--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroPocoSchemaRegistryTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroPocoSchemaRegistryTests.cs
@@ -1706,7 +1706,10 @@ public sealed class AvroPocoSchemaRegistryTests
         await Assert.That(allocated).IsEqualTo(0);
     }
 
+    // The warmup returns a 2 MiB buffer to ArrayPool<byte>.Shared. Keep the allocation
+    // window exclusive so another test cannot rent that buffer before measurement.
     [Test]
+    [NotInParallel]
     public async Task GeneratedCodec_RulesPathIsolatesSizingStateAcrossSerializerInstances()
     {
         using var registry = new MockSchemaRegistryClient();


### PR DESCRIPTION
## Summary

- run the shared ArrayPool-sensitive Avro allocation gate exclusively
- preserve the warmed serializer path and exact 0 B assertion
- document why full-suite parallelism can steal the warmed 2 MiB bucket

## Validation

- focused test: net10.0 1/1, net8.0 1/1
- full unit suite: net10.0 7,820/7,820
- full unit suite: net8.0 7,684/7,684
- build: 0 warnings, 0 errors
- `/simplify`: clean
- pre-push self-review: no findings

Closes #2859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated allocation-related test execution to run in isolation, preventing interference from concurrent tests.
  - Added documentation clarifying buffer warmup behavior and measurement requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->