### PR TITLE
Make consume filter exception test deterministic

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerRecordFilterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerRecordFilterTests.cs
@@ -225,7 +225,9 @@ public sealed class ConsumerRecordFilterTests
     }
 
     [Test]
-    public async Task ConsumeAsync_FilterExceptionPropagatesWithoutAdvancingPosition()
+    [Timeout(30_000)]
+    public async Task ConsumeAsync_FilterExceptionPropagatesWithoutAdvancingPosition(
+        CancellationToken testTimeout)
     {
         var fetch = CreatePendingFetchData(CreateRecord(0, "key", "value"));
         var topicPartition = fetch.TopicPartition;
@@ -235,8 +237,9 @@ public sealed class ConsumerRecordFilterTests
             new ThrowingFilter(expected),
             Serializers.String,
             Serializers.String);
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(1));
-        await using var records = consumer.ConsumeAsync(timeout.Token).GetAsyncEnumerator();
+        await using var records = consumer
+            .ConsumeAsync(CancellationToken.None)
+            .GetAsyncEnumerator(CancellationToken.None);
 
         var actual = (await Assert.That(async () => await records.MoveNextAsync())
             .Throws<InvalidOperationException>())!;

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerRecordFilterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerRecordFilterTests.cs
@@ -238,8 +238,8 @@ public sealed class ConsumerRecordFilterTests
             Serializers.String,
             Serializers.String);
         await using var records = consumer
-            .ConsumeAsync(CancellationToken.None)
-            .GetAsyncEnumerator(CancellationToken.None);
+            .ConsumeAsync(testTimeout)
+            .GetAsyncEnumerator(testTimeout);
 
         var actual = (await Assert.That(async () => await records.MoveNextAsync())
             .Throws<InvalidOperationException>())!;

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerRecordFilterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerRecordFilterTests.cs
@@ -238,8 +238,8 @@ public sealed class ConsumerRecordFilterTests
             Serializers.String,
             Serializers.String);
         await using var records = consumer
-            .ConsumeAsync(testTimeout)
-            .GetAsyncEnumerator(testTimeout);
+            .ConsumeAsync(CancellationToken.None)
+            .GetAsyncEnumerator(CancellationToken.None);
 
         var actual = (await Assert.That(async () => await records.MoveNextAsync())
             .Throws<InvalidOperationException>())!;


### PR DESCRIPTION
## Summary
- replace the one-second API cancellation guard with a TUnit-owned 30-second timeout
- pass CancellationToken.None explicitly at both async-enumeration boundaries so suite contention cannot mask the expected filter exception

## Test plan
- [x] Release unit build: 0 warnings, 0 errors
- [x] ConsumerRecordFilterTests: 25/25 on net10.0 and net8.0
- [x] Full unit suite: 8,092/8,092 net10.0; 7,956/7,956 net8.0

Closes #2905


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a 30-second timeout to the consumer filter exception-propagation test.
  * Improved cancellation handling to ensure the test reliably verifies exception propagation without advancing the consumer position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->