### PR TITLE
test: stabilize wave coalesce rearm

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -906,7 +906,6 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             enableDeliveryDiagnostics: true);
         var accumulator = new RecordAccumulator(options);
         var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
-        var injectSibling = 0;
         BrokerSender? sender = null;
         sender = CreateSender(
             pool,
@@ -914,35 +913,27 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             accumulator,
             (_, _, _, _, _) => { },
             onWaveCoalesceStarted: () =>
-            {
-                if (Volatile.Read(ref injectSibling) != 0)
-                    sender!.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 1));
-            });
+                sender!.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 1)));
 
-        // EnqueueBulk publishes separate channel events. Seed the known wave width before
-        // publishing so the live sender cannot dispatch the first event before its sibling
-        // has been written and thereby turn setup timing into an extra request.
-        var knownPartitions = (HashSet<TopicPartition>)typeof(BrokerSender).GetField(
-            "_knownPartitions",
-            BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
-        knownPartitions.Add(new TopicPartition("test-topic", 0));
-        knownPartitions.Add(new TopicPartition("test-topic", 1));
+        SeedKnownPartitions(
+            sender,
+            new TopicPartition("test-topic", 0),
+            new TopicPartition("test-topic", 1));
 
         try
         {
-            sender.EnqueueBulk(
-            [
-                CreateTestBatch(valueTaskSourcePool, "test-topic", 0),
-                CreateTestBatch(valueTaskSourcePool, "test-topic", 1)
-            ]);
-            await WaitUntilAsync(
-                () => Volatile.Read(ref connection.SendPipelinedAfterWriteCalls) == 1,
-                cancellationToken);
-
-            Volatile.Write(ref injectSibling, 1);
             sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0));
             await WaitUntilAsync(
-                () => Volatile.Read(ref connection.SendPipelinedAfterWriteCalls) == 2,
+                () => Volatile.Read(ref connection.SendPipelinedAfterWriteCalls) == 1
+                    && accumulator.GetDeliveryDiagnosticsSnapshot().CoalesceWidthHistogram
+                        .Single(bucket => bucket.MinimumWidth == 2).RequestCount == 1,
+                cancellationToken);
+
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0));
+            await WaitUntilAsync(
+                () => Volatile.Read(ref connection.SendPipelinedAfterWriteCalls) == 2
+                    && accumulator.GetDeliveryDiagnosticsSnapshot().CoalesceWidthHistogram
+                        .Single(bucket => bucket.MinimumWidth == 2).RequestCount == 2,
                 cancellationToken);
 
             await Assert.That(firstResponse.Task.IsCompleted).IsFalse();


### PR DESCRIPTION
## Summary

- replace non-atomic `EnqueueBulk` setup with synchronous sibling injection from the wave-start hook
- use the same controlled two-partition wave before and during an in-flight response, directly proving rearm behavior
- wait for both send count and width-2 diagnostic publication before asserting

## Root cause

`EnqueueBulk` publishes separate channel events. Under scheduler pressure, the producer test thread could be preempted after partition 0, allowing the sender's 500 µs zero-linger window to expire before partition 1 was written. The setup request then had width 1, so the final width-2 count was nondeterministically one.

## Validation

- `dotnet build tests/Dekaf.Tests.Unit --configuration Release`: 0 warnings, 0 errors
- focused test with ThreadPool constrained to 2 workers: net8.0 25/25; net10.0 25/25
- full unit suite: net8.0 7,726/7,726; net10.0 7,862/7,862

No `src/` changes; benchmark evidence is not applicable.

Fixes #2857

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated wave-coalescing coverage to validate sequential batch processing.
  * Added assertions for both requests and coalescing histogram counts.
  * Improved test setup for known partitions and sibling batch handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->