### PR TITLE
test: stabilize MPSC reserved-slot wake

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -908,6 +908,7 @@ public class MpscFetchBufferTests
         var second = CreateDummy("topic", 2);
 
         var firstWrite = StartDedicatedWrite(buffer, first);
+        using var readableCts = new CancellationTokenSource();
         Task<bool>? secondWrite = null;
         Task<bool>? waitForReadable = null;
         Exception? firstWriteFailure = null;
@@ -915,44 +916,58 @@ public class MpscFetchBufferTests
         var firstWritten = false;
         try
         {
-            await firstReserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
-            // Keep the buffer timeout out of the ordering proof. Under full-suite load the
-            // test continuation may be delayed while slot 0 is intentionally blocked, so a
-            // wall-clock timeout can win before finally releases the producer.
-            waitForReadable = buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None).AsTask();
-            await TestWait.UntilAsync(
-                () => GetConsumerWaiting(buffer) == 1 && IsReadWaiterActive(buffer),
-                TimeSpan.FromSeconds(5));
+            try
+            {
+                await firstReserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                // Keep the buffer timeout out of the ordering proof. Under full-suite load the
+                // test continuation may be delayed while slot 0 is intentionally blocked, so a
+                // wall-clock timeout can win before finally releases the producer.
+                waitForReadable = buffer.WaitToReadAsync(Timeout.Infinite, readableCts.Token).AsTask();
+                await TestWait.UntilAsync(
+                    () => GetConsumerWaiting(buffer) == 1 && IsReadWaiterActive(buffer),
+                    TimeSpan.FromSeconds(5));
 
-            secondWrite = StartDedicatedWrite(buffer, second);
-            await Assert.That(await secondWrite.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
-            await Assert.That(buffer.Count).IsEqualTo(2);
-            await Assert.That(waitForReadable.IsCompleted).IsFalse();
+                secondWrite = StartDedicatedWrite(buffer, second);
+                await Assert.That(await secondWrite.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+                await Assert.That(buffer.Count).IsEqualTo(2);
+                await Assert.That(waitForReadable.IsCompleted).IsFalse();
+            }
+            finally
+            {
+                allowFirstCommit.Set();
+                (firstWritten, firstWriteFailure) = await ObserveDedicatedWriteAsync(firstWrite);
+
+                if (secondWrite is not null)
+                    (_, secondWriteFailure) = await ObserveDedicatedWriteAsync(secondWrite);
+            }
+
+            if (firstWriteFailure is not null)
+                ExceptionDispatchInfo.Capture(firstWriteFailure).Throw();
+            if (secondWriteFailure is not null)
+                ExceptionDispatchInfo.Capture(secondWriteFailure).Throw();
+
+            await Assert.That(firstWritten).IsTrue();
+            // firstWrite completion proves slot 0 was published and its reader wake was queued.
+            // Bound only the subsequent completion observation so a product wake bug still fails.
+            await Assert.That(await waitForReadable!.WaitAsync(TimeSpan.FromSeconds(30))).IsTrue();
+            await Assert.That(buffer.TryRead(out var firstRead)).IsTrue();
+            await Assert.That(firstRead!.PartitionIndex).IsEqualTo(1);
+            firstRead.Dispose();
+            await Assert.That(buffer.TryRead(out var secondRead)).IsTrue();
+            await Assert.That(secondRead!.PartitionIndex).IsEqualTo(2);
+            secondRead.Dispose();
         }
         finally
         {
-            allowFirstCommit.Set();
-            (firstWritten, firstWriteFailure) = await ObserveDedicatedWriteAsync(firstWrite);
+            readableCts.Cancel();
+            if (waitForReadable is not null)
+            {
+                Task readableObservation = waitForReadable;
+                await readableObservation.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+            }
 
-            if (secondWrite is not null)
-                (_, secondWriteFailure) = await ObserveDedicatedWriteAsync(secondWrite);
+            buffer.Dispose(secondWrite is null ? firstWrite : Task.WhenAll(firstWrite, secondWrite));
         }
-
-        if (firstWriteFailure is not null)
-            ExceptionDispatchInfo.Capture(firstWriteFailure).Throw();
-        if (secondWriteFailure is not null)
-            ExceptionDispatchInfo.Capture(secondWriteFailure).Throw();
-
-        await Assert.That(firstWritten).IsTrue();
-        // firstWrite completion proves slot 0 was published and its reader wake was queued.
-        // Bound only the subsequent completion observation so a product wake bug still fails.
-        await Assert.That(await waitForReadable!.WaitAsync(TimeSpan.FromSeconds(30))).IsTrue();
-        await Assert.That(buffer.TryRead(out var firstRead)).IsTrue();
-        await Assert.That(firstRead!.PartitionIndex).IsEqualTo(1);
-        firstRead.Dispose();
-        await Assert.That(buffer.TryRead(out var secondRead)).IsTrue();
-        await Assert.That(secondRead!.PartitionIndex).IsEqualTo(2);
-        secondRead.Dispose();
     }
 
     private static Task<bool> StartDedicatedWrite(

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -916,7 +916,10 @@ public class MpscFetchBufferTests
         try
         {
             await firstReserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
-            waitForReadable = buffer.WaitToReadAsync(30_000, CancellationToken.None).AsTask();
+            // Keep the buffer timeout out of the ordering proof. Under full-suite load the
+            // test continuation may be delayed while slot 0 is intentionally blocked, so a
+            // wall-clock timeout can win before finally releases the producer.
+            waitForReadable = buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None).AsTask();
             await TestWait.UntilAsync(
                 () => GetConsumerWaiting(buffer) == 1 && IsReadWaiterActive(buffer),
                 TimeSpan.FromSeconds(5));
@@ -941,7 +944,9 @@ public class MpscFetchBufferTests
             ExceptionDispatchInfo.Capture(secondWriteFailure).Throw();
 
         await Assert.That(firstWritten).IsTrue();
-        await Assert.That(await waitForReadable!).IsTrue();
+        // firstWrite completion proves slot 0 was published and its reader wake was queued.
+        // Bound only the subsequent completion observation so a product wake bug still fails.
+        await Assert.That(await waitForReadable!.WaitAsync(TimeSpan.FromSeconds(30))).IsTrue();
         await Assert.That(buffer.TryRead(out var firstRead)).IsTrue();
         await Assert.That(firstRead!.PartitionIndex).IsEqualTo(1);
         firstRead.Dispose();


### PR DESCRIPTION
## Summary

- remove the buffer timeout from the phase where slot 0 is intentionally blocked
- start a bounded watchdog only after the dedicated slot-0 producer has published and queued the reader wake
- preserve the original ordering assertions and exception-safe producer cleanup

Closes #2865

## Validation

- Release unit build: 0 warnings, 0 errors
- focused test: 1/1 on net10 and 1/1 on net8
- deliberate in-process pressure via temporary TUnit `[Repeat(50)]`: 51/51 on net10 and 51/51 on net8; temporary attribute removed before commit
- full unit suite: 7,862/7,862 on net10 and 7,726/7,726 on net8
- `/simplify`, `git diff --check`, and immediate pre-push self-review: clean

No benchmark required: test-only synchronization change; production code and hot paths are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved timing and reliability for message-ordering scenarios.
  * Added cancellation and cleanup handling for blocked read operations.
  * Added validation for write failures before read assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->