### PR TITLE
Expose KIP-714 client instance IDs

### DIFF
--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -149,6 +149,8 @@ Guid? clientInstanceId = identity.ClientInstanceId;
 
 The property is `null` before telemetry negotiation succeeds, and remains `null` when
 telemetry is unavailable or unsupported by the broker. Reads use an allocation-free cache.
+Admin clients configured with `BootstrapControllers` do not start broker client telemetry,
+so their client instance ID remains `null`.
 After assignment, a refreshed subscription publishes its latest accepted identity atomically;
 the last assigned value remains readable after disposal.
 

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -133,3 +133,27 @@ All observable gauges are registered per client instance and stop reporting when
 Independently of OpenTelemetry, Dekaf implements [KIP-714 client metrics push telemetry](https://cwiki.apache.org/confluence/display/KAFKA/KIP-714%3A+Client+metrics+and+observability). When a broker has a client-metrics subscription configured, Dekaf clients automatically push standard client metrics to the broker at the subscribed interval — no client configuration required.
 
 Applications can also contribute their own metrics to broker subscriptions via `ProducerOptions.ApplicationMetrics` / `ConsumerOptions.ApplicationMetrics` with `ApplicationTelemetryMetric` (name, kind, and an observe callback).
+
+### Client instance IDs
+
+Built-in producers, consumers, Share Consumers, and Admin clients implement the optional
+`IKafkaClientIdentity` capability. Its `ClientInstanceId` property exposes the latest
+broker-assigned KIP-714 identity without blocking or starting network I/O:
+
+```csharp
+using Dekaf.Diagnostics;
+
+var identity = (IKafkaClientIdentity)producer;
+Guid? clientInstanceId = identity.ClientInstanceId;
+```
+
+The property is `null` before telemetry negotiation succeeds, and remains `null` when
+telemetry is unavailable or unsupported by the broker. Reads use an allocation-free cache.
+After assignment, a refreshed subscription publishes its latest accepted identity atomically;
+the last assigned value remains readable after disposal.
+
+`IKafkaClientStatusProvider.GetStatus()` includes the same value in its immutable
+`KafkaClientStatus.ClientInstanceId` snapshot. Status snapshots are intended for low-frequency
+readiness and support diagnostics because snapshot construction allocates. Use the direct
+identity property for frequent reads, and use the `Dekaf` OpenTelemetry meter above for
+continuous client metrics.

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -137,13 +137,13 @@ Applications can also contribute their own metrics to broker subscriptions via `
 ### Client instance IDs
 
 Built-in producers, consumers, Share Consumers, and Admin clients implement the optional
-`IKafkaClientIdentity` capability. Its `ClientInstanceId` property exposes the latest
+`IKafkaClientInstanceIdentity` capability. Its `ClientInstanceId` property exposes the latest
 broker-assigned KIP-714 identity without blocking or starting network I/O:
 
 ```csharp
 using Dekaf.Diagnostics;
 
-var identity = (IKafkaClientIdentity)producer;
+var identity = (IKafkaClientInstanceIdentity)producer;
 Guid? clientInstanceId = identity.ClientInstanceId;
 ```
 

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -169,6 +169,9 @@ public sealed class AdminClient :
         : _metadataManager.ClusterId;
 
     /// <inheritdoc />
+    public Guid? ClientInstanceId => _telemetryManager.ClientInstanceId;
+
+    /// <inheritdoc />
     public KafkaClientStatus GetStatus()
     {
         var stopped = Volatile.Read(ref _disposed) != 0;
@@ -178,7 +181,8 @@ public sealed class AdminClient :
                 KafkaClientRole.Admin,
                 _connectionPool,
                 _metadataManager,
-                stopped);
+                stopped,
+                clientInstanceId: ClientInstanceId);
         }
 
         var snapshot = controllerMetadataManager.Snapshot;
@@ -204,6 +208,7 @@ public sealed class AdminClient :
             snapshot.ClusterId,
             snapshot.LastRefreshed,
             stopped,
+            clientInstanceId: ClientInstanceId,
             brokers: brokers);
     }
 

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -26,6 +26,7 @@ public sealed class AdminClient :
     ITopicIdAdminClient,
     ITransactionRemediationAdminClient,
     IShareGroupDeletionAdminClient,
+    IKafkaClientInstanceIdentity,
     IKafkaClientStatusProvider
 {
     private const string MetadataQuorumTopic = "__cluster_metadata";

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1138,6 +1138,7 @@ internal static class ConsumerFetchPools
 /// <typeparam name="TValue">Value type.</typeparam>
 public sealed partial class KafkaConsumer<TKey, TValue> :
     IKafkaConsumer<TKey, TValue>,
+    IKafkaClientInstanceIdentity,
     IKafkaClientStatusProvider,
     IBoundedKafkaConsumer<TKey, TValue>,
     IConsumerGroupLiveness,

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2073,6 +2073,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     public string? ClusterId => _metadataManager.ClusterId;
 
     /// <inheritdoc />
+    public Guid? ClientInstanceId => _telemetryManager.ClientInstanceId;
+
+    /// <inheritdoc />
     public KafkaClientStatus GetStatus()
     {
         var stopped = Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _consumerDisposed) != 0;
@@ -2101,6 +2104,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             _connectionPool,
             _metadataManager,
             stopped,
+            clientInstanceId: ClientInstanceId,
             consumerGroup: consumerGroup);
     }
 

--- a/src/Dekaf/Diagnostics/KafkaClientStatus.cs
+++ b/src/Dekaf/Diagnostics/KafkaClientStatus.cs
@@ -16,6 +16,16 @@ public interface IKafkaClientIdentity
     /// before metadata supplies one.
     /// </summary>
     string? ClusterId { get; }
+
+    /// <summary>
+    /// Gets the broker-assigned KIP-714 client instance ID, or <see langword="null"/>
+    /// before telemetry negotiation succeeds or when the broker does not support telemetry.
+    /// </summary>
+    /// <remarks>
+    /// The value is the latest accepted immutable identity. It remains available after disposal
+    /// when negotiation completed before the client stopped.
+    /// </remarks>
+    Guid? ClientInstanceId { get; }
 }
 
 /// <summary>
@@ -60,6 +70,9 @@ public sealed class KafkaClientStatus
 
     /// <summary>The latest accepted Kafka cluster ID, when known.</summary>
     public string? ClusterId { get; init; }
+
+    /// <summary>The latest broker-assigned KIP-714 client instance ID, when known.</summary>
+    public Guid? ClientInstanceId { get; init; }
 
     /// <summary>UTC time of the latest accepted metadata update, when available.</summary>
     public DateTimeOffset? MetadataLastRefreshedAtUtc { get; init; }

--- a/src/Dekaf/Diagnostics/KafkaClientStatus.cs
+++ b/src/Dekaf/Diagnostics/KafkaClientStatus.cs
@@ -16,7 +16,17 @@ public interface IKafkaClientIdentity
     /// before metadata supplies one.
     /// </summary>
     string? ClusterId { get; }
+}
 
+/// <summary>
+/// Optional capability exposing the cached KIP-714 identity of a Kafka client.
+/// </summary>
+/// <remarks>
+/// Dekaf's built-in producer, consumer, share consumer, and admin client implement this
+/// interface. The property is a non-blocking cache read and never starts network I/O.
+/// </remarks>
+public interface IKafkaClientInstanceIdentity
+{
     /// <summary>
     /// Gets the broker-assigned KIP-714 client instance ID, or <see langword="null"/>
     /// before telemetry negotiation succeeds or when the broker does not support telemetry.

--- a/src/Dekaf/Diagnostics/KafkaClientStatusFactory.cs
+++ b/src/Dekaf/Diagnostics/KafkaClientStatusFactory.cs
@@ -11,6 +11,7 @@ internal static class KafkaClientStatusFactory
         IConnectionPool connectionPool,
         MetadataManager metadataManager,
         bool isStopped,
+        Guid? clientInstanceId = null,
         ProducerBacklogStatus? producer = null,
         ConsumerGroupStatus? consumerGroup = null) =>
         Capture(
@@ -19,6 +20,7 @@ internal static class KafkaClientStatusFactory
             metadataManager.ClusterId,
             metadataManager.Metadata.LastRefreshed,
             isStopped,
+            clientInstanceId,
             producer,
             consumerGroup);
 
@@ -28,6 +30,7 @@ internal static class KafkaClientStatusFactory
         string? clusterId,
         DateTimeOffset metadataLastRefreshed,
         bool isStopped,
+        Guid? clientInstanceId = null,
         ProducerBacklogStatus? producer = null,
         ConsumerGroupStatus? consumerGroup = null,
         IReadOnlyList<BrokerConnectionStatus>? brokers = null)
@@ -37,6 +40,7 @@ internal static class KafkaClientStatusFactory
             CapturedAtUtc = DateTimeOffset.UtcNow,
             Role = role,
             ClusterId = clusterId,
+            ClientInstanceId = clientInstanceId,
             MetadataLastRefreshedAtUtc = metadataLastRefreshed == default
                 ? null
                 : metadataLastRefreshed,

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -106,11 +106,15 @@ public sealed partial class KafkaProducer<TKey, TValue> :
     public string? ClusterId => _metadataManager.ClusterId;
 
     /// <inheritdoc />
+    public Guid? ClientInstanceId => _telemetryManager.ClientInstanceId;
+
+    /// <inheritdoc />
     public KafkaClientStatus GetStatus() => KafkaClientStatusFactory.Capture(
         KafkaClientRole.Producer,
         _connectionPool,
         _metadataManager,
         Volatile.Read(ref _disposed) != 0,
+        clientInstanceId: ClientInstanceId,
         producer: new ProducerBacklogStatus(
             _accumulator.BufferedBytes,
             _accumulator.MaxBufferMemory,

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -28,6 +28,7 @@ namespace Dekaf.Producer;
 public sealed partial class KafkaProducer<TKey, TValue> :
     IKafkaProducer<TKey, TValue>,
     IProducerMetadata,
+    IKafkaClientInstanceIdentity,
     IKafkaClientStatusProvider,
     IProducerDiagnostics,
     IProducerFastPath<TKey, TValue>,

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -162,7 +162,8 @@ Dekaf.Diagnostics.ConsumerGroupStatus.Assignment.get -> System.Collections.Gener
 Dekaf.Diagnostics.ProducerBacklogStatus.ProducerBacklogStatus(long BufferedBytes, ulong BufferCapacityBytes, int UnsealedBatchCount, long QueuedBatchCount, long InFlightBatchCount, long BufferPressureEventCount) -> void
 Dekaf.Diagnostics.ProducerBacklogStatus.BufferUtilization.get -> double
 Dekaf.Diagnostics.IKafkaClientIdentity.ClusterId.get -> string?
-Dekaf.Diagnostics.IKafkaClientIdentity.ClientInstanceId.get -> System.Guid?
+Dekaf.Diagnostics.IKafkaClientInstanceIdentity
+Dekaf.Diagnostics.IKafkaClientInstanceIdentity.ClientInstanceId.get -> System.Guid?
 Dekaf.Diagnostics.ProducerBacklogStatus.IsAtCapacity.get -> bool
 Dekaf.Diagnostics.BrokerConnectionStatus.BrokerId.get -> int
 Dekaf.Diagnostics.BrokerConnectionStatus.Host.get -> string!

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -139,6 +139,7 @@ Dekaf.Diagnostics.ProducerBacklogStatus.BufferPressureEventCount.init -> void
 Dekaf.Diagnostics.ConsumerGroupStatus
 Dekaf.Diagnostics.ConsumerGroupStatus.ConsumerGroupStatus() -> void
 Dekaf.Admin.AdminClient.ClusterId.get -> string?
+Dekaf.Admin.AdminClient.ClientInstanceId.get -> System.Guid?
 Dekaf.Admin.AdminClient.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!
 Dekaf.Diagnostics.ConsumerGroupStatus.HasConsumerGroup.get -> bool
 Dekaf.Diagnostics.ConsumerGroupStatus.HasConsumerGroup.init -> void
@@ -161,6 +162,7 @@ Dekaf.Diagnostics.ConsumerGroupStatus.Assignment.get -> System.Collections.Gener
 Dekaf.Diagnostics.ProducerBacklogStatus.ProducerBacklogStatus(long BufferedBytes, ulong BufferCapacityBytes, int UnsealedBatchCount, long QueuedBatchCount, long InFlightBatchCount, long BufferPressureEventCount) -> void
 Dekaf.Diagnostics.ProducerBacklogStatus.BufferUtilization.get -> double
 Dekaf.Diagnostics.IKafkaClientIdentity.ClusterId.get -> string?
+Dekaf.Diagnostics.IKafkaClientIdentity.ClientInstanceId.get -> System.Guid?
 Dekaf.Diagnostics.ProducerBacklogStatus.IsAtCapacity.get -> bool
 Dekaf.Diagnostics.BrokerConnectionStatus.BrokerId.get -> int
 Dekaf.Diagnostics.BrokerConnectionStatus.Host.get -> string!
@@ -191,6 +193,8 @@ Dekaf.Diagnostics.KafkaClientStatus.Role.init -> void
 Dekaf.Diagnostics.KafkaClientStatus.ClusterId.init -> void
 Dekaf.Diagnostics.KafkaClientStatus.MetadataLastRefreshedAtUtc.get -> System.DateTimeOffset?
 Dekaf.Diagnostics.KafkaClientStatus.ClusterId.get -> string?
+Dekaf.Diagnostics.KafkaClientStatus.ClientInstanceId.get -> System.Guid?
+Dekaf.Diagnostics.KafkaClientStatus.ClientInstanceId.init -> void
 Dekaf.Diagnostics.KafkaClientStatus.IsStopped.get -> bool
 Dekaf.Diagnostics.KafkaClientStatus.MetadataLastRefreshedAtUtc.init -> void
 Dekaf.Diagnostics.KafkaClientStatus.Brokers.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Diagnostics.BrokerConnectionStatus!>!
@@ -202,8 +206,10 @@ Dekaf.Diagnostics.KafkaClientStatus.ConsumerGroup.get -> Dekaf.Diagnostics.Consu
 Dekaf.Diagnostics.KafkaClientStatus.ConsumerGroup.init -> void
 Dekaf.Diagnostics.IKafkaClientStatusProvider.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!
 Dekaf.Consumer.KafkaConsumer<TKey, TValue>.ClusterId.get -> string?
+Dekaf.Consumer.KafkaConsumer<TKey, TValue>.ClientInstanceId.get -> System.Guid?
 Dekaf.Consumer.KafkaConsumer<TKey, TValue>.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!
 Dekaf.Producer.KafkaProducer<TKey, TValue>.ClusterId.get -> string?
+Dekaf.Producer.KafkaProducer<TKey, TValue>.ClientInstanceId.get -> System.Guid?
 Dekaf.Producer.KafkaProducer<TKey, TValue>.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!
 Dekaf.Serialization.IAsyncDeserializerPreparer<T> (forwarded, contained in Dekaf.Abstractions)
 Dekaf.Serialization.IAsyncDeserializerPreparer<T>.TryDeserialize(System.ReadOnlyMemory<byte> data, Dekaf.Serialization.SerializationContext context, out T value) -> bool (forwarded, contained in Dekaf.Abstractions)

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -139,6 +139,7 @@ Dekaf.Diagnostics.ProducerBacklogStatus.UnsealedBatchCount.init -> void
 Dekaf.Diagnostics.ConsumerGroupStatus
 Dekaf.Diagnostics.ConsumerGroupStatus.ConsumerGroupStatus() -> void
 Dekaf.Admin.AdminClient.ClusterId.get -> string?
+Dekaf.Admin.AdminClient.ClientInstanceId.get -> System.Guid?
 Dekaf.Admin.AdminClient.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!
 Dekaf.Diagnostics.ConsumerGroupStatus.HasConsumerGroup.get -> bool
 Dekaf.Diagnostics.ConsumerGroupStatus.HasConsumerGroup.init -> void
@@ -188,6 +189,8 @@ Dekaf.Diagnostics.KafkaClientStatus.Role.get -> Dekaf.Diagnostics.KafkaClientRol
 Dekaf.Diagnostics.KafkaClientStatus.Role.init -> void
 Dekaf.Diagnostics.KafkaClientStatus.CapturedAtUtc.get -> System.DateTimeOffset
 Dekaf.Diagnostics.KafkaClientStatus.ClusterId.get -> string?
+Dekaf.Diagnostics.KafkaClientStatus.ClientInstanceId.get -> System.Guid?
+Dekaf.Diagnostics.KafkaClientStatus.ClientInstanceId.init -> void
 Dekaf.Diagnostics.KafkaClientStatus.MetadataLastRefreshedAtUtc.init -> void
 Dekaf.Diagnostics.KafkaClientStatus.MetadataLastRefreshedAtUtc.get -> System.DateTimeOffset?
 Dekaf.Diagnostics.KafkaClientStatus.ClusterId.init -> void
@@ -201,9 +204,12 @@ Dekaf.Diagnostics.KafkaClientStatus.Brokers.init -> void
 Dekaf.Diagnostics.KafkaClientStatus.ConsumerGroup.init -> void
 Dekaf.Diagnostics.IKafkaClientStatusProvider.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!
 Dekaf.Diagnostics.IKafkaClientIdentity.ClusterId.get -> string?
+Dekaf.Diagnostics.IKafkaClientIdentity.ClientInstanceId.get -> System.Guid?
 Dekaf.Consumer.KafkaConsumer<TKey, TValue>.ClusterId.get -> string?
+Dekaf.Consumer.KafkaConsumer<TKey, TValue>.ClientInstanceId.get -> System.Guid?
 Dekaf.Consumer.KafkaConsumer<TKey, TValue>.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!
 Dekaf.Producer.KafkaProducer<TKey, TValue>.ClusterId.get -> string?
+Dekaf.Producer.KafkaProducer<TKey, TValue>.ClientInstanceId.get -> System.Guid?
 Dekaf.Producer.KafkaProducer<TKey, TValue>.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!
 Dekaf.Serialization.IAsyncDeserializerPreparer<T> (forwarded, contained in Dekaf.Abstractions)
 Dekaf.Serialization.IAsyncDeserializerPreparer<T>.TryDeserialize(System.ReadOnlyMemory<byte> data, Dekaf.Serialization.SerializationContext context, out T value) -> bool (forwarded, contained in Dekaf.Abstractions)

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -204,7 +204,8 @@ Dekaf.Diagnostics.KafkaClientStatus.Brokers.init -> void
 Dekaf.Diagnostics.KafkaClientStatus.ConsumerGroup.init -> void
 Dekaf.Diagnostics.IKafkaClientStatusProvider.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!
 Dekaf.Diagnostics.IKafkaClientIdentity.ClusterId.get -> string?
-Dekaf.Diagnostics.IKafkaClientIdentity.ClientInstanceId.get -> System.Guid?
+Dekaf.Diagnostics.IKafkaClientInstanceIdentity
+Dekaf.Diagnostics.IKafkaClientInstanceIdentity.ClientInstanceId.get -> System.Guid?
 Dekaf.Consumer.KafkaConsumer<TKey, TValue>.ClusterId.get -> string?
 Dekaf.Consumer.KafkaConsumer<TKey, TValue>.ClientInstanceId.get -> System.Guid?
 Dekaf.Consumer.KafkaConsumer<TKey, TValue>.GetStatus() -> Dekaf.Diagnostics.KafkaClientStatus!

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -9,6 +9,7 @@ using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
 using Dekaf.Retry;
 using Dekaf.Serialization;
+using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
 #if NETSTANDARD2_0
 using StringSet = System.Collections.Generic.IReadOnlyCollection<string>;
@@ -39,6 +40,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     private readonly ShareSessionManager _sessionManager = new();
     private readonly AcknowledgementTracker _ackTracker = new();
     private readonly CompressionCodecRegistry _compressionCodecs;
+    private readonly ClientTelemetryManager _telemetryManager;
     private readonly ILogger _logger;
 
     // ThreadStatic reusable SerializationContext to avoid per-record allocations in ParsePartitionRecords.
@@ -159,6 +161,11 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaShareConsumer<TKey, TValue>>.Instance;
 
         _compressionCodecs = CompressionCodecRegistry.Default;
+        _telemetryManager = new ClientTelemetryManager(
+            _connectionPool,
+            _metadataManager,
+            loggerFactory?.CreateLogger<ClientTelemetryManager>(),
+            payloadProvider: EmptyClientTelemetryPayloadProvider.Instance);
 
         _coordinator = new ShareConsumerCoordinator(
             options,
@@ -175,6 +182,9 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     public string? ClusterId => _metadataManager.ClusterId;
 
     /// <inheritdoc />
+    public Guid? ClientInstanceId => _telemetryManager.ClientInstanceId;
+
+    /// <inheritdoc />
     public KafkaClientStatus GetStatus()
     {
         var stopped = Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _disposed) != 0;
@@ -183,6 +193,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             _connectionPool,
             _metadataManager,
             stopped,
+            clientInstanceId: ClientInstanceId,
             consumerGroup: _coordinator.CaptureGroupStatus());
     }
 
@@ -212,6 +223,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 return;
 
             await _metadataManager.InitializeAsync(cancellationToken).ConfigureAwait(false);
+            await _telemetryManager.StartAsync(cancellationToken).ConfigureAwait(false);
             _initialized = true;
         }
         finally
@@ -582,6 +594,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
 
         // Step 3: Leave the share group
         await _coordinator.LeaveGroupAsync(cancellationToken).ConfigureAwait(false);
+
+        await _telemetryManager.StopAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
     }
 
     public async ValueTask DisposeAsync()
@@ -623,6 +637,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         }
 
         await _coordinator.DisposeAsync().ConfigureAwait(false);
+        await _telemetryManager.DisposeAsync().ConfigureAwait(false);
 
         if (_ownsInfrastructure)
         {

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -28,6 +28,7 @@ namespace Dekaf.ShareConsumer;
 /// </summary>
 internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     IKafkaShareConsumer<TKey, TValue>,
+    IKafkaClientInstanceIdentity,
     IKafkaClientStatusProvider
 {
     private readonly ShareConsumerOptions _options;

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -593,10 +593,16 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             LogCloseSessionsFailed(ex);
         }
 
-        // Step 3: Leave the share group
-        await _coordinator.LeaveGroupAsync(cancellationToken).ConfigureAwait(false);
-
-        await _telemetryManager.StopAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+        // Step 3: Leave the share group, then stop telemetry even if leaving fails.
+        try
+        {
+            await _coordinator.LeaveGroupAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await _telemetryManager.StopAsync(TimeSpan.FromSeconds(5), CancellationToken.None)
+                .ConfigureAwait(false);
+        }
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Dekaf/Telemetry/ClientTelemetryManager.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryManager.cs
@@ -48,6 +48,8 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
     private readonly IClientTelemetryPayloadProvider _payloadProvider;
     private readonly ILogger<ClientTelemetryManager> _logger;
     private readonly SemaphoreSlim _startLock = new(1, 1);
+    private readonly TaskCompletionSource<bool> _stopCompletion =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private CancellationTokenSource? _loopCts;
     private Task? _loopTask;
@@ -139,12 +141,15 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
 
         Volatile.Write(ref _stopRequested, 1);
         await _startLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var completesStop = false;
         try
         {
             if (Interlocked.Exchange(ref _stopped, 1) != 0)
             {
                 return;
             }
+
+            completesStop = true;
 
             using var timeoutCts = new CancellationTokenSource(timeout);
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
@@ -194,6 +199,8 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
         finally
         {
             _startLock.Release();
+            if (completesStop)
+                _stopCompletion.TrySetResult(true);
         }
     }
 
@@ -205,7 +212,11 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
         }
 
         await StopAsync(DefaultStopTimeout).ConfigureAwait(false);
-        _startLock.Dispose();
+        await _stopCompletion.Task.ConfigureAwait(false);
+
+        // A caller can pass the lifecycle pre-check immediately before disposal marks the manager
+        // disposed, then queue on this semaphore. Keep it alive until the manager becomes
+        // unreachable so those callers can drain without ObjectDisposedException.
     }
 
     private async Task RunLoopAsync(CancellationToken cancellationToken)

--- a/src/Dekaf/Telemetry/ClientTelemetryManager.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryManager.cs
@@ -53,6 +53,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
     private Task? _loopTask;
     private ClientTelemetrySubscription? _subscription;
     private int _started;
+    private int _stopRequested;
     private int _stopped;
     private int _disabled;
     private int _disposed;
@@ -81,7 +82,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
     public async ValueTask StartAsync(CancellationToken cancellationToken = default)
     {
         if (Volatile.Read(ref _disposed) != 0 ||
-            Volatile.Read(ref _stopped) != 0 ||
+            Volatile.Read(ref _stopRequested) != 0 ||
             Volatile.Read(ref _started) != 0 ||
             Volatile.Read(ref _disabled) != 0)
         {
@@ -92,7 +93,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
         try
         {
             if (Volatile.Read(ref _disposed) != 0 ||
-                Volatile.Read(ref _stopped) != 0 ||
+                Volatile.Read(ref _stopRequested) != 0 ||
                 Volatile.Read(ref _started) != 0 ||
                 Volatile.Read(ref _disabled) != 0)
             {
@@ -106,7 +107,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
             }
 
             if (Volatile.Read(ref _disposed) != 0 ||
-                Volatile.Read(ref _stopped) != 0 ||
+                Volatile.Read(ref _stopRequested) != 0 ||
                 Volatile.Read(ref _disabled) != 0)
             {
                 return;
@@ -126,7 +127,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
 
     public async ValueTask StopAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
-        if (Interlocked.Exchange(ref _stopped, 1) != 0)
+        if (Volatile.Read(ref _stopped) != 0)
         {
             return;
         }
@@ -136,9 +137,15 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
             timeout = DefaultStopTimeout;
         }
 
+        Volatile.Write(ref _stopRequested, 1);
         await _startLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
+            if (Interlocked.Exchange(ref _stopped, 1) != 0)
+            {
+                return;
+            }
+
             using var timeoutCts = new CancellationTokenSource(timeout);
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
             var stopToken = linkedCts.Token;

--- a/src/Dekaf/Telemetry/ClientTelemetryManager.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryManager.cs
@@ -73,8 +73,8 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
         _payloadProvider = payloadProvider ?? new ClientTelemetryPayloadProvider(_compressionCodecs);
     }
 
-    internal Guid ClientInstanceId => _subscription?.ClientInstanceId ?? Guid.Empty;
-    internal int SubscriptionId => _subscription?.SubscriptionId ?? -1;
+    internal Guid? ClientInstanceId => Volatile.Read(ref _subscription)?.ClientInstanceId;
+    internal int SubscriptionId => Volatile.Read(ref _subscription)?.SubscriptionId ?? -1;
     internal bool IsDisabled => Volatile.Read(ref _disabled) != 0;
     internal bool IsStarted => Volatile.Read(ref _started) != 0;
 
@@ -112,7 +112,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
                 return;
             }
 
-            _subscription = subscription;
+            Volatile.Write(ref _subscription, subscription);
             var loopCts = new CancellationTokenSource();
             _loopCts = loopCts;
             Volatile.Write(ref _started, 1);
@@ -164,7 +164,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
 
             if (!stopToken.IsCancellationRequested &&
                 Volatile.Read(ref _disabled) == 0 &&
-                _subscription is { } subscription)
+                Volatile.Read(ref _subscription) is { } subscription)
             {
                 try
                 {
@@ -207,7 +207,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
         {
             while (!cancellationToken.IsCancellationRequested && Volatile.Read(ref _disabled) == 0)
             {
-                var subscription = _subscription;
+                var subscription = Volatile.Read(ref _subscription);
                 if (subscription is null)
                 {
                     return;
@@ -230,7 +230,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
 
                     if (refreshed is not null)
                     {
-                        _subscription = refreshed;
+                        Volatile.Write(ref _subscription, refreshed);
                     }
                 }
             }

--- a/tests/Dekaf.Tests.Integration/ClientStatusIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ClientStatusIntegrationTests.cs
@@ -27,20 +27,23 @@ public sealed class ClientStatusIntegrationTests(KafkaTestContainer kafka) : Kaf
         await using var admin = client.CreateAdminClient().Build();
         _ = await admin.ListTopicsAsync(cancellationToken: cancellationToken);
 
-        var identities = new (string Role, IKafkaClientIdentity Identity)[]
+        var identities = new (
+            string Role,
+            IKafkaClientIdentity ClusterIdentity,
+            IKafkaClientInstanceIdentity InstanceIdentity)[]
         {
-            ("producer", (IKafkaClientIdentity)producer),
-            ("consumer", (IKafkaClientIdentity)consumer),
-            ("share consumer", (IKafkaClientIdentity)shareConsumer),
-            ("admin", (IKafkaClientIdentity)admin)
+            ("producer", (IKafkaClientIdentity)producer, (IKafkaClientInstanceIdentity)producer),
+            ("consumer", (IKafkaClientIdentity)consumer, (IKafkaClientInstanceIdentity)consumer),
+            ("share consumer", (IKafkaClientIdentity)shareConsumer, (IKafkaClientInstanceIdentity)shareConsumer),
+            ("admin", admin, admin)
         };
-        var clusterId = identities[0].Identity.ClusterId;
+        var clusterId = identities[0].ClusterIdentity.ClusterId;
 
         await Assert.That(clusterId).IsNotNull();
-        foreach (var (role, identity) in identities)
+        foreach (var (role, clusterIdentity, instanceIdentity) in identities)
         {
-            await Assert.That(identity.ClusterId).IsEqualTo(clusterId).Because($"{role} cluster ID");
-            await Assert.That(identity.ClientInstanceId).IsNull()
+            await Assert.That(clusterIdentity.ClusterId).IsEqualTo(clusterId).Because($"{role} cluster ID");
+            await Assert.That(instanceIdentity.ClientInstanceId).IsNull()
                 .Because($"{role} client instance ID without a broker telemetry receiver");
         }
     }

--- a/tests/Dekaf.Tests.Integration/ClientStatusIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ClientStatusIntegrationTests.cs
@@ -14,7 +14,8 @@ public sealed class ClientStatusIntegrationTests(KafkaTestContainer kafka) : Kaf
     [Test]
     [SupportsKafka(420)]
     [Timeout(90_000)]
-    public async Task SharedClients_ReportSameClusterIdentity(CancellationToken cancellationToken)
+    public async Task SharedClients_ReportSameClusterIdentityAndUnavailableTelemetry(
+        CancellationToken cancellationToken)
     {
         await using var client = Kafka.Connect(KafkaContainer.BootstrapServers);
         await using var producer = await client.CreateProducer<string, string>()
@@ -26,18 +27,22 @@ public sealed class ClientStatusIntegrationTests(KafkaTestContainer kafka) : Kaf
         await using var admin = client.CreateAdminClient().Build();
         _ = await admin.ListTopicsAsync(cancellationToken: cancellationToken);
 
-        var identities = new IKafkaClientIdentity[]
+        var identities = new (string Role, IKafkaClientIdentity Identity)[]
         {
-            (IKafkaClientIdentity)producer,
-            (IKafkaClientIdentity)consumer,
-            (IKafkaClientIdentity)shareConsumer,
-            (IKafkaClientIdentity)admin
+            ("producer", (IKafkaClientIdentity)producer),
+            ("consumer", (IKafkaClientIdentity)consumer),
+            ("share consumer", (IKafkaClientIdentity)shareConsumer),
+            ("admin", (IKafkaClientIdentity)admin)
         };
-        var clusterId = identities[0].ClusterId;
+        var clusterId = identities[0].Identity.ClusterId;
 
         await Assert.That(clusterId).IsNotNull();
-        foreach (var identity in identities)
-            await Assert.That(identity.ClusterId).IsEqualTo(clusterId);
+        foreach (var (role, identity) in identities)
+        {
+            await Assert.That(identity.ClusterId).IsEqualTo(clusterId).Because($"{role} cluster ID");
+            await Assert.That(identity.ClientInstanceId).IsNull()
+                .Because($"{role} client instance ID without a broker telemetry receiver");
+        }
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Integration/ClientStatusIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ClientStatusIntegrationTests.cs
@@ -35,7 +35,7 @@ public sealed class ClientStatusIntegrationTests(KafkaTestContainer kafka) : Kaf
             ("producer", (IKafkaClientIdentity)producer, (IKafkaClientInstanceIdentity)producer),
             ("consumer", (IKafkaClientIdentity)consumer, (IKafkaClientInstanceIdentity)consumer),
             ("share consumer", (IKafkaClientIdentity)shareConsumer, (IKafkaClientInstanceIdentity)shareConsumer),
-            ("admin", admin, admin)
+            ("admin", (IKafkaClientIdentity)admin, (IKafkaClientInstanceIdentity)admin)
         };
         var clusterId = identities[0].ClusterIdentity.ClusterId;
 

--- a/tests/Dekaf.Tests.Integration/ClientTelemetryIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ClientTelemetryIntegrationTests.cs
@@ -34,7 +34,7 @@ public sealed class ClientTelemetryIntegrationTests(KafkaTestContainer kafka) : 
         }
         else
         {
-            await Assert.That(telemetryManager.ClientInstanceId).IsEqualTo(Guid.Empty);
+            await Assert.That(telemetryManager.ClientInstanceId).IsNull();
             await Assert.That(telemetryManager.SubscriptionId).IsEqualTo(-1);
         }
     }

--- a/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
@@ -55,12 +55,12 @@ public sealed class KafkaClientStatusTests
         await Assert.That(adminStatus.ClusterId).IsNull();
         await Assert.That(adminStatus.ClientInstanceId).IsNull();
 
-        var identities = new IKafkaClientIdentity[]
+        var identities = new IKafkaClientInstanceIdentity[]
         {
-            (IKafkaClientIdentity)producer,
-            (IKafkaClientIdentity)consumer,
-            (IKafkaClientIdentity)shareConsumer,
-            (IKafkaClientIdentity)admin
+            (IKafkaClientInstanceIdentity)producer,
+            (IKafkaClientInstanceIdentity)consumer,
+            (IKafkaClientInstanceIdentity)shareConsumer,
+            admin
         };
         foreach (var identity in identities)
             await Assert.That(identity.ClientInstanceId).IsNull();
@@ -95,7 +95,7 @@ public sealed class KafkaClientStatusTests
         for (var i = 0; i < clients.Length; i++)
         {
             SetClientInstanceId(clients[i], expectedIds[i]);
-            var identity = (IKafkaClientIdentity)clients[i];
+            var identity = (IKafkaClientInstanceIdentity)clients[i];
             var status = ((IKafkaClientStatusProvider)clients[i]).GetStatus();
 
             await Assert.That(identity.ClientInstanceId).IsEqualTo(expectedIds[i]);
@@ -114,7 +114,7 @@ public sealed class KafkaClientStatusTests
 
         await producer.DisposeAsync();
 
-        await Assert.That(((IKafkaClientIdentity)producer).ClientInstanceId)
+        await Assert.That(((IKafkaClientInstanceIdentity)producer).ClientInstanceId)
             .IsEqualTo(clientInstanceId);
         var status = ((IKafkaClientStatusProvider)producer).GetStatus();
         await Assert.That(status.ClientInstanceId).IsEqualTo(clientInstanceId);

--- a/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/KafkaClientStatusTests.cs
@@ -10,6 +10,7 @@ using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 using Dekaf.ShareConsumer;
+using Dekaf.Telemetry;
 
 namespace Dekaf.Tests.Unit.Diagnostics;
 
@@ -41,6 +42,7 @@ public sealed class KafkaClientStatusTests
 
         await Assert.That(producerStatus.Role).IsEqualTo(KafkaClientRole.Producer);
         await Assert.That(producerStatus.ClusterId).IsNull();
+        await Assert.That(producerStatus.ClientInstanceId).IsNull();
         await Assert.That(producerStatus.Producer).IsNotNull();
         await Assert.That(producerStatus.Producer!.Value.BufferedBytes).IsEqualTo(0);
         await Assert.That(producerStatus.Producer.Value.BufferCapacityBytes).IsGreaterThan(0UL);
@@ -51,6 +53,72 @@ public sealed class KafkaClientStatusTests
         await Assert.That(shareStatus.ConsumerGroup!.HasConsumerGroup).IsTrue();
         await Assert.That(adminStatus.Role).IsEqualTo(KafkaClientRole.Admin);
         await Assert.That(adminStatus.ClusterId).IsNull();
+        await Assert.That(adminStatus.ClientInstanceId).IsNull();
+
+        var identities = new IKafkaClientIdentity[]
+        {
+            (IKafkaClientIdentity)producer,
+            (IKafkaClientIdentity)consumer,
+            (IKafkaClientIdentity)shareConsumer,
+            (IKafkaClientIdentity)admin
+        };
+        foreach (var identity in identities)
+            await Assert.That(identity.ClientInstanceId).IsNull();
+    }
+
+    [Test]
+    public async Task BuiltInClients_ExposeLatestCachedClientInstanceIdentity()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+        await using var shareConsumer = Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("identity-share-group")
+            .Build();
+        await using var admin = new AdminClient(new AdminClientOptions
+        {
+            BootstrapServers = ["localhost:9092"]
+        });
+        object[] clients = [producer, consumer, shareConsumer, admin];
+        Guid[] expectedIds =
+        [
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Guid.Parse("33333333-3333-3333-3333-333333333333"),
+            Guid.Parse("44444444-4444-4444-4444-444444444444")
+        ];
+
+        for (var i = 0; i < clients.Length; i++)
+        {
+            SetClientInstanceId(clients[i], expectedIds[i]);
+            var identity = (IKafkaClientIdentity)clients[i];
+            var status = ((IKafkaClientStatusProvider)clients[i]).GetStatus();
+
+            await Assert.That(identity.ClientInstanceId).IsEqualTo(expectedIds[i]);
+            await Assert.That(status.ClientInstanceId).IsEqualTo(expectedIds[i]);
+        }
+    }
+
+    [Test]
+    public async Task ClientInstanceIdentity_RemainsAvailableAfterDisposal()
+    {
+        var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+        var clientInstanceId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+        SetClientInstanceId(producer, clientInstanceId);
+
+        await producer.DisposeAsync();
+
+        await Assert.That(((IKafkaClientIdentity)producer).ClientInstanceId)
+            .IsEqualTo(clientInstanceId);
+        var status = ((IKafkaClientStatusProvider)producer).GetStatus();
+        await Assert.That(status.ClientInstanceId).IsEqualTo(clientInstanceId);
+        await Assert.That(status.IsStopped).IsTrue();
     }
 
     [Test]
@@ -255,6 +323,21 @@ public sealed class KafkaClientStatusTests
         (T)instance.GetType()
             .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!
             .GetValue(instance)!;
+
+    private static void SetClientInstanceId(object client, Guid clientInstanceId)
+    {
+        var telemetryManager = GetField<ClientTelemetryManager>(client, "_telemetryManager");
+        typeof(ClientTelemetryManager)
+            .GetField("_subscription", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(telemetryManager, new ClientTelemetrySubscription(
+                clientInstanceId,
+                SubscriptionId: 1,
+                CompressionType: 0,
+                PushIntervalMs: 60_000,
+                TelemetryMaxBytes: 1_024,
+                DeltaTemporality: false,
+                RequestedMetrics: []));
+    }
 
     private static void SetTrustedClusterId(MetadataManager metadataManager, string clusterId) =>
         typeof(MetadataManager)

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
@@ -109,6 +109,41 @@ public sealed class ShareConsumerConnectionOwnershipTests
     }
 
     [Test]
+    public async Task CloseAsync_CanceledLeaveToken_StillStopsTelemetry()
+    {
+        var options = CreateOptions();
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionByIndexAsync(1, 1, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<IKafkaConnection>(new IOException("coordinator unavailable")));
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        var consumer = new KafkaShareConsumer<string, string>(
+            options,
+            Substitute.For<IDeserializer<string>>(),
+            Substitute.For<IDeserializer<string>>(),
+            pool,
+            metadataManager);
+        SetMemberId(consumer, "member-1");
+        var coordinator = typeof(KafkaShareConsumer<string, string>)
+            .GetField("_coordinator", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(consumer)!;
+        typeof(ShareConsumerCoordinator)
+            .GetField("_coordinatorId", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(coordinator, 1);
+
+        await consumer.CloseAsync(new CancellationToken(canceled: true));
+
+        var telemetryManager = typeof(KafkaShareConsumer<string, string>)
+            .GetField("_telemetryManager", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(consumer)!;
+        var stopped = (int)telemetryManager.GetType()
+            .GetField("_stopped", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(telemetryManager)!;
+        await Assert.That(stopped).IsEqualTo(1);
+
+        await consumer.DisposeAsync();
+    }
+
+    [Test]
     public async Task SendShareFetchForPartitionsAsync_HoldsConnectionLeaseThroughRequest()
     {
         var options = CreateOptions();

--- a/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
@@ -173,6 +173,34 @@ public sealed class ClientTelemetryManagerTests
     }
 
     [Test]
+    public async Task DisposeAsync_DuringStop_WaitsForStopCompletion()
+    {
+        await using var context = new TelemetryTestContext();
+        context.Connection.Enqueue(Subscription(
+            Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"),
+            subscriptionId: 19,
+            pushIntervalMs: 60000));
+        context.Connection.BlockNextRequest<PushTelemetryRequest>();
+        await context.Manager.StartAsync();
+
+        var stopTask = context.Manager.StopAsync(TimeSpan.FromSeconds(2)).AsTask();
+        await context.Connection.WaitForBlockedRequestAsync(TimeSpan.FromSeconds(2));
+
+        var disposeTask = context.Manager.DisposeAsync().AsTask();
+        try
+        {
+            await Assert.That(disposeTask.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            context.Connection.ReleaseBlockedRequest();
+        }
+
+        await stopTask.WaitAsync(TimeSpan.FromSeconds(2));
+        await disposeTask.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+
+    [Test]
     public async Task StopAsync_TerminatingPushIncludesApplicationMetrics()
     {
         var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Producer);

--- a/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Reflection;
 using Dekaf.Compression;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -111,6 +112,42 @@ public sealed class ClientTelemetryManagerTests
 
         await Assert.That(context.Manager.IsStarted).IsFalse();
         await Assert.That(context.Connection.RequestsOfType<PushTelemetryRequest>().Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task StopAsync_CanceledWhileWaitingForStartLock_RemainsRetryable()
+    {
+        await using var context = new TelemetryTestContext();
+        context.Connection.Enqueue(Subscription(
+            Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd"),
+            subscriptionId: 18,
+            pushIntervalMs: 60000));
+        context.Connection.Enqueue(new PushTelemetryResponse { ErrorCode = ErrorCode.None });
+        await context.Manager.StartAsync();
+
+        var startLock = (SemaphoreSlim)typeof(ClientTelemetryManager)
+            .GetField("_startLock", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(context.Manager)!;
+        await startLock.WaitAsync();
+        try
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.Cancel();
+
+            await Assert.That(async () =>
+                    await context.Manager.StopAsync(TimeSpan.FromSeconds(2), cancellationSource.Token))
+                .Throws<OperationCanceledException>();
+        }
+        finally
+        {
+            startLock.Release();
+        }
+
+        await context.Manager.StopAsync(TimeSpan.FromSeconds(2));
+
+        var pushes = context.Connection.RequestsOfType<PushTelemetryRequest>();
+        await Assert.That(pushes.Count).IsEqualTo(1);
+        await Assert.That(pushes[0].Terminating).IsTrue();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
@@ -297,6 +297,7 @@ public sealed class ClientTelemetryManagerTests
 
         await Assert.That(context.Manager.IsDisabled).IsTrue();
         await Assert.That(context.Manager.IsStarted).IsFalse();
+        await Assert.That(context.Manager.ClientInstanceId).IsNull();
         await Assert.That(context.Connection.RequestsOfType<PushTelemetryRequest>().Count).IsEqualTo(0);
     }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ClientInstanceIdentityBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ClientInstanceIdentityBenchmarks.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Telemetry;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Measures the allocation-free cached KIP-714 identity read.</summary>
+[MemoryDiagnoser(displayGenColumns: false)]
+[ShortRunJob]
+public class ClientInstanceIdentityBenchmarks
+{
+    private static readonly FieldInfo SubscriptionField = typeof(ClientTelemetryManager)
+        .GetField("_subscription", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private ConnectionPool _connectionPool = null!;
+    private MetadataManager _metadataManager = null!;
+    private ClientTelemetryManager _unavailable = null!;
+    private ClientTelemetryManager _available = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _connectionPool = new ConnectionPool("identity-benchmark", new ConnectionOptions());
+        _metadataManager = new MetadataManager(_connectionPool, ["localhost:9092"]);
+        _unavailable = new ClientTelemetryManager(
+            _connectionPool,
+            _metadataManager,
+            payloadProvider: EmptyClientTelemetryPayloadProvider.Instance);
+        _available = new ClientTelemetryManager(
+            _connectionPool,
+            _metadataManager,
+            payloadProvider: EmptyClientTelemetryPayloadProvider.Instance);
+        SubscriptionField.SetValue(_available, new ClientTelemetrySubscription(
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            SubscriptionId: 1,
+            CompressionType: 0,
+            PushIntervalMs: 60_000,
+            TelemetryMaxBytes: 1_024,
+            DeltaTemporality: false,
+            RequestedMetrics: []));
+    }
+
+    [Benchmark(Baseline = true)]
+    public Guid? ReadUnavailable() => _unavailable.ClientInstanceId;
+
+    [Benchmark]
+    public Guid? ReadAvailable() => _available.ClientInstanceId;
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _unavailable.DisposeAsync().ConfigureAwait(false);
+        await _available.DisposeAsync().ConfigureAwait(false);
+        await _metadataManager.DisposeAsync().ConfigureAwait(false);
+        await _connectionPool.DisposeAsync().ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
## Summary

- add nullable, non-blocking `ClientInstanceId` through the new `IKafkaClientInstanceIdentity` optional capability and immutable status snapshots
- expose the cached KIP-714 identity from producer, consumer, Admin, and Share Consumer roles
- atomically publish refreshed telemetry subscriptions and add Share Consumer telemetry lifecycle ownership
- update public API baselines, observability docs, unit/integration coverage, and BenchmarkDotNet coverage

## Performance evidence

BenchmarkDotNet 0.15.8, .NET 10.0.11, 5 launches, 5 warmups, 10 measured iterations, `MemoryDiagnoser`.
The exact pre-rebase product parent was `5a613b2f448a48be1b546ca61bdfa84d28ae82b4`; the benchmarked candidate source is unchanged in final HEAD `9892c82edff69cb93cfbe7d935702c592707230f`.

| Read | Baseline A1 | Candidate B | Baseline A2 | Allocated A/B/A |
|---|---:|---:|---:|---:|
| unavailable ID | 1.435 ns | 0.2401 ns | 1.223 ns | 0 B / 0 B / 0 B |
| available ID | 1.339 ns | 0.3271 ns | 1.395 ns | 0 B / 0 B / 0 B |

Candidate was lower than both controls. These sub-nanosecond, overhead-subtracted distributions were multimodal, so the hard acceptance signal is unchanged zero allocation. No serialization, produce, consume, batch, channel, or receive hot path changed; throughput, latency, CPU/message, and stability are therefore unaffected by this diagnostic cached read.

## Validation

- `dotnet build --configuration Release`: passed, 0 warnings/errors
- full unit suite: 8,096/8,096 net10 and 7,960/7,960 net8
- focused identity tests: 9/9 on net10 and 9/9 on net8
- focused cancellation regression: 2/2 on net10 and 2/2 on net8
- package validation / ApiCompat against 1.13.0: passed
- Kafka 4.3.1 focused integration suite: 4/4
- documentation snippets: 288 compiled; 3 excluded; 155 known legacy failures matched
- `/simplify`: completed; removed one unsupported documentation overclaim, no performance-risking code rewrites

The default integration broker has no client-telemetry receiver, so real-broker role coverage verifies the documented unavailable/null contract. Protocol-backed unit coverage verifies available IDs, atomic refresh publication, status parity, unsupported brokers, pre-initialization, and disposal retention across all four roles.

Closes #2895

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added access to broker-assigned client instance IDs for producer, consumer, Share Consumer, and Admin clients.
  - Client instance IDs are also included in status snapshots and observability documentation.
  - IDs are nullable when unavailable and remain accessible after client disposal.

- **Bug Fixes**
  - Improved telemetry shutdown handling so canceled stop operations can be retried safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->