### PR TITLE
Paginate PR review threads in merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -735,6 +735,12 @@ jobs:
           PYTHONPATH: .github/scripts
         run: python3 -m unittest discover -s .github/scripts -p 'test_*.py'
 
+      - name: Test PR Merge Gate
+        shell: pwsh
+        run: |
+          ./scripts/Test-AssertPrGreenReviewHeuristics.ps1
+          ./scripts/Test-AssertPrGreenReviewThreads.ps1
+
       - name: Test Integration Category Runner
         run: bash scripts/tests/run-integration-categories-tests.sh
 

--- a/scripts/Assert-PrGreen.ps1
+++ b/scripts/Assert-PrGreen.ps1
@@ -30,6 +30,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot 'AssertPrGreenReviewHeuristics.ps1')
+. (Join-Path $PSScriptRoot 'AssertPrGreenReviewThreads.ps1')
 
 function Deny([string]$reason) {
     [Console]::Error.WriteLine("DO NOT MERGE #${Pr} -- $reason")
@@ -127,18 +128,39 @@ else {
     $owner, $name = $nwo.Trim() -split '/', 2
 }
 
-$query = 'query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100){pageInfo{hasNextPage} nodes{isResolved}}}}}'
-$threadsRaw = gh api graphql -f query=$query -F owner=$owner -F repo=$name -F pr=$Pr 2>$null
-if ($LASTEXITCODE -ne 0) { Deny "could not fetch review threads (exit $LASTEXITCODE)" }
+$query = 'query($owner:String!,$repo:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100,after:$cursor){pageInfo{hasNextPage endCursor} nodes{isResolved}}}}}'
 try {
-    $reviewThreads = ($threadsRaw | ConvertFrom-Json).data.repository.pullRequest.reviewThreads
+    $reviewThreads = @(Get-AllReviewThreads -FetchPage {
+        param($cursor)
+
+        $ghArgs = @(
+            'api', 'graphql',
+            '-f', "query=$query",
+            '-F', "owner=$owner",
+            '-F', "repo=$name",
+            '-F', "pr=$Pr"
+        )
+        if ($null -ne $cursor) {
+            $ghArgs += @('-f', "cursor=$cursor")
+        }
+
+        $threadsRaw = & gh @ghArgs 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            throw "gh api graphql failed (exit $LASTEXITCODE)."
+        }
+
+        $page = ($threadsRaw | ConvertFrom-Json).data.repository.pullRequest.reviewThreads
+        if ($null -eq $page) {
+            throw 'GraphQL response did not contain review threads.'
+        }
+
+        return $page
+    })
 }
 catch {
-    Deny "could not parse review threads: $($_.Exception.Message)"
+    Deny "could not fetch or parse review threads: $($_.Exception.Message)"
 }
-# More than one page means we cannot see every thread; deny rather than pass blind.
-if ($reviewThreads.pageInfo.hasNextPage) { Deny "more than 100 review threads -- too many to inspect safely" }
-$unresolved = @($reviewThreads.nodes | Where-Object { -not $_.isResolved }).Count
+$unresolved = @($reviewThreads | Where-Object { -not $_.isResolved }).Count
 if ($unresolved -gt 0) { Deny "$unresolved unresolved review thread(s)" }
 
 Write-Host "OK #${Pr} -- MERGEABLE, CLEAN, $($checks.Count) check(s) green, no unresolved threads. Safe to merge."

--- a/scripts/AssertPrGreenReviewThreads.ps1
+++ b/scripts/AssertPrGreenReviewThreads.ps1
@@ -29,6 +29,11 @@ function Get-AllReviewThreads {
                 throw 'Review-thread response contained a null thread.'
             }
 
+            $isResolvedProperty = $thread.PSObject.Properties['isResolved']
+            if ($null -eq $isResolvedProperty -or $isResolvedProperty.Value -isnot [bool]) {
+                throw 'Review-thread node did not contain a Boolean isResolved.'
+            }
+
             $threads.Add($thread)
         }
 

--- a/scripts/AssertPrGreenReviewThreads.ps1
+++ b/scripts/AssertPrGreenReviewThreads.ps1
@@ -1,0 +1,40 @@
+function Get-AllReviewThreads {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][scriptblock]$FetchPage
+    )
+
+    $threads = [System.Collections.Generic.List[object]]::new()
+    $seenCursors = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $cursor = $null
+
+    while ($true) {
+        $page = & $FetchPage $cursor
+        if ($null -eq $page -or $null -eq $page.pageInfo) {
+            throw 'Review-thread response did not contain pageInfo.'
+        }
+
+        foreach ($thread in @($page.nodes)) {
+            if ($null -eq $thread) {
+                throw 'Review-thread response contained a null thread.'
+            }
+
+            $threads.Add($thread)
+        }
+
+        if (-not [bool]$page.pageInfo.hasNextPage) {
+            return $threads.ToArray()
+        }
+
+        $nextCursor = [string]$page.pageInfo.endCursor
+        if ([string]::IsNullOrWhiteSpace($nextCursor)) {
+            throw 'Review-thread response has another page but no end cursor.'
+        }
+
+        if (-not $seenCursors.Add($nextCursor)) {
+            throw "Review-thread pagination repeated cursor '$nextCursor'."
+        }
+
+        $cursor = $nextCursor
+    }
+}

