### PR TITLE
test: stabilize prefetch enumerator disposal

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -792,6 +792,7 @@ public sealed class ConsumerPauseResumeCacheTests
         await using var ownedConsumer = consumer;
         IAsyncEnumerator<ConsumeResult<string, string>>? records = null;
         Task<bool>? moveNext = null;
+        var testCompleted = false;
 
         try
         {
@@ -812,6 +813,7 @@ public sealed class ConsumerPauseResumeCacheTests
             await Assert.That(records.Current.Topic).IsEqualTo(activePartition.Topic);
             await Assert.That(records.Current.Partition).IsEqualTo(activePartition.Partition);
             await Assert.That(records.Current.Offset).IsEqualTo(20);
+            testCompleted = true;
         }
         finally
         {
@@ -821,16 +823,22 @@ public sealed class ConsumerPauseResumeCacheTests
             {
                 if (moveNext is not null)
                 {
-                    await ((Task)moveNext).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+                    if (testCompleted)
+                        await moveNext;
+                    else
+                        await ((Task)moveNext).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
                 }
             }
             finally
             {
                 if (records is not null)
                 {
-                    await records.DisposeAsync()
-                        .AsTask()
-                        .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+                    if (testCompleted)
+                        await records.DisposeAsync();
+                    else
+                        await records.DisposeAsync()
+                            .AsTask()
+                            .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
                 }
             }
         }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -790,15 +790,18 @@ public sealed class ConsumerPauseResumeCacheTests
 
         using var consumeCancellation = new CancellationTokenSource();
         await using var ownedConsumer = consumer;
-        var records = consumer.ConsumeAsync(consumeCancellation.Token).GetAsyncEnumerator();
-        var moveNext = Task.Run(() => records.MoveNextAsync().AsTask());
-        var stagePendingClear = typeof(KafkaConsumer<string, string>).GetMethod(
-            "StagePendingFetchClear",
-            BindingFlags.Instance | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException("StagePendingFetchClear method not found");
+        IAsyncEnumerator<ConsumeResult<string, string>>? records = null;
+        Task<bool>? moveNext = null;
 
         try
         {
+            records = consumer.ConsumeAsync(consumeCancellation.Token).GetAsyncEnumerator();
+            moveNext = Task.Run(() => records.MoveNextAsync().AsTask());
+            var stagePendingClear = typeof(KafkaConsumer<string, string>).GetMethod(
+                "StagePendingFetchClear",
+                BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException("StagePendingFetchClear method not found");
+
             await Assert.That(waitEntered.Wait(TimeSpan.FromSeconds(5))).IsTrue();
             stagePendingClear.Invoke(consumer, [revokedPartition]);
             await Assert.That(prefetchBuffer.TryWrite(CreatePendingFetch(revokedPartition, 10, 1))).IsTrue();
@@ -816,12 +819,20 @@ public sealed class ConsumerPauseResumeCacheTests
             consumeCancellation.Cancel();
             try
             {
-                await moveNext;
+                if (moveNext is not null)
+                {
+                    await ((Task)moveNext).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+                }
             }
-            catch (OperationCanceledException) when (consumeCancellation.IsCancellationRequested)
+            finally
             {
+                if (records is not null)
+                {
+                    await records.DisposeAsync()
+                        .AsTask()
+                        .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+                }
             }
-            await records.DisposeAsync();
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -788,8 +788,9 @@ public sealed class ConsumerPauseResumeCacheTests
         prefetchBufferField.SetValue(consumer, prefetchBuffer);
         originalPrefetchBuffer.Dispose();
 
+        using var consumeCancellation = new CancellationTokenSource();
         await using var ownedConsumer = consumer;
-        await using var records = consumer.ConsumeAsync().GetAsyncEnumerator();
+        var records = consumer.ConsumeAsync(consumeCancellation.Token).GetAsyncEnumerator();
         var moveNext = Task.Run(() => records.MoveNextAsync().AsTask());
         var stagePendingClear = typeof(KafkaConsumer<string, string>).GetMethod(
             "StagePendingFetchClear",
@@ -802,16 +803,26 @@ public sealed class ConsumerPauseResumeCacheTests
             stagePendingClear.Invoke(consumer, [revokedPartition]);
             await Assert.That(prefetchBuffer.TryWrite(CreatePendingFetch(revokedPartition, 10, 1))).IsTrue();
             await Assert.That(prefetchBuffer.TryWrite(CreatePendingFetch(activePartition, 20, 1))).IsTrue();
+            releaseWait.Set();
+
+            await Assert.That(await moveNext.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(records.Current.Topic).IsEqualTo(activePartition.Topic);
+            await Assert.That(records.Current.Partition).IsEqualTo(activePartition.Partition);
+            await Assert.That(records.Current.Offset).IsEqualTo(20);
         }
         finally
         {
             releaseWait.Set();
+            consumeCancellation.Cancel();
+            try
+            {
+                await moveNext;
+            }
+            catch (OperationCanceledException) when (consumeCancellation.IsCancellationRequested)
+            {
+            }
+            await records.DisposeAsync();
         }
-
-        await Assert.That(await moveNext.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
-        await Assert.That(records.Current.Topic).IsEqualTo(activePartition.Topic);
-        await Assert.That(records.Current.Partition).IsEqualTo(activePartition.Partition);
-        await Assert.That(records.Current.Offset).IsEqualTo(20);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- make the prefetch-revocation test explicitly own its async enumerator
- on every exit, release the controlled wait, cancel and await the pending `MoveNextAsync`, then dispose
- prevent generated async-iterator `DisposeAsync()` from masking an earlier assertion with `NotSupportedException`

## Root cause

If an assertion failed before the test reached its normal `await moveNext`, `await using` unwound immediately while `MoveNextAsync` was still active. The compiler-generated async iterator rejects concurrent disposal with `NotSupportedException`, hiding the original test failure.

## Validation

- Release build: 0 warnings, 0 errors
- focused test: pass on net10.0 and net8.0
- fresh-process synchronization stress: 10/10 per TFM
- `ConsumerPauseResumeCacheTests`: 33/33 per TFM
- full unit: net10.0 7862/7862; net8.0 7726/7726

Closes #2863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of pause and resume cache tests by tracking whether assertions complete successfully.
  * Refined cleanup behavior so task and enumerator disposal failures are handled appropriately during incomplete or failed test execution.
  * Ensured cleanup operations complete normally after successful test execution, providing more accurate validation of asynchronous resource handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->