### PR TITLE
Make cross-connection throttle timing deterministic

### DIFF
--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionBrokerThrottleTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionBrokerThrottleTests.cs
@@ -35,7 +35,7 @@ public sealed class KafkaConnectionBrokerThrottleTests
 
             await CompleteApiVersionsRequestAsync(firstStream, throttleTimeMs, cancellationToken);
             var secondRequest = await ReadFrameAsync(secondStream, cancellationToken);
-            followUpReceived.TrySetResult(Stopwatch.GetTimestamp());
+            followUpReceived.TrySetResult(MonotonicClock.GetMilliseconds());
             await WriteApiVersionsResponseAsync(secondStream, secondRequest, 0, cancellationToken);
         }, cancellationToken);
 
@@ -50,7 +50,9 @@ public sealed class KafkaConnectionBrokerThrottleTests
             3,
             cancellationToken);
 
-        var followUpStarted = Stopwatch.GetTimestamp();
+        var followUpStartedMs = MonotonicClock.GetMilliseconds();
+        var remainingThrottleMs = throttleState.GetRemainingMilliseconds();
+        await Assert.That(remainingThrottleMs).IsGreaterThan(0);
         var followUpTask = second.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
             CreateApiVersionsRequest(),
             3,
@@ -58,13 +60,15 @@ public sealed class KafkaConnectionBrokerThrottleTests
 
         var earlyProgress = await Task.WhenAny(
             followUpReceived.Task,
-            Task.Delay(100, cancellationToken));
+            Task.Delay(Math.Max(1, remainingThrottleMs / 2), cancellationToken));
         await Assert.That(earlyProgress).IsNotSameReferenceAs(followUpReceived.Task);
 
         _ = await followUpTask;
-        var receivedAt = await followUpReceived.Task;
-        var elapsedMs = (receivedAt - followUpStarted) * 1000d / Stopwatch.Frequency;
-        await Assert.That(elapsedMs).IsGreaterThanOrEqualTo(200);
+        var receivedAtMs = await followUpReceived.Task;
+        var elapsedMs = receivedAtMs - followUpStartedMs;
+        const int clockResolutionToleranceMs = 1;
+        await Assert.That(elapsedMs + clockResolutionToleranceMs)
+            .IsGreaterThanOrEqualTo(remainingThrottleMs);
         await serverTask;
     }
 


### PR DESCRIPTION
Closes #2903.

## Summary

- sample the shared broker throttle state's actual remaining deadline before the follow-up request
- record request receipt with the same monotonic millisecond clock used by the throttle state
- derive the early-observation window from the sampled deadline and allow only its 1 ms clock quantization

This preserves the cross-physical-connection assertion while removing the fixed elapsed threshold that incorrectly assumed the full 300 ms deadline began at the test's measurement point.

## Validation

- focused test repeated 25/25 on `net10.0`
- focused test repeated 25/25 on `net8.0`
- `KafkaConnectionBrokerThrottleTests`: 6/6 on each target framework
- full unit suite: 8092/8092 on `net10.0`
- full unit suite: 7956/7956 on `net8.0`

Test-only change; no production hot path or benchmark impact.
