### PR TITLE
test(streams): await target assignment

### DIFF
--- a/tests/Dekaf.Tests.Integration/StreamsGroupMemberIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/StreamsGroupMemberIntegrationTests.cs
@@ -270,10 +270,20 @@ public sealed class StreamsGroupMemberIntegrationTests(KafkaTestContainer kafka)
         IStreamsGroupMember member,
         IReadOnlyCollection<int> expectedPartitions)
     {
-        var descriptions = await admin.DescribeStreamsGroupsAsync([member.GroupId]);
-        var targeted = descriptions[member.GroupId].Members.Single().TargetAssignment.ActiveTasks
-            .SelectMany(static taskSet => taskSet.Partitions)
-            .ToArray();
+        var memberId = member.Snapshot.MemberId;
+        var expected = expectedPartitions.ToHashSet();
+        var targeted = await TestWait.WaitForConditionAsync(
+            async () =>
+            {
+                var descriptions = await admin.DescribeStreamsGroupsAsync([member.GroupId]);
+                return descriptions[member.GroupId].Members
+                    .SingleOrDefault(candidate => candidate.MemberId == memberId)?
+                    .TargetAssignment.ActiveTasks
+                    .SelectMany(static taskSet => taskSet.Partitions)
+                    .ToArray() ?? [];
+            },
+            expected.SetEquals,
+            description: $"Streams target assignment for member {memberId}");
         await Assert.That(targeted).IsEquivalentTo(expectedPartitions);
 
         var heartbeat = await member.UpdateAsync(new StreamsGroupMemberUpdate());

--- a/tests/Dekaf.Tests.Integration/StreamsGroupMemberIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/StreamsGroupMemberIntegrationTests.cs
@@ -283,7 +283,8 @@ public sealed class StreamsGroupMemberIntegrationTests(KafkaTestContainer kafka)
                     .ToArray() ?? [];
             },
             expected.SetEquals,
-            description: $"Streams target assignment for member {memberId}");
+            description: $"Streams target assignment for member {memberId}",
+            formatObserved: static partitions => $"[{string.Join(", ", partitions)}]");
         await Assert.That(targeted).IsEquivalentTo(expectedPartitions);
 
         var heartbeat = await member.UpdateAsync(new StreamsGroupMemberUpdate());

--- a/tests/Dekaf.Tests.Integration/TestWait.cs
+++ b/tests/Dekaf.Tests.Integration/TestWait.cs
@@ -48,7 +48,8 @@ internal static class TestWait
         Func<T, bool> condition,
         int maxRetries = 10,
         int initialDelayMs = 500,
-        string? description = null)
+        string? description = null,
+        Func<T, string>? formatObserved = null)
     {
         T result = default!;
         for (var i = 0; i < maxRetries; i++)
@@ -59,8 +60,9 @@ internal static class TestWait
                 return result;
         }
 
+        var observed = formatObserved is null ? result?.ToString() : formatObserved(result);
         throw new TimeoutException(
             $"Condition not met after {maxRetries} checks" +
-            $"{(description is null ? "" : $": {description}")}; last observed: {result}");
+            $"{(description is null ? "" : $": {description}")}; last observed: {observed ?? "<null>"}");
     }
 }


### PR DESCRIPTION
## Summary

- wait for the broker-published Streams target assignment before acknowledging it
- match the joined member by ID while polling
- replace an immediate eventually-consistent assertion with the shared bounded admin wait

Closes #2907

## Verification

- `dotnet build tests/Dekaf.Tests.Integration --configuration Release` — 0 warnings, 0 errors
- Kafka 4.3.1 exact regression — 1/1 passed
- Kafka 4.3.1 `StreamsGroupMemberIntegrationTests` — 2/2 applicable passed, 3 Kafka 4.4-only tests skipped