### PR TITLE
test: make failed-leave max-poll expiry deterministic

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -842,12 +842,19 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             });
 
         var options = CreateConsumerProtocolOptions(
-            heartbeatIntervalMs: 10,
-            maxPollIntervalMs: 50);
+            heartbeatIntervalMs: 60_000,
+            maxPollIntervalMs: 300_000);
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
 
         await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, cancellationToken);
-        await leaveAttempted.Task.WaitAsync(cancellationToken);
+        await coordinator.StopHeartbeatAsync();
+        SetCoordinatorLongField(
+            coordinator,
+            "_lastPollTimestamp",
+            Stopwatch.GetTimestamp() - (Stopwatch.Frequency * 600L));
+
+        await InvokeConsumerProtocolHeartbeatLoopAsync(coordinator, cancellationToken);
+        await Assert.That(leaveAttempted.Task.IsCompleted).IsTrue();
 
         var exception = await Assert.That(async () =>
                 await coordinator.CommitOffsetsAsync(


### PR DESCRIPTION
Closes #2869

Replaces the 50 ms wall-clock wait in the failed-leave max-poll test with deterministic coordination: stop the scheduled heartbeat, force the poll timestamp overdue, invoke the heartbeat loop directly, and assert the leave attempt occurred before checking the commit fence.

Validation:
- Release unit build: 0 warnings, 0 errors.
- Exact test: 1/1 on net10.0 and net8.0.
- Temporary Repeat(100) pressure: 101/101 on each TFM; marker removed.
- ConsumerCoordinatorKip848Tests: 110/110 on each TFM.
- Full unit suite under concurrent dual-TFM load: 7,862/7,862 net10.0; 7,726/7,726 net8.0.
- Final simplify and immediate pre-push self-review completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for consumer commit behavior when the maximum poll interval is exceeded and leaving the group fails.
  * Made heartbeat timing deterministic to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->