### PR TITLE
test: verify streams-group membership against Kafka

### DIFF
--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -53,6 +53,7 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
     private volatile bool _initialized;
     private int _closeRequested;
     private int _disposed;
+    private int _heartbeatsSuspendedForTesting;
     private int _coordinatorId = -1;
     private int _memberEpoch;
     private int _heartbeatIntervalMs = 5_000;
@@ -133,6 +134,14 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
     }
 
     internal void MarkInitializedForTesting() => _initialized = true;
+
+    internal ValueTask<StreamsGroupHeartbeatResult> SuspendHeartbeatsForTestingAsync(
+        CancellationToken cancellationToken = default)
+    {
+        Volatile.Write(ref _heartbeatsSuspendedForTesting, 1);
+        _heartbeatTimer.Change(Timeout.Infinite, Timeout.Infinite);
+        return QueueOperationAsync(MemberCommand.ForUpdate(new StreamsGroupMemberUpdate()), cancellationToken);
+    }
 
     public ValueTask<StreamsGroupHeartbeatResult> JoinAsync(
         StreamsGroupMemberUpdate initialState,
@@ -1246,7 +1255,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
 
     private bool QueueHeartbeat()
     {
-        if (Volatile.Read(ref _closeRequested) != 0)
+        if (Volatile.Read(ref _closeRequested) != 0 ||
+            Volatile.Read(ref _heartbeatsSuspendedForTesting) != 0)
             return false;
         if (_commands.Writer.TryWrite(MemberCommand.Heartbeat))
             return true;
@@ -1264,8 +1274,11 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         return false;
     }
 
-    private void ScheduleHeartbeat() =>
-        _heartbeatTimer.Change(Math.Max(_heartbeatIntervalMs, 1), Timeout.Infinite);
+    private void ScheduleHeartbeat()
+    {
+        if (Volatile.Read(ref _heartbeatsSuspendedForTesting) == 0)
+            _heartbeatTimer.Change(Math.Max(_heartbeatIntervalMs, 1), Timeout.Infinite);
+    }
 
     private void ThrowIfClosed()
     {

--- a/src/Dekaf/Streams/StreamsGroupMember.cs
+++ b/src/Dekaf/Streams/StreamsGroupMember.cs
@@ -143,6 +143,8 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
         return QueueOperationAsync(MemberCommand.ForUpdate(new StreamsGroupMemberUpdate()), cancellationToken);
     }
 
+    internal bool QueueHeartbeatForTesting() => QueueHeartbeat();
+
     public ValueTask<StreamsGroupHeartbeatResult> JoinAsync(
         StreamsGroupMemberUpdate initialState,
         CancellationToken cancellationToken = default)
@@ -540,7 +542,9 @@ internal sealed class StreamsGroupMember : IStreamsGroupMember
 
     private async ValueTask ProcessBackgroundHeartbeatAsync()
     {
-        if (_memberEpoch <= 0 || Volatile.Read(ref _closeRequested) != 0)
+        if (_memberEpoch <= 0 ||
+            Volatile.Read(ref _closeRequested) != 0 ||
+            Volatile.Read(ref _heartbeatsSuspendedForTesting) != 0)
             return;
 
         try

--- a/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
@@ -30,17 +30,36 @@ public class KafkaContainerDefault : KafkaTestContainer
     /// </summary>
     internal static int ParseVersion(string tag)
     {
-        var parts = tag.Split('.');
-        if (parts.Length != 3
-            || !int.TryParse(parts[0], out var major)
-            || !int.TryParse(parts[1], out var minor)
-            || !int.TryParse(parts[2], out var patch))
-        {
-            throw new InvalidOperationException(
-                $"KAFKA_TEST_IMAGE_TAG must be a three-part version like '4.2.0', but was '{tag}'.");
-        }
+        var (major, minor, patch) = ParseVersionParts(tag);
 
         return major * 100 + minor * 10 + patch;
+    }
+
+    internal static bool SupportsVersion(string tag, int supportedKafkaVersion)
+    {
+        var (major, minor, patch) = ParseVersionParts(tag);
+        var supportedMajor = supportedKafkaVersion / 100;
+        var supportedMinor = supportedKafkaVersion / 10 % 10;
+        var supportedPatch = supportedKafkaVersion % 10;
+
+        return major > supportedMajor
+            || major == supportedMajor && minor > supportedMinor
+            || major == supportedMajor && minor == supportedMinor && patch >= supportedPatch;
+    }
+
+    private static (int Major, int Minor, int Patch) ParseVersionParts(string tag)
+    {
+        var parts = tag.Split('.');
+        if (parts.Length == 3
+            && int.TryParse(parts[0], out var major)
+            && int.TryParse(parts[1], out var minor)
+            && int.TryParse(parts[2], out var patch))
+        {
+            return (major, minor, patch);
+        }
+
+        throw new InvalidOperationException(
+            $"KAFKA_TEST_IMAGE_TAG must be a three-part version like '4.2.0', but was '{tag}'.");
     }
 
     // Testcontainers.Kafka generates a startup script that sets

--- a/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
@@ -76,7 +76,7 @@ public class KafkaContainerDefault : KafkaTestContainer
 
     protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder)
     {
-        if (Version < 420)
+        if (!SupportsVersion(Tag, 420))
         {
             return builder;
         }

--- a/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
@@ -74,6 +74,13 @@ public class KafkaContainerDefault : KafkaTestContainer
             .WithEnvironment("KAFKA_GROUP_SHARE_ENABLE", "true")
             .WithEnvironment("KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS", "classic,consumer,share,streams")
             .WithEnvironment("KAFKA_STREAMS_VERSION", "1")
+            // Keep Streams-group lifecycle tests deterministic without fixed-delay waits.
+            .WithEnvironment("KAFKA_GROUP_STREAMS_INITIAL_REBALANCE_DELAY_MS", "0")
+            .WithEnvironment("KAFKA_GROUP_STREAMS_ASSIGNMENT_INTERVAL_MS", "0")
+            .WithEnvironment("KAFKA_GROUP_STREAMS_HEARTBEAT_INTERVAL_MS", "500")
+            .WithEnvironment("KAFKA_GROUP_STREAMS_MIN_HEARTBEAT_INTERVAL_MS", "500")
+            .WithEnvironment("KAFKA_GROUP_STREAMS_SESSION_TIMEOUT_MS", "2000")
+            .WithEnvironment("KAFKA_GROUP_STREAMS_MIN_SESSION_TIMEOUT_MS", "1000")
             .WithEnvironment("KAFKA_GROUP_SHARE_RECORD_LOCK_DURATION_MS", "15000")
             .WithEnvironment("KAFKA_GROUP_SHARE_MIN_RECORD_LOCK_DURATION_MS", "5000")
             .WithEnvironment("KAFKA_GROUP_SHARE_MAX_RECORD_LOCK_DURATION_MS", "60000")

--- a/tests/Dekaf.Tests.Integration/KafkaVersionComparisonTests.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaVersionComparisonTests.cs
@@ -1,0 +1,18 @@
+namespace Dekaf.Tests.Integration;
+
+public sealed class KafkaVersionComparisonTests
+{
+    [Test]
+    [Arguments("4.3.10", 440, false)]
+    [Arguments("4.4.0", 440, true)]
+    [Arguments("4.4.1", 440, true)]
+    [Arguments("5.0.0", 440, true)]
+    public async Task SupportsVersionUsesSemanticComponentOrdering(
+        string imageTag,
+        int supportedKafkaVersion,
+        bool expected)
+    {
+        await Assert.That(KafkaContainerDefault.SupportsVersion(imageTag, supportedKafkaVersion))
+            .IsEqualTo(expected);
+    }
+}

--- a/tests/Dekaf.Tests.Integration/KafkaVersionComparisonTests.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaVersionComparisonTests.cs
@@ -1,5 +1,6 @@
 namespace Dekaf.Tests.Integration;
 
+[Category("ConsumerGroup")]
 public sealed class KafkaVersionComparisonTests
 {
     [Test]

--- a/tests/Dekaf.Tests.Integration/KafkaVersionComparisonTests.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaVersionComparisonTests.cs
@@ -3,6 +3,8 @@ namespace Dekaf.Tests.Integration;
 public sealed class KafkaVersionComparisonTests
 {
     [Test]
+    [Arguments("4.1.10", 420, false)]
+    [Arguments("4.2.0", 420, true)]
     [Arguments("4.3.10", 440, false)]
     [Arguments("4.4.0", 440, true)]
     [Arguments("4.4.1", 440, true)]

--- a/tests/Dekaf.Tests.Integration/StreamsGroupMemberIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/StreamsGroupMemberIntegrationTests.cs
@@ -53,6 +53,9 @@ public sealed class StreamsGroupMemberIntegrationTests(KafkaTestContainer kafka)
             GroupMembershipOperation = StreamsGroupMembershipOperation.LeaveGroup
         });
         await Assert.That(member.Snapshot.IsClosed).IsTrue();
+        var afterLeave = await admin.DescribeStreamsGroupsAsync([groupId]);
+        await Assert.That(afterLeave[groupId].Members
+            .Any(brokerGroupMember => brokerGroupMember.MemberId == firstMemberId)).IsFalse();
 
         await using var replacement = client.CreateStreamsGroupMember(new StreamsGroupMemberOptions
         {
@@ -154,6 +157,7 @@ public sealed class StreamsGroupMemberIntegrationTests(KafkaTestContainer kafka)
         var instanceId = $"streams-instance-{Guid.NewGuid():N}";
         await using var client = Kafka.Connect(KafkaContainer.BootstrapServers, builder =>
             builder.WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()));
+        await using var admin = client.CreateAdminClient().Build();
 
         await using var first = CreateStaticMember(client, groupId, instanceId);
         await first.InitializeAsync();
@@ -170,6 +174,15 @@ public sealed class StreamsGroupMemberIntegrationTests(KafkaTestContainer kafka)
         {
             GroupMembershipOperation = StreamsGroupMembershipOperation.RemainInGroup
         });
+        var retained = await admin.DescribeStreamsGroupsAsync([groupId]);
+        await Assert.That(retained[groupId].Members
+            .Any(member => member.MemberId == firstMemberId)).IsTrue();
+
+        await TestWait.WaitForConditionAsync(
+            async () => (await admin.DescribeStreamsGroupsAsync([groupId]))[groupId].Members,
+            members => members.All(member => member.MemberId != firstMemberId),
+            initialDelayMs: 250,
+            description: $"Streams member {firstMemberId} to expire from group {groupId}");
 
         await using var afterCrash = CreateStaticMember(client, groupId, instanceId);
         await afterCrash.InitializeAsync();

--- a/tests/Dekaf.Tests.Integration/StreamsGroupMemberIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/StreamsGroupMemberIntegrationTests.cs
@@ -6,6 +6,7 @@ using Dekaf.Streams;
 
 namespace Dekaf.Tests.Integration;
 
+[Category("ConsumerGroup")]
 [SupportsKafka(420)]
 public sealed class StreamsGroupMemberIntegrationTests(KafkaTestContainer kafka)
     : KafkaIntegrationTest(kafka)

--- a/tests/Dekaf.Tests.Integration/StreamsGroupMemberIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/StreamsGroupMemberIntegrationTests.cs
@@ -1,3 +1,7 @@
+using Dekaf.Errors;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
 using Dekaf.Streams;
 
 namespace Dekaf.Tests.Integration;
@@ -6,47 +10,350 @@ namespace Dekaf.Tests.Integration;
 public sealed class StreamsGroupMemberIntegrationTests(KafkaTestContainer kafka)
     : KafkaIntegrationTest(kafka)
 {
+    // Kafka 4.3.1 rejects task offsets and static membership as not yet supported.
+    // Kafka 4.4 completes the KIP-1071 lifecycle used by these gated tests.
+    private const int CompleteStreamsGroupSupport = 440;
+
     [Test]
-    public async Task MemberJoinsAndLeavesStreamsGroup()
+    public async Task MemberJoinsReceivesTasksLeavesAndRejoins()
     {
-        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 3).ConfigureAwait(false);
+        var groupId = $"streams-group-{Guid.NewGuid():N}";
         await using var client = Kafka.Connect(KafkaContainer.BootstrapServers, builder =>
             builder.WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()));
         await using var member = client.CreateStreamsGroupMember(new StreamsGroupMemberOptions
         {
-            GroupId = $"streams-group-{Guid.NewGuid():N}"
+            GroupId = groupId
         });
         await member.InitializeAsync();
 
-        var result = await member.JoinAsync(new StreamsGroupMemberUpdate
+        var join = await member.JoinAsync(CreateInitialState(topic, "process-a"));
+
+        await Assert.That(join.MemberEpoch).IsGreaterThan(0);
+        await using var admin = client.CreateAdminClient().Build();
+        await ReceiveActiveTasksAsync(admin, member, [0, 1, 2]);
+        var assignment = member.Snapshot.Assignment;
+        var acknowledged = await member.UpdateAsync(new StreamsGroupMemberUpdate
         {
-            Topology = new StreamsGroupTopology
-            {
-                Epoch = 0,
-                Subtopologies =
-                [
-                    new StreamsGroupSubtopology
-                    {
-                        SubtopologyId = "0",
-                        SourceTopics = [topic],
-                        SourceTopicRegex = [],
-                        StateChangelogTopics = [],
-                        RepartitionSinkTopics = [],
-                        RepartitionSourceTopics = [],
-                        CopartitionGroups = []
-                    }
-                ]
-            },
-            ActiveTasks = [],
-            StandbyTasks = [],
-            WarmupTasks = [],
-            ProcessId = "integration-process",
-            ClientTags = []
+            ActiveTasks = assignment.ActiveTasks,
+            StandbyTasks = assignment.StandbyTasks,
+            WarmupTasks = assignment.WarmupTasks
+        });
+        await Assert.That(acknowledged.MemberEpoch).IsGreaterThanOrEqualTo(join.MemberEpoch);
+
+        var described = await admin.DescribeStreamsGroupsAsync([groupId]);
+        var brokerMember = described[groupId].Members.Single();
+        await Assert.That(brokerMember.MemberId).IsEqualTo(member.Snapshot.MemberId);
+        await Assert.That(brokerMember.Assignment.ActiveTasks
+            .SelectMany(static taskSet => taskSet.Partitions)).IsEquivalentTo([0, 1, 2]);
+
+        var firstMemberId = member.Snapshot.MemberId;
+        await member.CloseAsync(new StreamsGroupCloseOptions
+        {
+            GroupMembershipOperation = StreamsGroupMembershipOperation.LeaveGroup
+        });
+        await Assert.That(member.Snapshot.IsClosed).IsTrue();
+
+        await using var replacement = client.CreateStreamsGroupMember(new StreamsGroupMemberOptions
+        {
+            GroupId = groupId
+        });
+        await replacement.InitializeAsync();
+        await replacement.JoinAsync(CreateInitialState(topic, "process-b"));
+        await Assert.That(replacement.Snapshot.MemberId).IsNotEqualTo(firstMemberId);
+        await replacement.CloseAsync(new StreamsGroupCloseOptions
+        {
+            GroupMembershipOperation = StreamsGroupMembershipOperation.LeaveGroup
+        });
+    }
+
+    [Test]
+    [SupportsKafka(CompleteStreamsGroupSupport)]
+    public async Task MemberReportsTaskOffsets()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        var groupId = $"streams-group-{Guid.NewGuid():N}";
+        await using var client = Kafka.Connect(KafkaContainer.BootstrapServers, builder =>
+            builder.WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()));
+        await using var member = client.CreateStreamsGroupMember(new StreamsGroupMemberOptions
+        {
+            GroupId = groupId
+        });
+        await member.InitializeAsync();
+        await member.JoinAsync(CreateInitialState(topic, "offset-process"));
+        await using var admin = client.CreateAdminClient().Build();
+        await ReceiveActiveTasksAsync(admin, member, [0]);
+        var assignment = member.Snapshot.Assignment;
+        await member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            ActiveTasks = assignment.ActiveTasks,
+            StandbyTasks = assignment.StandbyTasks,
+            WarmupTasks = assignment.WarmupTasks
         });
 
