### PR TITLE
test(consumer): separate timeout budgets

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
@@ -125,7 +125,9 @@ public sealed class ConsumerPartitionStopListenerTests
         };
         var consumer = CreateConsumer(
             listener,
-            defaultApiTimeoutMs: 5_000,
+            // Keep the API backstop above telemetry's independent five-second stop bound.
+            // The TUnit timeout remains the outer hang guard for the whole test.
+            defaultApiTimeoutMs: 20_000,
             partitionStopTimeout: TimeSpan.FromMilliseconds(50));
         var partition = new TopicPartition("topic-a", 0);
         consumer.Assign(partition);


### PR DESCRIPTION
## Summary

- separate the partition-stop behavior timeout from the consumer API backstop
- keep the 20-second API budget above telemetry's independent five-second stop bound
- retain TUnit's 30-second whole-test hang guard and deterministic cleanup

Closes #2856

## Root cause

The prior stabilization set `DefaultApiTimeoutMs` to 5 seconds, exactly equal to telemetry's stop bound. Under full-suite ThreadPool contention, earlier listener teardown consumed enough of that shared outer budget for telemetry stop to observe cancellation and fail the test.

## Verification

- Release unit build: 0 warnings, 0 errors
- focused test normal: net10 1/1; net8 1/1
- focused test with 1–2 worker threads: net10 1/1; net8 1/1
- full unit suites concurrently: net10 8,148/8,148; net8 8,012/8,012
- `/simplify` final review complete
- test-only change; benchmarks not applicable