### PR TITLE
test: stabilize partition stop timeout

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
@@ -142,8 +142,9 @@ public sealed class ConsumerPartitionStopListenerTests
         finally
         {
             releaseListener.TrySetResult();
-            await listenerCompleted.Task.WaitAsync(testTimeout);
             await consumer.DisposeAsync();
+            if (!testTimeout.IsCancellationRequested)
+                await listenerCompleted.Task.WaitAsync(testTimeout);
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
@@ -125,6 +125,7 @@ public sealed class ConsumerPartitionStopListenerTests
         };
         var consumer = CreateConsumer(
             listener,
+            defaultApiTimeoutMs: 5_000,
             partitionStopTimeout: TimeSpan.FromMilliseconds(50));
         var partition = new TopicPartition("topic-a", 0);
         consumer.Assign(partition);
@@ -146,8 +147,14 @@ public sealed class ConsumerPartitionStopListenerTests
             if (close is not null)
                 await close.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
             await consumer.DisposeAsync();
-            if (!testTimeout.IsCancellationRequested)
+            try
+            {
                 await listenerCompleted.Task.WaitAsync(testTimeout);
+            }
+            catch (OperationCanceledException) when (testTimeout.IsCancellationRequested)
+            {
+                // Preserve the original timeout failure after cleanup completes.
+            }
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
@@ -103,18 +103,16 @@ public sealed class ConsumerPartitionStopListenerTests
     }
 
     [Test]
-    public async Task CloseAsync_PartitionStopTimeout_CancelsListenerAndContinuesCleanup()
+    [Timeout(30_000)]
+    public async Task CloseAsync_PartitionStopTimeout_CancelsListenerAndContinuesCleanup(
+        CancellationToken testTimeout)
     {
-        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseListener = new TaskCompletionSource();
-        var listenerCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var listenerCompleted = new TaskCompletionSource();
         var listener = new TrackingPartitionStopListener
         {
-            OnStopped = async (_, cancellationToken) =>
+            OnStopped = async (_, _) =>
             {
-                using var registration = cancellationToken.Register(
-                    static state => ((TaskCompletionSource)state!).TrySetResult(),
-                    cancellationObserved);
                 try
                 {
                     await releaseListener.Task.ConfigureAwait(false);
@@ -133,10 +131,9 @@ public sealed class ConsumerPartitionStopListenerTests
 
         try
         {
-            var close = consumer.CloseAsync().AsTask();
+            var close = consumer.CloseAsync(CancellationToken.None).AsTask();
 
-            await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
-            await close.WaitAsync(TimeSpan.FromSeconds(5));
+            await close.WaitAsync(testTimeout);
 
             await Assert.That(listener.CancellationTokens[0].IsCancellationRequested).IsTrue();
             await Assert.That(listenerCompleted.Task.IsCompleted).IsFalse();
@@ -145,7 +142,7 @@ public sealed class ConsumerPartitionStopListenerTests
         finally
         {
             releaseListener.TrySetResult();
-            await listenerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await listenerCompleted.Task.WaitAsync(testTimeout);
             await consumer.DisposeAsync();
         }
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
@@ -128,10 +128,11 @@ public sealed class ConsumerPartitionStopListenerTests
             partitionStopTimeout: TimeSpan.FromMilliseconds(50));
         var partition = new TopicPartition("topic-a", 0);
         consumer.Assign(partition);
+        Task? close = null;
 
         try
         {
-            var close = consumer.CloseAsync(CancellationToken.None).AsTask();
+            close = consumer.CloseAsync(CancellationToken.None).AsTask();
 
             await close.WaitAsync(testTimeout);
 
@@ -142,6 +143,8 @@ public sealed class ConsumerPartitionStopListenerTests
         finally
         {
             releaseListener.TrySetResult();
+            if (close is not null)
+                await close.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
             await consumer.DisposeAsync();
             if (!testTimeout.IsCancellationRequested)
                 await listenerCompleted.Task.WaitAsync(testTimeout);


### PR DESCRIPTION
## Summary

- remove the redundant asynchronously-resumed cancellation observer that could lose a race to its five-second timeout under ThreadPool contention
- prove timeout cancellation from the listener token captured by the test double after `CloseAsync` completes
- use the TUnit test budget for shutdown and deterministic listener cleanup instead of independent wall-clock waits

## Validation

- `dotnet build tests/Dekaf.Tests.Unit --configuration Release`: 0 warnings, 0 errors
- focused test, normal: net8.0 1/1; net10.0 1/1
- focused test, forced 1-2 ThreadPool workers: net8.0 1/1; net10.0 1/1
- full unit suite, concurrent: net8.0 7,726/7,726; net10.0 7,862/7,862

No `src/` changes; benchmark evidence is not applicable.

Fixes #2856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for partition-stop timeout handling.
  * Added framework-provided timeout support and cancellation-aware waits to prevent test hangs.
  * Simplified synchronization while validating consumer shutdown behavior.
  * Strengthened cleanup verification to ensure listeners and consumers are released reliably after timeout cancellation.
  * Improved resilience when shutdown operations complete with cancellation or timeout errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->