-        await Assert.That(result.MemberEpoch).IsGreaterThan(0);
-        await Assert.That(member.Snapshot.IsJoined).IsTrue();
-        await member.CloseAsync();
-        await Assert.That(member.Snapshot.IsClosed).IsTrue();
+        await member.ReportTaskOffsetsAsync(new StreamsGroupTaskOffsetReport
+        {
+            TaskOffsets =
+            [
+                new StreamsGroupTaskOffset { SubtopologyId = "0", Partition = 0, Offset = 12 }
+            ],
+            TaskEndOffsets =
+            [
+                new StreamsGroupTaskOffset { SubtopologyId = "0", Partition = 0, Offset = 20 }
+            ]
+        });
+
+        var described = await admin.DescribeStreamsGroupsAsync([groupId]);
+        var brokerMember = described[groupId].Members.Single();
+        await Assert.That(brokerMember.TaskOffsets.Single().Offset).IsEqualTo(12);
+        await Assert.That(brokerMember.TaskEndOffsets.Single().Offset).IsEqualTo(20);
     }
+
+    [Test]
+    [SupportsKafka(CompleteStreamsGroupSupport)]
+    public async Task TopologyEpochMustAdvanceOneAtATime()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        await using var client = Kafka.Connect(KafkaContainer.BootstrapServers, builder =>
+            builder.WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()));
+        var groupId = $"streams-group-{Guid.NewGuid():N}";
+        await using var member = client.CreateStreamsGroupMember(new StreamsGroupMemberOptions
+        {
+            GroupId = groupId
+        });
+        await member.InitializeAsync();
+        var joined = await member.JoinAsync(CreateInitialState(topic, "topology-process"));
+
+        var invalidUpdate = member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            Topology = CreateTopology(topic, epoch: 2)
+        });
+        var exception = await Assert.That(async () => await invalidUpdate)
+            .Throws<GroupException>();
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.StreamsInvalidTopologyEpoch);
+        await Assert.That(member.Snapshot.IsJoined).IsTrue();
+
+        var updated = await member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            Topology = CreateTopology(topic, epoch: 1)
+        });
+        await Assert.That(updated.MemberEpoch).IsGreaterThan(joined.MemberEpoch);
+
+        await using var admin = client.CreateAdminClient().Build();
+        var described = await admin.DescribeStreamsGroupsAsync([groupId]);
+        await Assert.That(described[groupId].Topology!.Epoch).IsEqualTo(1);
+        await Assert.That(described[groupId].GroupEpoch).IsGreaterThan(1);
+    }
+
+    [Test]
+    [SupportsKafka(CompleteStreamsGroupSupport)]
+    public async Task StaticMemberRestartsAndCloseWithoutLeaveExpires()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        var groupId = $"streams-group-{Guid.NewGuid():N}";
+        var instanceId = $"streams-instance-{Guid.NewGuid():N}";
+        await using var client = Kafka.Connect(KafkaContainer.BootstrapServers, builder =>
+            builder.WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()));
+
+        await using var first = CreateStaticMember(client, groupId, instanceId);
+        await first.InitializeAsync();
+        await first.JoinAsync(CreateInitialState(topic, "static-process-a"));
+        var firstMemberId = first.Snapshot.MemberId;
+        await first.CloseAsync();
+
+        await using var restarted = CreateStaticMember(client, groupId, instanceId);
+        await restarted.InitializeAsync();
+        await restarted.JoinAsync(CreateInitialState(topic, "static-process-b"));
+        await Assert.That(restarted.Snapshot.MemberId).IsEqualTo(firstMemberId);
+        await Assert.That(restarted.Snapshot.IsJoined).IsTrue();
+        await restarted.CloseAsync(new StreamsGroupCloseOptions
+        {
+            GroupMembershipOperation = StreamsGroupMembershipOperation.RemainInGroup
+        });
+
+        await using var afterCrash = CreateStaticMember(client, groupId, instanceId);
+        await afterCrash.InitializeAsync();
+        await afterCrash.JoinAsync(CreateInitialState(topic, "static-process-c"));
+        await Assert.That(afterCrash.Snapshot.IsJoined).IsTrue();
+        await afterCrash.CloseAsync(new StreamsGroupCloseOptions
+        {
+            GroupMembershipOperation = StreamsGroupMembershipOperation.LeaveGroup
+        });
+    }
+
+    [Test]
+    public async Task MemberRecoversAfterBrokerFencesItsEpoch()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        var groupId = $"streams-group-{Guid.NewGuid():N}";
+        await using var client = Kafka.Connect(KafkaContainer.BootstrapServers, builder =>
+            builder.WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()));
+        await using var member = client.CreateStreamsGroupMember(new StreamsGroupMemberOptions
+        {
+            GroupId = groupId
+        });
+        await member.InitializeAsync();
+        await member.JoinAsync(CreateInitialState(topic, "fenced-process"));
+        await using var admin = client.CreateAdminClient().Build();
+        await ReceiveActiveTasksAsync(admin, member, [0]);
+        var staleEpoch = member.Snapshot.MemberEpoch;
+        var memberId = member.Snapshot.MemberId!;
+
+        await RemoveRejoinAndFenceRawMemberAsync(groupId, memberId, staleEpoch, topic);
+
+        var recovered = await member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            ProcessId = "recovered-process"
+        });
+        await Assert.That(recovered.MemberId).IsEqualTo(memberId);
+        await Assert.That(recovered.MemberEpoch).IsGreaterThan(staleEpoch);
+        await Assert.That(member.Snapshot.IsJoined).IsTrue();
+    }
+
+    private static IStreamsGroupMember CreateStaticMember(
+        KafkaClient client,
+        string groupId,
+        string instanceId) =>
+        client.CreateStreamsGroupMember(new StreamsGroupMemberOptions
+        {
+            GroupId = groupId,
+            InstanceId = instanceId,
+            RebalanceTimeout = TimeSpan.FromSeconds(10)
+        });
+
+    private static StreamsGroupMemberUpdate CreateInitialState(string topic, string processId) => new()
+    {
+        Topology = CreateTopology(topic, epoch: 0),
+        ActiveTasks = [],
+        StandbyTasks = [],
+        WarmupTasks = [],
+        ProcessId = processId,
+        ClientTags = []
+    };
+
+    private static StreamsGroupTopology CreateTopology(string topic, int epoch) => new()
+    {
+        Epoch = epoch,
+        Subtopologies =
+        [
+            new StreamsGroupSubtopology
+            {
+                SubtopologyId = "0",
+                SourceTopics = [topic],
+                SourceTopicRegex = [],
+                StateChangelogTopics = [],
+                RepartitionSinkTopics = [],
+                RepartitionSourceTopics = [],
+                CopartitionGroups = []
+            }
+        ]
+    };
+
+    private static async Task ReceiveActiveTasksAsync(
+        Dekaf.Admin.IAdminClient admin,
+        IStreamsGroupMember member,
+        IReadOnlyCollection<int> expectedPartitions)
+    {
+        var descriptions = await admin.DescribeStreamsGroupsAsync([member.GroupId]);
+        var targeted = descriptions[member.GroupId].Members.Single().TargetAssignment.ActiveTasks
+            .SelectMany(static taskSet => taskSet.Partitions)
+            .ToArray();
+        await Assert.That(targeted).IsEquivalentTo(expectedPartitions);
+
+        var heartbeat = await member.UpdateAsync(new StreamsGroupMemberUpdate());
+        var activeTasks = heartbeat.ActiveTasks ?? member.Snapshot.Assignment.ActiveTasks;
+        var assigned = activeTasks
+            .SelectMany(static taskSet => taskSet.Partitions)
+            .ToArray();
+        await Assert.That(assigned).IsEquivalentTo(expectedPartitions);
+    }
+
+    private async Task RemoveRejoinAndFenceRawMemberAsync(
+        string groupId,
+        string memberId,
+        int staleEpoch,
+        string topic)
+    {
+        await using var pool = new ConnectionPool(
+            "streams-fencing-test",
+            new ConnectionOptions { RequestTimeout = TimeSpan.FromSeconds(10) },
+            loggerFactory: null);
+        var endpoint = BootstrapServerList.Parse(KafkaContainer.BootstrapServers);
+        var bootstrap = await pool.GetConnectionAsync(endpoint.Host, endpoint.Port, CancellationToken.None);
+        var findVersion = ((IKafkaCapabilityProvider)bootstrap).Capabilities.NegotiateVersion(
+            ApiKey.FindCoordinator,
+            FindCoordinatorRequest.LowestSupportedVersion,
+            FindCoordinatorRequest.HighestSupportedVersion);
+        var coordinatorResponse = await bootstrap.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+            new FindCoordinatorRequest { Key = groupId, KeyType = CoordinatorType.Group },
+            findVersion,
+            CancellationToken.None);
+        var coordinator = coordinatorResponse.Coordinators.Single();
+        pool.RegisterBroker(coordinator.NodeId, coordinator.Host, coordinator.Port);
+        var connection = await pool.GetConnectionAsync(coordinator.NodeId, CancellationToken.None);
+        var heartbeatVersion = ((IKafkaCapabilityProvider)connection).Capabilities.NegotiateVersion(
+            ApiKey.StreamsGroupHeartbeat,
+            StreamsGroupHeartbeatRequest.LowestSupportedVersion,
+            StreamsGroupHeartbeatRequest.HighestSupportedVersion);
+
+        var leave = await connection.SendAsync<StreamsGroupHeartbeatRequest, StreamsGroupHeartbeatResponse>(
+            new StreamsGroupHeartbeatRequest
+            {
+                GroupId = groupId,
+                MemberId = memberId,
+                MemberEpoch = -1
+            },
+            heartbeatVersion,
+            CancellationToken.None);
+        await Assert.That(leave.ErrorCode).IsEqualTo(ErrorCode.None);
+
+        var rejoin = await connection.SendAsync<StreamsGroupHeartbeatRequest, StreamsGroupHeartbeatResponse>(
+            new StreamsGroupHeartbeatRequest
+            {
+                GroupId = groupId,
+                MemberId = memberId,
+                MemberEpoch = 0,
+                RebalanceTimeoutMs = 30_000,
+                Topology = CreateProtocolTopology(topic),
+                ActiveTasks = [],
+                StandbyTasks = [],
+                WarmupTasks = [],
+                ProcessId = "raw-process",
+                ClientTags = []
+            },
+            heartbeatVersion,
+            CancellationToken.None);
+        await Assert.That(rejoin.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(rejoin.MemberEpoch).IsGreaterThan(staleEpoch);
+
+        var fenced = await connection.SendAsync<StreamsGroupHeartbeatRequest, StreamsGroupHeartbeatResponse>(
+            new StreamsGroupHeartbeatRequest
+            {
+                GroupId = groupId,
+                MemberId = memberId,
+                MemberEpoch = staleEpoch,
+                ProcessId = "stale-process"
+            },
+            heartbeatVersion,
+            CancellationToken.None);
+        await Assert.That(fenced.ErrorCode).IsEqualTo(ErrorCode.FencedMemberEpoch);
+    }
+
+    private static StreamsGroupHeartbeatTopology CreateProtocolTopology(string topic) => new()
+    {
+        Epoch = 0,
+        Subtopologies =
+        [
+            new StreamsGroupHeartbeatSubtopology
+            {
+                SubtopologyId = "0",
+                SourceTopics = [topic],
+                SourceTopicRegex = [],
+                StateChangelogTopics = [],
+                RepartitionSinkTopics = [],
+                RepartitionSourceTopics = [],
+                CopartitionGroups = []
+            }
+        ]
+    };
 }