--- a/scripts/AssertPrGreenReviewThreads.ps1
+++ b/scripts/AssertPrGreenReviewThreads.ps1
@@ -14,6 +14,11 @@ function Get-AllReviewThreads {
             throw 'Review-thread response did not contain pageInfo.'
         }
 
+        $hasNextPageProperty = $page.pageInfo.PSObject.Properties['hasNextPage']
+        if ($null -eq $hasNextPageProperty -or $hasNextPageProperty.Value -isnot [bool]) {
+            throw 'Review-thread pageInfo did not contain a Boolean hasNextPage.'
+        }
+
         foreach ($thread in @($page.nodes)) {
             if ($null -eq $thread) {
                 throw 'Review-thread response contained a null thread.'
@@ -22,7 +27,7 @@ function Get-AllReviewThreads {
             $threads.Add($thread)
         }
 
-        if (-not [bool]$page.pageInfo.hasNextPage) {
+        if (-not $hasNextPageProperty.Value) {
             return $threads.ToArray()
         }
 

--- a/scripts/AssertPrGreenReviewThreads.ps1
+++ b/scripts/AssertPrGreenReviewThreads.ps1
@@ -19,7 +19,12 @@ function Get-AllReviewThreads {
             throw 'Review-thread pageInfo did not contain a Boolean hasNextPage.'
         }
 
-        foreach ($thread in @($page.nodes)) {
+        $nodesProperty = $page.PSObject.Properties['nodes']
+        if ($null -eq $nodesProperty -or $null -eq $nodesProperty.Value) {
+            throw 'Review-thread response did not contain nodes.'
+        }
+
+        foreach ($thread in @($nodesProperty.Value)) {
             if ($null -eq $thread) {
                 throw 'Review-thread response contained a null thread.'
             }

--- a/scripts/Test-AssertPrGreenReviewThreads.ps1
+++ b/scripts/Test-AssertPrGreenReviewThreads.ps1
@@ -101,6 +101,25 @@ foreach ($invalidPage in @(
     }
 }
 
+foreach ($invalidThread in @(
+    [pscustomobject]@{},
+    [pscustomobject]@{ isResolved = $null },
+    [pscustomobject]@{ isResolved = 'false' }
+)) {
+    $invalidIsResolvedThrew = $false
+    try {
+        Get-AllReviewThreads -FetchPage {
+            New-ReviewThreadPage -Threads @($invalidThread) -HasNextPage $false
+        }
+    }
+    catch {
+        $invalidIsResolvedThrew = $true
+    }
+    if (-not $invalidIsResolvedThrew) {
+        throw 'Expected a missing, null, or non-Boolean isResolved to fail closed.'
+    }
+}
+
 $fetchFailureThrew = $false
 try {
     Get-AllReviewThreads -FetchPage { throw 'simulated API failure' }

--- a/scripts/Test-AssertPrGreenReviewThreads.ps1
+++ b/scripts/Test-AssertPrGreenReviewThreads.ps1
@@ -1,0 +1,75 @@
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'AssertPrGreenReviewThreads.ps1')
+
+function New-ReviewThreadPage {
+    param(
+        [Parameter(Mandatory)][object[]]$Threads,
+        [Parameter(Mandatory)][bool]$HasNextPage,
+        [AllowNull()][string]$EndCursor
+    )
+
+    return [pscustomobject]@{
+        nodes = $Threads
+        pageInfo = [pscustomobject]@{
+            hasNextPage = $HasNextPage
+            endCursor = $EndCursor
+        }
+    }
+}
+
+$requestedCursors = [System.Collections.Generic.List[object]]::new()
+$resolvedFirstPage = 1..100 | ForEach-Object { [pscustomobject]@{ isResolved = $true } }
+$allResolved = @(Get-AllReviewThreads -FetchPage {
+    param($cursor)
+    $requestedCursors.Add($cursor)
+    if ($null -eq $cursor) {
+        return New-ReviewThreadPage -Threads $resolvedFirstPage -HasNextPage $true -EndCursor 'page-2'
+    }
+
+    return New-ReviewThreadPage -Threads @([pscustomobject]@{ isResolved = $true }) -HasNextPage $false
+})
+
+if ($allResolved.Count -ne 101) {
+    throw "Expected 101 resolved threads, got $($allResolved.Count)."
+}
+if ($requestedCursors.Count -ne 2 -or $null -ne $requestedCursors[0] -or $requestedCursors[1] -ne 'page-2') {
+    throw "Unexpected cursor sequence: $($requestedCursors -join ', ')."
+}
+
+$laterUnresolved = @(Get-AllReviewThreads -FetchPage {
+    param($cursor)
+    if ($null -eq $cursor) {
+        return New-ReviewThreadPage -Threads $resolvedFirstPage -HasNextPage $true -EndCursor 'page-2'
+    }
+
+    return New-ReviewThreadPage -Threads @([pscustomobject]@{ isResolved = $false }) -HasNextPage $false
+})
+if (@($laterUnresolved | Where-Object { -not $_.isResolved }).Count -ne 1) {
+    throw 'Expected an unresolved thread on the second page.'
+}
+
+$missingCursorThrew = $false
+try {
+    Get-AllReviewThreads -FetchPage {
+        New-ReviewThreadPage -Threads @() -HasNextPage $true
+    }
+}
+catch {
+    $missingCursorThrew = $true
+}
+if (-not $missingCursorThrew) {
+    throw 'Expected pagination without an end cursor to fail closed.'
+}
+
+$fetchFailureThrew = $false
+try {
+    Get-AllReviewThreads -FetchPage { throw 'simulated API failure' }
+}
+catch {
+    $fetchFailureThrew = $true
+}
+if (-not $fetchFailureThrew) {
+    throw 'Expected a page-fetch failure to propagate.'
+}
+
+Write-Host 'OK review-thread pagination tests passed.'

--- a/scripts/Test-AssertPrGreenReviewThreads.ps1
+++ b/scripts/Test-AssertPrGreenReviewThreads.ps1
@@ -61,6 +61,25 @@ if (-not $missingCursorThrew) {
     throw 'Expected pagination without an end cursor to fail closed.'
 }
 
+foreach ($invalidPageInfo in @(
+    [pscustomobject]@{},
+    [pscustomobject]@{ hasNextPage = $null },
+    [pscustomobject]@{ hasNextPage = 'false' }
+)) {
+    $invalidHasNextPageThrew = $false
+    try {
+        Get-AllReviewThreads -FetchPage {
+            [pscustomobject]@{ nodes = @(); pageInfo = $invalidPageInfo }
+        }
+    }
+    catch {
+        $invalidHasNextPageThrew = $true
+    }
+    if (-not $invalidHasNextPageThrew) {
+        throw 'Expected a missing, null, or non-Boolean hasNextPage to fail closed.'
+    }
+}
+
 $fetchFailureThrew = $false
 try {
     Get-AllReviewThreads -FetchPage { throw 'simulated API failure' }

--- a/scripts/Test-AssertPrGreenReviewThreads.ps1
+++ b/scripts/Test-AssertPrGreenReviewThreads.ps1
@@ -80,6 +80,27 @@ foreach ($invalidPageInfo in @(
     }
 }
 
+foreach ($invalidPage in @(
+    [pscustomobject]@{
+        pageInfo = [pscustomobject]@{ hasNextPage = $false }
+    },
+    [pscustomobject]@{
+        nodes = $null
+        pageInfo = [pscustomobject]@{ hasNextPage = $false }
+    }
+)) {
+    $invalidNodesThrew = $false
+    try {
+        Get-AllReviewThreads -FetchPage { $invalidPage }
+    }
+    catch {
+        $invalidNodesThrew = $true
+    }
+    if (-not $invalidNodesThrew) {
+        throw 'Expected missing or null nodes to fail closed.'
+    }
+}
+
 $fetchFailureThrew = $false
 try {
     Get-AllReviewThreads -FetchPage { throw 'simulated API failure' }


### PR DESCRIPTION
Closes #2900.

## What changed
- paginate every GraphQL review-thread page in the authoritative PR merge gate
- fail closed on missing/repeated cursors, malformed responses, and fetch failures
- add deterministic coverage for 101 resolved threads, a later-page unresolved thread, and pagination failures
- run PR merge-gate script tests in Code Quality CI

## Validation
- `pwsh scripts/Test-AssertPrGreenReviewThreads.ps1`
- `pwsh scripts/Test-AssertPrGreenReviewHeuristics.ps1`
- live read-only gate against PR #2823 traversed page 2 and correctly detected its 2 unresolved threads
- `/simplify` complete