--- a/tests/Dekaf.Tests.Integration/StreamsGroupMemberIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/StreamsGroupMemberIntegrationTests.cs
@@ -213,6 +213,8 @@ public sealed class StreamsGroupMemberIntegrationTests(KafkaTestContainer kafka)
         var staleEpoch = member.Snapshot.MemberEpoch;
         var memberId = member.Snapshot.MemberId!;
 
+        await ((StreamsGroupMember)member).SuspendHeartbeatsForTestingAsync();
+
         await RemoveRejoinAndFenceRawMemberAsync(groupId, memberId, staleEpoch, topic);
 
         var recovered = await member.UpdateAsync(new StreamsGroupMemberUpdate

--- a/tests/Dekaf.Tests.Integration/SupportsKafkaAttribute.cs
+++ b/tests/Dekaf.Tests.Integration/SupportsKafkaAttribute.cs
@@ -4,25 +4,30 @@ public class SupportsKafkaAttribute(int supportedKafkaVersion) : SkipAttribute(s
 {
     public override Task<bool> ShouldSkip(TestRegisteredContext context)
     {
-        var kafkaVersionUsedInTest = GetKafkaVersionUsedInTest(context);
+        var kafkaContainer = GetKafkaContainerUsedInTest(context);
 
-        return Task.FromResult(kafkaVersionUsedInTest < supportedKafkaVersion);
+        return Task.FromResult(kafkaContainer is KafkaContainerDefault
+            ? !KafkaContainerDefault.SupportsVersion(KafkaContainerDefault.ImageTag, supportedKafkaVersion)
+            : kafkaContainer.Version < supportedKafkaVersion);
     }
 
     protected override string GetSkipReason(TestRegisteredContext context)
     {
-        var kafkaVersionUsedInTest = GetKafkaVersionUsedInTest(context);
+        var kafkaContainer = GetKafkaContainerUsedInTest(context);
+        var kafkaVersionUsedInTest = kafkaContainer is KafkaContainerDefault
+            ? KafkaContainerDefault.ImageTag
+            : kafkaContainer.Version.ToString();
 
         return $"The test requires Kafka {supportedKafkaVersion} or above, but this test is testing {kafkaVersionUsedInTest}";
     }
 
-    private static int GetKafkaVersionUsedInTest(TestRegisteredContext context)
+    private static KafkaTestContainer GetKafkaContainerUsedInTest(TestRegisteredContext context)
     {
         return context.TestContext
             .Metadata
             .TestDetails
             .TestClassArguments
             .OfType<KafkaTestContainer>()
-            .First().Version;
+            .First();
     }
 }

--- a/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
+++ b/tests/Dekaf.Tests.Unit/Streams/StreamsGroupMemberTests.cs
@@ -919,6 +919,33 @@ public sealed class StreamsGroupMemberTests
     }
 
     [Test]
+    public async Task SuspendHeartbeatsForTestingAsync_DropsAlreadyQueuedHeartbeat()
+    {
+        var connection = new ScriptedConnection();
+        connection.EnqueueHeartbeat(Success(epoch: 1));
+        var blockedUpdate = new TaskCompletionSource<StreamsGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.EnqueueHeartbeat(blockedUpdate.Task);
+        connection.EnqueueHeartbeat(Success(epoch: 3));
+        connection.EnqueueHeartbeat(Success(epoch: 4));
+        await using var fixture = CreateFixture(connection);
+        await fixture.Member.JoinAsync(CreateInitialUpdate());
+        var update = fixture.Member.UpdateAsync(new StreamsGroupMemberUpdate
+        {
+            ProcessId = "blocked"
+        }).AsTask();
+        await connection.SecondHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(fixture.Member.QueueHeartbeatForTesting()).IsTrue();
+        var suspension = fixture.Member.SuspendHeartbeatsForTestingAsync().AsTask();
+        blockedUpdate.SetResult(Success(epoch: 2));
+
+        await update;
+        await suspension;
+        await Assert.That(connection.HeartbeatRequests).Count().IsEqualTo(3);
+    }
+
+    [Test]
     public async Task BackgroundHeartbeat_TransientFailureDoesNotBlockForegroundOperation()
     {
         var connection = new ScriptedConnection();


### PR DESCRIPTION
## Summary

- configure the Kafka fixture for deterministic Streams-group assignment and session timing
- verify public API join, active-task assignment/acknowledgement, explicit leave/rejoin, and stale-epoch fencing recovery against a real broker
- add task-offset, topology-epoch, static membership, close-without-leave, and rolling restart coverage behind an explicit Kafka 4.4 capability gate

Kafka 4.3.1 executes the supported lifecycle and fencing paths. It currently returns `InvalidRequest` with `TaskOffsets are not supported yet` and `Static membership is not yet supported`; the complete-lifecycle cases are therefore gated to Kafka 4.4 instead of being hidden behind retries or timing sleeps.

## Validation

- `dotnet build tests/Dekaf.Tests.Integration --configuration Release` — 0 warnings, 0 errors
- Kafka 4.3.1 / net10: 2 passed, 3 capability-skipped
- Kafka 4.3.1 / net8: 2 passed, 3 capability-skipped
- Kafka 4.2.1 / net10: 2 passed, 3 capability-skipped
- Kafka 4.1.2 / net10: 5 capability-skipped
- no benchmark required: test-fixture and integration-test changes only; no `src/` path changed

Closes #2788

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded integration coverage for Kafka Streams group membership and lifecycle behavior.
  * Added validation for task assignment, broker information, task offsets, topology progression, static membership restarts, member expiration, and recovery after broker fencing.
  * Improved test environment timing configuration for more reliable rebalance, heartbeat, and session behavior.
  * Added coverage for Kafka version compatibility, including major, minor, and patch-level version comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->