### PR TITLE
Validate inline Avro CHECK rules

### DIFF
--- a/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
@@ -10,6 +10,7 @@ internal sealed class AvroAggregateEqualityComparer(AvroSchema schema) : IValida
     private const int StackMapBucketCount = 32;
 
     private readonly AvroSchema _schema = schema;
+    private readonly bool _requiresSemanticEquality = ContainsFloating(schema, []);
 
     internal static AvroAggregateEqualityComparer? Create(AvroSchema schema) => schema.Tag switch
     {
@@ -17,6 +18,8 @@ internal sealed class AvroAggregateEqualityComparer(AvroSchema schema) : IValida
         AvroSchema.Type.Array or AvroSchema.Type.Map => new(schema),
         _ => null
     };
+
+    bool IValidationCelAggregateComparer.RequiresSemanticEquality => _requiresSemanticEquality;
 
     bool IValidationCelAggregateComparer.AreEqual(
         ReadOnlyMemory<byte> left,
@@ -94,6 +97,50 @@ internal sealed class AvroAggregateEqualityComparer(AvroSchema schema) : IValida
             default:
                 throw InvalidPayload($"unsupported schema type {schema.Tag}");
         }
+    }
+
+    private static bool ContainsFloating(
+        AvroSchema schema,
+        HashSet<AvroSchema> visited)
+    {
+        schema = AvroValueRulePlan.Unwrap(schema);
+        if (schema.Tag is AvroSchema.Type.Float or AvroSchema.Type.Double)
+            return true;
+        if (!visited.Add(schema))
+            return false;
+
+        return schema switch
+        {
+            global::Avro.RecordSchema record => ContainsFloating(record, visited),
+            global::Avro.ArraySchema array => ContainsFloating(array.ItemSchema, visited),
+            global::Avro.MapSchema map => ContainsFloating(map.ValueSchema, visited),
+            global::Avro.UnionSchema union => ContainsFloating(union, visited),
+            _ => false
+        };
+    }
+
+    private static bool ContainsFloating(
+        global::Avro.RecordSchema record,
+        HashSet<AvroSchema> visited)
+    {
+        for (var index = 0; index < record.Fields.Count; index++)
+        {
+            if (ContainsFloating(record.Fields[index].Schema, visited))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool ContainsFloating(
+        global::Avro.UnionSchema union,
+        HashSet<AvroSchema> visited)
+    {
+        for (var index = 0; index < union.Count; index++)
+        {
+            if (ContainsFloating(union[index], visited))
+                return true;
+        }
+        return false;
     }
 
     private static bool ArraysAreEqual(

--- a/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
@@ -52,11 +52,13 @@ internal sealed class AvroAggregateEqualityComparer(AvroSchema schema) : IValida
             case AvroSchema.Type.Enumeration:
                 return left.ReadLong() == right.ReadLong();
             case AvroSchema.Type.Float:
-                return BinaryPrimitives.ReadSingleLittleEndian(left.Read(sizeof(float)).Span) ==
-                    BinaryPrimitives.ReadSingleLittleEndian(right.Read(sizeof(float)).Span);
+                var leftFloat = BinaryPrimitives.ReadSingleLittleEndian(left.Read(sizeof(float)).Span);
+                var rightFloat = BinaryPrimitives.ReadSingleLittleEndian(right.Read(sizeof(float)).Span);
+                return !float.IsNaN(leftFloat) && leftFloat.CompareTo(rightFloat) == 0;
             case AvroSchema.Type.Double:
-                return BinaryPrimitives.ReadDoubleLittleEndian(left.Read(sizeof(double)).Span) ==
-                    BinaryPrimitives.ReadDoubleLittleEndian(right.Read(sizeof(double)).Span);
+                var leftDouble = BinaryPrimitives.ReadDoubleLittleEndian(left.Read(sizeof(double)).Span);
+                var rightDouble = BinaryPrimitives.ReadDoubleLittleEndian(right.Read(sizeof(double)).Span);
+                return !double.IsNaN(leftDouble) && leftDouble.CompareTo(rightDouble) == 0;
             case AvroSchema.Type.String:
             case AvroSchema.Type.Bytes:
                 return left.ReadLengthPrefixed().Span.SequenceEqual(right.ReadLengthPrefixed().Span);

--- a/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
@@ -46,6 +46,7 @@ internal sealed class AvroAggregateEqualityComparer(
     object schemaToken,
     bool rawEqualityCompatible) : IValidationCelAggregateComparer
 {
+    private const int MaximumMapEntryCount = 1_048_576;
     private const int StackRecordFieldCount = 16;
     private const int StackMapEntryCount = 16;
     private const int StackMapBucketCount = 32;
@@ -409,6 +410,11 @@ internal sealed class AvroAggregateEqualityComparer(
             if (count == 0)
                 return checked((int)total);
             total = checked(total + count);
+            if (total > MaximumMapEntryCount)
+            {
+                throw InvalidPayload(
+                    $"map entry count exceeds the supported limit of {MaximumMapEntryCount}");
+            }
             for (long index = 0; index < count; index++)
             {
                 _ = reader.ReadLengthPrefixed();
@@ -706,10 +712,6 @@ internal static class AvroValueSchemaComparer
                     ((global::Avro.MapSchema)left).ValueSchema,
                     ((global::Avro.MapSchema)right).ValueSchema,
                     pairs),
-                AvroSchema.Type.Union => UnionsAreEqual(
-                    (global::Avro.UnionSchema)left,
-                    (global::Avro.UnionSchema)right,
-                    pairs),
                 AvroSchema.Type.Fixed =>
                     ((global::Avro.FixedSchema)left).Size == ((global::Avro.FixedSchema)right).Size,
                 _ => true
@@ -777,18 +779,4 @@ internal static class AvroValueSchemaComparer
         return true;
     }
 
-    private static bool UnionsAreEqual(
-        global::Avro.UnionSchema left,
-        global::Avro.UnionSchema right,
-        HashSet<AvroSchemaPair> pairs)
-    {
-        if (left.Count != right.Count)
-            return false;
-        for (var index = 0; index < left.Count; index++)
-        {
-            if (!AreCelCompatible(left[index], right[index], pairs))
-                return false;
-        }
-        return true;
-    }
 }

--- a/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Text;
 using AvroSchema = global::Avro.Schema;
 
 namespace Dekaf.SchemaRegistry.Avro;
@@ -20,15 +21,18 @@ internal sealed class AvroAggregateEqualityComparerFactory
         {
             var group = _groups[index];
             if (AvroSchemaLogicalComparer.Instance.Equals(schema, group.Schema) ||
-                AvroValueSchemaComparer.AreEqual(schema, group.Schema))
+                AvroValueSchemaComparer.AreCelCompatible(schema, group.Schema))
             {
-                return new AvroAggregateEqualityComparer(schema, group);
+                return new AvroAggregateEqualityComparer(
+                    schema,
+                    group,
+                    AvroValueSchemaComparer.HaveSameEncoding(schema, group.Schema));
             }
         }
 
         var newGroup = new SchemaGroup(schema);
         _groups.Add(newGroup);
-        return new AvroAggregateEqualityComparer(schema, newGroup);
+        return new AvroAggregateEqualityComparer(schema, newGroup, rawEqualityCompatible: true);
     }
 
     private sealed class SchemaGroup(AvroSchema schema)
@@ -39,7 +43,8 @@ internal sealed class AvroAggregateEqualityComparerFactory
 
 internal sealed class AvroAggregateEqualityComparer(
     AvroSchema schema,
-    object schemaToken) : IValidationCelAggregateComparer
+    object schemaToken,
+    bool rawEqualityCompatible) : IValidationCelAggregateComparer
 {
     private const int StackMapEntryCount = 16;
     private const int StackMapBucketCount = 32;
@@ -49,7 +54,7 @@ internal sealed class AvroAggregateEqualityComparer(
     private readonly object _schemaToken = schemaToken;
 
     object? IValidationCelAggregateComparer.RawEqualityToken =>
-        _requiresSemanticEquality ? null : _schemaToken;
+        _requiresSemanticEquality || !rawEqualityCompatible ? null : _schemaToken;
 
     bool IValidationCelAggregateComparer.AreEqual(
         ReadOnlyMemory<byte> left,
@@ -62,68 +67,174 @@ internal sealed class AvroAggregateEqualityComparer(
 
         var leftReader = new AvroValidationReader(left);
         var rightReader = new AvroValidationReader(right);
-        return AreEqual(_schema, ref leftReader, ref rightReader) &&
+        return AreEqual(_schema, avroRight._schema, ref leftReader, ref rightReader) &&
             leftReader.End && rightReader.End;
     }
 
     private static bool AreEqual(
-        AvroSchema schema,
+        AvroSchema leftSchema,
+        AvroSchema rightSchema,
         ref AvroValidationReader left,
         ref AvroValidationReader right)
     {
-        schema = AvroValueRulePlan.Unwrap(schema);
-        switch (schema.Tag)
+        leftSchema = AvroValueRulePlan.Unwrap(leftSchema);
+        rightSchema = AvroValueRulePlan.Unwrap(rightSchema);
+        if (IsNumber(leftSchema.Tag) && IsNumber(rightSchema.Tag))
+        {
+            return ValidationCelBinaryNode.NumbersAreEqual(
+                ReadNumber(leftSchema.Tag, ref left),
+                ReadNumber(rightSchema.Tag, ref right));
+        }
+        if (IsBytes(leftSchema.Tag) && IsBytes(rightSchema.Tag))
+        {
+            return ReadBytes(leftSchema, ref left).Span.SequenceEqual(
+                ReadBytes(rightSchema, ref right).Span);
+        }
+        if (IsString(leftSchema.Tag) && IsString(rightSchema.Tag))
+            return StringValuesAreEqual(leftSchema, rightSchema, ref left, ref right);
+        if (leftSchema.Tag != rightSchema.Tag &&
+            !(leftSchema.Tag is AvroSchema.Type.Record or AvroSchema.Type.Error &&
+              rightSchema.Tag is AvroSchema.Type.Record or AvroSchema.Type.Error))
+        {
+            return false;
+        }
+
+        switch (leftSchema.Tag)
         {
             case AvroSchema.Type.Null:
                 return true;
             case AvroSchema.Type.Boolean:
                 return (left.Read(1).Span[0] != 0) == (right.Read(1).Span[0] != 0);
-            case AvroSchema.Type.Int:
-            case AvroSchema.Type.Long:
-            case AvroSchema.Type.Enumeration:
-                return left.ReadLong() == right.ReadLong();
-            case AvroSchema.Type.Float:
-                var leftFloat = BinaryPrimitives.ReadSingleLittleEndian(left.Read(sizeof(float)).Span);
-                var rightFloat = BinaryPrimitives.ReadSingleLittleEndian(right.Read(sizeof(float)).Span);
-                return !float.IsNaN(leftFloat) && leftFloat.CompareTo(rightFloat) == 0;
-            case AvroSchema.Type.Double:
-                var leftDouble = BinaryPrimitives.ReadDoubleLittleEndian(left.Read(sizeof(double)).Span);
-                var rightDouble = BinaryPrimitives.ReadDoubleLittleEndian(right.Read(sizeof(double)).Span);
-                return !double.IsNaN(leftDouble) && leftDouble.CompareTo(rightDouble) == 0;
-            case AvroSchema.Type.String:
-            case AvroSchema.Type.Bytes:
-                return left.ReadLengthPrefixed().Span.SequenceEqual(right.ReadLengthPrefixed().Span);
-            case AvroSchema.Type.Fixed:
-                var size = ((global::Avro.FixedSchema)schema).Size;
-                return left.Read(size).Span.SequenceEqual(right.Read(size).Span);
             case AvroSchema.Type.Record:
             case AvroSchema.Type.Error:
-                var record = (global::Avro.RecordSchema)schema;
-                for (var index = 0; index < record.Fields.Count; index++)
+                var leftRecord = (global::Avro.RecordSchema)leftSchema;
+                var rightRecord = (global::Avro.RecordSchema)rightSchema;
+                for (var index = 0; index < leftRecord.Fields.Count; index++)
                 {
-                    if (!AreEqual(record.Fields[index].Schema, ref left, ref right))
+                    if (!AreEqual(
+                            leftRecord.Fields[index].Schema,
+                            rightRecord.Fields[index].Schema,
+                            ref left,
+                            ref right))
+                    {
                         return false;
+                    }
                 }
                 return true;
             case AvroSchema.Type.Array:
                 return ArraysAreEqual(
-                    ((global::Avro.ArraySchema)schema).ItemSchema,
+                    ((global::Avro.ArraySchema)leftSchema).ItemSchema,
+                    ((global::Avro.ArraySchema)rightSchema).ItemSchema,
                     ref left,
                     ref right);
             case AvroSchema.Type.Map:
                 return MapsAreEqual(
-                    ((global::Avro.MapSchema)schema).ValueSchema,
+                    ((global::Avro.MapSchema)leftSchema).ValueSchema,
+                    ((global::Avro.MapSchema)rightSchema).ValueSchema,
                     ref left,
                     ref right);
             case AvroSchema.Type.Union:
-                var union = (global::Avro.UnionSchema)schema;
+                var leftUnion = (global::Avro.UnionSchema)leftSchema;
+                var rightUnion = (global::Avro.UnionSchema)rightSchema;
                 var leftBranch = left.ReadLong();
                 var rightBranch = right.ReadLong();
-                if (leftBranch != rightBranch || (ulong)leftBranch >= (ulong)union.Count)
+                if (leftBranch != rightBranch ||
+                    (ulong)leftBranch >= (ulong)leftUnion.Count ||
+                    (ulong)rightBranch >= (ulong)rightUnion.Count)
+                {
                     return false;
-                return AreEqual(union[(int)leftBranch], ref left, ref right);
+                }
+                return AreEqual(
+                    leftUnion[(int)leftBranch],
+                    rightUnion[(int)rightBranch],
+                    ref left,
+                    ref right);
             default:
-                throw InvalidPayload($"unsupported schema type {schema.Tag}");
+                throw InvalidPayload($"unsupported schema type {leftSchema.Tag}");
+        }
+    }
+
+    private static bool IsNumber(AvroSchema.Type type) =>
+        type is AvroSchema.Type.Int or AvroSchema.Type.Long or
+            AvroSchema.Type.Float or AvroSchema.Type.Double;
+
+    private static ValidationCelValue ReadNumber(
+        AvroSchema.Type type,
+        ref AvroValidationReader reader) => type switch
+    {
+        AvroSchema.Type.Int or AvroSchema.Type.Long =>
+            ValidationCelValue.FromNumber(reader.ReadLong()),
+        AvroSchema.Type.Float => ValidationCelValue.FromFloating(
+            BinaryPrimitives.ReadSingleLittleEndian(reader.Read(sizeof(float)).Span)),
+        AvroSchema.Type.Double => ValidationCelValue.FromFloating(
+            BinaryPrimitives.ReadDoubleLittleEndian(reader.Read(sizeof(double)).Span)),
+        _ => throw new InvalidOperationException("Numeric Avro schema expected.")
+    };
+
+    private static bool IsBytes(AvroSchema.Type type) =>
+        type is AvroSchema.Type.Bytes or AvroSchema.Type.Fixed;
+
+    private static ReadOnlyMemory<byte> ReadBytes(
+        AvroSchema schema,
+        ref AvroValidationReader reader) => schema.Tag == AvroSchema.Type.Bytes
+        ? reader.ReadLengthPrefixed()
+        : reader.Read(((global::Avro.FixedSchema)schema).Size);
+
+    private static bool IsString(AvroSchema.Type type) =>
+        type is AvroSchema.Type.String or AvroSchema.Type.Enumeration;
+
+    private static bool StringValuesAreEqual(
+        AvroSchema leftSchema,
+        AvroSchema rightSchema,
+        ref AvroValidationReader left,
+        ref AvroValidationReader right)
+    {
+        if (leftSchema is global::Avro.EnumSchema leftEnumeration)
+        {
+            var leftSymbol = left.ReadLong();
+            if ((ulong)leftSymbol >= (ulong)leftEnumeration.Symbols.Count)
+                return false;
+            if (rightSchema is global::Avro.EnumSchema rightEnumeration)
+            {
+                var rightSymbol = right.ReadLong();
+                return (ulong)rightSymbol < (ulong)rightEnumeration.Symbols.Count &&
+                    string.Equals(
+                        leftEnumeration.Symbols[(int)leftSymbol],
+                        rightEnumeration.Symbols[(int)rightSymbol],
+                        StringComparison.Ordinal);
+            }
+            return Utf8Equals(
+                leftEnumeration.Symbols[(int)leftSymbol],
+                right.ReadLengthPrefixed().Span);
+        }
+
+        var leftValue = left.ReadLengthPrefixed();
+        if (rightSchema is not global::Avro.EnumSchema enumeration)
+            return leftValue.Span.SequenceEqual(right.ReadLengthPrefixed().Span);
+        var symbol = right.ReadLong();
+        return (ulong)symbol < (ulong)enumeration.Symbols.Count &&
+            Utf8Equals(enumeration.Symbols[(int)symbol], leftValue.Span);
+    }
+
+    private static bool Utf8Equals(string text, ReadOnlySpan<byte> value)
+    {
+        var byteCount = Encoding.UTF8.GetByteCount(text);
+        if (byteCount != value.Length)
+            return false;
+
+        byte[]? rented = null;
+        Span<byte> encoded = byteCount <= 256
+            ? stackalloc byte[byteCount]
+            : (rented = ArrayPool<byte>.Shared.Rent(byteCount));
+        try
+        {
+            Encoding.UTF8.GetBytes(text.AsSpan(), encoded);
+            return encoded[..byteCount].SequenceEqual(value);
+        }
+        finally
+        {
+            if (rented is not null)
+                ArrayPool<byte>.Shared.Return(rented);
         }
     }
 
@@ -172,7 +283,8 @@ internal sealed class AvroAggregateEqualityComparer(
     }
 
     private static bool ArraysAreEqual(
-        AvroSchema itemSchema,
+        AvroSchema leftItemSchema,
+        AvroSchema rightItemSchema,
         ref AvroValidationReader left,
         ref AvroValidationReader right)
     {
@@ -186,7 +298,7 @@ internal sealed class AvroAggregateEqualityComparer(
                 rightRemaining = right.ReadCollectionCount();
             if (leftRemaining == 0 || rightRemaining == 0)
                 return leftRemaining == rightRemaining;
-            if (!AreEqual(itemSchema, ref left, ref right))
+            if (!AreEqual(leftItemSchema, rightItemSchema, ref left, ref right))
                 return false;
             leftRemaining--;
             rightRemaining--;
@@ -194,14 +306,15 @@ internal sealed class AvroAggregateEqualityComparer(
     }
 
     private static bool MapsAreEqual(
-        AvroSchema valueSchema,
+        AvroSchema leftValueSchema,
+        AvroSchema rightValueSchema,
         ref AvroValidationReader left,
         ref AvroValidationReader right)
     {
         var leftPayload = left.Source.Slice(left.Position);
         var rightPayload = right.Source.Slice(right.Position);
-        var leftCount = CountMapEntries(valueSchema, leftPayload);
-        var rightCount = CountMapEntries(valueSchema, rightPayload);
+        var leftCount = CountMapEntries(leftValueSchema, leftPayload);
+        var rightCount = CountMapEntries(rightValueSchema, rightPayload);
         if (leftCount != rightCount)
             return false;
 
@@ -217,9 +330,10 @@ internal sealed class AvroAggregateEqualityComparer(
         try
         {
             var leftSource = left.Source;
-            ReadMapEntries(valueSchema, ref left, entries, buckets);
+            ReadMapEntries(leftValueSchema, ref left, entries, buckets);
             return MatchMapEntries(
-                valueSchema,
+                leftValueSchema,
+                rightValueSchema,
                 leftSource,
                 ref right,
                 leftCount,
@@ -285,7 +399,8 @@ internal sealed class AvroAggregateEqualityComparer(
     }
 
     private static bool MatchMapEntries(
-        AvroSchema valueSchema,
+        AvroSchema leftValueSchema,
+        AvroSchema rightValueSchema,
         ReadOnlyMemory<byte> leftSource,
         ref AvroValidationReader reader,
         int entryCount,
@@ -302,7 +417,7 @@ internal sealed class AvroAggregateEqualityComparer(
             {
                 var key = reader.ReadLengthPrefixed();
                 var valueStart = reader.Position;
-                AvroValidationValueDecoder.Skip(valueSchema, ref reader);
+                AvroValidationValueDecoder.Skip(rightValueSchema, ref reader);
                 var valueLength = reader.Position - valueStart;
                 var bucket = (int)(Hash(key.Span) % (uint)buckets.Length);
                 var entryIndex = buckets[bucket];
@@ -316,7 +431,11 @@ internal sealed class AvroAggregateEqualityComparer(
                             leftSource.Slice(entry.ValueStart, entry.ValueLength));
                         var rightValue = new AvroValidationReader(
                             reader.Source.Slice(valueStart, valueLength));
-                        if (AreEqual(valueSchema, ref leftValue, ref rightValue) &&
+                        if (AreEqual(
+                                leftValueSchema,
+                                rightValueSchema,
+                                ref leftValue,
+                                ref rightValue) &&
                             leftValue.End && rightValue.End)
                         {
                             entry.Matched = true;
@@ -364,7 +483,7 @@ internal static class AvroValueSchemaComparer
     [ThreadStatic]
     private static HashSet<AvroSchemaPair>? t_pairs;
 
-    internal static bool AreEqual(AvroSchema left, AvroSchema right)
+    internal static bool AreCelCompatible(AvroSchema left, AvroSchema right)
     {
         if (ReferenceEquals(left, right))
             return true;
@@ -372,7 +491,7 @@ internal static class AvroValueSchemaComparer
         pairs.Clear();
         try
         {
-            return AreEqual(left, right, pairs);
+            return AreCelCompatible(left, right, pairs);
         }
         finally
         {
@@ -380,31 +499,136 @@ internal static class AvroValueSchemaComparer
         }
     }
 
-    private static bool AreEqual(
+    internal static bool HaveSameEncoding(AvroSchema left, AvroSchema right)
+    {
+        if (ReferenceEquals(left, right))
+            return true;
+        var pairs = t_pairs ??= new HashSet<AvroSchemaPair>(AvroSchemaPairReferenceComparer.Instance);
+        pairs.Clear();
+        try
+        {
+            return HaveSameEncoding(left, right, pairs);
+        }
+        finally
+        {
+            pairs.Clear();
+        }
+    }
+
+    private static bool HaveSameEncoding(
         AvroSchema left,
         AvroSchema right,
         HashSet<AvroSchemaPair> pairs)
     {
+        left = AvroValueRulePlan.Unwrap(left);
+        right = AvroValueRulePlan.Unwrap(right);
         if (ReferenceEquals(left, right))
             return true;
-        if (left.Tag != right.Tag)
-            return false;
-
-        var pair = default(AvroSchemaPair);
-        var pairAdded = false;
-        if (left is global::Avro.NamedSchema leftNamed)
+        if (left.Tag is AvroSchema.Type.Int or AvroSchema.Type.Long &&
+            right.Tag is AvroSchema.Type.Int or AvroSchema.Type.Long)
         {
-            if (right is not global::Avro.NamedSchema rightNamed ||
-                !string.Equals(leftNamed.Fullname, rightNamed.Fullname, StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            pair = new AvroSchemaPair(left, right);
-            if (!pairs.Add(pair))
-                return true;
-            pairAdded = true;
+            return true;
         }
+        if (left.Tag != right.Tag &&
+            !(left.Tag is AvroSchema.Type.Record or AvroSchema.Type.Error &&
+              right.Tag is AvroSchema.Type.Record or AvroSchema.Type.Error))
+        {
+            return false;
+        }
+
+        var pair = new AvroSchemaPair(left, right);
+        if (!pairs.Add(pair))
+            return true;
+
+        try
+        {
+            return left.Tag switch
+            {
+                AvroSchema.Type.Record or AvroSchema.Type.Error => RecordsHaveSameEncoding(
+                    (global::Avro.RecordSchema)left,
+                    (global::Avro.RecordSchema)right,
+                    pairs),
+                AvroSchema.Type.Array => HaveSameEncoding(
+                    ((global::Avro.ArraySchema)left).ItemSchema,
+                    ((global::Avro.ArraySchema)right).ItemSchema,
+                    pairs),
+                AvroSchema.Type.Map => HaveSameEncoding(
+                    ((global::Avro.MapSchema)left).ValueSchema,
+                    ((global::Avro.MapSchema)right).ValueSchema,
+                    pairs),
+                AvroSchema.Type.Union => UnionsHaveSameEncoding(
+                    (global::Avro.UnionSchema)left,
+                    (global::Avro.UnionSchema)right,
+                    pairs),
+                AvroSchema.Type.Fixed =>
+                    ((global::Avro.FixedSchema)left).Size == ((global::Avro.FixedSchema)right).Size,
+                AvroSchema.Type.Enumeration => EnumsAreEqual(
+                    (global::Avro.EnumSchema)left,
+                    (global::Avro.EnumSchema)right),
+                _ => true
+            };
+        }
+        finally
+        {
+            pairs.Remove(pair);
+        }
+    }
+
+    private static bool RecordsHaveSameEncoding(
+        global::Avro.RecordSchema left,
+        global::Avro.RecordSchema right,
+        HashSet<AvroSchemaPair> pairs)
+    {
+        if (left.Fields.Count != right.Fields.Count)
+            return false;
+        for (var index = 0; index < left.Fields.Count; index++)
+        {
+            if (!HaveSameEncoding(left.Fields[index].Schema, right.Fields[index].Schema, pairs))
+                return false;
+        }
+        return true;
+    }
+
+    private static bool UnionsHaveSameEncoding(
+        global::Avro.UnionSchema left,
+        global::Avro.UnionSchema right,
+        HashSet<AvroSchemaPair> pairs)
+    {
+        if (left.Count != right.Count)
+            return false;
+        for (var index = 0; index < left.Count; index++)
+        {
+            if (!HaveSameEncoding(left[index], right[index], pairs))
+                return false;
+        }
+        return true;
+    }
+
+    private static bool AreCelCompatible(
+        AvroSchema left,
+        AvroSchema right,
+        HashSet<AvroSchemaPair> pairs)
+    {
+        left = AvroValueRulePlan.Unwrap(left);
+        right = AvroValueRulePlan.Unwrap(right);
+        if (ReferenceEquals(left, right))
+            return true;
+        if (IsNumber(left.Tag) && IsNumber(right.Tag) ||
+            IsBytes(left.Tag) && IsBytes(right.Tag) ||
+            IsString(left.Tag) && IsString(right.Tag))
+        {
+            return true;
+        }
+        if (left.Tag != right.Tag &&
+            !(left.Tag is AvroSchema.Type.Record or AvroSchema.Type.Error &&
+              right.Tag is AvroSchema.Type.Record or AvroSchema.Type.Error))
+        {
+            return false;
+        }
+
+        var pair = new AvroSchemaPair(left, right);
+        if (!pairs.Add(pair))
+            return true;
 
         try
         {
@@ -414,14 +638,11 @@ internal static class AvroValueSchemaComparer
                     (global::Avro.RecordSchema)left,
                     (global::Avro.RecordSchema)right,
                     pairs),
-                AvroSchema.Type.Enumeration => EnumsAreEqual(
-                    (global::Avro.EnumSchema)left,
-                    (global::Avro.EnumSchema)right),
-                AvroSchema.Type.Array => AreEqual(
+                AvroSchema.Type.Array => AreCelCompatible(
                     ((global::Avro.ArraySchema)left).ItemSchema,
                     ((global::Avro.ArraySchema)right).ItemSchema,
                     pairs),
-                AvroSchema.Type.Map => AreEqual(
+                AvroSchema.Type.Map => AreCelCompatible(
                     ((global::Avro.MapSchema)left).ValueSchema,
                     ((global::Avro.MapSchema)right).ValueSchema,
                     pairs),
@@ -431,24 +652,24 @@ internal static class AvroValueSchemaComparer
                     pairs),
                 AvroSchema.Type.Fixed =>
                     ((global::Avro.FixedSchema)left).Size == ((global::Avro.FixedSchema)right).Size,
-                AvroSchema.Type.Logical =>
-                    string.Equals(
-                        ((global::Avro.LogicalSchema)left).LogicalTypeName,
-                        ((global::Avro.LogicalSchema)right).LogicalTypeName,
-                        StringComparison.Ordinal) &&
-                    AreEqual(
-                        ((global::Avro.LogicalSchema)left).BaseSchema,
-                        ((global::Avro.LogicalSchema)right).BaseSchema,
-                        pairs),
                 _ => true
             };
         }
         finally
         {
-            if (pairAdded)
-                pairs.Remove(pair);
+            pairs.Remove(pair);
         }
     }
+
+    private static bool IsNumber(AvroSchema.Type type) =>
+        type is AvroSchema.Type.Int or AvroSchema.Type.Long or
+            AvroSchema.Type.Float or AvroSchema.Type.Double;
+
+    private static bool IsBytes(AvroSchema.Type type) =>
+        type is AvroSchema.Type.Bytes or AvroSchema.Type.Fixed;
+
+    private static bool IsString(AvroSchema.Type type) =>
+        type is AvroSchema.Type.String or AvroSchema.Type.Enumeration;
 
     private static bool RecordsAreEqual(
         global::Avro.RecordSchema left,
@@ -462,7 +683,7 @@ internal static class AvroValueSchemaComparer
             var leftField = left.Fields[index];
             var rightField = right.Fields[index];
             if (!string.Equals(leftField.Name, rightField.Name, StringComparison.Ordinal) ||
-                !AreEqual(leftField.Schema, rightField.Schema, pairs))
+                !AreCelCompatible(leftField.Schema, rightField.Schema, pairs))
             {
                 return false;
             }
@@ -493,7 +714,7 @@ internal static class AvroValueSchemaComparer
             return false;
         for (var index = 0; index < left.Count; index++)
         {
-            if (!AreEqual(left[index], right[index], pairs))
+            if (!AreCelCompatible(left[index], right[index], pairs))
                 return false;
         }
         return true;

--- a/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
@@ -81,6 +81,9 @@ internal sealed class AvroAggregateEqualityComparer(
     object? IValidationCelAggregateComparer.RawEqualityToken =>
         _requiresSemanticEquality || !rawEqualityCompatible ? null : _schemaToken;
 
+    int IValidationCelAggregateComparer.GetSize(ReadOnlyMemory<byte> value) =>
+        AvroValidationValueDecoder.Count(_schema, value);
+
     bool IValidationCelAggregateComparer.AreEqual(
         ReadOnlyMemory<byte> left,
         IValidationCelAggregateComparer rightComparer,

--- a/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
@@ -8,6 +8,7 @@ namespace Dekaf.SchemaRegistry.Avro;
 internal sealed class AvroAggregateEqualityComparerFactory
 {
     private readonly List<SchemaGroup> _groups = [];
+    private readonly List<AvroAggregateEqualityComparer> _comparers = [];
 
     internal AvroAggregateEqualityComparer? Create(AvroSchema schema)
     {
@@ -17,22 +18,42 @@ internal sealed class AvroAggregateEqualityComparerFactory
             return null;
         }
 
+        SchemaGroup? selectedGroup = null;
+        var rawEqualityCompatible = true;
         for (var index = 0; index < _groups.Count; index++)
         {
             var group = _groups[index];
             if (AvroSchemaLogicalComparer.Instance.Equals(schema, group.Schema) ||
                 AvroValueSchemaComparer.AreCelCompatible(schema, group.Schema))
             {
-                return new AvroAggregateEqualityComparer(
-                    schema,
-                    group,
-                    AvroValueSchemaComparer.HaveSameEncoding(schema, group.Schema));
+                selectedGroup = group;
+                rawEqualityCompatible = AvroValueSchemaComparer.HaveSameEncoding(schema, group.Schema);
+                break;
             }
         }
 
-        var newGroup = new SchemaGroup(schema);
-        _groups.Add(newGroup);
-        return new AvroAggregateEqualityComparer(schema, newGroup, rawEqualityCompatible: true);
+        if (selectedGroup is null)
+        {
+            selectedGroup = new SchemaGroup(schema);
+            _groups.Add(selectedGroup);
+        }
+
+        var comparer = new AvroAggregateEqualityComparer(
+            schema,
+            selectedGroup,
+            rawEqualityCompatible);
+        for (var index = 0; index < _comparers.Count; index++)
+        {
+            var existing = _comparers[index];
+            if (AvroSchemaLogicalComparer.Instance.Equals(schema, existing.Schema) ||
+                AvroValueSchemaComparer.AreCelCompatible(schema, existing.Schema))
+            {
+                comparer.AddCompatible(existing);
+                existing.AddCompatible(comparer);
+            }
+        }
+        _comparers.Add(comparer);
+        return comparer;
     }
 
     private sealed class SchemaGroup(AvroSchema schema)
@@ -52,6 +73,8 @@ internal sealed class AvroAggregateEqualityComparer(
     private const int StackMapBucketCount = 32;
 
     private readonly AvroSchema _schema = schema;
+    private readonly HashSet<AvroSchema> _compatibleSchemas =
+        new(AvroSchemaReferenceComparer.Instance) { schema };
     private readonly bool _requiresSemanticEquality = ContainsFloating(schema, []);
     private readonly object _schemaToken = schemaToken;
 
@@ -64,7 +87,7 @@ internal sealed class AvroAggregateEqualityComparer(
         ReadOnlyMemory<byte> right)
     {
         if (rightComparer is not AvroAggregateEqualityComparer avroRight ||
-            !ReferenceEquals(_schemaToken, avroRight._schemaToken))
+            !_compatibleSchemas.Contains(avroRight._schema))
             return false;
 
         var leftReader = new AvroValidationReader(left);
@@ -72,6 +95,11 @@ internal sealed class AvroAggregateEqualityComparer(
         return AreEqual(_schema, avroRight._schema, ref leftReader, ref rightReader) &&
             leftReader.End && rightReader.End;
     }
+
+    internal AvroSchema Schema => _schema;
+
+    internal void AddCompatible(AvroAggregateEqualityComparer comparer) =>
+        _compatibleSchemas.Add(comparer._schema);
 
     private static bool AreEqual(
         AvroSchema leftSchema,

--- a/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
@@ -46,6 +46,7 @@ internal sealed class AvroAggregateEqualityComparer(
     object schemaToken,
     bool rawEqualityCompatible) : IValidationCelAggregateComparer
 {
+    private const int StackRecordFieldCount = 16;
     private const int StackMapEntryCount = 16;
     private const int StackMapBucketCount = 32;
 
@@ -123,18 +124,9 @@ internal sealed class AvroAggregateEqualityComparer(
             case AvroSchema.Type.Error:
                 var leftRecord = (global::Avro.RecordSchema)leftSchema;
                 var rightRecord = (global::Avro.RecordSchema)rightSchema;
-                for (var index = 0; index < leftRecord.Fields.Count; index++)
-                {
-                    if (!AreEqual(
-                            leftRecord.Fields[index].Schema,
-                            rightRecord.Fields[index].Schema,
-                            ref left,
-                            ref right))
-                    {
-                        return false;
-                    }
-                }
-                return true;
+                return ReferenceEquals(leftRecord, rightRecord)
+                    ? RecordsAreEqualInOrder(leftRecord, ref left, ref right)
+                    : RecordsAreEqualByName(leftRecord, rightRecord, ref left, ref right);
             case AvroSchema.Type.Array:
                 return ArraysAreEqual(
                     ((global::Avro.ArraySchema)leftSchema).ItemSchema,
@@ -149,6 +141,66 @@ internal sealed class AvroAggregateEqualityComparer(
                     ref right);
             default:
                 throw InvalidPayload($"unsupported schema type {leftSchema.Tag}");
+        }
+    }
+
+    private static bool RecordsAreEqualInOrder(
+        global::Avro.RecordSchema schema,
+        ref AvroValidationReader left,
+        ref AvroValidationReader right)
+    {
+        for (var index = 0; index < schema.Fields.Count; index++)
+        {
+            var fieldSchema = schema.Fields[index].Schema;
+            if (!AreEqual(fieldSchema, fieldSchema, ref left, ref right))
+                return false;
+        }
+        return true;
+    }
+
+    private static bool RecordsAreEqualByName(
+        global::Avro.RecordSchema leftSchema,
+        global::Avro.RecordSchema rightSchema,
+        ref AvroValidationReader left,
+        ref AvroValidationReader right)
+    {
+        RecordFieldPayload[]? rented = null;
+        Span<RecordFieldPayload> rightFields = rightSchema.Fields.Count <= StackRecordFieldCount
+            ? stackalloc RecordFieldPayload[StackRecordFieldCount]
+            : (rented = ArrayPool<RecordFieldPayload>.Shared.Rent(rightSchema.Fields.Count));
+        try
+        {
+            for (var index = 0; index < rightSchema.Fields.Count; index++)
+            {
+                var start = right.Position;
+                AvroValidationValueDecoder.Skip(rightSchema.Fields[index].Schema, ref right);
+                rightFields[index] = new RecordFieldPayload(start, right.Position - start);
+            }
+
+            for (var index = 0; index < leftSchema.Fields.Count; index++)
+            {
+                var leftField = leftSchema.Fields[index];
+                if (!rightSchema.TryGetField(leftField.Name, out var rightField))
+                    return false;
+                var payload = rightFields[rightField.Pos];
+                var rightFieldReader = new AvroValidationReader(
+                    right.Source.Slice(payload.Start, payload.Length));
+                if (!AreEqual(
+                        leftField.Schema,
+                        rightField.Schema,
+                        ref left,
+                        ref rightFieldReader) ||
+                    !rightFieldReader.End)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+        finally
+        {
+            if (rented is not null)
+                ArrayPool<RecordFieldPayload>.Shared.Return(rented);
         }
     }
 
@@ -474,6 +526,8 @@ internal sealed class AvroAggregateEqualityComparer(
         internal int Next { get; } = next;
         internal bool Matched { get; set; }
     }
+
+    private readonly record struct RecordFieldPayload(int Start, int Length);
 }
 
 internal static class AvroValueSchemaComparer
@@ -581,7 +635,11 @@ internal static class AvroValueSchemaComparer
             return false;
         for (var index = 0; index < left.Fields.Count; index++)
         {
-            if (!HaveSameEncoding(left.Fields[index].Schema, right.Fields[index].Schema, pairs))
+            if (!string.Equals(
+                    left.Fields[index].Name,
+                    right.Fields[index].Name,
+                    StringComparison.Ordinal) ||
+                !HaveSameEncoding(left.Fields[index].Schema, right.Fields[index].Schema, pairs))
                 return false;
         }
         return true;
@@ -696,8 +754,7 @@ internal static class AvroValueSchemaComparer
         for (var index = 0; index < left.Fields.Count; index++)
         {
             var leftField = left.Fields[index];
-            var rightField = right.Fields[index];
-            if (!string.Equals(leftField.Name, rightField.Name, StringComparison.Ordinal) ||
+            if (!right.TryGetField(leftField.Name, out var rightField) ||
                 !AreCelCompatible(leftField.Schema, rightField.Schema, pairs))
             {
                 return false;

--- a/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
@@ -138,8 +138,7 @@ internal sealed class AvroAggregateEqualityComparer(
                 var rightUnion = (global::Avro.UnionSchema)rightSchema;
                 var leftBranch = left.ReadLong();
                 var rightBranch = right.ReadLong();
-                if (leftBranch != rightBranch ||
-                    (ulong)leftBranch >= (ulong)leftUnion.Count ||
+                if ((ulong)leftBranch >= (ulong)leftUnion.Count ||
                     (ulong)rightBranch >= (ulong)rightUnion.Count)
                 {
                     return false;

--- a/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
@@ -4,22 +4,52 @@ using AvroSchema = global::Avro.Schema;
 
 namespace Dekaf.SchemaRegistry.Avro;
 
-internal sealed class AvroAggregateEqualityComparer(AvroSchema schema) : IValidationCelAggregateComparer
+internal sealed class AvroAggregateEqualityComparerFactory
+{
+    private readonly List<SchemaGroup> _groups = [];
+
+    internal AvroAggregateEqualityComparer? Create(AvroSchema schema)
+    {
+        if (schema.Tag is not (AvroSchema.Type.Record or AvroSchema.Type.Error or
+            AvroSchema.Type.Array or AvroSchema.Type.Map))
+        {
+            return null;
+        }
+
+        for (var index = 0; index < _groups.Count; index++)
+        {
+            var group = _groups[index];
+            if (AvroSchemaLogicalComparer.Instance.Equals(schema, group.Schema) ||
+                AvroValueSchemaComparer.AreEqual(schema, group.Schema))
+            {
+                return new AvroAggregateEqualityComparer(schema, group);
+            }
+        }
+
+        var newGroup = new SchemaGroup(schema);
+        _groups.Add(newGroup);
+        return new AvroAggregateEqualityComparer(schema, newGroup);
+    }
+
+    private sealed class SchemaGroup(AvroSchema schema)
+    {
+        internal AvroSchema Schema { get; } = schema;
+    }
+}
+
+internal sealed class AvroAggregateEqualityComparer(
+    AvroSchema schema,
+    object schemaToken) : IValidationCelAggregateComparer
 {
     private const int StackMapEntryCount = 16;
     private const int StackMapBucketCount = 32;
 
     private readonly AvroSchema _schema = schema;
     private readonly bool _requiresSemanticEquality = ContainsFloating(schema, []);
+    private readonly object _schemaToken = schemaToken;
 
-    internal static AvroAggregateEqualityComparer? Create(AvroSchema schema) => schema.Tag switch
-    {
-        AvroSchema.Type.Record or AvroSchema.Type.Error or
-        AvroSchema.Type.Array or AvroSchema.Type.Map => new(schema),
-        _ => null
-    };
-
-    bool IValidationCelAggregateComparer.RequiresSemanticEquality => _requiresSemanticEquality;
+    object? IValidationCelAggregateComparer.RawEqualityToken =>
+        _requiresSemanticEquality ? null : _schemaToken;
 
     bool IValidationCelAggregateComparer.AreEqual(
         ReadOnlyMemory<byte> left,
@@ -27,11 +57,8 @@ internal sealed class AvroAggregateEqualityComparer(AvroSchema schema) : IValida
         ReadOnlyMemory<byte> right)
     {
         if (rightComparer is not AvroAggregateEqualityComparer avroRight ||
-            (!AvroSchemaLogicalComparer.Instance.Equals(_schema, avroRight._schema) &&
-             !AvroValueSchemaComparer.AreEqual(_schema, avroRight._schema)))
-        {
+            !ReferenceEquals(_schemaToken, avroRight._schemaToken))
             return false;
-        }
 
         var leftReader = new AvroValidationReader(left);
         var rightReader = new AvroValidationReader(right);

--- a/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
@@ -18,11 +18,14 @@ internal sealed class AvroAggregateEqualityComparerFactory
             return null;
         }
 
+        var requiresDepthGuard = AvroAggregateEqualityComparer.IsRecursive(schema);
         SchemaGroup? selectedGroup = null;
         var rawEqualityCompatible = true;
         for (var index = 0; index < _groups.Count; index++)
         {
             var group = _groups[index];
+            if (requiresDepthGuard != group.RequiresDepthGuard)
+                continue;
             if (AvroSchemaLogicalComparer.Instance.Equals(schema, group.Schema) ||
                 AvroValueSchemaComparer.AreCelCompatible(schema, group.Schema))
             {
@@ -34,19 +37,21 @@ internal sealed class AvroAggregateEqualityComparerFactory
 
         if (selectedGroup is null)
         {
-            selectedGroup = new SchemaGroup(schema);
+            selectedGroup = new SchemaGroup(schema, requiresDepthGuard);
             _groups.Add(selectedGroup);
         }
 
         var comparer = new AvroAggregateEqualityComparer(
             schema,
             selectedGroup,
-            rawEqualityCompatible);
+            rawEqualityCompatible,
+            requiresDepthGuard);
         for (var index = 0; index < _comparers.Count; index++)
         {
             var existing = _comparers[index];
-            if (AvroSchemaLogicalComparer.Instance.Equals(schema, existing.Schema) ||
-                AvroValueSchemaComparer.AreCelCompatible(schema, existing.Schema))
+            if (requiresDepthGuard == existing.RequiresDepthGuard &&
+                (AvroSchemaLogicalComparer.Instance.Equals(schema, existing.Schema) ||
+                 AvroValueSchemaComparer.AreCelCompatible(schema, existing.Schema)))
             {
                 comparer.AddCompatible(existing);
                 existing.AddCompatible(comparer);
@@ -56,17 +61,20 @@ internal sealed class AvroAggregateEqualityComparerFactory
         return comparer;
     }
 
-    private sealed class SchemaGroup(AvroSchema schema)
+    private sealed class SchemaGroup(AvroSchema schema, bool requiresDepthGuard)
     {
         internal AvroSchema Schema { get; } = schema;
+        internal bool RequiresDepthGuard { get; } = requiresDepthGuard;
     }
 }
 
 internal sealed class AvroAggregateEqualityComparer(
     AvroSchema schema,
     object schemaToken,
-    bool rawEqualityCompatible) : IValidationCelAggregateComparer
+    bool rawEqualityCompatible,
+    bool requiresDepthGuard) : IValidationCelAggregateComparer
 {
+    internal const int MaximumComparisonDepth = 100;
     private const int MaximumMapEntryCount = 1_048_576;
     private const int StackRecordFieldCount = 16;
     private const int StackMapEntryCount = 16;
@@ -75,7 +83,8 @@ internal sealed class AvroAggregateEqualityComparer(
     private readonly AvroSchema _schema = schema;
     private readonly HashSet<AvroSchema> _compatibleSchemas =
         new(AvroSchemaReferenceComparer.Instance) { schema };
-    private readonly bool _requiresSemanticEquality = ContainsFloating(schema, []);
+    private readonly bool _requiresDepthGuard = requiresDepthGuard;
+    private readonly bool _requiresSemanticEquality = RequiresSemanticEquality(schema);
     private readonly object _schemaToken = schemaToken;
 
     object? IValidationCelAggregateComparer.RawEqualityToken =>
@@ -95,11 +104,23 @@ internal sealed class AvroAggregateEqualityComparer(
 
         var leftReader = new AvroValidationReader(left);
         var rightReader = new AvroValidationReader(right);
-        return AreEqual(_schema, avroRight._schema, ref leftReader, ref rightReader) &&
+        if (!_requiresDepthGuard)
+        {
+            return AreEqual(_schema, avroRight._schema, ref leftReader, ref rightReader) &&
+                leftReader.End && rightReader.End;
+        }
+
+        return AreEqualGuarded(
+                _schema,
+                avroRight._schema,
+                ref leftReader,
+                ref rightReader,
+                MaximumComparisonDepth) &&
             leftReader.End && rightReader.End;
     }
 
     internal AvroSchema Schema => _schema;
+    internal bool RequiresDepthGuard => _requiresDepthGuard;
 
     internal void AddCompatible(AvroAggregateEqualityComparer comparer) =>
         _compatibleSchemas.Add(comparer._schema);
@@ -176,6 +197,74 @@ internal sealed class AvroAggregateEqualityComparer(
         }
     }
 
+    private static bool AreEqualGuarded(
+        AvroSchema leftSchema,
+        AvroSchema rightSchema,
+        ref AvroValidationReader left,
+        ref AvroValidationReader right,
+        int remainingDepth)
+    {
+        leftSchema = AvroValueRulePlan.Unwrap(leftSchema);
+        rightSchema = AvroValueRulePlan.Unwrap(rightSchema);
+        if (leftSchema is global::Avro.UnionSchema leftUnion)
+        {
+            var branch = left.ReadLong();
+            if ((ulong)branch >= (ulong)leftUnion.Count)
+                return false;
+            leftSchema = AvroValueRulePlan.Unwrap(leftUnion[(int)branch]);
+        }
+        if (rightSchema is global::Avro.UnionSchema rightUnion)
+        {
+            var branch = right.ReadLong();
+            if ((ulong)branch >= (ulong)rightUnion.Count)
+                return false;
+            rightSchema = AvroValueRulePlan.Unwrap(rightUnion[(int)branch]);
+        }
+
+        if (!IsAggregate(leftSchema.Tag) || !IsAggregate(rightSchema.Tag))
+            return AreEqual(leftSchema, rightSchema, ref left, ref right);
+        if (leftSchema.Tag != rightSchema.Tag &&
+            !(leftSchema.Tag is AvroSchema.Type.Record or AvroSchema.Type.Error &&
+              rightSchema.Tag is AvroSchema.Type.Record or AvroSchema.Type.Error))
+        {
+            return false;
+        }
+        if (remainingDepth == 0)
+        {
+            throw InvalidPayload(
+                $"aggregate recursion exceeds {MaximumComparisonDepth} levels");
+        }
+        remainingDepth--;
+
+        return leftSchema.Tag switch
+        {
+            AvroSchema.Type.Record or AvroSchema.Type.Error =>
+                GuardedRecordsAreEqual(
+                    (global::Avro.RecordSchema)leftSchema,
+                    (global::Avro.RecordSchema)rightSchema,
+                    ref left,
+                    ref right,
+                    remainingDepth),
+            AvroSchema.Type.Array => GuardedArraysAreEqual(
+                ((global::Avro.ArraySchema)leftSchema).ItemSchema,
+                ((global::Avro.ArraySchema)rightSchema).ItemSchema,
+                ref left,
+                ref right,
+                remainingDepth),
+            AvroSchema.Type.Map => GuardedMapsAreEqual(
+                ((global::Avro.MapSchema)leftSchema).ValueSchema,
+                ((global::Avro.MapSchema)rightSchema).ValueSchema,
+                ref left,
+                ref right,
+                remainingDepth),
+            _ => throw InvalidPayload($"unsupported schema type {leftSchema.Tag}")
+        };
+    }
+
+    private static bool IsAggregate(AvroSchema.Type type) =>
+        type is AvroSchema.Type.Record or AvroSchema.Type.Error or
+            AvroSchema.Type.Array or AvroSchema.Type.Map;
+
     private static bool RecordsAreEqualInOrder(
         global::Avro.RecordSchema schema,
         ref AvroValidationReader left,
@@ -222,6 +311,87 @@ internal sealed class AvroAggregateEqualityComparer(
                         rightField.Schema,
                         ref left,
                         ref rightFieldReader) ||
+                    !rightFieldReader.End)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+        finally
+        {
+            if (rented is not null)
+                ArrayPool<RecordFieldPayload>.Shared.Return(rented);
+        }
+    }
+
+    private static bool GuardedRecordsAreEqual(
+        global::Avro.RecordSchema leftSchema,
+        global::Avro.RecordSchema rightSchema,
+        ref AvroValidationReader left,
+        ref AvroValidationReader right,
+        int remainingDepth)
+    {
+        if (!ReferenceEquals(leftSchema, rightSchema))
+        {
+            return GuardedRecordsAreEqualByName(
+                leftSchema,
+                rightSchema,
+                ref left,
+                ref right,
+                remainingDepth);
+        }
+
+        for (var index = 0; index < leftSchema.Fields.Count; index++)
+        {
+            var fieldSchema = leftSchema.Fields[index].Schema;
+            if (!AreEqualGuarded(
+                    fieldSchema,
+                    fieldSchema,
+                    ref left,
+                    ref right,
+                    remainingDepth))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static bool GuardedRecordsAreEqualByName(
+        global::Avro.RecordSchema leftSchema,
+        global::Avro.RecordSchema rightSchema,
+        ref AvroValidationReader left,
+        ref AvroValidationReader right,
+        int remainingDepth)
+    {
+        RecordFieldPayload[]? rented = null;
+        Span<RecordFieldPayload> rightFields = rightSchema.Fields.Count <= StackRecordFieldCount
+            ? stackalloc RecordFieldPayload[StackRecordFieldCount]
+            : (rented = ArrayPool<RecordFieldPayload>.Shared.Rent(rightSchema.Fields.Count));
+        try
+        {
+            for (var index = 0; index < rightSchema.Fields.Count; index++)
+            {
+                var start = right.Position;
+                SkipGuarded(rightSchema.Fields[index].Schema, ref right, remainingDepth);
+                rightFields[index] = new RecordFieldPayload(start, right.Position - start);
+            }
+
+            for (var index = 0; index < leftSchema.Fields.Count; index++)
+            {
+                var leftField = leftSchema.Fields[index];
+                if (!rightSchema.TryGetField(leftField.Name, out var rightField))
+                    return false;
+                var payload = rightFields[rightField.Pos];
+                var rightFieldReader = new AvroValidationReader(
+                    right.Source.Slice(payload.Start, payload.Length));
+                if (!AreEqualGuarded(
+                        leftField.Schema,
+                        rightField.Schema,
+                        ref left,
+                        ref rightFieldReader,
+                        remainingDepth) ||
                     !rightFieldReader.End)
                 {
                     return false;
@@ -364,6 +534,64 @@ internal sealed class AvroAggregateEqualityComparer(
         return false;
     }
 
+    internal static bool IsRecursive(AvroSchema schema) =>
+        ContainsRecursion(
+            schema,
+            new HashSet<AvroSchema>(AvroSchemaReferenceComparer.Instance),
+            new HashSet<AvroSchema>(AvroSchemaReferenceComparer.Instance));
+
+    private static bool RequiresSemanticEquality(AvroSchema schema) => ContainsFloating(schema, []);
+
+    private static bool ContainsRecursion(
+        AvroSchema schema,
+        HashSet<AvroSchema> active,
+        HashSet<AvroSchema> visited)
+    {
+        schema = AvroValueRulePlan.Unwrap(schema);
+        if (active.Contains(schema))
+            return true;
+        if (!visited.Add(schema))
+            return false;
+
+        active.Add(schema);
+        var recursive = schema switch
+        {
+            global::Avro.RecordSchema record => ContainsRecursion(record, active, visited),
+            global::Avro.ArraySchema array => ContainsRecursion(array.ItemSchema, active, visited),
+            global::Avro.MapSchema map => ContainsRecursion(map.ValueSchema, active, visited),
+            global::Avro.UnionSchema union => ContainsRecursion(union, active, visited),
+            _ => false
+        };
+        active.Remove(schema);
+        return recursive;
+    }
+
+    private static bool ContainsRecursion(
+        global::Avro.RecordSchema record,
+        HashSet<AvroSchema> active,
+        HashSet<AvroSchema> visited)
+    {
+        for (var index = 0; index < record.Fields.Count; index++)
+        {
+            if (ContainsRecursion(record.Fields[index].Schema, active, visited))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool ContainsRecursion(
+        global::Avro.UnionSchema union,
+        HashSet<AvroSchema> active,
+        HashSet<AvroSchema> visited)
+    {
+        for (var index = 0; index < union.Count; index++)
+        {
+            if (ContainsRecursion(union[index], active, visited))
+                return true;
+        }
+        return false;
+    }
+
     private static bool ArraysAreEqual(
         AvroSchema leftItemSchema,
         AvroSchema rightItemSchema,
@@ -382,6 +610,37 @@ internal sealed class AvroAggregateEqualityComparer(
                 return leftRemaining == rightRemaining;
             if (!AreEqual(leftItemSchema, rightItemSchema, ref left, ref right))
                 return false;
+            leftRemaining--;
+            rightRemaining--;
+        }
+    }
+
+    private static bool GuardedArraysAreEqual(
+        AvroSchema leftItemSchema,
+        AvroSchema rightItemSchema,
+        ref AvroValidationReader left,
+        ref AvroValidationReader right,
+        int remainingDepth)
+    {
+        var leftRemaining = 0L;
+        var rightRemaining = 0L;
+        while (true)
+        {
+            if (leftRemaining == 0)
+                leftRemaining = left.ReadCollectionCount();
+            if (rightRemaining == 0)
+                rightRemaining = right.ReadCollectionCount();
+            if (leftRemaining == 0 || rightRemaining == 0)
+                return leftRemaining == rightRemaining;
+            if (!AreEqualGuarded(
+                    leftItemSchema,
+                    rightItemSchema,
+                    ref left,
+                    ref right,
+                    remainingDepth))
+            {
+                return false;
+            }
             leftRemaining--;
             rightRemaining--;
         }
@@ -428,6 +687,182 @@ internal sealed class AvroAggregateEqualityComparer(
                 ArrayPool<MapEntry>.Shared.Return(rentedEntries);
             if (rentedBuckets is not null)
                 ArrayPool<int>.Shared.Return(rentedBuckets);
+        }
+    }
+
+    private static bool GuardedMapsAreEqual(
+        AvroSchema leftValueSchema,
+        AvroSchema rightValueSchema,
+        ref AvroValidationReader left,
+        ref AvroValidationReader right,
+        int remainingDepth)
+    {
+        var leftPayload = left.Source.Slice(left.Position);
+        var rightPayload = right.Source.Slice(right.Position);
+        var leftCount = CountMapEntriesGuarded(leftValueSchema, leftPayload, remainingDepth);
+        var rightCount = CountMapEntriesGuarded(rightValueSchema, rightPayload, remainingDepth);
+        if (leftCount != rightCount)
+            return false;
+
+        MapEntry[]? rentedEntries = null;
+        int[]? rentedBuckets = null;
+        Span<MapEntry> entries = leftCount <= StackMapEntryCount
+            ? stackalloc MapEntry[StackMapEntryCount]
+            : (rentedEntries = ArrayPool<MapEntry>.Shared.Rent(leftCount));
+        Span<int> buckets = leftCount <= StackMapEntryCount
+            ? stackalloc int[StackMapBucketCount]
+            : (rentedBuckets = ArrayPool<int>.Shared.Rent(leftCount));
+        buckets.Fill(-1);
+        try
+        {
+            var leftSource = left.Source;
+            ReadMapEntriesGuarded(
+                leftValueSchema,
+                ref left,
+                entries,
+                buckets,
+                remainingDepth);
+            return GuardedMatchMapEntries(
+                leftValueSchema,
+                rightValueSchema,
+                leftSource,
+                ref right,
+                leftCount,
+                entries,
+                buckets,
+                remainingDepth);
+        }
+        finally
+        {
+            if (rentedEntries is not null)
+                ArrayPool<MapEntry>.Shared.Return(rentedEntries);
+            if (rentedBuckets is not null)
+                ArrayPool<int>.Shared.Return(rentedBuckets);
+        }
+    }
+
+    private static void SkipGuarded(
+        AvroSchema schema,
+        ref AvroValidationReader reader,
+        int remainingDepth)
+    {
+        schema = AvroValueRulePlan.Unwrap(schema);
+        if (schema is global::Avro.UnionSchema union)
+        {
+            var branch = reader.ReadLong();
+            if ((ulong)branch >= (ulong)union.Count)
+                throw InvalidPayload($"invalid union index {branch}");
+            SkipGuarded(union[(int)branch], ref reader, remainingDepth);
+            return;
+        }
+
+        if (IsAggregate(schema.Tag))
+        {
+            if (remainingDepth == 0)
+            {
+                throw InvalidPayload(
+                    $"aggregate recursion exceeds {MaximumComparisonDepth} levels");
+            }
+            remainingDepth--;
+        }
+
+        switch (schema.Tag)
+        {
+            case AvroSchema.Type.Null:
+                return;
+            case AvroSchema.Type.Boolean:
+                _ = reader.Read(1);
+                return;
+            case AvroSchema.Type.Int:
+            case AvroSchema.Type.Long:
+                _ = reader.ReadLong();
+                return;
+            case AvroSchema.Type.Enumeration:
+                var symbolIndex = reader.ReadLong();
+                if ((ulong)symbolIndex >= (ulong)((global::Avro.EnumSchema)schema).Symbols.Count)
+                    throw InvalidPayload($"invalid enum index {symbolIndex}");
+                return;
+            case AvroSchema.Type.Float:
+                _ = reader.Read(sizeof(float));
+                return;
+            case AvroSchema.Type.Double:
+                _ = reader.Read(sizeof(double));
+                return;
+            case AvroSchema.Type.String:
+            case AvroSchema.Type.Bytes:
+                _ = reader.ReadLengthPrefixed();
+                return;
+            case AvroSchema.Type.Fixed:
+                _ = reader.Read(((global::Avro.FixedSchema)schema).Size);
+                return;
+            case AvroSchema.Type.Record:
+            case AvroSchema.Type.Error:
+                var record = (global::Avro.RecordSchema)schema;
+                for (var index = 0; index < record.Fields.Count; index++)
+                    SkipGuarded(record.Fields[index].Schema, ref reader, remainingDepth);
+                return;
+            case AvroSchema.Type.Array:
+                SkipCollectionGuarded(
+                    ((global::Avro.ArraySchema)schema).ItemSchema,
+                    isMap: false,
+                    ref reader,
+                    remainingDepth);
+                return;
+            case AvroSchema.Type.Map:
+                SkipCollectionGuarded(
+                    ((global::Avro.MapSchema)schema).ValueSchema,
+                    isMap: true,
+                    ref reader,
+                    remainingDepth);
+                return;
+            default:
+                throw InvalidPayload($"unsupported schema type {schema.Tag}");
+        }
+    }
+
+    private static void SkipCollectionGuarded(
+        AvroSchema valueSchema,
+        bool isMap,
+        ref AvroValidationReader reader,
+        int remainingDepth)
+    {
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return;
+            for (long index = 0; index < count; index++)
+            {
+                if (isMap)
+                    _ = reader.ReadLengthPrefixed();
+                SkipGuarded(valueSchema, ref reader, remainingDepth);
+            }
+        }
+    }
+
+    private static int CountMapEntriesGuarded(
+        AvroSchema valueSchema,
+        ReadOnlyMemory<byte> payload,
+        int remainingDepth)
+    {
+        var reader = new AvroValidationReader(payload);
+        var total = 0L;
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return checked((int)total);
+            total = checked(total + count);
+            if (total > MaximumMapEntryCount)
+            {
+                throw InvalidPayload(
+                    $"map entry count exceeds the supported limit of {MaximumMapEntryCount}");
+            }
+            for (long index = 0; index < count; index++)
+            {
+                _ = reader.ReadLengthPrefixed();
+                SkipGuarded(valueSchema, ref reader, remainingDepth);
+            }
         }
     }
 
@@ -485,6 +920,38 @@ internal sealed class AvroAggregateEqualityComparer(
         }
     }
 
+    private static void ReadMapEntriesGuarded(
+        AvroSchema valueSchema,
+        ref AvroValidationReader reader,
+        scoped Span<MapEntry> entries,
+        scoped Span<int> buckets,
+        int remainingDepth)
+    {
+        var entryIndex = 0;
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return;
+            for (long index = 0; index < count; index++)
+            {
+                var key = reader.ReadLengthPrefixed();
+                var keyStart = reader.Position - key.Length;
+                var valueStart = reader.Position;
+                SkipGuarded(valueSchema, ref reader, remainingDepth);
+                var hash = Hash(key.Span);
+                var bucket = (int)(hash % (uint)buckets.Length);
+                entries[entryIndex] = new MapEntry(
+                    keyStart,
+                    key.Length,
+                    valueStart,
+                    reader.Position - valueStart,
+                    buckets[bucket]);
+                buckets[bucket] = entryIndex++;
+            }
+        }
+    }
+
     private static bool MatchMapEntries(
         AvroSchema leftValueSchema,
         AvroSchema rightValueSchema,
@@ -523,6 +990,61 @@ internal sealed class AvroAggregateEqualityComparer(
                                 rightValueSchema,
                                 ref leftValue,
                                 ref rightValue) &&
+                            leftValue.End && rightValue.End)
+                        {
+                            entry.Matched = true;
+                            matched++;
+                            break;
+                        }
+                    }
+                    entryIndex = entry.Next;
+                }
+                if (entryIndex < 0)
+                    return false;
+            }
+        }
+    }
+
+    private static bool GuardedMatchMapEntries(
+        AvroSchema leftValueSchema,
+        AvroSchema rightValueSchema,
+        ReadOnlyMemory<byte> leftSource,
+        ref AvroValidationReader reader,
+        int entryCount,
+        scoped Span<MapEntry> entries,
+        scoped ReadOnlySpan<int> buckets,
+        int remainingDepth)
+    {
+        var matched = 0;
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return matched == entryCount;
+            for (long index = 0; index < count; index++)
+            {
+                var key = reader.ReadLengthPrefixed();
+                var valueStart = reader.Position;
+                SkipGuarded(rightValueSchema, ref reader, remainingDepth);
+                var valueLength = reader.Position - valueStart;
+                var bucket = (int)(Hash(key.Span) % (uint)buckets.Length);
+                var entryIndex = buckets[bucket];
+                while (entryIndex >= 0)
+                {
+                    ref var entry = ref entries[entryIndex];
+                    if (!entry.Matched && key.Span.SequenceEqual(
+                            leftSource.Span.Slice(entry.KeyStart, entry.KeyLength)))
+                    {
+                        var leftValue = new AvroValidationReader(
+                            leftSource.Slice(entry.ValueStart, entry.ValueLength));
+                        var rightValue = new AvroValidationReader(
+                            reader.Source.Slice(valueStart, valueLength));
+                        if (AreEqualGuarded(
+                                leftValueSchema,
+                                rightValueSchema,
+                                ref leftValue,
+                                ref rightValue,
+                                remainingDepth) &&
                             leftValue.End && rightValue.End)
                         {
                             entry.Matched = true;

--- a/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
@@ -24,8 +24,6 @@ internal sealed class AvroAggregateEqualityComparerFactory
         for (var index = 0; index < _groups.Count; index++)
         {
             var group = _groups[index];
-            if (requiresDepthGuard != group.RequiresDepthGuard)
-                continue;
             if (AvroSchemaLogicalComparer.Instance.Equals(schema, group.Schema) ||
                 AvroValueSchemaComparer.AreCelCompatible(schema, group.Schema))
             {
@@ -37,7 +35,7 @@ internal sealed class AvroAggregateEqualityComparerFactory
 
         if (selectedGroup is null)
         {
-            selectedGroup = new SchemaGroup(schema, requiresDepthGuard);
+            selectedGroup = new SchemaGroup(schema);
             _groups.Add(selectedGroup);
         }
 
@@ -49,9 +47,8 @@ internal sealed class AvroAggregateEqualityComparerFactory
         for (var index = 0; index < _comparers.Count; index++)
         {
             var existing = _comparers[index];
-            if (requiresDepthGuard == existing.RequiresDepthGuard &&
-                (AvroSchemaLogicalComparer.Instance.Equals(schema, existing.Schema) ||
-                 AvroValueSchemaComparer.AreCelCompatible(schema, existing.Schema)))
+            if (AvroSchemaLogicalComparer.Instance.Equals(schema, existing.Schema) ||
+                AvroValueSchemaComparer.AreCelCompatible(schema, existing.Schema))
             {
                 comparer.AddCompatible(existing);
                 existing.AddCompatible(comparer);
@@ -61,10 +58,9 @@ internal sealed class AvroAggregateEqualityComparerFactory
         return comparer;
     }
 
-    private sealed class SchemaGroup(AvroSchema schema, bool requiresDepthGuard)
+    private sealed class SchemaGroup(AvroSchema schema)
     {
         internal AvroSchema Schema { get; } = schema;
-        internal bool RequiresDepthGuard { get; } = requiresDepthGuard;
     }
 }
 
@@ -104,7 +100,7 @@ internal sealed class AvroAggregateEqualityComparer(
 
         var leftReader = new AvroValidationReader(left);
         var rightReader = new AvroValidationReader(right);
-        if (!_requiresDepthGuard)
+        if (!_requiresDepthGuard && !avroRight._requiresDepthGuard)
         {
             return AreEqual(_schema, avroRight._schema, ref leftReader, ref rightReader) &&
                 leftReader.End && rightReader.End;
@@ -120,7 +116,6 @@ internal sealed class AvroAggregateEqualityComparer(
     }
 
     internal AvroSchema Schema => _schema;
-    internal bool RequiresDepthGuard => _requiresDepthGuard;
 
     internal void AddCompatible(AvroAggregateEqualityComparer comparer) =>
         _compatibleSchemas.Add(comparer._schema);

--- a/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
@@ -79,6 +79,20 @@ internal sealed class AvroAggregateEqualityComparer(
     {
         leftSchema = AvroValueRulePlan.Unwrap(leftSchema);
         rightSchema = AvroValueRulePlan.Unwrap(rightSchema);
+        if (leftSchema is global::Avro.UnionSchema leftUnion)
+        {
+            var branch = left.ReadLong();
+            if ((ulong)branch >= (ulong)leftUnion.Count)
+                return false;
+            leftSchema = AvroValueRulePlan.Unwrap(leftUnion[(int)branch]);
+        }
+        if (rightSchema is global::Avro.UnionSchema rightUnion)
+        {
+            var branch = right.ReadLong();
+            if ((ulong)branch >= (ulong)rightUnion.Count)
+                return false;
+            rightSchema = AvroValueRulePlan.Unwrap(rightUnion[(int)branch]);
+        }
         if (IsNumber(leftSchema.Tag) && IsNumber(rightSchema.Tag))
         {
             return ValidationCelBinaryNode.NumbersAreEqual(
@@ -131,21 +145,6 @@ internal sealed class AvroAggregateEqualityComparer(
                 return MapsAreEqual(
                     ((global::Avro.MapSchema)leftSchema).ValueSchema,
                     ((global::Avro.MapSchema)rightSchema).ValueSchema,
-                    ref left,
-                    ref right);
-            case AvroSchema.Type.Union:
-                var leftUnion = (global::Avro.UnionSchema)leftSchema;
-                var rightUnion = (global::Avro.UnionSchema)rightSchema;
-                var leftBranch = left.ReadLong();
-                var rightBranch = right.ReadLong();
-                if ((ulong)leftBranch >= (ulong)leftUnion.Count ||
-                    (ulong)rightBranch >= (ulong)rightUnion.Count)
-                {
-                    return false;
-                }
-                return AreEqual(
-                    leftUnion[(int)leftBranch],
-                    rightUnion[(int)rightBranch],
                     ref left,
                     ref right);
             default:
@@ -612,6 +611,10 @@ internal static class AvroValueSchemaComparer
         right = AvroValueRulePlan.Unwrap(right);
         if (ReferenceEquals(left, right))
             return true;
+        if (left is global::Avro.UnionSchema leftUnion)
+            return AnyBranchIsCompatible(leftUnion, right, pairs);
+        if (right is global::Avro.UnionSchema rightUnion)
+            return AnyBranchIsCompatible(rightUnion, left, pairs);
         if (IsNumber(left.Tag) && IsNumber(right.Tag) ||
             IsBytes(left.Tag) && IsBytes(right.Tag) ||
             IsString(left.Tag) && IsString(right.Tag))
@@ -658,6 +661,19 @@ internal static class AvroValueSchemaComparer
         {
             pairs.Remove(pair);
         }
+    }
+
+    private static bool AnyBranchIsCompatible(
+        global::Avro.UnionSchema union,
+        AvroSchema other,
+        HashSet<AvroSchemaPair> pairs)
+    {
+        for (var index = 0; index < union.Count; index++)
+        {
+            if (AreCelCompatible(union[index], other, pairs))
+                return true;
+        }
+        return false;
     }
 
     private static bool IsNumber(AvroSchema.Type type) =>

--- a/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
@@ -1,0 +1,283 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using AvroSchema = global::Avro.Schema;
+
+namespace Dekaf.SchemaRegistry.Avro;
+
+internal sealed class AvroAggregateEqualityComparer(AvroSchema schema) : IValidationCelAggregateComparer
+{
+    private const int StackMapEntryCount = 16;
+    private const int StackMapBucketCount = 32;
+
+    private readonly AvroSchema _schema = schema;
+
+    internal static AvroAggregateEqualityComparer? Create(AvroSchema schema) => schema.Tag switch
+    {
+        AvroSchema.Type.Record or AvroSchema.Type.Error or
+        AvroSchema.Type.Array or AvroSchema.Type.Map => new(schema),
+        _ => null
+    };
+
+    bool IValidationCelAggregateComparer.AreEqual(
+        ReadOnlyMemory<byte> left,
+        IValidationCelAggregateComparer rightComparer,
+        ReadOnlyMemory<byte> right)
+    {
+        if (rightComparer is not AvroAggregateEqualityComparer avroRight ||
+            !AvroSchemaLogicalComparer.Instance.Equals(_schema, avroRight._schema))
+        {
+            return false;
+        }
+
+        var leftReader = new AvroValidationReader(left);
+        var rightReader = new AvroValidationReader(right);
+        return AreEqual(_schema, ref leftReader, ref rightReader) &&
+            leftReader.End && rightReader.End;
+    }
+
+    private static bool AreEqual(
+        AvroSchema schema,
+        ref AvroValidationReader left,
+        ref AvroValidationReader right)
+    {
+        schema = AvroValueRulePlan.Unwrap(schema);
+        switch (schema.Tag)
+        {
+            case AvroSchema.Type.Null:
+                return true;
+            case AvroSchema.Type.Boolean:
+                return (left.Read(1).Span[0] != 0) == (right.Read(1).Span[0] != 0);
+            case AvroSchema.Type.Int:
+            case AvroSchema.Type.Long:
+            case AvroSchema.Type.Enumeration:
+                return left.ReadLong() == right.ReadLong();
+            case AvroSchema.Type.Float:
+                return BinaryPrimitives.ReadSingleLittleEndian(left.Read(sizeof(float)).Span) ==
+                    BinaryPrimitives.ReadSingleLittleEndian(right.Read(sizeof(float)).Span);
+            case AvroSchema.Type.Double:
+                return BinaryPrimitives.ReadDoubleLittleEndian(left.Read(sizeof(double)).Span) ==
+                    BinaryPrimitives.ReadDoubleLittleEndian(right.Read(sizeof(double)).Span);
+            case AvroSchema.Type.String:
+            case AvroSchema.Type.Bytes:
+                return left.ReadLengthPrefixed().Span.SequenceEqual(right.ReadLengthPrefixed().Span);
+            case AvroSchema.Type.Fixed:
+                var size = ((global::Avro.FixedSchema)schema).Size;
+                return left.Read(size).Span.SequenceEqual(right.Read(size).Span);
+            case AvroSchema.Type.Record:
+            case AvroSchema.Type.Error:
+                var record = (global::Avro.RecordSchema)schema;
+                for (var index = 0; index < record.Fields.Count; index++)
+                {
+                    if (!AreEqual(record.Fields[index].Schema, ref left, ref right))
+                        return false;
+                }
+                return true;
+            case AvroSchema.Type.Array:
+                return ArraysAreEqual(
+                    ((global::Avro.ArraySchema)schema).ItemSchema,
+                    ref left,
+                    ref right);
+            case AvroSchema.Type.Map:
+                return MapsAreEqual(
+                    ((global::Avro.MapSchema)schema).ValueSchema,
+                    ref left,
+                    ref right);
+            case AvroSchema.Type.Union:
+                var union = (global::Avro.UnionSchema)schema;
+                var leftBranch = left.ReadLong();
+                var rightBranch = right.ReadLong();
+                if (leftBranch != rightBranch || (ulong)leftBranch >= (ulong)union.Count)
+                    return false;
+                return AreEqual(union[(int)leftBranch], ref left, ref right);
+            default:
+                throw InvalidPayload($"unsupported schema type {schema.Tag}");
+        }
+    }
+
+    private static bool ArraysAreEqual(
+        AvroSchema itemSchema,
+        ref AvroValidationReader left,
+        ref AvroValidationReader right)
+    {
+        var leftRemaining = 0L;
+        var rightRemaining = 0L;
+        while (true)
+        {
+            if (leftRemaining == 0)
+                leftRemaining = left.ReadCollectionCount();
+            if (rightRemaining == 0)
+                rightRemaining = right.ReadCollectionCount();
+            if (leftRemaining == 0 || rightRemaining == 0)
+                return leftRemaining == rightRemaining;
+            if (!AreEqual(itemSchema, ref left, ref right))
+                return false;
+            leftRemaining--;
+            rightRemaining--;
+        }
+    }
+
+    private static bool MapsAreEqual(
+        AvroSchema valueSchema,
+        ref AvroValidationReader left,
+        ref AvroValidationReader right)
+    {
+        var leftPayload = left.Source.Slice(left.Position);
+        var rightPayload = right.Source.Slice(right.Position);
+        var leftCount = CountMapEntries(valueSchema, leftPayload);
+        var rightCount = CountMapEntries(valueSchema, rightPayload);
+        if (leftCount != rightCount)
+            return false;
+
+        MapEntry[]? rentedEntries = null;
+        int[]? rentedBuckets = null;
+        Span<MapEntry> entries = leftCount <= StackMapEntryCount
+            ? stackalloc MapEntry[StackMapEntryCount]
+            : (rentedEntries = ArrayPool<MapEntry>.Shared.Rent(leftCount));
+        Span<int> buckets = leftCount <= StackMapEntryCount
+            ? stackalloc int[StackMapBucketCount]
+            : (rentedBuckets = ArrayPool<int>.Shared.Rent(leftCount));
+        buckets.Fill(-1);
+        try
+        {
+            var leftSource = left.Source;
+            ReadMapEntries(valueSchema, ref left, entries, buckets);
+            return MatchMapEntries(
+                valueSchema,
+                leftSource,
+                ref right,
+                leftCount,
+                entries,
+                buckets);
+        }
+        finally
+        {
+            if (rentedEntries is not null)
+                ArrayPool<MapEntry>.Shared.Return(rentedEntries);
+            if (rentedBuckets is not null)
+                ArrayPool<int>.Shared.Return(rentedBuckets);
+        }
+    }
+
+    private static int CountMapEntries(AvroSchema valueSchema, ReadOnlyMemory<byte> payload)
+    {
+        var reader = new AvroValidationReader(payload);
+        var total = 0L;
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return checked((int)total);
+            total = checked(total + count);
+            for (long index = 0; index < count; index++)
+            {
+                _ = reader.ReadLengthPrefixed();
+                AvroValidationValueDecoder.Skip(valueSchema, ref reader);
+            }
+        }
+    }
+
+    private static void ReadMapEntries(
+        AvroSchema valueSchema,
+        ref AvroValidationReader reader,
+        scoped Span<MapEntry> entries,
+        scoped Span<int> buckets)
+    {
+        var entryIndex = 0;
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return;
+            for (long index = 0; index < count; index++)
+            {
+                var key = reader.ReadLengthPrefixed();
+                var keyStart = reader.Position - key.Length;
+                var valueStart = reader.Position;
+                AvroValidationValueDecoder.Skip(valueSchema, ref reader);
+                var hash = Hash(key.Span);
+                var bucket = (int)(hash % (uint)buckets.Length);
+                entries[entryIndex] = new MapEntry(
+                    keyStart,
+                    key.Length,
+                    valueStart,
+                    reader.Position - valueStart,
+                    buckets[bucket]);
+                buckets[bucket] = entryIndex++;
+            }
+        }
+    }
+
+    private static bool MatchMapEntries(
+        AvroSchema valueSchema,
+        ReadOnlyMemory<byte> leftSource,
+        ref AvroValidationReader reader,
+        int entryCount,
+        scoped Span<MapEntry> entries,
+        scoped ReadOnlySpan<int> buckets)
+    {
+        var matched = 0;
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return matched == entryCount;
+            for (long index = 0; index < count; index++)
+            {
+                var key = reader.ReadLengthPrefixed();
+                var valueStart = reader.Position;
+                AvroValidationValueDecoder.Skip(valueSchema, ref reader);
+                var valueLength = reader.Position - valueStart;
+                var bucket = (int)(Hash(key.Span) % (uint)buckets.Length);
+                var entryIndex = buckets[bucket];
+                while (entryIndex >= 0)
+                {
+                    ref var entry = ref entries[entryIndex];
+                    if (!entry.Matched && key.Span.SequenceEqual(
+                            leftSource.Span.Slice(entry.KeyStart, entry.KeyLength)))
+                    {
+                        var leftValue = new AvroValidationReader(
+                            leftSource.Slice(entry.ValueStart, entry.ValueLength));
+                        var rightValue = new AvroValidationReader(
+                            reader.Source.Slice(valueStart, valueLength));
+                        if (AreEqual(valueSchema, ref leftValue, ref rightValue) &&
+                            leftValue.End && rightValue.End)
+                        {
+                            entry.Matched = true;
+                            matched++;
+                            break;
+                        }
+                    }
+                    entryIndex = entry.Next;
+                }
+                if (entryIndex < 0)
+                    return false;
+            }
+        }
+    }
+
+    private static uint Hash(ReadOnlySpan<byte> value)
+    {
+        var hash = 2166136261u;
+        for (var index = 0; index < value.Length; index++)
+            hash = (hash ^ value[index]) * 16777619u;
+        return hash;
+    }
+
+    private static SchemaRegistryRuleException InvalidPayload(string reason) =>
+        new($"Could not evaluate Avro validation rules: {reason}.");
+
+    private struct MapEntry(
+        int keyStart,
+        int keyLength,
+        int valueStart,
+        int valueLength,
+        int next)
+    {
+        internal int KeyStart { get; } = keyStart;
+        internal int KeyLength { get; } = keyLength;
+        internal int ValueStart { get; } = valueStart;
+        internal int ValueLength { get; } = valueLength;
+        internal int Next { get; } = next;
+        internal bool Matched { get; set; }
+    }
+}

--- a/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
@@ -27,7 +27,8 @@ internal sealed class AvroAggregateEqualityComparer(AvroSchema schema) : IValida
         ReadOnlyMemory<byte> right)
     {
         if (rightComparer is not AvroAggregateEqualityComparer avroRight ||
-            !AvroSchemaLogicalComparer.Instance.Equals(_schema, avroRight._schema))
+            (!AvroSchemaLogicalComparer.Instance.Equals(_schema, avroRight._schema) &&
+             !AvroValueSchemaComparer.AreEqual(_schema, avroRight._schema)))
         {
             return false;
         }
@@ -328,5 +329,146 @@ internal sealed class AvroAggregateEqualityComparer(AvroSchema schema) : IValida
         internal int ValueLength { get; } = valueLength;
         internal int Next { get; } = next;
         internal bool Matched { get; set; }
+    }
+}
+
+internal static class AvroValueSchemaComparer
+{
+    [ThreadStatic]
+    private static HashSet<AvroSchemaPair>? t_pairs;
+
+    internal static bool AreEqual(AvroSchema left, AvroSchema right)
+    {
+        if (ReferenceEquals(left, right))
+            return true;
+        var pairs = t_pairs ??= new HashSet<AvroSchemaPair>(AvroSchemaPairReferenceComparer.Instance);
+        pairs.Clear();
+        try
+        {
+            return AreEqual(left, right, pairs);
+        }
+        finally
+        {
+            pairs.Clear();
+        }
+    }
+
+    private static bool AreEqual(
+        AvroSchema left,
+        AvroSchema right,
+        HashSet<AvroSchemaPair> pairs)
+    {
+        if (ReferenceEquals(left, right))
+            return true;
+        if (left.Tag != right.Tag)
+            return false;
+
+        var pair = default(AvroSchemaPair);
+        var pairAdded = false;
+        if (left is global::Avro.NamedSchema leftNamed)
+        {
+            if (right is not global::Avro.NamedSchema rightNamed ||
+                !string.Equals(leftNamed.Fullname, rightNamed.Fullname, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            pair = new AvroSchemaPair(left, right);
+            if (!pairs.Add(pair))
+                return true;
+            pairAdded = true;
+        }
+
+        try
+        {
+            return left.Tag switch
+            {
+                AvroSchema.Type.Record or AvroSchema.Type.Error => RecordsAreEqual(
+                    (global::Avro.RecordSchema)left,
+                    (global::Avro.RecordSchema)right,
+                    pairs),
+                AvroSchema.Type.Enumeration => EnumsAreEqual(
+                    (global::Avro.EnumSchema)left,
+                    (global::Avro.EnumSchema)right),
+                AvroSchema.Type.Array => AreEqual(
+                    ((global::Avro.ArraySchema)left).ItemSchema,
+                    ((global::Avro.ArraySchema)right).ItemSchema,
+                    pairs),
+                AvroSchema.Type.Map => AreEqual(
+                    ((global::Avro.MapSchema)left).ValueSchema,
+                    ((global::Avro.MapSchema)right).ValueSchema,
+                    pairs),
+                AvroSchema.Type.Union => UnionsAreEqual(
+                    (global::Avro.UnionSchema)left,
+                    (global::Avro.UnionSchema)right,
+                    pairs),
+                AvroSchema.Type.Fixed =>
+                    ((global::Avro.FixedSchema)left).Size == ((global::Avro.FixedSchema)right).Size,
+                AvroSchema.Type.Logical =>
+                    string.Equals(
+                        ((global::Avro.LogicalSchema)left).LogicalTypeName,
+                        ((global::Avro.LogicalSchema)right).LogicalTypeName,
+                        StringComparison.Ordinal) &&
+                    AreEqual(
+                        ((global::Avro.LogicalSchema)left).BaseSchema,
+                        ((global::Avro.LogicalSchema)right).BaseSchema,
+                        pairs),
+                _ => true
+            };
+        }
+        finally
+        {
+            if (pairAdded)
+                pairs.Remove(pair);
+        }
+    }
+
+    private static bool RecordsAreEqual(
+        global::Avro.RecordSchema left,
+        global::Avro.RecordSchema right,
+        HashSet<AvroSchemaPair> pairs)
+    {
+        if (left.Fields.Count != right.Fields.Count)
+            return false;
+        for (var index = 0; index < left.Fields.Count; index++)
+        {
+            var leftField = left.Fields[index];
+            var rightField = right.Fields[index];
+            if (!string.Equals(leftField.Name, rightField.Name, StringComparison.Ordinal) ||
+                !AreEqual(leftField.Schema, rightField.Schema, pairs))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static bool EnumsAreEqual(
+        global::Avro.EnumSchema left,
+        global::Avro.EnumSchema right)
+    {
+        if (left.Symbols.Count != right.Symbols.Count)
+            return false;
+        for (var index = 0; index < left.Symbols.Count; index++)
+        {
+            if (!string.Equals(left.Symbols[index], right.Symbols[index], StringComparison.Ordinal))
+                return false;
+        }
+        return true;
+    }
+
+    private static bool UnionsAreEqual(
+        global::Avro.UnionSchema left,
+        global::Avro.UnionSchema right,
+        HashSet<AvroSchemaPair> pairs)
+    {
+        if (left.Count != right.Count)
+            return false;
+        for (var index = 0; index < left.Count; index++)
+        {
+            if (!AreEqual(left[index], right[index], pairs))
+                return false;
+        }
+        return true;
     }
 }

--- a/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroAggregateEqualityComparer.cs
@@ -167,7 +167,7 @@ internal sealed class AvroAggregateEqualityComparer(
             case AvroSchema.Type.Null:
                 return true;
             case AvroSchema.Type.Boolean:
-                return (left.Read(1).Span[0] != 0) == (right.Read(1).Span[0] != 0);
+                return left.ReadBoolean() == right.ReadBoolean();
             case AvroSchema.Type.Record:
             case AvroSchema.Type.Error:
                 var leftRecord = (global::Avro.RecordSchema)leftSchema;
@@ -766,7 +766,7 @@ internal sealed class AvroAggregateEqualityComparer(
             case AvroSchema.Type.Null:
                 return;
             case AvroSchema.Type.Boolean:
-                _ = reader.Read(1);
+                _ = reader.ReadBoolean();
                 return;
             case AvroSchema.Type.Int:
             case AvroSchema.Type.Long:

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -406,6 +406,7 @@ internal sealed class AvroValueRulePlan
                     ref reader,
                     resolution,
                     now,
+                    failFast,
                     ref nestedViolations,
                     ref path);
                 rootSize = _fields.Length;
@@ -442,20 +443,33 @@ internal sealed class AvroValueRulePlan
         ref AvroValidationReader reader,
         AvroMemberResolution resolution,
         long now,
+        bool failFast,
         ref List<ValidationRuleError>? nestedViolations,
         scoped ref AvroValidationPath path)
     {
         for (var index = 0; index < _fields.Length; index++)
         {
             var start = reader.Position;
-            var value = ValidateRecordFieldAndCapture(
-                _fields[index],
-                ref reader,
-                now,
-                _schemaRules.NeedsRecordFieldSize(index),
-                ref nestedViolations,
-                ref path,
-                out var size);
+            var field = _fields[index];
+            var needsSize = _schemaRules.NeedsRecordFieldSize(index);
+            ValidationCelValue value;
+            int size;
+            if (failFast && nestedViolations is not null)
+            {
+                value = CaptureRecordField(field, ref reader, needsSize, out size);
+            }
+            else
+            {
+                value = ValidateRecordFieldAndCapture(
+                    field,
+                    ref reader,
+                    now,
+                    failFast,
+                    needsSize,
+                    ref nestedViolations,
+                    ref path,
+                    out size);
+            }
             _schemaRules.ResolveRecordField(
                 index,
                 reader.Source.Slice(start, reader.Position - start),
@@ -469,6 +483,7 @@ internal sealed class AvroValueRulePlan
         AvroFieldRulePlan field,
         ref AvroValidationReader reader,
         long now,
+        bool failFast,
         bool needsSize,
         ref List<ValidationRuleError>? violations,
         scoped ref AvroValidationPath path,
@@ -484,7 +499,7 @@ internal sealed class AvroValueRulePlan
                     field,
                     ref reader,
                     now,
-                    failFast: false,
+                    failFast,
                     ref violations,
                     ref path,
                     out size);
@@ -496,7 +511,7 @@ internal sealed class AvroValueRulePlan
                 field,
                 ref reader,
                 now,
-                failFast: false,
+                failFast,
                 needsSize,
                 ref violations,
                 ref path,
@@ -508,7 +523,7 @@ internal sealed class AvroValueRulePlan
         var value = field.Child.ValidateAndCapture(
             ref reader,
             now,
-            failFast: false,
+            failFast,
             needsSize,
             ref violations,
             ref path,
@@ -1266,6 +1281,22 @@ internal sealed class AvroValueRulePlan
                 size = AvroValidationValueDecoder.Count(field.Field.Schema, payload);
         }
         path.Truncate(mark);
+        return value;
+    }
+
+    private static ValidationCelValue CaptureRecordField(
+        AvroFieldRulePlan field,
+        ref AvroValidationReader reader,
+        bool needsSize,
+        out int size)
+    {
+        var start = reader.Position;
+        var value = field.Child.ReadValue(ref reader);
+        size = needsSize && value.SizeIndex == 0
+            ? AvroValidationValueDecoder.Count(
+                field.Field.Schema,
+                reader.Source.Slice(start, reader.Position - start))
+            : -1;
         return value;
     }
 

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -3625,6 +3625,15 @@ internal ref struct AvroValidationReader(ReadOnlyMemory<byte> source)
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal bool ReadBoolean()
+    {
+        var value = Read(1).Span[0];
+        if (value > 1)
+            ThrowInvalidBoolean(value);
+        return value != 0;
+    }
+
     internal long ReadLong()
     {
         ulong encoded = 0;
@@ -3668,6 +3677,10 @@ internal ref struct AvroValidationReader(ReadOnlyMemory<byte> source)
 
     private static SchemaRegistryRuleException InvalidPayload(string reason) =>
         new($"Could not evaluate Avro validation rules: {reason}.");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal static void ThrowInvalidBoolean(byte value) =>
+        throw InvalidPayload($"invalid boolean value {value}");
 }
 
 internal static class AvroValidationValueDecoder
@@ -3706,7 +3719,7 @@ internal static class AvroValidationValueDecoder
             case AvroSchema.Type.Null:
                 return ValidationCelValue.Null;
             case AvroSchema.Type.Boolean:
-                return ValidationCelValue.FromBoolean(reader.Read(1).Span[0] != 0);
+                return ValidationCelValue.FromBoolean(reader.ReadBoolean());
             case AvroSchema.Type.Int:
             case AvroSchema.Type.Long:
                 return ValidationCelValue.FromNumber(reader.ReadLong());
@@ -3883,7 +3896,7 @@ internal static class AvroValidationValueDecoder
             case AvroSchema.Type.Null:
                 return;
             case AvroSchema.Type.Boolean:
-                _ = reader.Read(1);
+                _ = reader.ReadBoolean();
                 return;
             case AvroSchema.Type.Int:
             case AvroSchema.Type.Long:
@@ -4013,7 +4026,7 @@ internal static class AvroValidationValueDecoder
             case AvroSchema.Type.Null:
                 return;
             case AvroSchema.Type.Boolean:
-                _ = reader.Read(1);
+                _ = reader.ReadBoolean();
                 return;
             case AvroSchema.Type.Int:
             case AvroSchema.Type.Long:

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -448,6 +448,7 @@ internal sealed class AvroValueRulePlan
                 _fields[index],
                 ref reader,
                 now,
+                _schemaRules.NeedsRecordFieldSize(index),
                 ref nestedViolations,
                 ref path,
                 out var size);
@@ -464,6 +465,7 @@ internal sealed class AvroValueRulePlan
         AvroFieldRulePlan field,
         ref AvroValidationReader reader,
         long now,
+        bool needsSize,
         ref List<ValidationRuleError>? violations,
         scoped ref AvroValidationPath path,
         out int size)
@@ -502,6 +504,8 @@ internal sealed class AvroValueRulePlan
         var value = field.Child.ValidateAndCapture(
             ref reader,
             now,
+            failFast: false,
+            needsSize,
             ref violations,
             ref path,
             out size);
@@ -530,6 +534,8 @@ internal sealed class AvroValueRulePlan
         var value = field.Child.ValidateAndCapture(
             ref reader,
             now,
+            failFast,
+            field.Rules.UsesRootSize,
             ref nestedViolations,
             ref path,
             out size);
@@ -549,6 +555,8 @@ internal sealed class AvroValueRulePlan
     private ValidationCelValue ValidateAndCapture(
         ref AvroValidationReader reader,
         long now,
+        bool failFast,
+        bool needsSize,
         ref List<ValidationRuleError>? violations,
         scoped ref AvroValidationPath path,
         out int size)
@@ -560,16 +568,16 @@ internal sealed class AvroValueRulePlan
             switch (_schema)
             {
                 case global::Avro.RecordSchema:
-                    ValidateRecord(ref reader, now, failFast: false, ref violations, ref path);
+                    ValidateRecord(ref reader, now, failFast, ref violations, ref path);
                     size = _fields.Length;
                     kind = ValidationCelValueKind.Object;
                     break;
                 case global::Avro.ArraySchema:
-                    size = ValidateArray(ref reader, now, failFast: false, ref violations, ref path);
+                    size = ValidateArray(ref reader, now, failFast, ref violations, ref path);
                     kind = ValidationCelValueKind.Array;
                     break;
                 case global::Avro.MapSchema:
-                    size = ValidateMap(ref reader, now, failFast: false, ref violations, ref path);
+                    size = ValidateMap(ref reader, now, failFast, ref violations, ref path);
                     kind = ValidationCelValueKind.Object;
                     break;
                 default:
@@ -577,7 +585,7 @@ internal sealed class AvroValueRulePlan
                     return Validate(
                         ref reader,
                         now,
-                        failFast: false,
+                        failFast,
                         ref violations,
                         ref path);
             }
@@ -591,10 +599,10 @@ internal sealed class AvroValueRulePlan
         var value = Validate(
             ref reader,
             now,
-            failFast: false,
+            failFast,
             ref violations,
             ref path);
-        size = value.SizeIndex == 0
+        size = needsSize && value.SizeIndex == 0
             ? AvroValidationValueDecoder.Count(
                 _schema,
                 reader.Source.Slice(valueStart, reader.Position - valueStart))
@@ -651,6 +659,8 @@ internal sealed class AvroValueRulePlan
                 var value = valuePlan.ValidateAndCapture(
                     ref reader,
                     now,
+                    failFast: false,
+                    needsSize: true,
                     ref nestedViolations,
                     ref path,
                     out var size);
@@ -696,16 +706,16 @@ internal sealed class AvroValueRulePlan
         switch (_schema)
         {
             case global::Avro.RecordSchema:
-                ValidateRecord(ref reader, now, failFast: false, ref nestedViolations, ref path);
+                ValidateRecord(ref reader, now, failFast, ref nestedViolations, ref path);
                 rootSize = _fields.Length;
                 valueKind = ValidationCelValueKind.Object;
                 break;
             case global::Avro.ArraySchema:
-                rootSize = ValidateArray(ref reader, now, failFast: false, ref nestedViolations, ref path);
+                rootSize = ValidateArray(ref reader, now, failFast, ref nestedViolations, ref path);
                 valueKind = ValidationCelValueKind.Array;
                 break;
             case global::Avro.MapSchema:
-                rootSize = ValidateMap(ref reader, now, failFast: false, ref nestedViolations, ref path);
+                rootSize = ValidateMap(ref reader, now, failFast, ref nestedViolations, ref path);
                 valueKind = ValidationCelValueKind.Object;
                 break;
             default:
@@ -826,9 +836,11 @@ internal sealed class AvroValueRulePlan
                 path.Truncate(mark);
                 if (failFast && violations is not null)
                 {
-                    for (var remaining = index + 1; remaining < count; remaining++)
+                    var remainingInBlock = count - index - 1;
+                    for (long remaining = 0; remaining < remainingInBlock; remaining++)
                         AvroValidationValueDecoder.Skip(item._schema, ref reader);
-                    SkipRemainingCollection(item._schema, ref reader);
+                    itemIndex = checked(itemIndex + (int)remainingInBlock +
+                        SkipRemainingCollection(item._schema, ref reader));
                     return itemIndex;
                 }
             }
@@ -859,37 +871,43 @@ internal sealed class AvroValueRulePlan
                 path.Truncate(mark);
                 if (failFast && violations is not null)
                 {
-                    for (var remaining = index + 1; remaining < count; remaining++)
+                    var remainingInBlock = count - index - 1;
+                    for (long remaining = 0; remaining < remainingInBlock; remaining++)
                     {
                         _ = reader.ReadLengthPrefixed();
                         AvroValidationValueDecoder.Skip(valuePlan._schema, ref reader);
                     }
-                    SkipRemainingMap(valuePlan._schema, ref reader);
+                    itemCount = checked(itemCount + (int)remainingInBlock +
+                        SkipRemainingMap(valuePlan._schema, ref reader));
                     return itemCount;
                 }
             }
         }
     }
 
-    private static void SkipRemainingCollection(AvroSchema item, ref AvroValidationReader reader)
+    private static int SkipRemainingCollection(AvroSchema item, ref AvroValidationReader reader)
     {
+        var itemCount = 0;
         while (true)
         {
             var count = reader.ReadCollectionCount();
             if (count == 0)
-                return;
+                return itemCount;
+            itemCount = checked(itemCount + (int)count);
             for (long index = 0; index < count; index++)
                 AvroValidationValueDecoder.Skip(item, ref reader);
         }
     }
 
-    private static void SkipRemainingMap(AvroSchema value, ref AvroValidationReader reader)
+    private static int SkipRemainingMap(AvroSchema value, ref AvroValidationReader reader)
     {
+        var itemCount = 0;
         while (true)
         {
             var count = reader.ReadCollectionCount();
             if (count == 0)
-                return;
+                return itemCount;
+            itemCount = checked(itemCount + (int)count);
             for (long index = 0; index < count; index++)
             {
                 _ = reader.ReadLengthPrefixed();
@@ -1448,6 +1466,9 @@ internal sealed class AvroCompiledRuleSet
             resolution.Members,
             resolution.Sizes);
 
+    internal bool NeedsRecordFieldSize(int fieldIndex) =>
+        _members!.NeedsRecordFieldSize(fieldIndex);
+
     internal void ResolveUnionBranch(
         int branch,
         ReadOnlyMemory<byte> payload,
@@ -1846,6 +1867,9 @@ internal sealed class AvroMemberResolver
             node.ResolveCaptured(payload, value, size, values, sizes);
     }
 
+    internal bool NeedsRecordFieldSize(int fieldIndex) =>
+        _fields[fieldIndex]?.NeedsSize ?? false;
+
     internal void ResolveUnionBranch(
         int branch,
         ReadOnlyMemory<byte> payload,
@@ -1985,6 +2009,7 @@ internal sealed class AvroMemberResolver
         }
         internal int MemberIndex { get; private set; } = -1;
         internal bool HasTargets => MemberIndex >= 0 || _children.Count != 0;
+        internal bool NeedsSize => _needsSize;
 
         internal void AddMemberIndex(int memberIndex, bool needsSize)
         {

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -56,11 +56,16 @@ internal sealed class AvroInlineRuleValidator
 internal sealed class AvroValueRulePlan
 {
     private readonly AvroSchema _schema;
+    private readonly AvroSchema _ruleSchema;
     private AvroCompiledRuleSet _schemaRules = AvroCompiledRuleSet.Empty;
     private AvroFieldRulePlan[] _fields = [];
     private AvroValueRulePlan[] _children = [];
 
-    private AvroValueRulePlan(AvroSchema schema) => _schema = Unwrap(schema);
+    private AvroValueRulePlan(AvroSchema schema)
+    {
+        _schema = Unwrap(schema);
+        _ruleSchema = schema;
+    }
 
     internal bool HasAnyRules { get; private set; }
 
@@ -68,7 +73,6 @@ internal sealed class AvroValueRulePlan
         AvroSchema schema,
         Dictionary<AvroSchema, AvroValueRulePlan> plans)
     {
-        schema = Unwrap(schema);
         if (plans.TryGetValue(schema, out var existing))
             return existing;
 
@@ -81,7 +85,7 @@ internal sealed class AvroValueRulePlan
     private void Initialize(Dictionary<AvroSchema, AvroValueRulePlan> plans)
     {
         _schemaRules = AvroCompiledRuleSet.Compile(
-            AvroInlineRuleParser.ReadRules(_schema),
+            AvroInlineRuleParser.ReadRules(_ruleSchema),
             _schema);
 
         switch (_schema)
@@ -91,8 +95,7 @@ internal sealed class AvroValueRulePlan
                 for (var index = 0; index < record.Fields.Count; index++)
                 {
                     var field = record.Fields[index];
-                    var fieldSchema = Unwrap(field.Schema);
-                    var child = Create(fieldSchema, plans);
+                    var child = Create(field.Schema, plans);
                     _fields[index] = new AvroFieldRulePlan(
                         field,
                         AvroCompiledRuleSet.Compile(
@@ -372,26 +375,6 @@ internal sealed class AvroValueRulePlan
     internal static AvroSchema Unwrap(AvroSchema schema) =>
         schema is global::Avro.LogicalSchema logical ? logical.BaseSchema : schema;
 
-    internal static global::Avro.RecordSchema? FindRecord(AvroSchema schema)
-    {
-        schema = Unwrap(schema);
-        if (schema is global::Avro.RecordSchema record)
-            return record;
-        if (schema is not global::Avro.UnionSchema union)
-            return null;
-        global::Avro.RecordSchema? result = null;
-        for (var index = 0; index < union.Count; index++)
-        {
-            var candidate = FindRecord(union[index]);
-            if (candidate is null)
-                continue;
-            if (result is not null && !ReferenceEquals(result, candidate))
-                return null;
-            result = candidate;
-        }
-        return result;
-    }
-
     private static SchemaRegistryRuleException InvalidPayload(string reason) =>
         new($"Could not evaluate Avro validation rules: {reason}.");
 }
@@ -452,10 +435,9 @@ internal sealed class AvroCompiledRuleSet
             usesCachedEquality |= rule.UsesCachedEquality;
         }
 
-        var recordSchema = AvroValueRulePlan.FindRecord(valueSchema);
-        var members = usedMemberIndexes.Count == 0 || recordSchema is null
+        var members = usedMemberIndexes.Count == 0
             ? null
-            : AvroMemberResolver.Create(valueSchema, recordSchema, memberPaths, usedMemberIndexes);
+            : AvroMemberResolver.Create(valueSchema, memberPaths, usedMemberIndexes);
         return new AvroCompiledRuleSet(
             compiled,
             members,
@@ -524,26 +506,81 @@ internal sealed class AvroCompiledRuleSet
 internal sealed class AvroMemberResolver
 {
     private readonly AvroSchema _valueSchema;
-    private readonly global::Avro.RecordSchema _recordSchema;
+    private readonly AvroMemberResolver?[]? _unionBranches;
     private readonly AvroMemberNode?[] _fields;
 
-    private AvroMemberResolver(AvroSchema valueSchema, global::Avro.RecordSchema recordSchema)
+    private AvroMemberResolver(global::Avro.RecordSchema recordSchema)
     {
-        _valueSchema = AvroValueRulePlan.Unwrap(valueSchema);
-        _recordSchema = recordSchema;
+        _valueSchema = recordSchema;
         _fields = new AvroMemberNode?[recordSchema.Fields.Count];
     }
 
-    internal static AvroMemberResolver Create(
+    private AvroMemberResolver(global::Avro.UnionSchema unionSchema)
+    {
+        _valueSchema = unionSchema;
+        _unionBranches = new AvroMemberResolver?[unionSchema.Count];
+        _fields = [];
+    }
+
+    internal static AvroMemberResolver? Create(
         AvroSchema valueSchema,
-        global::Avro.RecordSchema recordSchema,
         IReadOnlyList<byte[][]> paths,
         IReadOnlyCollection<int> usedIndexes)
     {
-        var resolver = new AvroMemberResolver(valueSchema, recordSchema);
-        resolver.SetSchemas(recordSchema);
+        valueSchema = AvroValueRulePlan.Unwrap(valueSchema);
+        if (valueSchema is global::Avro.RecordSchema record)
+            return CreateRecord(record, paths, usedIndexes);
+        if (valueSchema is not global::Avro.UnionSchema union)
+            return null;
+
+        var resolver = new AvroMemberResolver(union);
+        var resolvedIndexes = new bool[paths.Count];
+        for (var branchIndex = 0; branchIndex < union.Count; branchIndex++)
+        {
+            if (AvroValueRulePlan.Unwrap(union[branchIndex]) is not global::Avro.RecordSchema branch)
+                continue;
+
+            AvroMemberResolver? branchResolver = null;
+            foreach (var memberIndex in usedIndexes)
+            {
+                var path = paths[memberIndex];
+                var name = Encoding.UTF8.GetString(path[0]);
+                if (FindField(branch, name) is null)
+                    continue;
+
+                branchResolver ??= CreateRecord(branch);
+                branchResolver.Add(branch, path, memberIndex, depth: 0);
+                resolvedIndexes[memberIndex] = true;
+            }
+            resolver._unionBranches![branchIndex] = branchResolver;
+        }
+
         foreach (var memberIndex in usedIndexes)
-            resolver.Add(recordSchema, paths[memberIndex], memberIndex, depth: 0);
+        {
+            if (!resolvedIndexes[memberIndex])
+            {
+                throw new SchemaRegistryRuleException(
+                    $"Avro validation rule refers to unknown field '{Encoding.UTF8.GetString(paths[memberIndex][0])}' on every record union branch.");
+            }
+        }
+        return resolver;
+    }
+
+    private static AvroMemberResolver CreateRecord(
+        global::Avro.RecordSchema record,
+        IReadOnlyList<byte[][]> paths,
+        IReadOnlyCollection<int> usedIndexes)
+    {
+        var resolver = CreateRecord(record);
+        foreach (var memberIndex in usedIndexes)
+            resolver.Add(record, paths[memberIndex], memberIndex, depth: 0);
+        return resolver;
+    }
+
+    private static AvroMemberResolver CreateRecord(global::Avro.RecordSchema record)
+    {
+        var resolver = new AvroMemberResolver(record);
+        resolver.SetSchemas(record);
         return resolver;
     }
 
@@ -572,14 +609,18 @@ internal sealed class AvroMemberResolver
         ValidationCelSizeValues sizes)
     {
         var reader = new AvroValidationReader(payload);
-        if (_valueSchema is global::Avro.UnionSchema union)
+        if (_unionBranches is not null)
         {
+            var union = (global::Avro.UnionSchema)_valueSchema;
             var branch = reader.ReadLong();
             if ((ulong)branch >= (ulong)union.Count)
                 throw new SchemaRegistryRuleException(
                     $"Could not evaluate Avro validation rules: invalid union index {branch}.");
-            if (!ReferenceEquals(AvroValueRulePlan.Unwrap(union[(int)branch]), _recordSchema))
-                return;
+            _unionBranches[(int)branch]?.Resolve(
+                reader.Source.Slice(reader.Position),
+                values,
+                sizes);
+            return;
         }
         for (var index = 0; index < _fields.Length; index++)
         {
@@ -698,8 +739,7 @@ internal sealed class AvroMemberResolver
         {
             if (!_children.TryGetValue(record, out var child))
             {
-                child = new AvroMemberResolver(record, record);
-                child.SetSchemas(record);
+                child = CreateRecord(record);
                 _children.Add(record, child);
             }
             child.Add(record, path, memberIndex, depth);

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -82,7 +82,7 @@ internal sealed class AvroValueRulePlan
     {
         _schemaRules = AvroCompiledRuleSet.Compile(
             AvroInlineRuleParser.ReadRules(_schema),
-            _schema as global::Avro.RecordSchema);
+            _schema);
 
         switch (_schema)
         {
@@ -97,7 +97,7 @@ internal sealed class AvroValueRulePlan
                         field,
                         AvroCompiledRuleSet.Compile(
                             AvroInlineRuleParser.ReadRules(field),
-                            FindRecord(fieldSchema)),
+                            field.Schema),
                         child);
                 }
                 break;
@@ -429,7 +429,7 @@ internal sealed class AvroCompiledRuleSet
 
     internal static AvroCompiledRuleSet Compile(
         IReadOnlyList<ValidationRule> rules,
-        global::Avro.RecordSchema? valueSchema)
+        AvroSchema valueSchema)
     {
         if (rules.Count == 0)
             return Empty;
@@ -452,9 +452,10 @@ internal sealed class AvroCompiledRuleSet
             usesCachedEquality |= rule.UsesCachedEquality;
         }
 
-        var members = usedMemberIndexes.Count == 0 || valueSchema is null
+        var recordSchema = AvroValueRulePlan.FindRecord(valueSchema);
+        var members = usedMemberIndexes.Count == 0 || recordSchema is null
             ? null
-            : AvroMemberResolver.Create(valueSchema, memberPaths, usedMemberIndexes);
+            : AvroMemberResolver.Create(valueSchema, recordSchema, memberPaths, usedMemberIndexes);
         return new AvroCompiledRuleSet(
             compiled,
             members,
@@ -522,20 +523,27 @@ internal sealed class AvroCompiledRuleSet
 
 internal sealed class AvroMemberResolver
 {
+    private readonly AvroSchema _valueSchema;
+    private readonly global::Avro.RecordSchema _recordSchema;
     private readonly AvroMemberNode?[] _fields;
 
-    private AvroMemberResolver(global::Avro.RecordSchema schema) =>
-        _fields = new AvroMemberNode?[schema.Fields.Count];
+    private AvroMemberResolver(AvroSchema valueSchema, global::Avro.RecordSchema recordSchema)
+    {
+        _valueSchema = AvroValueRulePlan.Unwrap(valueSchema);
+        _recordSchema = recordSchema;
+        _fields = new AvroMemberNode?[recordSchema.Fields.Count];
+    }
 
     internal static AvroMemberResolver Create(
-        global::Avro.RecordSchema schema,
+        AvroSchema valueSchema,
+        global::Avro.RecordSchema recordSchema,
         IReadOnlyList<byte[][]> paths,
         IReadOnlyCollection<int> usedIndexes)
     {
-        var resolver = new AvroMemberResolver(schema);
-        resolver.SetSchemas(schema);
+        var resolver = new AvroMemberResolver(valueSchema, recordSchema);
+        resolver.SetSchemas(recordSchema);
         foreach (var memberIndex in usedIndexes)
-            resolver.Add(schema, paths[memberIndex], memberIndex, depth: 0);
+            resolver.Add(recordSchema, paths[memberIndex], memberIndex, depth: 0);
         return resolver;
     }
 
@@ -564,6 +572,15 @@ internal sealed class AvroMemberResolver
         ValidationCelSizeValues sizes)
     {
         var reader = new AvroValidationReader(payload);
+        if (_valueSchema is global::Avro.UnionSchema union)
+        {
+            var branch = reader.ReadLong();
+            if ((ulong)branch >= (ulong)union.Count)
+                throw new SchemaRegistryRuleException(
+                    $"Could not evaluate Avro validation rules: invalid union index {branch}.");
+            if (!ReferenceEquals(AvroValueRulePlan.Unwrap(union[(int)branch]), _recordSchema))
+                return;
+        }
         for (var index = 0; index < _fields.Length; index++)
         {
             var node = _fields[index];
@@ -681,7 +698,7 @@ internal sealed class AvroMemberResolver
         {
             if (!_children.TryGetValue(record, out var child))
             {
-                child = new AvroMemberResolver(record);
+                child = new AvroMemberResolver(record, record);
                 child.SetSchemas(record);
                 _children.Add(record, child);
             }
@@ -935,11 +952,18 @@ internal static class AvroValidationValueDecoder
     internal static int Count(AvroSchema schema, ReadOnlyMemory<byte> payload)
     {
         schema = AvroValueRulePlan.Unwrap(schema);
+        var reader = new AvroValidationReader(payload);
+        if (schema is global::Avro.UnionSchema union)
+        {
+            var branch = reader.ReadLong();
+            if ((ulong)branch >= (ulong)union.Count)
+                throw InvalidPayload($"invalid union index {branch}");
+            schema = AvroValueRulePlan.Unwrap(union[(int)branch]);
+        }
         if (schema is global::Avro.RecordSchema record)
             return record.Fields.Count;
         if (schema is not (global::Avro.ArraySchema or global::Avro.MapSchema))
             return -1;
-        var reader = new AvroValidationReader(payload);
         var count = 0L;
         while (true)
         {

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -61,6 +61,7 @@ internal sealed class AvroValueRulePlan
     private AvroCompiledRuleSet _schemaRules = AvroCompiledRuleSet.Empty;
     private AvroFieldRulePlan[] _fields = [];
     private AvroValueRulePlan[] _children = [];
+    private int[] _deferredSchemaRuleFieldIndexes = [];
     private bool _hasNestedRules;
 
     private AvroValueRulePlan(AvroSchema schema)
@@ -157,6 +158,27 @@ internal sealed class AvroValueRulePlan
                 }
             }
         }
+
+        foreach (var plan in plans.Values)
+            plan.InitializeDeferredSchemaRuleFields();
+    }
+
+    private void InitializeDeferredSchemaRuleFields()
+    {
+        var lastMemberFieldIndex = _schemaRules.LastRecordMemberIndex;
+        if (lastMemberFieldIndex <= 0)
+            return;
+
+        List<int>? deferred = null;
+        for (var index = 0; index < lastMemberFieldIndex; index++)
+        {
+            var field = _fields[index];
+            if (field.Rules.IsEmpty && !field.Child.HasAnyRules)
+                continue;
+            (deferred ??= []).Add(index);
+        }
+        if (deferred is not null)
+            _deferredSchemaRuleFieldIndexes = [.. deferred];
     }
 
     internal ValidationCelValue Validate(
@@ -168,6 +190,19 @@ internal sealed class AvroValueRulePlan
     {
         if (!HasAnyRules)
             return ReadValue(ref reader);
+
+        if (!_schemaRules.IsEmpty
+            && !_schemaRules.UsesRootValue
+            && _hasNestedRules
+            && _schema is global::Avro.RecordSchema)
+        {
+            return ValidateRecordWithDeferredNestedRules(
+                ref reader,
+                now,
+                failFast,
+                ref violations,
+                ref path);
+        }
 
         var value = ValidationCelValue.Missing;
         var preview = default(AvroValidationReader);
@@ -396,6 +431,170 @@ internal sealed class AvroValueRulePlan
         }
     }
 
+    private ValidationCelValue ValidateRecordWithDeferredNestedRules(
+        ref AvroValidationReader reader,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path)
+    {
+        // Resolve only the prefix needed by the record rule, evaluate that rule,
+        // then validate deferred fields in wire order. This preserves parent-first
+        // failures without rescanning the complete record on valid payloads.
+        var lastMemberFieldIndex = _schemaRules.LastRecordMemberIndex;
+        if (lastMemberFieldIndex < 0)
+        {
+            _schemaRules.EvaluateResolvedWithoutRoot(
+                _schemaRules.BeginMemberResolution(),
+                payloadLength: 0,
+                now,
+                failFast,
+                ref violations,
+                ref path);
+            if (failFast && violations is not null)
+            {
+                AvroValidationValueDecoder.Skip(_schema, ref reader);
+                return ValidationCelValue.Missing;
+            }
+
+            ValidateRecord(ref reader, now, failFast, ref violations, ref path);
+            return ValidationCelValue.Missing;
+        }
+
+        var deferredIndexes = _deferredSchemaRuleFieldIndexes;
+        var offsetCount = deferredIndexes.Length * 2;
+        int[]? rentedOffsets = null;
+        Span<int> offsets = offsetCount <= 128
+            ? stackalloc int[offsetCount]
+            : (rentedOffsets = ArrayPool<int>.Shared.Rent(offsetCount));
+        try
+        {
+            var resolution = _schemaRules.BeginMemberResolution();
+            var recordStart = reader.Position;
+            var lastFieldPayload = _schemaRules.ResolveRecordPrefix(
+                ref reader,
+                deferredIndexes,
+                offsets,
+                resolution);
+
+            _schemaRules.EvaluateResolvedWithoutRoot(
+                resolution,
+                reader.Position - recordStart,
+                now,
+                failFast,
+                ref violations,
+                ref path);
+            if (failFast && violations is not null)
+            {
+                SkipRecordFields(ref reader, lastMemberFieldIndex + 1);
+                return ValidationCelValue.Missing;
+            }
+
+            for (var index = 0; index < deferredIndexes.Length; index++)
+            {
+                var fieldReader = new AvroValidationReader(
+                    reader.Source.Slice(offsets[index * 2], offsets[index * 2 + 1]));
+                ValidateDeferredRecordField(
+                    _fields[deferredIndexes[index]],
+                    ref fieldReader,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path);
+                if (failFast && violations is not null)
+                {
+                    SkipRecordFields(ref reader, lastMemberFieldIndex + 1);
+                    return ValidationCelValue.Missing;
+                }
+            }
+
+            var lastField = _fields[lastMemberFieldIndex];
+            if (!lastField.Rules.IsEmpty || lastField.Child.HasAnyRules)
+            {
+                var fieldReader = new AvroValidationReader(
+                    reader.Source.Slice(lastFieldPayload.Start, lastFieldPayload.Length));
+                ValidateDeferredRecordField(
+                    lastField,
+                    ref fieldReader,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path);
+                if (failFast && violations is not null)
+                {
+                    SkipRecordFields(ref reader, lastMemberFieldIndex + 1);
+                    return ValidationCelValue.Missing;
+                }
+            }
+
+            for (var index = lastMemberFieldIndex + 1; index < _fields.Length; index++)
+            {
+                ValidateDeferredRecordField(
+                    _fields[index],
+                    ref reader,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path);
+                if (failFast && violations is not null)
+                {
+                    SkipRecordFields(ref reader, index + 1);
+                    break;
+                }
+            }
+            return ValidationCelValue.Missing;
+        }
+        finally
+        {
+            if (rentedOffsets is not null)
+                ArrayPool<int>.Shared.Return(rentedOffsets);
+        }
+    }
+
+    private void SkipRecordFields(ref AvroValidationReader reader, int startIndex)
+    {
+        for (var index = startIndex; index < _fields.Length; index++)
+            AvroValidationValueDecoder.Skip(_fields[index].Field.Schema, ref reader);
+    }
+
+    private static void ValidateDeferredRecordField(
+        AvroFieldRulePlan field,
+        ref AvroValidationReader reader,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path)
+    {
+        var mark = path.Length;
+        path.AppendField(field.Field.Name);
+        if (field.Rules.IsEmpty)
+        {
+            _ = field.Child.Validate(ref reader, now, failFast, ref violations, ref path);
+        }
+        else
+        {
+            var fieldStart = reader.Position;
+            var preview = reader;
+            var value = field.Child.ReadValue(ref preview);
+            var payload = preview.Source.Slice(fieldStart, preview.Position - fieldStart);
+            field.Rules.Evaluate(
+                value,
+                payload,
+                now,
+                failFast,
+                ref violations,
+                ref path,
+                value.SizeIndex == 0
+                    ? AvroValidationValueDecoder.Count(field.Field.Schema, payload)
+                    : -1);
+            if ((failFast && violations is not null) || !field.Child.HasAnyRules)
+                reader = preview;
+            else
+                _ = field.Child.Validate(ref reader, now, failFast, ref violations, ref path);
+        }
+        path.Truncate(mark);
+    }
+
     private ValidationCelValue ReadValue(ref AvroValidationReader reader)
     {
         if (_schema is not global::Avro.UnionSchema union)
@@ -419,6 +618,12 @@ internal sealed record AvroFieldRulePlan(
     AvroCompiledRuleSet Rules,
     AvroValueRulePlan Child);
 
+internal readonly record struct AvroMemberResolution(
+    ValidationCelMemberValues Members,
+    ValidationCelSizeValues Sizes);
+
+internal readonly record struct AvroFieldPayload(int Start, int Length);
+
 internal sealed class AvroCompiledRuleSet
 {
     internal static AvroCompiledRuleSet Empty { get; } = new([], null, false, false, false, false, 0, null);
@@ -430,6 +635,7 @@ internal sealed class AvroCompiledRuleSet
     private readonly bool _usesCachedEquality;
     private readonly bool _usesRootAggregateEquality;
     private readonly int _memberCount;
+    private readonly int _lastRecordMemberIndex;
 
     private AvroCompiledRuleSet(
         CompiledValidationRule[] rules,
@@ -448,6 +654,7 @@ internal sealed class AvroCompiledRuleSet
         _usesCachedEquality = usesCachedEquality;
         _usesRootAggregateEquality = usesRootAggregateEquality;
         _memberCount = memberCount;
+        _lastRecordMemberIndex = members?.LastRecordMemberIndex ?? -1;
         if (!usesRootAggregateEquality || valueSchema is null)
             return;
 
@@ -467,6 +674,7 @@ internal sealed class AvroCompiledRuleSet
     internal bool IsEmpty => _rules.Length == 0;
     internal bool UsesRootValue { get; }
     internal bool UsesSize { get; }
+    internal int LastRecordMemberIndex => _lastRecordMemberIndex;
 
     internal static AvroCompiledRuleSet Compile(
         IReadOnlyList<ValidationRule> rules,
@@ -584,22 +792,56 @@ internal sealed class AvroCompiledRuleSet
         ref List<ValidationRuleError>? violations,
         scoped ref AvroValidationPath path)
     {
-        var memberValues = _memberCount == 0
-            ? default
-            : CompiledValidationRule.GetMemberValues(_memberCount);
-        var sizes = UsesSize || _members is not null
-            ? CompiledValidationRule.GetSizeValues(_memberCount + 1)
-            : default;
+        var resolution = BeginMemberResolution();
         var start = reader.Position;
         if (_members is null)
             AvroValidationValueDecoder.Skip(valueSchema, ref reader);
         else
-            _members.Resolve(ref reader, memberValues, sizes);
+            _members.Resolve(ref reader, resolution.Members, resolution.Sizes);
+
+        EvaluateResolvedWithoutRoot(
+            resolution,
+            reader.Position - start,
+            now,
+            failFast,
+            ref violations,
+            ref path);
+    }
+
+    internal AvroMemberResolution BeginMemberResolution() => new(
+        _memberCount == 0
+            ? default
+            : CompiledValidationRule.GetMemberValues(_memberCount),
+        UsesSize || _members is not null
+            ? CompiledValidationRule.GetSizeValues(_memberCount + 1)
+            : default);
+
+    internal AvroFieldPayload ResolveRecordPrefix(
+        ref AvroValidationReader reader,
+        int[] deferredFieldIndexes,
+        scoped Span<int> deferredFieldOffsets,
+        AvroMemberResolution resolution) =>
+        _members!.ResolveRecordPrefix(
+            ref reader,
+            _lastRecordMemberIndex,
+            deferredFieldIndexes,
+            deferredFieldOffsets,
+            resolution.Members,
+            resolution.Sizes);
+
+    internal void EvaluateResolvedWithoutRoot(
+        AvroMemberResolution resolution,
+        int payloadLength,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path)
+    {
         var equalityGeneration = _usesCachedEquality
             ? CompiledValidationRule.BeginEqualityResolution()
             : 0;
 
-        ValidationCelStrings.Begin(_memberCount + 1, reader.Position - start);
+        ValidationCelStrings.Begin(_memberCount + 1, payloadLength);
         try
         {
             for (var index = 0; index < _rules.Length; index++)
@@ -610,8 +852,8 @@ internal sealed class AvroCompiledRuleSet
                     var result = rule.Evaluate(
                         ValidationCelValue.Missing,
                         now,
-                        memberValues,
-                        sizes,
+                        resolution.Members,
+                        resolution.Sizes,
                         equalityGeneration,
                         rootAggregateComparer: null);
                     if (result.Kind == ValidationResultKind.Boolean ? result.Boolean : result.String!.Length == 0)
@@ -658,6 +900,19 @@ internal sealed class AvroMemberResolver
     private readonly AvroSchema _valueSchema;
     private readonly AvroMemberResolver?[]? _unionBranches;
     private readonly AvroMemberNode?[] _fields;
+
+    internal int LastRecordMemberIndex
+    {
+        get
+        {
+            for (var index = _fields.Length - 1; index >= 0; index--)
+            {
+                if (_fields[index]?.HasTargets == true)
+                    return index;
+            }
+            return -1;
+        }
+    }
 
     private AvroMemberResolver(global::Avro.RecordSchema recordSchema)
     {
@@ -800,6 +1055,48 @@ internal sealed class AvroMemberResolver
                 AvroValidationValueDecoder.Skip(schema, ref reader);
             }
         }
+    }
+
+    internal AvroFieldPayload ResolveRecordPrefix(
+        ref AvroValidationReader reader,
+        int lastFieldIndex,
+        int[] deferredFieldIndexes,
+        scoped Span<int> deferredFieldOffsets,
+        ValidationCelMemberValues values,
+        ValidationCelSizeValues sizes)
+    {
+        var deferredPosition = 0;
+        var lastFieldStart = 0;
+        var lastFieldLength = 0;
+        for (var index = 0; index <= lastFieldIndex; index++)
+        {
+            var fieldStart = reader.Position;
+            var node = _fields[index]
+                ?? throw new InvalidOperationException("Avro validation member resolver is incomplete.");
+            var schema = node.Schema!;
+            AvroValidationValueDecoder.Skip(schema, ref reader);
+            var fieldLength = reader.Position - fieldStart;
+            if (index == lastFieldIndex)
+            {
+                lastFieldStart = fieldStart;
+                lastFieldLength = fieldLength;
+            }
+            else if (deferredPosition < deferredFieldIndexes.Length
+                && deferredFieldIndexes[deferredPosition] == index)
+            {
+                deferredFieldOffsets[deferredPosition * 2] = fieldStart;
+                deferredFieldOffsets[deferredPosition * 2 + 1] = fieldLength;
+                deferredPosition++;
+            }
+            if (node.HasTargets)
+            {
+                node.Resolve(
+                    reader.Source.Slice(fieldStart, fieldLength),
+                    values,
+                    sizes);
+            }
+        }
+        return new AvroFieldPayload(lastFieldStart, lastFieldLength);
     }
 
     private static global::Avro.Field? FindField(global::Avro.RecordSchema schema, string name)

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -61,6 +61,7 @@ internal sealed class AvroValueRulePlan
     private AvroCompiledRuleSet _schemaRules = AvroCompiledRuleSet.Empty;
     private AvroFieldRulePlan[] _fields = [];
     private AvroValueRulePlan[] _children = [];
+    private bool _hasNestedRules;
 
     private AvroValueRulePlan(AvroSchema schema)
     {
@@ -121,7 +122,12 @@ internal sealed class AvroValueRulePlan
 
         HasAnyRules = !_schemaRules.IsEmpty;
         for (var index = 0; index < _fields.Length; index++)
-            HasAnyRules |= !_fields[index].Rules.IsEmpty;
+        {
+            if (_fields[index].Rules.IsEmpty)
+                continue;
+            HasAnyRules = true;
+            _hasNestedRules = true;
+        }
     }
 
     internal static void Complete(Dictionary<AvroSchema, AvroValueRulePlan> plans)
@@ -132,24 +138,22 @@ internal sealed class AvroValueRulePlan
             changed = false;
             foreach (var plan in plans.Values)
             {
-                if (plan.HasAnyRules)
-                    continue;
-                for (var index = 0; index < plan._fields.Length; index++)
+                if (!plan._hasNestedRules)
                 {
-                    if (plan._fields[index].Child.HasAnyRules)
+                    for (var index = 0; index < plan._fields.Length; index++)
                     {
-                        plan.HasAnyRules = true;
-                        changed = true;
+                        if (!plan._fields[index].Child.HasAnyRules)
+                            continue;
+                        plan._hasNestedRules = true;
                         break;
                     }
+                    for (var index = 0; !plan._hasNestedRules && index < plan._children.Length; index++)
+                        plan._hasNestedRules = plan._children[index].HasAnyRules;
                 }
-                for (var index = 0; !plan.HasAnyRules && index < plan._children.Length; index++)
+                if (!plan.HasAnyRules && plan._hasNestedRules)
                 {
-                    if (plan._children[index].HasAnyRules)
-                    {
-                        plan.HasAnyRules = true;
-                        changed = true;
-                    }
+                    plan.HasAnyRules = true;
+                    changed = true;
                 }
             }
         }
@@ -185,6 +189,11 @@ internal sealed class AvroValueRulePlan
                 ref path,
                 rootSize);
             if (failFast && violations is not null)
+            {
+                reader = preview;
+                return value;
+            }
+            if (!_hasNestedRules)
             {
                 reader = preview;
                 return value;

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -55,6 +55,13 @@ internal sealed class AvroInlineRuleValidator
 
 internal sealed class AvroValueRulePlan
 {
+    private enum ValidationStrategy : byte
+    {
+        Standard,
+        AggregateRoot,
+        DeferredRecord
+    }
+
     private readonly AvroSchema _schema;
     private readonly AvroSchema _ruleSchema;
     private readonly ReadOnlyMemory<byte>[]? _enumSymbols;
@@ -63,6 +70,7 @@ internal sealed class AvroValueRulePlan
     private AvroValueRulePlan[] _children = [];
     private int[] _deferredSchemaRuleFieldIndexes = [];
     private bool _hasNestedRules;
+    private ValidationStrategy _validationStrategy;
 
     private AvroValueRulePlan(AvroSchema schema)
     {
@@ -160,7 +168,25 @@ internal sealed class AvroValueRulePlan
         }
 
         foreach (var plan in plans.Values)
+        {
             plan.InitializeDeferredSchemaRuleFields();
+            plan._validationStrategy = plan.GetValidationStrategy();
+        }
+    }
+
+    private ValidationStrategy GetValidationStrategy()
+    {
+        if (!_hasNestedRules || _schemaRules.IsEmpty)
+            return ValidationStrategy.Standard;
+        if (_schemaRules.UsesRootValue
+            && !_schemaRules.HasMembers
+            && _schema is global::Avro.RecordSchema or global::Avro.ArraySchema or global::Avro.MapSchema)
+        {
+            return ValidationStrategy.AggregateRoot;
+        }
+        return !_schemaRules.UsesRootValue && _schema is global::Avro.RecordSchema
+            ? ValidationStrategy.DeferredRecord
+            : ValidationStrategy.Standard;
     }
 
     private void InitializeDeferredSchemaRuleFields()
@@ -191,11 +217,18 @@ internal sealed class AvroValueRulePlan
         if (!HasAnyRules)
             return ReadValue(ref reader);
 
-        if (!_schemaRules.IsEmpty
-            && !_schemaRules.UsesRootValue
-            && _hasNestedRules
-            && _schema is global::Avro.RecordSchema)
+        if (_validationStrategy != ValidationStrategy.Standard)
         {
+            if (_validationStrategy == ValidationStrategy.AggregateRoot)
+            {
+                return ValidateAggregateWithRootRules(
+                    ref reader,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path);
+            }
+
             return ValidateRecordWithDeferredNestedRules(
                 ref reader,
                 now,
@@ -254,10 +287,10 @@ internal sealed class AvroValueRulePlan
                 ValidateRecord(ref reader, now, failFast, ref violations, ref path);
                 break;
             case global::Avro.ArraySchema:
-                ValidateArray(ref reader, now, failFast, ref violations, ref path);
+                _ = ValidateArray(ref reader, now, failFast, ref violations, ref path);
                 break;
             case global::Avro.MapSchema:
-                ValidateMap(ref reader, now, failFast, ref violations, ref path);
+                _ = ValidateMap(ref reader, now, failFast, ref violations, ref path);
                 break;
             case global::Avro.UnionSchema:
                 ValidateUnion(ref reader, now, failFast, ref violations, ref path);
@@ -269,6 +302,60 @@ internal sealed class AvroValueRulePlan
                     reader = preview;
                 break;
         }
+        return value;
+    }
+
+    private ValidationCelValue ValidateAggregateWithRootRules(
+        ref AvroValidationReader reader,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path)
+    {
+        var start = reader.Position;
+        List<ValidationRuleError>? nestedViolations = null;
+        int rootSize;
+        ValidationCelValueKind valueKind;
+        switch (_schema)
+        {
+            case global::Avro.RecordSchema:
+                ValidateRecord(ref reader, now, failFast: false, ref nestedViolations, ref path);
+                rootSize = _fields.Length;
+                valueKind = ValidationCelValueKind.Object;
+                break;
+            case global::Avro.ArraySchema:
+                rootSize = ValidateArray(ref reader, now, failFast: false, ref nestedViolations, ref path);
+                valueKind = ValidationCelValueKind.Array;
+                break;
+            case global::Avro.MapSchema:
+                rootSize = ValidateMap(ref reader, now, failFast: false, ref nestedViolations, ref path);
+                valueKind = ValidationCelValueKind.Object;
+                break;
+            default:
+                throw new InvalidOperationException("Root aggregate validation requires a record, array, or map schema.");
+        }
+
+        var payload = reader.Source.Slice(start, reader.Position - start);
+        var value = ValidationCelValue.FromCollection(valueKind, payload, sizeIndex: 0);
+        _schemaRules.Evaluate(
+            value,
+            payload,
+            now,
+            failFast,
+            ref violations,
+            ref path,
+            rootSize);
+        if (nestedViolations is null || (failFast && violations is not null))
+            return value;
+
+        violations ??= new List<ValidationRuleError>(failFast ? 1 : nestedViolations.Count);
+        if (failFast)
+        {
+            violations.Add(nestedViolations[0]);
+            return value;
+        }
+        for (var index = 0; index < nestedViolations.Count; index++)
+            violations.Add(nestedViolations[index]);
         return value;
     }
 
@@ -339,7 +426,7 @@ internal sealed class AvroValueRulePlan
             ref path);
     }
 
-    private void ValidateArray(
+    private int ValidateArray(
         ref AvroValidationReader reader,
         long now,
         bool failFast,
@@ -352,7 +439,7 @@ internal sealed class AvroValueRulePlan
         {
             var count = reader.ReadCollectionCount();
             if (count == 0)
-                return;
+                return itemIndex;
             for (long index = 0; index < count; index++)
             {
                 var mark = path.Length;
@@ -364,13 +451,13 @@ internal sealed class AvroValueRulePlan
                     for (var remaining = index + 1; remaining < count; remaining++)
                         AvroValidationValueDecoder.Skip(item._schema, ref reader);
                     SkipRemainingCollection(item._schema, ref reader);
-                    return;
+                    return itemIndex;
                 }
             }
         }
     }
 
-    private void ValidateMap(
+    private int ValidateMap(
         ref AvroValidationReader reader,
         long now,
         bool failFast,
@@ -378,13 +465,15 @@ internal sealed class AvroValueRulePlan
         scoped ref AvroValidationPath path)
     {
         var valuePlan = _children[0];
+        var itemCount = 0;
         while (true)
         {
             var count = reader.ReadCollectionCount();
             if (count == 0)
-                return;
+                return itemCount;
             for (long index = 0; index < count; index++)
             {
+                itemCount = checked(itemCount + 1);
                 var key = reader.ReadLengthPrefixed();
                 var mark = path.Length;
                 path.AppendMapKey(key.Span);
@@ -398,7 +487,7 @@ internal sealed class AvroValueRulePlan
                         AvroValidationValueDecoder.Skip(valuePlan._schema, ref reader);
                     }
                     SkipRemainingMap(valuePlan._schema, ref reader);
-                    return;
+                    return itemCount;
                 }
             }
         }
@@ -674,6 +763,7 @@ internal sealed class AvroCompiledRuleSet
     internal bool IsEmpty => _rules.Length == 0;
     internal bool UsesRootValue { get; }
     internal bool UsesSize { get; }
+    internal bool HasMembers => _members is not null;
     internal int LastRecordMemberIndex => _lastRecordMemberIndex;
 
     internal static AvroCompiledRuleSet Compile(
@@ -900,6 +990,7 @@ internal sealed class AvroMemberResolver
     private readonly AvroSchema _valueSchema;
     private readonly AvroMemberResolver?[]? _unionBranches;
     private readonly AvroMemberNode?[] _fields;
+    private readonly Dictionary<ReadOnlyMemory<byte>, AvroMemberNode>? _mapValues;
 
     internal int LastRecordMemberIndex
     {
@@ -927,6 +1018,13 @@ internal sealed class AvroMemberResolver
         _fields = [];
     }
 
+    private AvroMemberResolver(global::Avro.MapSchema mapSchema)
+    {
+        _valueSchema = mapSchema;
+        _fields = [];
+        _mapValues = new Dictionary<ReadOnlyMemory<byte>, AvroMemberNode>(AvroUtf8MemoryComparer.Instance);
+    }
+
     internal static AvroMemberResolver? Create(
         AvroSchema valueSchema,
         IReadOnlyList<byte[][]> paths,
@@ -935,6 +1033,8 @@ internal sealed class AvroMemberResolver
         valueSchema = AvroValueRulePlan.Unwrap(valueSchema);
         if (valueSchema is global::Avro.RecordSchema record)
             return CreateRecord(record, paths, usedIndexes);
+        if (valueSchema is global::Avro.MapSchema map)
+            return CreateMap(map, paths, usedIndexes);
         if (valueSchema is not global::Avro.UnionSchema union)
             return null;
 
@@ -942,7 +1042,8 @@ internal sealed class AvroMemberResolver
         var resolvedIndexes = new bool[paths.Count];
         for (var branchIndex = 0; branchIndex < union.Count; branchIndex++)
         {
-            if (AvroValueRulePlan.Unwrap(union[branchIndex]) is not global::Avro.RecordSchema branch)
+            var branch = AvroValueRulePlan.Unwrap(union[branchIndex]);
+            if (branch is not (global::Avro.RecordSchema or global::Avro.MapSchema))
                 continue;
 
             AvroMemberResolver? branchResolver = null;
@@ -952,8 +1053,17 @@ internal sealed class AvroMemberResolver
                 if (!CanResolve(branch, path, depth: 0))
                     continue;
 
-                branchResolver ??= CreateRecord(branch);
-                branchResolver.Add(branch, path, memberIndex, depth: 0);
+                if (branch is global::Avro.RecordSchema branchRecord)
+                {
+                    branchResolver ??= CreateRecord(branchRecord);
+                    branchResolver.Add(branchRecord, path, memberIndex, depth: 0);
+                }
+                else
+                {
+                    var branchMap = (global::Avro.MapSchema)branch;
+                    branchResolver ??= CreateMap(branchMap);
+                    branchResolver.Add(branchMap, path, memberIndex, depth: 0);
+                }
                 resolvedIndexes[memberIndex] = true;
             }
             resolver._unionBranches![branchIndex] = branchResolver;
@@ -988,6 +1098,19 @@ internal sealed class AvroMemberResolver
         return resolver;
     }
 
+    private static AvroMemberResolver CreateMap(
+        global::Avro.MapSchema map,
+        IReadOnlyList<byte[][]> paths,
+        IReadOnlyCollection<int> usedIndexes)
+    {
+        var resolver = CreateMap(map);
+        foreach (var memberIndex in usedIndexes)
+            resolver.Add(map, paths[memberIndex], memberIndex, depth: 0);
+        return resolver;
+    }
+
+    private static AvroMemberResolver CreateMap(global::Avro.MapSchema map) => new(map);
+
     private void Add(
         global::Avro.RecordSchema schema,
         byte[][] path,
@@ -1007,6 +1130,26 @@ internal sealed class AvroMemberResolver
         node.AddChild(field.Schema, path, memberIndex, depth + 1);
     }
 
+    private void Add(
+        global::Avro.MapSchema schema,
+        byte[][] path,
+        int memberIndex,
+        int depth)
+    {
+        var key = (ReadOnlyMemory<byte>)path[depth];
+        if (!_mapValues!.TryGetValue(key, out var node))
+        {
+            node = new AvroMemberNode { Schema = schema.ValueSchema };
+            _mapValues.Add(key, node);
+        }
+        if (depth == path.Length - 1)
+        {
+            node.AddMemberIndex(memberIndex);
+            return;
+        }
+        node.AddChild(schema.ValueSchema, path, memberIndex, depth + 1);
+    }
+
     internal void Resolve(
         ReadOnlyMemory<byte> payload,
         ValidationCelMemberValues values,
@@ -1021,6 +1164,11 @@ internal sealed class AvroMemberResolver
         ValidationCelMemberValues values,
         ValidationCelSizeValues sizes)
     {
+        if (_mapValues is not null)
+        {
+            ResolveMap((global::Avro.MapSchema)_valueSchema, ref reader, values, sizes);
+            return;
+        }
         if (_unionBranches is not null)
         {
             var union = (global::Avro.UnionSchema)_valueSchema;
@@ -1053,6 +1201,33 @@ internal sealed class AvroMemberResolver
             else
             {
                 AvroValidationValueDecoder.Skip(schema, ref reader);
+            }
+        }
+    }
+
+    private void ResolveMap(
+        global::Avro.MapSchema map,
+        ref AvroValidationReader reader,
+        ValidationCelMemberValues values,
+        ValidationCelSizeValues sizes)
+    {
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return;
+            for (long index = 0; index < count; index++)
+            {
+                var key = reader.ReadLengthPrefixed();
+                var valueStart = reader.Position;
+                AvroValidationValueDecoder.Skip(map.ValueSchema, ref reader);
+                if (_mapValues!.TryGetValue(key, out var node))
+                {
+                    node.Resolve(
+                        reader.Source.Slice(valueStart, reader.Position - valueStart),
+                        values,
+                        sizes);
+                }
             }
         }
     }
@@ -1119,25 +1294,24 @@ internal sealed class AvroMemberResolver
     }
 
     private static bool CanResolve(
-        global::Avro.RecordSchema schema,
+        AvroSchema schema,
         byte[][] path,
         int depth)
     {
-        var field = FindField(schema, Encoding.UTF8.GetString(path[depth]));
-        if (field is null)
-            return false;
-        if (depth == path.Length - 1)
-            return true;
-
-        var childSchema = AvroValueRulePlan.Unwrap(field.Schema);
-        if (childSchema is global::Avro.RecordSchema record)
-            return CanResolve(record, path, depth + 1);
-        if (childSchema is not global::Avro.UnionSchema union)
+        schema = AvroValueRulePlan.Unwrap(schema);
+        if (schema is global::Avro.RecordSchema record)
+        {
+            var field = FindField(record, Encoding.UTF8.GetString(path[depth]));
+            return field is not null &&
+                (depth == path.Length - 1 || CanResolve(field.Schema, path, depth + 1));
+        }
+        if (schema is global::Avro.MapSchema map)
+            return depth == path.Length - 1 || CanResolve(map.ValueSchema, path, depth + 1);
+        if (schema is not global::Avro.UnionSchema union)
             return false;
         for (var index = 0; index < union.Count; index++)
         {
-            if (AvroValueRulePlan.Unwrap(union[index]) is global::Avro.RecordSchema branch &&
-                CanResolve(branch, path, depth + 1))
+            if (CanResolve(union[index], path, depth))
                 return true;
         }
         return false;
@@ -1221,38 +1395,47 @@ internal sealed class AvroMemberResolver
                 var found = false;
                 for (var index = 0; index < union.Count; index++)
                 {
-                    if (AvroValueRulePlan.Unwrap(union[index]) is not global::Avro.RecordSchema branch)
+                    var branch = AvroValueRulePlan.Unwrap(union[index]);
+                    if (branch is not (global::Avro.RecordSchema or global::Avro.MapSchema))
                         continue;
                     if (!CanResolve(branch, path, depth))
                         continue;
-                    AddRecordChild(branch, path, memberIndex, depth);
+                    AddResolverChild(branch, path, memberIndex, depth);
                     found = true;
                 }
                 if (found)
                     return;
             }
-            else if (schema is global::Avro.RecordSchema record)
+            else if (schema is global::Avro.RecordSchema or global::Avro.MapSchema)
             {
-                AddRecordChild(record, path, memberIndex, depth);
+                AddResolverChild(schema, path, memberIndex, depth);
                 return;
             }
 
             throw new SchemaRegistryRuleException(
-                "Avro validation member path can only descend through records or record unions.");
+                "Avro validation member path can only descend through records, maps, or their unions.");
         }
 
-        private void AddRecordChild(
-            global::Avro.RecordSchema record,
+        private void AddResolverChild(
+            AvroSchema schema,
             byte[][] path,
             int memberIndex,
             int depth)
         {
-            if (!_children.TryGetValue(record, out var child))
+            if (!_children.TryGetValue(schema, out var child))
             {
-                child = CreateRecord(record);
-                _children.Add(record, child);
+                child = schema switch
+                {
+                    global::Avro.RecordSchema record => CreateRecord(record),
+                    global::Avro.MapSchema map => CreateMap(map),
+                    _ => throw new InvalidOperationException("Avro validation member resolver child is unsupported.")
+                };
+                _children.Add(schema, child);
             }
-            child.Add(record, path, memberIndex, depth);
+            if (schema is global::Avro.RecordSchema recordSchema)
+                child.Add(recordSchema, path, memberIndex, depth);
+            else
+                child.Add((global::Avro.MapSchema)schema, path, memberIndex, depth);
         }
 
         internal void Resolve(
@@ -1307,7 +1490,7 @@ internal sealed class AvroMemberResolver
                         $"Could not evaluate Avro validation rules: invalid union index {branch}.");
                 schema = AvroValueRulePlan.Unwrap(union[(int)branch]);
             }
-            if (schema is global::Avro.RecordSchema record && _children.TryGetValue(record, out var child))
+            if (_children.TryGetValue(schema, out var child))
             {
                 child.Resolve(
                     childReader.Source.Slice(childReader.Position),
@@ -1355,6 +1538,25 @@ internal sealed class AvroMemberResolver
                 _unionEnumSymbols![(int)branch],
                 ref reader);
         }
+    }
+}
+
+internal sealed class AvroUtf8MemoryComparer : IEqualityComparer<ReadOnlyMemory<byte>>
+{
+    internal static readonly AvroUtf8MemoryComparer Instance = new();
+
+    private AvroUtf8MemoryComparer() { }
+
+    public bool Equals(ReadOnlyMemory<byte> left, ReadOnlyMemory<byte> right) =>
+        left.Span.SequenceEqual(right.Span);
+
+    public int GetHashCode(ReadOnlyMemory<byte> value)
+    {
+        var hash = 2166136261u;
+        var span = value.Span;
+        for (var index = 0; index < span.Length; index++)
+            hash = (hash ^ span[index]) * 16777619u;
+        return unchecked((int)hash);
     }
 }
 

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -59,7 +59,8 @@ internal sealed class AvroValueRulePlan
     {
         Standard,
         AggregateRoot,
-        DeferredRecord
+        DeferredRecord,
+        DeferredMembers
     }
 
     private readonly AvroSchema _schema;
@@ -184,9 +185,16 @@ internal sealed class AvroValueRulePlan
         {
             return ValidationStrategy.AggregateRoot;
         }
-        return !_schemaRules.UsesRootValue && _schema is global::Avro.RecordSchema
-            ? ValidationStrategy.DeferredRecord
-            : ValidationStrategy.Standard;
+        if (!_schemaRules.UsesRootValue && _schemaRules.HasMembers)
+        {
+            return _schema switch
+            {
+                global::Avro.RecordSchema => ValidationStrategy.DeferredRecord,
+                global::Avro.MapSchema or global::Avro.UnionSchema => ValidationStrategy.DeferredMembers,
+                _ => ValidationStrategy.Standard
+            };
+        }
+        return ValidationStrategy.Standard;
     }
 
     private void InitializeDeferredSchemaRuleFields()
@@ -222,6 +230,16 @@ internal sealed class AvroValueRulePlan
             if (_validationStrategy == ValidationStrategy.AggregateRoot)
             {
                 return ValidateAggregateWithRootRules(
+                    ref reader,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path);
+            }
+
+            if (_validationStrategy == ValidationStrategy.DeferredMembers)
+            {
+                return ValidateWithDeferredMemberRules(
                     ref reader,
                     now,
                     failFast,
@@ -305,6 +323,125 @@ internal sealed class AvroValueRulePlan
         return value;
     }
 
+    private ValidationCelValue ValidateWithDeferredMemberRules(
+        ref AvroValidationReader reader,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path)
+    {
+        var resolution = _schemaRules.BeginMemberResolution();
+        var start = reader.Position;
+        List<ValidationRuleError>? nestedViolations = null;
+        switch (_schema)
+        {
+            case global::Avro.MapSchema:
+                ValidateMapWithMemberResolution(
+                    ref reader,
+                    resolution,
+                    now,
+                    ref nestedViolations,
+                    ref path);
+                break;
+            case global::Avro.UnionSchema:
+                ValidateUnionWithMemberResolution(
+                    ref reader,
+                    resolution,
+                    now,
+                    ref nestedViolations,
+                    ref path);
+                break;
+            default:
+                throw new InvalidOperationException("Deferred member validation requires a map or union schema.");
+        }
+
+        _schemaRules.EvaluateResolvedWithoutRoot(
+            resolution,
+            reader.Position - start,
+            now,
+            failFast,
+            ref violations,
+            ref path);
+        AppendNestedViolations(nestedViolations, failFast, ref violations);
+        return ValidationCelValue.Missing;
+    }
+
+    private void ValidateUnionWithMemberResolution(
+        ref AvroValidationReader reader,
+        AvroMemberResolution resolution,
+        long now,
+        ref List<ValidationRuleError>? nestedViolations,
+        scoped ref AvroValidationPath path)
+    {
+        var union = (global::Avro.UnionSchema)_schema;
+        var branch = reader.ReadLong();
+        if ((ulong)branch >= (ulong)union.Count)
+            throw InvalidPayload($"invalid union index {branch}");
+
+        var payloadStart = reader.Position;
+        _ = _children[(int)branch].Validate(
+            ref reader,
+            now,
+            failFast: false,
+            ref nestedViolations,
+            ref path);
+        _schemaRules.ResolveUnionBranch(
+            (int)branch,
+            reader.Source.Slice(payloadStart, reader.Position - payloadStart),
+            resolution);
+    }
+
+    private void ValidateMapWithMemberResolution(
+        ref AvroValidationReader reader,
+        AvroMemberResolution resolution,
+        long now,
+        ref List<ValidationRuleError>? nestedViolations,
+        scoped ref AvroValidationPath path)
+    {
+        var valuePlan = _children[0];
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return;
+            for (long index = 0; index < count; index++)
+            {
+                var key = reader.ReadLengthPrefixed();
+                var valueStart = reader.Position;
+                var mark = path.Length;
+                path.AppendMapKey(key.Span);
+                _ = valuePlan.Validate(
+                    ref reader,
+                    now,
+                    failFast: false,
+                    ref nestedViolations,
+                    ref path);
+                path.Truncate(mark);
+                _schemaRules.ResolveMapEntry(
+                    key,
+                    reader.Source.Slice(valueStart, reader.Position - valueStart),
+                    resolution);
+            }
+        }
+    }
+
+    private static void AppendNestedViolations(
+        List<ValidationRuleError>? nestedViolations,
+        bool failFast,
+        ref List<ValidationRuleError>? violations)
+    {
+        if (nestedViolations is null || (failFast && violations is not null))
+            return;
+        violations ??= new List<ValidationRuleError>(failFast ? 1 : nestedViolations.Count);
+        if (failFast)
+        {
+            violations.Add(nestedViolations[0]);
+            return;
+        }
+        for (var index = 0; index < nestedViolations.Count; index++)
+            violations.Add(nestedViolations[index]);
+    }
+
     private ValidationCelValue ValidateAggregateWithRootRules(
         ref AvroValidationReader reader,
         long now,
@@ -345,17 +482,7 @@ internal sealed class AvroValueRulePlan
             ref violations,
             ref path,
             rootSize);
-        if (nestedViolations is null || (failFast && violations is not null))
-            return value;
-
-        violations ??= new List<ValidationRuleError>(failFast ? 1 : nestedViolations.Count);
-        if (failFast)
-        {
-            violations.Add(nestedViolations[0]);
-            return value;
-        }
-        for (var index = 0; index < nestedViolations.Count; index++)
-            violations.Add(nestedViolations[index]);
+        AppendNestedViolations(nestedViolations, failFast, ref violations);
         return value;
     }
 
@@ -919,6 +1046,18 @@ internal sealed class AvroCompiledRuleSet
             resolution.Members,
             resolution.Sizes);
 
+    internal void ResolveMapEntry(
+        ReadOnlyMemory<byte> key,
+        ReadOnlyMemory<byte> payload,
+        AvroMemberResolution resolution) =>
+        _members!.ResolveMapEntry(key, payload, resolution.Members, resolution.Sizes);
+
+    internal void ResolveUnionBranch(
+        int branch,
+        ReadOnlyMemory<byte> payload,
+        AvroMemberResolution resolution) =>
+        _members!.ResolveUnionBranch(branch, payload, resolution.Members, resolution.Sizes);
+
     internal void EvaluateResolvedWithoutRoot(
         AvroMemberResolution resolution,
         int payloadLength,
@@ -1230,6 +1369,27 @@ internal sealed class AvroMemberResolver
                 }
             }
         }
+    }
+
+    internal void ResolveMapEntry(
+        ReadOnlyMemory<byte> key,
+        ReadOnlyMemory<byte> payload,
+        ValidationCelMemberValues values,
+        ValidationCelSizeValues sizes)
+    {
+        if (_mapValues!.TryGetValue(key, out var node))
+            node.Resolve(payload, values, sizes);
+    }
+
+    internal void ResolveUnionBranch(
+        int branch,
+        ReadOnlyMemory<byte> payload,
+        ValidationCelMemberValues values,
+        ValidationCelSizeValues sizes)
+    {
+        var resolver = _unionBranches![branch];
+        if (resolver is not null)
+            resolver.Resolve(payload, values, sizes);
     }
 
     internal AvroFieldPayload ResolveRecordPrefix(

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -158,13 +158,17 @@ internal sealed class AvroValueRulePlan
         if (!HasAnyRules)
             return AvroValidationValueDecoder.Read(_schema, ref reader);
 
-        var start = reader.Position;
-        var preview = reader;
-        var value = AvroValidationValueDecoder.Read(_schema, ref preview);
-        var payload = preview.Source.Slice(start, preview.Position - start);
-        var rootSize = value.SizeIndex == 0 ? AvroValidationValueDecoder.Count(_schema, payload) : -1;
+        var value = ValidationCelValue.Missing;
+        var preview = default(AvroValidationReader);
         if (!_schemaRules.IsEmpty)
         {
+            var start = reader.Position;
+            preview = reader;
+            value = AvroValidationValueDecoder.Read(_schema, ref preview);
+            var payload = preview.Source.Slice(start, preview.Position - start);
+            var rootSize = value.SizeIndex == 0
+                ? AvroValidationValueDecoder.Count(_schema, payload)
+                : -1;
             _schemaRules.Evaluate(
                 value,
                 payload,
@@ -195,7 +199,10 @@ internal sealed class AvroValueRulePlan
                 ValidateUnion(ref reader, now, failFast, ref violations, ref path);
                 break;
             default:
-                reader = preview;
+                if (_schemaRules.IsEmpty)
+                    value = AvroValidationValueDecoder.Read(_schema, ref reader);
+                else
+                    reader = preview;
                 break;
         }
         return value;
@@ -471,7 +478,7 @@ internal sealed class AvroCompiledRuleSet
         var memberValues = _memberCount == 0
             ? default
             : CompiledValidationRule.GetMemberValues(_memberCount);
-        var sizes = UsesSize || _members is not null
+        var sizes = UsesSize || _members is not null || rootSize >= 0
             ? CompiledValidationRule.GetSizeValues(_memberCount + 1)
             : default;
         if (rootSize >= 0)
@@ -855,11 +862,23 @@ internal static class AvroValidationValueDecoder
                     null,
                     reader.Source.Slice(recordStart, reader.Position - recordStart));
             case AvroSchema.Type.Array:
+            {
+                var collectionStart = reader.Position;
                 SkipCollection(((global::Avro.ArraySchema)schema).ItemSchema, isMap: false, ref reader);
-                return ValidationCelValue.FromCollection(ValidationCelValueKind.Array, 0);
+                return ValidationCelValue.FromCollection(
+                    ValidationCelValueKind.Array,
+                    reader.Source.Slice(collectionStart, reader.Position - collectionStart),
+                    0);
+            }
             case AvroSchema.Type.Map:
+            {
+                var collectionStart = reader.Position;
                 SkipCollection(((global::Avro.MapSchema)schema).ValueSchema, isMap: true, ref reader);
-                return ValidationCelValue.FromCollection(ValidationCelValueKind.Object, 0);
+                return ValidationCelValue.FromCollection(
+                    ValidationCelValueKind.Object,
+                    reader.Source.Slice(collectionStart, reader.Position - collectionStart),
+                    0);
+            }
             case AvroSchema.Type.Union:
                 var union = (global::Avro.UnionSchema)schema;
                 var branch = reader.ReadLong();

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -618,8 +618,28 @@ internal sealed class AvroMemberResolver
     {
         private readonly Dictionary<AvroSchema, AvroMemberResolver> _children =
             new(AvroSchemaReferenceComparer.Instance);
+        private AvroSchema? _schema;
+        private AvroAggregateEqualityComparer? _aggregateComparer;
+        private AvroAggregateEqualityComparer?[]? _unionComparers;
 
-        internal AvroSchema? Schema { get; set; }
+        internal AvroSchema? Schema
+        {
+            get => _schema;
+            set
+            {
+                _schema = value;
+                var schema = AvroValueRulePlan.Unwrap(value!);
+                _aggregateComparer = AvroAggregateEqualityComparer.Create(schema);
+                if (schema is not global::Avro.UnionSchema union)
+                    return;
+                _unionComparers = new AvroAggregateEqualityComparer?[union.Count];
+                for (var index = 0; index < union.Count; index++)
+                {
+                    _unionComparers[index] = AvroAggregateEqualityComparer.Create(
+                        AvroValueRulePlan.Unwrap(union[index]));
+                }
+            }
+        }
         internal int MemberIndex { get; set; } = -1;
         internal bool HasTargets => MemberIndex >= 0 || _children.Count != 0;
 
@@ -680,14 +700,14 @@ internal sealed class AvroMemberResolver
             if (MemberIndex >= 0)
             {
                 var valueReader = new AvroValidationReader(payload);
-                var value = AvroValidationValueDecoder.Read(schema, ref valueReader);
+                var value = ReadValue(schema, ref valueReader, out var aggregateComparer);
                 if (value.SizeIndex == 0)
                 {
                     var sizeIndex = MemberIndex + 1;
                     sizes.Set(sizeIndex, AvroValidationValueDecoder.Count(schema, payload));
                     value = value with { SizeIndex = sizeIndex };
                 }
-                values.SetValue(MemberIndex, value);
+                values.SetValue(MemberIndex, value, aggregateComparer);
             }
 
             if (_children.Count == 0)
@@ -709,6 +729,26 @@ internal sealed class AvroMemberResolver
                     values,
                     sizes);
             }
+        }
+
+        private ValidationCelValue ReadValue(
+            AvroSchema schema,
+            ref AvroValidationReader reader,
+            out AvroAggregateEqualityComparer? aggregateComparer)
+        {
+            schema = AvroValueRulePlan.Unwrap(schema);
+            if (schema is not global::Avro.UnionSchema union)
+            {
+                aggregateComparer = _aggregateComparer;
+                return AvroValidationValueDecoder.Read(schema, ref reader);
+            }
+
+            var branch = reader.ReadLong();
+            if ((ulong)branch >= (ulong)union.Count)
+                throw new SchemaRegistryRuleException(
+                    $"Could not evaluate Avro validation rules: invalid union index {branch}.");
+            aggregateComparer = _unionComparers![(int)branch];
+            return AvroValidationValueDecoder.Read(union[(int)branch], ref reader);
         }
     }
 }

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -29,6 +29,7 @@ internal sealed class AvroInlineRuleValidator
         List<ValidationRuleError>? violations = null;
         var path = new AvroValidationPath(t_pathBuffer ??= new char[256]);
         var reader = new AvroValidationReader(payload);
+        var valueResolutionDepth = CompiledValidationRule.ValueResolutionDepth;
         try
         {
             _root.Validate(
@@ -42,6 +43,8 @@ internal sealed class AvroInlineRuleValidator
         }
         finally
         {
+            if (CompiledValidationRule.ValueResolutionDepth != valueResolutionDepth)
+                CompiledValidationRule.RestoreValueResolutionDepth(valueResolutionDepth);
             path.Dispose();
         }
 
@@ -379,6 +382,7 @@ internal sealed class AvroValueRulePlan
             failFast,
             ref violations,
             ref path);
+        resolution.Dispose();
         AppendNestedViolations(nestedViolations, failFast, ref violations);
         return ValidationCelValue.Missing;
     }
@@ -432,6 +436,7 @@ internal sealed class AvroValueRulePlan
             failFast,
             ref violations,
             ref path);
+        resolution.Dispose();
         AppendNestedViolations(nestedViolations, failFast, ref violations);
         return value;
     }
@@ -913,13 +918,15 @@ internal sealed class AvroValueRulePlan
         var lastMemberFieldIndex = _schemaRules.LastRecordMemberIndex;
         if (lastMemberFieldIndex < 0)
         {
+            var resolution = _schemaRules.BeginMemberResolution();
             _schemaRules.EvaluateResolvedWithoutRoot(
-                _schemaRules.BeginMemberResolution(),
+                resolution,
                 payloadLength: 0,
                 now,
                 failFast,
                 ref violations,
                 ref path);
+            resolution.Dispose();
             if (failFast && violations is not null)
             {
                 AvroValidationValueDecoder.Skip(_schema, ref reader);
@@ -953,6 +960,7 @@ internal sealed class AvroValueRulePlan
                 failFast,
                 ref violations,
                 ref path);
+            resolution.Dispose();
             if (failFast && violations is not null)
             {
                 SkipRecordFields(ref reader, lastMemberFieldIndex + 1);
@@ -1100,7 +1108,11 @@ internal sealed record AvroFieldRulePlan(
 
 internal readonly record struct AvroMemberResolution(
     ValidationCelMemberValues Members,
-    ValidationCelSizeValues Sizes);
+    ValidationCelSizeValues Sizes,
+    ValidationCelValueResolution ValueResolution) : IDisposable
+{
+    public void Dispose() => ValueResolution.Dispose();
+}
 
 internal readonly record struct AvroFieldPayload(int Start, int Length);
 
@@ -1217,11 +1229,19 @@ internal sealed class AvroCompiledRuleSet
         scoped ref AvroValidationPath path,
         int rootSize = -1)
     {
+        var isNested = CompiledValidationRule.HasActiveValueResolution;
+        var valueResolution = isNested
+            ? CompiledValidationRule.BeginValueResolution()
+            : default;
         var memberValues = _memberCount == 0
             ? default
-            : CompiledValidationRule.GetMemberValues(_memberCount);
+            : isNested
+                ? CompiledValidationRule.GetMemberValues(_memberCount, valueResolution)
+                : CompiledValidationRule.GetMemberValues(_memberCount);
         var sizes = UsesSize || _members is not null || rootSize >= 0
-            ? CompiledValidationRule.GetSizeValues(_memberCount + 1)
+            ? isNested
+                ? CompiledValidationRule.GetSizeValues(_memberCount + 1, valueResolution)
+                : CompiledValidationRule.GetSizeValues(_memberCount + 1)
             : default;
         if (rootSize >= 0)
             sizes.Set(0, rootSize);
@@ -1264,13 +1284,15 @@ internal sealed class AvroCompiledRuleSet
                 }
 
                 if (failFast)
-                    return;
+                    break;
             }
         }
         finally
         {
             ValidationCelStrings.End();
         }
+        if (isNested)
+            valueResolution.Dispose();
     }
 
     internal void EvaluateResolved(
@@ -1353,15 +1375,21 @@ internal sealed class AvroCompiledRuleSet
             failFast,
             ref violations,
             ref path);
+        resolution.Dispose();
     }
 
-    internal AvroMemberResolution BeginMemberResolution() => new(
-        _memberCount == 0
-            ? default
-            : CompiledValidationRule.GetMemberValues(_memberCount),
-        UsesSize || _members is not null
-            ? CompiledValidationRule.GetSizeValues(_memberCount + 1)
-            : default);
+    internal AvroMemberResolution BeginMemberResolution()
+    {
+        var valueResolution = CompiledValidationRule.BeginValueResolution();
+        return new AvroMemberResolution(
+            _memberCount == 0
+                ? default
+                : CompiledValidationRule.GetMemberValues(_memberCount, valueResolution),
+            UsesSize || _members is not null
+                ? CompiledValidationRule.GetSizeValues(_memberCount + 1, valueResolution)
+                : default,
+            valueResolution);
+    }
 
     internal AvroFieldPayload ResolveRecordPrefix(
         ref AvroValidationReader reader,

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -2266,10 +2266,12 @@ internal sealed class AvroMemberResolver
                 var additionalIndexes = _additionalMemberIndexes;
                 if (additionalIndexes is null)
                 {
+                    var sizeIndex = MemberIndex + 1;
                     if (_needsSize && value.SizeIndex == 0)
-                    {
-                        var sizeIndex = MemberIndex + 1;
                         sizes.Set(sizeIndex, AvroValidationValueDecoder.Count(schema, payload));
+                    if (value.Kind is ValidationCelValueKind.Array or ValidationCelValueKind.Object &&
+                        value.SizeIndex == 0)
+                    {
                         value = value with { SizeIndex = sizeIndex };
                     }
                     values.SetValue(MemberIndex, value, aggregateComparer);
@@ -2361,10 +2363,12 @@ internal sealed class AvroMemberResolver
             ValidationCelSizeValues sizes,
             AvroAggregateEqualityComparer? aggregateComparer)
         {
+            var sizeIndex = memberIndex + 1;
             if (size >= 0)
-            {
-                var sizeIndex = memberIndex + 1;
                 sizes.Set(sizeIndex, size);
+            if (value.Kind is ValidationCelValueKind.Array or ValidationCelValueKind.Object &&
+                value.SizeIndex == 0)
+            {
                 value = value with { SizeIndex = sizeIndex };
             }
             values.SetValue(memberIndex, value, aggregateComparer);

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -57,6 +57,7 @@ internal sealed class AvroValueRulePlan
 {
     private readonly AvroSchema _schema;
     private readonly AvroSchema _ruleSchema;
+    private readonly ReadOnlyMemory<byte>[]? _enumSymbols;
     private AvroCompiledRuleSet _schemaRules = AvroCompiledRuleSet.Empty;
     private AvroFieldRulePlan[] _fields = [];
     private AvroValueRulePlan[] _children = [];
@@ -65,6 +66,7 @@ internal sealed class AvroValueRulePlan
     {
         _schema = Unwrap(schema);
         _ruleSchema = schema;
+        _enumSymbols = AvroValidationValueDecoder.EncodeEnumSymbols(_schema);
     }
 
     internal bool HasAnyRules { get; private set; }
@@ -161,7 +163,7 @@ internal sealed class AvroValueRulePlan
         scoped ref AvroValidationPath path)
     {
         if (!HasAnyRules)
-            return AvroValidationValueDecoder.Read(_schema, ref reader);
+            return ReadValue(ref reader);
 
         var value = ValidationCelValue.Missing;
         var preview = default(AvroValidationReader);
@@ -169,7 +171,7 @@ internal sealed class AvroValueRulePlan
         {
             var start = reader.Position;
             preview = reader;
-            value = AvroValidationValueDecoder.Read(_schema, ref preview);
+            value = ReadValue(ref preview);
             var payload = preview.Source.Slice(start, preview.Position - start);
             var rootSize = value.SizeIndex == 0
                 ? AvroValidationValueDecoder.Count(_schema, payload)
@@ -205,7 +207,7 @@ internal sealed class AvroValueRulePlan
                 break;
             default:
                 if (_schemaRules.IsEmpty)
-                    value = AvroValidationValueDecoder.Read(_schema, ref reader);
+                    value = ReadValue(ref reader);
                 else
                     reader = preview;
                 break;
@@ -233,7 +235,7 @@ internal sealed class AvroValueRulePlan
             {
                 var fieldStart = reader.Position;
                 var preview = reader;
-                var value = AvroValidationValueDecoder.Read(field.Field.Schema, ref preview);
+                var value = field.Child.ReadValue(ref preview);
                 var payload = preview.Source.Slice(fieldStart, preview.Position - fieldStart);
                 field.Rules.Evaluate(
                     value,
@@ -372,6 +374,17 @@ internal sealed class AvroValueRulePlan
         }
     }
 
+    private ValidationCelValue ReadValue(ref AvroValidationReader reader)
+    {
+        if (_schema is not global::Avro.UnionSchema union)
+            return AvroValidationValueDecoder.Read(_schema, _enumSymbols, ref reader);
+
+        var branch = reader.ReadLong();
+        if ((ulong)branch >= (ulong)union.Count)
+            throw InvalidPayload($"invalid union index {branch}");
+        return _children[(int)branch].ReadValue(ref reader);
+    }
+
     internal static AvroSchema Unwrap(AvroSchema schema) =>
         schema is global::Avro.LogicalSchema logical ? logical.BaseSchema : schema;
 
@@ -386,11 +399,14 @@ internal sealed record AvroFieldRulePlan(
 
 internal sealed class AvroCompiledRuleSet
 {
-    internal static AvroCompiledRuleSet Empty { get; } = new([], null, false, false, 0);
+    internal static AvroCompiledRuleSet Empty { get; } = new([], null, false, false, false, 0, null);
 
     private readonly CompiledValidationRule[] _rules;
     private readonly AvroMemberResolver? _members;
+    private readonly AvroAggregateEqualityComparer? _rootAggregateComparer;
+    private readonly AvroAggregateEqualityComparer?[]? _rootUnionComparers;
     private readonly bool _usesCachedEquality;
+    private readonly bool _usesRootAggregateEquality;
     private readonly int _memberCount;
 
     private AvroCompiledRuleSet(
@@ -398,13 +414,30 @@ internal sealed class AvroCompiledRuleSet
         AvroMemberResolver? members,
         bool usesSize,
         bool usesCachedEquality,
-        int memberCount)
+        bool usesRootAggregateEquality,
+        int memberCount,
+        AvroSchema? valueSchema)
     {
         _rules = rules;
         _members = members;
         UsesSize = usesSize;
         _usesCachedEquality = usesCachedEquality;
+        _usesRootAggregateEquality = usesRootAggregateEquality;
         _memberCount = memberCount;
+        if (!usesRootAggregateEquality || valueSchema is null)
+            return;
+
+        valueSchema = AvroValueRulePlan.Unwrap(valueSchema);
+        _rootAggregateComparer = AvroAggregateEqualityComparer.Create(valueSchema);
+        if (valueSchema is not global::Avro.UnionSchema union)
+            return;
+
+        _rootUnionComparers = new AvroAggregateEqualityComparer?[union.Count];
+        for (var index = 0; index < union.Count; index++)
+        {
+            _rootUnionComparers[index] = AvroAggregateEqualityComparer.Create(
+                AvroValueRulePlan.Unwrap(union[index]));
+        }
     }
 
     internal bool IsEmpty => _rules.Length == 0;
@@ -423,6 +456,7 @@ internal sealed class AvroCompiledRuleSet
         var compiled = new CompiledValidationRule[rules.Count];
         var usesSize = false;
         var usesCachedEquality = false;
+        var usesRootAggregateEquality = false;
         for (var index = 0; index < rules.Count; index++)
         {
             var rule = CompiledValidationRule.Compile(
@@ -433,6 +467,7 @@ internal sealed class AvroCompiledRuleSet
             compiled[index] = rule;
             usesSize |= rule.UsesSize;
             usesCachedEquality |= rule.UsesCachedEquality;
+            usesRootAggregateEquality |= rule.UsesRootAggregateEquality;
         }
 
         var members = usedMemberIndexes.Count == 0
@@ -443,7 +478,9 @@ internal sealed class AvroCompiledRuleSet
             members,
             usesSize,
             usesCachedEquality,
-            memberPaths.Count);
+            usesRootAggregateEquality,
+            memberPaths.Count,
+            valueSchema);
     }
 
     internal void Evaluate(
@@ -467,6 +504,9 @@ internal sealed class AvroCompiledRuleSet
         var equalityGeneration = _usesCachedEquality
             ? CompiledValidationRule.BeginEqualityResolution()
             : 0;
+        var rootAggregateComparer = _usesRootAggregateEquality
+            ? GetRootAggregateComparer(payload)
+            : null;
 
         ValidationCelStrings.Begin(_memberCount + 1, payload.Length);
         try
@@ -476,7 +516,13 @@ internal sealed class AvroCompiledRuleSet
                 var rule = _rules[index];
                 try
                 {
-                    var result = rule.Evaluate(value, now, memberValues, sizes, equalityGeneration);
+                    var result = rule.Evaluate(
+                        value,
+                        now,
+                        memberValues,
+                        sizes,
+                        equalityGeneration,
+                        rootAggregateComparer);
                     if (result.Kind == ValidationResultKind.Boolean ? result.Boolean : result.String!.Length == 0)
                         continue;
                     (violations ??= []).Add(new ValidationRuleError(
@@ -500,6 +546,19 @@ internal sealed class AvroCompiledRuleSet
         {
             ValidationCelStrings.End();
         }
+    }
+
+    private AvroAggregateEqualityComparer? GetRootAggregateComparer(ReadOnlyMemory<byte> payload)
+    {
+        if (_rootUnionComparers is null)
+            return _rootAggregateComparer;
+
+        var reader = new AvroValidationReader(payload);
+        var branch = reader.ReadLong();
+        if ((ulong)branch >= (ulong)_rootUnionComparers.Length)
+            throw new SchemaRegistryRuleException(
+                $"Could not evaluate Avro validation rules: invalid union index {branch}.");
+        return _rootUnionComparers[(int)branch];
     }
 }
 
@@ -676,6 +735,8 @@ internal sealed class AvroMemberResolver
         private AvroSchema? _schema;
         private AvroAggregateEqualityComparer? _aggregateComparer;
         private AvroAggregateEqualityComparer?[]? _unionComparers;
+        private ReadOnlyMemory<byte>[]? _enumSymbols;
+        private ReadOnlyMemory<byte>[]?[]? _unionEnumSymbols;
 
         internal AvroSchema? Schema
         {
@@ -685,13 +746,16 @@ internal sealed class AvroMemberResolver
                 _schema = value;
                 var schema = AvroValueRulePlan.Unwrap(value!);
                 _aggregateComparer = AvroAggregateEqualityComparer.Create(schema);
+                _enumSymbols = AvroValidationValueDecoder.EncodeEnumSymbols(schema);
                 if (schema is not global::Avro.UnionSchema union)
                     return;
                 _unionComparers = new AvroAggregateEqualityComparer?[union.Count];
+                _unionEnumSymbols = new ReadOnlyMemory<byte>[]?[union.Count];
                 for (var index = 0; index < union.Count; index++)
                 {
-                    _unionComparers[index] = AvroAggregateEqualityComparer.Create(
-                        AvroValueRulePlan.Unwrap(union[index]));
+                    var branch = AvroValueRulePlan.Unwrap(union[index]);
+                    _unionComparers[index] = AvroAggregateEqualityComparer.Create(branch);
+                    _unionEnumSymbols[index] = AvroValidationValueDecoder.EncodeEnumSymbols(branch);
                 }
             }
         }
@@ -794,7 +858,7 @@ internal sealed class AvroMemberResolver
             if (schema is not global::Avro.UnionSchema union)
             {
                 aggregateComparer = _aggregateComparer;
-                return AvroValidationValueDecoder.Read(schema, ref reader);
+                return AvroValidationValueDecoder.Read(schema, _enumSymbols, ref reader);
             }
 
             var branch = reader.ReadLong();
@@ -802,7 +866,10 @@ internal sealed class AvroMemberResolver
                 throw new SchemaRegistryRuleException(
                     $"Could not evaluate Avro validation rules: invalid union index {branch}.");
             aggregateComparer = _unionComparers![(int)branch];
-            return AvroValidationValueDecoder.Read(union[(int)branch], ref reader);
+            return AvroValidationValueDecoder.Read(
+                union[(int)branch],
+                _unionEnumSymbols![(int)branch],
+                ref reader);
         }
     }
 }
@@ -917,7 +984,22 @@ internal ref struct AvroValidationReader(ReadOnlyMemory<byte> source)
 
 internal static class AvroValidationValueDecoder
 {
-    internal static ValidationCelValue Read(AvroSchema schema, ref AvroValidationReader reader)
+    internal static ReadOnlyMemory<byte>[]? EncodeEnumSymbols(AvroSchema schema)
+    {
+        schema = AvroValueRulePlan.Unwrap(schema);
+        if (schema is not global::Avro.EnumSchema enumeration)
+            return null;
+
+        var symbols = new ReadOnlyMemory<byte>[enumeration.Symbols.Count];
+        for (var index = 0; index < symbols.Length; index++)
+            symbols[index] = Encoding.UTF8.GetBytes(enumeration.Symbols[index]);
+        return symbols;
+    }
+
+    internal static ValidationCelValue Read(
+        AvroSchema schema,
+        ReadOnlyMemory<byte>[]? enumSymbols,
+        ref AvroValidationReader reader)
     {
         schema = AvroValueRulePlan.Unwrap(schema);
         switch (schema.Tag)
@@ -934,7 +1016,9 @@ internal static class AvroValidationValueDecoder
                 var symbolIndex = reader.ReadLong();
                 if ((ulong)symbolIndex >= (ulong)enumeration.Symbols.Count)
                     throw InvalidPayload($"invalid enum index {symbolIndex}");
-                return ValidationCelValue.FromString(enumeration.Symbols[(int)symbolIndex]);
+                if (enumSymbols is null)
+                    throw new InvalidOperationException("Avro enum symbols were not compiled for validation.");
+                return ValidationCelValue.FromUtf8String(enumSymbols[(int)symbolIndex]);
             case AvroSchema.Type.Float:
                 return ValidationCelValue.FromFloating(
                     BinaryPrimitives.ReadSingleLittleEndian(reader.Read(sizeof(float)).Span));
@@ -980,14 +1064,67 @@ internal static class AvroValidationValueDecoder
                 var branch = reader.ReadLong();
                 if ((ulong)branch >= (ulong)union.Count)
                     throw InvalidPayload($"invalid union index {branch}");
-                return Read(union[(int)branch], ref reader);
+                return Read(union[(int)branch], enumSymbols, ref reader);
             default:
                 throw InvalidPayload($"unsupported schema type {schema.Tag}");
         }
     }
 
-    internal static void Skip(AvroSchema schema, ref AvroValidationReader reader) =>
-        _ = Read(schema, ref reader);
+    internal static void Skip(AvroSchema schema, ref AvroValidationReader reader)
+    {
+        schema = AvroValueRulePlan.Unwrap(schema);
+        switch (schema.Tag)
+        {
+            case AvroSchema.Type.Null:
+                return;
+            case AvroSchema.Type.Boolean:
+                _ = reader.Read(1);
+                return;
+            case AvroSchema.Type.Int:
+            case AvroSchema.Type.Long:
+                _ = reader.ReadLong();
+                return;
+            case AvroSchema.Type.Enumeration:
+                var symbolIndex = reader.ReadLong();
+                if ((ulong)symbolIndex >= (ulong)((global::Avro.EnumSchema)schema).Symbols.Count)
+                    throw InvalidPayload($"invalid enum index {symbolIndex}");
+                return;
+            case AvroSchema.Type.Float:
+                _ = reader.Read(sizeof(float));
+                return;
+            case AvroSchema.Type.Double:
+                _ = reader.Read(sizeof(double));
+                return;
+            case AvroSchema.Type.String:
+            case AvroSchema.Type.Bytes:
+                _ = reader.ReadLengthPrefixed();
+                return;
+            case AvroSchema.Type.Fixed:
+                _ = reader.Read(((global::Avro.FixedSchema)schema).Size);
+                return;
+            case AvroSchema.Type.Record:
+            case AvroSchema.Type.Error:
+                var record = (global::Avro.RecordSchema)schema;
+                for (var index = 0; index < record.Fields.Count; index++)
+                    Skip(record.Fields[index].Schema, ref reader);
+                return;
+            case AvroSchema.Type.Array:
+                SkipCollection(((global::Avro.ArraySchema)schema).ItemSchema, isMap: false, ref reader);
+                return;
+            case AvroSchema.Type.Map:
+                SkipCollection(((global::Avro.MapSchema)schema).ValueSchema, isMap: true, ref reader);
+                return;
+            case AvroSchema.Type.Union:
+                var union = (global::Avro.UnionSchema)schema;
+                var branch = reader.ReadLong();
+                if ((ulong)branch >= (ulong)union.Count)
+                    throw InvalidPayload($"invalid union index {branch}");
+                Skip(union[(int)branch], ref reader);
+                return;
+            default:
+                throw InvalidPayload($"unsupported schema type {schema.Tag}");
+        }
+    }
 
     internal static int Count(AvroSchema schema, ReadOnlyMemory<byte> payload)
     {

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -285,7 +285,7 @@ internal sealed class AvroValueRulePlan
             {
                 value = ReadValue(ref preview);
                 var payload = preview.Source.Slice(start, preview.Position - start);
-                var rootSize = value.SizeIndex == 0
+                var rootSize = value.SizeIndex == 0 && _schemaRules.UsesRootSize
                     ? AvroValidationValueDecoder.Count(_schema, payload)
                     : -1;
                 _schemaRules.Evaluate(
@@ -350,9 +350,9 @@ internal sealed class AvroValueRulePlan
         ref List<ValidationRuleError>? violations,
         scoped ref AvroValidationPath path)
     {
-        var resolution = _schemaRules.BeginMemberResolution();
-        var start = reader.Position;
+        using var resolution = _schemaRules.BeginMemberResolution();
         List<ValidationRuleError>? nestedViolations = null;
+        var start = reader.Position;
         switch (_schema)
         {
             case global::Avro.MapSchema:
@@ -374,7 +374,6 @@ internal sealed class AvroValueRulePlan
             default:
                 throw new InvalidOperationException("Deferred member validation requires a map or union schema.");
         }
-
         _schemaRules.EvaluateResolvedWithoutRoot(
             resolution,
             reader.Position - start,
@@ -382,7 +381,6 @@ internal sealed class AvroValueRulePlan
             failFast,
             ref violations,
             ref path);
-        resolution.Dispose();
         AppendNestedViolations(nestedViolations, failFast, ref violations);
         return ValidationCelValue.Missing;
     }
@@ -394,11 +392,10 @@ internal sealed class AvroValueRulePlan
         ref List<ValidationRuleError>? violations,
         scoped ref AvroValidationPath path)
     {
-        var resolution = _schemaRules.BeginMemberResolution();
-        var start = reader.Position;
+        using var resolution = _schemaRules.BeginMemberResolution();
         List<ValidationRuleError>? nestedViolations = null;
+        var start = reader.Position;
         int rootSize;
-        ValidationCelValueKind valueKind;
         switch (_schema)
         {
             case global::Avro.RecordSchema:
@@ -409,7 +406,6 @@ internal sealed class AvroValueRulePlan
                     ref nestedViolations,
                     ref path);
                 rootSize = _fields.Length;
-                valueKind = ValidationCelValueKind.Object;
                 break;
             case global::Avro.MapSchema:
                 rootSize = ValidateMapWithMemberResolution(
@@ -418,15 +414,13 @@ internal sealed class AvroValueRulePlan
                     now,
                     ref nestedViolations,
                     ref path);
-                valueKind = ValidationCelValueKind.Object;
                 break;
             default:
                 throw new InvalidOperationException(
                     "Mixed root/member validation requires a record or map schema.");
         }
-
         var payload = reader.Source.Slice(start, reader.Position - start);
-        var value = ValidationCelValue.FromCollection(valueKind, payload, sizeIndex: 0);
+        var value = ValidationCelValue.FromCollection(ValidationCelValueKind.Object, payload, sizeIndex: 0);
         _schemaRules.EvaluateResolved(
             value,
             payload,
@@ -436,7 +430,6 @@ internal sealed class AvroValueRulePlan
             failFast,
             ref violations,
             ref path);
-        resolution.Dispose();
         AppendNestedViolations(nestedViolations, failFast, ref violations);
         return value;
     }
@@ -773,7 +766,7 @@ internal sealed class AvroValueRulePlan
                     failFast,
                     ref violations,
                     ref path,
-                    value.SizeIndex == 0
+                    value.SizeIndex == 0 && field.Rules.UsesRootSize
                         ? AvroValidationValueDecoder.Count(field.Field.Schema, payload)
                         : -1);
 
@@ -918,15 +911,16 @@ internal sealed class AvroValueRulePlan
         var lastMemberFieldIndex = _schemaRules.LastRecordMemberIndex;
         if (lastMemberFieldIndex < 0)
         {
-            var resolution = _schemaRules.BeginMemberResolution();
-            _schemaRules.EvaluateResolvedWithoutRoot(
-                resolution,
-                payloadLength: 0,
-                now,
-                failFast,
-                ref violations,
-                ref path);
-            resolution.Dispose();
+            {
+                using var resolution = _schemaRules.BeginMemberResolution();
+                _schemaRules.EvaluateResolvedWithoutRoot(
+                    resolution,
+                    payloadLength: 0,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path);
+            }
             if (failFast && violations is not null)
             {
                 AvroValidationValueDecoder.Skip(_schema, ref reader);
@@ -945,22 +939,24 @@ internal sealed class AvroValueRulePlan
             : (rentedOffsets = ArrayPool<int>.Shared.Rent(offsetCount));
         try
         {
-            var resolution = _schemaRules.BeginMemberResolution();
-            var recordStart = reader.Position;
-            var lastFieldPayload = _schemaRules.ResolveRecordPrefix(
-                ref reader,
-                deferredIndexes,
-                offsets,
-                resolution);
+            AvroFieldPayload lastFieldPayload;
+            {
+                using var resolution = _schemaRules.BeginMemberResolution();
+                var recordStart = reader.Position;
+                lastFieldPayload = _schemaRules.ResolveRecordPrefix(
+                    ref reader,
+                    deferredIndexes,
+                    offsets,
+                    resolution);
 
-            _schemaRules.EvaluateResolvedWithoutRoot(
-                resolution,
-                reader.Position - recordStart,
-                now,
-                failFast,
-                ref violations,
-                ref path);
-            resolution.Dispose();
+                _schemaRules.EvaluateResolvedWithoutRoot(
+                    resolution,
+                    reader.Position - recordStart,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path);
+            }
             if (failFast && violations is not null)
             {
                 SkipRecordFields(ref reader, lastMemberFieldIndex + 1);
@@ -1072,7 +1068,7 @@ internal sealed class AvroValueRulePlan
                 failFast,
                 ref violations,
                 ref path,
-                value.SizeIndex == 0
+                value.SizeIndex == 0 && field.Rules.UsesRootSize
                     ? AvroValidationValueDecoder.Count(field.Field.Schema, payload)
                     : -1);
             if ((failFast && violations is not null) || !field.Child.HasAnyRules)
@@ -1119,7 +1115,7 @@ internal readonly record struct AvroFieldPayload(int Start, int Length);
 internal sealed class AvroCompiledRuleSet
 {
     internal static AvroCompiledRuleSet Empty { get; } = new(
-        [], null, false, false, false, false, 0, null, new AvroAggregateEqualityComparerFactory());
+        [], null, false, false, false, false, false, 0, null, new AvroAggregateEqualityComparerFactory());
 
     private readonly CompiledValidationRule[] _rules;
     private readonly AvroMemberResolver? _members;
@@ -1134,6 +1130,7 @@ internal sealed class AvroCompiledRuleSet
         CompiledValidationRule[] rules,
         AvroMemberResolver? members,
         bool usesRootValue,
+        bool usesRootSize,
         bool usesSize,
         bool usesCachedEquality,
         bool usesRootAggregateEquality,
@@ -1144,6 +1141,7 @@ internal sealed class AvroCompiledRuleSet
         _rules = rules;
         _members = members;
         UsesRootValue = usesRootValue;
+        UsesRootSize = usesRootSize;
         UsesSize = usesSize;
         _usesCachedEquality = usesCachedEquality;
         _usesRootAggregateEquality = usesRootAggregateEquality;
@@ -1167,6 +1165,7 @@ internal sealed class AvroCompiledRuleSet
 
     internal bool IsEmpty => _rules.Length == 0;
     internal bool UsesRootValue { get; }
+    internal bool UsesRootSize { get; }
     internal bool UsesSize { get; }
     internal bool HasMembers => _members is not null;
     internal int LastRecordMemberIndex => _lastRecordMemberIndex;
@@ -1181,9 +1180,11 @@ internal sealed class AvroCompiledRuleSet
         var memberIndexes = new Dictionary<string, int>(StringComparer.Ordinal);
         var memberPaths = new List<byte[][]>();
         var usedMemberIndexes = new HashSet<int>();
+        var sizedMemberIndexes = new HashSet<int>();
         var compiled = new CompiledValidationRule[rules.Count];
         var usesSize = false;
         var usesRootValue = false;
+        var usesRootSize = false;
         var usesCachedEquality = false;
         var usesRootAggregateEquality = false;
         for (var index = 0; index < rules.Count; index++)
@@ -1192,9 +1193,11 @@ internal sealed class AvroCompiledRuleSet
                 rules[index],
                 memberIndexes,
                 memberPaths,
-                usedMemberIndexes);
+                usedMemberIndexes,
+                sizedMemberIndexes: sizedMemberIndexes);
             compiled[index] = rule;
             usesRootValue |= rule.UsesRootValue;
+            usesRootSize |= rule.UsesRootSize;
             usesSize |= rule.UsesSize;
             usesCachedEquality |= rule.UsesCachedEquality;
             usesRootAggregateEquality |= rule.UsesRootAggregateEquality;
@@ -1207,11 +1210,13 @@ internal sealed class AvroCompiledRuleSet
                 valueSchema,
                 memberPaths,
                 usedMemberIndexes,
+                sizedMemberIndexes,
                 aggregateComparerFactory);
         return new AvroCompiledRuleSet(
             compiled,
             members,
             usesRootValue,
+            usesRootSize,
             usesSize,
             usesCachedEquality,
             usesRootAggregateEquality,
@@ -1233,66 +1238,72 @@ internal sealed class AvroCompiledRuleSet
         var valueResolution = isNested
             ? CompiledValidationRule.BeginValueResolution()
             : default;
-        var memberValues = _memberCount == 0
-            ? default
-            : isNested
-                ? CompiledValidationRule.GetMemberValues(_memberCount, valueResolution)
-                : CompiledValidationRule.GetMemberValues(_memberCount);
-        var sizes = UsesSize || _members is not null || rootSize >= 0
-            ? isNested
-                ? CompiledValidationRule.GetSizeValues(_memberCount + 1, valueResolution)
-                : CompiledValidationRule.GetSizeValues(_memberCount + 1)
-            : default;
-        if (rootSize >= 0)
-            sizes.Set(0, rootSize);
-        _members?.Resolve(payload, memberValues, sizes);
-        var equalityGeneration = _usesCachedEquality
-            ? CompiledValidationRule.BeginEqualityResolution()
-            : 0;
-        var rootAggregateComparer = _usesRootAggregateEquality
-            ? GetRootAggregateComparer(payload)
-            : null;
-
-        ValidationCelStrings.Begin(_memberCount + 1, payload.Length);
         try
         {
-            for (var index = 0; index < _rules.Length; index++)
-            {
-                var rule = _rules[index];
-                try
-                {
-                    var result = rule.Evaluate(
-                        value,
-                        now,
-                        memberValues,
-                        sizes,
-                        equalityGeneration,
-                        rootAggregateComparer);
-                    if (result.Kind == ValidationResultKind.Boolean ? result.Boolean : result.String!.Length == 0)
-                        continue;
-                    (violations ??= []).Add(new ValidationRuleError(
-                        rule.Rule,
-                        path.ToString(),
-                        result.Kind == ValidationResultKind.String ? result.String : null));
-                }
-                catch (SchemaRegistryRuleException exception)
-                {
-                    (violations ??= []).Add(new ValidationRuleError(
-                        rule.Rule,
-                        path.ToString(),
-                        cause: exception));
-                }
+            var memberValues = _memberCount == 0
+                ? default
+                : isNested
+                    ? CompiledValidationRule.GetMemberValues(_memberCount, valueResolution)
+                    : CompiledValidationRule.GetMemberValues(_memberCount);
+            var sizes = UsesSize || _members is not null || rootSize >= 0
+                ? isNested
+                    ? CompiledValidationRule.GetSizeValues(_memberCount + 1, valueResolution)
+                    : CompiledValidationRule.GetSizeValues(_memberCount + 1)
+                : default;
+            if (rootSize >= 0)
+                sizes.Set(0, rootSize);
+            _members?.Resolve(payload, memberValues, sizes);
+            var equalityGeneration = _usesCachedEquality
+                ? CompiledValidationRule.BeginEqualityResolution()
+                : 0;
+            var rootAggregateComparer = _usesRootAggregateEquality
+                ? GetRootAggregateComparer(payload)
+                : null;
 
-                if (failFast)
-                    break;
+            ValidationCelStrings.Begin(_memberCount + 1, payload.Length);
+            try
+            {
+                for (var index = 0; index < _rules.Length; index++)
+                {
+                    var rule = _rules[index];
+                    try
+                    {
+                        var result = rule.Evaluate(
+                            value,
+                            now,
+                            memberValues,
+                            sizes,
+                            equalityGeneration,
+                            rootAggregateComparer);
+                        if (result.Kind == ValidationResultKind.Boolean ? result.Boolean : result.String!.Length == 0)
+                            continue;
+                        (violations ??= []).Add(new ValidationRuleError(
+                            rule.Rule,
+                            path.ToString(),
+                            result.Kind == ValidationResultKind.String ? result.String : null));
+                    }
+                    catch (SchemaRegistryRuleException exception)
+                    {
+                        (violations ??= []).Add(new ValidationRuleError(
+                            rule.Rule,
+                            path.ToString(),
+                            cause: exception));
+                    }
+
+                    if (failFast)
+                        break;
+                }
+            }
+            finally
+            {
+                ValidationCelStrings.End();
             }
         }
         finally
         {
-            ValidationCelStrings.End();
+            if (isNested)
+                valueResolution.Dispose();
         }
-        if (isNested)
-            valueResolution.Dispose();
     }
 
     internal void EvaluateResolved(
@@ -1361,7 +1372,7 @@ internal sealed class AvroCompiledRuleSet
         ref List<ValidationRuleError>? violations,
         scoped ref AvroValidationPath path)
     {
-        var resolution = BeginMemberResolution();
+        using var resolution = BeginMemberResolution();
         var start = reader.Position;
         if (_members is null)
             AvroValidationValueDecoder.Skip(valueSchema, ref reader);
@@ -1375,7 +1386,6 @@ internal sealed class AvroCompiledRuleSet
             failFast,
             ref violations,
             ref path);
-        resolution.Dispose();
     }
 
     internal AvroMemberResolution BeginMemberResolution()
@@ -1564,13 +1574,14 @@ internal sealed class AvroMemberResolver
         AvroSchema valueSchema,
         IReadOnlyList<byte[][]> paths,
         IReadOnlyCollection<int> usedIndexes,
+        IReadOnlySet<int> sizedIndexes,
         AvroAggregateEqualityComparerFactory aggregateComparerFactory)
     {
         valueSchema = AvroValueRulePlan.Unwrap(valueSchema);
         if (valueSchema is global::Avro.RecordSchema record)
-            return CreateRecord(record, paths, usedIndexes, aggregateComparerFactory);
+            return CreateRecord(record, paths, usedIndexes, sizedIndexes, aggregateComparerFactory);
         if (valueSchema is global::Avro.MapSchema map)
-            return CreateMap(map, paths, usedIndexes, aggregateComparerFactory);
+            return CreateMap(map, paths, usedIndexes, sizedIndexes, aggregateComparerFactory);
         if (valueSchema is not global::Avro.UnionSchema union)
             return null;
 
@@ -1592,13 +1603,23 @@ internal sealed class AvroMemberResolver
                 if (branch is global::Avro.RecordSchema branchRecord)
                 {
                     branchResolver ??= CreateRecord(branchRecord, aggregateComparerFactory);
-                    branchResolver.Add(branchRecord, path, memberIndex, depth: 0);
+                    branchResolver.Add(
+                        branchRecord,
+                        path,
+                        memberIndex,
+                        sizedIndexes.Contains(memberIndex),
+                        depth: 0);
                 }
                 else
                 {
                     var branchMap = (global::Avro.MapSchema)branch;
                     branchResolver ??= CreateMap(branchMap, aggregateComparerFactory);
-                    branchResolver.Add(branchMap, path, memberIndex, depth: 0);
+                    branchResolver.Add(
+                        branchMap,
+                        path,
+                        memberIndex,
+                        sizedIndexes.Contains(memberIndex),
+                        depth: 0);
                 }
                 resolvedIndexes[memberIndex] = true;
             }
@@ -1620,11 +1641,17 @@ internal sealed class AvroMemberResolver
         global::Avro.RecordSchema record,
         IReadOnlyList<byte[][]> paths,
         IReadOnlyCollection<int> usedIndexes,
+        IReadOnlySet<int> sizedIndexes,
         AvroAggregateEqualityComparerFactory aggregateComparerFactory)
     {
         var resolver = CreateRecord(record, aggregateComparerFactory);
         foreach (var memberIndex in usedIndexes)
-            resolver.Add(record, paths[memberIndex], memberIndex, depth: 0);
+            resolver.Add(
+                record,
+                paths[memberIndex],
+                memberIndex,
+                sizedIndexes.Contains(memberIndex),
+                depth: 0);
         return resolver;
     }
 
@@ -1641,11 +1668,17 @@ internal sealed class AvroMemberResolver
         global::Avro.MapSchema map,
         IReadOnlyList<byte[][]> paths,
         IReadOnlyCollection<int> usedIndexes,
+        IReadOnlySet<int> sizedIndexes,
         AvroAggregateEqualityComparerFactory aggregateComparerFactory)
     {
         var resolver = CreateMap(map, aggregateComparerFactory);
         foreach (var memberIndex in usedIndexes)
-            resolver.Add(map, paths[memberIndex], memberIndex, depth: 0);
+            resolver.Add(
+                map,
+                paths[memberIndex],
+                memberIndex,
+                sizedIndexes.Contains(memberIndex),
+                depth: 0);
         return resolver;
     }
 
@@ -1658,6 +1691,7 @@ internal sealed class AvroMemberResolver
         global::Avro.RecordSchema schema,
         byte[][] path,
         int memberIndex,
+        bool needsSize,
         int depth)
     {
         var name = Encoding.UTF8.GetString(path[depth]);
@@ -1667,16 +1701,17 @@ internal sealed class AvroMemberResolver
         var node = _fields[field.Pos] ??= new AvroMemberNode(_aggregateComparerFactory);
         if (depth == path.Length - 1)
         {
-            node.AddMemberIndex(memberIndex);
+            node.AddMemberIndex(memberIndex, needsSize);
             return;
         }
-        node.AddChild(field.Schema, path, memberIndex, depth + 1);
+        node.AddChild(field.Schema, path, memberIndex, needsSize, depth + 1);
     }
 
     private void Add(
         global::Avro.MapSchema schema,
         byte[][] path,
         int memberIndex,
+        bool needsSize,
         int depth)
     {
         var key = (ReadOnlyMemory<byte>)path[depth];
@@ -1687,10 +1722,10 @@ internal sealed class AvroMemberResolver
         }
         if (depth == path.Length - 1)
         {
-            node.AddMemberIndex(memberIndex);
+            node.AddMemberIndex(memberIndex, needsSize);
             return;
         }
-        node.AddChild(schema.ValueSchema, path, memberIndex, depth + 1);
+        node.AddChild(schema.ValueSchema, path, memberIndex, needsSize, depth + 1);
     }
 
     internal void Resolve(
@@ -1925,6 +1960,7 @@ internal sealed class AvroMemberResolver
         private ReadOnlyMemory<byte>[]? _enumSymbols;
         private ReadOnlyMemory<byte>[]?[]? _unionEnumSymbols;
         private int[]? _additionalMemberIndexes;
+        private bool _needsSize;
 
         internal AvroSchema? Schema
         {
@@ -1950,8 +1986,9 @@ internal sealed class AvroMemberResolver
         internal int MemberIndex { get; private set; } = -1;
         internal bool HasTargets => MemberIndex >= 0 || _children.Count != 0;
 
-        internal void AddMemberIndex(int memberIndex)
+        internal void AddMemberIndex(int memberIndex, bool needsSize)
         {
+            _needsSize |= needsSize;
             if (MemberIndex < 0)
             {
                 MemberIndex = memberIndex;
@@ -1979,6 +2016,7 @@ internal sealed class AvroMemberResolver
             AvroSchema schema,
             byte[][] path,
             int memberIndex,
+            bool needsSize,
             int depth)
         {
             schema = AvroValueRulePlan.Unwrap(schema);
@@ -1992,7 +2030,7 @@ internal sealed class AvroMemberResolver
                         continue;
                     if (!CanResolve(branch, path, depth))
                         continue;
-                    AddResolverChild(branch, path, memberIndex, depth);
+                    AddResolverChild(branch, path, memberIndex, needsSize, depth);
                     found = true;
                 }
                 if (found)
@@ -2000,7 +2038,7 @@ internal sealed class AvroMemberResolver
             }
             else if (schema is global::Avro.RecordSchema or global::Avro.MapSchema)
             {
-                AddResolverChild(schema, path, memberIndex, depth);
+                AddResolverChild(schema, path, memberIndex, needsSize, depth);
                 return;
             }
 
@@ -2012,6 +2050,7 @@ internal sealed class AvroMemberResolver
             AvroSchema schema,
             byte[][] path,
             int memberIndex,
+            bool needsSize,
             int depth)
         {
             if (!_children.TryGetValue(schema, out var child))
@@ -2025,9 +2064,9 @@ internal sealed class AvroMemberResolver
                 _children.Add(schema, child);
             }
             if (schema is global::Avro.RecordSchema recordSchema)
-                child.Add(recordSchema, path, memberIndex, depth);
+                child.Add(recordSchema, path, memberIndex, needsSize, depth);
             else
-                child.Add((global::Avro.MapSchema)schema, path, memberIndex, depth);
+                child.Add((global::Avro.MapSchema)schema, path, memberIndex, needsSize, depth);
         }
 
         internal void Resolve(
@@ -2043,7 +2082,7 @@ internal sealed class AvroMemberResolver
                 var additionalIndexes = _additionalMemberIndexes;
                 if (additionalIndexes is null)
                 {
-                    if (value.SizeIndex == 0)
+                    if (_needsSize && value.SizeIndex == 0)
                     {
                         var sizeIndex = MemberIndex + 1;
                         sizes.Set(sizeIndex, AvroValidationValueDecoder.Count(schema, payload));
@@ -2054,7 +2093,7 @@ internal sealed class AvroMemberResolver
                 else
                 {
                     var size = -1;
-                    if (value.SizeIndex == 0)
+                    if (_needsSize && value.SizeIndex == 0)
                         size = AvroValidationValueDecoder.Count(schema, payload);
                     SetMemberValue(MemberIndex, value, size, values, sizes, aggregateComparer);
                     for (var index = 0; index < additionalIndexes.Length; index++)

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -1245,11 +1245,11 @@ internal sealed class AvroValueRulePlan
         {
             var fieldStart = reader.Position;
             var preview = reader;
-            value = field.Child.ReadValue(ref preview);
+            value = field.Child.ReadValue(
+                ref preview,
+                needsSize || field.Rules.UsesRootSize,
+                out size);
             var payload = preview.Source.Slice(fieldStart, preview.Position - fieldStart);
-            size = value.SizeIndex == 0 && field.Rules.UsesRootSize
-                ? AvroValidationValueDecoder.Count(field.Field.Schema, payload)
-                : -1;
             field.Rules.Evaluate(
                 value,
                 payload,
@@ -1277,8 +1277,6 @@ internal sealed class AvroValueRulePlan
                 if (size < 0)
                     size = capturedSize;
             }
-            if (needsSize && size < 0 && value.SizeIndex == 0)
-                size = AvroValidationValueDecoder.Count(field.Field.Schema, payload);
         }
         path.Truncate(mark);
         return value;
@@ -1290,25 +1288,26 @@ internal sealed class AvroValueRulePlan
         bool needsSize,
         out int size)
     {
-        var start = reader.Position;
-        var value = field.Child.ReadValue(ref reader);
-        size = needsSize && value.SizeIndex == 0
-            ? AvroValidationValueDecoder.Count(
-                field.Field.Schema,
-                reader.Source.Slice(start, reader.Position - start))
-            : -1;
-        return value;
+        return field.Child.ReadValue(ref reader, needsSize, out size);
     }
 
     private ValidationCelValue ReadValue(ref AvroValidationReader reader)
     {
+        return ReadValue(ref reader, needsSize: false, out _);
+    }
+
+    private ValidationCelValue ReadValue(
+        ref AvroValidationReader reader,
+        bool needsSize,
+        out int size)
+    {
         if (_schema is not global::Avro.UnionSchema union)
-            return AvroValidationValueDecoder.Read(_schema, _enumSymbols, ref reader);
+            return AvroValidationValueDecoder.Read(_schema, _enumSymbols, ref reader, needsSize, out size);
 
         var branch = reader.ReadLong();
         if ((ulong)branch >= (ulong)union.Count)
             throw InvalidPayload($"invalid union index {branch}");
-        return _children[(int)branch].ReadValue(ref reader);
+        return _children[(int)branch].ReadValue(ref reader, needsSize, out size);
     }
 
     internal static AvroSchema Unwrap(AvroSchema schema) =>
@@ -2386,15 +2385,28 @@ internal sealed class AvroMemberResolver
             ValidationCelSizeValues sizes)
         {
             var schema = AvroValueRulePlan.Unwrap(Schema!);
-            if (value.Kind == ValidationCelValueKind.Missing || schema is global::Avro.UnionSchema)
+            if (value.Kind == ValidationCelValueKind.Missing)
             {
                 Resolve(payload, values, sizes);
                 return;
             }
 
+            var aggregateComparer = _aggregateComparer;
+            if (schema is global::Avro.UnionSchema union)
+            {
+                var branchReader = new AvroValidationReader(payload);
+                var branch = branchReader.ReadLong();
+                if ((ulong)branch >= (ulong)union.Count)
+                    throw new SchemaRegistryRuleException(
+                        $"Could not evaluate Avro validation rules: invalid union index {branch}.");
+                schema = AvroValueRulePlan.Unwrap(union[(int)branch]);
+                aggregateComparer = _unionComparers![(int)branch];
+                payload = branchReader.Source.Slice(branchReader.Position);
+            }
+
             if (MemberIndex >= 0)
             {
-                SetMemberValue(MemberIndex, value, size, values, sizes, _aggregateComparer);
+                SetMemberValue(MemberIndex, value, size, values, sizes, aggregateComparer);
                 var additionalIndexes = _additionalMemberIndexes;
                 if (additionalIndexes is not null)
                 {
@@ -2406,7 +2418,7 @@ internal sealed class AvroMemberResolver
                             size,
                             values,
                             sizes,
-                            _aggregateComparer);
+                            aggregateComparer);
                     }
                 }
             }
@@ -2607,7 +2619,18 @@ internal static class AvroValidationValueDecoder
         ReadOnlyMemory<byte>[]? enumSymbols,
         ref AvroValidationReader reader)
     {
+        return Read(schema, enumSymbols, ref reader, needsSize: false, out _);
+    }
+
+    internal static ValidationCelValue Read(
+        AvroSchema schema,
+        ReadOnlyMemory<byte>[]? enumSymbols,
+        ref AvroValidationReader reader,
+        bool needsSize,
+        out int size)
+    {
         schema = AvroValueRulePlan.Unwrap(schema);
+        size = -1;
         switch (schema.Tag)
         {
             case AvroSchema.Type.Null:
@@ -2643,6 +2666,8 @@ internal static class AvroValidationValueDecoder
                 var record = (global::Avro.RecordSchema)schema;
                 for (var index = 0; index < record.Fields.Count; index++)
                     Skip(record.Fields[index].Schema, ref reader);
+                if (needsSize)
+                    size = record.Fields.Count;
                 return ValidationCelValue.FromCollection(
                     ValidationCelValueKind.Object,
                     reader.Source.Slice(recordStart, reader.Position - recordStart),
@@ -2650,7 +2675,11 @@ internal static class AvroValidationValueDecoder
             case AvroSchema.Type.Array:
             {
                 var collectionStart = reader.Position;
-                SkipCollection(((global::Avro.ArraySchema)schema).ItemSchema, isMap: false, ref reader);
+                var itemSchema = ((global::Avro.ArraySchema)schema).ItemSchema;
+                if (needsSize)
+                    size = SkipCollectionAndCount(itemSchema, isMap: false, ref reader);
+                else
+                    SkipCollection(itemSchema, isMap: false, ref reader);
                 return ValidationCelValue.FromCollection(
                     ValidationCelValueKind.Array,
                     reader.Source.Slice(collectionStart, reader.Position - collectionStart),
@@ -2659,7 +2688,11 @@ internal static class AvroValidationValueDecoder
             case AvroSchema.Type.Map:
             {
                 var collectionStart = reader.Position;
-                SkipCollection(((global::Avro.MapSchema)schema).ValueSchema, isMap: true, ref reader);
+                var valueSchema = ((global::Avro.MapSchema)schema).ValueSchema;
+                if (needsSize)
+                    size = SkipCollectionAndCount(valueSchema, isMap: true, ref reader);
+                else
+                    SkipCollection(valueSchema, isMap: true, ref reader);
                 return ValidationCelValue.FromCollection(
                     ValidationCelValueKind.Object,
                     reader.Source.Slice(collectionStart, reader.Position - collectionStart),
@@ -2670,7 +2703,7 @@ internal static class AvroValidationValueDecoder
                 var branch = reader.ReadLong();
                 if ((ulong)branch >= (ulong)union.Count)
                     throw InvalidPayload($"invalid union index {branch}");
-                return Read(union[(int)branch], enumSymbols, ref reader);
+                return Read(union[(int)branch], enumSymbols, ref reader, needsSize, out size);
             default:
                 throw InvalidPayload($"unsupported schema type {schema.Tag}");
         }
@@ -2779,6 +2812,27 @@ internal static class AvroValidationValueDecoder
             var count = reader.ReadCollectionCount();
             if (count == 0)
                 return;
+            for (long index = 0; index < count; index++)
+            {
+                if (isMap)
+                    _ = reader.ReadLengthPrefixed();
+                Skip(valueSchema, ref reader);
+            }
+        }
+    }
+
+    private static int SkipCollectionAndCount(
+        AvroSchema valueSchema,
+        bool isMap,
+        ref AvroValidationReader reader)
+    {
+        var itemCount = 0L;
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return checked((int)itemCount);
+            itemCount = checked(itemCount + count);
             for (long index = 0; index < count; index++)
             {
                 if (isMap)

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -370,6 +370,7 @@ internal sealed class AvroValueRulePlan
                     ref reader,
                     resolution,
                     now,
+                    failFast,
                     ref nestedViolations,
                     ref path);
                 break;
@@ -491,15 +492,15 @@ internal sealed class AvroValueRulePlan
                 return capturedValue;
             }
 
-            ValidateDeferredRecordField(
+            return ValidateDeferredRecordField(
                 field,
                 ref reader,
                 now,
                 failFast: false,
+                needsSize,
                 ref violations,
-                ref path);
-            size = -1;
-            return ValidationCelValue.Missing;
+                ref path,
+                out size);
         }
 
         var mark = path.Length;
@@ -617,6 +618,7 @@ internal sealed class AvroValueRulePlan
         ref AvroValidationReader reader,
         AvroMemberResolution resolution,
         long now,
+        bool failFast,
         ref List<ValidationRuleError>? nestedViolations,
         scoped ref AvroValidationPath path)
     {
@@ -629,7 +631,7 @@ internal sealed class AvroValueRulePlan
         _ = _children[(int)branch].Validate(
             ref reader,
             now,
-            failFast: false,
+            failFast,
             ref nestedViolations,
             ref path);
         _schemaRules.ResolveUnionBranch(
@@ -1131,8 +1133,10 @@ internal sealed class AvroValueRulePlan
                     ref fieldReader,
                     now,
                     failFast,
+                    needsSize: false,
                     ref violations,
-                    ref path);
+                    ref path,
+                    out _);
                 if (failFast && violations is not null)
                 {
                     SkipRecordFields(ref reader, lastMemberFieldIndex + 1);
@@ -1150,8 +1154,10 @@ internal sealed class AvroValueRulePlan
                     ref fieldReader,
                     now,
                     failFast,
+                    needsSize: false,
                     ref violations,
-                    ref path);
+                    ref path,
+                    out _);
                 if (failFast && violations is not null)
                 {
                     SkipRecordFields(ref reader, lastMemberFieldIndex + 1);
@@ -1166,8 +1172,10 @@ internal sealed class AvroValueRulePlan
                     ref reader,
                     now,
                     failFast,
+                    needsSize: false,
                     ref violations,
-                    ref path);
+                    ref path,
+                    out _);
                 if (failFast && violations is not null)
                 {
                     SkipRecordFields(ref reader, index + 1);
@@ -1189,37 +1197,44 @@ internal sealed class AvroValueRulePlan
             AvroValidationValueDecoder.Skip(_fields[index].Field.Schema, ref reader);
     }
 
-    private static void ValidateDeferredRecordField(
+    private static ValidationCelValue ValidateDeferredRecordField(
         AvroFieldRulePlan field,
         ref AvroValidationReader reader,
         long now,
         bool failFast,
+        bool needsSize,
         ref List<ValidationRuleError>? violations,
-        scoped ref AvroValidationPath path)
+        scoped ref AvroValidationPath path,
+        out int size)
     {
         var mark = path.Length;
         path.AppendField(field.Field.Name);
+        ValidationCelValue value;
         if (field.Rules.IsEmpty)
         {
-            _ = field.Child.Validate(ref reader, now, failFast, ref violations, ref path);
+            value = field.Child.Validate(ref reader, now, failFast, ref violations, ref path);
+            size = -1;
         }
         else if (CanFuseFieldRules(field))
         {
-            _ = EvaluateFieldRulesWithNestedTraversal(
+            value = EvaluateFieldRulesWithNestedTraversal(
                 field,
                 ref reader,
                 now,
                 failFast,
                 ref violations,
                 ref path,
-                out _);
+                out size);
         }
         else
         {
             var fieldStart = reader.Position;
             var preview = reader;
-            var value = field.Child.ReadValue(ref preview);
+            value = field.Child.ReadValue(ref preview);
             var payload = preview.Source.Slice(fieldStart, preview.Position - fieldStart);
+            size = value.SizeIndex == 0 && field.Rules.UsesRootSize
+                ? AvroValidationValueDecoder.Count(field.Field.Schema, payload)
+                : -1;
             field.Rules.Evaluate(
                 value,
                 payload,
@@ -1227,15 +1242,31 @@ internal sealed class AvroValueRulePlan
                 failFast,
                 ref violations,
                 ref path,
-                value.SizeIndex == 0 && field.Rules.UsesRootSize
-                    ? AvroValidationValueDecoder.Count(field.Field.Schema, payload)
-                    : -1);
+                size);
             if ((failFast && violations is not null) || !field.Child.HasAnyRules)
+            {
                 reader = preview;
+            }
             else
-                _ = field.Child.Validate(ref reader, now, failFast, ref violations, ref path);
+            {
+                var capturedValue = field.Child.ValidateAndCapture(
+                    ref reader,
+                    now,
+                    failFast,
+                    needsSize && size < 0,
+                    ref violations,
+                    ref path,
+                    out var capturedSize);
+                if (capturedValue.Kind != ValidationCelValueKind.Missing)
+                    value = capturedValue;
+                if (size < 0)
+                    size = capturedSize;
+            }
+            if (needsSize && size < 0 && value.SizeIndex == 0)
+                size = AvroValidationValueDecoder.Count(field.Field.Schema, payload);
         }
         path.Truncate(mark);
+        return value;
     }
 
     private ValidationCelValue ReadValue(ref AvroValidationReader reader)

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -175,19 +175,32 @@ internal sealed class AvroValueRulePlan
         {
             var start = reader.Position;
             preview = reader;
-            value = ReadValue(ref preview);
-            var payload = preview.Source.Slice(start, preview.Position - start);
-            var rootSize = value.SizeIndex == 0
-                ? AvroValidationValueDecoder.Count(_schema, payload)
-                : -1;
-            _schemaRules.Evaluate(
-                value,
-                payload,
-                now,
-                failFast,
-                ref violations,
-                ref path,
-                rootSize);
+            if (_schemaRules.UsesRootValue)
+            {
+                value = ReadValue(ref preview);
+                var payload = preview.Source.Slice(start, preview.Position - start);
+                var rootSize = value.SizeIndex == 0
+                    ? AvroValidationValueDecoder.Count(_schema, payload)
+                    : -1;
+                _schemaRules.Evaluate(
+                    value,
+                    payload,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path,
+                    rootSize);
+            }
+            else
+            {
+                _schemaRules.EvaluateWithoutRoot(
+                    ref preview,
+                    _schema,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path);
+            }
             if (failFast && violations is not null)
             {
                 reader = preview;
@@ -408,7 +421,7 @@ internal sealed record AvroFieldRulePlan(
 
 internal sealed class AvroCompiledRuleSet
 {
-    internal static AvroCompiledRuleSet Empty { get; } = new([], null, false, false, false, 0, null);
+    internal static AvroCompiledRuleSet Empty { get; } = new([], null, false, false, false, false, 0, null);
 
     private readonly CompiledValidationRule[] _rules;
     private readonly AvroMemberResolver? _members;
@@ -421,6 +434,7 @@ internal sealed class AvroCompiledRuleSet
     private AvroCompiledRuleSet(
         CompiledValidationRule[] rules,
         AvroMemberResolver? members,
+        bool usesRootValue,
         bool usesSize,
         bool usesCachedEquality,
         bool usesRootAggregateEquality,
@@ -429,6 +443,7 @@ internal sealed class AvroCompiledRuleSet
     {
         _rules = rules;
         _members = members;
+        UsesRootValue = usesRootValue;
         UsesSize = usesSize;
         _usesCachedEquality = usesCachedEquality;
         _usesRootAggregateEquality = usesRootAggregateEquality;
@@ -450,6 +465,7 @@ internal sealed class AvroCompiledRuleSet
     }
 
     internal bool IsEmpty => _rules.Length == 0;
+    internal bool UsesRootValue { get; }
     internal bool UsesSize { get; }
 
     internal static AvroCompiledRuleSet Compile(
@@ -464,6 +480,7 @@ internal sealed class AvroCompiledRuleSet
         var usedMemberIndexes = new HashSet<int>();
         var compiled = new CompiledValidationRule[rules.Count];
         var usesSize = false;
+        var usesRootValue = false;
         var usesCachedEquality = false;
         var usesRootAggregateEquality = false;
         for (var index = 0; index < rules.Count; index++)
@@ -474,6 +491,7 @@ internal sealed class AvroCompiledRuleSet
                 memberPaths,
                 usedMemberIndexes);
             compiled[index] = rule;
+            usesRootValue |= rule.UsesRootValue;
             usesSize |= rule.UsesSize;
             usesCachedEquality |= rule.UsesCachedEquality;
             usesRootAggregateEquality |= rule.UsesRootAggregateEquality;
@@ -485,6 +503,7 @@ internal sealed class AvroCompiledRuleSet
         return new AvroCompiledRuleSet(
             compiled,
             members,
+            usesRootValue,
             usesSize,
             usesCachedEquality,
             usesRootAggregateEquality,
@@ -532,6 +551,69 @@ internal sealed class AvroCompiledRuleSet
                         sizes,
                         equalityGeneration,
                         rootAggregateComparer);
+                    if (result.Kind == ValidationResultKind.Boolean ? result.Boolean : result.String!.Length == 0)
+                        continue;
+                    (violations ??= []).Add(new ValidationRuleError(
+                        rule.Rule,
+                        path.ToString(),
+                        result.Kind == ValidationResultKind.String ? result.String : null));
+                }
+                catch (SchemaRegistryRuleException exception)
+                {
+                    (violations ??= []).Add(new ValidationRuleError(
+                        rule.Rule,
+                        path.ToString(),
+                        cause: exception));
+                }
+
+                if (failFast)
+                    return;
+            }
+        }
+        finally
+        {
+            ValidationCelStrings.End();
+        }
+    }
+
+    internal void EvaluateWithoutRoot(
+        ref AvroValidationReader reader,
+        AvroSchema valueSchema,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path)
+    {
+        var memberValues = _memberCount == 0
+            ? default
+            : CompiledValidationRule.GetMemberValues(_memberCount);
+        var sizes = UsesSize || _members is not null
+            ? CompiledValidationRule.GetSizeValues(_memberCount + 1)
+            : default;
+        var start = reader.Position;
+        if (_members is null)
+            AvroValidationValueDecoder.Skip(valueSchema, ref reader);
+        else
+            _members.Resolve(ref reader, memberValues, sizes);
+        var equalityGeneration = _usesCachedEquality
+            ? CompiledValidationRule.BeginEqualityResolution()
+            : 0;
+
+        ValidationCelStrings.Begin(_memberCount + 1, reader.Position - start);
+        try
+        {
+            for (var index = 0; index < _rules.Length; index++)
+            {
+                var rule = _rules[index];
+                try
+                {
+                    var result = rule.Evaluate(
+                        ValidationCelValue.Missing,
+                        now,
+                        memberValues,
+                        sizes,
+                        equalityGeneration,
+                        rootAggregateComparer: null);
                     if (result.Kind == ValidationResultKind.Boolean ? result.Boolean : result.String!.Length == 0)
                         continue;
                     (violations ??= []).Add(new ValidationRuleError(
@@ -612,8 +694,7 @@ internal sealed class AvroMemberResolver
             foreach (var memberIndex in usedIndexes)
             {
                 var path = paths[memberIndex];
-                var name = Encoding.UTF8.GetString(path[0]);
-                if (FindField(branch, name) is null)
+                if (!CanResolve(branch, path, depth: 0))
                     continue;
 
                 branchResolver ??= CreateRecord(branch);
@@ -665,7 +746,7 @@ internal sealed class AvroMemberResolver
         var node = _fields[field.Pos] ??= new AvroMemberNode();
         if (depth == path.Length - 1)
         {
-            node.MemberIndex = memberIndex;
+            node.AddMemberIndex(memberIndex);
             return;
         }
         node.AddChild(field.Schema, path, memberIndex, depth + 1);
@@ -677,6 +758,14 @@ internal sealed class AvroMemberResolver
         ValidationCelSizeValues sizes)
     {
         var reader = new AvroValidationReader(payload);
+        Resolve(ref reader, values, sizes);
+    }
+
+    internal void Resolve(
+        ref AvroValidationReader reader,
+        ValidationCelMemberValues values,
+        ValidationCelSizeValues sizes)
+    {
         if (_unionBranches is not null)
         {
             var union = (global::Avro.UnionSchema)_valueSchema;
@@ -684,10 +773,11 @@ internal sealed class AvroMemberResolver
             if ((ulong)branch >= (ulong)union.Count)
                 throw new SchemaRegistryRuleException(
                     $"Could not evaluate Avro validation rules: invalid union index {branch}.");
-            _unionBranches[(int)branch]?.Resolve(
-                reader.Source.Slice(reader.Position),
-                values,
-                sizes);
+            var resolver = _unionBranches[(int)branch];
+            if (resolver is null)
+                AvroValidationValueDecoder.Skip(union[(int)branch], ref reader);
+            else
+                resolver.Resolve(ref reader, values, sizes);
             return;
         }
         for (var index = 0; index < _fields.Length; index++)
@@ -731,6 +821,31 @@ internal sealed class AvroMemberResolver
         return null;
     }
 
+    private static bool CanResolve(
+        global::Avro.RecordSchema schema,
+        byte[][] path,
+        int depth)
+    {
+        var field = FindField(schema, Encoding.UTF8.GetString(path[depth]));
+        if (field is null)
+            return false;
+        if (depth == path.Length - 1)
+            return true;
+
+        var childSchema = AvroValueRulePlan.Unwrap(field.Schema);
+        if (childSchema is global::Avro.RecordSchema record)
+            return CanResolve(record, path, depth + 1);
+        if (childSchema is not global::Avro.UnionSchema union)
+            return false;
+        for (var index = 0; index < union.Count; index++)
+        {
+            if (AvroValueRulePlan.Unwrap(union[index]) is global::Avro.RecordSchema branch &&
+                CanResolve(branch, path, depth + 1))
+                return true;
+        }
+        return false;
+    }
+
     internal void SetSchemas(global::Avro.RecordSchema schema)
     {
         for (var index = 0; index < schema.Fields.Count; index++)
@@ -746,6 +861,7 @@ internal sealed class AvroMemberResolver
         private AvroAggregateEqualityComparer?[]? _unionComparers;
         private ReadOnlyMemory<byte>[]? _enumSymbols;
         private ReadOnlyMemory<byte>[]?[]? _unionEnumSymbols;
+        private int[]? _additionalMemberIndexes;
 
         internal AvroSchema? Schema
         {
@@ -768,8 +884,33 @@ internal sealed class AvroMemberResolver
                 }
             }
         }
-        internal int MemberIndex { get; set; } = -1;
+        internal int MemberIndex { get; private set; } = -1;
         internal bool HasTargets => MemberIndex >= 0 || _children.Count != 0;
+
+        internal void AddMemberIndex(int memberIndex)
+        {
+            if (MemberIndex < 0)
+            {
+                MemberIndex = memberIndex;
+                return;
+            }
+            if (MemberIndex == memberIndex)
+                return;
+
+            var indexes = _additionalMemberIndexes;
+            if (indexes is null)
+            {
+                _additionalMemberIndexes = [memberIndex];
+                return;
+            }
+            for (var index = 0; index < indexes.Length; index++)
+            {
+                if (indexes[index] == memberIndex)
+                    return;
+            }
+            Array.Resize(ref _additionalMemberIndexes, indexes.Length + 1);
+            _additionalMemberIndexes[^1] = memberIndex;
+        }
 
         internal void AddChild(
             AvroSchema schema,
@@ -781,12 +922,11 @@ internal sealed class AvroMemberResolver
             if (schema is global::Avro.UnionSchema union)
             {
                 var found = false;
-                var nextName = Encoding.UTF8.GetString(path[depth]);
                 for (var index = 0; index < union.Count; index++)
                 {
                     if (AvroValueRulePlan.Unwrap(union[index]) is not global::Avro.RecordSchema branch)
                         continue;
-                    if (FindField(branch, nextName) is null)
+                    if (!CanResolve(branch, path, depth))
                         continue;
                     AddRecordChild(branch, path, memberIndex, depth);
                     found = true;
@@ -828,13 +968,34 @@ internal sealed class AvroMemberResolver
             {
                 var valueReader = new AvroValidationReader(payload);
                 var value = ReadValue(schema, ref valueReader, out var aggregateComparer);
-                if (value.SizeIndex == 0)
+                var additionalIndexes = _additionalMemberIndexes;
+                if (additionalIndexes is null)
                 {
-                    var sizeIndex = MemberIndex + 1;
-                    sizes.Set(sizeIndex, AvroValidationValueDecoder.Count(schema, payload));
-                    value = value with { SizeIndex = sizeIndex };
+                    if (value.SizeIndex == 0)
+                    {
+                        var sizeIndex = MemberIndex + 1;
+                        sizes.Set(sizeIndex, AvroValidationValueDecoder.Count(schema, payload));
+                        value = value with { SizeIndex = sizeIndex };
+                    }
+                    values.SetValue(MemberIndex, value, aggregateComparer);
                 }
-                values.SetValue(MemberIndex, value, aggregateComparer);
+                else
+                {
+                    var size = -1;
+                    if (value.SizeIndex == 0)
+                        size = AvroValidationValueDecoder.Count(schema, payload);
+                    SetMemberValue(MemberIndex, value, size, values, sizes, aggregateComparer);
+                    for (var index = 0; index < additionalIndexes.Length; index++)
+                    {
+                        SetMemberValue(
+                            additionalIndexes[index],
+                            value,
+                            size,
+                            values,
+                            sizes,
+                            aggregateComparer);
+                    }
+                }
             }
 
             if (_children.Count == 0)
@@ -856,6 +1017,23 @@ internal sealed class AvroMemberResolver
                     values,
                     sizes);
             }
+        }
+
+        private static void SetMemberValue(
+            int memberIndex,
+            ValidationCelValue value,
+            int size,
+            ValidationCelMemberValues values,
+            ValidationCelSizeValues sizes,
+            AvroAggregateEqualityComparer? aggregateComparer)
+        {
+            if (size >= 0)
+            {
+                var sizeIndex = memberIndex + 1;
+                sizes.Set(sizeIndex, size);
+                value = value with { SizeIndex = sizeIndex };
+            }
+            values.SetValue(memberIndex, value, aggregateComparer);
         }
 
         private ValidationCelValue ReadValue(

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -1,0 +1,1015 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using AvroSchema = global::Avro.Schema;
+
+namespace Dekaf.SchemaRegistry.Avro;
+
+internal sealed class AvroInlineRuleValidator
+{
+    [ThreadStatic]
+    private static char[]? t_pathBuffer;
+
+    private readonly AvroValueRulePlan _root;
+
+    internal AvroInlineRuleValidator(AvroSchema schema)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+        var plans = new Dictionary<AvroSchema, AvroValueRulePlan>(AvroSchemaReferenceComparer.Instance);
+        _root = AvroValueRulePlan.Create(schema, plans);
+        AvroValueRulePlan.Complete(plans);
+    }
+
+    internal void Validate(ReadOnlyMemory<byte> payload, int schemaId, bool failFast)
+    {
+        List<ValidationRuleError>? violations = null;
+        var path = new AvroValidationPath(t_pathBuffer ??= new char[256]);
+        var reader = new AvroValidationReader(payload);
+        try
+        {
+            _root.Validate(
+                ref reader,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                failFast,
+                ref violations,
+                ref path);
+            if (!reader.End)
+                throw InvalidPayload("trailing bytes remain after the root value");
+        }
+        finally
+        {
+            path.Dispose();
+        }
+
+        if (violations is not null)
+            throw new ValidationRulesFailedException(violations);
+    }
+
+    private static SchemaRegistryRuleException InvalidPayload(string reason) =>
+        new($"Could not evaluate Avro validation rules: {reason}.");
+}
+
+internal sealed class AvroValueRulePlan
+{
+    private readonly AvroSchema _schema;
+    private AvroCompiledRuleSet _schemaRules = AvroCompiledRuleSet.Empty;
+    private AvroFieldRulePlan[] _fields = [];
+    private AvroValueRulePlan[] _children = [];
+
+    private AvroValueRulePlan(AvroSchema schema) => _schema = Unwrap(schema);
+
+    internal bool HasAnyRules { get; private set; }
+
+    internal static AvroValueRulePlan Create(
+        AvroSchema schema,
+        Dictionary<AvroSchema, AvroValueRulePlan> plans)
+    {
+        schema = Unwrap(schema);
+        if (plans.TryGetValue(schema, out var existing))
+            return existing;
+
+        var plan = new AvroValueRulePlan(schema);
+        plans.Add(schema, plan);
+        plan.Initialize(plans);
+        return plan;
+    }
+
+    private void Initialize(Dictionary<AvroSchema, AvroValueRulePlan> plans)
+    {
+        _schemaRules = AvroCompiledRuleSet.Compile(
+            AvroInlineRuleParser.ReadRules(_schema),
+            _schema as global::Avro.RecordSchema);
+
+        switch (_schema)
+        {
+            case global::Avro.RecordSchema record:
+                _fields = new AvroFieldRulePlan[record.Fields.Count];
+                for (var index = 0; index < record.Fields.Count; index++)
+                {
+                    var field = record.Fields[index];
+                    var fieldSchema = Unwrap(field.Schema);
+                    var child = Create(fieldSchema, plans);
+                    _fields[index] = new AvroFieldRulePlan(
+                        field,
+                        AvroCompiledRuleSet.Compile(
+                            AvroInlineRuleParser.ReadRules(field),
+                            FindRecord(fieldSchema)),
+                        child);
+                }
+                break;
+            case global::Avro.ArraySchema array:
+                _children = [Create(array.ItemSchema, plans)];
+                break;
+            case global::Avro.MapSchema map:
+                _children = [Create(map.ValueSchema, plans)];
+                break;
+            case global::Avro.UnionSchema union:
+                _children = new AvroValueRulePlan[union.Count];
+                for (var index = 0; index < union.Count; index++)
+                    _children[index] = Create(union[index], plans);
+                break;
+        }
+
+        HasAnyRules = !_schemaRules.IsEmpty;
+        for (var index = 0; index < _fields.Length; index++)
+            HasAnyRules |= !_fields[index].Rules.IsEmpty;
+    }
+
+    internal static void Complete(Dictionary<AvroSchema, AvroValueRulePlan> plans)
+    {
+        var changed = true;
+        while (changed)
+        {
+            changed = false;
+            foreach (var plan in plans.Values)
+            {
+                if (plan.HasAnyRules)
+                    continue;
+                for (var index = 0; index < plan._fields.Length; index++)
+                {
+                    if (plan._fields[index].Child.HasAnyRules)
+                    {
+                        plan.HasAnyRules = true;
+                        changed = true;
+                        break;
+                    }
+                }
+                for (var index = 0; !plan.HasAnyRules && index < plan._children.Length; index++)
+                {
+                    if (plan._children[index].HasAnyRules)
+                    {
+                        plan.HasAnyRules = true;
+                        changed = true;
+                    }
+                }
+            }
+        }
+    }
+
+    internal ValidationCelValue Validate(
+        ref AvroValidationReader reader,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path)
+    {
+        if (!HasAnyRules)
+            return AvroValidationValueDecoder.Read(_schema, ref reader);
+
+        var start = reader.Position;
+        var preview = reader;
+        var value = AvroValidationValueDecoder.Read(_schema, ref preview);
+        var payload = preview.Source.Slice(start, preview.Position - start);
+        var rootSize = value.SizeIndex == 0 ? AvroValidationValueDecoder.Count(_schema, payload) : -1;
+        if (!_schemaRules.IsEmpty)
+        {
+            _schemaRules.Evaluate(
+                value,
+                payload,
+                now,
+                failFast,
+                ref violations,
+                ref path,
+                rootSize);
+            if (failFast && violations is not null)
+            {
+                reader = preview;
+                return value;
+            }
+        }
+
+        switch (_schema)
+        {
+            case global::Avro.RecordSchema:
+                ValidateRecord(ref reader, now, failFast, ref violations, ref path);
+                break;
+            case global::Avro.ArraySchema:
+                ValidateArray(ref reader, now, failFast, ref violations, ref path);
+                break;
+            case global::Avro.MapSchema:
+                ValidateMap(ref reader, now, failFast, ref violations, ref path);
+                break;
+            case global::Avro.UnionSchema:
+                ValidateUnion(ref reader, now, failFast, ref violations, ref path);
+                break;
+            default:
+                reader = preview;
+                break;
+        }
+        return value;
+    }
+
+    private void ValidateRecord(
+        ref AvroValidationReader reader,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path)
+    {
+        for (var index = 0; index < _fields.Length; index++)
+        {
+            var field = _fields[index];
+            var mark = path.Length;
+            path.AppendField(field.Field.Name);
+            var fieldStart = reader.Position;
+            var preview = reader;
+            var value = AvroValidationValueDecoder.Read(field.Field.Schema, ref preview);
+            var payload = preview.Source.Slice(fieldStart, preview.Position - fieldStart);
+            if (!field.Rules.IsEmpty)
+            {
+                field.Rules.Evaluate(
+                    value,
+                    payload,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path,
+                    value.SizeIndex == 0
+                        ? AvroValidationValueDecoder.Count(field.Field.Schema, payload)
+                        : -1);
+            }
+
+            if (!(failFast && violations is not null))
+            {
+                _ = field.Child.Validate(
+                    ref reader,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path);
+            }
+            else
+            {
+                reader = preview;
+            }
+            path.Truncate(mark);
+            if (failFast && violations is not null)
+            {
+                for (var remaining = index + 1; remaining < _fields.Length; remaining++)
+                    AvroValidationValueDecoder.Skip(_fields[remaining].Field.Schema, ref reader);
+                return;
+            }
+        }
+    }
+
+    private void ValidateUnion(
+        ref AvroValidationReader reader,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path)
+    {
+        var union = (global::Avro.UnionSchema)_schema;
+        var branch = reader.ReadLong();
+        if ((ulong)branch >= (ulong)union.Count)
+            throw InvalidPayload($"invalid union index {branch}");
+        _ = _children[(int)branch].Validate(
+            ref reader,
+            now,
+            failFast,
+            ref violations,
+            ref path);
+    }
+
+    private void ValidateArray(
+        ref AvroValidationReader reader,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path)
+    {
+        var item = _children[0];
+        var itemIndex = 0;
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return;
+            for (long index = 0; index < count; index++)
+            {
+                var mark = path.Length;
+                path.AppendIndex(itemIndex++);
+                _ = item.Validate(ref reader, now, failFast, ref violations, ref path);
+                path.Truncate(mark);
+                if (failFast && violations is not null)
+                {
+                    for (var remaining = index + 1; remaining < count; remaining++)
+                        AvroValidationValueDecoder.Skip(item._schema, ref reader);
+                    SkipRemainingCollection(item._schema, ref reader);
+                    return;
+                }
+            }
+        }
+    }
+
+    private void ValidateMap(
+        ref AvroValidationReader reader,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path)
+    {
+        var valuePlan = _children[0];
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return;
+            for (long index = 0; index < count; index++)
+            {
+                var key = reader.ReadLengthPrefixed();
+                var mark = path.Length;
+                path.AppendMapKey(key.Span);
+                _ = valuePlan.Validate(ref reader, now, failFast, ref violations, ref path);
+                path.Truncate(mark);
+                if (failFast && violations is not null)
+                {
+                    for (var remaining = index + 1; remaining < count; remaining++)
+                    {
+                        _ = reader.ReadLengthPrefixed();
+                        AvroValidationValueDecoder.Skip(valuePlan._schema, ref reader);
+                    }
+                    SkipRemainingMap(valuePlan._schema, ref reader);
+                    return;
+                }
+            }
+        }
+    }
+
+    private static void SkipRemainingCollection(AvroSchema item, ref AvroValidationReader reader)
+    {
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return;
+            for (long index = 0; index < count; index++)
+                AvroValidationValueDecoder.Skip(item, ref reader);
+        }
+    }
+
+    private static void SkipRemainingMap(AvroSchema value, ref AvroValidationReader reader)
+    {
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return;
+            for (long index = 0; index < count; index++)
+            {
+                _ = reader.ReadLengthPrefixed();
+                AvroValidationValueDecoder.Skip(value, ref reader);
+            }
+        }
+    }
+
+    internal static AvroSchema Unwrap(AvroSchema schema) =>
+        schema is global::Avro.LogicalSchema logical ? logical.BaseSchema : schema;
+
+    internal static global::Avro.RecordSchema? FindRecord(AvroSchema schema)
+    {
+        schema = Unwrap(schema);
+        if (schema is global::Avro.RecordSchema record)
+            return record;
+        if (schema is not global::Avro.UnionSchema union)
+            return null;
+        global::Avro.RecordSchema? result = null;
+        for (var index = 0; index < union.Count; index++)
+        {
+            var candidate = FindRecord(union[index]);
+            if (candidate is null)
+                continue;
+            if (result is not null && !ReferenceEquals(result, candidate))
+                return null;
+            result = candidate;
+        }
+        return result;
+    }
+
+    private static SchemaRegistryRuleException InvalidPayload(string reason) =>
+        new($"Could not evaluate Avro validation rules: {reason}.");
+}
+
+internal sealed record AvroFieldRulePlan(
+    global::Avro.Field Field,
+    AvroCompiledRuleSet Rules,
+    AvroValueRulePlan Child);
+
+internal sealed class AvroCompiledRuleSet
+{
+    internal static AvroCompiledRuleSet Empty { get; } = new([], null, false, false, 0);
+
+    private readonly CompiledValidationRule[] _rules;
+    private readonly AvroMemberResolver? _members;
+    private readonly bool _usesCachedEquality;
+    private readonly int _memberCount;
+
+    private AvroCompiledRuleSet(
+        CompiledValidationRule[] rules,
+        AvroMemberResolver? members,
+        bool usesSize,
+        bool usesCachedEquality,
+        int memberCount)
+    {
+        _rules = rules;
+        _members = members;
+        UsesSize = usesSize;
+        _usesCachedEquality = usesCachedEquality;
+        _memberCount = memberCount;
+    }
+
+    internal bool IsEmpty => _rules.Length == 0;
+    internal bool UsesSize { get; }
+
+    internal static AvroCompiledRuleSet Compile(
+        IReadOnlyList<ValidationRule> rules,
+        global::Avro.RecordSchema? valueSchema)
+    {
+        if (rules.Count == 0)
+            return Empty;
+
+        var memberIndexes = new Dictionary<string, int>(StringComparer.Ordinal);
+        var memberPaths = new List<byte[][]>();
+        var usedMemberIndexes = new HashSet<int>();
+        var compiled = new CompiledValidationRule[rules.Count];
+        var usesSize = false;
+        var usesCachedEquality = false;
+        for (var index = 0; index < rules.Count; index++)
+        {
+            var rule = CompiledValidationRule.Compile(
+                rules[index],
+                memberIndexes,
+                memberPaths,
+                usedMemberIndexes);
+            compiled[index] = rule;
+            usesSize |= rule.UsesSize;
+            usesCachedEquality |= rule.UsesCachedEquality;
+        }
+
+        var members = usedMemberIndexes.Count == 0 || valueSchema is null
+            ? null
+            : AvroMemberResolver.Create(valueSchema, memberPaths, usedMemberIndexes);
+        return new AvroCompiledRuleSet(
+            compiled,
+            members,
+            usesSize,
+            usesCachedEquality,
+            memberPaths.Count);
+    }
+
+    internal void Evaluate(
+        ValidationCelValue value,
+        ReadOnlyMemory<byte> payload,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path,
+        int rootSize = -1)
+    {
+        var memberValues = _memberCount == 0
+            ? default
+            : CompiledValidationRule.GetMemberValues(_memberCount);
+        var sizes = UsesSize || _members is not null
+            ? CompiledValidationRule.GetSizeValues(_memberCount + 1)
+            : default;
+        if (rootSize >= 0)
+            sizes.Set(0, rootSize);
+        _members?.Resolve(payload, memberValues, sizes);
+        var equalityGeneration = _usesCachedEquality
+            ? CompiledValidationRule.BeginEqualityResolution()
+            : 0;
+
+        ValidationCelStrings.Begin(_memberCount + 1, payload.Length);
+        try
+        {
+            for (var index = 0; index < _rules.Length; index++)
+            {
+                var rule = _rules[index];
+                try
+                {
+                    var result = rule.Evaluate(value, now, memberValues, sizes, equalityGeneration);
+                    if (result.Kind == ValidationResultKind.Boolean ? result.Boolean : result.String!.Length == 0)
+                        continue;
+                    (violations ??= []).Add(new ValidationRuleError(
+                        rule.Rule,
+                        path.ToString(),
+                        result.Kind == ValidationResultKind.String ? result.String : null));
+                }
+                catch (SchemaRegistryRuleException exception)
+                {
+                    (violations ??= []).Add(new ValidationRuleError(
+                        rule.Rule,
+                        path.ToString(),
+                        cause: exception));
+                }
+
+                if (failFast)
+                    return;
+            }
+        }
+        finally
+        {
+            ValidationCelStrings.End();
+        }
+    }
+}
+
+internal sealed class AvroMemberResolver
+{
+    private readonly AvroMemberNode?[] _fields;
+
+    private AvroMemberResolver(global::Avro.RecordSchema schema) =>
+        _fields = new AvroMemberNode?[schema.Fields.Count];
+
+    internal static AvroMemberResolver Create(
+        global::Avro.RecordSchema schema,
+        IReadOnlyList<byte[][]> paths,
+        IReadOnlyCollection<int> usedIndexes)
+    {
+        var resolver = new AvroMemberResolver(schema);
+        resolver.SetSchemas(schema);
+        foreach (var memberIndex in usedIndexes)
+            resolver.Add(schema, paths[memberIndex], memberIndex, depth: 0);
+        return resolver;
+    }
+
+    private void Add(
+        global::Avro.RecordSchema schema,
+        byte[][] path,
+        int memberIndex,
+        int depth)
+    {
+        var name = Encoding.UTF8.GetString(path[depth]);
+        var field = FindField(schema, name)
+            ?? throw new SchemaRegistryRuleException(
+                $"Avro validation rule refers to unknown field '{name}' on '{schema.Fullname}'.");
+        var node = _fields[field.Pos] ??= new AvroMemberNode();
+        if (depth == path.Length - 1)
+        {
+            node.MemberIndex = memberIndex;
+            return;
+        }
+        node.AddChild(field.Schema, path, memberIndex, depth + 1);
+    }
+
+    internal void Resolve(
+        ReadOnlyMemory<byte> payload,
+        ValidationCelMemberValues values,
+        ValidationCelSizeValues sizes)
+    {
+        var reader = new AvroValidationReader(payload);
+        for (var index = 0; index < _fields.Length; index++)
+        {
+            var node = _fields[index];
+            var schema = node?.Schema;
+            if (schema is null)
+                throw new InvalidOperationException("Avro validation member resolver is incomplete.");
+            if (node!.HasTargets)
+            {
+                var start = reader.Position;
+                AvroValidationValueDecoder.Skip(schema, ref reader);
+                node.Resolve(
+                    reader.Source.Slice(start, reader.Position - start),
+                    values,
+                    sizes);
+            }
+            else
+            {
+                AvroValidationValueDecoder.Skip(schema, ref reader);
+            }
+        }
+    }
+
+    private static global::Avro.Field? FindField(global::Avro.RecordSchema schema, string name)
+    {
+        for (var index = 0; index < schema.Fields.Count; index++)
+        {
+            var field = schema.Fields[index];
+            if (string.Equals(field.Name, name, StringComparison.Ordinal))
+                return field;
+            var aliases = field.Aliases;
+            if (aliases is null)
+                continue;
+            for (var aliasIndex = 0; aliasIndex < aliases.Count; aliasIndex++)
+            {
+                if (string.Equals(aliases[aliasIndex], name, StringComparison.Ordinal))
+                    return field;
+            }
+        }
+        return null;
+    }
+
+    internal void SetSchemas(global::Avro.RecordSchema schema)
+    {
+        for (var index = 0; index < schema.Fields.Count; index++)
+            (_fields[index] ??= new AvroMemberNode()).Schema = schema.Fields[index].Schema;
+    }
+
+    private sealed class AvroMemberNode
+    {
+        private readonly Dictionary<AvroSchema, AvroMemberResolver> _children =
+            new(AvroSchemaReferenceComparer.Instance);
+
+        internal AvroSchema? Schema { get; set; }
+        internal int MemberIndex { get; set; } = -1;
+        internal bool HasTargets => MemberIndex >= 0 || _children.Count != 0;
+
+        internal void AddChild(
+            AvroSchema schema,
+            byte[][] path,
+            int memberIndex,
+            int depth)
+        {
+            schema = AvroValueRulePlan.Unwrap(schema);
+            if (schema is global::Avro.UnionSchema union)
+            {
+                var found = false;
+                var nextName = Encoding.UTF8.GetString(path[depth]);
+                for (var index = 0; index < union.Count; index++)
+                {
+                    if (AvroValueRulePlan.Unwrap(union[index]) is not global::Avro.RecordSchema branch)
+                        continue;
+                    if (FindField(branch, nextName) is null)
+                        continue;
+                    AddRecordChild(branch, path, memberIndex, depth);
+                    found = true;
+                }
+                if (found)
+                    return;
+            }
+            else if (schema is global::Avro.RecordSchema record)
+            {
+                AddRecordChild(record, path, memberIndex, depth);
+                return;
+            }
+
+            throw new SchemaRegistryRuleException(
+                "Avro validation member path can only descend through records or record unions.");
+        }
+
+        private void AddRecordChild(
+            global::Avro.RecordSchema record,
+            byte[][] path,
+            int memberIndex,
+            int depth)
+        {
+            if (!_children.TryGetValue(record, out var child))
+            {
+                child = new AvroMemberResolver(record);
+                child.SetSchemas(record);
+                _children.Add(record, child);
+            }
+            child.Add(record, path, memberIndex, depth);
+        }
+
+        internal void Resolve(
+            ReadOnlyMemory<byte> payload,
+            ValidationCelMemberValues values,
+            ValidationCelSizeValues sizes)
+        {
+            var schema = Schema!;
+            if (MemberIndex >= 0)
+            {
+                var valueReader = new AvroValidationReader(payload);
+                var value = AvroValidationValueDecoder.Read(schema, ref valueReader);
+                if (value.SizeIndex == 0)
+                {
+                    var sizeIndex = MemberIndex + 1;
+                    sizes.Set(sizeIndex, AvroValidationValueDecoder.Count(schema, payload));
+                    value = value with { SizeIndex = sizeIndex };
+                }
+                values.SetValue(MemberIndex, value);
+            }
+
+            if (_children.Count == 0)
+                return;
+            var childReader = new AvroValidationReader(payload);
+            schema = AvroValueRulePlan.Unwrap(schema);
+            if (schema is global::Avro.UnionSchema union)
+            {
+                var branch = childReader.ReadLong();
+                if ((ulong)branch >= (ulong)union.Count)
+                    throw new SchemaRegistryRuleException(
+                        $"Could not evaluate Avro validation rules: invalid union index {branch}.");
+                schema = AvroValueRulePlan.Unwrap(union[(int)branch]);
+            }
+            if (schema is global::Avro.RecordSchema record && _children.TryGetValue(record, out var child))
+            {
+                child.Resolve(
+                    childReader.Source.Slice(childReader.Position),
+                    values,
+                    sizes);
+            }
+        }
+    }
+}
+
+internal static class AvroInlineRuleParser
+{
+    internal static IReadOnlyList<ValidationRule> ReadRules(AvroSchema schema) =>
+        ReadRules(schema.GetProperty("confluent:rules"), "schema");
+
+    internal static IReadOnlyList<ValidationRule> ReadRules(global::Avro.Field field) =>
+        ReadRules(field.GetProperty("confluent:rules"), $"field '{field.Name}'");
+
+    private static IReadOnlyList<ValidationRule> ReadRules(string? json, string owner)
+    {
+        if (string.IsNullOrEmpty(json))
+            return [];
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            if (document.RootElement.ValueKind != JsonValueKind.Array)
+                throw InvalidDeclaration($"Avro {owner} 'confluent:rules' must be an array");
+            var rules = new List<ValidationRule>();
+            foreach (var element in document.RootElement.EnumerateArray())
+            {
+                if (element.ValueKind != JsonValueKind.Object)
+                    throw InvalidDeclaration($"Avro {owner} 'confluent:rules' entries must be objects");
+                rules.Add(new ValidationRule
+                {
+                    Name = GetOptionalString(element, "name"),
+                    Doc = GetOptionalString(element, "doc"),
+                    Expr = GetOptionalString(element, "expr"),
+                    Sql = GetOptionalString(element, "sql")
+                });
+            }
+            return rules;
+        }
+        catch (JsonException exception)
+        {
+            throw new SchemaRegistryRuleException(
+                $"Could not parse Avro {owner} 'confluent:rules'.",
+                exception);
+        }
+    }
+
+    private static string? GetOptionalString(JsonElement owner, string name) =>
+        owner.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static SchemaRegistryRuleException InvalidDeclaration(string message) => new(message + ".");
+}
+
+internal ref struct AvroValidationReader(ReadOnlyMemory<byte> source)
+{
+    internal ReadOnlyMemory<byte> Source { get; } = source;
+    internal int Position { get; private set; }
+    internal bool End => Position == Source.Length;
+
+    internal ReadOnlyMemory<byte> Read(int length)
+    {
+        if (length < 0 || length > Source.Length - Position)
+            throw InvalidPayload("payload ended before the value completed");
+        var result = Source.Slice(Position, length);
+        Position += length;
+        return result;
+    }
+
+    internal long ReadLong()
+    {
+        ulong encoded = 0;
+        for (var shift = 0; shift < 70; shift += 7)
+        {
+            if (Position >= Source.Length)
+                throw InvalidPayload("payload ended inside a variable-length integer");
+            var current = Source.Span[Position++];
+            if (shift == 63 && current > 1)
+                throw InvalidPayload("variable-length integer is invalid");
+            encoded |= (ulong)(current & 0x7f) << shift;
+            if ((current & 0x80) == 0)
+                return (long)(encoded >> 1) ^ -((long)encoded & 1);
+        }
+        throw InvalidPayload("variable-length integer is invalid");
+    }
+
+    internal int ReadLength()
+    {
+        var length = ReadLong();
+        if ((ulong)length > int.MaxValue)
+            throw InvalidPayload($"length {length} is invalid");
+        return (int)length;
+    }
+
+    internal ReadOnlyMemory<byte> ReadLengthPrefixed() => Read(ReadLength());
+
+    internal long ReadCollectionCount()
+    {
+        var count = ReadLong();
+        if (count >= 0)
+            return count;
+        if (count == long.MinValue)
+            throw InvalidPayload("collection block count is invalid");
+        count = -count;
+        var byteCount = ReadLong();
+        if (byteCount < 0 || byteCount > Source.Length - Position)
+            throw InvalidPayload("collection block byte count is invalid");
+        return count;
+    }
+
+    private static SchemaRegistryRuleException InvalidPayload(string reason) =>
+        new($"Could not evaluate Avro validation rules: {reason}.");
+}
+
+internal static class AvroValidationValueDecoder
+{
+    internal static ValidationCelValue Read(AvroSchema schema, ref AvroValidationReader reader)
+    {
+        schema = AvroValueRulePlan.Unwrap(schema);
+        switch (schema.Tag)
+        {
+            case AvroSchema.Type.Null:
+                return ValidationCelValue.Null;
+            case AvroSchema.Type.Boolean:
+                return ValidationCelValue.FromBoolean(reader.Read(1).Span[0] != 0);
+            case AvroSchema.Type.Int:
+            case AvroSchema.Type.Long:
+            case AvroSchema.Type.Enumeration:
+                return ValidationCelValue.FromNumber(reader.ReadLong());
+            case AvroSchema.Type.Float:
+                return ValidationCelValue.FromFloating(
+                    BinaryPrimitives.ReadSingleLittleEndian(reader.Read(sizeof(float)).Span));
+            case AvroSchema.Type.Double:
+                return ValidationCelValue.FromFloating(
+                    BinaryPrimitives.ReadDoubleLittleEndian(reader.Read(sizeof(double)).Span));
+            case AvroSchema.Type.String:
+                return ValidationCelValue.FromUtf8String(reader.ReadLengthPrefixed());
+            case AvroSchema.Type.Bytes:
+                return ValidationCelValue.FromBytes(reader.ReadLengthPrefixed());
+            case AvroSchema.Type.Fixed:
+                return ValidationCelValue.FromBytes(reader.Read(((global::Avro.FixedSchema)schema).Size));
+            case AvroSchema.Type.Record:
+            case AvroSchema.Type.Error:
+                var recordStart = reader.Position;
+                var record = (global::Avro.RecordSchema)schema;
+                for (var index = 0; index < record.Fields.Count; index++)
+                    Skip(record.Fields[index].Schema, ref reader);
+                return new ValidationCelValue(
+                    ValidationCelValueKind.Object,
+                    default,
+                    false,
+                    0,
+                    null,
+                    reader.Source.Slice(recordStart, reader.Position - recordStart));
+            case AvroSchema.Type.Array:
+                SkipCollection(((global::Avro.ArraySchema)schema).ItemSchema, isMap: false, ref reader);
+                return ValidationCelValue.FromCollection(ValidationCelValueKind.Array, 0);
+            case AvroSchema.Type.Map:
+                SkipCollection(((global::Avro.MapSchema)schema).ValueSchema, isMap: true, ref reader);
+                return ValidationCelValue.FromCollection(ValidationCelValueKind.Object, 0);
+            case AvroSchema.Type.Union:
+                var union = (global::Avro.UnionSchema)schema;
+                var branch = reader.ReadLong();
+                if ((ulong)branch >= (ulong)union.Count)
+                    throw InvalidPayload($"invalid union index {branch}");
+                return Read(union[(int)branch], ref reader);
+            default:
+                throw InvalidPayload($"unsupported schema type {schema.Tag}");
+        }
+    }
+
+    internal static void Skip(AvroSchema schema, ref AvroValidationReader reader) =>
+        _ = Read(schema, ref reader);
+
+    internal static int Count(AvroSchema schema, ReadOnlyMemory<byte> payload)
+    {
+        schema = AvroValueRulePlan.Unwrap(schema);
+        if (schema is not (global::Avro.ArraySchema or global::Avro.MapSchema))
+            return -1;
+        var reader = new AvroValidationReader(payload);
+        var count = 0L;
+        while (true)
+        {
+            var blockCount = reader.ReadCollectionCount();
+            if (blockCount == 0)
+                return checked((int)count);
+            count = checked(count + blockCount);
+            for (long index = 0; index < blockCount; index++)
+            {
+                if (schema is global::Avro.MapSchema map)
+                {
+                    _ = reader.ReadLengthPrefixed();
+                    Skip(map.ValueSchema, ref reader);
+                }
+                else
+                {
+                    Skip(((global::Avro.ArraySchema)schema).ItemSchema, ref reader);
+                }
+            }
+        }
+    }
+
+    private static void SkipCollection(
+        AvroSchema valueSchema,
+        bool isMap,
+        ref AvroValidationReader reader)
+    {
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return;
+            for (long index = 0; index < count; index++)
+            {
+                if (isMap)
+                    _ = reader.ReadLengthPrefixed();
+                Skip(valueSchema, ref reader);
+            }
+        }
+    }
+
+    private static SchemaRegistryRuleException InvalidPayload(string reason) =>
+        new($"Could not evaluate Avro validation rules: {reason}.");
+}
+
+internal ref struct AvroValidationPath
+{
+    private Span<char> _buffer;
+    private char[]? _rented;
+
+    internal AvroValidationPath(Span<char> initialBuffer)
+    {
+        _buffer = initialBuffer;
+        _rented = null;
+        _buffer[0] = '$';
+        Length = 1;
+    }
+
+    internal int Length { get; private set; }
+
+    internal void AppendField(string name)
+    {
+        EnsureCapacity(name.Length + (Length == 0 ? 0 : 1));
+        if (Length != 0)
+            _buffer[Length++] = '.';
+        name.AsSpan().CopyTo(_buffer[Length..]);
+        Length += name.Length;
+    }
+
+    internal void AppendIndex(int index)
+    {
+        Span<char> digits = stackalloc char[11];
+        if (!index.TryFormat(digits, out var written, provider: CultureInfo.InvariantCulture))
+            throw new InvalidOperationException("Could not format Avro validation path index.");
+        EnsureCapacity(written + 2);
+        _buffer[Length++] = '[';
+        digits[..written].CopyTo(_buffer[Length..]);
+        Length += written;
+        _buffer[Length++] = ']';
+    }
+
+    internal void AppendMapKey(ReadOnlySpan<byte> utf8)
+    {
+        var characterCount = Encoding.UTF8.GetCharCount(utf8);
+        EnsureCapacity(checked(characterCount * 2 + 4));
+        _buffer[Length++] = '[';
+        _buffer[Length++] = '"';
+        var start = Length;
+        var decoded = Encoding.UTF8.GetChars(utf8, _buffer[start..]);
+        var escapes = 0;
+        for (var index = 0; index < decoded; index++)
+        {
+            if (_buffer[start + index] is '"' or '\\')
+                escapes++;
+        }
+        var source = start + decoded - 1;
+        var destination = start + decoded + escapes - 1;
+        while (source >= start)
+        {
+            var character = _buffer[source--];
+            _buffer[destination--] = character;
+            if (character is '"' or '\\')
+                _buffer[destination--] = '\\';
+        }
+        Length = start + decoded + escapes;
+        _buffer[Length++] = '"';
+        _buffer[Length++] = ']';
+    }
+
+    internal void Truncate(int length) => Length = length;
+    public override string ToString() => new(_buffer[..Length]);
+
+    internal void Dispose()
+    {
+        if (_rented is not null)
+            ArrayPool<char>.Shared.Return(_rented);
+        _rented = null;
+        _buffer = default;
+    }
+
+    private void EnsureCapacity(int additional)
+    {
+        var required = checked(Length + additional);
+        if (required <= _buffer.Length)
+            return;
+        var replacement = ArrayPool<char>.Shared.Rent(Math.Max(required, _buffer.Length * 2));
+        _buffer[..Length].CopyTo(replacement);
+        if (_rented is not null)
+            ArrayPool<char>.Shared.Return(_rented);
+        _rented = replacement;
+        _buffer = replacement;
+    }
+}

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -2581,7 +2581,12 @@ internal ref struct AvroValidationPath
     internal void AppendMapKey(ReadOnlySpan<byte> utf8)
     {
         var characterCount = Encoding.UTF8.GetCharCount(utf8);
-        EnsureCapacity(checked(characterCount * 2 + 4));
+        if (characterCount > (int.MaxValue - 4) / 2)
+        {
+            throw new SchemaRegistryRuleException(
+                "Could not evaluate Avro validation rules: map key is too large.");
+        }
+        EnsureCapacity(characterCount * 2 + 4);
         _buffer[Length++] = '[';
         _buffer[Length++] = '"';
         var start = Length;

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -73,6 +73,7 @@ internal sealed class AvroValueRulePlan
     private readonly AvroSchema _schema;
     private readonly AvroSchema _ruleSchema;
     private readonly ReadOnlyMemory<byte>[]? _enumSymbols;
+    private readonly bool _requiresBoundedValueDecoding;
     private readonly bool _requiresValidationDepthGuard;
     private AvroCompiledRuleSet _schemaRules = AvroCompiledRuleSet.Empty;
     private AvroFieldRulePlan[] _fields = [];
@@ -86,9 +87,10 @@ internal sealed class AvroValueRulePlan
         _schema = Unwrap(schema);
         _ruleSchema = schema;
         _enumSymbols = AvroValidationValueDecoder.EncodeEnumSymbols(_schema);
+        _requiresBoundedValueDecoding = AvroAggregateEqualityComparer.IsRecursive(_schema);
         _requiresValidationDepthGuard =
             _schema is global::Avro.RecordSchema &&
-            AvroAggregateEqualityComparer.IsRecursive(_schema);
+            _requiresBoundedValueDecoding;
     }
 
     internal bool HasAnyRules { get; private set; }
@@ -240,7 +242,11 @@ internal sealed class AvroValueRulePlan
         scoped ref AvroValidationPath path)
     {
         if (!HasAnyRules)
-            return ReadValue(ref reader);
+            return ReadRuleValue(
+                ref reader,
+                path.RemainingValidationDepth,
+                needsSize: false,
+                out _);
 
         // Keep the non-recursive dispatch inline: routing it through ValidateCore regresses
         // warmed validation. Recursive schemas alone pay for the guarded helper call.
@@ -302,11 +308,12 @@ internal sealed class AvroValueRulePlan
             preview = reader;
             if (_schemaRules.UsesRootValue)
             {
-                value = ReadValue(ref preview);
+                value = ReadRuleValue(
+                    ref preview,
+                    path.RemainingValidationDepth,
+                    _schemaRules.UsesRootSize,
+                    out var rootSize);
                 var payload = preview.Source.Slice(start, preview.Position - start);
-                var rootSize = value.SizeIndex == 0 && _schemaRules.UsesRootSize
-                    ? AvroValidationValueDecoder.Count(_schema, payload)
-                    : -1;
                 _schemaRules.Evaluate(
                     value,
                     payload,
@@ -320,7 +327,8 @@ internal sealed class AvroValueRulePlan
             {
                 _schemaRules.EvaluateWithoutRoot(
                     ref preview,
-                    _schema,
+                    this,
+                    path.RemainingValidationDepth,
                     now,
                     failFast,
                     ref violations,
@@ -352,9 +360,13 @@ internal sealed class AvroValueRulePlan
             case global::Avro.UnionSchema:
                 ValidateUnion(ref reader, now, failFast, ref violations, ref path);
                 break;
-            default:
-                if (_schemaRules.IsEmpty)
-                    value = ReadValue(ref reader);
+                default:
+                    if (_schemaRules.IsEmpty)
+                    value = ReadRuleValue(
+                        ref reader,
+                        path.RemainingValidationDepth,
+                        needsSize: false,
+                        out _);
                 else
                     reader = preview;
                 break;
@@ -437,11 +449,13 @@ internal sealed class AvroValueRulePlan
             preview = reader;
             if (_schemaRules.UsesRootValue)
             {
-                value = ReadValue(ref preview);
+                var valueDecodingDepth = CurrentValueDecodingDepth(ref path);
+                value = ReadRuleValue(
+                    ref preview,
+                    valueDecodingDepth,
+                    _schemaRules.UsesRootSize,
+                    out var rootSize);
                 var payload = preview.Source.Slice(start, preview.Position - start);
-                var rootSize = value.SizeIndex == 0 && _schemaRules.UsesRootSize
-                    ? AvroValidationValueDecoder.Count(_schema, payload)
-                    : -1;
                 _schemaRules.Evaluate(
                     value,
                     payload,
@@ -455,7 +469,8 @@ internal sealed class AvroValueRulePlan
             {
                 _schemaRules.EvaluateWithoutRoot(
                     ref preview,
-                    _schema,
+                    this,
+                    CurrentValueDecodingDepth(ref path),
                     now,
                     failFast,
                     ref violations,
@@ -489,7 +504,11 @@ internal sealed class AvroValueRulePlan
                 break;
             default:
                 if (_schemaRules.IsEmpty)
-                    value = ReadValue(ref reader);
+                    value = ReadRuleValue(
+                        ref reader,
+                        CurrentValueDecodingDepth(ref path),
+                        needsSize: false,
+                        out _);
                 else
                     reader = preview;
                 break;
@@ -614,7 +633,12 @@ internal sealed class AvroValueRulePlan
             int size;
             if (failFast && nestedViolations is not null)
             {
-                value = CaptureRecordField(field, ref reader, needsSize, out size);
+                value = CaptureRecordField(
+                    field,
+                    ref reader,
+                    path.RemainingValidationDepth,
+                    needsSize,
+                    out size);
             }
             else
             {
@@ -804,9 +828,9 @@ internal sealed class AvroValueRulePlan
             ref violations,
             ref path);
         size = needsSize && value.SizeIndex == 0
-            ? AvroValidationValueDecoder.Count(
-                _schema,
-                reader.Source.Slice(valueStart, reader.Position - valueStart))
+            ? CountValue(
+                reader.Source.Slice(valueStart, reader.Position - valueStart),
+                CurrentValueDecodingDepth(ref path))
             : -1;
         return value;
     }
@@ -821,7 +845,11 @@ internal sealed class AvroValueRulePlan
     {
         var start = reader.Position;
         var preview = reader;
-        var value = ReadValue(ref preview, needsSize: true, out size);
+        var value = ReadRuleValue(
+            ref preview,
+            CurrentValueDecodingDepth(ref path),
+            needsSize: true,
+            out size);
         var payload = preview.Source.Slice(start, preview.Position - start);
         _schemaRules.Evaluate(
             value,
@@ -1172,7 +1200,14 @@ Deferred:
             ValidationCelValue value;
             int size;
             if (failFast && nestedViolations is not null)
-                value = CaptureRecordField(field, ref reader, needsSize, out size);
+            {
+                value = CaptureRecordField(
+                    field,
+                    ref reader,
+                    path.RemainingValidationDepth,
+                    needsSize,
+                    out size);
+            }
             else
                 value = ValidateRecordFieldAndCapture(
                     field,
@@ -1211,7 +1246,14 @@ Deferred:
             ValidationCelValue value;
             int size;
             if (failFast && nestedViolations is not null)
-                value = CaptureRecordField(field, ref reader, needsSize, out size);
+            {
+                value = CaptureRecordField(
+                    field,
+                    ref reader,
+                    path.RemainingValidationDepth,
+                    needsSize,
+                    out size);
+            }
             else if (field.Rules.IsEmpty && fieldResolver.HasChildren)
             {
                 var mark = path.Length;
@@ -1274,7 +1316,7 @@ Deferred:
                 var valueStart = reader.Position;
                 if (failFast && nestedViolations is not null)
                 {
-                    AvroValidationValueDecoder.Skip(valuePlan._schema, ref reader);
+                    valuePlan.SkipValue(ref reader, path.RemainingValidationDepth);
                     valueResolver?.Resolve(
                         reader.Source.Slice(valueStart, reader.Position - valueStart),
                         resolution.Members,
@@ -1478,7 +1520,7 @@ Deferred:
                 var valueStart = reader.Position;
                 if (nestedViolations is not null)
                 {
-                    AvroValidationValueDecoder.Skip(valuePlan._schema, ref reader);
+                    valuePlan.SkipValue(ref reader, path.RemainingValidationDepth);
                     ResolveMapEntry(
                         hasSizeDemand,
                         key,
@@ -1624,7 +1666,11 @@ Deferred:
             {
                 var fieldStart = reader.Position;
                 var preview = reader;
-                var value = field.Child.ReadValue(ref preview);
+                var value = field.Child.ReadRuleValue(
+                    ref preview,
+                    path.RemainingValidationDepth,
+                    field.Rules.UsesRootSize,
+                    out var rootSize);
                 var payload = preview.Source.Slice(fieldStart, preview.Position - fieldStart);
                 field.Rules.Evaluate(
                     value,
@@ -1633,9 +1679,7 @@ Deferred:
                     failFast,
                     ref violations,
                     ref path,
-                    value.SizeIndex == 0 && field.Rules.UsesRootSize
-                        ? AvroValidationValueDecoder.Count(field.Field.Schema, payload)
-                        : -1);
+                    rootSize);
 
                 if ((failFast && violations is not null) || !field.Child.HasAnyRules)
                     reader = preview;
@@ -1646,7 +1690,11 @@ Deferred:
             if (failFast && violations is not null)
             {
                 for (var remaining = index + 1; remaining < _fields.Length; remaining++)
-                    AvroValidationValueDecoder.Skip(_fields[remaining].Field.Schema, ref reader);
+                {
+                    _fields[remaining].Child.SkipValue(
+                        ref reader,
+                        path.RemainingValidationDepth);
+                }
                 return;
             }
         }
@@ -1695,9 +1743,12 @@ Deferred:
                 {
                     var remainingInBlock = count - index - 1;
                     for (long remaining = 0; remaining < remainingInBlock; remaining++)
-                        AvroValidationValueDecoder.Skip(item._schema, ref reader);
+                        item.SkipValue(ref reader, path.RemainingValidationDepth);
                     itemIndex = checked(itemIndex + (int)remainingInBlock +
-                        SkipRemainingCollection(item._schema, ref reader));
+                        SkipRemainingCollection(
+                            item,
+                            ref reader,
+                            path.RemainingValidationDepth));
                     return itemIndex;
                 }
             }
@@ -1732,17 +1783,23 @@ Deferred:
                     for (long remaining = 0; remaining < remainingInBlock; remaining++)
                     {
                         _ = reader.ReadLengthPrefixed();
-                        AvroValidationValueDecoder.Skip(valuePlan._schema, ref reader);
+                        valuePlan.SkipValue(ref reader, path.RemainingValidationDepth);
                     }
                     itemCount = checked(itemCount + (int)remainingInBlock +
-                        SkipRemainingMap(valuePlan._schema, ref reader));
+                        SkipRemainingMap(
+                            valuePlan,
+                            ref reader,
+                            path.RemainingValidationDepth));
                     return itemCount;
                 }
             }
         }
     }
 
-    private static int SkipRemainingCollection(AvroSchema item, ref AvroValidationReader reader)
+    private static int SkipRemainingCollection(
+        AvroValueRulePlan item,
+        ref AvroValidationReader reader,
+        int remainingValidationDepth)
     {
         var itemCount = 0;
         while (true)
@@ -1752,11 +1809,14 @@ Deferred:
                 return itemCount;
             itemCount = checked(itemCount + (int)count);
             for (long index = 0; index < count; index++)
-                AvroValidationValueDecoder.Skip(item, ref reader);
+                item.SkipValue(ref reader, remainingValidationDepth);
         }
     }
 
-    private static int SkipRemainingMap(AvroSchema value, ref AvroValidationReader reader)
+    private static int SkipRemainingMap(
+        AvroValueRulePlan value,
+        ref AvroValidationReader reader,
+        int remainingValidationDepth)
     {
         var itemCount = 0;
         while (true)
@@ -1768,7 +1828,7 @@ Deferred:
             for (long index = 0; index < count; index++)
             {
                 _ = reader.ReadLengthPrefixed();
-                AvroValidationValueDecoder.Skip(value, ref reader);
+                value.SkipValue(ref reader, remainingValidationDepth);
             }
         }
     }
@@ -1798,7 +1858,7 @@ Deferred:
             }
             if (failFast && violations is not null)
             {
-                AvroValidationValueDecoder.Skip(_schema, ref reader);
+                SkipValue(ref reader, CurrentValueDecodingDepth(ref path));
                 return ValidationCelValue.Missing;
             }
 
@@ -1822,6 +1882,7 @@ Deferred:
                     ref reader,
                     deferredIndexes,
                     offsets,
+                    path.RemainingValidationDepth,
                     resolution);
 
                 _schemaRules.EvaluateResolvedWithoutRoot(
@@ -1834,7 +1895,10 @@ Deferred:
             }
             if (failFast && violations is not null)
             {
-                SkipRecordFields(ref reader, lastMemberFieldIndex + 1);
+                SkipRecordFields(
+                    ref reader,
+                    lastMemberFieldIndex + 1,
+                    path.RemainingValidationDepth);
                 return ValidationCelValue.Missing;
             }
 
@@ -1853,7 +1917,10 @@ Deferred:
                     out _);
                 if (failFast && violations is not null)
                 {
-                    SkipRecordFields(ref reader, lastMemberFieldIndex + 1);
+                    SkipRecordFields(
+                        ref reader,
+                        lastMemberFieldIndex + 1,
+                        path.RemainingValidationDepth);
                     return ValidationCelValue.Missing;
                 }
             }
@@ -1874,7 +1941,10 @@ Deferred:
                     out _);
                 if (failFast && violations is not null)
                 {
-                    SkipRecordFields(ref reader, lastMemberFieldIndex + 1);
+                    SkipRecordFields(
+                        ref reader,
+                        lastMemberFieldIndex + 1,
+                        path.RemainingValidationDepth);
                     return ValidationCelValue.Missing;
                 }
             }
@@ -1892,7 +1962,10 @@ Deferred:
                     out _);
                 if (failFast && violations is not null)
                 {
-                    SkipRecordFields(ref reader, index + 1);
+                    SkipRecordFields(
+                        ref reader,
+                        index + 1,
+                        path.RemainingValidationDepth);
                     break;
                 }
             }
@@ -1905,10 +1978,13 @@ Deferred:
         }
     }
 
-    private void SkipRecordFields(ref AvroValidationReader reader, int startIndex)
+    private void SkipRecordFields(
+        ref AvroValidationReader reader,
+        int startIndex,
+        int remainingValidationDepth)
     {
         for (var index = startIndex; index < _fields.Length; index++)
-            AvroValidationValueDecoder.Skip(_fields[index].Field.Schema, ref reader);
+            _fields[index].Child.SkipValue(ref reader, remainingValidationDepth);
     }
 
     private static ValidationCelValue ValidateDeferredRecordField(
@@ -1944,8 +2020,9 @@ Deferred:
         {
             var fieldStart = reader.Position;
             var preview = reader;
-            value = field.Child.ReadValue(
+            value = field.Child.ReadRuleValue(
                 ref preview,
+                path.RemainingValidationDepth,
                 needsSize || field.Rules.UsesRootSize,
                 out size);
             var payload = preview.Source.Slice(fieldStart, preview.Position - fieldStart);
@@ -1984,29 +2061,76 @@ Deferred:
     private static ValidationCelValue CaptureRecordField(
         AvroFieldRulePlan field,
         ref AvroValidationReader reader,
+        int remainingValidationDepth,
         bool needsSize,
         out int size)
     {
-        return field.Child.ReadValue(ref reader, needsSize, out size);
+        return field.Child.ReadRuleValue(
+            ref reader,
+            remainingValidationDepth,
+            needsSize,
+            out size);
     }
 
-    private ValidationCelValue ReadValue(ref AvroValidationReader reader)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int CurrentValueDecodingDepth(scoped ref AvroValidationPath path) =>
+        path.RemainingValidationDepth + (_requiresValidationDepthGuard ? 1 : 0);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void SkipValue(ref AvroValidationReader reader, int remainingValidationDepth)
     {
-        return ReadValue(ref reader, needsSize: false, out _);
+        if (_requiresBoundedValueDecoding)
+        {
+            AvroValidationValueDecoder.SkipBounded(
+                _schema,
+                ref reader,
+                remainingValidationDepth);
+            return;
+        }
+        AvroValidationValueDecoder.Skip(_schema, ref reader);
     }
 
-    private ValidationCelValue ReadValue(
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int CountValue(ReadOnlyMemory<byte> payload, int remainingValidationDepth) =>
+        _requiresBoundedValueDecoding
+            ? AvroValidationValueDecoder.CountBounded(
+                _schema,
+                payload,
+                remainingValidationDepth)
+            : AvroValidationValueDecoder.Count(_schema, payload);
+
+    private ValidationCelValue ReadRuleValue(
         ref AvroValidationReader reader,
+        int remainingValidationDepth,
         bool needsSize,
         out int size)
     {
-        if (_schema is not global::Avro.UnionSchema union)
-            return AvroValidationValueDecoder.Read(_schema, _enumSymbols, ref reader, needsSize, out size);
+        if (_schema is global::Avro.UnionSchema union)
+        {
+            var branch = reader.ReadLong();
+            if ((ulong)branch >= (ulong)union.Count)
+                throw InvalidPayload($"invalid union index {branch}");
+            return _children[(int)branch].ReadRuleValue(
+                ref reader,
+                remainingValidationDepth,
+                needsSize,
+                out size);
+        }
 
-        var branch = reader.ReadLong();
-        if ((ulong)branch >= (ulong)union.Count)
-            throw InvalidPayload($"invalid union index {branch}");
-        return _children[(int)branch].ReadValue(ref reader, needsSize, out size);
+        return _requiresBoundedValueDecoding
+            ? AvroValidationValueDecoder.ReadBounded(
+                _schema,
+                _enumSymbols,
+                ref reader,
+                remainingValidationDepth,
+                needsSize,
+                out size)
+            : AvroValidationValueDecoder.Read(
+                _schema,
+                _enumSymbols,
+                ref reader,
+                needsSize,
+                out size);
     }
 
     internal static AvroSchema Unwrap(AvroSchema schema) =>
@@ -2299,7 +2423,8 @@ internal sealed class AvroCompiledRuleSet
 
     internal void EvaluateWithoutRoot(
         ref AvroValidationReader reader,
-        AvroSchema valueSchema,
+        AvroValueRulePlan valuePlan,
+        int remainingValidationDepth,
         long now,
         bool failFast,
         ref List<ValidationRuleError>? violations,
@@ -2308,9 +2433,15 @@ internal sealed class AvroCompiledRuleSet
         using var resolution = BeginMemberResolution();
         var start = reader.Position;
         if (_members is null)
-            AvroValidationValueDecoder.Skip(valueSchema, ref reader);
+            valuePlan.SkipValue(ref reader, remainingValidationDepth);
         else
-            _members.Resolve(ref reader, resolution.Members, resolution.Sizes);
+        {
+            _members.Resolve(
+                ref reader,
+                resolution.Members,
+                resolution.Sizes,
+                remainingValidationDepth);
+        }
 
         EvaluateResolvedWithoutRoot(
             resolution,
@@ -2403,12 +2534,14 @@ internal sealed class AvroCompiledRuleSet
         ref AvroValidationReader reader,
         int[] deferredFieldIndexes,
         scoped Span<int> deferredFieldOffsets,
+        int remainingValidationDepth,
         AvroMemberResolution resolution) =>
         _members!.ResolveRecordPrefix(
             ref reader,
             _lastRecordMemberIndex,
             deferredFieldIndexes,
             deferredFieldOffsets,
+            remainingValidationDepth,
             resolution.Members,
             resolution.Sizes);
 
@@ -2536,6 +2669,9 @@ internal sealed class AvroMemberResolver
     private readonly AvroMemberResolver?[]? _unionBranches;
     private readonly AvroMemberNode?[] _fields;
     private readonly Dictionary<ReadOnlyMemory<byte>, AvroMemberNode>? _mapValues;
+    private readonly bool _requiresValidationDepthGuard;
+    private readonly bool _requiresBoundedMapValueDecoding;
+    private readonly bool[]? _unionRequiresBoundedValueDecoding;
     private bool _hasMapEntrySizeDemand;
     private bool _hasDescendantTargets;
 
@@ -2562,6 +2698,7 @@ internal sealed class AvroMemberResolver
         _valueSchema = recordSchema;
         _aggregateComparerFactory = aggregateComparerFactory;
         _fields = new AvroMemberNode?[recordSchema.Fields.Count];
+        _requiresValidationDepthGuard = AvroAggregateEqualityComparer.IsRecursive(recordSchema);
     }
 
     private AvroMemberResolver(
@@ -2571,6 +2708,12 @@ internal sealed class AvroMemberResolver
         _valueSchema = unionSchema;
         _aggregateComparerFactory = aggregateComparerFactory;
         _unionBranches = new AvroMemberResolver?[unionSchema.Count];
+        _unionRequiresBoundedValueDecoding = new bool[unionSchema.Count];
+        for (var index = 0; index < unionSchema.Count; index++)
+        {
+            _unionRequiresBoundedValueDecoding[index] =
+                AvroAggregateEqualityComparer.IsRecursive(unionSchema[index]);
+        }
         _fields = [];
     }
 
@@ -2582,6 +2725,8 @@ internal sealed class AvroMemberResolver
         _aggregateComparerFactory = aggregateComparerFactory;
         _fields = [];
         _mapValues = new Dictionary<ReadOnlyMemory<byte>, AvroMemberNode>(AvroUtf8MemoryComparer.Instance);
+        _requiresBoundedMapValueDecoding =
+            AvroAggregateEqualityComparer.IsRecursive(mapSchema.ValueSchema);
     }
 
     internal static AvroMemberResolver? Create(
@@ -2751,17 +2896,27 @@ internal sealed class AvroMemberResolver
         ValidationCelSizeValues sizes)
     {
         var reader = new AvroValidationReader(payload);
-        Resolve(ref reader, values, sizes);
+        Resolve(
+            ref reader,
+            values,
+            sizes,
+            AvroInlineRuleValidator.MaximumValidationDepth);
     }
 
     internal void Resolve(
         ref AvroValidationReader reader,
         ValidationCelMemberValues values,
-        ValidationCelSizeValues sizes)
+        ValidationCelSizeValues sizes,
+        int remainingValidationDepth)
     {
         if (_mapValues is not null)
         {
-            ResolveMap((global::Avro.MapSchema)_valueSchema, ref reader, values, sizes);
+            ResolveMap(
+                (global::Avro.MapSchema)_valueSchema,
+                ref reader,
+                values,
+                sizes,
+                remainingValidationDepth);
             return;
         }
         if (_unionBranches is not null)
@@ -2773,10 +2928,21 @@ internal sealed class AvroMemberResolver
                     $"Could not evaluate Avro validation rules: invalid union index {branch}.");
             var resolver = _unionBranches[(int)branch];
             if (resolver is null)
-                AvroValidationValueDecoder.Skip(union[(int)branch], ref reader);
+            {
+                SkipValue(
+                    union[(int)branch],
+                    _unionRequiresBoundedValueDecoding![(int)branch],
+                    ref reader,
+                    remainingValidationDepth);
+            }
             else
-                resolver.Resolve(ref reader, values, sizes);
+                resolver.Resolve(ref reader, values, sizes, remainingValidationDepth);
             return;
+        }
+        if (_requiresValidationDepthGuard)
+        {
+            remainingValidationDepth =
+                AvroValidationValueDecoder.ConsumeRecordDepth(remainingValidationDepth);
         }
         for (var index = 0; index < _fields.Length; index++)
         {
@@ -2787,7 +2953,7 @@ internal sealed class AvroMemberResolver
             if (node!.HasTargets)
             {
                 var start = reader.Position;
-                AvroValidationValueDecoder.Skip(schema, ref reader);
+                node.SkipValue(ref reader, remainingValidationDepth);
                 node.Resolve(
                     reader.Source.Slice(start, reader.Position - start),
                     values,
@@ -2795,7 +2961,7 @@ internal sealed class AvroMemberResolver
             }
             else
             {
-                AvroValidationValueDecoder.Skip(schema, ref reader);
+                node.SkipValue(ref reader, remainingValidationDepth);
             }
         }
     }
@@ -2804,7 +2970,8 @@ internal sealed class AvroMemberResolver
         global::Avro.MapSchema map,
         ref AvroValidationReader reader,
         ValidationCelMemberValues values,
-        ValidationCelSizeValues sizes)
+        ValidationCelSizeValues sizes,
+        int remainingValidationDepth)
     {
         while (true)
         {
@@ -2815,7 +2982,11 @@ internal sealed class AvroMemberResolver
             {
                 var key = reader.ReadLengthPrefixed();
                 var valueStart = reader.Position;
-                AvroValidationValueDecoder.Skip(map.ValueSchema, ref reader);
+                SkipValue(
+                    map.ValueSchema,
+                    _requiresBoundedMapValueDecoding,
+                    ref reader,
+                    remainingValidationDepth);
                 if (_mapValues!.TryGetValue(key, out var node))
                 {
                     node.Resolve(
@@ -2825,6 +2996,24 @@ internal sealed class AvroMemberResolver
                 }
             }
         }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SkipValue(
+        AvroSchema schema,
+        bool requiresBoundedValueDecoding,
+        ref AvroValidationReader reader,
+        int remainingValidationDepth)
+    {
+        if (requiresBoundedValueDecoding)
+        {
+            AvroValidationValueDecoder.SkipBounded(
+                schema,
+                ref reader,
+                remainingValidationDepth);
+            return;
+        }
+        AvroValidationValueDecoder.Skip(schema, ref reader);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -2895,6 +3084,7 @@ internal sealed class AvroMemberResolver
         int lastFieldIndex,
         int[] deferredFieldIndexes,
         scoped Span<int> deferredFieldOffsets,
+        int remainingValidationDepth,
         ValidationCelMemberValues values,
         ValidationCelSizeValues sizes)
     {
@@ -2907,7 +3097,7 @@ internal sealed class AvroMemberResolver
             var node = _fields[index]
                 ?? throw new InvalidOperationException("Avro validation member resolver is incomplete.");
             var schema = node.Schema!;
-            AvroValidationValueDecoder.Skip(schema, ref reader);
+            node.SkipValue(ref reader, remainingValidationDepth);
             var fieldLength = reader.Position - fieldStart;
             if (index == lastFieldIndex)
             {
@@ -2994,6 +3184,8 @@ internal sealed class AvroMemberResolver
         private ReadOnlyMemory<byte>[]?[]? _unionEnumSymbols;
         private int[]? _additionalMemberIndexes;
         private bool _needsSize;
+        private bool _requiresBoundedValueDecoding;
+        private bool[]? _unionRequiresBoundedValueDecoding;
 
         internal AvroSchema? Schema
         {
@@ -3004,15 +3196,19 @@ internal sealed class AvroMemberResolver
                 var schema = AvroValueRulePlan.Unwrap(value!);
                 _aggregateComparer = aggregateComparerFactory.Create(schema);
                 _enumSymbols = AvroValidationValueDecoder.EncodeEnumSymbols(schema);
+                _requiresBoundedValueDecoding = AvroAggregateEqualityComparer.IsRecursive(schema);
                 if (schema is not global::Avro.UnionSchema union)
                     return;
                 _unionComparers = new AvroAggregateEqualityComparer?[union.Count];
                 _unionEnumSymbols = new ReadOnlyMemory<byte>[]?[union.Count];
+                _unionRequiresBoundedValueDecoding = new bool[union.Count];
                 for (var index = 0; index < union.Count; index++)
                 {
                     var branch = AvroValueRulePlan.Unwrap(union[index]);
                     _unionComparers[index] = aggregateComparerFactory.Create(branch);
                     _unionEnumSymbols[index] = AvroValidationValueDecoder.EncodeEnumSymbols(branch);
+                    _unionRequiresBoundedValueDecoding[index] =
+                        AvroAggregateEqualityComparer.IsRecursive(branch);
                 }
             }
         }
@@ -3020,6 +3216,20 @@ internal sealed class AvroMemberResolver
         internal bool HasTargets => MemberIndex >= 0 || _children.Count != 0;
         internal bool HasChildren => _children.Count != 0;
         internal bool NeedsSize => _needsSize;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void SkipValue(ref AvroValidationReader reader, int remainingValidationDepth)
+        {
+            if (_requiresBoundedValueDecoding)
+            {
+                AvroValidationValueDecoder.SkipBounded(
+                    Schema!,
+                    ref reader,
+                    remainingValidationDepth);
+                return;
+            }
+            AvroValidationValueDecoder.Skip(Schema!, ref reader);
+        }
 
         internal bool TryGetChildResolver(
             AvroSchema schema,
@@ -3118,13 +3328,18 @@ internal sealed class AvroMemberResolver
             if (MemberIndex >= 0)
             {
                 var valueReader = new AvroValidationReader(payload);
-                var value = ReadValue(schema, ref valueReader, out var aggregateComparer);
+                var value = ReadValue(
+                    schema,
+                    ref valueReader,
+                    _needsSize,
+                    out var size,
+                    out var aggregateComparer);
                 var additionalIndexes = _additionalMemberIndexes;
                 if (additionalIndexes is null)
                 {
                     var sizeIndex = MemberIndex + 1;
-                    if (_needsSize && value.SizeIndex == 0)
-                        sizes.Set(sizeIndex, AvroValidationValueDecoder.Count(schema, payload));
+                    if (size >= 0)
+                        sizes.Set(sizeIndex, size);
                     if (value.Kind is ValidationCelValueKind.Array or ValidationCelValueKind.Object &&
                         value.SizeIndex == 0)
                     {
@@ -3134,9 +3349,6 @@ internal sealed class AvroMemberResolver
                 }
                 else
                 {
-                    var size = -1;
-                    if (_needsSize && value.SizeIndex == 0)
-                        size = AvroValidationValueDecoder.Count(schema, payload);
                     SetMemberValue(MemberIndex, value, size, values, sizes, aggregateComparer);
                     for (var index = 0; index < additionalIndexes.Length; index++)
                     {
@@ -3284,13 +3496,28 @@ internal sealed class AvroMemberResolver
         private ValidationCelValue ReadValue(
             AvroSchema schema,
             ref AvroValidationReader reader,
+            bool needsSize,
+            out int size,
             out AvroAggregateEqualityComparer? aggregateComparer)
         {
             schema = AvroValueRulePlan.Unwrap(schema);
             if (schema is not global::Avro.UnionSchema union)
             {
                 aggregateComparer = _aggregateComparer;
-                return AvroValidationValueDecoder.Read(schema, _enumSymbols, ref reader);
+                return _requiresBoundedValueDecoding
+                    ? AvroValidationValueDecoder.ReadBounded(
+                        schema,
+                        _enumSymbols,
+                        ref reader,
+                        AvroInlineRuleValidator.MaximumValidationDepth,
+                        needsSize,
+                        out size)
+                    : AvroValidationValueDecoder.Read(
+                        schema,
+                        _enumSymbols,
+                        ref reader,
+                        needsSize,
+                        out size);
             }
 
             var branch = reader.ReadLong();
@@ -3298,10 +3525,20 @@ internal sealed class AvroMemberResolver
                 throw new SchemaRegistryRuleException(
                     $"Could not evaluate Avro validation rules: invalid union index {branch}.");
             aggregateComparer = _unionComparers![(int)branch];
-            return AvroValidationValueDecoder.Read(
-                union[(int)branch],
-                _unionEnumSymbols![(int)branch],
-                ref reader);
+            return _unionRequiresBoundedValueDecoding![(int)branch]
+                ? AvroValidationValueDecoder.ReadBounded(
+                    union[(int)branch],
+                    _unionEnumSymbols![(int)branch],
+                    ref reader,
+                    AvroInlineRuleValidator.MaximumValidationDepth,
+                    needsSize,
+                    out size)
+                : AvroValidationValueDecoder.Read(
+                    union[(int)branch],
+                    _unionEnumSymbols![(int)branch],
+                    ref reader,
+                    needsSize,
+                    out size);
         }
     }
 }
@@ -3542,6 +3779,232 @@ internal static class AvroValidationValueDecoder
         }
     }
 
+    internal static ValidationCelValue ReadBounded(
+        AvroSchema schema,
+        ReadOnlyMemory<byte>[]? enumSymbols,
+        ref AvroValidationReader reader,
+        int remainingValidationDepth,
+        bool needsSize,
+        out int size)
+    {
+        schema = AvroValueRulePlan.Unwrap(schema);
+        size = -1;
+        switch (schema.Tag)
+        {
+            case AvroSchema.Type.Record:
+            case AvroSchema.Type.Error:
+            {
+                var start = reader.Position;
+                SkipBounded(schema, ref reader, remainingValidationDepth);
+                if (needsSize)
+                    size = ((global::Avro.RecordSchema)schema).Fields.Count;
+                return ValidationCelValue.FromCollection(
+                    ValidationCelValueKind.Object,
+                    reader.Source.Slice(start, reader.Position - start),
+                    0);
+            }
+            case AvroSchema.Type.Array:
+            {
+                var start = reader.Position;
+                var itemSchema = ((global::Avro.ArraySchema)schema).ItemSchema;
+                if (needsSize)
+                    size = SkipBoundedCollectionAndCount(
+                        itemSchema,
+                        isMap: false,
+                        ref reader,
+                        remainingValidationDepth);
+                else
+                    SkipBoundedCollection(
+                        itemSchema,
+                        isMap: false,
+                        ref reader,
+                        remainingValidationDepth);
+                return ValidationCelValue.FromCollection(
+                    ValidationCelValueKind.Array,
+                    reader.Source.Slice(start, reader.Position - start),
+                    0);
+            }
+            case AvroSchema.Type.Map:
+            {
+                var start = reader.Position;
+                var valueSchema = ((global::Avro.MapSchema)schema).ValueSchema;
+                if (needsSize)
+                    size = SkipBoundedCollectionAndCount(
+                        valueSchema,
+                        isMap: true,
+                        ref reader,
+                        remainingValidationDepth);
+                else
+                    SkipBoundedCollection(
+                        valueSchema,
+                        isMap: true,
+                        ref reader,
+                        remainingValidationDepth);
+                return ValidationCelValue.FromCollection(
+                    ValidationCelValueKind.Object,
+                    reader.Source.Slice(start, reader.Position - start),
+                    0);
+            }
+            case AvroSchema.Type.Union:
+            {
+                var union = (global::Avro.UnionSchema)schema;
+                var branch = reader.ReadLong();
+                if ((ulong)branch >= (ulong)union.Count)
+                    throw InvalidPayload($"invalid union index {branch}");
+                return ReadBounded(
+                    union[(int)branch],
+                    enumSymbols,
+                    ref reader,
+                    remainingValidationDepth,
+                    needsSize,
+                    out size);
+            }
+            default:
+                return Read(schema, enumSymbols, ref reader, needsSize, out size);
+        }
+    }
+
+    internal static void SkipBounded(
+        AvroSchema schema,
+        ref AvroValidationReader reader,
+        int remainingValidationDepth)
+    {
+        SkipBoundedCore(schema, ref reader, remainingValidationDepth);
+    }
+
+    private static void SkipBoundedCore(
+        AvroSchema schema,
+        ref AvroValidationReader reader,
+        int remainingValidationDepth)
+    {
+        schema = AvroValueRulePlan.Unwrap(schema);
+        switch (schema.Tag)
+        {
+            case AvroSchema.Type.Null:
+                return;
+            case AvroSchema.Type.Boolean:
+                _ = reader.Read(1);
+                return;
+            case AvroSchema.Type.Int:
+            case AvroSchema.Type.Long:
+                _ = reader.ReadLong();
+                return;
+            case AvroSchema.Type.Enumeration:
+                var symbolIndex = reader.ReadLong();
+                if ((ulong)symbolIndex >= (ulong)((global::Avro.EnumSchema)schema).Symbols.Count)
+                    throw InvalidPayload($"invalid enum index {symbolIndex}");
+                return;
+            case AvroSchema.Type.Float:
+                _ = reader.Read(sizeof(float));
+                return;
+            case AvroSchema.Type.Double:
+                _ = reader.Read(sizeof(double));
+                return;
+            case AvroSchema.Type.String:
+            case AvroSchema.Type.Bytes:
+                _ = reader.ReadLengthPrefixed();
+                return;
+            case AvroSchema.Type.Fixed:
+                _ = reader.Read(((global::Avro.FixedSchema)schema).Size);
+                return;
+            case AvroSchema.Type.Record:
+            case AvroSchema.Type.Error:
+            {
+                remainingValidationDepth = ConsumeRecordDepth(remainingValidationDepth);
+                var record = (global::Avro.RecordSchema)schema;
+                for (var index = 0; index < record.Fields.Count; index++)
+                {
+                    SkipBoundedCore(
+                        record.Fields[index].Schema,
+                        ref reader,
+                        remainingValidationDepth);
+                }
+                return;
+            }
+            case AvroSchema.Type.Array:
+                SkipBoundedCollection(
+                    ((global::Avro.ArraySchema)schema).ItemSchema,
+                    isMap: false,
+                    ref reader,
+                    remainingValidationDepth);
+                return;
+            case AvroSchema.Type.Map:
+                SkipBoundedCollection(
+                    ((global::Avro.MapSchema)schema).ValueSchema,
+                    isMap: true,
+                    ref reader,
+                    remainingValidationDepth);
+                return;
+            case AvroSchema.Type.Union:
+                var union = (global::Avro.UnionSchema)schema;
+                var branch = reader.ReadLong();
+                if ((ulong)branch >= (ulong)union.Count)
+                    throw InvalidPayload($"invalid union index {branch}");
+                SkipBoundedCore(
+                    union[(int)branch],
+                    ref reader,
+                    remainingValidationDepth);
+                return;
+            default:
+                throw InvalidPayload($"unsupported schema type {schema.Tag}");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int ConsumeRecordDepth(int remainingValidationDepth)
+    {
+        if (remainingValidationDepth == 0)
+            ThrowExcessiveValidationDepth();
+        return remainingValidationDepth - 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowExcessiveValidationDepth() =>
+        throw new SchemaRegistryRuleException(
+            $"Could not evaluate Avro validation rules: value recursion exceeds {AvroInlineRuleValidator.MaximumValidationDepth} levels.");
+
+    private static void SkipBoundedCollection(
+        AvroSchema valueSchema,
+        bool isMap,
+        ref AvroValidationReader reader,
+        int remainingValidationDepth)
+    {
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return;
+            for (long index = 0; index < count; index++)
+            {
+                if (isMap)
+                    _ = reader.ReadLengthPrefixed();
+                SkipBoundedCore(valueSchema, ref reader, remainingValidationDepth);
+            }
+        }
+    }
+
+    private static int SkipBoundedCollectionAndCount(
+        AvroSchema valueSchema,
+        bool isMap,
+        ref AvroValidationReader reader,
+        int remainingValidationDepth)
+    {
+        var itemCount = 0L;
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return checked((int)itemCount);
+            itemCount = checked(itemCount + count);
+            for (long index = 0; index < count; index++)
+            {
+                if (isMap)
+                    _ = reader.ReadLengthPrefixed();
+                SkipBoundedCore(valueSchema, ref reader, remainingValidationDepth);
+            }
+        }
+    }
+
     internal static void Skip(AvroSchema schema, ref AvroValidationReader reader)
     {
         schema = AvroValueRulePlan.Unwrap(schema);
@@ -3635,6 +4098,41 @@ internal static class AvroValidationValueDecoder
         }
     }
 
+    internal static int CountBounded(
+        AvroSchema schema,
+        ReadOnlyMemory<byte> payload,
+        int remainingValidationDepth)
+    {
+        schema = AvroValueRulePlan.Unwrap(schema);
+        var reader = new AvroValidationReader(payload);
+        if (schema is global::Avro.UnionSchema union)
+        {
+            var branch = reader.ReadLong();
+            if ((ulong)branch >= (ulong)union.Count)
+                throw InvalidPayload($"invalid union index {branch}");
+            schema = AvroValueRulePlan.Unwrap(union[(int)branch]);
+        }
+        if (schema is global::Avro.RecordSchema record)
+            return record.Fields.Count;
+        if (schema is global::Avro.ArraySchema array)
+        {
+            return SkipBoundedCollectionAndCount(
+                array.ItemSchema,
+                isMap: false,
+                ref reader,
+                remainingValidationDepth);
+        }
+        if (schema is global::Avro.MapSchema map)
+        {
+            return SkipBoundedCollectionAndCount(
+                map.ValueSchema,
+                isMap: true,
+                ref reader,
+                remainingValidationDepth);
+        }
+        return -1;
+    }
+
     private static void SkipCollection(
         AvroSchema valueSchema,
         bool isMap,
@@ -3695,6 +4193,7 @@ internal ref struct AvroValidationPath
     }
 
     internal int Length { get; private set; }
+    internal int RemainingValidationDepth => _remainingValidationDepth;
 
     internal void EnterValidation()
     {

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -10,6 +10,8 @@ namespace Dekaf.SchemaRegistry.Avro;
 
 internal sealed class AvroInlineRuleValidator
 {
+    internal const int MaximumValidationDepth = 100;
+
     [ThreadStatic]
     private static char[]? t_pathBuffer;
 
@@ -71,6 +73,7 @@ internal sealed class AvroValueRulePlan
     private readonly AvroSchema _schema;
     private readonly AvroSchema _ruleSchema;
     private readonly ReadOnlyMemory<byte>[]? _enumSymbols;
+    private readonly bool _requiresValidationDepthGuard;
     private AvroCompiledRuleSet _schemaRules = AvroCompiledRuleSet.Empty;
     private AvroFieldRulePlan[] _fields = [];
     private AvroValueRulePlan[] _children = [];
@@ -83,6 +86,9 @@ internal sealed class AvroValueRulePlan
         _schema = Unwrap(schema);
         _ruleSchema = schema;
         _enumSymbols = AvroValidationValueDecoder.EncodeEnumSymbols(_schema);
+        _requiresValidationDepthGuard =
+            _schema is global::Avro.RecordSchema &&
+            AvroAggregateEqualityComparer.IsRecursive(_schema);
     }
 
     internal bool HasAnyRules { get; private set; }
@@ -236,6 +242,153 @@ internal sealed class AvroValueRulePlan
         if (!HasAnyRules)
             return ReadValue(ref reader);
 
+        // Keep the non-recursive dispatch inline: routing it through ValidateCore regresses
+        // warmed validation. Recursive schemas alone pay for the guarded helper call.
+        if (_requiresValidationDepthGuard)
+        {
+            return ValidateWithDepthGuard(
+                ref reader,
+                now,
+                failFast,
+                ref violations,
+                ref path);
+        }
+
+        if (_validationStrategy != ValidationStrategy.Standard)
+        {
+            if (_validationStrategy == ValidationStrategy.AggregateRoot)
+            {
+                return ValidateAggregateWithRootRules(
+                    ref reader,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path);
+            }
+
+            if (_validationStrategy == ValidationStrategy.AggregateRootAndMembers)
+            {
+                return ValidateAggregateWithRootAndMemberRules(
+                    ref reader,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path);
+            }
+
+            if (_validationStrategy == ValidationStrategy.DeferredMembers)
+            {
+                return ValidateWithDeferredMemberRules(
+                    ref reader,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path);
+            }
+
+            return ValidateRecordWithDeferredNestedRules(
+                ref reader,
+                now,
+                failFast,
+                ref violations,
+                ref path);
+        }
+
+        var value = ValidationCelValue.Missing;
+        var preview = default(AvroValidationReader);
+        if (!_schemaRules.IsEmpty)
+        {
+            var start = reader.Position;
+            preview = reader;
+            if (_schemaRules.UsesRootValue)
+            {
+                value = ReadValue(ref preview);
+                var payload = preview.Source.Slice(start, preview.Position - start);
+                var rootSize = value.SizeIndex == 0 && _schemaRules.UsesRootSize
+                    ? AvroValidationValueDecoder.Count(_schema, payload)
+                    : -1;
+                _schemaRules.Evaluate(
+                    value,
+                    payload,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path,
+                    rootSize);
+            }
+            else
+            {
+                _schemaRules.EvaluateWithoutRoot(
+                    ref preview,
+                    _schema,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path);
+            }
+            if (failFast && violations is not null)
+            {
+                reader = preview;
+                return value;
+            }
+            if (!_hasNestedRules)
+            {
+                reader = preview;
+                return value;
+            }
+        }
+
+        switch (_schema)
+        {
+            case global::Avro.RecordSchema:
+                ValidateRecord(ref reader, now, failFast, ref violations, ref path);
+                break;
+            case global::Avro.ArraySchema:
+                _ = ValidateArray(ref reader, now, failFast, ref violations, ref path);
+                break;
+            case global::Avro.MapSchema:
+                _ = ValidateMap(ref reader, now, failFast, ref violations, ref path);
+                break;
+            case global::Avro.UnionSchema:
+                ValidateUnion(ref reader, now, failFast, ref violations, ref path);
+                break;
+            default:
+                if (_schemaRules.IsEmpty)
+                    value = ReadValue(ref reader);
+                else
+                    reader = preview;
+                break;
+        }
+        return value;
+    }
+
+    private ValidationCelValue ValidateWithDepthGuard(
+        ref AvroValidationReader reader,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path)
+    {
+        path.EnterValidation();
+        // A thrown validation exception terminates the root operation and disposes the path;
+        // only successful traversal needs to restore the sibling depth.
+        var value = ValidateCore(
+            ref reader,
+            now,
+            failFast,
+            ref violations,
+            ref path);
+        path.ExitValidation();
+        return value;
+    }
+
+    private ValidationCelValue ValidateCore(
+        ref AvroValidationReader reader,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path)
+    {
         if (_validationStrategy != ValidationStrategy.Standard)
         {
             if (_validationStrategy == ValidationStrategy.AggregateRoot)
@@ -3530,16 +3683,30 @@ internal ref struct AvroValidationPath
 {
     private Span<char> _buffer;
     private char[]? _rented;
+    private int _remainingValidationDepth;
 
     internal AvroValidationPath(Span<char> initialBuffer)
     {
         _buffer = initialBuffer;
         _rented = null;
+        _remainingValidationDepth = AvroInlineRuleValidator.MaximumValidationDepth;
         _buffer[0] = '$';
         Length = 1;
     }
 
     internal int Length { get; private set; }
+
+    internal void EnterValidation()
+    {
+        if (_remainingValidationDepth == 0)
+        {
+            throw new SchemaRegistryRuleException(
+                $"Could not evaluate Avro validation rules: value recursion exceeds {AvroInlineRuleValidator.MaximumValidationDepth} levels.");
+        }
+        _remainingValidationDepth--;
+    }
+
+    internal void ExitValidation() => _remainingValidationDepth++;
 
     internal void AppendField(string name)
     {

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -842,7 +842,8 @@ internal readonly record struct AvroFieldPayload(int Start, int Length);
 
 internal sealed class AvroCompiledRuleSet
 {
-    internal static AvroCompiledRuleSet Empty { get; } = new([], null, false, false, false, false, 0, null);
+    internal static AvroCompiledRuleSet Empty { get; } = new(
+        [], null, false, false, false, false, 0, null, new AvroAggregateEqualityComparerFactory());
 
     private readonly CompiledValidationRule[] _rules;
     private readonly AvroMemberResolver? _members;
@@ -861,7 +862,8 @@ internal sealed class AvroCompiledRuleSet
         bool usesCachedEquality,
         bool usesRootAggregateEquality,
         int memberCount,
-        AvroSchema? valueSchema)
+        AvroSchema? valueSchema,
+        AvroAggregateEqualityComparerFactory aggregateComparerFactory)
     {
         _rules = rules;
         _members = members;
@@ -875,14 +877,14 @@ internal sealed class AvroCompiledRuleSet
             return;
 
         valueSchema = AvroValueRulePlan.Unwrap(valueSchema);
-        _rootAggregateComparer = AvroAggregateEqualityComparer.Create(valueSchema);
+        _rootAggregateComparer = aggregateComparerFactory.Create(valueSchema);
         if (valueSchema is not global::Avro.UnionSchema union)
             return;
 
         _rootUnionComparers = new AvroAggregateEqualityComparer?[union.Count];
         for (var index = 0; index < union.Count; index++)
         {
-            _rootUnionComparers[index] = AvroAggregateEqualityComparer.Create(
+            _rootUnionComparers[index] = aggregateComparerFactory.Create(
                 AvroValueRulePlan.Unwrap(union[index]));
         }
     }
@@ -922,9 +924,14 @@ internal sealed class AvroCompiledRuleSet
             usesRootAggregateEquality |= rule.UsesRootAggregateEquality;
         }
 
+        var aggregateComparerFactory = new AvroAggregateEqualityComparerFactory();
         var members = usedMemberIndexes.Count == 0
             ? null
-            : AvroMemberResolver.Create(valueSchema, memberPaths, usedMemberIndexes);
+            : AvroMemberResolver.Create(
+                valueSchema,
+                memberPaths,
+                usedMemberIndexes,
+                aggregateComparerFactory);
         return new AvroCompiledRuleSet(
             compiled,
             members,
@@ -933,7 +940,8 @@ internal sealed class AvroCompiledRuleSet
             usesCachedEquality,
             usesRootAggregateEquality,
             memberPaths.Count,
-            valueSchema);
+            valueSchema,
+            aggregateComparerFactory);
     }
 
     internal void Evaluate(
@@ -1127,6 +1135,7 @@ internal sealed class AvroCompiledRuleSet
 internal sealed class AvroMemberResolver
 {
     private readonly AvroSchema _valueSchema;
+    private readonly AvroAggregateEqualityComparerFactory _aggregateComparerFactory;
     private readonly AvroMemberResolver?[]? _unionBranches;
     private readonly AvroMemberNode?[] _fields;
     private readonly Dictionary<ReadOnlyMemory<byte>, AvroMemberNode>? _mapValues;
@@ -1144,22 +1153,31 @@ internal sealed class AvroMemberResolver
         }
     }
 
-    private AvroMemberResolver(global::Avro.RecordSchema recordSchema)
+    private AvroMemberResolver(
+        global::Avro.RecordSchema recordSchema,
+        AvroAggregateEqualityComparerFactory aggregateComparerFactory)
     {
         _valueSchema = recordSchema;
+        _aggregateComparerFactory = aggregateComparerFactory;
         _fields = new AvroMemberNode?[recordSchema.Fields.Count];
     }
 
-    private AvroMemberResolver(global::Avro.UnionSchema unionSchema)
+    private AvroMemberResolver(
+        global::Avro.UnionSchema unionSchema,
+        AvroAggregateEqualityComparerFactory aggregateComparerFactory)
     {
         _valueSchema = unionSchema;
+        _aggregateComparerFactory = aggregateComparerFactory;
         _unionBranches = new AvroMemberResolver?[unionSchema.Count];
         _fields = [];
     }
 
-    private AvroMemberResolver(global::Avro.MapSchema mapSchema)
+    private AvroMemberResolver(
+        global::Avro.MapSchema mapSchema,
+        AvroAggregateEqualityComparerFactory aggregateComparerFactory)
     {
         _valueSchema = mapSchema;
+        _aggregateComparerFactory = aggregateComparerFactory;
         _fields = [];
         _mapValues = new Dictionary<ReadOnlyMemory<byte>, AvroMemberNode>(AvroUtf8MemoryComparer.Instance);
     }
@@ -1167,17 +1185,18 @@ internal sealed class AvroMemberResolver
     internal static AvroMemberResolver? Create(
         AvroSchema valueSchema,
         IReadOnlyList<byte[][]> paths,
-        IReadOnlyCollection<int> usedIndexes)
+        IReadOnlyCollection<int> usedIndexes,
+        AvroAggregateEqualityComparerFactory aggregateComparerFactory)
     {
         valueSchema = AvroValueRulePlan.Unwrap(valueSchema);
         if (valueSchema is global::Avro.RecordSchema record)
-            return CreateRecord(record, paths, usedIndexes);
+            return CreateRecord(record, paths, usedIndexes, aggregateComparerFactory);
         if (valueSchema is global::Avro.MapSchema map)
-            return CreateMap(map, paths, usedIndexes);
+            return CreateMap(map, paths, usedIndexes, aggregateComparerFactory);
         if (valueSchema is not global::Avro.UnionSchema union)
             return null;
 
-        var resolver = new AvroMemberResolver(union);
+        var resolver = new AvroMemberResolver(union, aggregateComparerFactory);
         var resolvedIndexes = new bool[paths.Count];
         for (var branchIndex = 0; branchIndex < union.Count; branchIndex++)
         {
@@ -1194,13 +1213,13 @@ internal sealed class AvroMemberResolver
 
                 if (branch is global::Avro.RecordSchema branchRecord)
                 {
-                    branchResolver ??= CreateRecord(branchRecord);
+                    branchResolver ??= CreateRecord(branchRecord, aggregateComparerFactory);
                     branchResolver.Add(branchRecord, path, memberIndex, depth: 0);
                 }
                 else
                 {
                     var branchMap = (global::Avro.MapSchema)branch;
-                    branchResolver ??= CreateMap(branchMap);
+                    branchResolver ??= CreateMap(branchMap, aggregateComparerFactory);
                     branchResolver.Add(branchMap, path, memberIndex, depth: 0);
                 }
                 resolvedIndexes[memberIndex] = true;
@@ -1222,17 +1241,20 @@ internal sealed class AvroMemberResolver
     private static AvroMemberResolver CreateRecord(
         global::Avro.RecordSchema record,
         IReadOnlyList<byte[][]> paths,
-        IReadOnlyCollection<int> usedIndexes)
+        IReadOnlyCollection<int> usedIndexes,
+        AvroAggregateEqualityComparerFactory aggregateComparerFactory)
     {
-        var resolver = CreateRecord(record);
+        var resolver = CreateRecord(record, aggregateComparerFactory);
         foreach (var memberIndex in usedIndexes)
             resolver.Add(record, paths[memberIndex], memberIndex, depth: 0);
         return resolver;
     }
 
-    private static AvroMemberResolver CreateRecord(global::Avro.RecordSchema record)
+    private static AvroMemberResolver CreateRecord(
+        global::Avro.RecordSchema record,
+        AvroAggregateEqualityComparerFactory aggregateComparerFactory)
     {
-        var resolver = new AvroMemberResolver(record);
+        var resolver = new AvroMemberResolver(record, aggregateComparerFactory);
         resolver.SetSchemas(record);
         return resolver;
     }
@@ -1240,15 +1262,19 @@ internal sealed class AvroMemberResolver
     private static AvroMemberResolver CreateMap(
         global::Avro.MapSchema map,
         IReadOnlyList<byte[][]> paths,
-        IReadOnlyCollection<int> usedIndexes)
+        IReadOnlyCollection<int> usedIndexes,
+        AvroAggregateEqualityComparerFactory aggregateComparerFactory)
     {
-        var resolver = CreateMap(map);
+        var resolver = CreateMap(map, aggregateComparerFactory);
         foreach (var memberIndex in usedIndexes)
             resolver.Add(map, paths[memberIndex], memberIndex, depth: 0);
         return resolver;
     }
 
-    private static AvroMemberResolver CreateMap(global::Avro.MapSchema map) => new(map);
+    private static AvroMemberResolver CreateMap(
+        global::Avro.MapSchema map,
+        AvroAggregateEqualityComparerFactory aggregateComparerFactory) =>
+        new(map, aggregateComparerFactory);
 
     private void Add(
         global::Avro.RecordSchema schema,
@@ -1260,7 +1286,7 @@ internal sealed class AvroMemberResolver
         var field = FindField(schema, name)
             ?? throw new SchemaRegistryRuleException(
                 $"Avro validation rule refers to unknown field '{name}' on '{schema.Fullname}'.");
-        var node = _fields[field.Pos] ??= new AvroMemberNode();
+        var node = _fields[field.Pos] ??= new AvroMemberNode(_aggregateComparerFactory);
         if (depth == path.Length - 1)
         {
             node.AddMemberIndex(memberIndex);
@@ -1278,7 +1304,7 @@ internal sealed class AvroMemberResolver
         var key = (ReadOnlyMemory<byte>)path[depth];
         if (!_mapValues!.TryGetValue(key, out var node))
         {
-            node = new AvroMemberNode { Schema = schema.ValueSchema };
+            node = new AvroMemberNode(_aggregateComparerFactory) { Schema = schema.ValueSchema };
             _mapValues.Add(key, node);
         }
         if (depth == path.Length - 1)
@@ -1480,10 +1506,12 @@ internal sealed class AvroMemberResolver
     internal void SetSchemas(global::Avro.RecordSchema schema)
     {
         for (var index = 0; index < schema.Fields.Count; index++)
-            (_fields[index] ??= new AvroMemberNode()).Schema = schema.Fields[index].Schema;
+            (_fields[index] ??= new AvroMemberNode(_aggregateComparerFactory)).Schema =
+                schema.Fields[index].Schema;
     }
 
-    private sealed class AvroMemberNode
+    private sealed class AvroMemberNode(
+        AvroAggregateEqualityComparerFactory aggregateComparerFactory)
     {
         private readonly Dictionary<AvroSchema, AvroMemberResolver> _children =
             new(AvroSchemaReferenceComparer.Instance);
@@ -1501,7 +1529,7 @@ internal sealed class AvroMemberResolver
             {
                 _schema = value;
                 var schema = AvroValueRulePlan.Unwrap(value!);
-                _aggregateComparer = AvroAggregateEqualityComparer.Create(schema);
+                _aggregateComparer = aggregateComparerFactory.Create(schema);
                 _enumSymbols = AvroValidationValueDecoder.EncodeEnumSymbols(schema);
                 if (schema is not global::Avro.UnionSchema union)
                     return;
@@ -1510,7 +1538,7 @@ internal sealed class AvroMemberResolver
                 for (var index = 0; index < union.Count; index++)
                 {
                     var branch = AvroValueRulePlan.Unwrap(union[index]);
-                    _unionComparers[index] = AvroAggregateEqualityComparer.Create(branch);
+                    _unionComparers[index] = aggregateComparerFactory.Create(branch);
                     _unionEnumSymbols[index] = AvroValidationValueDecoder.EncodeEnumSymbols(branch);
                 }
             }
@@ -1586,8 +1614,8 @@ internal sealed class AvroMemberResolver
             {
                 child = schema switch
                 {
-                    global::Avro.RecordSchema record => CreateRecord(record),
-                    global::Avro.MapSchema map => CreateMap(map),
+                    global::Avro.RecordSchema record => CreateRecord(record, aggregateComparerFactory),
+                    global::Avro.MapSchema map => CreateMap(map, aggregateComparerFactory),
                     _ => throw new InvalidOperationException("Avro validation member resolver child is unsupported.")
                 };
                 _children.Add(schema, child);

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -359,6 +359,7 @@ internal sealed class AvroValueRulePlan
             case global::Avro.MapSchema:
                 ValidateMapWithMemberResolution(
                     ref reader,
+                    _schemaRules,
                     resolution,
                     now,
                     failFast,
@@ -368,6 +369,7 @@ internal sealed class AvroValueRulePlan
             case global::Avro.UnionSchema:
                 ValidateUnionWithMemberResolution(
                     ref reader,
+                    _schemaRules,
                     resolution,
                     now,
                     failFast,
@@ -404,6 +406,7 @@ internal sealed class AvroValueRulePlan
             case global::Avro.RecordSchema:
                 ValidateRecordWithMemberResolution(
                     ref reader,
+                    _schemaRules,
                     resolution,
                     now,
                     failFast,
@@ -414,6 +417,7 @@ internal sealed class AvroValueRulePlan
             case global::Avro.MapSchema:
                 rootSize = ValidateMapWithMemberResolution(
                     ref reader,
+                    _schemaRules,
                     resolution,
                     now,
                     failFast,
@@ -441,6 +445,7 @@ internal sealed class AvroValueRulePlan
 
     private void ValidateRecordWithMemberResolution(
         ref AvroValidationReader reader,
+        AvroCompiledRuleSet rules,
         AvroMemberResolution resolution,
         long now,
         bool failFast,
@@ -451,7 +456,7 @@ internal sealed class AvroValueRulePlan
         {
             var start = reader.Position;
             var field = _fields[index];
-            var needsSize = _schemaRules.NeedsRecordFieldSize(index);
+            var needsSize = rules.NeedsRecordFieldSize(index);
             ValidationCelValue value;
             int size;
             if (failFast && nestedViolations is not null)
@@ -470,7 +475,7 @@ internal sealed class AvroValueRulePlan
                     ref path,
                     out size);
             }
-            _schemaRules.ResolveRecordField(
+            rules.ResolveRecordField(
                 index,
                 reader.Source.Slice(start, reader.Position - start),
                 value,
@@ -533,11 +538,12 @@ internal sealed class AvroValueRulePlan
     }
 
     private static bool CanFuseFieldRules(AvroFieldRulePlan field) =>
-        field.Child.HasAnyRules &&
+        (field.Child.HasAnyRules || field.Rules.HasMembers) &&
         field.Child._schemaRules.IsEmpty &&
         field.Rules.UsesRootValue &&
-        !field.Rules.HasMembers &&
-        field.Child._schema is global::Avro.RecordSchema or global::Avro.ArraySchema or global::Avro.MapSchema;
+        (field.Rules.HasMembers
+            ? field.Child._schema is global::Avro.RecordSchema or global::Avro.MapSchema or global::Avro.UnionSchema
+            : field.Child._schema is global::Avro.RecordSchema or global::Avro.ArraySchema or global::Avro.MapSchema);
 
     private static ValidationCelValue EvaluateFieldRulesWithNestedTraversal(
         AvroFieldRulePlan field,
@@ -548,6 +554,18 @@ internal sealed class AvroValueRulePlan
         scoped ref AvroValidationPath path,
         out int size)
     {
+        if (field.Rules.HasMembers)
+        {
+            return EvaluateMemberFieldRulesWithNestedTraversal(
+                field,
+                ref reader,
+                now,
+                failFast,
+                ref violations,
+                ref path,
+                out size);
+        }
+
         var start = reader.Position;
         List<ValidationRuleError>? nestedViolations = null;
         var value = field.Child.ValidateAndCapture(
@@ -687,8 +705,174 @@ internal sealed class AvroValueRulePlan
         return value;
     }
 
+    private static ValidationCelValue EvaluateMemberFieldRulesWithNestedTraversal(
+        AvroFieldRulePlan field,
+        ref AvroValidationReader reader,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path,
+        out int size)
+    {
+        using var resolution = field.Rules.BeginIsolatedMemberResolution();
+        List<ValidationRuleError>? nestedViolations = null;
+        var child = field.Child;
+        var start = reader.Position;
+        ValidationCelValue value;
+        switch (child._schema)
+        {
+            case global::Avro.RecordSchema:
+                child.ValidateRecordWithMemberResolution(
+                    ref reader,
+                    field.Rules,
+                    resolution,
+                    now,
+                    failFast,
+                    ref nestedViolations,
+                    ref path);
+                size = child._fields.Length;
+                value = ValidationCelValue.FromCollection(
+                    ValidationCelValueKind.Object,
+                    reader.Source.Slice(start, reader.Position - start),
+                    sizeIndex: 0);
+                break;
+            case global::Avro.MapSchema:
+                size = child.ValidateMapWithMemberResolution(
+                    ref reader,
+                    field.Rules,
+                    resolution,
+                    now,
+                    failFast,
+                    ref nestedViolations,
+                    ref path);
+                value = ValidationCelValue.FromCollection(
+                    ValidationCelValueKind.Object,
+                    reader.Source.Slice(start, reader.Position - start),
+                    sizeIndex: 0);
+                break;
+            case global::Avro.UnionSchema:
+                value = child.ValidateUnionFieldRulesWithMemberTraversal(
+                    ref reader,
+                    field.Rules.MemberResolver,
+                    resolution,
+                    now,
+                    failFast,
+                    ref nestedViolations,
+                    ref path,
+                    out size);
+                break;
+            default:
+                throw new InvalidOperationException(
+                    "Fused member field validation requires a record, map, or union schema.");
+        }
+
+        var payload = reader.Source.Slice(start, reader.Position - start);
+        field.Rules.EvaluateResolved(
+            value,
+            payload,
+            resolution,
+            size,
+            now,
+            failFast,
+            ref violations,
+            ref path);
+        AppendNestedViolations(nestedViolations, failFast, ref violations);
+        return value;
+    }
+
+    private ValidationCelValue ValidateUnionFieldRulesWithMemberTraversal(
+        ref AvroValidationReader reader,
+        AvroMemberResolver memberResolver,
+        AvroMemberResolution resolution,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? nestedViolations,
+        scoped ref AvroValidationPath path,
+        out int size)
+    {
+        var union = (global::Avro.UnionSchema)_schema;
+        var branch = reader.ReadLong();
+        if ((ulong)branch >= (ulong)union.Count)
+            throw InvalidPayload($"invalid union index {branch}");
+
+        var child = _children[(int)branch];
+        var start = reader.Position;
+        var branchResolver = memberResolver.GetUnionBranchResolver((int)branch);
+        if (branchResolver is not null &&
+            child._schemaRules.IsEmpty &&
+            child._schema is global::Avro.RecordSchema)
+        {
+            child.ValidateRecordWithMemberResolver(
+                ref reader,
+                branchResolver,
+                resolution,
+                now,
+                failFast,
+                ref nestedViolations,
+                ref path);
+            size = child._fields.Length;
+            return ValidationCelValue.FromCollection(
+                ValidationCelValueKind.Object,
+                reader.Source.Slice(start, reader.Position - start),
+                sizeIndex: 0);
+        }
+
+        var value = child.ValidateAndCapture(
+            ref reader,
+            now,
+            failFast,
+            needsSize: false,
+            ref nestedViolations,
+            ref path,
+            out size);
+        branchResolver?.Resolve(
+            reader.Source.Slice(start, reader.Position - start),
+            resolution.Members,
+            resolution.Sizes);
+        return value;
+    }
+
+    private void ValidateRecordWithMemberResolver(
+        ref AvroValidationReader reader,
+        AvroMemberResolver memberResolver,
+        AvroMemberResolution resolution,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? nestedViolations,
+        scoped ref AvroValidationPath path)
+    {
+        for (var index = 0; index < _fields.Length; index++)
+        {
+            var start = reader.Position;
+            var field = _fields[index];
+            var needsSize = memberResolver.NeedsRecordFieldSize(index);
+            ValidationCelValue value;
+            int size;
+            if (failFast && nestedViolations is not null)
+                value = CaptureRecordField(field, ref reader, needsSize, out size);
+            else
+                value = ValidateRecordFieldAndCapture(
+                    field,
+                    ref reader,
+                    now,
+                    failFast,
+                    needsSize,
+                    ref nestedViolations,
+                    ref path,
+                    out size);
+            memberResolver.ResolveRecordField(
+                index,
+                reader.Source.Slice(start, reader.Position - start),
+                value,
+                size,
+                resolution.Members,
+                resolution.Sizes);
+        }
+    }
+
     private void ValidateUnionWithMemberResolution(
         ref AvroValidationReader reader,
+        AvroCompiledRuleSet rules,
         AvroMemberResolution resolution,
         long now,
         bool failFast,
@@ -707,7 +891,7 @@ internal sealed class AvroValueRulePlan
             failFast,
             ref nestedViolations,
             ref path);
-        _schemaRules.ResolveUnionBranch(
+        rules.ResolveUnionBranch(
             (int)branch,
             reader.Source.Slice(payloadStart, reader.Position - payloadStart),
             resolution);
@@ -715,6 +899,7 @@ internal sealed class AvroValueRulePlan
 
     private int ValidateMapWithMemberResolution(
         ref AvroValidationReader reader,
+        AvroCompiledRuleSet rules,
         AvroMemberResolution resolution,
         long now,
         bool failFast,
@@ -725,15 +910,17 @@ internal sealed class AvroValueRulePlan
         {
             return ValidateMapWithFailFastMemberResolution(
                 ref reader,
+                rules,
                 resolution,
                 now,
                 ref nestedViolations,
                 ref path);
         }
-        if (_schemaRules.HasMapEntrySizeDemand)
+        if (rules.HasMapEntrySizeDemand)
         {
             return ValidateMapWithSizedMemberResolution(
                 ref reader,
+                rules,
                 resolution,
                 now,
                 ref nestedViolations,
@@ -763,7 +950,7 @@ internal sealed class AvroValueRulePlan
                     ref path,
                     out var size);
                 path.Truncate(mark);
-                _schemaRules.ResolveMapEntry(
+                rules.ResolveMapEntry(
                     key,
                     reader.Source.Slice(valueStart, reader.Position - valueStart),
                     value,
@@ -775,6 +962,7 @@ internal sealed class AvroValueRulePlan
 
     private int ValidateMapWithSizedMemberResolution(
         ref AvroValidationReader reader,
+        AvroCompiledRuleSet rules,
         AvroMemberResolution resolution,
         long now,
         ref List<ValidationRuleError>? nestedViolations,
@@ -791,7 +979,7 @@ internal sealed class AvroValueRulePlan
             {
                 itemCount = checked(itemCount + 1);
                 var key = reader.ReadLengthPrefixed();
-                _schemaRules.TryGetMapEntryResolver(key, out var memberResolver);
+                rules.TryGetMapEntryResolver(key, out var memberResolver);
                 var valueStart = reader.Position;
                 var mark = path.Length;
                 path.AppendMapKey(key.Span);
@@ -816,13 +1004,14 @@ internal sealed class AvroValueRulePlan
 
     private int ValidateMapWithFailFastMemberResolution(
         ref AvroValidationReader reader,
+        AvroCompiledRuleSet rules,
         AvroMemberResolution resolution,
         long now,
         ref List<ValidationRuleError>? nestedViolations,
         scoped ref AvroValidationPath path)
     {
         var valuePlan = _children[0];
-        var hasSizeDemand = _schemaRules.HasMapEntrySizeDemand;
+        var hasSizeDemand = rules.HasMapEntrySizeDemand;
         var itemCount = 0;
         while (true)
         {
@@ -835,7 +1024,7 @@ internal sealed class AvroValueRulePlan
                 var key = reader.ReadLengthPrefixed();
                 AvroMemberResolver.AvroMemberNode? memberResolver = null;
                 if (hasSizeDemand)
-                    _schemaRules.TryGetMapEntryResolver(key, out memberResolver);
+                    rules.TryGetMapEntryResolver(key, out memberResolver);
                 var valueStart = reader.Position;
                 if (nestedViolations is not null)
                 {
@@ -845,6 +1034,7 @@ internal sealed class AvroValueRulePlan
                         key,
                         memberResolver,
                         reader.Source.Slice(valueStart, reader.Position - valueStart),
+                        rules,
                         resolution);
                     continue;
                 }
@@ -872,23 +1062,24 @@ internal sealed class AvroValueRulePlan
                 }
                 else
                 {
-                    _schemaRules.ResolveMapEntry(key, payload, value, size, resolution);
+                    rules.ResolveMapEntry(key, payload, value, size, resolution);
                 }
             }
         }
     }
 
-    private void ResolveMapEntry(
+    private static void ResolveMapEntry(
         bool hasSizeDemand,
         ReadOnlyMemory<byte> key,
         AvroMemberResolver.AvroMemberNode? memberResolver,
         ReadOnlyMemory<byte> payload,
+        AvroCompiledRuleSet rules,
         AvroMemberResolution resolution)
     {
         if (hasSizeDemand)
             memberResolver?.Resolve(payload, resolution.Members, resolution.Sizes);
         else
-            _schemaRules.ResolveMapEntry(key, payload, resolution);
+            rules.ResolveMapEntry(key, payload, resolution);
     }
 
     private static void AppendNestedViolations(
@@ -1383,9 +1574,16 @@ internal sealed record AvroFieldRulePlan(
 internal readonly record struct AvroMemberResolution(
     ValidationCelMemberValues Members,
     ValidationCelSizeValues Sizes,
-    ValidationCelValueResolution ValueResolution) : IDisposable
+    ValidationCelValueResolution ValueResolution,
+    int IsolatedIndex = -1) : IDisposable
 {
-    public void Dispose() => ValueResolution.Dispose();
+    public void Dispose()
+    {
+        if (IsolatedIndex < 0)
+            ValueResolution.Dispose();
+        else
+            AvroCompiledRuleSet.EndIsolatedMemberResolution(IsolatedIndex);
+    }
 }
 
 internal readonly record struct AvroFieldPayload(int Start, int Length);
@@ -1403,6 +1601,12 @@ internal sealed class AvroCompiledRuleSet
     private readonly bool _usesRootAggregateEquality;
     private readonly int _memberCount;
     private readonly int _lastRecordMemberIndex;
+
+    [ThreadStatic]
+    private static ValidationCelValueResolutionFrame[]? t_isolatedMemberResolutionFrames;
+
+    [ThreadStatic]
+    private static int t_isolatedMemberResolutionDepth;
 
     private AvroCompiledRuleSet(
         CompiledValidationRule[] rules,
@@ -1446,6 +1650,7 @@ internal sealed class AvroCompiledRuleSet
     internal bool UsesRootSize { get; }
     internal bool UsesSize { get; }
     internal bool HasMembers => _members is not null;
+    internal AvroMemberResolver MemberResolver => _members!;
     internal int LastRecordMemberIndex => _lastRecordMemberIndex;
 
     internal static AvroCompiledRuleSet Compile(
@@ -1677,6 +1882,71 @@ internal sealed class AvroCompiledRuleSet
                 ? CompiledValidationRule.GetSizeValues(_memberCount + 1, valueResolution)
                 : default,
             valueResolution);
+    }
+
+    internal AvroMemberResolution BeginIsolatedMemberResolution()
+    {
+        var index = t_isolatedMemberResolutionDepth++;
+        var frames = t_isolatedMemberResolutionFrames;
+        if (frames is null || frames.Length <= index)
+        {
+            Array.Resize(
+                ref t_isolatedMemberResolutionFrames,
+                Math.Max(index + 1, 4));
+            frames = t_isolatedMemberResolutionFrames;
+        }
+
+        ref var frame = ref frames[index];
+        var members = GetIsolatedMemberValues(_memberCount, ref frame);
+        var sizes = UsesSize || _members is not null
+            ? GetIsolatedSizeValues(_memberCount + 1, ref frame)
+            : default;
+        return new AvroMemberResolution(members, sizes, default, index);
+    }
+
+    private static ValidationCelMemberValues GetIsolatedMemberValues(
+        int count,
+        ref ValidationCelValueResolutionFrame frame)
+    {
+        if (count == 0)
+            return default;
+
+        var values = frame.MemberValues;
+        if (values is null || values.Length < count)
+            frame.MemberValues = values = new ValidationCelMemberSlot[Math.Max(count, 8)];
+        frame.MemberGeneration = unchecked(frame.MemberGeneration + 1);
+        if (frame.MemberGeneration == 0)
+        {
+            Array.Clear(values);
+            frame.MemberGeneration = 1;
+        }
+        return new ValidationCelMemberValues(values, frame.MemberGeneration);
+    }
+
+    private static ValidationCelSizeValues GetIsolatedSizeValues(
+        int count,
+        ref ValidationCelValueResolutionFrame frame)
+    {
+        var values = frame.SizeValues;
+        if (values is null || values.Length < count)
+            frame.SizeValues = values = new ValidationCelSizeSlot[Math.Max(count, 8)];
+        frame.SizeGeneration = unchecked(frame.SizeGeneration + 1);
+        if (frame.SizeGeneration == 0)
+        {
+            Array.Clear(values);
+            frame.SizeGeneration = 1;
+        }
+        return new ValidationCelSizeValues(values, frame.SizeGeneration);
+    }
+
+    internal static void EndIsolatedMemberResolution(int index)
+    {
+        if (t_isolatedMemberResolutionDepth != index + 1)
+        {
+            throw new InvalidOperationException(
+                "Isolated Avro member resolutions must be released in reverse order.");
+        }
+        t_isolatedMemberResolutionDepth--;
     }
 
     internal AvroFieldPayload ResolveRecordPrefix(
@@ -2108,6 +2378,9 @@ internal sealed class AvroMemberResolver
         ReadOnlyMemory<byte> key,
         out AvroMemberNode? memberResolver) =>
         _mapValues!.TryGetValue(key, out memberResolver);
+
+    internal AvroMemberResolver? GetUnionBranchResolver(int branch) =>
+        _unionBranches![branch];
 
     internal void ResolveMapEntry(
         ReadOnlyMemory<byte> key,

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -22,6 +22,8 @@ internal sealed class AvroInlineRuleValidator
         AvroValueRulePlan.Complete(plans);
     }
 
+    internal bool HasAnyRules => _root.HasAnyRules;
+
     internal void Validate(ReadOnlyMemory<byte> payload, int schemaId, bool failFast)
     {
         List<ValidationRuleError>? violations = null;
@@ -220,12 +222,16 @@ internal sealed class AvroValueRulePlan
             var field = _fields[index];
             var mark = path.Length;
             path.AppendField(field.Field.Name);
-            var fieldStart = reader.Position;
-            var preview = reader;
-            var value = AvroValidationValueDecoder.Read(field.Field.Schema, ref preview);
-            var payload = preview.Source.Slice(fieldStart, preview.Position - fieldStart);
-            if (!field.Rules.IsEmpty)
+            if (field.Rules.IsEmpty)
             {
+                _ = field.Child.Validate(ref reader, now, failFast, ref violations, ref path);
+            }
+            else
+            {
+                var fieldStart = reader.Position;
+                var preview = reader;
+                var value = AvroValidationValueDecoder.Read(field.Field.Schema, ref preview);
+                var payload = preview.Source.Slice(fieldStart, preview.Position - fieldStart);
                 field.Rules.Evaluate(
                     value,
                     payload,
@@ -236,20 +242,11 @@ internal sealed class AvroValueRulePlan
                     value.SizeIndex == 0
                         ? AvroValidationValueDecoder.Count(field.Field.Schema, payload)
                         : -1);
-            }
 
-            if (!(failFast && violations is not null))
-            {
-                _ = field.Child.Validate(
-                    ref reader,
-                    now,
-                    failFast,
-                    ref violations,
-                    ref path);
-            }
-            else
-            {
-                reader = preview;
+                if ((failFast && violations is not null) || !field.Child.HasAnyRules)
+                    reader = preview;
+                else
+                    _ = field.Child.Validate(ref reader, now, failFast, ref violations, ref path);
             }
             path.Truncate(mark);
             if (failFast && violations is not null)
@@ -874,8 +871,13 @@ internal static class AvroValidationValueDecoder
                 return ValidationCelValue.FromBoolean(reader.Read(1).Span[0] != 0);
             case AvroSchema.Type.Int:
             case AvroSchema.Type.Long:
-            case AvroSchema.Type.Enumeration:
                 return ValidationCelValue.FromNumber(reader.ReadLong());
+            case AvroSchema.Type.Enumeration:
+                var enumeration = (global::Avro.EnumSchema)schema;
+                var symbolIndex = reader.ReadLong();
+                if ((ulong)symbolIndex >= (ulong)enumeration.Symbols.Count)
+                    throw InvalidPayload($"invalid enum index {symbolIndex}");
+                return ValidationCelValue.FromString(enumeration.Symbols[(int)symbolIndex]);
             case AvroSchema.Type.Float:
                 return ValidationCelValue.FromFloating(
                     BinaryPrimitives.ReadSingleLittleEndian(reader.Read(sizeof(float)).Span));

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using AvroSchema = global::Avro.Schema;
@@ -360,6 +361,7 @@ internal sealed class AvroValueRulePlan
                     ref reader,
                     resolution,
                     now,
+                    failFast,
                     ref nestedViolations,
                     ref path);
                 break;
@@ -412,6 +414,7 @@ internal sealed class AvroValueRulePlan
                     ref reader,
                     resolution,
                     now,
+                    failFast,
                     ref nestedViolations,
                     ref path);
                 break;
@@ -639,9 +642,29 @@ internal sealed class AvroValueRulePlan
         ref AvroValidationReader reader,
         AvroMemberResolution resolution,
         long now,
+        bool failFast,
         ref List<ValidationRuleError>? nestedViolations,
         scoped ref AvroValidationPath path)
     {
+        if (failFast)
+        {
+            return ValidateMapWithFailFastMemberResolution(
+                ref reader,
+                resolution,
+                now,
+                ref nestedViolations,
+                ref path);
+        }
+        if (_schemaRules.HasMapEntrySizeDemand)
+        {
+            return ValidateMapWithSizedMemberResolution(
+                ref reader,
+                resolution,
+                now,
+                ref nestedViolations,
+                ref path);
+        }
+
         var valuePlan = _children[0];
         var itemCount = 0;
         while (true)
@@ -660,7 +683,7 @@ internal sealed class AvroValueRulePlan
                     ref reader,
                     now,
                     failFast: false,
-                    needsSize: true,
+                    needsSize: false,
                     ref nestedViolations,
                     ref path,
                     out var size);
@@ -673,6 +696,124 @@ internal sealed class AvroValueRulePlan
                     resolution);
             }
         }
+    }
+
+    private int ValidateMapWithSizedMemberResolution(
+        ref AvroValidationReader reader,
+        AvroMemberResolution resolution,
+        long now,
+        ref List<ValidationRuleError>? nestedViolations,
+        scoped ref AvroValidationPath path)
+    {
+        var valuePlan = _children[0];
+        var itemCount = 0;
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return itemCount;
+            for (long index = 0; index < count; index++)
+            {
+                itemCount = checked(itemCount + 1);
+                var key = reader.ReadLengthPrefixed();
+                _schemaRules.TryGetMapEntryResolver(key, out var memberResolver);
+                var valueStart = reader.Position;
+                var mark = path.Length;
+                path.AppendMapKey(key.Span);
+                var value = valuePlan.ValidateAndCapture(
+                    ref reader,
+                    now,
+                    failFast: false,
+                    memberResolver?.NeedsSize ?? false,
+                    ref nestedViolations,
+                    ref path,
+                    out var size);
+                path.Truncate(mark);
+                memberResolver?.ResolveCaptured(
+                    reader.Source.Slice(valueStart, reader.Position - valueStart),
+                    value,
+                    size,
+                    resolution.Members,
+                    resolution.Sizes);
+            }
+        }
+    }
+
+    private int ValidateMapWithFailFastMemberResolution(
+        ref AvroValidationReader reader,
+        AvroMemberResolution resolution,
+        long now,
+        ref List<ValidationRuleError>? nestedViolations,
+        scoped ref AvroValidationPath path)
+    {
+        var valuePlan = _children[0];
+        var hasSizeDemand = _schemaRules.HasMapEntrySizeDemand;
+        var itemCount = 0;
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return itemCount;
+            for (long index = 0; index < count; index++)
+            {
+                itemCount = checked(itemCount + 1);
+                var key = reader.ReadLengthPrefixed();
+                AvroMemberResolver.AvroMemberNode? memberResolver = null;
+                if (hasSizeDemand)
+                    _schemaRules.TryGetMapEntryResolver(key, out memberResolver);
+                var valueStart = reader.Position;
+                if (nestedViolations is not null)
+                {
+                    AvroValidationValueDecoder.Skip(valuePlan._schema, ref reader);
+                    ResolveMapEntry(
+                        hasSizeDemand,
+                        key,
+                        memberResolver,
+                        reader.Source.Slice(valueStart, reader.Position - valueStart),
+                        resolution);
+                    continue;
+                }
+
+                var mark = path.Length;
+                path.AppendMapKey(key.Span);
+                var value = valuePlan.ValidateAndCapture(
+                    ref reader,
+                    now,
+                    failFast: true,
+                    memberResolver?.NeedsSize ?? false,
+                    ref nestedViolations,
+                    ref path,
+                    out var size);
+                path.Truncate(mark);
+                var payload = reader.Source.Slice(valueStart, reader.Position - valueStart);
+                if (hasSizeDemand)
+                {
+                    memberResolver?.ResolveCaptured(
+                        payload,
+                        value,
+                        size,
+                        resolution.Members,
+                        resolution.Sizes);
+                }
+                else
+                {
+                    _schemaRules.ResolveMapEntry(key, payload, value, size, resolution);
+                }
+            }
+        }
+    }
+
+    private void ResolveMapEntry(
+        bool hasSizeDemand,
+        ReadOnlyMemory<byte> key,
+        AvroMemberResolver.AvroMemberNode? memberResolver,
+        ReadOnlyMemory<byte> payload,
+        AvroMemberResolution resolution)
+    {
+        if (hasSizeDemand)
+            memberResolver?.Resolve(payload, resolution.Members, resolution.Sizes);
+        else
+            _schemaRules.ResolveMapEntry(key, payload, resolution);
     }
 
     private static void AppendNestedViolations(
@@ -1432,6 +1573,14 @@ internal sealed class AvroCompiledRuleSet
             resolution.Members,
             resolution.Sizes);
 
+    internal bool HasMapEntrySizeDemand => _members!.HasMapEntrySizeDemand;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryGetMapEntryResolver(
+        ReadOnlyMemory<byte> key,
+        out AvroMemberResolver.AvroMemberNode? memberResolver) =>
+        _members!.TryGetMapEntryResolver(key, out memberResolver);
+
     internal void ResolveMapEntry(
         ReadOnlyMemory<byte> key,
         ReadOnlyMemory<byte> payload,
@@ -1548,6 +1697,9 @@ internal sealed class AvroMemberResolver
     private readonly AvroMemberResolver?[]? _unionBranches;
     private readonly AvroMemberNode?[] _fields;
     private readonly Dictionary<ReadOnlyMemory<byte>, AvroMemberNode>? _mapValues;
+    private bool _hasMapEntrySizeDemand;
+
+    internal bool HasMapEntrySizeDemand => _hasMapEntrySizeDemand;
 
     internal int LastRecordMemberIndex
     {
@@ -1744,6 +1896,7 @@ internal sealed class AvroMemberResolver
         if (depth == path.Length - 1)
         {
             node.AddMemberIndex(memberIndex, needsSize);
+            _hasMapEntrySizeDemand |= needsSize;
             return;
         }
         node.AddChild(schema.ValueSchema, path, memberIndex, needsSize, depth + 1);
@@ -1830,6 +1983,12 @@ internal sealed class AvroMemberResolver
             }
         }
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryGetMapEntryResolver(
+        ReadOnlyMemory<byte> key,
+        out AvroMemberNode? memberResolver) =>
+        _mapValues!.TryGetValue(key, out memberResolver);
 
     internal void ResolveMapEntry(
         ReadOnlyMemory<byte> key,
@@ -1973,7 +2132,7 @@ internal sealed class AvroMemberResolver
                 schema.Fields[index].Schema;
     }
 
-    private sealed class AvroMemberNode(
+    internal sealed class AvroMemberNode(
         AvroAggregateEqualityComparerFactory aggregateComparerFactory)
     {
         private readonly Dictionary<AvroSchema, AvroMemberResolver> _children =

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -799,24 +799,41 @@ internal sealed class AvroValueRulePlan
         var start = reader.Position;
         var branchResolver = memberResolver.GetUnionBranchResolver((int)branch);
         if (branchResolver is not null &&
-            child._schemaRules.IsEmpty &&
-            child._schema is global::Avro.RecordSchema)
+            child._schemaRules.IsEmpty)
         {
-            child.ValidateRecordWithMemberResolver(
-                ref reader,
-                branchResolver,
-                resolution,
-                now,
-                failFast,
-                ref nestedViolations,
-                ref path);
-            size = child._fields.Length;
+            switch (child._schema)
+            {
+                case global::Avro.RecordSchema:
+                    child.ValidateRecordWithMemberResolver(
+                        ref reader,
+                        branchResolver,
+                        resolution,
+                        now,
+                        failFast,
+                        ref nestedViolations,
+                        ref path);
+                    size = child._fields.Length;
+                    break;
+                case global::Avro.MapSchema:
+                    size = child.ValidateMapWithMemberResolver(
+                        ref reader,
+                        branchResolver,
+                        resolution,
+                        now,
+                        failFast,
+                        ref nestedViolations,
+                        ref path);
+                    break;
+                default:
+                    goto Deferred;
+            }
             return ValidationCelValue.FromCollection(
                 ValidationCelValueKind.Object,
                 reader.Source.Slice(start, reader.Position - start),
                 sizeIndex: 0);
         }
 
+Deferred:
         var value = child.ValidateAndCapture(
             ref reader,
             now,
@@ -832,6 +849,146 @@ internal sealed class AvroValueRulePlan
         return value;
     }
 
+    private ValidationCelValue ValidateAndCaptureWithMemberNode(
+        ref AvroValidationReader reader,
+        AvroMemberResolver.AvroMemberNode memberNode,
+        AvroMemberResolution resolution,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? nestedViolations,
+        scoped ref AvroValidationPath path,
+        out int size)
+    {
+        var start = reader.Position;
+        if (_schemaRules.IsEmpty &&
+            memberNode.TryGetChildResolver(_schema, out var childResolver))
+        {
+            ValidationCelValue value;
+            switch (_schema)
+            {
+                case global::Avro.RecordSchema:
+                    ValidateRecordWithMemberResolver(
+                        ref reader,
+                        childResolver,
+                        resolution,
+                        now,
+                        failFast,
+                        ref nestedViolations,
+                        ref path);
+                    size = _fields.Length;
+                    break;
+                case global::Avro.MapSchema:
+                    size = ValidateMapWithMemberResolver(
+                        ref reader,
+                        childResolver,
+                        resolution,
+                        now,
+                        failFast,
+                        ref nestedViolations,
+                        ref path);
+                    break;
+                default:
+                    goto Deferred;
+            }
+            value = ValidationCelValue.FromCollection(
+                ValidationCelValueKind.Object,
+                reader.Source.Slice(start, reader.Position - start),
+                sizeIndex: 0);
+            memberNode.ResolveCapturedValue(
+                reader.Source.Slice(start, reader.Position - start),
+                value,
+                size,
+                resolution.Members,
+                resolution.Sizes);
+            return value;
+        }
+
+        if (_schemaRules.IsEmpty && _schema is global::Avro.UnionSchema union)
+        {
+            var branch = reader.ReadLong();
+            if ((ulong)branch >= (ulong)union.Count)
+                throw InvalidPayload($"invalid union index {branch}");
+
+            var child = _children[(int)branch];
+            var childStart = reader.Position;
+            if (child._schemaRules.IsEmpty &&
+                memberNode.TryGetChildResolver(child._schema, out childResolver))
+            {
+                switch (child._schema)
+                {
+                    case global::Avro.RecordSchema:
+                        child.ValidateRecordWithMemberResolver(
+                            ref reader,
+                            childResolver,
+                            resolution,
+                            now,
+                            failFast,
+                            ref nestedViolations,
+                            ref path);
+                        size = child._fields.Length;
+                        break;
+                    case global::Avro.MapSchema:
+                        size = child.ValidateMapWithMemberResolver(
+                            ref reader,
+                            childResolver,
+                            resolution,
+                            now,
+                            failFast,
+                            ref nestedViolations,
+                            ref path);
+                        break;
+                    default:
+                        goto DeferredBranch;
+                }
+                var value = ValidationCelValue.FromCollection(
+                    ValidationCelValueKind.Object,
+                    reader.Source.Slice(childStart, reader.Position - childStart),
+                    sizeIndex: 0);
+                memberNode.ResolveCapturedValue(
+                    reader.Source.Slice(start, reader.Position - start),
+                    value,
+                    size,
+                    resolution.Members,
+                    resolution.Sizes);
+                return value;
+            }
+
+DeferredBranch:
+            var branchValue = child.ValidateAndCapture(
+                ref reader,
+                now,
+                failFast,
+                memberNode.NeedsSize,
+                ref nestedViolations,
+                ref path,
+                out size);
+            memberNode.ResolveCaptured(
+                reader.Source.Slice(start, reader.Position - start),
+                branchValue,
+                size,
+                resolution.Members,
+                resolution.Sizes);
+            return branchValue;
+        }
+
+Deferred:
+        var capturedValue = ValidateAndCapture(
+            ref reader,
+            now,
+            failFast,
+            memberNode.NeedsSize,
+            ref nestedViolations,
+            ref path,
+            out size);
+        memberNode.ResolveCaptured(
+            reader.Source.Slice(start, reader.Position - start),
+            capturedValue,
+            size,
+            resolution.Members,
+            resolution.Sizes);
+        return capturedValue;
+    }
+
     private void ValidateRecordWithMemberResolver(
         ref AvroValidationReader reader,
         AvroMemberResolver memberResolver,
@@ -841,6 +998,19 @@ internal sealed class AvroValueRulePlan
         ref List<ValidationRuleError>? nestedViolations,
         scoped ref AvroValidationPath path)
     {
+        if (memberResolver.HasDescendantTargets)
+        {
+            ValidateRecordWithDescendantMemberResolver(
+                ref reader,
+                memberResolver,
+                resolution,
+                now,
+                failFast,
+                ref nestedViolations,
+                ref path);
+            return;
+        }
+
         for (var index = 0; index < _fields.Length; index++)
         {
             var start = reader.Position;
@@ -867,6 +1037,133 @@ internal sealed class AvroValueRulePlan
                 size,
                 resolution.Members,
                 resolution.Sizes);
+        }
+    }
+
+    private void ValidateRecordWithDescendantMemberResolver(
+        ref AvroValidationReader reader,
+        AvroMemberResolver memberResolver,
+        AvroMemberResolution resolution,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? nestedViolations,
+        scoped ref AvroValidationPath path)
+    {
+        for (var index = 0; index < _fields.Length; index++)
+        {
+            var start = reader.Position;
+            var field = _fields[index];
+            var fieldResolver = memberResolver.GetRecordFieldResolver(index);
+            var needsSize = fieldResolver.NeedsSize;
+            ValidationCelValue value;
+            int size;
+            if (failFast && nestedViolations is not null)
+                value = CaptureRecordField(field, ref reader, needsSize, out size);
+            else if (field.Rules.IsEmpty && fieldResolver.HasChildren)
+            {
+                var mark = path.Length;
+                path.AppendField(field.Field.Name);
+                value = field.Child.ValidateAndCaptureWithMemberNode(
+                    ref reader,
+                    fieldResolver,
+                    resolution,
+                    now,
+                    failFast,
+                    ref nestedViolations,
+                    ref path,
+                    out size);
+                path.Truncate(mark);
+                continue;
+            }
+            else
+                value = ValidateRecordFieldAndCapture(
+                    field,
+                    ref reader,
+                    now,
+                    failFast,
+                    needsSize,
+                    ref nestedViolations,
+                    ref path,
+                    out size);
+            if (fieldResolver.HasTargets)
+            {
+                fieldResolver.ResolveCaptured(
+                    reader.Source.Slice(start, reader.Position - start),
+                    value,
+                    size,
+                    resolution.Members,
+                    resolution.Sizes);
+            }
+        }
+    }
+
+    private int ValidateMapWithMemberResolver(
+        ref AvroValidationReader reader,
+        AvroMemberResolver memberResolver,
+        AvroMemberResolution resolution,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? nestedViolations,
+        scoped ref AvroValidationPath path)
+    {
+        var valuePlan = _children[0];
+        var itemCount = 0;
+        while (true)
+        {
+            var count = reader.ReadCollectionCount();
+            if (count == 0)
+                return itemCount;
+            for (long index = 0; index < count; index++)
+            {
+                itemCount = checked(itemCount + 1);
+                var key = reader.ReadLengthPrefixed();
+                memberResolver.TryGetMapEntryResolver(key, out var valueResolver);
+                var valueStart = reader.Position;
+                if (failFast && nestedViolations is not null)
+                {
+                    AvroValidationValueDecoder.Skip(valuePlan._schema, ref reader);
+                    valueResolver?.Resolve(
+                        reader.Source.Slice(valueStart, reader.Position - valueStart),
+                        resolution.Members,
+                        resolution.Sizes);
+                    continue;
+                }
+
+                var mark = path.Length;
+                path.AppendMapKey(key.Span);
+                ValidationCelValue value;
+                int size;
+                if (valueResolver?.HasChildren == true)
+                {
+                    value = valuePlan.ValidateAndCaptureWithMemberNode(
+                        ref reader,
+                        valueResolver,
+                        resolution,
+                        now,
+                        failFast,
+                        ref nestedViolations,
+                        ref path,
+                        out size);
+                }
+                else
+                {
+                    value = valuePlan.ValidateAndCapture(
+                        ref reader,
+                        now,
+                        failFast,
+                        valueResolver?.NeedsSize ?? false,
+                        ref nestedViolations,
+                        ref path,
+                        out size);
+                    valueResolver?.ResolveCaptured(
+                        reader.Source.Slice(valueStart, reader.Position - valueStart),
+                        value,
+                        size,
+                        resolution.Members,
+                        resolution.Sizes);
+                }
+                path.Truncate(mark);
+            }
         }
     }
 
@@ -2087,8 +2384,10 @@ internal sealed class AvroMemberResolver
     private readonly AvroMemberNode?[] _fields;
     private readonly Dictionary<ReadOnlyMemory<byte>, AvroMemberNode>? _mapValues;
     private bool _hasMapEntrySizeDemand;
+    private bool _hasDescendantTargets;
 
     internal bool HasMapEntrySizeDemand => _hasMapEntrySizeDemand;
+    internal bool HasDescendantTargets => _hasDescendantTargets;
 
     internal int LastRecordMemberIndex
     {
@@ -2266,6 +2565,7 @@ internal sealed class AvroMemberResolver
             node.AddMemberIndex(memberIndex, needsSize);
             return;
         }
+        _hasDescendantTargets = true;
         node.AddChild(field.Schema, path, memberIndex, needsSize, depth + 1);
     }
 
@@ -2288,6 +2588,7 @@ internal sealed class AvroMemberResolver
             _hasMapEntrySizeDemand |= needsSize;
             return;
         }
+        _hasDescendantTargets = true;
         node.AddChild(schema.ValueSchema, path, memberIndex, needsSize, depth + 1);
     }
 
@@ -2417,6 +2718,10 @@ internal sealed class AvroMemberResolver
         if (node.HasTargets)
             node.ResolveCaptured(payload, value, size, values, sizes);
     }
+
+    internal AvroMemberNode GetRecordFieldResolver(int fieldIndex) =>
+        _fields[fieldIndex]
+            ?? throw new InvalidOperationException("Avro validation member resolver is incomplete.");
 
     internal bool NeedsRecordFieldSize(int fieldIndex) =>
         _fields[fieldIndex]?.NeedsSize ?? false;
@@ -2560,7 +2865,13 @@ internal sealed class AvroMemberResolver
         }
         internal int MemberIndex { get; private set; } = -1;
         internal bool HasTargets => MemberIndex >= 0 || _children.Count != 0;
+        internal bool HasChildren => _children.Count != 0;
         internal bool NeedsSize => _needsSize;
+
+        internal bool TryGetChildResolver(
+            AvroSchema schema,
+            out AvroMemberResolver childResolver) =>
+            _children.TryGetValue(AvroValueRulePlan.Unwrap(schema), out childResolver!);
 
         internal void AddMemberIndex(int memberIndex, bool needsSize)
         {
@@ -2758,6 +3069,44 @@ internal sealed class AvroMemberResolver
                 return;
             if (_children.TryGetValue(schema, out var child))
                 child.Resolve(payload, values, sizes);
+        }
+
+        internal void ResolveCapturedValue(
+            ReadOnlyMemory<byte> payload,
+            ValidationCelValue value,
+            int size,
+            ValidationCelMemberValues values,
+            ValidationCelSizeValues sizes)
+        {
+            if (MemberIndex < 0)
+                return;
+
+            var schema = AvroValueRulePlan.Unwrap(Schema!);
+            var aggregateComparer = _aggregateComparer;
+            if (schema is global::Avro.UnionSchema union)
+            {
+                var branchReader = new AvroValidationReader(payload);
+                var branch = branchReader.ReadLong();
+                if ((ulong)branch >= (ulong)union.Count)
+                    throw new SchemaRegistryRuleException(
+                        $"Could not evaluate Avro validation rules: invalid union index {branch}.");
+                aggregateComparer = _unionComparers![(int)branch];
+            }
+
+            SetMemberValue(MemberIndex, value, size, values, sizes, aggregateComparer);
+            var additionalIndexes = _additionalMemberIndexes;
+            if (additionalIndexes is null)
+                return;
+            for (var index = 0; index < additionalIndexes.Length; index++)
+            {
+                SetMemberValue(
+                    additionalIndexes[index],
+                    value,
+                    size,
+                    values,
+                    sizes,
+                    aggregateComparer);
+            }
         }
 
         private static void SetMemberValue(

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -59,6 +59,7 @@ internal sealed class AvroValueRulePlan
     {
         Standard,
         AggregateRoot,
+        AggregateRootAndMembers,
         DeferredRecord,
         DeferredMembers
     }
@@ -177,6 +178,12 @@ internal sealed class AvroValueRulePlan
 
     private ValidationStrategy GetValidationStrategy()
     {
+        if (_schemaRules.UsesRootValue
+            && _schemaRules.HasMembers
+            && _schema is global::Avro.RecordSchema or global::Avro.MapSchema)
+        {
+            return ValidationStrategy.AggregateRootAndMembers;
+        }
         if (!_hasNestedRules || _schemaRules.IsEmpty)
             return ValidationStrategy.Standard;
         if (_schemaRules.UsesRootValue
@@ -230,6 +237,16 @@ internal sealed class AvroValueRulePlan
             if (_validationStrategy == ValidationStrategy.AggregateRoot)
             {
                 return ValidateAggregateWithRootRules(
+                    ref reader,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path);
+            }
+
+            if (_validationStrategy == ValidationStrategy.AggregateRootAndMembers)
+            {
+                return ValidateAggregateWithRootAndMemberRules(
                     ref reader,
                     now,
                     failFast,
@@ -366,6 +383,227 @@ internal sealed class AvroValueRulePlan
         return ValidationCelValue.Missing;
     }
 
+    private ValidationCelValue ValidateAggregateWithRootAndMemberRules(
+        ref AvroValidationReader reader,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path)
+    {
+        var resolution = _schemaRules.BeginMemberResolution();
+        var start = reader.Position;
+        List<ValidationRuleError>? nestedViolations = null;
+        int rootSize;
+        ValidationCelValueKind valueKind;
+        switch (_schema)
+        {
+            case global::Avro.RecordSchema:
+                ValidateRecordWithMemberResolution(
+                    ref reader,
+                    resolution,
+                    now,
+                    ref nestedViolations,
+                    ref path);
+                rootSize = _fields.Length;
+                valueKind = ValidationCelValueKind.Object;
+                break;
+            case global::Avro.MapSchema:
+                rootSize = ValidateMapWithMemberResolution(
+                    ref reader,
+                    resolution,
+                    now,
+                    ref nestedViolations,
+                    ref path);
+                valueKind = ValidationCelValueKind.Object;
+                break;
+            default:
+                throw new InvalidOperationException(
+                    "Mixed root/member validation requires a record or map schema.");
+        }
+
+        var payload = reader.Source.Slice(start, reader.Position - start);
+        var value = ValidationCelValue.FromCollection(valueKind, payload, sizeIndex: 0);
+        _schemaRules.EvaluateResolved(
+            value,
+            payload,
+            resolution,
+            rootSize,
+            now,
+            failFast,
+            ref violations,
+            ref path);
+        AppendNestedViolations(nestedViolations, failFast, ref violations);
+        return value;
+    }
+
+    private void ValidateRecordWithMemberResolution(
+        ref AvroValidationReader reader,
+        AvroMemberResolution resolution,
+        long now,
+        ref List<ValidationRuleError>? nestedViolations,
+        scoped ref AvroValidationPath path)
+    {
+        for (var index = 0; index < _fields.Length; index++)
+        {
+            var start = reader.Position;
+            var value = ValidateRecordFieldAndCapture(
+                _fields[index],
+                ref reader,
+                now,
+                ref nestedViolations,
+                ref path,
+                out var size);
+            _schemaRules.ResolveRecordField(
+                index,
+                reader.Source.Slice(start, reader.Position - start),
+                value,
+                size,
+                resolution);
+        }
+    }
+
+    private static ValidationCelValue ValidateRecordFieldAndCapture(
+        AvroFieldRulePlan field,
+        ref AvroValidationReader reader,
+        long now,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path,
+        out int size)
+    {
+        if (!field.Rules.IsEmpty)
+        {
+            if (CanFuseFieldRules(field))
+            {
+                var fieldMark = path.Length;
+                path.AppendField(field.Field.Name);
+                var capturedValue = EvaluateFieldRulesWithNestedTraversal(
+                    field,
+                    ref reader,
+                    now,
+                    failFast: false,
+                    ref violations,
+                    ref path,
+                    out size);
+                path.Truncate(fieldMark);
+                return capturedValue;
+            }
+
+            ValidateDeferredRecordField(
+                field,
+                ref reader,
+                now,
+                failFast: false,
+                ref violations,
+                ref path);
+            size = -1;
+            return ValidationCelValue.Missing;
+        }
+
+        var mark = path.Length;
+        path.AppendField(field.Field.Name);
+        var value = field.Child.ValidateAndCapture(
+            ref reader,
+            now,
+            ref violations,
+            ref path,
+            out size);
+        path.Truncate(mark);
+        return value;
+    }
+
+    private static bool CanFuseFieldRules(AvroFieldRulePlan field) =>
+        field.Child.HasAnyRules &&
+        field.Child._schemaRules.IsEmpty &&
+        field.Rules.UsesRootValue &&
+        !field.Rules.HasMembers &&
+        field.Child._schema is global::Avro.RecordSchema or global::Avro.ArraySchema or global::Avro.MapSchema;
+
+    private static ValidationCelValue EvaluateFieldRulesWithNestedTraversal(
+        AvroFieldRulePlan field,
+        ref AvroValidationReader reader,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path,
+        out int size)
+    {
+        var start = reader.Position;
+        List<ValidationRuleError>? nestedViolations = null;
+        var value = field.Child.ValidateAndCapture(
+            ref reader,
+            now,
+            ref nestedViolations,
+            ref path,
+            out size);
+        var payload = reader.Source.Slice(start, reader.Position - start);
+        field.Rules.Evaluate(
+            value,
+            payload,
+            now,
+            failFast,
+            ref violations,
+            ref path,
+            size);
+        AppendNestedViolations(nestedViolations, failFast, ref violations);
+        return value;
+    }
+
+    private ValidationCelValue ValidateAndCapture(
+        ref AvroValidationReader reader,
+        long now,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path,
+        out int size)
+    {
+        if (_schemaRules.IsEmpty)
+        {
+            var start = reader.Position;
+            ValidationCelValueKind kind;
+            switch (_schema)
+            {
+                case global::Avro.RecordSchema:
+                    ValidateRecord(ref reader, now, failFast: false, ref violations, ref path);
+                    size = _fields.Length;
+                    kind = ValidationCelValueKind.Object;
+                    break;
+                case global::Avro.ArraySchema:
+                    size = ValidateArray(ref reader, now, failFast: false, ref violations, ref path);
+                    kind = ValidationCelValueKind.Array;
+                    break;
+                case global::Avro.MapSchema:
+                    size = ValidateMap(ref reader, now, failFast: false, ref violations, ref path);
+                    kind = ValidationCelValueKind.Object;
+                    break;
+                default:
+                    size = -1;
+                    return Validate(
+                        ref reader,
+                        now,
+                        failFast: false,
+                        ref violations,
+                        ref path);
+            }
+            return ValidationCelValue.FromCollection(
+                kind,
+                reader.Source.Slice(start, reader.Position - start),
+                sizeIndex: 0);
+        }
+
+        var valueStart = reader.Position;
+        var value = Validate(
+            ref reader,
+            now,
+            failFast: false,
+            ref violations,
+            ref path);
+        size = value.SizeIndex == 0
+            ? AvroValidationValueDecoder.Count(
+                _schema,
+                reader.Source.Slice(valueStart, reader.Position - valueStart))
+            : -1;
+        return value;
+    }
+
     private void ValidateUnionWithMemberResolution(
         ref AvroValidationReader reader,
         AvroMemberResolution resolution,
@@ -391,7 +629,7 @@ internal sealed class AvroValueRulePlan
             resolution);
     }
 
-    private void ValidateMapWithMemberResolution(
+    private int ValidateMapWithMemberResolution(
         ref AvroValidationReader reader,
         AvroMemberResolution resolution,
         long now,
@@ -399,27 +637,31 @@ internal sealed class AvroValueRulePlan
         scoped ref AvroValidationPath path)
     {
         var valuePlan = _children[0];
+        var itemCount = 0;
         while (true)
         {
             var count = reader.ReadCollectionCount();
             if (count == 0)
-                return;
+                return itemCount;
             for (long index = 0; index < count; index++)
             {
+                itemCount = checked(itemCount + 1);
                 var key = reader.ReadLengthPrefixed();
                 var valueStart = reader.Position;
                 var mark = path.Length;
                 path.AppendMapKey(key.Span);
-                _ = valuePlan.Validate(
+                var value = valuePlan.ValidateAndCapture(
                     ref reader,
                     now,
-                    failFast: false,
                     ref nestedViolations,
-                    ref path);
+                    ref path,
+                    out var size);
                 path.Truncate(mark);
                 _schemaRules.ResolveMapEntry(
                     key,
                     reader.Source.Slice(valueStart, reader.Position - valueStart),
+                    value,
+                    size,
                     resolution);
             }
         }
@@ -501,6 +743,17 @@ internal sealed class AvroValueRulePlan
             if (field.Rules.IsEmpty)
             {
                 _ = field.Child.Validate(ref reader, now, failFast, ref violations, ref path);
+            }
+            else if (CanFuseFieldRules(field))
+            {
+                _ = EvaluateFieldRulesWithNestedTraversal(
+                    field,
+                    ref reader,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path,
+                    out _);
             }
             else
             {
@@ -787,6 +1040,17 @@ internal sealed class AvroValueRulePlan
         {
             _ = field.Child.Validate(ref reader, now, failFast, ref violations, ref path);
         }
+        else if (CanFuseFieldRules(field))
+        {
+            _ = EvaluateFieldRulesWithNestedTraversal(
+                field,
+                ref reader,
+                now,
+                failFast,
+                ref violations,
+                ref path,
+                out _);
+        }
         else
         {
             var fieldStart = reader.Position;
@@ -1009,6 +1273,64 @@ internal sealed class AvroCompiledRuleSet
         }
     }
 
+    internal void EvaluateResolved(
+        ValidationCelValue value,
+        ReadOnlyMemory<byte> payload,
+        AvroMemberResolution resolution,
+        int rootSize,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path)
+    {
+        resolution.Sizes.Set(0, rootSize);
+        var equalityGeneration = _usesCachedEquality
+            ? CompiledValidationRule.BeginEqualityResolution()
+            : 0;
+        var rootAggregateComparer = _usesRootAggregateEquality
+            ? GetRootAggregateComparer(payload)
+            : null;
+
+        ValidationCelStrings.Begin(_memberCount + 1, payload.Length);
+        try
+        {
+            for (var index = 0; index < _rules.Length; index++)
+            {
+                var rule = _rules[index];
+                try
+                {
+                    var result = rule.Evaluate(
+                        value,
+                        now,
+                        resolution.Members,
+                        resolution.Sizes,
+                        equalityGeneration,
+                        rootAggregateComparer);
+                    if (result.Kind == ValidationResultKind.Boolean ? result.Boolean : result.String!.Length == 0)
+                        continue;
+                    (violations ??= []).Add(new ValidationRuleError(
+                        rule.Rule,
+                        path.ToString(),
+                        result.Kind == ValidationResultKind.String ? result.String : null));
+                }
+                catch (SchemaRegistryRuleException exception)
+                {
+                    (violations ??= []).Add(new ValidationRuleError(
+                        rule.Rule,
+                        path.ToString(),
+                        cause: exception));
+                }
+
+                if (failFast)
+                    return;
+            }
+        }
+        finally
+        {
+            ValidationCelStrings.End();
+        }
+    }
+
     internal void EvaluateWithoutRoot(
         ref AvroValidationReader reader,
         AvroSchema valueSchema,
@@ -1059,6 +1381,34 @@ internal sealed class AvroCompiledRuleSet
         ReadOnlyMemory<byte> payload,
         AvroMemberResolution resolution) =>
         _members!.ResolveMapEntry(key, payload, resolution.Members, resolution.Sizes);
+
+    internal void ResolveMapEntry(
+        ReadOnlyMemory<byte> key,
+        ReadOnlyMemory<byte> payload,
+        ValidationCelValue value,
+        int size,
+        AvroMemberResolution resolution) =>
+        _members!.ResolveMapEntry(
+            key,
+            payload,
+            value,
+            size,
+            resolution.Members,
+            resolution.Sizes);
+
+    internal void ResolveRecordField(
+        int fieldIndex,
+        ReadOnlyMemory<byte> payload,
+        ValidationCelValue value,
+        int size,
+        AvroMemberResolution resolution) =>
+        _members!.ResolveRecordField(
+            fieldIndex,
+            payload,
+            value,
+            size,
+            resolution.Members,
+            resolution.Sizes);
 
     internal void ResolveUnionBranch(
         int branch,
@@ -1407,6 +1757,32 @@ internal sealed class AvroMemberResolver
             node.Resolve(payload, values, sizes);
     }
 
+    internal void ResolveMapEntry(
+        ReadOnlyMemory<byte> key,
+        ReadOnlyMemory<byte> payload,
+        ValidationCelValue value,
+        int size,
+        ValidationCelMemberValues values,
+        ValidationCelSizeValues sizes)
+    {
+        if (_mapValues!.TryGetValue(key, out var node))
+            node.ResolveCaptured(payload, value, size, values, sizes);
+    }
+
+    internal void ResolveRecordField(
+        int fieldIndex,
+        ReadOnlyMemory<byte> payload,
+        ValidationCelValue value,
+        int size,
+        ValidationCelMemberValues values,
+        ValidationCelSizeValues sizes)
+    {
+        var node = _fields[fieldIndex]
+            ?? throw new InvalidOperationException("Avro validation member resolver is incomplete.");
+        if (node.HasTargets)
+            node.ResolveCaptured(payload, value, size, values, sizes);
+    }
+
     internal void ResolveUnionBranch(
         int branch,
         ReadOnlyMemory<byte> payload,
@@ -1685,6 +2061,45 @@ internal sealed class AvroMemberResolver
                     values,
                     sizes);
             }
+        }
+
+        internal void ResolveCaptured(
+            ReadOnlyMemory<byte> payload,
+            ValidationCelValue value,
+            int size,
+            ValidationCelMemberValues values,
+            ValidationCelSizeValues sizes)
+        {
+            var schema = AvroValueRulePlan.Unwrap(Schema!);
+            if (value.Kind == ValidationCelValueKind.Missing || schema is global::Avro.UnionSchema)
+            {
+                Resolve(payload, values, sizes);
+                return;
+            }
+
+            if (MemberIndex >= 0)
+            {
+                SetMemberValue(MemberIndex, value, size, values, sizes, _aggregateComparer);
+                var additionalIndexes = _additionalMemberIndexes;
+                if (additionalIndexes is not null)
+                {
+                    for (var index = 0; index < additionalIndexes.Length; index++)
+                    {
+                        SetMemberValue(
+                            additionalIndexes[index],
+                            value,
+                            size,
+                            values,
+                            sizes,
+                            _aggregateComparer);
+                    }
+                }
+            }
+
+            if (_children.Count == 0)
+                return;
+            if (_children.TryGetValue(schema, out var child))
+                child.Resolve(payload, values, sizes);
         }
 
         private static void SetMemberValue(

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -614,6 +614,17 @@ internal sealed class AvroValueRulePlan
                 sizeIndex: 0);
         }
 
+        if (needsSize && _validationStrategy == ValidationStrategy.Standard)
+        {
+            return ValidateSchemaRulesAndCapture(
+                ref reader,
+                now,
+                failFast,
+                ref violations,
+                ref path,
+                out size);
+        }
+
         var valueStart = reader.Position;
         var value = Validate(
             ref reader,
@@ -626,6 +637,53 @@ internal sealed class AvroValueRulePlan
                 _schema,
                 reader.Source.Slice(valueStart, reader.Position - valueStart))
             : -1;
+        return value;
+    }
+
+    private ValidationCelValue ValidateSchemaRulesAndCapture(
+        ref AvroValidationReader reader,
+        long now,
+        bool failFast,
+        ref List<ValidationRuleError>? violations,
+        scoped ref AvroValidationPath path,
+        out int size)
+    {
+        var start = reader.Position;
+        var preview = reader;
+        var value = ReadValue(ref preview, needsSize: true, out size);
+        var payload = preview.Source.Slice(start, preview.Position - start);
+        _schemaRules.Evaluate(
+            value,
+            payload,
+            now,
+            failFast,
+            ref violations,
+            ref path,
+            _schemaRules.UsesRootSize ? size : -1);
+        if ((failFast && violations is not null) || !_hasNestedRules)
+        {
+            reader = preview;
+            return value;
+        }
+
+        switch (_schema)
+        {
+            case global::Avro.RecordSchema:
+                ValidateRecord(ref reader, now, failFast, ref violations, ref path);
+                break;
+            case global::Avro.ArraySchema:
+                _ = ValidateArray(ref reader, now, failFast, ref violations, ref path);
+                break;
+            case global::Avro.MapSchema:
+                _ = ValidateMap(ref reader, now, failFast, ref violations, ref path);
+                break;
+            case global::Avro.UnionSchema:
+                ValidateUnion(ref reader, now, failFast, ref violations, ref path);
+                break;
+            default:
+                reader = preview;
+                break;
+        }
         return value;
     }
 

--- a/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroInlineRuleValidator.cs
@@ -896,13 +896,10 @@ internal static class AvroValidationValueDecoder
                 var record = (global::Avro.RecordSchema)schema;
                 for (var index = 0; index < record.Fields.Count; index++)
                     Skip(record.Fields[index].Schema, ref reader);
-                return new ValidationCelValue(
+                return ValidationCelValue.FromCollection(
                     ValidationCelValueKind.Object,
-                    default,
-                    false,
-                    0,
-                    null,
-                    reader.Source.Slice(recordStart, reader.Position - recordStart));
+                    reader.Source.Slice(recordStart, reader.Position - recordStart),
+                    0);
             case AvroSchema.Type.Array:
             {
                 var collectionStart = reader.Position;
@@ -938,6 +935,8 @@ internal static class AvroValidationValueDecoder
     internal static int Count(AvroSchema schema, ReadOnlyMemory<byte> payload)
     {
         schema = AvroValueRulePlan.Unwrap(schema);
+        if (schema is global::Avro.RecordSchema record)
+            return record.Fields.Count;
         if (schema is not (global::Avro.ArraySchema or global::Avro.MapSchema))
             return -1;
         var reader = new AvroValidationReader(payload);

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Avro.Generic;
 using Avro.IO;
@@ -73,6 +74,7 @@ public sealed class AvroSchemaRegistryDeserializer<
     private readonly SchemaRegistryMigrationRunner? _migrationRunner;
     private readonly AvroTaggedFieldTransformerProvider _taggedFieldTransformers = new();
     private readonly AvroInlineRuleValidatorProvider? _inlineRuleValidators;
+    private long _lastInlineValidationDecision = -1;
 
     /// <summary>
     /// Creates a new Avro Schema Registry deserializer.
@@ -353,29 +355,16 @@ public sealed class AvroSchemaRegistryDeserializer<
         // Extract Avro payload. Array-backed payloads decode in place; other memory falls back to a pooled copy.
         var payloadMemory = data[payloadOffset..];
         AvroSchema? migrationReaderSchema = null;
-        if (_ruleExecutor is null && _inlineRuleValidators is null)
-        {
-            var directCodecState = AvroCodecThreadStateCache.Deserialization ??= new AvroDeserializationThreadState();
-            return ReadAvroPayload(
-                payloadMemory,
-                writerSchema,
-                migrationReaderSchema: null,
-                codecState: directCodecState);
-        }
-
         if (_ruleExecutor is null)
         {
-            _inlineRuleValidators!.Get(writerSchema).Validate(
-                payloadMemory,
-                schemaId,
-                _config.ValidationRulesFailFast);
-            var validatedCodecState = AvroCodecThreadStateCache.Deserialization ??=
-                new AvroDeserializationThreadState();
+            GetInlineValidator(schemaId, writerSchema)?.Validate(
+                payloadMemory, schemaId, _config.ValidationRulesFailFast);
+            var codecState = AvroCodecThreadStateCache.Deserialization ??= new AvroDeserializationThreadState();
             return ReadAvroPayload(
                 payloadMemory,
                 writerSchema,
                 migrationReaderSchema: null,
-                codecState: validatedCodecState);
+                codecState);
         }
 
         var taggedWorkspaceOperation = AvroTaggedFieldTransformerProvider.BeginOperation();
@@ -691,6 +680,24 @@ public sealed class AvroSchemaRegistryDeserializer<
         string? Subject,
         Schema Schema,
         AvroSchema WriterSchema);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private AvroInlineRuleValidator? GetInlineValidator(int schemaId, AvroSchema writerSchema)
+    {
+        if (_inlineRuleValidators is null)
+            return null;
+
+        var cached = Volatile.Read(ref _lastInlineValidationDecision);
+        if (cached >= 0 && (int)(cached >> 1) == schemaId && (cached & 1) == 0)
+            return null;
+
+        var validator = _inlineRuleValidators.Get(writerSchema);
+        var hasRules = validator.HasAnyRules;
+        Volatile.Write(
+            ref _lastInlineValidationDecision,
+            ((long)schemaId << 1) | (hasRules ? 1L : 0L));
+        return hasRules ? validator : null;
+    }
 
     private string GetSubjectName(int schemaId, Schema schema, SerializationContext context)
     {

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
@@ -476,6 +476,7 @@ public sealed class AvroSchemaRegistryDeserializer<
                     ((IInlineValidationRuleExecutor)_inlineRuleValidators!).Validate(
                         payloadMemory,
                         migration.PayloadSchemaId,
+                        subject,
                         migration.PayloadSchema,
                         _config.ValidationRulesFailFast);
                 }

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
@@ -63,6 +63,7 @@ public sealed class AvroSchemaRegistryDeserializer<
     private readonly ConcurrentQueue<KeyValuePair<GuidTopicKey, Lazy<Task<GuidResolvedSchema>>>>
         _guidSchemaEvictionQueue = new();
     private int _cachedGuidSchemaCount;
+    private int _nextGuidSchemaId;
     private readonly ConcurrentDictionary<AvroSchemaPair, GenericDatumReader<GenericRecord>> _genericReaders =
         new(AvroSchemaPairReferenceComparer.Instance);
     private readonly ConcurrentDictionary<AvroSchemaPair, SpecificDatumReader<T>> _specificReaders =
@@ -88,7 +89,7 @@ public sealed class AvroSchemaRegistryDeserializer<
         bool ownsClient = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
-        _taggedFieldTransformers = new AvroTaggedFieldTransformerProvider(schemaRegistry);
+        _taggedFieldTransformers = new AvroTaggedFieldTransformerProvider();
         _config = config ?? new AvroDeserializerConfig();
         if (_config.SchemaIdStrategy is not (SchemaIdDeserializerStrategy.Dual or SchemaIdDeserializerStrategy.Prefix or SchemaIdDeserializerStrategy.Header))
             throw new ArgumentOutOfRangeException(nameof(config), _config.SchemaIdStrategy, "Unknown schema identity strategy.");
@@ -128,6 +129,7 @@ public sealed class AvroSchemaRegistryDeserializer<
 
     bool IAsyncDeserializerPreparationRequirement.RequiresPreparation =>
         _config.SchemaIdStrategy != SchemaIdDeserializerStrategy.Prefix
+        || _migrationRunner is not null
         || _ruleExecutor is not null && _subjectNames is { RequiresPreparation: true };
 
     ValueTask IAsyncDeserializerPreparer<T>.PrepareAsync(
@@ -154,9 +156,12 @@ public sealed class AvroSchemaRegistryDeserializer<
 
         if (_config.SchemaIdStrategy == SchemaIdDeserializerStrategy.Prefix)
         {
+            if (!DeserializerSubjectNameCache.TryReadSchemaId(data, out var prefixSchemaId))
+                return default;
+            if (_migrationRunner is not null)
+                return PrepareMigrationAsync(prefixSchemaId, context, cancellationToken);
             return _ruleExecutor is not null
                 && _subjectNames is { RequiresPreparation: true } prefixSubjectNames
-                && DeserializerSubjectNameCache.TryReadSchemaId(data, out var prefixSchemaId)
                 ? prefixSubjectNames.PrepareAsync(
                     _schemaRegistry,
                     prefixSchemaId,
@@ -170,14 +175,20 @@ public sealed class AvroSchemaRegistryDeserializer<
         var identity = ReadIdentity(data, identityHeader, out _);
         if (identity.SchemaGuid is { } schemaGuid)
         {
-            return new ValueTask(GetGuidSchemaAsync(
+            var resolution = GetGuidSchemaAsync(
                 new GuidTopicKey(
                     schemaGuid,
                     context.Topic,
                     context.Component == SerializationComponent.Key,
                     _subjectNames?.Generation ?? 0),
-                cancellationToken));
+                cancellationToken);
+            return _migrationRunner is null
+                ? new ValueTask(resolution)
+                : PrepareGuidMigrationAsync(resolution, context, cancellationToken);
         }
+
+        if (_migrationRunner is not null)
+            return PrepareMigrationAsync(identity.SchemaId!.Value, context, cancellationToken);
 
         return _ruleExecutor is not null
             && _subjectNames is { RequiresPreparation: true } subjectNames
@@ -189,6 +200,93 @@ public sealed class AvroSchemaRegistryDeserializer<
                 FallbackRecordName,
                 cancellationToken)
             : default;
+    }
+
+    private async ValueTask PrepareGuidMigrationAsync(
+        Task<GuidResolvedSchema> resolution,
+        SerializationContext context,
+        CancellationToken cancellationToken)
+    {
+        var resolved = await resolution.ConfigureAwait(false);
+        await PrepareMigrationSchemasAsync(
+                resolved.SchemaId,
+                resolved.Subject!,
+                resolved.Schema,
+                resolved.WriterSchema,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async ValueTask PrepareMigrationAsync(
+        int schemaId,
+        SerializationContext context,
+        CancellationToken cancellationToken)
+    {
+        var unscopedSchema = await _schemaRegistry.GetSchemaAsync(schemaId, cancellationToken)
+            .ConfigureAwait(false);
+        if (_subjectNames is { RequiresPreparation: true } subjectNames)
+        {
+            await subjectNames.PrepareAsync(
+                    _schemaRegistry,
+                    schemaId,
+                    context.Topic,
+                    context.Component == SerializationComponent.Key,
+                    FallbackRecordName,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        var subject = GetSubjectName(schemaId, unscopedSchema, context);
+        var scopedSchema = await _schemaRegistry.GetSchemaAsync(schemaId, subject, cancellationToken)
+            .ConfigureAwait(false);
+        var writerSchema = await AvroSchemaReferenceResolver.ParseAsync(
+                _schemaRegistry,
+                scopedSchema,
+                cancellationToken)
+            .ConfigureAwait(false);
+        await PrepareMigrationSchemasAsync(
+                schemaId,
+                subject,
+                scopedSchema,
+                writerSchema,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async ValueTask PrepareMigrationSchemasAsync(
+        int schemaId,
+        string subject,
+        Schema writerRegistrySchema,
+        AvroSchema writerSchema,
+        CancellationToken cancellationToken)
+    {
+        _ = _taggedFieldTransformers.GetResolved(writerRegistrySchema, writerSchema);
+        _inlineRuleValidators?.Register(writerRegistrySchema, writerSchema);
+        var targets = await _migrationRunner!.PrepareAsync(
+                schemaId,
+                subject,
+                writerRegistrySchema,
+                cancellationToken)
+            .ConfigureAwait(false);
+        await PrepareMigrationSchemaAsync(targets.ReaderSchema.Schema, cancellationToken)
+            .ConfigureAwait(false);
+        while (targets.MoveNext(out var target))
+        {
+            await PrepareMigrationSchemaAsync(target.Schema, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask PrepareMigrationSchemaAsync(
+        Schema registrySchema,
+        CancellationToken cancellationToken)
+    {
+        var resolved = await AvroSchemaReferenceResolver.ParseAsync(
+                _schemaRegistry,
+                registrySchema,
+                cancellationToken)
+            .ConfigureAwait(false);
+        _ = _taggedFieldTransformers.GetResolved(registrySchema, resolved);
+        _inlineRuleValidators?.Register(registrySchema, resolved);
     }
 
     bool IAsyncDeserializerPreparer<T>.TryDeserialize(
@@ -346,10 +444,10 @@ public sealed class AvroSchemaRegistryDeserializer<
         int payloadOffset,
         string? preparedSubject)
     {
-        var schemaId = identity.SchemaId ?? -1;
         var guidSchema = identity.SchemaGuid is { } schemaGuid
             ? GetGuidSchemaCached(schemaGuid, context)
             : null;
+        var schemaId = guidSchema?.SchemaId ?? identity.SchemaId!.Value;
 
         // Get writer schema from registry (cached with lazy initialization)
         var writerSchema = guidSchema?.WriterSchema ?? GetWriterSchemaCached(schemaId);
@@ -582,7 +680,11 @@ public sealed class AvroSchemaRegistryDeserializer<
             var unscopedWriterSchema = unscopedNames is null
                 ? AvroSchema.Parse(unscopedSchema.SchemaString)
                 : AvroSchema.Parse(unscopedSchema.SchemaString, unscopedNames);
-            return new GuidResolvedSchema(-1, null, unscopedSchema, unscopedWriterSchema);
+            return new GuidResolvedSchema(
+                Interlocked.Decrement(ref _nextGuidSchemaId),
+                null,
+                unscopedSchema,
+                unscopedWriterSchema);
         }
 
         var subject = _subjectNames is null
@@ -687,20 +789,20 @@ public sealed class AvroSchemaRegistryDeserializer<
         AvroSchema WriterSchema);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private AvroInlineRuleValidator? GetInlineValidator(int schemaId, AvroSchema writerSchema)
+    internal AvroInlineRuleValidator? GetInlineValidator(int schemaId, AvroSchema writerSchema)
     {
         if (_inlineRuleValidators is null)
             return null;
 
         var cached = Volatile.Read(ref _lastInlineValidationDecision);
-        if (cached >= 0 && (int)(cached >> 1) == schemaId && (cached & 1) == 0)
+        if (cached >= 0 && (int)(uint)(cached >> 1) == schemaId && (cached & 1) == 0)
             return null;
 
         var validator = _inlineRuleValidators.Get(writerSchema);
         var hasRules = validator.HasAnyRules;
         Volatile.Write(
             ref _lastInlineValidationDecision,
-            ((long)schemaId << 1) | (hasRules ? 1L : 0L));
+            ((long)(uint)schemaId << 1) | (hasRules ? 1L : 0L));
         return hasRules ? validator : null;
     }
 

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
@@ -72,6 +72,7 @@ public sealed class AvroSchemaRegistryDeserializer<
     private readonly DeserializerSubjectNameCache? _subjectNames;
     private readonly SchemaRegistryMigrationRunner? _migrationRunner;
     private readonly AvroTaggedFieldTransformerProvider _taggedFieldTransformers = new();
+    private readonly AvroInlineRuleValidatorProvider? _inlineRuleValidators;
 
     /// <summary>
     /// Creates a new Avro Schema Registry deserializer.
@@ -89,6 +90,9 @@ public sealed class AvroSchemaRegistryDeserializer<
         if (_config.SchemaIdStrategy is not (SchemaIdDeserializerStrategy.Dual or SchemaIdDeserializerStrategy.Prefix or SchemaIdDeserializerStrategy.Header))
             throw new ArgumentOutOfRangeException(nameof(config), _config.SchemaIdStrategy, "Unknown schema identity strategy.");
         _ruleExecutor = _config.RuleExecutor;
+        _inlineRuleValidators = AvroValidationConfiguration.Create(
+            _config.ValidationRulesExecution,
+            _config.RuleExecutor);
         _ownsClient = ownsClient;
         if (_config.UseLatestVersion && !string.IsNullOrEmpty(_config.ReaderSchema))
         {
@@ -349,7 +353,7 @@ public sealed class AvroSchemaRegistryDeserializer<
         // Extract Avro payload. Array-backed payloads decode in place; other memory falls back to a pooled copy.
         var payloadMemory = data[payloadOffset..];
         AvroSchema? migrationReaderSchema = null;
-        if (_ruleExecutor is null)
+        if (_ruleExecutor is null && _inlineRuleValidators is null)
         {
             var directCodecState = AvroCodecThreadStateCache.Deserialization ??= new AvroDeserializationThreadState();
             return ReadAvroPayload(
@@ -357,6 +361,21 @@ public sealed class AvroSchemaRegistryDeserializer<
                 writerSchema,
                 migrationReaderSchema: null,
                 codecState: directCodecState);
+        }
+
+        if (_ruleExecutor is null)
+        {
+            _inlineRuleValidators!.Get(writerSchema).Validate(
+                payloadMemory,
+                schemaId,
+                _config.ValidationRulesFailFast);
+            var validatedCodecState = AvroCodecThreadStateCache.Deserialization ??=
+                new AvroDeserializationThreadState();
+            return ReadAvroPayload(
+                payloadMemory,
+                writerSchema,
+                migrationReaderSchema: null,
+                codecState: validatedCodecState);
         }
 
         var taggedWorkspaceOperation = AvroTaggedFieldTransformerProvider.BeginOperation();
@@ -400,7 +419,35 @@ public sealed class AvroSchemaRegistryDeserializer<
                     _taggedFieldTransformers.Get(schema, writerSchema));
                 try
                 {
-                    payloadMemory = _ruleExecutor.TransformDeserializedPayload(payloadMemory, ruleContext);
+                    if (_inlineRuleValidators is not null &&
+                        _ruleExecutor is SchemaRegistryRuleExecutor builtInRuleExecutor)
+                    {
+                        var validator = _inlineRuleValidators.Register(schema, writerSchema);
+                        payloadMemory = builtInRuleExecutor.TransformDeserializedEncodingPayload(
+                            payloadMemory,
+                            ruleContext);
+                        if (_config.ValidationRulesExecution == ValidationRulesExecution.BeforeDomainRules)
+                        {
+                            validator.Validate(
+                                payloadMemory,
+                                schemaId,
+                                _config.ValidationRulesFailFast);
+                        }
+                        payloadMemory = builtInRuleExecutor.TransformDeserializedDomainPayload(
+                            payloadMemory,
+                            ruleContext);
+                        if (_config.ValidationRulesExecution == ValidationRulesExecution.AfterDomainRules)
+                        {
+                            validator.Validate(
+                                payloadMemory,
+                                schemaId,
+                                _config.ValidationRulesFailFast);
+                        }
+                    }
+                    else
+                    {
+                        payloadMemory = _ruleExecutor.TransformDeserializedPayload(payloadMemory, ruleContext);
+                    }
                 }
                 finally
                 {
@@ -409,16 +456,37 @@ public sealed class AvroSchemaRegistryDeserializer<
             }
             else
             {
-                var migration = _migrationRunner.Transform(
-                    payloadMemory,
-                    schemaId,
-                    subject,
-                    schema,
-                    context,
-                    SchemaRegistryPayloadFormat.Avro,
-                    _taggedFieldTransformers);
+                _inlineRuleValidators?.Register(schema, writerSchema);
+                var migration = _config.ValidationRulesExecution == ValidationRulesExecution.BeforeDomainRules
+                    ? _migrationRunner.TransformWithBeforeDomainValidation(
+                        payloadMemory,
+                        schemaId,
+                        subject,
+                        schema,
+                        context,
+                        SchemaRegistryPayloadFormat.Avro,
+                        _inlineRuleValidators!,
+                        _config.ValidationRulesFailFast,
+                        _taggedFieldTransformers)
+                    : _migrationRunner.Transform(
+                        payloadMemory,
+                        schemaId,
+                        subject,
+                        schema,
+                        context,
+                        SchemaRegistryPayloadFormat.Avro,
+                        _taggedFieldTransformers);
                 payloadMemory = migration.Payload;
                 writerSchema = GetWriterSchemaCached(migration.PayloadSchemaId);
+                _inlineRuleValidators?.Register(migration.PayloadSchema, writerSchema);
+                if (_config.ValidationRulesExecution == ValidationRulesExecution.AfterDomainRules)
+                {
+                    ((IInlineValidationRuleExecutor)_inlineRuleValidators!).Validate(
+                        payloadMemory,
+                        migration.PayloadSchemaId,
+                        migration.PayloadSchema,
+                        _config.ValidationRulesFailFast);
+                }
                 migrationReaderSchema = GetWriterSchemaCached(migration.ReaderSchema.Id);
             }
             var codecState = AvroCodecThreadStateCache.Deserialization ??= new AvroDeserializationThreadState();

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
@@ -72,7 +72,7 @@ public sealed class AvroSchemaRegistryDeserializer<
     private readonly AvroSchema? _readerSchema;
     private readonly DeserializerSubjectNameCache? _subjectNames;
     private readonly SchemaRegistryMigrationRunner? _migrationRunner;
-    private readonly AvroTaggedFieldTransformerProvider _taggedFieldTransformers = new();
+    private readonly AvroTaggedFieldTransformerProvider _taggedFieldTransformers;
     private readonly AvroInlineRuleValidatorProvider? _inlineRuleValidators;
     private long _lastInlineValidationDecision = -1;
 
@@ -88,11 +88,13 @@ public sealed class AvroSchemaRegistryDeserializer<
         bool ownsClient = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
+        _taggedFieldTransformers = new AvroTaggedFieldTransformerProvider(schemaRegistry);
         _config = config ?? new AvroDeserializerConfig();
         if (_config.SchemaIdStrategy is not (SchemaIdDeserializerStrategy.Dual or SchemaIdDeserializerStrategy.Prefix or SchemaIdDeserializerStrategy.Header))
             throw new ArgumentOutOfRangeException(nameof(config), _config.SchemaIdStrategy, "Unknown schema identity strategy.");
         _ruleExecutor = _config.RuleExecutor;
         _inlineRuleValidators = AvroValidationConfiguration.Create(
+            schemaRegistry,
             _config.ValidationRulesExecution,
             _config.RuleExecutor);
         _ownsClient = ownsClient;
@@ -466,7 +468,8 @@ public sealed class AvroSchemaRegistryDeserializer<
                         SchemaRegistryPayloadFormat.Avro,
                         _taggedFieldTransformers);
                 payloadMemory = migration.Payload;
-                writerSchema = GetWriterSchemaCached(migration.PayloadSchemaId);
+                writerSchema = _inlineRuleValidators?.GetResolvedSchema(migration.PayloadSchema)
+                    ?? GetWriterSchemaCached(migration.PayloadSchemaId);
                 _inlineRuleValidators?.Register(migration.PayloadSchema, writerSchema);
                 if (_config.ValidationRulesExecution == ValidationRulesExecution.AfterDomainRules)
                 {
@@ -476,7 +479,8 @@ public sealed class AvroSchemaRegistryDeserializer<
                         migration.PayloadSchema,
                         _config.ValidationRulesFailFast);
                 }
-                migrationReaderSchema = GetWriterSchemaCached(migration.ReaderSchema.Id);
+                migrationReaderSchema = _inlineRuleValidators?.GetResolvedSchema(migration.ReaderSchema.Schema)
+                    ?? GetWriterSchemaCached(migration.ReaderSchema.Id);
             }
             var codecState = AvroCodecThreadStateCache.Deserialization ??= new AvroDeserializationThreadState();
             return ReadAvroPayload(payloadMemory, writerSchema, migrationReaderSchema, codecState);
@@ -844,7 +848,11 @@ public sealed class AvroSchemaRegistryDeserializer<
                 throw new InvalidOperationException(
                     $"Schema with ID {schemaId} is not an Avro schema. Type: {registrySchema.SchemaType}");
 
-            return AvroSchema.Parse(registrySchema.SchemaString);
+            return await Poco.AvroSchemaReferenceResolver.ParseAsync(
+                    _schemaRegistry,
+                    registrySchema,
+                    CancellationToken.None)
+                .ConfigureAwait(false);
         }
         catch
         {

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -444,7 +444,7 @@ public sealed class AvroSchemaRegistrySerializer<
             var payload = new ReadOnlyMemory<byte>(memoryStream.GetBuffer(), 0, avroPayloadLength);
             if (_config.RuleExecutor is null)
             {
-                _inlineRuleValidators!.Get(avroSchema).Validate(
+                _inlineRuleValidators!.Register(schemaEntry.Schema!, avroSchema).Validate(
                     payload,
                     schemaId,
                     _config.ValidationRulesFailFast);

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -97,7 +97,7 @@ public sealed class AvroSchemaRegistrySerializer<
         bool ownsClient = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
-        _taggedFieldTransformers = new AvroTaggedFieldTransformerProvider(schemaRegistry);
+        _taggedFieldTransformers = new AvroTaggedFieldTransformerProvider();
         _config = config ?? new AvroSerializerConfig();
         _schemaIdStrategy = _config.SchemaIdStrategy;
         _schemaSelectionMode = SchemaRegistrySerializerConfigValidator.ValidateAndResolve(
@@ -616,11 +616,13 @@ public sealed class AvroSchemaRegistrySerializer<
             return _config.RuleExecutor!.TransformSerializedPayload(payload, context);
         }
 
-        var validator = _inlineRuleValidators.RegisterSerializerSchema(registrySchema, avroSchema);
-        if (_config.ValidationRulesExecution == ValidationRulesExecution.BeforeDomainRules)
+        var validator = GetInlineValidator(schemaId, registrySchema, avroSchema);
+        if (validator is not null &&
+            _config.ValidationRulesExecution == ValidationRulesExecution.BeforeDomainRules)
             validator.Validate(payload, schemaId, _config.ValidationRulesFailFast);
         payload = ruleExecutor.TransformSerializedDomainPayload(payload, context);
-        if (_config.ValidationRulesExecution == ValidationRulesExecution.AfterDomainRules)
+        if (validator is not null &&
+            _config.ValidationRulesExecution == ValidationRulesExecution.AfterDomainRules)
             validator.Validate(payload, schemaId, _config.ValidationRulesFailFast);
         return ruleExecutor.TransformSerializedEncodingPayload(payload, context);
     }

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -176,15 +176,72 @@ public sealed class AvroSchemaRegistrySerializer<
         ArgumentNullException.ThrowIfNull(value);
         var avroSchema = GetSchemaForValue(value);
         var cache = GetSubjectSchemaIdCache(avroSchema);
-        if (cache.TryGet(topic, isKey, out var cached))
-            return new ValueTask<ResolvedSchemaContext>(ToResolvedContext(cached));
+        var preparation = cache.TryGet(topic, isKey, out var cached)
+            ? new ValueTask<ResolvedSchemaContext>(ToResolvedContext(cached))
+            : PrepareCoreAsync(
+                topic,
+                isKey,
+                avroSchema,
+                cache,
+                cancellationToken);
+        return PrepareInlineValidationAsync(preparation, avroSchema, cancellationToken);
+    }
 
-        return PrepareCoreAsync(
-            topic,
-            isKey,
-            avroSchema,
-            cache,
-            cancellationToken);
+    private ValueTask<ResolvedSchemaContext> PrepareInlineValidationAsync(
+        ValueTask<ResolvedSchemaContext> preparation,
+        AvroSchema runtimeSchema,
+        CancellationToken cancellationToken)
+    {
+        if (_inlineRuleValidators is null)
+            return preparation;
+        if (preparation.IsCompletedSuccessfully)
+        {
+            var resolved = preparation.Result;
+            var cached = Volatile.Read(ref _lastInlineValidationDecision);
+            if (cached >= 0 && (int)(cached >> 1) == resolved.SchemaId)
+                return new ValueTask<ResolvedSchemaContext>(resolved);
+            var validationPreparation = _inlineRuleValidators.PrepareSerializerSchemaAsync(
+                resolved.Schema,
+                runtimeSchema,
+                cancellationToken);
+            if (validationPreparation.IsCompletedSuccessfully)
+            {
+                CacheInlineValidationDecision(resolved.SchemaId, validationPreparation.Result);
+                return new ValueTask<ResolvedSchemaContext>(resolved);
+            }
+            return AwaitValidationCompletionAsync(this, resolved, validationPreparation);
+        }
+
+        return AwaitPreparationAndValidationAsync(this, preparation, runtimeSchema, cancellationToken);
+
+        static async ValueTask<ResolvedSchemaContext> AwaitValidationCompletionAsync(
+            AvroSchemaRegistrySerializer<T> serializer,
+            ResolvedSchemaContext resolved,
+            ValueTask<AvroInlineRuleValidator> pending)
+        {
+            var validator = await pending.ConfigureAwait(false);
+            serializer.CacheInlineValidationDecision(resolved.SchemaId, validator);
+            return resolved;
+        }
+
+        static async ValueTask<ResolvedSchemaContext> AwaitPreparationAndValidationAsync(
+            AvroSchemaRegistrySerializer<T> serializer,
+            ValueTask<ResolvedSchemaContext> pending,
+            AvroSchema runtimeSchema,
+            CancellationToken cancellationToken)
+        {
+            var resolved = await pending.ConfigureAwait(false);
+            var cached = Volatile.Read(ref serializer._lastInlineValidationDecision);
+            if (cached >= 0 && (int)(cached >> 1) == resolved.SchemaId)
+                return resolved;
+            var validator = await serializer._inlineRuleValidators!.PrepareSerializerSchemaAsync(
+                    resolved.Schema,
+                    runtimeSchema,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            serializer.CacheInlineValidationDecision(resolved.SchemaId, validator);
+            return resolved;
+        }
     }
 
     /// <inheritdoc />
@@ -534,11 +591,17 @@ public sealed class AvroSchemaRegistrySerializer<
 
         var validator = _inlineRuleValidators!.RegisterSerializerSchema(registrySchema, avroSchema);
         var hasRules = validator.HasAnyRules;
-        Volatile.Write(
-            ref _lastInlineValidationDecision,
-            ((long)schemaId << 1) | (hasRules ? 1L : 0L));
+        CacheInlineValidationDecision(schemaId, validator);
         return hasRules ? validator : null;
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void CacheInlineValidationDecision(
+        int schemaId,
+        AvroInlineRuleValidator validator) =>
+        Volatile.Write(
+            ref _lastInlineValidationDecision,
+            ((long)schemaId << 1) | (validator.HasAnyRules ? 1L : 0L));
 
     private ReadOnlyMemory<byte> TransformSerializedPayload(
         ReadOnlyMemory<byte> payload,

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -73,6 +73,7 @@ public sealed class AvroSchemaRegistrySerializer<
     private readonly AllocationFreeSpecificRecordWriter<T>? _specificWriter;
     private readonly AvroSchema? _writerSchema;
     private readonly AvroTaggedFieldTransformerProvider _taggedFieldTransformers = new();
+    private readonly AvroInlineRuleValidatorProvider? _inlineRuleValidators;
     private int _dynamicSchemaCacheCount;
     private int _overflowDynamicSchemaCacheCount;
     private int _hasEvictedOverflowLogicalSchemas;
@@ -103,6 +104,9 @@ public sealed class AvroSchemaRegistrySerializer<
             _config.AutoRegisterSchemas);
         if (_schemaIdStrategy is not (SchemaIdSerializerStrategy.Prefix or SchemaIdSerializerStrategy.Header))
             throw new ArgumentOutOfRangeException(nameof(config), _schemaIdStrategy, "Unknown schema identity strategy.");
+        _inlineRuleValidators = AvroValidationConfiguration.Create(
+            _config.ValidationRulesExecution,
+            _config.RuleExecutor);
         if (_config.CustomSubjectNameStrategy is null)
         {
             _asyncSubjectNameStrategy = _config.AsyncSubjectNameStrategy
@@ -250,7 +254,7 @@ public sealed class AvroSchemaRegistrySerializer<
         var schemaId = schemaEntry.SchemaId;
 
         var codecState = AvroCodecThreadStateCache.Serialization ??= new AvroSerializationThreadState();
-        if (_config.RuleExecutor is null)
+        if (_config.RuleExecutor is null && _inlineRuleValidators is null)
         {
             if (_schemaIdStrategy == SchemaIdSerializerStrategy.Prefix)
                 SerializeDirect(value, ref destination, schemaId, codecState);
@@ -293,7 +297,7 @@ public sealed class AvroSchemaRegistrySerializer<
         var schemaId = schemaEntry.SchemaId;
 
         var codecState = AvroCodecThreadStateCache.Serialization ??= new AvroSerializationThreadState();
-        if (_config.RuleExecutor is null)
+        if (_config.RuleExecutor is null && _inlineRuleValidators is null)
         {
             if (_schemaIdStrategy == SchemaIdSerializerStrategy.Prefix)
                 SerializeDirect(value, ref destination, schemaId, codecState);
@@ -438,22 +442,37 @@ public sealed class AvroSchemaRegistrySerializer<
 
             var avroPayloadLength = (int)memoryStream.Position;
             var payload = new ReadOnlyMemory<byte>(memoryStream.GetBuffer(), 0, avroPayloadLength);
-            var taggedFieldTransformer = _taggedFieldTransformers.Get(schemaEntry.Schema!, avroSchema);
-            var ruleContext = SchemaRegistryRuleContext.RentWithTaggedFieldTransformer(
-                context.Topic,
-                context.Component,
-                schemaId,
-                schemaEntry.Subject,
-                schemaEntry.Schema,
-                SchemaRegistryPayloadFormat.Avro,
-                taggedFieldTransformer);
-            try
+            if (_config.RuleExecutor is null)
             {
-                payload = _config.RuleExecutor!.TransformSerializedPayload(payload, ruleContext);
+                _inlineRuleValidators!.Get(avroSchema).Validate(
+                    payload,
+                    schemaId,
+                    _config.ValidationRulesFailFast);
             }
-            finally
+            else
             {
-                ruleContext.Return();
+                var taggedFieldTransformer = _taggedFieldTransformers.Get(schemaEntry.Schema!, avroSchema);
+                var ruleContext = SchemaRegistryRuleContext.RentWithTaggedFieldTransformer(
+                    context.Topic,
+                    context.Component,
+                    schemaId,
+                    schemaEntry.Subject,
+                    schemaEntry.Schema,
+                    SchemaRegistryPayloadFormat.Avro,
+                    taggedFieldTransformer);
+                try
+                {
+                    payload = TransformSerializedPayload(
+                        payload,
+                        ruleContext,
+                        schemaId,
+                        schemaEntry.Schema!,
+                        avroSchema);
+                }
+                finally
+                {
+                    ruleContext.Return();
+                }
             }
 
             var payloadOffset = SchemaIdentitySerialization.GetPayloadOffset(_schemaIdStrategy);
@@ -475,6 +494,28 @@ public sealed class AvroSchemaRegistrySerializer<
             if (memoryStream.Capacity > MaxRetainedAvroPayloadBufferSize)
                 memoryStream.DetachBuffer();
         }
+    }
+
+    private ReadOnlyMemory<byte> TransformSerializedPayload(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleContext context,
+        int schemaId,
+        Schema registrySchema,
+        AvroSchema avroSchema)
+    {
+        if (_inlineRuleValidators is null ||
+            _config.RuleExecutor is not SchemaRegistryRuleExecutor ruleExecutor)
+        {
+            return _config.RuleExecutor!.TransformSerializedPayload(payload, context);
+        }
+
+        var validator = _inlineRuleValidators.Register(registrySchema, avroSchema);
+        if (_config.ValidationRulesExecution == ValidationRulesExecution.BeforeDomainRules)
+            validator.Validate(payload, schemaId, _config.ValidationRulesFailFast);
+        payload = ruleExecutor.TransformSerializedDomainPayload(payload, context);
+        if (_config.ValidationRulesExecution == ValidationRulesExecution.AfterDomainRules)
+            validator.Validate(payload, schemaId, _config.ValidationRulesFailFast);
+        return ruleExecutor.TransformSerializedEncodingPayload(payload, context);
     }
 
     private static int GrowPayloadSizeHint(int currentHint, int requiredCapacity)

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -72,7 +72,7 @@ public sealed class AvroSchemaRegistrySerializer<
     private readonly int _maxOverflowLogicalSchemas;
     private readonly AllocationFreeSpecificRecordWriter<T>? _specificWriter;
     private readonly AvroSchema? _writerSchema;
-    private readonly AvroTaggedFieldTransformerProvider _taggedFieldTransformers = new();
+    private readonly AvroTaggedFieldTransformerProvider _taggedFieldTransformers;
     private readonly AvroInlineRuleValidatorProvider? _inlineRuleValidators;
     private int _dynamicSchemaCacheCount;
     private int _overflowDynamicSchemaCacheCount;
@@ -97,6 +97,7 @@ public sealed class AvroSchemaRegistrySerializer<
         bool ownsClient = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
+        _taggedFieldTransformers = new AvroTaggedFieldTransformerProvider(schemaRegistry);
         _config = config ?? new AvroSerializerConfig();
         _schemaIdStrategy = _config.SchemaIdStrategy;
         _schemaSelectionMode = SchemaRegistrySerializerConfigValidator.ValidateAndResolve(
@@ -106,6 +107,7 @@ public sealed class AvroSchemaRegistrySerializer<
         if (_schemaIdStrategy is not (SchemaIdSerializerStrategy.Prefix or SchemaIdSerializerStrategy.Header))
             throw new ArgumentOutOfRangeException(nameof(config), _schemaIdStrategy, "Unknown schema identity strategy.");
         _inlineRuleValidators = AvroValidationConfiguration.Create(
+            schemaRegistry,
             _config.ValidationRulesExecution,
             _config.RuleExecutor);
         if (_config.CustomSubjectNameStrategy is null)

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -532,7 +532,7 @@ public sealed class AvroSchemaRegistrySerializer<
         if (cached >= 0 && (int)(cached >> 1) == schemaId && (cached & 1) == 0)
             return null;
 
-        var validator = _inlineRuleValidators!.Register(registrySchema, avroSchema);
+        var validator = _inlineRuleValidators!.RegisterSerializerSchema(registrySchema, avroSchema);
         var hasRules = validator.HasAnyRules;
         Volatile.Write(
             ref _lastInlineValidationDecision,
@@ -553,7 +553,7 @@ public sealed class AvroSchemaRegistrySerializer<
             return _config.RuleExecutor!.TransformSerializedPayload(payload, context);
         }
 
-        var validator = _inlineRuleValidators.Register(registrySchema, avroSchema);
+        var validator = _inlineRuleValidators.RegisterSerializerSchema(registrySchema, avroSchema);
         if (_config.ValidationRulesExecution == ValidationRulesExecution.BeforeDomainRules)
             validator.Validate(payload, schemaId, _config.ValidationRulesFailFast);
         payload = ruleExecutor.TransformSerializedDomainPayload(payload, context);
@@ -837,7 +837,8 @@ public sealed class AvroSchemaRegistrySerializer<
                     subject,
                     registrySchema,
                     cancellationToken).ConfigureAwait(false);
-            var registeredSchema = _config.RuleExecutor is SchemaRegistryRuleExecutor
+            var registeredSchema = _config.RuleExecutor is SchemaRegistryRuleExecutor ||
+                                   _config.ValidationRulesExecution != ValidationRulesExecution.Disabled
                 ? await _schemaRegistry.GetSchemaAsync(schemaId, subject, cancellationToken).ConfigureAwait(false)
                 : registrySchema;
             return await CreateResolvedValueAsync(

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -80,6 +80,7 @@ public sealed class AvroSchemaRegistrySerializer<
     private DynamicSchemaCache? _lastDynamicSchemaCache;
     private DynamicSchemaCache? _previousDynamicSchemaCache;
     private SubjectSchemaIdCache? _associatedSubjectSchemaIdCache;
+    private long _lastInlineValidationDecision = -1;
 
     bool IRecordHeaderSerializer.ProducesRecordHeaders =>
         _schemaIdStrategy == SchemaIdSerializerStrategy.Header;
@@ -254,7 +255,10 @@ public sealed class AvroSchemaRegistrySerializer<
         var schemaId = schemaEntry.SchemaId;
 
         var codecState = AvroCodecThreadStateCache.Serialization ??= new AvroSerializationThreadState();
-        if (_config.RuleExecutor is null && _inlineRuleValidators is null)
+        AvroInlineRuleValidator? inlineValidator = null;
+        if (_config.RuleExecutor is null &&
+            (_inlineRuleValidators is null ||
+             (inlineValidator = GetInlineValidator(schemaId, schemaEntry.Schema!, avroSchema)) is null))
         {
             if (_schemaIdStrategy == SchemaIdSerializerStrategy.Prefix)
                 SerializeDirect(value, ref destination, schemaId, codecState);
@@ -263,7 +267,15 @@ public sealed class AvroSchemaRegistrySerializer<
             return;
         }
 
-        SerializeWithRuleExecutor(value, ref destination, context, schemaEntry, schemaId, avroSchema, codecState);
+        SerializeWithRuleExecutor(
+            value,
+            ref destination,
+            context,
+            schemaEntry,
+            schemaId,
+            avroSchema,
+            codecState,
+            inlineValidator);
     }
 
     void IAsyncSerializerPreparationAdmission<T>.SerializePrepared<TWriter>(
@@ -297,7 +309,10 @@ public sealed class AvroSchemaRegistrySerializer<
         var schemaId = schemaEntry.SchemaId;
 
         var codecState = AvroCodecThreadStateCache.Serialization ??= new AvroSerializationThreadState();
-        if (_config.RuleExecutor is null && _inlineRuleValidators is null)
+        AvroInlineRuleValidator? inlineValidator = null;
+        if (_config.RuleExecutor is null &&
+            (_inlineRuleValidators is null ||
+             (inlineValidator = GetInlineValidator(schemaId, schemaEntry.Schema!, avroSchema)) is null))
         {
             if (_schemaIdStrategy == SchemaIdSerializerStrategy.Prefix)
                 SerializeDirect(value, ref destination, schemaId, codecState);
@@ -306,7 +321,15 @@ public sealed class AvroSchemaRegistrySerializer<
             return;
         }
 
-        SerializeWithRuleExecutor(value, ref destination, context, schemaEntry, schemaId, avroSchema, codecState);
+        SerializeWithRuleExecutor(
+            value,
+            ref destination,
+            context,
+            schemaEntry,
+            schemaId,
+            avroSchema,
+            codecState,
+            inlineValidator);
     }
 
     private SerializerPreparationAdmission ToAdmission(in ResolvedSchemaContext context)
@@ -423,7 +446,8 @@ public sealed class AvroSchemaRegistrySerializer<
         SubjectSchemaIdCache.SubjectSchemaIdCacheEntry schemaEntry,
         int schemaId,
         AvroSchema avroSchema,
-        AvroSerializationThreadState codecState)
+        AvroSerializationThreadState codecState,
+        AvroInlineRuleValidator? inlineValidator)
         where TWriter : IBufferWriter<byte>
 #if NET10_0_OR_GREATER
         , allows ref struct
@@ -444,7 +468,7 @@ public sealed class AvroSchemaRegistrySerializer<
             var payload = new ReadOnlyMemory<byte>(memoryStream.GetBuffer(), 0, avroPayloadLength);
             if (_config.RuleExecutor is null)
             {
-                _inlineRuleValidators!.Register(schemaEntry.Schema!, avroSchema).Validate(
+                inlineValidator!.Validate(
                     payload,
                     schemaId,
                     _config.ValidationRulesFailFast);
@@ -494,6 +518,24 @@ public sealed class AvroSchemaRegistrySerializer<
             if (memoryStream.Capacity > MaxRetainedAvroPayloadBufferSize)
                 memoryStream.DetachBuffer();
         }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private AvroInlineRuleValidator? GetInlineValidator(
+        int schemaId,
+        RegistrySchema registrySchema,
+        AvroSchema avroSchema)
+    {
+        var cached = Volatile.Read(ref _lastInlineValidationDecision);
+        if (cached >= 0 && (int)(cached >> 1) == schemaId && (cached & 1) == 0)
+            return null;
+
+        var validator = _inlineRuleValidators!.Register(registrySchema, avroSchema);
+        var hasRules = validator.HasAnyRules;
+        Volatile.Write(
+            ref _lastInlineValidationDecision,
+            ((long)schemaId << 1) | (hasRules ? 1L : 0L));
+        return hasRules ? validator : null;
     }
 
     private ReadOnlyMemory<byte> TransformSerializedPayload(

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSerializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSerializerConfig.cs
@@ -75,6 +75,18 @@ public sealed class AvroSerializerConfig
     /// Optional rule executor applied to Avro payload bytes before the Schema Registry envelope is written.
     /// </summary>
     public ISchemaRegistryRuleExecutor? RuleExecutor { get; init; }
+
+    /// <summary>
+    /// Selects when inline <c>confluent:rules</c> CHECK constraints run.
+    /// Default is disabled. When <see cref="RuleExecutor"/> is also configured,
+    /// it must be a <see cref="SchemaRegistryRuleExecutor"/> so rule boundaries are known.
+    /// </summary>
+    public ValidationRulesExecution ValidationRulesExecution { get; init; }
+
+    /// <summary>
+    /// Stops Avro inline validation after its first violation when enabled.
+    /// </summary>
+    public bool ValidationRulesFailFast { get; init; }
 }
 
 /// <summary>
@@ -123,4 +135,16 @@ public sealed class AvroDeserializerConfig
     /// Optional rule executor applied to Avro payload bytes after the Schema Registry envelope is read.
     /// </summary>
     public ISchemaRegistryRuleExecutor? RuleExecutor { get; init; }
+
+    /// <summary>
+    /// Selects when inline <c>confluent:rules</c> CHECK constraints run.
+    /// Default is disabled. When <see cref="RuleExecutor"/> is also configured,
+    /// it must be a <see cref="SchemaRegistryRuleExecutor"/> so rule boundaries are known.
+    /// </summary>
+    public ValidationRulesExecution ValidationRulesExecution { get; init; }
+
+    /// <summary>
+    /// Stops Avro inline validation after its first violation when enabled.
+    /// </summary>
+    public bool ValidationRulesFailFast { get; init; }
 }

--- a/src/Dekaf.SchemaRegistry.Avro/AvroTaggedFieldTransformer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroTaggedFieldTransformer.cs
@@ -1373,15 +1373,11 @@ internal sealed class AvroTaggedFieldTransformerProvider : ISchemaRegistryTagged
     private readonly ConditionalWeakTable<RegistrySchema, AvroSchema> _resolvedSchemas = new();
     private readonly ConditionalWeakTable<RegistrySchema, PayloadSchemaTransformers>.CreateValueCallback
         _createPayloadTransformers;
-    private readonly ISchemaRegistryClient? _schemaRegistry;
     private SerializerTransformerEntry? _lastSerializerTransformer;
     private PayloadSchemaTransformers? _lastPayloadSchema;
 
-    internal AvroTaggedFieldTransformerProvider(ISchemaRegistryClient? schemaRegistry = null)
-    {
-        _schemaRegistry = schemaRegistry;
+    internal AvroTaggedFieldTransformerProvider() =>
         _createPayloadTransformers = CreatePayloadTransformers;
-    }
 
     public ISchemaRegistryTaggedFieldTransformer Get(
         RegistrySchema payloadSchema,
@@ -1407,16 +1403,13 @@ internal sealed class AvroTaggedFieldTransformerProvider : ISchemaRegistryTagged
     {
         if (_resolvedSchemas.TryGetValue(schema, out var resolved))
             return resolved;
-        if (_schemaRegistry is null && schema.References is { Count: > 0 })
+        if (schema.References is { Count: > 0 })
         {
             throw new SchemaRegistryRuleException(
-                "Could not resolve registered Avro schema references without a Schema Registry client.");
+                "Referenced Avro schema is not prepared. Consume through an asynchronous API or call WarmupAsync first.");
         }
 
-        resolved = Poco.AvroSchemaReferenceResolver.Parse(
-            _schemaRegistry!,
-            schema,
-            TimeSpan.FromSeconds(30));
+        resolved = AvroSchema.Parse(schema.SchemaString);
         _resolvedSchemas.AddOrUpdate(schema, resolved);
         return _resolvedSchemas.GetValue(
             schema,

--- a/src/Dekaf.SchemaRegistry.Avro/AvroTaggedFieldTransformer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroTaggedFieldTransformer.cs
@@ -1373,11 +1373,15 @@ internal sealed class AvroTaggedFieldTransformerProvider : ISchemaRegistryTagged
     private readonly ConditionalWeakTable<RegistrySchema, AvroSchema> _resolvedSchemas = new();
     private readonly ConditionalWeakTable<RegistrySchema, PayloadSchemaTransformers>.CreateValueCallback
         _createPayloadTransformers;
+    private readonly ISchemaRegistryClient? _schemaRegistry;
     private SerializerTransformerEntry? _lastSerializerTransformer;
     private PayloadSchemaTransformers? _lastPayloadSchema;
 
-    internal AvroTaggedFieldTransformerProvider() =>
+    internal AvroTaggedFieldTransformerProvider(ISchemaRegistryClient? schemaRegistry = null)
+    {
+        _schemaRegistry = schemaRegistry;
         _createPayloadTransformers = CreatePayloadTransformers;
+    }
 
     public ISchemaRegistryTaggedFieldTransformer Get(
         RegistrySchema payloadSchema,
@@ -1397,7 +1401,27 @@ internal sealed class AvroTaggedFieldTransformerProvider : ISchemaRegistryTagged
     }
 
     private PayloadSchemaTransformers CreatePayloadTransformers(RegistrySchema payloadSchema) =>
-        new(payloadSchema, _resolvedSchemas);
+        new(payloadSchema, ResolveSchema(payloadSchema), this);
+
+    private AvroSchema ResolveSchema(RegistrySchema schema)
+    {
+        if (_resolvedSchemas.TryGetValue(schema, out var resolved))
+            return resolved;
+        if (_schemaRegistry is null && schema.References is { Count: > 0 })
+        {
+            throw new SchemaRegistryRuleException(
+                "Could not resolve registered Avro schema references without a Schema Registry client.");
+        }
+
+        resolved = Poco.AvroSchemaReferenceResolver.Parse(
+            _schemaRegistry!,
+            schema,
+            TimeSpan.FromSeconds(30));
+        _resolvedSchemas.AddOrUpdate(schema, resolved);
+        return _resolvedSchemas.GetValue(
+            schema,
+            static _ => throw new InvalidOperationException("Resolved Avro schema cache changed unexpectedly."));
+    }
 
     internal ISchemaRegistryTaggedFieldTransformer GetResolved(
         RegistrySchema payloadSchema,
@@ -1414,7 +1438,7 @@ internal sealed class AvroTaggedFieldTransformerProvider : ISchemaRegistryTagged
                 payloadTransformers = new PayloadSchemaTransformers(
                     payloadSchema,
                     avroSchema,
-                    _resolvedSchemas);
+                    this);
                 _payloadSchemas.AddOrUpdate(payloadSchema, payloadTransformers);
             }
 
@@ -1486,26 +1510,19 @@ internal sealed class AvroTaggedFieldTransformerProvider : ISchemaRegistryTagged
     private sealed class PayloadSchemaTransformers
     {
         private readonly AvroSchema _payloadSchema;
-        private readonly ConditionalWeakTable<RegistrySchema, AvroSchema> _resolvedSchemas;
+        private readonly AvroTaggedFieldTransformerProvider _provider;
         private readonly ConditionalWeakTable<RegistrySchema, TransformerEntry> _owners = new();
         private readonly ConditionalWeakTable<RegistrySchema, TransformerEntry>.CreateValueCallback _create;
         private TransformerEntry? _lastOwner;
 
         public PayloadSchemaTransformers(
             RegistrySchema payloadSchema,
-            ConditionalWeakTable<RegistrySchema, AvroSchema> resolvedSchemas)
-            : this(payloadSchema, AvroSchema.Parse(payloadSchema.SchemaString), resolvedSchemas)
-        {
-        }
-
-        public PayloadSchemaTransformers(
-            RegistrySchema payloadSchema,
             AvroSchema avroSchema,
-            ConditionalWeakTable<RegistrySchema, AvroSchema> resolvedSchemas)
+            AvroTaggedFieldTransformerProvider provider)
         {
             PayloadSchema = payloadSchema;
             _payloadSchema = avroSchema;
-            _resolvedSchemas = resolvedSchemas;
+            _provider = provider;
             _create = Create;
         }
 
@@ -1530,9 +1547,7 @@ internal sealed class AvroTaggedFieldTransformerProvider : ISchemaRegistryTagged
                 owner,
                 ReferenceEquals(owner, PayloadSchema)
                     ? _payloadSchema
-                    : _resolvedSchemas.TryGetValue(owner, out var resolved)
-                        ? resolved
-                        : AvroSchema.Parse(owner.SchemaString)));
+                    : _provider.ResolveSchema(owner)));
     }
 
     private sealed class TransformerEntry(

--- a/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
@@ -52,6 +52,17 @@ internal sealed class AvroInlineRuleValidatorProvider : IInlineValidationRuleExe
         return RegisterSlow(registrySchema, resolvedSchema);
     }
 
+    internal AvroInlineRuleValidator RegisterSerializerSchema(
+        RegistrySchema registrySchema,
+        AvroSchema runtimeSchema)
+    {
+        if (_registeredSchemas.TryGetValue(registrySchema, out var existing))
+            return existing;
+        return registrySchema.References is { Count: > 0 }
+            ? Register(registrySchema, GetResolvedSchema(registrySchema))
+            : Register(registrySchema, runtimeSchema);
+    }
+
     internal AvroSchema GetResolvedSchema(RegistrySchema registrySchema)
     {
         if (_resolvedSchemas.TryGetValue(registrySchema, out var resolved))

--- a/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
@@ -7,6 +7,7 @@ namespace Dekaf.SchemaRegistry.Avro;
 internal static class AvroValidationConfiguration
 {
     internal static AvroInlineRuleValidatorProvider? Create(
+        ISchemaRegistryClient schemaRegistry,
         ValidationRulesExecution execution,
         ISchemaRegistryRuleExecutor? ruleExecutor)
     {
@@ -25,7 +26,7 @@ internal static class AvroValidationConfiguration
             throw new NotSupportedException(
                 "Inline validation rules require SchemaRegistryRuleExecutor so domain and encoding rule boundaries are known.");
         }
-        return new AvroInlineRuleValidatorProvider();
+        return new AvroInlineRuleValidatorProvider(schemaRegistry);
     }
 }
 
@@ -33,7 +34,12 @@ internal sealed class AvroInlineRuleValidatorProvider : IInlineValidationRuleExe
 {
     private readonly ConditionalWeakTable<AvroSchema, AvroInlineRuleValidator> _schemas = new();
     private readonly ConditionalWeakTable<RegistrySchema, AvroInlineRuleValidator> _registeredSchemas = new();
+    private readonly ConditionalWeakTable<RegistrySchema, AvroSchema> _resolvedSchemas = new();
+    private readonly ISchemaRegistryClient? _schemaRegistry;
     private SchemaValidatorCacheEntry? _lastSchema;
+
+    internal AvroInlineRuleValidatorProvider(ISchemaRegistryClient? schemaRegistry = null) =>
+        _schemaRegistry = schemaRegistry;
 
     internal AvroInlineRuleValidator Get(AvroSchema schema) =>
         _schemas.GetValue(schema, static value => new AvroInlineRuleValidator(value));
@@ -42,7 +48,28 @@ internal sealed class AvroInlineRuleValidatorProvider : IInlineValidationRuleExe
     {
         if (_registeredSchemas.TryGetValue(registrySchema, out var existing))
             return existing;
+        CacheResolvedSchema(registrySchema, resolvedSchema);
         return RegisterSlow(registrySchema, resolvedSchema);
+    }
+
+    internal AvroSchema GetResolvedSchema(RegistrySchema registrySchema)
+    {
+        if (_resolvedSchemas.TryGetValue(registrySchema, out var resolved))
+            return resolved;
+        if (_schemaRegistry is null)
+        {
+            throw new SchemaRegistryRuleException(
+                "Could not resolve registered Avro schema references without a Schema Registry client.");
+        }
+
+        resolved = Poco.AvroSchemaReferenceResolver.Parse(
+            _schemaRegistry,
+            registrySchema,
+            TimeSpan.FromSeconds(30));
+        _ = Register(registrySchema, resolved);
+        return _resolvedSchemas.GetValue(
+            registrySchema,
+            static _ => throw new InvalidOperationException("Resolved Avro schema cache changed unexpectedly."));
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -74,11 +101,11 @@ internal sealed class AvroInlineRuleValidatorProvider : IInlineValidationRuleExe
         var cached = Volatile.Read(ref _lastSchema);
         var validator = cached is { SchemaId: var cachedSchemaId } && cachedSchemaId == schemaId
             ? cached.Validator
-            : Resolve(schemaId, schema);
+            : ResolveValidator(schemaId, schema);
         validator.Validate(payload, schemaId, failFast);
     }
 
-    private AvroInlineRuleValidator Resolve(int schemaId, RegistrySchema schema)
+    private AvroInlineRuleValidator ResolveValidator(int schemaId, RegistrySchema schema)
     {
         if (schema.SchemaType != SchemaType.Avro)
         {
@@ -86,9 +113,25 @@ internal sealed class AvroInlineRuleValidatorProvider : IInlineValidationRuleExe
                 $"Schema {schemaId} is not an Avro schema (type: {schema.SchemaType}).");
         }
         if (!_registeredSchemas.TryGetValue(schema, out var validator))
-            validator = Register(schema, AvroSchema.Parse(schema.SchemaString));
+            validator = Register(schema, GetResolvedSchema(schema));
         Volatile.Write(ref _lastSchema, new SchemaValidatorCacheEntry(schemaId, validator));
         return validator;
+    }
+
+    private void CacheResolvedSchema(RegistrySchema registrySchema, AvroSchema resolvedSchema)
+    {
+        if (_resolvedSchemas.TryGetValue(registrySchema, out _))
+            return;
+        try
+        {
+            _resolvedSchemas.Add(registrySchema, resolvedSchema);
+        }
+        catch (ArgumentException)
+        {
+            _ = _resolvedSchemas.GetValue(
+                registrySchema,
+                static _ => throw new InvalidOperationException("Resolved Avro schema cache changed unexpectedly."));
+        }
     }
 
     private static AvroSchema ParseRegisteredSchema(

--- a/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
@@ -97,16 +97,13 @@ internal sealed class AvroInlineRuleValidatorProvider : IInlineValidationRuleExe
     {
         if (_resolvedSchemas.TryGetValue(registrySchema, out var resolved))
             return resolved;
-        if (_schemaRegistry is null)
+        if (registrySchema.References is { Count: > 0 })
         {
             throw new SchemaRegistryRuleException(
-                "Could not resolve registered Avro schema references without a Schema Registry client.");
+                "Referenced Avro schema is not prepared. Consume through an asynchronous API or call WarmupAsync first.");
         }
 
-        resolved = Poco.AvroSchemaReferenceResolver.Parse(
-            _schemaRegistry,
-            registrySchema,
-            TimeSpan.FromSeconds(30));
+        resolved = AvroSchema.Parse(registrySchema.SchemaString);
         _ = Register(registrySchema, resolved);
         return _resolvedSchemas.GetValue(
             registrySchema,

--- a/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
@@ -145,10 +145,9 @@ internal sealed class AvroInlineRuleValidatorProvider : IInlineValidationRuleExe
         for (var index = 0; index < references.Count; index++)
         {
             var visited = new HashSet<AvroSchema>(AvroSchemaReferenceComparer.Instance);
-            var referenced = FindNamedSchema(resolvedSchema, references[index].Name, visited)
-                ?? throw new SchemaRegistryRuleException(
-                    $"Could not resolve Avro validation schema reference '{references[index].Name}'.");
-            _ = names.Add(referenced);
+            var referenced = FindNamedSchema(resolvedSchema, references[index].Name, visited);
+            if (referenced is not null)
+                _ = names.Add(referenced);
         }
         return AvroSchema.Parse(registrySchema.SchemaString, names);
     }

--- a/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
@@ -58,9 +58,7 @@ internal sealed class AvroInlineRuleValidatorProvider : IInlineValidationRuleExe
     {
         if (_registeredSchemas.TryGetValue(registrySchema, out var existing))
             return existing;
-        return registrySchema.References is { Count: > 0 }
-            ? Register(registrySchema, GetResolvedSchema(registrySchema))
-            : Register(registrySchema, runtimeSchema);
+        return Register(registrySchema, runtimeSchema);
     }
 
     internal ValueTask<AvroInlineRuleValidator> PrepareSerializerSchemaAsync(

--- a/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
@@ -1,0 +1,94 @@
+using System.Runtime.CompilerServices;
+using AvroSchema = global::Avro.Schema;
+using RegistrySchema = Dekaf.SchemaRegistry.Schema;
+
+namespace Dekaf.SchemaRegistry.Avro;
+
+internal static class AvroValidationConfiguration
+{
+    internal static AvroInlineRuleValidatorProvider? Create(
+        ValidationRulesExecution execution,
+        ISchemaRegistryRuleExecutor? ruleExecutor)
+    {
+        if (!Enum.IsDefined(execution))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(execution),
+                execution,
+                "Unsupported inline validation execution mode.");
+        }
+        if (execution == ValidationRulesExecution.Disabled)
+            return null;
+        if (ruleExecutor is not null and not SchemaRegistryRuleExecutor &&
+            !ReferenceEquals(ruleExecutor, SchemaRegistryMigrationRunner.MarkerRuleExecutor))
+        {
+            throw new NotSupportedException(
+                "Inline validation rules require SchemaRegistryRuleExecutor so domain and encoding rule boundaries are known.");
+        }
+        return new AvroInlineRuleValidatorProvider();
+    }
+}
+
+internal sealed class AvroInlineRuleValidatorProvider : IInlineValidationRuleExecutor
+{
+    private readonly ConditionalWeakTable<AvroSchema, AvroInlineRuleValidator> _schemas = new();
+    private readonly ConditionalWeakTable<RegistrySchema, AvroInlineRuleValidator> _registeredSchemas = new();
+    private SchemaValidatorCacheEntry? _lastSchema;
+
+    internal AvroInlineRuleValidator Get(AvroSchema schema) =>
+        _schemas.GetValue(schema, static value => new AvroInlineRuleValidator(value));
+
+    internal AvroInlineRuleValidator Register(RegistrySchema registrySchema, AvroSchema avroSchema)
+    {
+        if (_registeredSchemas.TryGetValue(registrySchema, out var existing))
+            return existing;
+        return RegisterSlow(registrySchema, avroSchema);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private AvroInlineRuleValidator RegisterSlow(RegistrySchema registrySchema, AvroSchema avroSchema)
+    {
+        var validator = Get(avroSchema);
+        try
+        {
+            _registeredSchemas.Add(registrySchema, validator);
+        }
+        catch (ArgumentException)
+        {
+            validator = _registeredSchemas.GetValue(
+                registrySchema,
+                static _ => throw new InvalidOperationException("Registered Avro validator cache changed unexpectedly."));
+        }
+        return validator;
+    }
+
+    void IInlineValidationRuleExecutor.Validate(
+        ReadOnlyMemory<byte> payload,
+        int schemaId,
+        string? subject,
+        RegistrySchema schema,
+        bool failFast)
+    {
+        var cached = Volatile.Read(ref _lastSchema);
+        var validator = cached is { SchemaId: var cachedSchemaId } && cachedSchemaId == schemaId
+            ? cached.Validator
+            : Resolve(schemaId, schema);
+        validator.Validate(payload, schemaId, failFast);
+    }
+
+    private AvroInlineRuleValidator Resolve(int schemaId, RegistrySchema schema)
+    {
+        if (schema.SchemaType != SchemaType.Avro)
+        {
+            throw new SchemaRegistryRuleException(
+                $"Schema {schemaId} is not an Avro schema (type: {schema.SchemaType}).");
+        }
+        var validator = _registeredSchemas.GetValue(
+            schema,
+            static value => new AvroInlineRuleValidator(AvroSchema.Parse(value.SchemaString)));
+        Volatile.Write(ref _lastSchema, new SchemaValidatorCacheEntry(schemaId, validator));
+        return validator;
+    }
+
+    private sealed record SchemaValidatorCacheEntry(int SchemaId, AvroInlineRuleValidator Validator);
+}

--- a/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
@@ -38,17 +38,19 @@ internal sealed class AvroInlineRuleValidatorProvider : IInlineValidationRuleExe
     internal AvroInlineRuleValidator Get(AvroSchema schema) =>
         _schemas.GetValue(schema, static value => new AvroInlineRuleValidator(value));
 
-    internal AvroInlineRuleValidator Register(RegistrySchema registrySchema, AvroSchema avroSchema)
+    internal AvroInlineRuleValidator Register(RegistrySchema registrySchema, AvroSchema resolvedSchema)
     {
         if (_registeredSchemas.TryGetValue(registrySchema, out var existing))
             return existing;
-        return RegisterSlow(registrySchema, avroSchema);
+        return RegisterSlow(registrySchema, resolvedSchema);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private AvroInlineRuleValidator RegisterSlow(RegistrySchema registrySchema, AvroSchema avroSchema)
+    private AvroInlineRuleValidator RegisterSlow(
+        RegistrySchema registrySchema,
+        AvroSchema resolvedSchema)
     {
-        var validator = Get(avroSchema);
+        var validator = new AvroInlineRuleValidator(ParseRegisteredSchema(registrySchema, resolvedSchema));
         try
         {
             _registeredSchemas.Add(registrySchema, validator);
@@ -83,11 +85,80 @@ internal sealed class AvroInlineRuleValidatorProvider : IInlineValidationRuleExe
             throw new SchemaRegistryRuleException(
                 $"Schema {schemaId} is not an Avro schema (type: {schema.SchemaType}).");
         }
-        var validator = _registeredSchemas.GetValue(
-            schema,
-            static value => new AvroInlineRuleValidator(AvroSchema.Parse(value.SchemaString)));
+        var validator = Register(schema, AvroSchema.Parse(schema.SchemaString));
         Volatile.Write(ref _lastSchema, new SchemaValidatorCacheEntry(schemaId, validator));
         return validator;
+    }
+
+    private static AvroSchema ParseRegisteredSchema(
+        RegistrySchema registrySchema,
+        AvroSchema resolvedSchema)
+    {
+        if (registrySchema.References is not { Count: > 0 } references)
+            return AvroSchema.Parse(registrySchema.SchemaString);
+
+        var names = new global::Avro.SchemaNames();
+        for (var index = 0; index < references.Count; index++)
+        {
+            var visited = new HashSet<AvroSchema>(AvroSchemaReferenceComparer.Instance);
+            var referenced = FindNamedSchema(resolvedSchema, references[index].Name, visited)
+                ?? throw new SchemaRegistryRuleException(
+                    $"Could not resolve Avro validation schema reference '{references[index].Name}'.");
+            _ = names.Add(referenced);
+        }
+        return AvroSchema.Parse(registrySchema.SchemaString, names);
+    }
+
+    private static global::Avro.NamedSchema? FindNamedSchema(
+        AvroSchema schema,
+        string fullName,
+        HashSet<AvroSchema> visited)
+    {
+        if (!visited.Add(schema))
+            return null;
+        if (schema is global::Avro.NamedSchema named &&
+            string.Equals(named.Fullname, fullName, StringComparison.Ordinal))
+        {
+            return named;
+        }
+
+        return schema switch
+        {
+            global::Avro.LogicalSchema logical => FindNamedSchema(logical.BaseSchema, fullName, visited),
+            global::Avro.RecordSchema record => FindNamedFieldSchema(record, fullName, visited),
+            global::Avro.ArraySchema array => FindNamedSchema(array.ItemSchema, fullName, visited),
+            global::Avro.MapSchema map => FindNamedSchema(map.ValueSchema, fullName, visited),
+            global::Avro.UnionSchema union => FindNamedUnionSchema(union, fullName, visited),
+            _ => null
+        };
+    }
+
+    private static global::Avro.NamedSchema? FindNamedFieldSchema(
+        global::Avro.RecordSchema record,
+        string fullName,
+        HashSet<AvroSchema> visited)
+    {
+        for (var index = 0; index < record.Fields.Count; index++)
+        {
+            var found = FindNamedSchema(record.Fields[index].Schema, fullName, visited);
+            if (found is not null)
+                return found;
+        }
+        return null;
+    }
+
+    private static global::Avro.NamedSchema? FindNamedUnionSchema(
+        global::Avro.UnionSchema union,
+        string fullName,
+        HashSet<AvroSchema> visited)
+    {
+        for (var index = 0; index < union.Count; index++)
+        {
+            var found = FindNamedSchema(union[index], fullName, visited);
+            if (found is not null)
+                return found;
+        }
+        return null;
     }
 
     private sealed record SchemaValidatorCacheEntry(int SchemaId, AvroInlineRuleValidator Validator);

--- a/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
@@ -85,7 +85,8 @@ internal sealed class AvroInlineRuleValidatorProvider : IInlineValidationRuleExe
             throw new SchemaRegistryRuleException(
                 $"Schema {schemaId} is not an Avro schema (type: {schema.SchemaType}).");
         }
-        var validator = Register(schema, AvroSchema.Parse(schema.SchemaString));
+        if (!_registeredSchemas.TryGetValue(schema, out var validator))
+            validator = Register(schema, AvroSchema.Parse(schema.SchemaString));
         Volatile.Write(ref _lastSchema, new SchemaValidatorCacheEntry(schemaId, validator));
         return validator;
     }

--- a/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroValidationConfiguration.cs
@@ -63,6 +63,36 @@ internal sealed class AvroInlineRuleValidatorProvider : IInlineValidationRuleExe
             : Register(registrySchema, runtimeSchema);
     }
 
+    internal ValueTask<AvroInlineRuleValidator> PrepareSerializerSchemaAsync(
+        RegistrySchema registrySchema,
+        AvroSchema runtimeSchema,
+        CancellationToken cancellationToken)
+    {
+        if (_registeredSchemas.TryGetValue(registrySchema, out var existing))
+            return new ValueTask<AvroInlineRuleValidator>(existing);
+        if (registrySchema.References is not { Count: > 0 })
+            return new ValueTask<AvroInlineRuleValidator>(Register(registrySchema, runtimeSchema));
+        if (_schemaRegistry is null)
+        {
+            throw new SchemaRegistryRuleException(
+                "Could not resolve registered Avro schema references without a Schema Registry client.");
+        }
+
+        return PrepareReferencedSerializerSchemaAsync(registrySchema, cancellationToken);
+    }
+
+    private async ValueTask<AvroInlineRuleValidator> PrepareReferencedSerializerSchemaAsync(
+        RegistrySchema registrySchema,
+        CancellationToken cancellationToken)
+    {
+        var resolvedSchema = await Poco.AvroSchemaReferenceResolver.ParseAsync(
+                _schemaRegistry!,
+                registrySchema,
+                cancellationToken)
+            .ConfigureAwait(false);
+        return Register(registrySchema, resolvedSchema);
+    }
+
     internal AvroSchema GetResolvedSchema(RegistrySchema registrySchema)
     {
         if (_resolvedSchemas.TryGetValue(registrySchema, out var resolved))

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistryDeserializer.cs
@@ -48,6 +48,7 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
     private int _nextGuidPlanId;
 
     internal int CachedPlanCount => Volatile.Read(ref _cachedPlanCount);
+    internal long LastInlineValidationDecision => Volatile.Read(ref _lastInlineValidationDecision);
 
     /// <summary>Creates a generated POCO Avro deserializer.</summary>
     public AvroPocoSchemaRegistryDeserializer(
@@ -509,14 +510,14 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
             return null;
 
         var cached = Volatile.Read(ref _lastInlineValidationDecision);
-        if (cached >= 0 && (int)(cached >> 1) == schemaId && (cached & 1) == 0)
+        if (cached >= 0 && (int)(uint)(cached >> 1) == schemaId && (cached & 1) == 0)
             return null;
 
         var validator = _inlineRuleValidators.Get(GetValidationSchema(schemaId, plan));
         var hasRules = validator.HasAnyRules;
         Volatile.Write(
             ref _lastInlineValidationDecision,
-            ((long)schemaId << 1) | (hasRules ? 1L : 0L));
+            ((long)(uint)schemaId << 1) | (hasRules ? 1L : 0L));
         return hasRules ? validator : null;
     }
 

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistryDeserializer.cs
@@ -35,7 +35,7 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
     private readonly ConcurrentQueue<KeyValuePair<int, AvroPocoReaderPlan>> _planEvictionQueue = new();
     private readonly ConcurrentDictionary<PreparedRuleKey, PreparedRuleState> _preparedRuleStates = new();
     private readonly ConcurrentQueue<PreparedRuleKey> _preparedRuleStateEvictionQueue = new();
-    private readonly AvroTaggedFieldTransformerProvider _taggedFieldTransformers = new();
+    private readonly AvroTaggedFieldTransformerProvider _taggedFieldTransformers;
     private readonly SchemaRegistryMigrationRunner? _migrationRunner;
     private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
     private readonly DeserializerSubjectNameCache? _subjectNames;
@@ -56,6 +56,7 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
         bool ownsClient = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
+        _taggedFieldTransformers = new AvroTaggedFieldTransformerProvider(schemaRegistry);
         _config = config ?? new AvroDeserializerConfig();
         if (_config.SchemaIdStrategy is not (
             SchemaIdDeserializerStrategy.Dual
@@ -70,6 +71,7 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
         _ownsClient = ownsClient;
         _ruleExecutor = _config.RuleExecutor;
         _inlineRuleValidators = AvroValidationConfiguration.Create(
+            schemaRegistry,
             _config.ValidationRulesExecution,
             _config.RuleExecutor);
         if (!string.IsNullOrEmpty(_config.ReaderSchema))
@@ -879,6 +881,12 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
         {
             var plan = await GetPlanAsync(target.Id, cancellationToken).ConfigureAwait(false);
             PrepareTaggedTransformer(target.Id, target.Schema, plan);
+            if (_inlineRuleValidators is not null)
+            {
+                _inlineRuleValidators.Register(
+                    target.Schema,
+                    GetValidationSchema(target.Id, target.Schema, plan));
+            }
             (plans ??= []).Add(target.Id, plan);
         }
         return plans;
@@ -1010,9 +1018,21 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
         if (_plans.TryGetValue(schemaId, out var cached))
             return cached;
 
-        var plan = BuildPlan(schemaId, schema);
+        var plan = schema.References is { Count: > 0 } && _inlineRuleValidators is not null
+            ? BuildResolvedValidationPlan(schemaId, schema)
+            : BuildPlan(schemaId, schema);
         CacheSuccessfulPlan(schemaId, plan);
         return _plans.TryGetValue(schemaId, out cached) ? cached : plan;
+    }
+
+    private AvroPocoReaderPlan BuildResolvedValidationPlan(int schemaId, Schema schema)
+    {
+        var parsed = _inlineRuleValidators!.GetResolvedSchema(schema) as AvroRecordSchema
+            ?? throw new InvalidOperationException("POCO Avro writer schema must be a record.");
+        var plan = AvroPocoReaderPlanBuilder.Build<T, TCodec>(parsed);
+        plan.ResolvedWriterSchema = parsed;
+        _resolvedSchemas[schemaId] = new ResolvedAvroSchema(plan, parsed);
+        return plan;
     }
 
     private async Task<AvroPocoReaderPlan> GetPlanAsync(int schemaId, CancellationToken cancellationToken)

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistryDeserializer.cs
@@ -56,7 +56,7 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
         bool ownsClient = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
-        _taggedFieldTransformers = new AvroTaggedFieldTransformerProvider(schemaRegistry);
+        _taggedFieldTransformers = new AvroTaggedFieldTransformerProvider();
         _config = config ?? new AvroDeserializerConfig();
         if (_config.SchemaIdStrategy is not (
             SchemaIdDeserializerStrategy.Dual

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistryDeserializer.cs
@@ -1262,7 +1262,21 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
                     .ConfigureAwait(false)
                 : null;
             var schemaId = Interlocked.Decrement(ref _nextGuidPlanId);
-            var plan = BuildPlan(schemaId, unscopedSchema, names);
+            AvroPocoReaderPlan plan;
+            if (_inlineRuleValidators is null)
+            {
+                plan = BuildPlan(schemaId, unscopedSchema, names);
+            }
+            else
+            {
+                ValidateAvroSchema(schemaId, unscopedSchema);
+                var parsed = (names is null
+                        ? AvroSchema.Parse(unscopedSchema.SchemaString)
+                        : AvroSchema.Parse(unscopedSchema.SchemaString, names)) as AvroRecordSchema
+                    ?? throw new InvalidOperationException("POCO Avro writer schema must be a record.");
+                plan = AvroPocoReaderPlanBuilder.Build<T, TCodec>(parsed);
+                plan.ResolvedWriterSchema = parsed;
+            }
             CacheSuccessfulPlan(schemaId, plan);
             return new GuidResolvedSchema(schemaId, plan);
         }

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistryDeserializer.cs
@@ -39,6 +39,7 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
     private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
     private readonly DeserializerSubjectNameCache? _subjectNames;
     private readonly bool _canUseSynchronousRuleCache;
+    private readonly AvroInlineRuleValidatorProvider? _inlineRuleValidators;
     private PreparedRuleState? _lastPreparedRuleState;
     private int _cachedPlanCount;
     private int _cachedPreparedRuleStateCount;
@@ -66,6 +67,9 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
         }
         _ownsClient = ownsClient;
         _ruleExecutor = _config.RuleExecutor;
+        _inlineRuleValidators = AvroValidationConfiguration.Create(
+            _config.ValidationRulesExecution,
+            _config.RuleExecutor);
         if (!string.IsNullOrEmpty(_config.ReaderSchema))
         {
             throw new ArgumentException(
@@ -470,10 +474,21 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
                 context.Component == SerializationComponent.Key,
                 _subjectNames?.Generation ?? 0));
         var payload = data[payloadOffset..];
-        if (_ruleExecutor is null)
+        if (_ruleExecutor is null && _inlineRuleValidators is null)
         {
             var directReader = new AvroValueReader(payload.Span);
             return TCodec.Read(ref directReader, GetPlanCached(schemaId));
+        }
+
+        if (_ruleExecutor is null)
+        {
+            var validatedPlan = GetPlanCached(schemaId);
+            _inlineRuleValidators!.Get(GetValidationSchema(schemaId, validatedPlan)).Validate(
+                payload,
+                schemaId,
+                _config.ValidationRulesFailFast);
+            var validatedReader = new AvroValueReader(payload.Span);
+            return TCodec.Read(ref validatedReader, validatedPlan);
         }
 
         if (_canUseSynchronousRuleCache)
@@ -540,7 +555,12 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
             SchemaRegistryPayloadFormat.Avro);
         try
         {
-            payload = _ruleExecutor!.TransformDeserializedPayload(payload, ruleContext);
+            payload = TransformDeserializedPayload(
+                payload,
+                schemaId,
+                scopedSchema,
+                plan,
+                ruleContext);
         }
         finally
         {
@@ -583,7 +603,12 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
             SchemaRegistryPayloadFormat.Avro);
         try
         {
-            payload = _ruleExecutor!.TransformDeserializedPayload(payload, ruleContext);
+            payload = TransformDeserializedPayload(
+                payload,
+                schemaId,
+                scopedSchema,
+                plan,
+                ruleContext);
         }
         finally
         {
@@ -615,7 +640,12 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
                 _taggedFieldTransformers.Get(scopedSchema));
             try
             {
-                payload = _ruleExecutor!.TransformDeserializedPayload(payload, ruleContext);
+                payload = TransformDeserializedPayload(
+                    payload,
+                    schemaId,
+                    scopedSchema,
+                    plan,
+                    ruleContext);
             }
             finally
             {
@@ -642,16 +672,34 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
         var taggedWorkspaceOperation = AvroTaggedFieldTransformerProvider.BeginOperation();
         try
         {
-            var migration = _migrationRunner!.Transform(
-                payload,
-                schemaId,
-                subject,
-                scopedSchema,
-                context,
-                SchemaRegistryPayloadFormat.Avro,
-                _taggedFieldTransformers,
-                skipLatestRefresh);
-            var reader = new AvroValueReader(migration.Payload.Span);
+            if (_inlineRuleValidators is not null)
+            {
+                var writerPlan = GetOrBuildPlanCached(schemaId, scopedSchema);
+                _inlineRuleValidators.Register(
+                    scopedSchema,
+                    GetValidationSchema(schemaId, scopedSchema, writerPlan));
+            }
+            var migration = _config.ValidationRulesExecution == ValidationRulesExecution.BeforeDomainRules
+                ? _migrationRunner!.TransformWithBeforeDomainValidation(
+                    payload,
+                    schemaId,
+                    subject,
+                    scopedSchema,
+                    context,
+                    SchemaRegistryPayloadFormat.Avro,
+                    _inlineRuleValidators!,
+                    _config.ValidationRulesFailFast,
+                    _taggedFieldTransformers,
+                    skipLatestRefresh)
+                : _migrationRunner!.Transform(
+                    payload,
+                    schemaId,
+                    subject,
+                    scopedSchema,
+                    context,
+                    SchemaRegistryPayloadFormat.Avro,
+                    _taggedFieldTransformers,
+                    skipLatestRefresh);
             var preparedKey = new PreparedRuleKey(
                 schemaId,
                 context.Topic,
@@ -665,12 +713,76 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
                        preparedState.TryGetPlan(migration.PayloadSchemaId, out var preparedPlan)
                 ? preparedPlan
                 : GetOrBuildPlanCached(migration.PayloadSchemaId, migration.PayloadSchema);
+            if (_inlineRuleValidators is not null)
+            {
+                var validationSchema = GetValidationSchema(
+                    migration.PayloadSchemaId,
+                    migration.PayloadSchema,
+                    plan);
+                _inlineRuleValidators.Register(migration.PayloadSchema, validationSchema);
+                if (_config.ValidationRulesExecution == ValidationRulesExecution.AfterDomainRules)
+                {
+                    ((IInlineValidationRuleExecutor)_inlineRuleValidators).Validate(
+                        migration.Payload,
+                        migration.PayloadSchemaId,
+                        migration.PayloadSchema,
+                        _config.ValidationRulesFailFast);
+                }
+            }
+            var reader = new AvroValueReader(migration.Payload.Span);
             return TCodec.Read(ref reader, plan);
         }
         finally
         {
             taggedWorkspaceOperation.Dispose();
         }
+    }
+
+    private ReadOnlyMemory<byte> TransformDeserializedPayload(
+        ReadOnlyMemory<byte> payload,
+        int schemaId,
+        Schema scopedSchema,
+        AvroPocoReaderPlan plan,
+        SchemaRegistryRuleContext context)
+    {
+        if (_inlineRuleValidators is null ||
+            _ruleExecutor is not SchemaRegistryRuleExecutor ruleExecutor)
+        {
+            return _ruleExecutor!.TransformDeserializedPayload(payload, context);
+        }
+
+        var validator = _inlineRuleValidators.Register(
+            scopedSchema,
+            GetValidationSchema(schemaId, scopedSchema, plan));
+        payload = ruleExecutor.TransformDeserializedEncodingPayload(payload, context);
+        if (_config.ValidationRulesExecution == ValidationRulesExecution.BeforeDomainRules)
+            validator.Validate(payload, schemaId, _config.ValidationRulesFailFast);
+        payload = ruleExecutor.TransformDeserializedDomainPayload(payload, context);
+        if (_config.ValidationRulesExecution == ValidationRulesExecution.AfterDomainRules)
+            validator.Validate(payload, schemaId, _config.ValidationRulesFailFast);
+        return payload;
+    }
+
+    private AvroSchema GetValidationSchema(int schemaId, AvroPocoReaderPlan plan)
+    {
+        if (plan.ResolvedWriterSchema is { } resolved)
+            return resolved;
+        var schema = _schemaRegistry.GetSchemaSync(schemaId, RegistryTimeout);
+        return GetValidationSchema(schemaId, schema, plan);
+    }
+
+    private AvroSchema GetValidationSchema(
+        int schemaId,
+        Schema schema,
+        AvroPocoReaderPlan plan)
+    {
+        if (plan.ResolvedWriterSchema is { } resolved)
+            return resolved;
+        if (_resolvedSchemas.TryGetValue(schemaId, out var cached))
+            return cached.Schema;
+        var parsed = AvroSchema.Parse(schema.SchemaString);
+        plan.ResolvedWriterSchema = parsed;
+        return parsed;
     }
 
     private AvroPocoReaderPlan GetPlanCached(int schemaId)

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistryDeserializer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using Dekaf.SchemaRegistry.Avro;
 using Dekaf.Serialization;
 using AvroRecordSchema = global::Avro.RecordSchema;
@@ -41,6 +42,7 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
     private readonly bool _canUseSynchronousRuleCache;
     private readonly AvroInlineRuleValidatorProvider? _inlineRuleValidators;
     private PreparedRuleState? _lastPreparedRuleState;
+    private long _lastInlineValidationDecision = -1;
     private int _cachedPlanCount;
     private int _cachedPreparedRuleStateCount;
     private int _nextGuidPlanId;
@@ -352,7 +354,10 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
             return true;
         }
 
-        var reader = new AvroValueReader(data.Span[payloadOffset..]);
+        var payload = data[payloadOffset..];
+        GetInlineValidator(schemaId, plan)?.Validate(
+            payload, schemaId, _config.ValidationRulesFailFast);
+        var reader = new AvroValueReader(payload.Span);
         value = TCodec.Read(ref reader, plan);
         return true;
     }
@@ -482,19 +487,35 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
 
         if (_ruleExecutor is null)
         {
-            var validatedPlan = GetPlanCached(schemaId);
-            _inlineRuleValidators!.Get(GetValidationSchema(schemaId, validatedPlan)).Validate(
-                payload,
-                schemaId,
-                _config.ValidationRulesFailFast);
-            var validatedReader = new AvroValueReader(payload.Span);
-            return TCodec.Read(ref validatedReader, validatedPlan);
+            var directPlan = GetPlanCached(schemaId);
+            GetInlineValidator(schemaId, directPlan)?.Validate(
+                payload, schemaId, _config.ValidationRulesFailFast);
+            var directReader = new AvroValueReader(payload.Span);
+            return TCodec.Read(ref directReader, directPlan);
         }
 
         if (_canUseSynchronousRuleCache)
             return DeserializeWithRules(payload, schemaId, context);
 
         return DeserializeWithPreparedRulesOrFallback(payload, schemaId, context);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private AvroInlineRuleValidator? GetInlineValidator(int schemaId, AvroPocoReaderPlan plan)
+    {
+        if (_inlineRuleValidators is null)
+            return null;
+
+        var cached = Volatile.Read(ref _lastInlineValidationDecision);
+        if (cached >= 0 && (int)(cached >> 1) == schemaId && (cached & 1) == 0)
+            return null;
+
+        var validator = _inlineRuleValidators.Get(GetValidationSchema(schemaId, plan));
+        var hasRules = validator.HasAnyRules;
+        Volatile.Write(
+            ref _lastInlineValidationDecision,
+            ((long)schemaId << 1) | (hasRules ? 1L : 0L));
+        return hasRules ? validator : null;
     }
 
     private T DeserializeWithPreparedRulesOrFallback(

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistryDeserializer.cs
@@ -748,6 +748,7 @@ public sealed class AvroPocoSchemaRegistryDeserializer<T, TCodec>
                     ((IInlineValidationRuleExecutor)_inlineRuleValidators).Validate(
                         migration.Payload,
                         migration.PayloadSchemaId,
+                        subject,
                         migration.PayloadSchema,
                         _config.ValidationRulesFailFast);
                 }

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistrySerializer.cs
@@ -45,6 +45,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
     private readonly SubjectSchemaIdCache _subjectCache = new();
     private readonly SchemaResolutionCache<SubjectSchemaIdCache.SubjectSchemaIdCacheValue> _resolutionCache = new();
     private readonly AvroTaggedFieldTransformerProvider _taggedFieldTransformers = new();
+    private readonly AvroInlineRuleValidatorProvider? _inlineRuleValidators;
     private AvroPocoSerializerBufferState? _primaryRuleBuffer;
     private ConditionalWeakTable<Thread, AvroPocoSerializerBufferState>? _additionalRuleBuffers;
     private SubjectSchemaIdCache? _associatedSubjectCache;
@@ -67,6 +68,9 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
             _config.AutoRegisterSchemas);
         if (_schemaIdStrategy is not (SchemaIdSerializerStrategy.Prefix or SchemaIdSerializerStrategy.Header))
             throw new ArgumentOutOfRangeException(nameof(config), _schemaIdStrategy, "Unknown schema identity strategy.");
+        _inlineRuleValidators = AvroValidationConfiguration.Create(
+            _config.ValidationRulesExecution,
+            _config.RuleExecutor);
         if (_config.CustomSubjectNameStrategy is null)
         {
             _asyncSubjectNameStrategy = _config.AsyncSubjectNameStrategy
@@ -229,7 +233,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
         var entry = GetSchemaForContext(
             context.Topic,
             context.Component == SerializationComponent.Key);
-        if (_config.RuleExecutor is null)
+        if (_config.RuleExecutor is null && _inlineRuleValidators is null)
         {
             if (_schemaIdStrategy == SchemaIdSerializerStrategy.Prefix)
                 SerializeDirect(value, ref destination, entry.SchemaId);
@@ -238,9 +242,9 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
             return;
         }
 
-        if (entry.Schema!.RuleSet is null)
+        if (_config.RuleExecutor is null || entry.Schema!.RuleSet is null)
         {
-            SerializeWithRules(value, ref destination, context, entry, _config.RuleExecutor!);
+            SerializeWithRules(value, ref destination, context, entry, _config.RuleExecutor);
             return;
         }
 
@@ -281,7 +285,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
         , allows ref struct
 #endif
     {
-        if (_config.RuleExecutor is null)
+        if (_config.RuleExecutor is null && _inlineRuleValidators is null)
         {
             if (_schemaIdStrategy == SchemaIdSerializerStrategy.Prefix)
                 SerializeDirect(value, ref destination, entry.SchemaId);
@@ -290,9 +294,9 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
             return;
         }
 
-        if (entry.Schema!.RuleSet is null)
+        if (_config.RuleExecutor is null || entry.Schema!.RuleSet is null)
         {
-            SerializeWithRules(value, ref destination, context, entry, _config.RuleExecutor!);
+            SerializeWithRules(value, ref destination, context, entry, _config.RuleExecutor);
             return;
         }
 
@@ -438,7 +442,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
         ref TWriter destination,
         SerializationContext context,
         SubjectSchemaIdCache.SubjectSchemaIdCacheEntry entry,
-        ISchemaRegistryRuleExecutor ruleExecutor)
+        ISchemaRegistryRuleExecutor? ruleExecutor)
         where TWriter : IBufferWriter<byte>
 #if NET10_0_OR_GREATER
         , allows ref struct
@@ -474,20 +478,30 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
             }
 
             var payload = new ReadOnlyMemory<byte>(buffer, 0, length);
-            var ruleContext = SchemaRegistryRuleContext.Rent(
-                context.Topic,
-                context.Component,
-                entry.SchemaId,
-                entry.Subject!,
-                entry.Schema!,
-                SchemaRegistryPayloadFormat.Avro);
-            try
+            if (ruleExecutor is null)
             {
-                payload = ruleExecutor.TransformSerializedPayload(payload, ruleContext);
+                _inlineRuleValidators!.Get(GeneratedSchema.Value).Validate(
+                    payload,
+                    entry.SchemaId,
+                    _config.ValidationRulesFailFast);
             }
-            finally
+            else
             {
-                ruleContext.Return();
+                var ruleContext = SchemaRegistryRuleContext.Rent(
+                    context.Topic,
+                    context.Component,
+                    entry.SchemaId,
+                    entry.Subject!,
+                    entry.Schema!,
+                    SchemaRegistryPayloadFormat.Avro);
+                try
+                {
+                    payload = TransformSerializedPayload(payload, ruleContext, entry);
+                }
+                finally
+                {
+                    ruleContext.Return();
+                }
             }
 
             var payloadOffset = SchemaIdentitySerialization.GetPayloadOffset(_schemaIdStrategy);
@@ -577,7 +591,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
         }
     }
 
-    private static ReadOnlyMemory<byte> TransformWithTaggedFields(
+    private ReadOnlyMemory<byte> TransformWithTaggedFields(
         ReadOnlyMemory<byte> payload,
         SerializationContext context,
         SubjectSchemaIdCache.SubjectSchemaIdCacheEntry entry,
@@ -597,7 +611,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
                 taggedFieldTransformers.Get(entry.Schema!, GeneratedSchema.Value));
             try
             {
-                return ruleExecutor.TransformSerializedPayload(payload, ruleContext);
+                return TransformSerializedPayload(payload, ruleContext, entry);
             }
             finally
             {
@@ -608,6 +622,26 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
         {
             taggedWorkspaceOperation.Dispose();
         }
+    }
+
+    private ReadOnlyMemory<byte> TransformSerializedPayload(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleContext context,
+        SubjectSchemaIdCache.SubjectSchemaIdCacheEntry entry)
+    {
+        if (_inlineRuleValidators is null ||
+            _config.RuleExecutor is not SchemaRegistryRuleExecutor ruleExecutor)
+        {
+            return _config.RuleExecutor!.TransformSerializedPayload(payload, context);
+        }
+
+        var validator = _inlineRuleValidators.Register(entry.Schema!, GeneratedSchema.Value);
+        if (_config.ValidationRulesExecution == ValidationRulesExecution.BeforeDomainRules)
+            validator.Validate(payload, entry.SchemaId, _config.ValidationRulesFailFast);
+        payload = ruleExecutor.TransformSerializedDomainPayload(payload, context);
+        if (_config.ValidationRulesExecution == ValidationRulesExecution.AfterDomainRules)
+            validator.Validate(payload, entry.SchemaId, _config.ValidationRulesFailFast);
+        return ruleExecutor.TransformSerializedEncodingPayload(payload, context);
     }
 
     private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry GetSchemaForContext(string topic, bool isKey)

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistrySerializer.cs
@@ -46,6 +46,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
     private readonly SchemaResolutionCache<SubjectSchemaIdCache.SubjectSchemaIdCacheValue> _resolutionCache = new();
     private readonly AvroTaggedFieldTransformerProvider _taggedFieldTransformers = new();
     private readonly AvroInlineRuleValidatorProvider? _inlineRuleValidators;
+    private long _lastInlineValidationDecision = -1;
     private AvroPocoSerializerBufferState? _primaryRuleBuffer;
     private ConditionalWeakTable<Thread, AvroPocoSerializerBufferState>? _additionalRuleBuffers;
     private SubjectSchemaIdCache? _associatedSubjectCache;
@@ -233,7 +234,10 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
         var entry = GetSchemaForContext(
             context.Topic,
             context.Component == SerializationComponent.Key);
-        if (_config.RuleExecutor is null && _inlineRuleValidators is null)
+        AvroInlineRuleValidator? inlineValidator = null;
+        if (_config.RuleExecutor is null &&
+            (_inlineRuleValidators is null ||
+             (inlineValidator = GetInlineValidator(entry.SchemaId, entry.Schema!)) is null))
         {
             if (_schemaIdStrategy == SchemaIdSerializerStrategy.Prefix)
                 SerializeDirect(value, ref destination, entry.SchemaId);
@@ -244,7 +248,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
 
         if (_config.RuleExecutor is null || entry.Schema!.RuleSet is null)
         {
-            SerializeWithRules(value, ref destination, context, entry, _config.RuleExecutor);
+            SerializeWithRules(value, ref destination, context, entry, _config.RuleExecutor, inlineValidator);
             return;
         }
 
@@ -285,7 +289,10 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
         , allows ref struct
 #endif
     {
-        if (_config.RuleExecutor is null && _inlineRuleValidators is null)
+        AvroInlineRuleValidator? inlineValidator = null;
+        if (_config.RuleExecutor is null &&
+            (_inlineRuleValidators is null ||
+             (inlineValidator = GetInlineValidator(entry.SchemaId, entry.Schema!)) is null))
         {
             if (_schemaIdStrategy == SchemaIdSerializerStrategy.Prefix)
                 SerializeDirect(value, ref destination, entry.SchemaId);
@@ -296,7 +303,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
 
         if (_config.RuleExecutor is null || entry.Schema!.RuleSet is null)
         {
-            SerializeWithRules(value, ref destination, context, entry, _config.RuleExecutor);
+            SerializeWithRules(value, ref destination, context, entry, _config.RuleExecutor, inlineValidator);
             return;
         }
 
@@ -442,7 +449,8 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
         ref TWriter destination,
         SerializationContext context,
         SubjectSchemaIdCache.SubjectSchemaIdCacheEntry entry,
-        ISchemaRegistryRuleExecutor? ruleExecutor)
+        ISchemaRegistryRuleExecutor? ruleExecutor,
+        AvroInlineRuleValidator? inlineValidator)
         where TWriter : IBufferWriter<byte>
 #if NET10_0_OR_GREATER
         , allows ref struct
@@ -480,7 +488,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
             var payload = new ReadOnlyMemory<byte>(buffer, 0, length);
             if (ruleExecutor is null)
             {
-                _inlineRuleValidators!.Register(entry.Schema!, GeneratedSchema.Value).Validate(
+                inlineValidator!.Validate(
                     payload,
                     entry.SchemaId,
                     _config.ValidationRulesFailFast);
@@ -521,6 +529,21 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
             if (bufferIsPooled)
                 ArrayPool<byte>.Shared.Return(buffer);
         }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private AvroInlineRuleValidator? GetInlineValidator(int schemaId, RegistrySchema registrySchema)
+    {
+        var cached = Volatile.Read(ref _lastInlineValidationDecision);
+        if (cached >= 0 && (int)(cached >> 1) == schemaId && (cached & 1) == 0)
+            return null;
+
+        var validator = _inlineRuleValidators!.Register(registrySchema, GeneratedSchema.Value);
+        var hasRules = validator.HasAnyRules;
+        Volatile.Write(
+            ref _lastInlineValidationDecision,
+            ((long)schemaId << 1) | (hasRules ? 1L : 0L));
+        return hasRules ? validator : null;
     }
 
     private void SerializeWithTaggedRules<TWriter>(

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistrySerializer.cs
@@ -540,7 +540,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
         if (cached >= 0 && (int)(cached >> 1) == schemaId && (cached & 1) == 0)
             return null;
 
-        var validator = _inlineRuleValidators!.Register(registrySchema, GeneratedSchema.Value);
+        var validator = _inlineRuleValidators!.RegisterSerializerSchema(registrySchema, GeneratedSchema.Value);
         var hasRules = validator.HasAnyRules;
         Volatile.Write(
             ref _lastInlineValidationDecision,
@@ -660,7 +660,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
             return _config.RuleExecutor!.TransformSerializedPayload(payload, context);
         }
 
-        var validator = _inlineRuleValidators.Register(entry.Schema!, GeneratedSchema.Value);
+        var validator = _inlineRuleValidators.RegisterSerializerSchema(entry.Schema!, GeneratedSchema.Value);
         if (_config.ValidationRulesExecution == ValidationRulesExecution.BeforeDomainRules)
             validator.Validate(payload, entry.SchemaId, _config.ValidationRulesFailFast);
         payload = ruleExecutor.TransformSerializedDomainPayload(payload, context);
@@ -782,7 +782,8 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
                     subject,
                     schema,
                     cancellationToken).ConfigureAwait(false);
-            var registeredSchema = _config.RuleExecutor is SchemaRegistryRuleExecutor
+            var registeredSchema = _config.RuleExecutor is SchemaRegistryRuleExecutor ||
+                                   _config.ValidationRulesExecution != ValidationRulesExecution.Disabled
                 ? await _schemaRegistry.GetSchemaAsync(schemaId, subject, cancellationToken).ConfigureAwait(false)
                 : schema;
             return await CreateResolvedValueAsync(

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistrySerializer.cs
@@ -116,20 +116,28 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
         CancellationToken cancellationToken = default)
     {
         var cache = _subjectCache;
+        ValueTask<ResolvedSchemaContext> preparation;
         if (cache.TryGet(topic, isKey, out var cached))
-            return new ValueTask<ResolvedSchemaContext>(ToResolvedContext(cached));
-
+        {
+            preparation = new ValueTask<ResolvedSchemaContext>(ToResolvedContext(cached));
+            return PrepareInlineValidationAsync(preparation, cancellationToken);
+        }
         if (_asyncSubjectNameStrategy is not null)
         {
             cache = Volatile.Read(ref _associatedSubjectCache)!;
             if (cache.TryGet(topic, isKey, out cached))
-                return new ValueTask<ResolvedSchemaContext>(ToResolvedContext(cached));
-
-            return PrepareAssociatedCoreAsync(
-                topic,
-                isKey,
-                cache,
-                cancellationToken);
+            {
+                preparation = new ValueTask<ResolvedSchemaContext>(ToResolvedContext(cached));
+            }
+            else
+            {
+                preparation = PrepareAssociatedCoreAsync(
+                    topic,
+                    isKey,
+                    cache,
+                    cancellationToken);
+            }
+            return PrepareInlineValidationAsync(preparation, cancellationToken);
         }
 
         var subject = GetSubjectName(topic, isKey);
@@ -137,15 +145,73 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
         if (resolution.IsCompletedSuccessfully)
         {
             var value = resolution.Result;
-            return new ValueTask<ResolvedSchemaContext>(ToResolvedContext(
+            preparation = new ValueTask<ResolvedSchemaContext>(ToResolvedContext(
                 cache.CacheEntry(
                     topic,
                     isKey,
                     subject,
                     in value)));
         }
+        else
+        {
+            preparation = AwaitResolutionAsync(topic, isKey, subject, cache, resolution);
+        }
+        return PrepareInlineValidationAsync(preparation, cancellationToken);
+    }
 
-        return AwaitResolutionAsync(topic, isKey, subject, cache, resolution);
+    private ValueTask<ResolvedSchemaContext> PrepareInlineValidationAsync(
+        ValueTask<ResolvedSchemaContext> preparation,
+        CancellationToken cancellationToken)
+    {
+        if (_inlineRuleValidators is null)
+            return preparation;
+        if (preparation.IsCompletedSuccessfully)
+        {
+            var resolved = preparation.Result;
+            var cached = Volatile.Read(ref _lastInlineValidationDecision);
+            if (cached >= 0 && (int)(cached >> 1) == resolved.SchemaId)
+                return new ValueTask<ResolvedSchemaContext>(resolved);
+            var validationPreparation = _inlineRuleValidators.PrepareSerializerSchemaAsync(
+                resolved.Schema,
+                GeneratedSchema.Value,
+                cancellationToken);
+            if (validationPreparation.IsCompletedSuccessfully)
+            {
+                CacheInlineValidationDecision(resolved.SchemaId, validationPreparation.Result);
+                return new ValueTask<ResolvedSchemaContext>(resolved);
+            }
+            return AwaitValidationCompletionAsync(this, resolved, validationPreparation);
+        }
+
+        return AwaitPreparationAndValidationAsync(this, preparation, cancellationToken);
+
+        static async ValueTask<ResolvedSchemaContext> AwaitValidationCompletionAsync(
+            AvroPocoSchemaRegistrySerializer<T, TCodec> serializer,
+            ResolvedSchemaContext resolved,
+            ValueTask<AvroInlineRuleValidator> pending)
+        {
+            var validator = await pending.ConfigureAwait(false);
+            serializer.CacheInlineValidationDecision(resolved.SchemaId, validator);
+            return resolved;
+        }
+
+        static async ValueTask<ResolvedSchemaContext> AwaitPreparationAndValidationAsync(
+            AvroPocoSchemaRegistrySerializer<T, TCodec> serializer,
+            ValueTask<ResolvedSchemaContext> pending,
+            CancellationToken cancellationToken)
+        {
+            var resolved = await pending.ConfigureAwait(false);
+            var cached = Volatile.Read(ref serializer._lastInlineValidationDecision);
+            if (cached >= 0 && (int)(cached >> 1) == resolved.SchemaId)
+                return resolved;
+            var validator = await serializer._inlineRuleValidators!.PrepareSerializerSchemaAsync(
+                    resolved.Schema,
+                    GeneratedSchema.Value,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            serializer.CacheInlineValidationDecision(resolved.SchemaId, validator);
+            return resolved;
+        }
     }
 
     private async ValueTask<ResolvedSchemaContext> PrepareAssociatedCoreAsync(
@@ -542,11 +608,17 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
 
         var validator = _inlineRuleValidators!.RegisterSerializerSchema(registrySchema, GeneratedSchema.Value);
         var hasRules = validator.HasAnyRules;
-        Volatile.Write(
-            ref _lastInlineValidationDecision,
-            ((long)schemaId << 1) | (hasRules ? 1L : 0L));
+        CacheInlineValidationDecision(schemaId, validator);
         return hasRules ? validator : null;
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void CacheInlineValidationDecision(
+        int schemaId,
+        AvroInlineRuleValidator validator) =>
+        Volatile.Write(
+            ref _lastInlineValidationDecision,
+            ((long)schemaId << 1) | (validator.HasAnyRules ? 1L : 0L));
 
     private void SerializeWithTaggedRules<TWriter>(
         T value,

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistrySerializer.cs
@@ -61,7 +61,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
         bool ownsClient = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
-        _taggedFieldTransformers = new AvroTaggedFieldTransformerProvider(schemaRegistry);
+        _taggedFieldTransformers = new AvroTaggedFieldTransformerProvider();
         _config = config ?? new AvroSerializerConfig();
         _schemaIdStrategy = _config.SchemaIdStrategy;
         _schemaSelectionMode = SchemaRegistrySerializerConfigValidator.ValidateAndResolve(
@@ -732,11 +732,13 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
             return _config.RuleExecutor!.TransformSerializedPayload(payload, context);
         }
 
-        var validator = _inlineRuleValidators.RegisterSerializerSchema(entry.Schema!, GeneratedSchema.Value);
-        if (_config.ValidationRulesExecution == ValidationRulesExecution.BeforeDomainRules)
+        var validator = GetInlineValidator(entry.SchemaId, entry.Schema!);
+        if (validator is not null &&
+            _config.ValidationRulesExecution == ValidationRulesExecution.BeforeDomainRules)
             validator.Validate(payload, entry.SchemaId, _config.ValidationRulesFailFast);
         payload = ruleExecutor.TransformSerializedDomainPayload(payload, context);
-        if (_config.ValidationRulesExecution == ValidationRulesExecution.AfterDomainRules)
+        if (validator is not null &&
+            _config.ValidationRulesExecution == ValidationRulesExecution.AfterDomainRules)
             validator.Validate(payload, entry.SchemaId, _config.ValidationRulesFailFast);
         return ruleExecutor.TransformSerializedEncodingPayload(payload, context);
     }

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistrySerializer.cs
@@ -480,7 +480,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
             var payload = new ReadOnlyMemory<byte>(buffer, 0, length);
             if (ruleExecutor is null)
             {
-                _inlineRuleValidators!.Get(GeneratedSchema.Value).Validate(
+                _inlineRuleValidators!.Register(entry.Schema!, GeneratedSchema.Value).Validate(
                     payload,
                     entry.SchemaId,
                     _config.ValidationRulesFailFast);

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroPocoSchemaRegistrySerializer.cs
@@ -44,7 +44,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
     private readonly RegistrySchema _schema;
     private readonly SubjectSchemaIdCache _subjectCache = new();
     private readonly SchemaResolutionCache<SubjectSchemaIdCache.SubjectSchemaIdCacheValue> _resolutionCache = new();
-    private readonly AvroTaggedFieldTransformerProvider _taggedFieldTransformers = new();
+    private readonly AvroTaggedFieldTransformerProvider _taggedFieldTransformers;
     private readonly AvroInlineRuleValidatorProvider? _inlineRuleValidators;
     private long _lastInlineValidationDecision = -1;
     private AvroPocoSerializerBufferState? _primaryRuleBuffer;
@@ -61,6 +61,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
         bool ownsClient = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
+        _taggedFieldTransformers = new AvroTaggedFieldTransformerProvider(schemaRegistry);
         _config = config ?? new AvroSerializerConfig();
         _schemaIdStrategy = _config.SchemaIdStrategy;
         _schemaSelectionMode = SchemaRegistrySerializerConfigValidator.ValidateAndResolve(
@@ -70,6 +71,7 @@ public sealed class AvroPocoSchemaRegistrySerializer<T, TCodec>
         if (_schemaIdStrategy is not (SchemaIdSerializerStrategy.Prefix or SchemaIdSerializerStrategy.Header))
             throw new ArgumentOutOfRangeException(nameof(config), _schemaIdStrategy, "Unknown schema identity strategy.");
         _inlineRuleValidators = AvroValidationConfiguration.Create(
+            schemaRegistry,
             _config.ValidationRulesExecution,
             _config.RuleExecutor);
         if (_config.CustomSubjectNameStrategy is null)

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroSchemaReferenceResolver.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroSchemaReferenceResolver.cs
@@ -20,16 +20,6 @@ internal static class AvroSchemaReferenceResolver
         return AvroSchema.Parse(schema.SchemaString, names);
     }
 
-    internal static AvroSchema Parse(
-        ISchemaRegistryClient schemaRegistry,
-        RegistrySchema schema,
-        TimeSpan timeout) =>
-        ParseAsync(schemaRegistry, schema, CancellationToken.None)
-            .WaitAsync(timeout)
-            .ConfigureAwait(false)
-            .GetAwaiter()
-            .GetResult();
-
     internal static async Task<AvroSchemaNames> ResolveAsync(
         ISchemaRegistryClient schemaRegistry,
         RegistrySchema schema,

--- a/src/Dekaf.SchemaRegistry.Avro/Poco/AvroSchemaReferenceResolver.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/Poco/AvroSchemaReferenceResolver.cs
@@ -9,6 +9,27 @@ internal static class AvroSchemaReferenceResolver
 {
     private const int MaxReferenceDepth = 128;
 
+    internal static async Task<AvroSchema> ParseAsync(
+        ISchemaRegistryClient schemaRegistry,
+        RegistrySchema schema,
+        CancellationToken cancellationToken)
+    {
+        if (schema.References is not { Count: > 0 })
+            return AvroSchema.Parse(schema.SchemaString);
+        var names = await ResolveAsync(schemaRegistry, schema, cancellationToken).ConfigureAwait(false);
+        return AvroSchema.Parse(schema.SchemaString, names);
+    }
+
+    internal static AvroSchema Parse(
+        ISchemaRegistryClient schemaRegistry,
+        RegistrySchema schema,
+        TimeSpan timeout) =>
+        ParseAsync(schemaRegistry, schema, CancellationToken.None)
+            .WaitAsync(timeout)
+            .ConfigureAwait(false)
+            .GetAwaiter()
+            .GetResult();
+
     internal static async Task<AvroSchemaNames> ResolveAsync(
         ISchemaRegistryClient schemaRegistry,
         RegistrySchema schema,

--- a/src/Dekaf.SchemaRegistry.Avro/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.SchemaRegistry.Avro/PublicAPI.Unshipped.txt
@@ -1,4 +1,12 @@
 #nullable enable
+Dekaf.SchemaRegistry.Avro.AvroDeserializerConfig.ValidationRulesExecution.get -> Dekaf.SchemaRegistry.ValidationRulesExecution
+Dekaf.SchemaRegistry.Avro.AvroDeserializerConfig.ValidationRulesExecution.init -> void
+Dekaf.SchemaRegistry.Avro.AvroDeserializerConfig.ValidationRulesFailFast.get -> bool
+Dekaf.SchemaRegistry.Avro.AvroDeserializerConfig.ValidationRulesFailFast.init -> void
+Dekaf.SchemaRegistry.Avro.AvroSerializerConfig.ValidationRulesExecution.get -> Dekaf.SchemaRegistry.ValidationRulesExecution
+Dekaf.SchemaRegistry.Avro.AvroSerializerConfig.ValidationRulesExecution.init -> void
+Dekaf.SchemaRegistry.Avro.AvroSerializerConfig.ValidationRulesFailFast.get -> bool
+Dekaf.SchemaRegistry.Avro.AvroSerializerConfig.ValidationRulesFailFast.init -> void
 Dekaf.SchemaRegistry.Avro.AvroDeserializerConfig.AsyncSubjectNameStrategy.get -> Dekaf.SchemaRegistry.IAsyncSubjectNameStrategy?
 Dekaf.SchemaRegistry.Avro.AvroDeserializerConfig.AsyncSubjectNameStrategy.init -> void
 Dekaf.SchemaRegistry.Avro.AvroSerializerConfig.AsyncSubjectNameStrategy.get -> Dekaf.SchemaRegistry.IAsyncSubjectNameStrategy?

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufInlineRuleValidator.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufInlineRuleValidator.cs
@@ -463,6 +463,7 @@ internal sealed class ProtobufMessageRulePlan
     private ProtobufFieldRulePlan[] _allFields = [];
     private ProtobufFieldRulePlan[] _ruleFields = [];
     private int _fieldSlotCount;
+    private int _implicitRootSize;
     private int _oneofCount;
     private bool _usesSizes;
     private bool _hasMaps;
@@ -530,6 +531,8 @@ internal sealed class ProtobufMessageRulePlan
             if (!rules.IsEmpty)
                 (ruleFields ??= []).Add(field);
             _usesSizes |= descriptor.IsRepeated || rules.UsesSize;
+            if (!descriptor.HasPresence)
+                _implicitRootSize++;
             _hasMaps |= descriptor.IsMap;
             _requiresRuleSnapshots |= rules.RequiresMemberResolution;
         }
@@ -597,7 +600,7 @@ internal sealed class ProtobufMessageRulePlan
                 $"Could not evaluate Protobuf validation rules: message recursion exceeds {ProtobufInlineRuleValidator.MaximumValidationDepth} levels.");
         }
 
-        if (!_messageRules.IsEmpty)
+        if (!_messageRules.IsEmpty && !_messageRules.UsesRootSize)
         {
             _messageRules.Evaluate(
                 ValidationCelValue.FromCollection(ValidationCelValueKind.Object, 0),
@@ -612,7 +615,21 @@ internal sealed class ProtobufMessageRulePlan
         }
 
         if (_fields.Count == 0)
+        {
+            if (_messageRules.UsesRootSize)
+            {
+                _messageRules.Evaluate(
+                    ValidationCelValue.FromCollection(ValidationCelValueKind.Object, 0),
+                    payload,
+                    schemaId,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path,
+                    rootSize: 0);
+            }
             return;
+        }
 
         var values = CompiledValidationRule.GetMemberValues(_fieldSlotCount);
         var sizes = _usesSizes || _oneofCount != 0
@@ -621,6 +638,7 @@ internal sealed class ProtobufMessageRulePlan
         var oneofOffset = _fieldSlotCount + 1;
         var mergedMessages = new ProtobufMergedMessageBuffers(_fieldSlotCount);
         var reader = new ProtobufValidationWireReader(payload);
+        var rootSize = _messageRules.UsesRootSize ? _implicitRootSize : -1;
         try
         {
             while (reader.TryRead(out var wireField))
@@ -629,7 +647,24 @@ internal sealed class ProtobufMessageRulePlan
                     !field.Matches(wireField))
                     continue;
 
+                if (rootSize >= 0 && field.AddsPresentRootMember(values, sizes, oneofOffset))
+                    rootSize++;
                 field.Observe(wireField, values, sizes, oneofOffset, ref mergedMessages);
+            }
+
+            if (_messageRules.UsesRootSize)
+            {
+                _messageRules.Evaluate(
+                    ValidationCelValue.FromCollection(ValidationCelValueKind.Object, 0),
+                    payload,
+                    schemaId,
+                    now,
+                    failFast,
+                    ref violations,
+                    ref path,
+                    rootSize);
+                if (failFast && violations is not null)
+                    return;
             }
 
             var singularChildren = new ProtobufSingularChildEntries(_allFields.Length);
@@ -840,6 +875,14 @@ internal sealed class ProtobufFieldRulePlan(
     internal ProtobufCompiledRuleSet Rules { get; } = rules;
     internal ProtobufMessageRulePlan? Child { get; } = child;
     internal int RuntimeIndex { get; } = runtimeIndex;
+
+    internal bool AddsPresentRootMember(
+        ValidationCelMemberValues values,
+        ValidationCelSizeValues sizes,
+        int oneofOffset) =>
+        Descriptor.HasPresence &&
+        !values.IsSet(RuntimeIndex) &&
+        (oneofIndex < 0 || !sizes.TryGet(oneofOffset + oneofIndex, out _));
 
     internal bool Matches(ProtobufValidationWireField field) =>
         ProtobufValidationValueDecoder.MatchesField(Descriptor, field, _isClosedEnum);
@@ -1452,7 +1495,7 @@ internal ref struct ProtobufMapEntries
 
 internal sealed class ProtobufCompiledRuleSet
 {
-    internal static ProtobufCompiledRuleSet Empty { get; } = new([], null, null, null, false, false, 0);
+    internal static ProtobufCompiledRuleSet Empty { get; } = new([], null, null, null, false, false, false, 0);
 
     private readonly CompiledValidationRule[] _rules;
     private readonly ProtobufMemberResolver? _members;
@@ -1467,6 +1510,7 @@ internal sealed class ProtobufCompiledRuleSet
         MessageDescriptor? valueDescriptor,
         FieldDescriptor? valueFieldDescriptor,
         bool usesSize,
+        bool usesRootSize,
         bool usesCachedEquality,
         int memberCount)
     {
@@ -1475,12 +1519,14 @@ internal sealed class ProtobufCompiledRuleSet
         _valueDescriptor = valueDescriptor;
         _valueFieldDescriptor = valueFieldDescriptor;
         UsesSize = usesSize;
+        UsesRootSize = usesRootSize;
         _usesCachedEquality = usesCachedEquality;
         _memberCount = memberCount;
     }
 
     internal bool IsEmpty => _rules.Length == 0;
     internal bool UsesSize { get; }
+    internal bool UsesRootSize { get; }
     internal bool RequiresMemberResolution => _members is not null;
 
     internal static ProtobufCompiledRuleSet Compile(
@@ -1496,6 +1542,7 @@ internal sealed class ProtobufCompiledRuleSet
         var usedMemberIndexes = new HashSet<int>();
         var compiled = new CompiledValidationRule[rules.Count];
         var usesSize = false;
+        var usesRootSize = false;
         var usesCachedEquality = false;
         var equalityIndexOffset = 0;
         for (var index = 0; index < rules.Count; index++)
@@ -1508,6 +1555,7 @@ internal sealed class ProtobufCompiledRuleSet
                 equalityIndexOffset);
             compiled[index] = rule;
             usesSize |= rule.UsesSize;
+            usesRootSize |= rule.UsesRootSize;
             usesCachedEquality |= rule.UsesCachedEquality;
             equalityIndexOffset += rule.EqualityPairs.Length;
         }
@@ -1521,6 +1569,7 @@ internal sealed class ProtobufCompiledRuleSet
             valueDescriptor,
             valueFieldDescriptor,
             usesSize,
+            usesRootSize,
             usesCachedEquality,
             memberPaths.Count);
     }

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryMigrationRunner.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryMigrationRunner.cs
@@ -60,7 +60,7 @@ internal sealed class SchemaRegistryMigrationRunner
         {
             if (!IsExpired(plan))
                 return new ValueTask<PreparedTargetEnumerator>(
-                    PreparedTargetEnumerator.Create(plan.Steps));
+                    PreparedTargetEnumerator.Create(plan.ReaderSchema, plan.Steps));
 
             _plans.TryRemove(subject, writerSchema, plan);
             return AwaitPreparedPlanAsync(schemaId, subject, writerSchema, cancellationToken);
@@ -72,7 +72,7 @@ internal sealed class SchemaRegistryMigrationRunner
             {
                 Volatile.Write(ref _lastPlan, plan);
                 return new ValueTask<PreparedTargetEnumerator>(
-                    PreparedTargetEnumerator.Create(plan.Steps));
+                    PreparedTargetEnumerator.Create(plan.ReaderSchema, plan.Steps));
             }
 
             _plans.TryRemove(subject, writerSchema, plan);
@@ -102,7 +102,7 @@ internal sealed class SchemaRegistryMigrationRunner
 
         Volatile.Write(ref _lastPlan, plan);
         plan.MarkPrepared();
-        return PreparedTargetEnumerator.Create(plan.Steps);
+        return PreparedTargetEnumerator.Create(plan.ReaderSchema, plan.Steps);
     }
 
     internal bool TryUsePreparedPlan(int schemaId, string subject, Schema writerSchema)
@@ -713,16 +713,23 @@ internal sealed class SchemaRegistryMigrationRunner
 
     internal struct PreparedTargetEnumerator
     {
+        private readonly RegisteredSchema? _readerSchema;
         private readonly MigrationStep[]? _steps;
         private int _index;
 
-        private PreparedTargetEnumerator(MigrationStep[] steps)
+        private PreparedTargetEnumerator(RegisteredSchema readerSchema, MigrationStep[] steps)
         {
+            _readerSchema = readerSchema;
             _steps = steps;
             _index = 0;
         }
 
-        internal static PreparedTargetEnumerator Create(MigrationStep[] steps) => new(steps);
+        internal static PreparedTargetEnumerator Create(
+            RegisteredSchema readerSchema,
+            MigrationStep[] steps) => new(readerSchema, steps);
+
+        internal RegisteredSchema ReaderSchema => _readerSchema ??
+            throw new InvalidOperationException("Migration plan is not prepared.");
 
         internal bool MoveNext(out RegisteredSchema target)
         {

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryRules.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryRules.cs
@@ -735,6 +735,40 @@ public sealed class SchemaRegistryRuleExecutor : ISchemaRegistryRuleExecutor
         SchemaRegistryRuleContext context)
         => ApplyReadRuleCollection(payload, context, useEncodingRules: false);
 
+    private ReadOnlyMemory<byte> ApplyWriteRuleCollection(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleContext context,
+        bool useEncodingRules)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var ruleSet = context.Schema?.RuleSet;
+        if (ruleSet is null || !ruleSet.HasDomainOrEncodingRules || !ShouldExecute(ruleSet))
+            return payload;
+
+        if (ruleSet.HasFixedRuleCollections)
+        {
+            var plan = _executionPlans.GetValue(ruleSet, _createExecutionPlan);
+            var start = useEncodingRules ? plan.WriteDomainStepCount : 0;
+            var count = useEncodingRules
+                ? plan.WriteSteps.Length - plan.WriteDomainStepCount
+                : plan.WriteDomainStepCount;
+            return ApplyRules(
+                payload,
+                context,
+                plan.WriteSteps,
+                start,
+                count,
+                SchemaRegistryRuleDirection.Write);
+        }
+
+        return ApplyRules(
+            payload,
+            context,
+            useEncodingRules ? ruleSet.EncodingRules : ruleSet.DomainRules,
+            SchemaRegistryRuleDirection.Write);
+    }
+
     internal ReadOnlyMemory<byte> TransformDeserializedDomainPayload(
         ReadOnlyMemory<byte> payload,
         SchemaRegistryRuleContext context,

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryRules.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryRules.cs
@@ -735,40 +735,6 @@ public sealed class SchemaRegistryRuleExecutor : ISchemaRegistryRuleExecutor
         SchemaRegistryRuleContext context)
         => ApplyReadRuleCollection(payload, context, useEncodingRules: false);
 
-    private ReadOnlyMemory<byte> ApplyWriteRuleCollection(
-        ReadOnlyMemory<byte> payload,
-        SchemaRegistryRuleContext context,
-        bool useEncodingRules)
-    {
-        ArgumentNullException.ThrowIfNull(context);
-
-        var ruleSet = context.Schema?.RuleSet;
-        if (ruleSet is null || !ruleSet.HasDomainOrEncodingRules || !ShouldExecute(ruleSet))
-            return payload;
-
-        if (ruleSet.HasFixedRuleCollections)
-        {
-            var plan = _executionPlans.GetValue(ruleSet, _createExecutionPlan);
-            var start = useEncodingRules ? plan.WriteDomainStepCount : 0;
-            var count = useEncodingRules
-                ? plan.WriteSteps.Length - plan.WriteDomainStepCount
-                : plan.WriteDomainStepCount;
-            return ApplyRules(
-                payload,
-                context,
-                plan.WriteSteps,
-                start,
-                count,
-                SchemaRegistryRuleDirection.Write);
-        }
-
-        return ApplyRules(
-            payload,
-            context,
-            useEncodingRules ? ruleSet.EncodingRules : ruleSet.DomainRules,
-            SchemaRegistryRuleDirection.Write);
-    }
-
     internal ReadOnlyMemory<byte> TransformDeserializedDomainPayload(
         ReadOnlyMemory<byte> payload,
         SchemaRegistryRuleContext context,

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -190,6 +190,7 @@ internal sealed class CompiledValidationRule
     private CompiledValidationRule(
         ValidationRule rule,
         ValidationCelNode? expression,
+        bool usesRootValue = false,
         bool usesSize = false,
         ValidationCelEqualityPair[]? equalityPairs = null,
         bool usesCachedEquality = false,
@@ -198,6 +199,7 @@ internal sealed class CompiledValidationRule
     {
         Rule = rule;
         _expression = expression;
+        UsesRootValue = usesRootValue;
         UsesSize = usesSize;
         EqualityPairs = equalityPairs ?? [];
         UsesCachedEquality = usesCachedEquality || EqualityPairs.Length != 0;
@@ -206,6 +208,7 @@ internal sealed class CompiledValidationRule
     }
 
     internal ValidationRule Rule { get; }
+    internal bool UsesRootValue { get; }
     internal bool UsesSize { get; }
     internal ValidationCelEqualityPair[] EqualityPairs { get; }
     internal bool UsesCachedEquality { get; }
@@ -241,6 +244,7 @@ internal sealed class CompiledValidationRule
             return new CompiledValidationRule(
                 rule,
                 expression,
+                parser.UsesRootValue,
                 parser.UsesSize,
                 parser.EqualityPairs,
                 parser.UsesCachedEquality,
@@ -2868,6 +2872,7 @@ internal sealed class ValidationCelParser
     private readonly List<ValidationCelEqualityPair> _equalityPairs = [];
     private readonly int _equalityIndexOffset;
     private readonly Dictionary<ValidationCelEqualityOperands, int>? _equalityIndexes;
+    internal bool UsesRootValue { get; private set; }
     internal bool UsesCachedEquality { get; private set; }
     internal bool UsesRootAggregateEquality { get; private set; }
 
@@ -3088,7 +3093,10 @@ internal sealed class ValidationCelParser
     private ValidationCelThisNode CreateThisNode(string identifier)
     {
         if (identifier.Length == 4)
+        {
+            UsesRootValue = true;
             return new ValidationCelThisNode(-1);
+        }
 
         var memberPath = identifier[5..];
         var segments = memberPath.Split('.');

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -507,6 +507,11 @@ internal sealed class CompiledValidationRule
         int rightIndex,
         out bool value)
     {
+        if (equalityGeneration == 0)
+        {
+            value = false;
+            return false;
+        }
         NormalizeEqualityIndexes(ref leftIndex, ref rightIndex);
         ref readonly var slot = ref t_pairEqualities[GetEqualitySlot(leftIndex, rightIndex)];
         value = slot.Value;
@@ -521,6 +526,8 @@ internal sealed class CompiledValidationRule
         int rightIndex,
         bool value)
     {
+        if (equalityGeneration == 0)
+            return;
         NormalizeEqualityIndexes(ref leftIndex, ref rightIndex);
         ref var slot = ref t_pairEqualities[GetEqualitySlot(leftIndex, rightIndex)];
         slot.LeftIndex = leftIndex;
@@ -1859,9 +1866,11 @@ internal sealed class ValidationCelUnaryNode(ValidationCelTokenKind operation, V
 internal sealed class ValidationCelBinaryNode(
     ValidationCelTokenKind operation,
     ValidationCelNode left,
-    ValidationCelNode right) : ValidationCelNode
+    ValidationCelNode right,
+    int equalityIndex = -1) : ValidationCelNode
 {
     private const double MaximumExactlyRepresentableDoubleInteger = 9_007_199_254_740_992d;
+    private readonly int _equalityIndex = equalityIndex;
     private readonly bool _usesAggregateValueIndexes =
         operation is ValidationCelTokenKind.Equal or ValidationCelTokenKind.NotEqual &&
         left.HasAggregateValueIndex &&
@@ -1907,7 +1916,7 @@ internal sealed class ValidationCelBinaryNode(
         };
     }
 
-    private static bool AreEqual(
+    private bool AreEqual(
         ValidationCelValue left,
         ValidationCelValue right,
         ValidationCelContext context,
@@ -1931,20 +1940,27 @@ internal sealed class ValidationCelBinaryNode(
         };
     }
 
-    private static bool AreAggregateValuesEqual(
+    private bool AreAggregateValuesEqual(
         ValidationCelValue left,
         ValidationCelValue right,
         ValidationCelContext context,
         int leftValueIndex,
         int rightValueIndex)
     {
+        if (_equalityIndex >= 0 && CompiledValidationRule.TryGetEquality(
+                context.EqualityGeneration,
+                _equalityIndex,
+                out var value))
+        {
+            return value;
+        }
         if (leftValueIndex < 0 || rightValueIndex < 0)
             return CompareAggregateValues(left, right);
         if (CompiledValidationRule.TryGetEquality(
                 context.EqualityGeneration,
                 leftValueIndex,
                 rightValueIndex,
-                out var value))
+                out value))
             return value;
 
         value = CompareAggregateValues(
@@ -2085,9 +2101,15 @@ internal sealed class ValidationCelBinaryNode(
             return left.Floating.CompareTo(right.Floating);
         }
         if (left.IsFloating)
+        {
+            if (right.IsFloatingLiteral)
+                return left.Floating.CompareTo(right.Floating);
             return CompareFloatingToExact(left.Floating, right);
+        }
         if (right.IsFloating)
         {
+            if (left.IsFloatingLiteral)
+                return left.Floating.CompareTo(right.Floating);
             var comparison = CompareFloatingToExact(right.Floating, left);
             return comparison.HasValue ? -comparison.Value : null;
         }
@@ -3163,7 +3185,7 @@ internal sealed class ValidationCelParser
                     leftValue.ValueIndex,
                     rightValue.ValueIndex));
             }
-            var equality = new ValidationCelBinaryNode(operation, left, right);
+            var equality = new ValidationCelBinaryNode(operation, left, right, equalityIndex);
             UsesCachedEquality |= equality.UsesCachedEquality;
             UsesRootAggregateEquality |= equality.UsesRootAggregateEquality;
             left = equality;

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -1859,6 +1859,7 @@ internal sealed class ValidationCelBinaryNode(
     ValidationCelNode left,
     ValidationCelNode right) : ValidationCelNode
 {
+    private const double MaximumExactlyRepresentableDoubleInteger = 9_007_199_254_740_992d;
     private readonly bool _usesAggregateValueIndexes =
         operation is ValidationCelTokenKind.Equal or ValidationCelTokenKind.NotEqual &&
         left.HasAggregateValueIndex &&
@@ -2008,15 +2009,65 @@ internal sealed class ValidationCelBinaryNode(
         throw Unsupported("Comparison operands must have matching numeric or string types.");
     }
 
-    private static ValidationCelValue Add(ValidationCelValue left, ValidationCelValue right) =>
-        left.IsFloating || right.IsFloating
-            ? ValidationCelValue.FromFloating(GetFloatingNumber(left) + GetFloatingNumber(right))
-            : ValidationCelValue.FromNumber(RequireNumber(left) + RequireNumber(right));
+    private static ValidationCelValue Add(ValidationCelValue left, ValidationCelValue right)
+    {
+        if (!left.IsFloating && !right.IsFloating)
+            return ValidationCelValue.FromNumber(RequireNumber(left) + RequireNumber(right));
+        var leftFloating = GetFloatingNumber(left);
+        var rightFloating = GetFloatingNumber(right);
+        if (!RequiresDecimalMixedArithmetic(left, leftFloating) &&
+            !RequiresDecimalMixedArithmetic(right, rightFloating))
+        {
+            return ValidationCelValue.FromFloating(leftFloating + rightFloating);
+        }
+        return TryGetDecimalArithmeticNumber(left, out var leftNumber) &&
+            TryGetDecimalArithmeticNumber(right, out var rightNumber)
+            ? ValidationCelValue.FromNumber(leftNumber + rightNumber)
+            : ValidationCelValue.FromFloating(leftFloating + rightFloating);
+    }
 
-    private static ValidationCelValue Subtract(ValidationCelValue left, ValidationCelValue right) =>
-        left.IsFloating || right.IsFloating
-            ? ValidationCelValue.FromFloating(GetFloatingNumber(left) - GetFloatingNumber(right))
-            : ValidationCelValue.FromNumber(RequireNumber(left) - RequireNumber(right));
+    private static ValidationCelValue Subtract(ValidationCelValue left, ValidationCelValue right)
+    {
+        if (!left.IsFloating && !right.IsFloating)
+            return ValidationCelValue.FromNumber(RequireNumber(left) - RequireNumber(right));
+        var leftFloating = GetFloatingNumber(left);
+        var rightFloating = GetFloatingNumber(right);
+        if (!RequiresDecimalMixedArithmetic(left, leftFloating) &&
+            !RequiresDecimalMixedArithmetic(right, rightFloating))
+        {
+            return ValidationCelValue.FromFloating(leftFloating - rightFloating);
+        }
+        return TryGetDecimalArithmeticNumber(left, out var leftNumber) &&
+            TryGetDecimalArithmeticNumber(right, out var rightNumber)
+            ? ValidationCelValue.FromNumber(leftNumber - rightNumber)
+            : ValidationCelValue.FromFloating(leftFloating - rightFloating);
+    }
+
+    private static bool RequiresDecimalMixedArithmetic(
+        ValidationCelValue value,
+        double floating) =>
+        !value.IsFloating && Math.Abs(floating) >= MaximumExactlyRepresentableDoubleInteger;
+
+    private static bool TryGetDecimalArithmeticNumber(
+        ValidationCelValue value,
+        out decimal number)
+    {
+        if (!value.IsFloating)
+        {
+            number = RequireNumber(value);
+            return true;
+        }
+
+        var floating = value.Floating;
+        number = 0;
+        if (double.IsNaN(floating) || double.IsInfinity(floating) ||
+            floating <= (double)decimal.MinValue || floating >= (double)decimal.MaxValue)
+        {
+            return false;
+        }
+        number = (decimal)floating;
+        return true;
+    }
 
     private static double GetFloatingNumber(ValidationCelValue value) =>
         value.IsFloating || value.IsFloatingLiteral

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -192,19 +192,24 @@ internal sealed class CompiledValidationRule
         ValidationCelNode? expression,
         bool usesSize = false,
         ValidationCelEqualityPair[]? equalityPairs = null,
+        bool usesCachedEquality = false,
+        bool usesRootAggregateEquality = false,
         string? compilationError = null)
     {
         Rule = rule;
         _expression = expression;
         UsesSize = usesSize;
         EqualityPairs = equalityPairs ?? [];
+        UsesCachedEquality = usesCachedEquality || EqualityPairs.Length != 0;
+        UsesRootAggregateEquality = usesRootAggregateEquality;
         _compilationError = compilationError;
     }
 
     internal ValidationRule Rule { get; }
     internal bool UsesSize { get; }
     internal ValidationCelEqualityPair[] EqualityPairs { get; }
-    internal bool UsesCachedEquality => EqualityPairs.Length != 0;
+    internal bool UsesCachedEquality { get; }
+    internal bool UsesRootAggregateEquality { get; }
 
     internal static CompiledValidationRule Compile(
         ValidationRule rule,
@@ -237,7 +242,9 @@ internal sealed class CompiledValidationRule
                 rule,
                 expression,
                 parser.UsesSize,
-                parser.EqualityPairs);
+                parser.EqualityPairs,
+                parser.UsesCachedEquality,
+                parser.UsesRootAggregateEquality);
         }
         catch (SchemaRegistryRuleException exception)
         {
@@ -261,14 +268,16 @@ internal sealed class CompiledValidationRule
             nowUnixMilliseconds,
             memberValues,
             sizes,
-            equalityGeneration);
+            equalityGeneration,
+            rootAggregateComparer: null);
 
     internal ValidationResult Evaluate(
         ValidationCelValue value,
         long nowUnixMilliseconds,
         ValidationCelMemberValues memberValues,
         ValidationCelSizeValues sizes,
-        uint equalityGeneration)
+        uint equalityGeneration,
+        IValidationCelAggregateComparer? rootAggregateComparer = null)
         => EvaluateCore(
             default,
             value,
@@ -276,7 +285,8 @@ internal sealed class CompiledValidationRule
             nowUnixMilliseconds,
             memberValues,
             sizes,
-            equalityGeneration);
+            equalityGeneration,
+            rootAggregateComparer);
 
     private ValidationResult EvaluateCore(
         ReadOnlyMemory<byte> value,
@@ -285,7 +295,8 @@ internal sealed class CompiledValidationRule
         long nowUnixMilliseconds,
         ValidationCelMemberValues memberValues,
         ValidationCelSizeValues sizes,
-        uint equalityGeneration)
+        uint equalityGeneration,
+        IValidationCelAggregateComparer? rootAggregateComparer)
     {
         if (_compilationError is not null)
             throw new SchemaRegistryRuleException(_compilationError);
@@ -299,7 +310,8 @@ internal sealed class CompiledValidationRule
                 nowUnixMilliseconds,
                 memberValues,
                 sizes,
-                equalityGeneration));
+                equalityGeneration,
+                rootAggregateComparer));
             return result.Kind switch
             {
                 ValidationCelValueKind.Boolean => ValidationResult.FromBoolean(result.Boolean),
@@ -455,7 +467,8 @@ internal readonly record struct ValidationCelContext(
     long NowUnixMilliseconds,
     ValidationCelMemberValues MemberValues,
     ValidationCelSizeValues Sizes,
-    uint EqualityGeneration);
+    uint EqualityGeneration,
+    IValidationCelAggregateComparer? RootAggregateComparer);
 
 internal struct ValidationCelMemberSlot
 {
@@ -1680,6 +1693,9 @@ internal sealed class ValidationCelBinaryNode(
         _leftValueIndex >= 0 &&
         _rightValueIndex >= 0;
 
+    internal bool UsesRootAggregateEquality =>
+        UsesCachedEquality && (_leftValueIndex == 0 || _rightValueIndex == 0);
+
     internal override ValidationCelValue Evaluate(ValidationCelContext context)
     {
         var leftValue = left.Evaluate(context);
@@ -1746,8 +1762,8 @@ internal sealed class ValidationCelBinaryNode(
         value = CompareAggregateValues(
             left,
             right,
-            GetAggregateComparer(context.MemberValues, _leftValueIndex),
-            GetAggregateComparer(context.MemberValues, _rightValueIndex));
+            GetAggregateComparer(context, _leftValueIndex),
+            GetAggregateComparer(context, _rightValueIndex));
         CompiledValidationRule.SetEquality(
             context.EqualityGeneration,
             _leftValueIndex,
@@ -1757,10 +1773,10 @@ internal sealed class ValidationCelBinaryNode(
     }
 
     private static IValidationCelAggregateComparer? GetAggregateComparer(
-        ValidationCelMemberValues memberValues,
-        int valueIndex) => valueIndex > 0
-            ? memberValues.GetAggregateComparer(valueIndex - 1)
-            : null;
+        ValidationCelContext context,
+        int valueIndex) => valueIndex == 0
+            ? context.RootAggregateComparer
+            : context.MemberValues.GetAggregateComparer(valueIndex - 1);
 
     private static bool CompareAggregateValues(ValidationCelValue left, ValidationCelValue right) =>
         CompareAggregateValues(left, right, leftComparer: null, rightComparer: null);
@@ -2812,6 +2828,8 @@ internal sealed class ValidationCelParser
     private readonly List<ValidationCelEqualityPair> _equalityPairs = [];
     private readonly int _equalityIndexOffset;
     private readonly Dictionary<ValidationCelEqualityOperands, int>? _equalityIndexes;
+    internal bool UsesCachedEquality { get; private set; }
+    internal bool UsesRootAggregateEquality { get; private set; }
 
     private ValidationCelNode ParseConditional()
     {
@@ -2855,7 +2873,10 @@ internal sealed class ValidationCelParser
                     leftValue.ValueIndex,
                     rightValue.ValueIndex));
             }
-            left = new ValidationCelBinaryNode(operation, left, right);
+            var equality = new ValidationCelBinaryNode(operation, left, right);
+            UsesCachedEquality |= equality.UsesCachedEquality;
+            UsesRootAggregateEquality |= equality.UsesRootAggregateEquality;
+            left = equality;
         }
         return left;
     }

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -1194,6 +1194,12 @@ internal readonly record struct ValidationCelValue(
         ReadOnlyMemory<byte> binaryPayload = default) =>
         new(kind, default, false, 0, null, binaryPayload, SizeIndex: sizeIndex);
 
+    internal static ValidationCelValue FromCollection(
+        ValidationCelValueKind kind,
+        ReadOnlyMemory<byte> encoded,
+        int sizeIndex) =>
+        new(kind, default, false, 0, null, encoded, SizeIndex: sizeIndex);
+
     internal static ValidationCelValue FromJson(ReadOnlyMemory<byte> json, int sizeIndex = -1)
     {
         if (json.IsEmpty)
@@ -1636,10 +1642,19 @@ internal sealed class ValidationCelUnaryNode(ValidationCelTokenKind operation, V
 internal sealed class ValidationCelBinaryNode(
     ValidationCelTokenKind operation,
     ValidationCelNode left,
-    ValidationCelNode right,
-    int equalityIndex = -1) : ValidationCelNode
+    ValidationCelNode right) : ValidationCelNode
 {
-    private readonly int _equalityIndex = equalityIndex;
+    private readonly int _leftValueIndex = left is ValidationCelThisNode leftThis
+        ? leftThis.ValueIndex
+        : -1;
+    private readonly int _rightValueIndex = right is ValidationCelThisNode rightThis
+        ? rightThis.ValueIndex
+        : -1;
+
+    internal bool UsesCachedEquality =>
+        (operation is ValidationCelTokenKind.Equal or ValidationCelTokenKind.NotEqual) &&
+        _leftValueIndex >= 0 &&
+        _rightValueIndex >= 0;
 
     internal override ValidationCelValue Evaluate(ValidationCelContext context)
     {
@@ -1688,52 +1703,48 @@ internal sealed class ValidationCelBinaryNode(
             ValidationCelValueKind.Number => AreNumbersEqual(left, right),
             ValidationCelValueKind.String => ValidationCelStrings.Evaluate(left, right, ValidationCelStringOperation.Equal),
             ValidationCelValueKind.Bytes => left.Utf8Literal.Span.SequenceEqual(right.Utf8Literal.Span),
-            ValidationCelValueKind.Object when left.Json.IsEmpty && right.Json.IsEmpty =>
-                AreBinaryObjectValuesEqual(left, right, equalityGeneration),
             ValidationCelValueKind.Object or ValidationCelValueKind.Array =>
-                AreJsonValuesEqual(left, right, equalityGeneration),
+                AreAggregateValuesEqual(left, right, equalityGeneration),
             _ => false
         };
     }
 
-    private bool AreBinaryObjectValuesEqual(
+    private bool AreAggregateValuesEqual(
         ValidationCelValue left,
         ValidationCelValue right,
         uint equalityGeneration)
     {
-        if (equalityGeneration != 0 && _equalityIndex >= 0 && CompiledValidationRule.TryGetEquality(
-                equalityGeneration,
-                _equalityIndex,
-                out var value))
-        {
-            return value;
-        }
-        return left.Utf8Literal.Span.SequenceEqual(right.Utf8Literal.Span);
-    }
-
-    private bool AreJsonValuesEqual(
-        ValidationCelValue left,
-        ValidationCelValue right,
-        uint equalityGeneration)
-    {
-        if (_equalityIndex < 0)
-            return ValidationCelJsonEquality.AreEqual(left.Json.Span, right.Json.Span);
+        if (_leftValueIndex < 0 || _rightValueIndex < 0)
+            return CompareAggregateValues(left, right);
         if (CompiledValidationRule.TryGetEquality(
                 equalityGeneration,
-                _equalityIndex,
+                _leftValueIndex,
+                _rightValueIndex,
                 out var value))
             return value;
 
-        value = ValidationCelJsonEquality.AreEqual(left.Json.Span, right.Json.Span);
+        value = CompareAggregateValues(left, right);
         CompiledValidationRule.SetEquality(
             equalityGeneration,
-            _equalityIndex,
+            _leftValueIndex,
+            _rightValueIndex,
             value);
         return value;
     }
 
     private static bool AreNumbersEqual(ValidationCelValue left, ValidationCelValue right) =>
         !HasNaN(left, right) && CompareNumbers(left, right) == 0;
+
+    private static bool CompareAggregateValues(ValidationCelValue left, ValidationCelValue right)
+    {
+        if (left.Json.IsEmpty || right.Json.IsEmpty)
+        {
+            return left.Json.IsEmpty && right.Json.IsEmpty &&
+                left.Utf8Literal.Span.SequenceEqual(right.Utf8Literal.Span);
+        }
+
+        return ValidationCelJsonEquality.AreEqual(left.Json.Span, right.Json.Span);
+    }
 
     private static int Compare(ValidationCelValue left, ValidationCelValue right)
     {
@@ -2801,7 +2812,7 @@ internal sealed class ValidationCelParser
                     leftValue.ValueIndex,
                     rightValue.ValueIndex));
             }
-            left = new ValidationCelBinaryNode(operation, left, right, equalityIndex);
+            left = new ValidationCelBinaryNode(operation, left, right);
         }
         return left;
     }

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -1082,7 +1082,7 @@ internal enum ValidationCelValueKind : byte
 
 internal interface IValidationCelAggregateComparer
 {
-    bool RequiresSemanticEquality { get; }
+    object? RawEqualityToken { get; }
 
     bool AreEqual(
         ReadOnlyMemory<byte> left,
@@ -1823,9 +1823,12 @@ internal sealed class ValidationCelBinaryNode(
         {
             if (!left.Json.IsEmpty || !right.Json.IsEmpty)
                 return false;
-            if ((leftComparer is null || !leftComparer.RequiresSemanticEquality) &&
-                (rightComparer is null || !rightComparer.RequiresSemanticEquality) &&
-                left.Utf8Literal.Span.SequenceEqual(right.Utf8Literal.Span))
+            if (left.Utf8Literal.Span.SequenceEqual(right.Utf8Literal.Span) &&
+                (leftComparer is null
+                    ? rightComparer is null
+                    : rightComparer is not null &&
+                      leftComparer.RawEqualityToken is { } leftToken &&
+                      ReferenceEquals(leftToken, rightComparer.RawEqualityToken)))
                 return true;
             if (leftComparer is not null && rightComparer is not null)
             {

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -1766,7 +1766,7 @@ internal sealed class ValidationCelBinaryNode(
         {
             ValidationCelValueKind.Null => true,
             ValidationCelValueKind.Boolean => left.Boolean == right.Boolean,
-            ValidationCelValueKind.Number => CompareNumbers(left, right) is 0,
+            ValidationCelValueKind.Number => NumbersAreEqual(left, right),
             ValidationCelValueKind.String => ValidationCelStrings.Evaluate(left, right, ValidationCelStringOperation.Equal),
             ValidationCelValueKind.Bytes => left.Utf8Literal.Span.SequenceEqual(right.Utf8Literal.Span),
             ValidationCelValueKind.Object or ValidationCelValueKind.Array =>
@@ -1803,6 +1803,9 @@ internal sealed class ValidationCelBinaryNode(
             value);
         return value;
     }
+
+    internal static bool NumbersAreEqual(ValidationCelValue left, ValidationCelValue right) =>
+        CompareNumbers(left, right) is 0;
 
     private static IValidationCelAggregateComparer? GetAggregateComparer(
         ValidationCelContext context,
@@ -3267,9 +3270,7 @@ internal sealed class ValidationCelParser
         return new ValidationCelToken(ValidationCelTokenKind.Number, _expression[start.._position]);
     }
 
-    private ValidationCelToken ReadString(
-        char quote,
-        ValidationCelTokenKind kind = ValidationCelTokenKind.String)
+    private ValidationCelToken ReadString(char quote)
     {
         _position++;
         var builder = new StringBuilder();
@@ -3277,7 +3278,7 @@ internal sealed class ValidationCelParser
         {
             var character = _expression[_position++];
             if (character == quote)
-                return new ValidationCelToken(kind, builder.ToString());
+                return new ValidationCelToken(ValidationCelTokenKind.String, builder.ToString());
             if (character != '\\')
             {
                 builder.Append(character);

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -462,6 +462,7 @@ internal struct ValidationCelMemberSlot
     internal int Start;
     internal int Length;
     internal ValidationCelValue Value;
+    internal IValidationCelAggregateComparer? AggregateComparer;
     internal bool IsTyped;
     internal bool IsPresent;
     internal uint Generation;
@@ -497,20 +498,33 @@ internal readonly struct ValidationCelMemberValues(
             : ValidationCelValue.FromJson(source.Slice(value.Start, value.Length), index + 1);
     }
 
+    internal IValidationCelAggregateComparer? GetAggregateComparer(int index)
+    {
+        ref readonly var value = ref values[index];
+        return value.Generation == generation && value.IsTyped
+            ? value.AggregateComparer
+            : null;
+    }
+
     internal void Set(int index, int start, int length)
     {
         ref var value = ref values[index];
         value.Start = start;
         value.Length = length;
+        value.AggregateComparer = null;
         value.IsTyped = false;
         value.IsPresent = true;
         value.Generation = generation;
     }
 
-    internal void SetValue(int index, ValidationCelValue typedValue)
+    internal void SetValue(
+        int index,
+        ValidationCelValue typedValue,
+        IValidationCelAggregateComparer? aggregateComparer = null)
     {
         ref var value = ref values[index];
         value.Value = typedValue;
+        value.AggregateComparer = aggregateComparer;
         value.IsTyped = true;
         value.IsPresent = true;
         value.Generation = generation;
@@ -1047,6 +1061,14 @@ internal enum ValidationCelValueKind : byte
     Bytes,
     Object,
     Array
+}
+
+internal interface IValidationCelAggregateComparer
+{
+    bool AreEqual(
+        ReadOnlyMemory<byte> left,
+        IValidationCelAggregateComparer rightComparer,
+        ReadOnlyMemory<byte> right);
 }
 
 internal readonly record struct ValidationCelValue(
@@ -1670,17 +1692,13 @@ internal sealed class ValidationCelBinaryNode(
             ValidationCelTokenKind.And or ValidationCelTokenKind.Or =>
                 ValidationCelValue.FromBoolean(RequireBoolean(rightValue)),
             ValidationCelTokenKind.Equal => ValidationCelValue.FromBoolean(
-                AreEqual(leftValue, rightValue, context.EqualityGeneration)),
+                AreEqual(leftValue, rightValue, context)),
             ValidationCelTokenKind.NotEqual => ValidationCelValue.FromBoolean(
-                !AreEqual(leftValue, rightValue, context.EqualityGeneration)),
-            ValidationCelTokenKind.Less => ValidationCelValue.FromBoolean(
-                !HasNaN(leftValue, rightValue) && Compare(leftValue, rightValue) < 0),
-            ValidationCelTokenKind.LessOrEqual => ValidationCelValue.FromBoolean(
-                !HasNaN(leftValue, rightValue) && Compare(leftValue, rightValue) <= 0),
-            ValidationCelTokenKind.Greater => ValidationCelValue.FromBoolean(
-                !HasNaN(leftValue, rightValue) && Compare(leftValue, rightValue) > 0),
-            ValidationCelTokenKind.GreaterOrEqual => ValidationCelValue.FromBoolean(
-                !HasNaN(leftValue, rightValue) && Compare(leftValue, rightValue) >= 0),
+                !AreEqual(leftValue, rightValue, context)),
+            ValidationCelTokenKind.Less => ValidationCelValue.FromBoolean(Compare(leftValue, rightValue) is < 0),
+            ValidationCelTokenKind.LessOrEqual => ValidationCelValue.FromBoolean(Compare(leftValue, rightValue) is <= 0),
+            ValidationCelTokenKind.Greater => ValidationCelValue.FromBoolean(Compare(leftValue, rightValue) is > 0),
+            ValidationCelTokenKind.GreaterOrEqual => ValidationCelValue.FromBoolean(Compare(leftValue, rightValue) is >= 0),
             ValidationCelTokenKind.Plus => Add(leftValue, rightValue),
             ValidationCelTokenKind.Minus => Subtract(leftValue, rightValue),
             _ => throw Unsupported("Unsupported binary operator.")
@@ -1690,7 +1708,7 @@ internal sealed class ValidationCelBinaryNode(
     private bool AreEqual(
         ValidationCelValue left,
         ValidationCelValue right,
-        uint equalityGeneration)
+        ValidationCelContext context)
     {
         if (left.Kind == ValidationCelValueKind.Missing || right.Kind == ValidationCelValueKind.Missing)
             throw Unsupported("Cannot compare a missing CEL member; guard optional members with has(...).");
@@ -1700,11 +1718,11 @@ internal sealed class ValidationCelBinaryNode(
         {
             ValidationCelValueKind.Null => true,
             ValidationCelValueKind.Boolean => left.Boolean == right.Boolean,
-            ValidationCelValueKind.Number => AreNumbersEqual(left, right),
+            ValidationCelValueKind.Number => CompareNumbers(left, right) is 0,
             ValidationCelValueKind.String => ValidationCelStrings.Evaluate(left, right, ValidationCelStringOperation.Equal),
             ValidationCelValueKind.Bytes => left.Utf8Literal.Span.SequenceEqual(right.Utf8Literal.Span),
             ValidationCelValueKind.Object or ValidationCelValueKind.Array =>
-                AreAggregateValuesEqual(left, right, equalityGeneration),
+                AreAggregateValuesEqual(left, right, context),
             _ => false
         };
     }
@@ -1712,41 +1730,65 @@ internal sealed class ValidationCelBinaryNode(
     private bool AreAggregateValuesEqual(
         ValidationCelValue left,
         ValidationCelValue right,
-        uint equalityGeneration)
+        ValidationCelContext context)
     {
         if (_leftValueIndex < 0 || _rightValueIndex < 0)
             return CompareAggregateValues(left, right);
         if (CompiledValidationRule.TryGetEquality(
-                equalityGeneration,
+                context.EqualityGeneration,
                 _leftValueIndex,
                 _rightValueIndex,
                 out var value))
             return value;
 
-        value = CompareAggregateValues(left, right);
+        value = CompareAggregateValues(
+            left,
+            right,
+            GetAggregateComparer(context.MemberValues, _leftValueIndex),
+            GetAggregateComparer(context.MemberValues, _rightValueIndex));
         CompiledValidationRule.SetEquality(
-            equalityGeneration,
+            context.EqualityGeneration,
             _leftValueIndex,
             _rightValueIndex,
             value);
         return value;
     }
 
-    private static bool AreNumbersEqual(ValidationCelValue left, ValidationCelValue right) =>
-        !HasNaN(left, right) && CompareNumbers(left, right) == 0;
+    private static IValidationCelAggregateComparer? GetAggregateComparer(
+        ValidationCelMemberValues memberValues,
+        int valueIndex) => valueIndex > 0
+            ? memberValues.GetAggregateComparer(valueIndex - 1)
+            : null;
 
-    private static bool CompareAggregateValues(ValidationCelValue left, ValidationCelValue right)
+    private static bool CompareAggregateValues(ValidationCelValue left, ValidationCelValue right) =>
+        CompareAggregateValues(left, right, leftComparer: null, rightComparer: null);
+
+    private static bool CompareAggregateValues(
+        ValidationCelValue left,
+        ValidationCelValue right,
+        IValidationCelAggregateComparer? leftComparer,
+        IValidationCelAggregateComparer? rightComparer)
     {
         if (left.Json.IsEmpty || right.Json.IsEmpty)
         {
-            return left.Json.IsEmpty && right.Json.IsEmpty &&
-                left.Utf8Literal.Span.SequenceEqual(right.Utf8Literal.Span);
+            if (!left.Json.IsEmpty || !right.Json.IsEmpty)
+                return false;
+            if (left.Utf8Literal.Span.SequenceEqual(right.Utf8Literal.Span))
+                return true;
+            if (leftComparer is not null && rightComparer is not null)
+            {
+                return leftComparer.AreEqual(
+                    left.Utf8Literal,
+                    rightComparer,
+                    right.Utf8Literal);
+            }
+            return false;
         }
 
         return ValidationCelJsonEquality.AreEqual(left.Json.Span, right.Json.Span);
     }
 
-    private static int Compare(ValidationCelValue left, ValidationCelValue right)
+    private static int? Compare(ValidationCelValue left, ValidationCelValue right)
     {
         if (left.Kind == ValidationCelValueKind.Number && right.Kind == ValidationCelValueKind.Number)
             return CompareNumbers(left, right);
@@ -1770,14 +1812,15 @@ internal sealed class ValidationCelBinaryNode(
             ? value.Floating
             : (double)RequireNumber(value);
 
-    private static bool HasNaN(ValidationCelValue left, ValidationCelValue right) =>
-        left.IsFloating && double.IsNaN(left.Floating) ||
-        right.IsFloating && double.IsNaN(right.Floating);
-
-    private static int CompareNumbers(ValidationCelValue left, ValidationCelValue right)
+    private static int? CompareNumbers(ValidationCelValue left, ValidationCelValue right)
     {
         if (left.IsFloating || right.IsFloating)
         {
+            if (left.IsFloating && double.IsNaN(left.Floating) ||
+                right.IsFloating && double.IsNaN(right.Floating))
+            {
+                return null;
+            }
             if (left.IsFloating)
             {
                 if (right.IsFloating || right.IsFloatingLiteral)

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -1628,7 +1628,18 @@ internal readonly ref struct ValidationCelJsonNumber
 
 internal abstract class ValidationCelNode
 {
+    internal virtual bool HasAggregateValueIndex => false;
+    internal virtual bool HasRootAggregateValueIndex => false;
+
     internal abstract ValidationCelValue Evaluate(ValidationCelContext context);
+
+    internal virtual ValidationCelValue EvaluateAggregate(
+        ValidationCelContext context,
+        out int valueIndex)
+    {
+        valueIndex = -1;
+        return Evaluate(context);
+    }
 }
 
 internal sealed class ValidationCelLiteralNode(ValidationCelValue value) : ValidationCelNode
@@ -1641,6 +1652,8 @@ internal sealed class ValidationCelLiteralNode(ValidationCelValue value) : Valid
 internal sealed class ValidationCelThisNode(int memberIndex) : ValidationCelNode
 {
     internal int ValueIndex => memberIndex + 1;
+    internal override bool HasAggregateValueIndex => true;
+    internal override bool HasRootAggregateValueIndex => memberIndex < 0;
 
     internal bool IsPresent(ValidationCelContext context) =>
         memberIndex < 0 || context.MemberValues.IsPresent(memberIndex);
@@ -1653,6 +1666,14 @@ internal sealed class ValidationCelThisNode(int memberIndex) : ValidationCelNode
             : ValidationCelValue.FromJson(
                 memberIndex < 0 ? context.This : context.MemberValues.Get(memberIndex, context.This),
                 memberIndex + 1);
+
+    internal override ValidationCelValue EvaluateAggregate(
+        ValidationCelContext context,
+        out int valueIndex)
+    {
+        valueIndex = ValueIndex;
+        return Evaluate(context);
+    }
 }
 
 internal sealed class ValidationCelNowNode : ValidationCelNode
@@ -1681,38 +1702,41 @@ internal sealed class ValidationCelBinaryNode(
     ValidationCelNode left,
     ValidationCelNode right) : ValidationCelNode
 {
-    private readonly int _leftValueIndex = left is ValidationCelThisNode leftThis
-        ? leftThis.ValueIndex
-        : -1;
-    private readonly int _rightValueIndex = right is ValidationCelThisNode rightThis
-        ? rightThis.ValueIndex
-        : -1;
+    private readonly bool _usesAggregateValueIndexes =
+        operation is ValidationCelTokenKind.Equal or ValidationCelTokenKind.NotEqual &&
+        left.HasAggregateValueIndex &&
+        right.HasAggregateValueIndex;
 
-    internal bool UsesCachedEquality =>
-        (operation is ValidationCelTokenKind.Equal or ValidationCelTokenKind.NotEqual) &&
-        _leftValueIndex >= 0 &&
-        _rightValueIndex >= 0;
+    internal bool UsesCachedEquality => _usesAggregateValueIndexes;
 
     internal bool UsesRootAggregateEquality =>
-        UsesCachedEquality && (_leftValueIndex == 0 || _rightValueIndex == 0);
+        UsesCachedEquality &&
+        (left.HasRootAggregateValueIndex || right.HasRootAggregateValueIndex);
 
     internal override ValidationCelValue Evaluate(ValidationCelContext context)
     {
-        var leftValue = left.Evaluate(context);
+        var isEquality = operation is ValidationCelTokenKind.Equal or ValidationCelTokenKind.NotEqual;
+        var leftValueIndex = -1;
+        var leftValue = isEquality
+            ? left.EvaluateAggregate(context, out leftValueIndex)
+            : left.Evaluate(context);
         if (operation == ValidationCelTokenKind.And && !RequireBoolean(leftValue))
             return ValidationCelValue.False;
         if (operation == ValidationCelTokenKind.Or && RequireBoolean(leftValue))
             return ValidationCelValue.True;
 
-        var rightValue = right.Evaluate(context);
+        var rightValueIndex = -1;
+        var rightValue = isEquality
+            ? right.EvaluateAggregate(context, out rightValueIndex)
+            : right.Evaluate(context);
         return operation switch
         {
             ValidationCelTokenKind.And or ValidationCelTokenKind.Or =>
                 ValidationCelValue.FromBoolean(RequireBoolean(rightValue)),
             ValidationCelTokenKind.Equal => ValidationCelValue.FromBoolean(
-                AreEqual(leftValue, rightValue, context)),
+                AreEqual(leftValue, rightValue, context, leftValueIndex, rightValueIndex)),
             ValidationCelTokenKind.NotEqual => ValidationCelValue.FromBoolean(
-                !AreEqual(leftValue, rightValue, context)),
+                !AreEqual(leftValue, rightValue, context, leftValueIndex, rightValueIndex)),
             ValidationCelTokenKind.Less => ValidationCelValue.FromBoolean(Compare(leftValue, rightValue) is < 0),
             ValidationCelTokenKind.LessOrEqual => ValidationCelValue.FromBoolean(Compare(leftValue, rightValue) is <= 0),
             ValidationCelTokenKind.Greater => ValidationCelValue.FromBoolean(Compare(leftValue, rightValue) is > 0),
@@ -1723,10 +1747,12 @@ internal sealed class ValidationCelBinaryNode(
         };
     }
 
-    private bool AreEqual(
+    private static bool AreEqual(
         ValidationCelValue left,
         ValidationCelValue right,
-        ValidationCelContext context)
+        ValidationCelContext context,
+        int leftValueIndex,
+        int rightValueIndex)
     {
         if (left.Kind == ValidationCelValueKind.Missing || right.Kind == ValidationCelValueKind.Missing)
             throw Unsupported("Cannot compare a missing CEL member; guard optional members with has(...).");
@@ -1740,34 +1766,36 @@ internal sealed class ValidationCelBinaryNode(
             ValidationCelValueKind.String => ValidationCelStrings.Evaluate(left, right, ValidationCelStringOperation.Equal),
             ValidationCelValueKind.Bytes => left.Utf8Literal.Span.SequenceEqual(right.Utf8Literal.Span),
             ValidationCelValueKind.Object or ValidationCelValueKind.Array =>
-                AreAggregateValuesEqual(left, right, context),
+                AreAggregateValuesEqual(left, right, context, leftValueIndex, rightValueIndex),
             _ => false
         };
     }
 
-    private bool AreAggregateValuesEqual(
+    private static bool AreAggregateValuesEqual(
         ValidationCelValue left,
         ValidationCelValue right,
-        ValidationCelContext context)
+        ValidationCelContext context,
+        int leftValueIndex,
+        int rightValueIndex)
     {
-        if (_leftValueIndex < 0 || _rightValueIndex < 0)
+        if (leftValueIndex < 0 || rightValueIndex < 0)
             return CompareAggregateValues(left, right);
         if (CompiledValidationRule.TryGetEquality(
                 context.EqualityGeneration,
-                _leftValueIndex,
-                _rightValueIndex,
+                leftValueIndex,
+                rightValueIndex,
                 out var value))
             return value;
 
         value = CompareAggregateValues(
             left,
             right,
-            GetAggregateComparer(context, _leftValueIndex),
-            GetAggregateComparer(context, _rightValueIndex));
+            GetAggregateComparer(context, leftValueIndex),
+            GetAggregateComparer(context, rightValueIndex));
         CompiledValidationRule.SetEquality(
             context.EqualityGeneration,
-            _leftValueIndex,
-            _rightValueIndex,
+            leftValueIndex,
+            rightValueIndex,
             value);
         return value;
     }
@@ -2467,10 +2495,22 @@ internal sealed class ValidationCelConditionalNode(
     ValidationCelNode whenTrue,
     ValidationCelNode whenFalse) : ValidationCelNode
 {
+    internal override bool HasAggregateValueIndex =>
+        whenTrue.HasAggregateValueIndex || whenFalse.HasAggregateValueIndex;
+
+    internal override bool HasRootAggregateValueIndex =>
+        whenTrue.HasRootAggregateValueIndex || whenFalse.HasRootAggregateValueIndex;
+
     internal override ValidationCelValue Evaluate(ValidationCelContext context) =>
         RequireBoolean(condition.Evaluate(context))
             ? whenTrue.Evaluate(context)
             : whenFalse.Evaluate(context);
+
+    internal override ValidationCelValue EvaluateAggregate(
+        ValidationCelContext context,
+        out int valueIndex) => RequireBoolean(condition.Evaluate(context))
+        ? whenTrue.EvaluateAggregate(context, out valueIndex)
+        : whenFalse.EvaluateAggregate(context, out valueIndex);
 }
 
 internal sealed class ValidationCelFunctionNode(

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -182,6 +182,15 @@ internal sealed class CompiledValidationRule
     private static ValidationCelEqualitySlot[]? t_equalities;
 
     [ThreadStatic]
+    private static ValidationCelValueResolutionFrame[]? t_valueResolutionFrames;
+
+    [ThreadStatic]
+    private static int t_valueResolutionDepth;
+
+    [ThreadStatic]
+    private static ValidationCelEqualitySlots t_pairEqualities;
+
+    [ThreadStatic]
     private static uint t_equalityGeneration;
 
     private readonly ValidationCelNode? _expression;
@@ -366,6 +375,83 @@ internal sealed class CompiledValidationRule
         return new ValidationCelSizeValues(sizes, generation);
     }
 
+    internal static ValidationCelValueResolution BeginValueResolution()
+    {
+        var index = t_valueResolutionDepth++;
+        var frameIndex = index - 1;
+        var frames = t_valueResolutionFrames;
+        if (frameIndex >= 0 && (frames is null || frames.Length <= frameIndex))
+            GrowValueResolutionFrames(frameIndex + 1);
+        return new ValidationCelValueResolution(index);
+    }
+
+    internal static bool HasActiveValueResolution => t_valueResolutionDepth != 0;
+
+    internal static int ValueResolutionDepth => t_valueResolutionDepth;
+
+    internal static void RestoreValueResolutionDepth(int depth) =>
+        t_valueResolutionDepth = depth;
+
+    internal static ValidationCelMemberValues GetMemberValues(
+        int count,
+        ValidationCelValueResolution resolution)
+    {
+        if (resolution.Index == 0)
+            return GetMemberValues(count);
+
+        var index = resolution.Index - 1;
+        ref var frame = ref t_valueResolutionFrames![index];
+        var values = frame.MemberValues;
+        if (values is null || values.Length < count)
+            frame.MemberValues = values = new ValidationCelMemberSlot[Math.Max(count, 8)];
+
+        ref var generation = ref frame.MemberGeneration;
+        generation = unchecked(generation + 1);
+        if (generation == 0)
+        {
+            Array.Clear(values);
+            generation = 1;
+        }
+        return new ValidationCelMemberValues(values, generation);
+    }
+
+    internal static ValidationCelSizeValues GetSizeValues(
+        int count,
+        ValidationCelValueResolution resolution)
+    {
+        if (resolution.Index == 0)
+            return GetSizeValues(count);
+
+        var index = resolution.Index - 1;
+        ref var frame = ref t_valueResolutionFrames![index];
+        var sizes = frame.SizeValues;
+        if (sizes is null || sizes.Length < count)
+            frame.SizeValues = sizes = new ValidationCelSizeSlot[Math.Max(count, 8)];
+
+        ref var generation = ref frame.SizeGeneration;
+        generation = unchecked(generation + 1);
+        if (generation == 0)
+        {
+            Array.Clear(sizes);
+            generation = 1;
+        }
+        return new ValidationCelSizeValues(sizes, generation);
+    }
+
+    internal static void EndValueResolution(ValidationCelValueResolution resolution)
+    {
+        if (t_valueResolutionDepth != resolution.Index + 1)
+            throw new InvalidOperationException("CEL value resolutions must be released in reverse order.");
+        t_valueResolutionDepth--;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void GrowValueResolutionFrames(int count)
+    {
+        var length = Math.Max(count, 4);
+        Array.Resize(ref t_valueResolutionFrames, length);
+    }
+
     internal static uint BeginEqualityResolution()
     {
         var equalities = t_equalities;
@@ -374,6 +460,7 @@ internal sealed class CompiledValidationRule
         if (unchecked(++t_equalityGeneration) == 0)
         {
             Array.Clear(equalities);
+            t_pairEqualities = default;
             t_equalityGeneration = 1;
         }
         return t_equalityGeneration;
@@ -407,6 +494,43 @@ internal sealed class CompiledValidationRule
         slot.Value = value;
         slot.Generation = equalityGeneration;
     }
+
+    internal static bool TryGetEquality(
+        uint equalityGeneration,
+        int leftIndex,
+        int rightIndex,
+        out bool value)
+    {
+        NormalizeEqualityIndexes(ref leftIndex, ref rightIndex);
+        ref readonly var slot = ref t_pairEqualities[GetEqualitySlot(leftIndex, rightIndex)];
+        value = slot.Value;
+        return slot.Generation == equalityGeneration &&
+            slot.LeftIndex == leftIndex &&
+            slot.RightIndex == rightIndex;
+    }
+
+    internal static void SetEquality(
+        uint equalityGeneration,
+        int leftIndex,
+        int rightIndex,
+        bool value)
+    {
+        NormalizeEqualityIndexes(ref leftIndex, ref rightIndex);
+        ref var slot = ref t_pairEqualities[GetEqualitySlot(leftIndex, rightIndex)];
+        slot.LeftIndex = leftIndex;
+        slot.RightIndex = rightIndex;
+        slot.Value = value;
+        slot.Generation = equalityGeneration;
+    }
+
+    private static void NormalizeEqualityIndexes(ref int leftIndex, ref int rightIndex)
+    {
+        if (leftIndex > rightIndex)
+            (leftIndex, rightIndex) = (rightIndex, leftIndex);
+    }
+
+    private static int GetEqualitySlot(int leftIndex, int rightIndex) =>
+        (int)(((uint)leftIndex * 397u ^ (uint)rightIndex) & 7u);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void EnsureEqualityCapacity(int equalityIndex)
@@ -462,6 +586,21 @@ internal sealed class CompiledValidationRule
         t_resolvedMemberLength = value.Length;
         return memberValues;
     }
+}
+
+internal readonly struct ValidationCelValueResolution(int index) : IDisposable
+{
+    internal int Index { get; } = index;
+
+    public void Dispose() => CompiledValidationRule.EndValueResolution(this);
+}
+
+internal struct ValidationCelValueResolutionFrame
+{
+    internal ValidationCelMemberSlot[]? MemberValues;
+    internal uint MemberGeneration;
+    internal ValidationCelSizeSlot[]? SizeValues;
+    internal uint SizeGeneration;
 }
 
 internal readonly record struct ValidationCelContext(
@@ -589,8 +728,16 @@ internal readonly struct ValidationCelSizeValues(
 
 internal struct ValidationCelEqualitySlot
 {
+    internal int LeftIndex;
+    internal int RightIndex;
     internal bool Value;
     internal uint Generation;
+}
+
+[InlineArray(8)]
+internal struct ValidationCelEqualitySlots
+{
+    private ValidationCelEqualitySlot _element0;
 }
 
 internal readonly record struct ValidationCelEqualityPair(

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -1237,6 +1237,8 @@ internal interface IValidationCelAggregateComparer
 {
     object? RawEqualityToken { get; }
 
+    int GetSize(ReadOnlyMemory<byte> value);
+
     bool AreEqual(
         ReadOnlyMemory<byte> left,
         IValidationCelAggregateComparer rightComparer,
@@ -2746,7 +2748,7 @@ internal sealed class ValidationCelFunctionNode(
         if (name == "size")
         {
             RequireArgumentCount(1);
-            return ValidationCelValue.FromNumber(GetSize(arguments[0].Evaluate(context), context.Sizes));
+            return ValidationCelValue.FromNumber(GetSize(arguments[0].Evaluate(context), context));
         }
 
         if (name is "startsWith" or "endsWith" or "contains")
@@ -2778,15 +2780,29 @@ internal sealed class ValidationCelFunctionNode(
             throw Unsupported($"CEL function '{name}' expects {expected.ToString(CultureInfo.InvariantCulture)} argument(s).");
     }
 
-    private static int GetSize(ValidationCelValue value, ValidationCelSizeValues sizes)
+    private static int GetSize(ValidationCelValue value, ValidationCelContext context)
     {
-        if (value.SizeIndex >= 0 && sizes.TryGet(value.SizeIndex, out var cached))
+        if (value.SizeIndex >= 0 && context.Sizes.TryGet(value.SizeIndex, out var cached))
             return cached;
 
-        var size = GetSizeCore(value);
+        var size = value.Kind is ValidationCelValueKind.Array or ValidationCelValueKind.Object &&
+                   value.Json.IsEmpty
+            ? GetEncodedAggregateSize(value, context)
+            : GetSizeCore(value);
         if (value.SizeIndex >= 0)
-            sizes.Set(value.SizeIndex, size);
+            context.Sizes.Set(value.SizeIndex, size);
         return size;
+    }
+
+    private static int GetEncodedAggregateSize(
+        ValidationCelValue value,
+        ValidationCelContext context)
+    {
+        var comparer = value.SizeIndex == 0
+            ? context.RootAggregateComparer
+            : context.MemberValues.GetAggregateComparer(value.SizeIndex - 1);
+        return comparer?.GetSize(value.Utf8Literal) ??
+            throw Unsupported("CEL function 'size' could not resolve the encoded aggregate schema.");
     }
 
     private static int GetSizeCore(ValidationCelValue value)
@@ -3109,7 +3125,10 @@ internal sealed class ValidationCelParser
         }
         var whenTrue = ParseConditional();
         Expect(ValidationCelTokenKind.Colon);
-        return new ValidationCelConditionalNode(condition, whenTrue, ParseConditional());
+        var whenFalse = ParseConditional();
+        if (sizedMemberCount >= 0)
+            RollbackSizedMembers(sizedMemberCount);
+        return new ValidationCelConditionalNode(condition, whenTrue, whenFalse);
     }
 
     private ValidationCelNode ParseOr()

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -3141,7 +3141,9 @@ internal sealed class ValidationCelParser
         return new ValidationCelToken(ValidationCelTokenKind.Number, _expression[start.._position]);
     }
 
-    private ValidationCelToken ReadString(char quote)
+    private ValidationCelToken ReadString(
+        char quote,
+        ValidationCelTokenKind kind = ValidationCelTokenKind.String)
     {
         _position++;
         var builder = new StringBuilder();
@@ -3149,7 +3151,7 @@ internal sealed class ValidationCelParser
         {
             var character = _expression[_position++];
             if (character == quote)
-                return new ValidationCelToken(ValidationCelTokenKind.String, builder.ToString());
+                return new ValidationCelToken(kind, builder.ToString());
             if (character != '\\')
             {
                 builder.Append(character);

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -200,6 +200,7 @@ internal sealed class CompiledValidationRule
         ValidationRule rule,
         ValidationCelNode? expression,
         bool usesRootValue = false,
+        bool usesRootSize = false,
         bool usesSize = false,
         ValidationCelEqualityPair[]? equalityPairs = null,
         bool usesCachedEquality = false,
@@ -209,6 +210,7 @@ internal sealed class CompiledValidationRule
         Rule = rule;
         _expression = expression;
         UsesRootValue = usesRootValue;
+        UsesRootSize = usesRootSize;
         UsesSize = usesSize;
         EqualityPairs = equalityPairs ?? [];
         UsesCachedEquality = usesCachedEquality || EqualityPairs.Length != 0;
@@ -218,6 +220,7 @@ internal sealed class CompiledValidationRule
 
     internal ValidationRule Rule { get; }
     internal bool UsesRootValue { get; }
+    internal bool UsesRootSize { get; }
     internal bool UsesSize { get; }
     internal ValidationCelEqualityPair[] EqualityPairs { get; }
     internal bool UsesCachedEquality { get; }
@@ -229,7 +232,8 @@ internal sealed class CompiledValidationRule
         List<byte[][]> memberPaths,
         HashSet<int> usedMemberIndexes,
         int equalityIndexOffset = 0,
-        Dictionary<ValidationCelEqualityOperands, int>? equalityIndexes = null)
+        Dictionary<ValidationCelEqualityOperands, int>? equalityIndexes = null,
+        HashSet<int>? sizedMemberIndexes = null)
     {
         ArgumentNullException.ThrowIfNull(rule);
         if (string.IsNullOrWhiteSpace(rule.Expr))
@@ -248,12 +252,14 @@ internal sealed class CompiledValidationRule
                 memberPaths,
                 usedMemberIndexes,
                 equalityIndexOffset,
-                equalityIndexes);
+                equalityIndexes,
+                sizedMemberIndexes);
             var expression = parser.Parse();
             return new CompiledValidationRule(
                 rule,
                 expression,
                 parser.UsesRootValue,
+                parser.UsesRootSize,
                 parser.UsesSize,
                 parser.EqualityPairs,
                 parser.UsesCachedEquality,
@@ -2992,6 +2998,8 @@ internal sealed class ValidationCelParser
     private readonly Dictionary<string, int> _memberIndexes;
     private readonly List<byte[][]> _memberPaths;
     private readonly HashSet<int> _usedMemberIndexes;
+    private readonly HashSet<int>? _sizedMemberIndexes;
+    private int _sizeArgumentDepth;
     private int _position;
     private ValidationCelToken _current;
 
@@ -3001,7 +3009,8 @@ internal sealed class ValidationCelParser
         List<byte[][]> memberPaths,
         HashSet<int> usedMemberIndexes,
         int equalityIndexOffset,
-        Dictionary<ValidationCelEqualityOperands, int>? equalityIndexes)
+        Dictionary<ValidationCelEqualityOperands, int>? equalityIndexes,
+        HashSet<int>? sizedMemberIndexes)
     {
         _expression = expression;
         _memberIndexes = memberIndexes;
@@ -3009,6 +3018,7 @@ internal sealed class ValidationCelParser
         _usedMemberIndexes = usedMemberIndexes;
         _equalityIndexOffset = equalityIndexOffset;
         _equalityIndexes = equalityIndexes;
+        _sizedMemberIndexes = sizedMemberIndexes;
         _current = ReadNextToken();
     }
 
@@ -3026,6 +3036,7 @@ internal sealed class ValidationCelParser
     private readonly int _equalityIndexOffset;
     private readonly Dictionary<ValidationCelEqualityOperands, int>? _equalityIndexes;
     internal bool UsesRootValue { get; private set; }
+    internal bool UsesRootSize { get; private set; }
     internal bool UsesCachedEquality { get; private set; }
     internal bool UsesRootAggregateEquality { get; private set; }
 
@@ -3170,8 +3181,20 @@ internal sealed class ValidationCelParser
         }
         else if (TryTake(ValidationCelTokenKind.LeftParen))
         {
-            var arguments = ParseArguments();
-            UsesSize |= identifier == "size";
+            var isSize = identifier == "size";
+            if (isSize)
+                _sizeArgumentDepth++;
+            ValidationCelNode[] arguments;
+            try
+            {
+                arguments = ParseArguments();
+            }
+            finally
+            {
+                if (isSize)
+                    _sizeArgumentDepth--;
+            }
+            UsesSize |= isSize;
             return identifier == "timestamp"
                 ? ParseTimestamp(arguments)
                 : new ValidationCelFunctionNode(identifier, arguments);
@@ -3248,6 +3271,7 @@ internal sealed class ValidationCelParser
         if (identifier.Length == 4)
         {
             UsesRootValue = true;
+            UsesRootSize |= _sizeArgumentDepth != 0;
             return new ValidationCelThisNode(-1);
         }
 
@@ -3267,6 +3291,8 @@ internal sealed class ValidationCelParser
             _memberPaths.Add(path);
         }
         _usedMemberIndexes.Add(memberIndex);
+        if (_sizeArgumentDepth != 0)
+            _sizedMemberIndexes?.Add(memberIndex);
         return new ValidationCelThisNode(memberIndex);
     }
 

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -2999,6 +2999,7 @@ internal sealed class ValidationCelParser
     private readonly List<byte[][]> _memberPaths;
     private readonly HashSet<int> _usedMemberIndexes;
     private readonly HashSet<int>? _sizedMemberIndexes;
+    private readonly List<int>? _sizedMemberAdditions;
     private int _sizeArgumentDepth;
     private int _position;
     private ValidationCelToken _current;
@@ -3019,6 +3020,7 @@ internal sealed class ValidationCelParser
         _equalityIndexOffset = equalityIndexOffset;
         _equalityIndexes = equalityIndexes;
         _sizedMemberIndexes = sizedMemberIndexes;
+        _sizedMemberAdditions = sizedMemberIndexes is null ? null : [];
         _current = ReadNextToken();
     }
 
@@ -3042,9 +3044,18 @@ internal sealed class ValidationCelParser
 
     private ValidationCelNode ParseConditional()
     {
+        var sizedMemberCount = _sizeArgumentDepth == 0
+            ? -1
+            : _sizedMemberAdditions?.Count ?? 0;
+        var usedRootSize = UsesRootSize;
         var condition = ParseOr();
         if (!TryTake(ValidationCelTokenKind.Question))
             return condition;
+        if (sizedMemberCount >= 0)
+        {
+            RollbackSizedMembers(sizedMemberCount);
+            UsesRootSize = usedRootSize;
+        }
         var whenTrue = ParseConditional();
         Expect(ValidationCelTokenKind.Colon);
         return new ValidationCelConditionalNode(condition, whenTrue, ParseConditional());
@@ -3291,9 +3302,19 @@ internal sealed class ValidationCelParser
             _memberPaths.Add(path);
         }
         _usedMemberIndexes.Add(memberIndex);
-        if (_sizeArgumentDepth != 0)
-            _sizedMemberIndexes?.Add(memberIndex);
+        if (_sizeArgumentDepth != 0 && _sizedMemberIndexes?.Add(memberIndex) == true)
+            _sizedMemberAdditions!.Add(memberIndex);
         return new ValidationCelThisNode(memberIndex);
+    }
+
+    private void RollbackSizedMembers(int count)
+    {
+        var additions = _sizedMemberAdditions;
+        if (additions is null || additions.Count == count)
+            return;
+        for (var index = additions.Count - 1; index >= count; index--)
+            _sizedMemberIndexes!.Remove(additions[index]);
+        additions.RemoveRange(count, additions.Count - count);
     }
 
     private ValidationCelNode ParseParenthesized()

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -1814,24 +1814,18 @@ internal sealed class ValidationCelBinaryNode(
 
     private static int? CompareNumbers(ValidationCelValue left, ValidationCelValue right)
     {
-        if (left.IsFloating || right.IsFloating)
+        if (left.IsFloating && right.IsFloating)
         {
-            if (left.IsFloating && double.IsNaN(left.Floating) ||
-                right.IsFloating && double.IsNaN(right.Floating))
-            {
+            if (double.IsNaN(left.Floating) || double.IsNaN(right.Floating))
                 return null;
-            }
-            if (left.IsFloating)
-            {
-                if (right.IsFloating || right.IsFloatingLiteral)
-                    return left.Floating.CompareTo(right.Floating);
-            }
-            else if (left.IsFloatingLiteral)
-                return left.Floating.CompareTo(right.Floating);
-
-            return left.IsFloating
-                ? CompareFloatingToExact(left.Floating, right)
-                : -CompareFloatingToExact(right.Floating, left);
+            return left.Floating.CompareTo(right.Floating);
+        }
+        if (left.IsFloating)
+            return CompareFloatingToExact(left.Floating, right);
+        if (right.IsFloating)
+        {
+            var comparison = CompareFloatingToExact(right.Floating, left);
+            return comparison.HasValue ? -comparison.Value : null;
         }
 
         // Number values reuse the Boolean slot to mark a successful decimal parse.
@@ -1845,8 +1839,10 @@ internal sealed class ValidationCelBinaryNode(
         return CompareExactNumbers(left, right);
     }
 
-    private static int CompareFloatingToExact(double floating, ValidationCelValue exact)
+    private static int? CompareFloatingToExact(double floating, ValidationCelValue exact)
     {
+        if (double.IsNaN(floating))
+            return null;
         if (double.IsPositiveInfinity(floating))
             return 1;
         if (double.IsNegativeInfinity(floating))

--- a/src/Dekaf.SchemaRegistry/ValidationRules.cs
+++ b/src/Dekaf.SchemaRegistry/ValidationRules.cs
@@ -1065,6 +1065,8 @@ internal enum ValidationCelValueKind : byte
 
 internal interface IValidationCelAggregateComparer
 {
+    bool RequiresSemanticEquality { get; }
+
     bool AreEqual(
         ReadOnlyMemory<byte> left,
         IValidationCelAggregateComparer rightComparer,
@@ -1773,7 +1775,9 @@ internal sealed class ValidationCelBinaryNode(
         {
             if (!left.Json.IsEmpty || !right.Json.IsEmpty)
                 return false;
-            if (left.Utf8Literal.Span.SequenceEqual(right.Utf8Literal.Span))
+            if ((leftComparer is null || !leftComparer.RequiresSemanticEquality) &&
+                (rightComparer is null || !rightComparer.RequiresSemanticEquality) &&
+                left.Utf8Literal.Span.SequenceEqual(right.Utf8Literal.Span))
                 return true;
             if (leftComparer is not null && rightComparer is not null)
             {

--- a/tests/Dekaf.Tests.Integration/AvroSerializerIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/AvroSerializerIntegrationTests.cs
@@ -56,6 +56,83 @@ public class AvroSerializerIntegrationTests(KafkaWithSchemaRegistryContainer tes
         }
         """;
 
+    private const string InlineValidationRecordSchema = """
+        {
+            "type": "record",
+            "name": "InlineValidationRecord",
+            "namespace": "test",
+            "fields": [{
+                "name": "id",
+                "type": "int",
+                "confluent:rules": [{ "name": "positive-id", "expr": "this > 0" }]
+            }]
+        }
+        """;
+
+    [Test]
+    public async Task AvroInlineValidation_RejectsInvalidAndRoundTripsValidRecord()
+    {
+        var topic = await testInfra.CreateTestTopicAsync();
+        using var registryClient = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = testInfra.RegistryUrl
+        });
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(
+            registryClient,
+            new AvroSerializerConfig
+            {
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
+        await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(
+            registryClient,
+            new AvroDeserializerConfig
+            {
+                ValidationRulesExecution = ValidationRulesExecution.AfterDomainRules
+            });
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(InlineValidationRecordSchema);
+        var valid = new GenericRecord(schema);
+        valid.Add("id", 42);
+        var invalid = new GenericRecord(schema);
+        invalid.Add("id", -1);
+        await using var producer = await Kafka.CreateProducer<string, GenericRecord>()
+            .WithBootstrapServers(testInfra.BootstrapServers)
+            .WithClientId("avro-inline-validation-producer")
+            .WithValueSerializer(serializer)
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, GenericRecord>
+        {
+            Topic = topic,
+            Key = "valid",
+            Value = valid
+        }, CancellationToken.None);
+        await Assert.That(async () => await producer.ProduceAsync(new ProducerMessage<string, GenericRecord>
+        {
+            Topic = topic,
+            Key = "invalid",
+            Value = invalid
+        }, CancellationToken.None)).Throws<ValidationRulesFailedException>();
+
+        await using var consumer = await Kafka.CreateConsumer<string, GenericRecord>()
+            .WithBootstrapServers(testInfra.BootstrapServers)
+            .WithClientId("avro-inline-validation-consumer")
+            .WithGroupId($"avro-inline-validation-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithValueDeserializer(deserializer)
+            .BuildAsync();
+        consumer.Subscribe(topic);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        GenericRecord? consumed = null;
+        await foreach (var message in consumer.ConsumeAsync(cts.Token))
+        {
+            consumed = message.Value;
+            break;
+        }
+
+        await Assert.That(consumed).IsNotNull();
+        await Assert.That(consumed!["id"]).IsEqualTo(42);
+    }
+
     [Test]
     public async Task AvroSerializer_ProduceAndConsume_RoundTrips()
     {

--- a/tests/Dekaf.Tests.Unit/Protos/protobuf_validation.proto
+++ b/tests/Dekaf.Tests.Unit/Protos/protobuf_validation.proto
@@ -266,6 +266,23 @@ message ValidationSint32BenchmarkEnvelope {
   }];
 }
 
+message ValidationRootSizeEnvelope {
+  option (confluent.message_meta) = {
+    rules: {
+      name: "root-size"
+      expr: "size(this) == 2 + (has(this.nickname) ? 1 : 0) + (has(this.email) ? 1 : 0)"
+    }
+  };
+
+  int32 age = 1;
+  repeated string tags = 2;
+  optional string nickname = 3;
+  oneof contact {
+    string email = 4;
+    string phone = 5;
+  }
+}
+
 enum ValidationStatus {
   VALIDATION_STATUS_UNSPECIFIED = 0;
   VALIDATION_STATUS_ACTIVE = 1;

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Globalization;
 using Avro;
 using Avro.Generic;
 using Avro.IO;
@@ -602,12 +603,15 @@ public class AvroInlineRuleValidatorTests
         var record = new GenericRecord(schema);
         record.Add("value", 0.5d);
 
-        new AvroInlineRuleValidator(schema).Validate(
-            Serialize(record, schema),
-            26,
-            failFast: false);
+        var validator = new AvroInlineRuleValidator(schema);
+        var payload = Serialize(record, schema);
+        validator.Validate(payload, 26, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 26, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
 
-        await Task.CompletedTask;
+        await Assert.That(allocated).IsEqualTo(0);
     }
 
     [Test]
@@ -630,6 +634,36 @@ public class AvroInlineRuleValidatorTests
         var schema = (RecordSchema)AvroSchema.Parse(schemaText);
         var record = new GenericRecord(schema);
         record.Add("value", 9007199254740992d);
+
+        new AvroInlineRuleValidator(schema).Validate(
+            Serialize(record, schema),
+            26,
+            failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Validate_MixedFloatingArithmeticPreservesExactIntegerPrecision()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "FloatingArithmeticPrecisionRuleRecord",
+              "confluent:rules": [{
+                "name": "precision",
+                "expr": "this.exact - this.floating == 9007199254740992 && this.floating + this.exact == 9007199254740994"
+              }],
+              "fields": [
+                { "name": "exact", "type": "long" },
+                { "name": "floating", "type": "double" }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("exact", 9007199254740993L);
+        record.Add("floating", 1d);
 
         new AvroInlineRuleValidator(schema).Validate(
             Serialize(record, schema),
@@ -1019,6 +1053,55 @@ public class AvroInlineRuleValidatorTests
         new AvroInlineRuleValidator(schema).Validate(payload, 31, failFast: false);
 
         await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Validate_EqualMapsUsePooledIndexWithoutAllocating()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "PooledMapEqualityRecord",
+              "confluent:rules": [{ "name": "equal", "expr": "this.left == this.right" }],
+              "fields": [
+                { "name": "left", "type": { "type": "map", "values": "int" } },
+                { "name": "right", "type": { "type": "map", "values": "int" } }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var left = new Dictionary<string, object>();
+        var right = new Dictionary<string, object>();
+        for (var index = 0; index < 17; index++)
+            left.Add(index.ToString(CultureInfo.InvariantCulture), index);
+        for (var index = 16; index >= 0; index--)
+            right.Add(index.ToString(CultureInfo.InvariantCulture), index);
+        var record = new GenericRecord(schema);
+        record.Add("left", left);
+        record.Add("right", right);
+        var validator = new AvroInlineRuleValidator(schema);
+        var payload = Serialize(record, schema);
+
+        validator.Validate(payload, 31, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 31, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Validate_MapEqualityRejectsOversizedEntryIndex()
+    {
+        var schema = AvroSchema.Parse("""{ "type": "map", "values": "null" }""");
+        var comparer = new AvroAggregateEqualityComparerFactory().Create(schema)!;
+        ReadOnlyMemory<byte> payload = new byte[] { 0x82, 0x80, 0x80, 0x01 };
+
+        var exception = Assert.Throws<SchemaRegistryRuleException>(() =>
+            ((IValidationCelAggregateComparer)comparer).AreEqual(payload, comparer, default));
+
+        await Assert.That(exception.Message).Contains("supported limit");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -1528,6 +1528,62 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_RecursiveAndFiniteAggregateSchemasCompareSelectedValues()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "RecursiveFiniteEqualityRecord",
+              "confluent:rules": [{ "name": "equal", "expr": "this.left == this.right" }],
+              "fields": [
+                {
+                  "name": "left",
+                  "type": {
+                    "type": "record",
+                    "name": "RecursiveFiniteNode",
+                    "fields": [
+                      { "name": "value", "type": "int" },
+                      { "name": "next", "type": ["null", "RecursiveFiniteNode"] }
+                    ]
+                  }
+                },
+                {
+                  "name": "right",
+                  "type": {
+                    "type": "record",
+                    "name": "FiniteNode",
+                    "fields": [
+                      { "name": "value", "type": "int" },
+                      { "name": "next", "type": "null" }
+                    ]
+                  }
+                }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var leftSchema = (RecordSchema)schema.Fields[0].Schema;
+        var rightSchema = (RecordSchema)schema.Fields[1].Schema;
+        var left = new GenericRecord(leftSchema);
+        left.Add("value", 1);
+        left.Add("next", null);
+        var right = new GenericRecord(rightSchema);
+        right.Add("value", 1);
+        right.Add("next", null);
+        var record = new GenericRecord(schema);
+        record.Add("left", left);
+        record.Add("right", right);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        validator.Validate(Serialize(record, schema), 29, failFast: false);
+        right.Add("value", 2);
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 29, failFast: false));
+
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("equal");
+    }
+
+    [Test]
     public async Task Validate_ConditionalAggregateEqualityUsesSelectedComparer()
     {
         const string schemaText = """

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -226,6 +226,47 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_RecordMemberFailFastRetainsOnlyFirstNestedViolation()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "RecordFailFastNestedRuleValue",
+              "confluent:rules": [{ "name": "selected", "expr": "has(this.items)" }],
+              "fields": [{
+                "name": "items",
+                "type": {
+                  "type": "array",
+                  "items": {
+                    "type": "int",
+                    "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                  }
+                }
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var singleValue = new GenericRecord(schema);
+        singleValue.Add("items", new[] { -1 });
+        var manyValue = new GenericRecord(schema);
+        manyValue.Add("items", Enumerable.Repeat(-1, 128).ToArray());
+        var singlePayload = Serialize(singleValue, schema);
+        var manyPayload = Serialize(manyValue, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(manyPayload, 18, failFast: true));
+        _ = MeasureFailedValidationAllocation(validator, singlePayload);
+        _ = MeasureFailedValidationAllocation(validator, manyPayload);
+        var singleAllocated = MeasureFailedValidationAllocation(validator, singlePayload);
+        var manyAllocated = MeasureFailedValidationAllocation(validator, manyPayload);
+
+        await Assert.That(exception.Violations).HasSingleItem();
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("positive");
+        await Assert.That(manyAllocated).IsLessThanOrEqualTo(singleAllocated + 1024);
+    }
+
+    [Test]
     public async Task Validate_RootArrayAndMapValuesShareNestedTraversal()
     {
         const string arraySchemaText = """

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -765,6 +765,36 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_EqualUnionAndConcreteArraysUseSelectedBranch()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "UnionConcreteAggregateEqualityRecord",
+              "confluent:rules": [{ "name": "equal", "expr": "this.left == this.right" }],
+              "fields": [
+                { "name": "left", "type": { "type": "array", "items": ["null", "int"] } },
+                { "name": "right", "type": { "type": "array", "items": "int" } }
+              ]
+            }
+            """;
+        var validator = new AvroInlineRuleValidator(AvroSchema.Parse(schemaText));
+        ReadOnlyMemory<byte> payload = new byte[]
+        {
+            2, 2, 2, 0,
+            2, 2, 0
+        };
+
+        validator.Validate(payload, 27, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 27, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Validate_BytesLiteralDecodesHexEscapes()
     {
         const string schemaText = """

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -2270,6 +2270,7 @@ public class AvroInlineRuleValidatorTests
             ((IInlineValidationRuleExecutor)provider).Validate(
                 Serialize(record, resolvedSchema),
                 33,
+                subject: null,
                 registrySchema,
                 failFast: false));
 

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -15,6 +15,8 @@ namespace Dekaf.Tests.Unit.SchemaRegistry;
 public class AvroInlineRuleValidatorTests
 {
     private static readonly int[] TwoItems = [1, 2];
+    private static readonly float[] OneFloat = [1f];
+    private static readonly float[] TwoFloat = [2f];
 
     private const string IntegrationSchema = """
         {
@@ -84,6 +86,124 @@ public class AvroInlineRuleValidatorTests
         await Assert.That(exception.Message).Contains("$.labels[\"region\"]: label");
         await Assert.That(failFastException.Violations.Count).IsEqualTo(1);
         await Assert.That(failFastException.Violations[0].Rule.Name).IsEqualTo("root");
+    }
+
+    [Test]
+    public async Task Validate_RootAggregateValueAndNestedRulesShareTraversal()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "RootValueNestedRuleRecord",
+              "confluent:rules": [{ "name": "root-size", "expr": "size(this) == 1" }],
+              "fields": [{
+                "name": "items",
+                "type": {
+                  "type": "array",
+                  "items": {
+                    "type": "int",
+                    "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                  }
+                }
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("items", TwoItems);
+        var payload = Serialize(record, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        validator.Validate(payload, 17, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 17, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        record.Add("items", new[] { 1, -1 });
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 17, failFast: false));
+
+        await Assert.That(allocated).IsEqualTo(0);
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("positive");
+    }
+
+    [Test]
+    public async Task Validate_RootArrayAndMapValuesShareNestedTraversal()
+    {
+        const string arraySchemaText = """
+            {
+              "type": "array",
+              "confluent:rules": [{ "name": "array-size", "expr": "size(this) == 2" }],
+              "items": {
+                "type": "int",
+                "confluent:rules": [{ "name": "positive-item", "expr": "this > 0" }]
+              }
+            }
+            """;
+        const string mapSchemaText = """
+            {
+              "type": "map",
+              "confluent:rules": [{ "name": "map-size", "expr": "size(this) == 1" }],
+              "values": {
+                "type": "int",
+                "confluent:rules": [{ "name": "positive-value", "expr": "this > 0" }]
+              }
+            }
+            """;
+        ReadOnlyMemory<byte> arrayPayload = new byte[] { 4, 2, 4, 0 };
+        ReadOnlyMemory<byte> mapPayload = new byte[]
+        {
+            2, 12, (byte)'r', (byte)'e', (byte)'g', (byte)'i', (byte)'o', (byte)'n', 2, 0
+        };
+        var arrayValidator = new AvroInlineRuleValidator(AvroSchema.Parse(arraySchemaText));
+        var mapValidator = new AvroInlineRuleValidator(AvroSchema.Parse(mapSchemaText));
+
+        arrayValidator.Validate(arrayPayload, 17, failFast: false);
+        mapValidator.Validate(mapPayload, 17, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+        {
+            arrayValidator.Validate(arrayPayload, 17, failFast: false);
+            mapValidator.Validate(mapPayload, 17, failFast: false);
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Validate_RecordRulesResolveStringMapKeys()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "MapMemberRuleRecord",
+              "confluent:rules": [{
+                "name": "region",
+                "expr": "this.labels.region == 'us' && !has(this.labels.missing)"
+              }],
+              "fields": [{ "name": "labels", "type": { "type": "map", "values": "string" } }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("labels", new Dictionary<string, string> { ["region"] = "us" });
+        var payload = Serialize(record, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        validator.Validate(payload, 17, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 17, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        record.Add("labels", new Dictionary<string, string> { ["region"] = "eu" });
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 17, failFast: false));
+
+        await Assert.That(allocated).IsEqualTo(0);
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("region");
     }
 
     [Test]
@@ -376,6 +496,48 @@ public class AvroInlineRuleValidatorTests
         Assert.Throws<ValidationRulesFailedException>(() =>
             validator.Validate(Serialize(record, schema), 27, failFast: false));
         await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Validate_EqualAggregateMembersIgnoreSchemaAnnotations()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "AnnotatedAggregateEqualityRecord",
+              "confluent:rules": [{ "name": "equal", "expr": "this.left == this.right" }],
+              "fields": [
+                {
+                  "name": "left",
+                  "type": {
+                    "type": "array",
+                    "items": "float",
+                    "confluent:rules": [{ "name": "annotation", "expr": "true" }]
+                  }
+                },
+                { "name": "right", "type": { "type": "array", "items": "float" } }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("left", OneFloat);
+        record.Add("right", OneFloat);
+        var payload = Serialize(record, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        validator.Validate(payload, 27, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 27, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        record.Add("right", TwoFloat);
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 27, failFast: false));
+
+        await Assert.That(allocated).IsEqualTo(0);
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("equal");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -2036,6 +2036,53 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_InvalidBooleanEncodingIsRejectedByReadAndSkipPaths()
+    {
+        const string readSchemaText = """
+            {
+              "type": "record",
+              "name": "InvalidBooleanReadRecord",
+              "fields": [{
+                "name": "enabled",
+                "type": "boolean",
+                "confluent:rules": [{ "name": "enabled", "expr": "this == true" }]
+              }]
+            }
+            """;
+        const string skipSchemaText = """
+            {
+              "type": "record",
+              "name": "InvalidBooleanSkipRecord",
+              "confluent:rules": [{ "name": "always", "expr": "true" }],
+              "fields": [{ "name": "enabled", "type": "boolean" }]
+            }
+            """;
+        var readValidator = new AvroInlineRuleValidator(AvroSchema.Parse(readSchemaText));
+        var skipValidator = new AvroInlineRuleValidator(AvroSchema.Parse(skipSchemaText));
+
+        var readException = Assert.Throws<SchemaRegistryRuleException>(() =>
+            readValidator.Validate(new byte[] { 2 }, 35, failFast: false));
+        var skipException = Assert.Throws<SchemaRegistryRuleException>(() =>
+            skipValidator.Validate(new byte[] { 2 }, 35, failFast: false));
+
+        await Assert.That(readException.Message).Contains("invalid boolean value 2");
+        await Assert.That(skipException.Message).Contains("invalid boolean value 2");
+    }
+
+    [Test]
+    public async Task Validate_AggregateEqualityRejectsInvalidBooleanEncoding()
+    {
+        var schema = AvroSchema.Parse("""{ "type": "array", "items": "boolean" }""");
+        var comparer = new AvroAggregateEqualityComparerFactory().Create(schema)!;
+        ReadOnlyMemory<byte> payload = new byte[] { 2, 2, 0 };
+
+        var exception = Assert.Throws<SchemaRegistryRuleException>(() =>
+            ((IValidationCelAggregateComparer)comparer).AreEqual(payload, comparer, payload));
+
+        await Assert.That(exception.Message).Contains("invalid boolean value 2");
+    }
+
+    [Test]
     public async Task Serializer_EnabledValidationRejectsInvalidGenericRecord()
     {
         var schema = (RecordSchema)AvroSchema.Parse(IntegrationSchema);

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -8,6 +8,7 @@ using Dekaf.SchemaRegistry;
 using Dekaf.SchemaRegistry.Avro;
 using Dekaf.SchemaRegistry.Avro.Poco;
 using Dekaf.Serialization;
+using NSubstitute;
 using AvroSchema = Avro.Schema;
 
 namespace Dekaf.Tests.Unit.SchemaRegistry;
@@ -311,6 +312,84 @@ public class AvroInlineRuleValidatorTests
         }
 
         await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Validate_MapMemberAndNestedRulesPreserveParentFirstOrder()
+    {
+        const string schemaText = """
+            {
+              "type": "map",
+              "confluent:rules": [{ "name": "selected", "expr": "this.selected.code > 0" }],
+              "values": {
+                "type": "record",
+                "name": "MapNestedRuleValue",
+                "fields": [{
+                  "name": "code",
+                  "type": "int",
+                  "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                }]
+              }
+            }
+            """;
+        var schema = (MapSchema)AvroSchema.Parse(schemaText);
+        var valueSchema = (RecordSchema)schema.ValueSchema;
+        var invalidValue = new GenericRecord(valueSchema);
+        invalidValue.Add("code", -1);
+        var payload = Serialize(
+            new Dictionary<string, object> { ["selected"] = invalidValue },
+            schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        var all = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(payload, 18, failFast: false));
+        var first = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(payload, 18, failFast: true));
+
+        await Assert.That(all.Violations).Count().IsEqualTo(2);
+        await Assert.That(all.Violations[0].Rule.Name).IsEqualTo("selected");
+        await Assert.That(all.Violations[1].Rule.Name).IsEqualTo("positive");
+        await Assert.That(first.Violations).HasSingleItem();
+        await Assert.That(first.Violations[0].Rule.Name).IsEqualTo("selected");
+    }
+
+    [Test]
+    public async Task Validate_UnionMemberAndNestedRulesPreserveParentFirstOrder()
+    {
+        const string schemaText = """
+            {
+              "type": [
+                "null",
+                {
+                  "type": "record",
+                  "name": "UnionNestedRuleValue",
+                  "fields": [{
+                    "name": "code",
+                    "type": "int",
+                    "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                  }]
+                }
+              ],
+              "confluent:rules": [{ "name": "selected", "expr": "this.code > 0" }]
+            }
+            """;
+        var schema = (UnionSchema)AvroSchema.Parse(schemaText);
+        var valueSchema = (RecordSchema)schema[1];
+        var invalidValue = new GenericRecord(valueSchema);
+        invalidValue.Add("code", -1);
+        var payload = Serialize(invalidValue, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        var all = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(payload, 18, failFast: false));
+        var first = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(payload, 18, failFast: true));
+
+        await Assert.That(all.Violations).Count().IsEqualTo(2);
+        await Assert.That(all.Violations[0].Rule.Name).IsEqualTo("selected");
+        await Assert.That(all.Violations[1].Rule.Name).IsEqualTo("positive");
+        await Assert.That(first.Violations).HasSingleItem();
+        await Assert.That(first.Violations[0].Rule.Name).IsEqualTo("selected");
     }
 
     [Test]
@@ -864,6 +943,137 @@ public class AvroInlineRuleValidatorTests
         Assert.Throws<ValidationRulesFailedException>(() =>
             serializer.Serialize(record, ref destination, CreateContext()));
 
+        await Assert.That(destination.WrittenCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Serializer_AutoRegisterUsesRulesFromExistingRegistrySchema()
+    {
+        const string runtimeSchemaText = """
+            {
+              "type": "record",
+              "name": "IntegratedRuleRecord",
+              "fields": [{ "name": "age", "type": "int" }]
+            }
+            """;
+        var registeredSchema = new Dekaf.SchemaRegistry.Schema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = IntegrationSchema
+        };
+        var registry = Substitute.For<ISchemaRegistryClient>();
+        registry.GetOrRegisterSchemaAsync(
+                "validation-topic-value",
+                Arg.Any<Dekaf.SchemaRegistry.Schema>(),
+                Arg.Any<CancellationToken>())
+            .Returns(42);
+        registry.GetSchemaAsync(
+                42,
+                "validation-topic-value",
+                Arg.Any<CancellationToken>())
+            .Returns(registeredSchema);
+        var runtimeSchema = (RecordSchema)AvroSchema.Parse(runtimeSchemaText);
+        var record = new GenericRecord(runtimeSchema);
+        record.Add("age", -1);
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(
+            registry,
+            new AvroSerializerConfig
+            {
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
+        var destination = new ArrayBufferWriter<byte>();
+
+        Assert.Throws<ValidationRulesFailedException>(() =>
+            serializer.Serialize(record, ref destination, CreateContext()));
+
+        await registry.Received(1).GetSchemaAsync(
+            42,
+            "validation-topic-value",
+            Arg.Any<CancellationToken>());
+        await Assert.That(destination.WrittenCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Serializer_ResolvesReferencedRegistryRulesBeforeValidation()
+    {
+        const string runtimeSchemaText = """
+            {
+              "type": "record",
+              "name": "ReferenceRoot",
+              "namespace": "Dekaf.Tests",
+              "fields": [{
+                "name": "child",
+                "type": {
+                  "type": "record",
+                  "name": "ReferencedChild",
+                  "fields": [{ "name": "code", "type": "int" }]
+                }
+              }]
+            }
+            """;
+        const string registeredChildSchemaText = """
+            {
+              "type": "record",
+              "name": "ReferencedChild",
+              "namespace": "Dekaf.Tests",
+              "fields": [{
+                "name": "code",
+                "type": "int",
+                "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+              }]
+            }
+            """;
+        const string registeredRootSchemaText = """
+            {
+              "type": "record",
+              "name": "ReferenceRoot",
+              "namespace": "Dekaf.Tests",
+              "fields": [{ "name": "child", "type": "Dekaf.Tests.ReferencedChild" }]
+            }
+            """;
+        using var registry = new MockSchemaRegistryClient();
+        _ = await registry.RegisterSchemaAsync(
+            "referenced-child",
+            new Dekaf.SchemaRegistry.Schema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = registeredChildSchemaText
+            });
+        _ = await registry.RegisterSchemaAsync(
+            "validation-topic-value",
+            new Dekaf.SchemaRegistry.Schema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = registeredRootSchemaText,
+                References =
+                [
+                    new SchemaReference
+                    {
+                        Name = "Dekaf.Tests.ReferencedChild",
+                        Subject = "referenced-child",
+                        Version = 1
+                    }
+                ]
+            });
+        var runtimeSchema = (RecordSchema)AvroSchema.Parse(runtimeSchemaText);
+        var runtimeChildSchema = (RecordSchema)runtimeSchema.Fields[0].Schema;
+        var child = new GenericRecord(runtimeChildSchema);
+        child.Add("code", -1);
+        var record = new GenericRecord(runtimeSchema);
+        record.Add("child", child);
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(
+            registry,
+            new AvroSerializerConfig
+            {
+                UseLatestVersion = true,
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
+        var destination = new ArrayBufferWriter<byte>();
+
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            serializer.Serialize(record, ref destination, CreateContext()));
+
+        await Assert.That(exception.Message).Contains("$.child.code: positive");
         await Assert.That(destination.WrittenCount).IsEqualTo(0);
     }
 
@@ -1508,6 +1718,15 @@ public class AvroInlineRuleValidatorTests
         using var stream = new MemoryStream();
         var encoder = new BinaryEncoder(stream);
         new GenericDatumWriter<GenericRecord>(schema).Write(record, encoder);
+        encoder.Flush();
+        return stream.ToArray();
+    }
+
+    private static byte[] Serialize(object value, AvroSchema schema)
+    {
+        using var stream = new MemoryStream();
+        var encoder = new BinaryEncoder(stream);
+        new GenericDatumWriter<object>(schema).Write(value, encoder);
         encoder.Flush();
         return stream.ToArray();
     }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -226,6 +226,63 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_DescendantFieldMemberAndNestedRulesShareTraversal()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "DescendantFieldMemberRuleRecord",
+              "fields": [{
+                "name": "container",
+                "confluent:rules": [{ "name": "descendant", "expr": "this.child.code > 0" }],
+                "type": {
+                  "type": "record",
+                  "name": "DescendantFieldMemberContainer",
+                  "fields": [{
+                    "name": "child",
+                    "type": {
+                      "type": "record",
+                      "name": "DescendantFieldMemberChild",
+                      "fields": [{
+                        "name": "code",
+                        "type": "int",
+                        "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                      }]
+                    }
+                  }]
+                }
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var containerSchema = (RecordSchema)schema.Fields[0].Schema;
+        var childSchema = (RecordSchema)containerSchema.Fields[0].Schema;
+        var child = new GenericRecord(childSchema);
+        child.Add("code", 1);
+        var container = new GenericRecord(containerSchema);
+        container.Add("child", child);
+        var record = new GenericRecord(schema);
+        record.Add("container", container);
+        var payload = Serialize(record, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        validator.Validate(payload, 30, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 30, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        child.Add("code", -1);
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 30, failFast: false));
+
+        await Assert.That(allocated).IsEqualTo(0);
+        await Assert.That(exception.Violations.Count).IsEqualTo(2);
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("descendant");
+        await Assert.That(exception.Violations[1].Rule.Name).IsEqualTo("positive");
+    }
+
+    [Test]
     public async Task Validate_MixedParentAndNestedMemberRulesPreserveParentMembers()
     {
         const string schemaText = """
@@ -844,6 +901,58 @@ public class AvroInlineRuleValidatorTests
         var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
 
         await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Validate_UnionMapFieldMemberAndNestedRulesShareTraversal()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "UnionMapFieldMemberRecord",
+              "fields": [{
+                "name": "value",
+                "type": ["null", {
+                  "type": "map",
+                  "values": {
+                    "type": "record",
+                    "name": "UnionMapFieldMemberValue",
+                    "fields": [{
+                      "name": "code",
+                      "type": "int",
+                      "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                    }]
+                  }
+                }],
+                "confluent:rules": [{ "name": "selected", "expr": "this.selected.code > 0" }]
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var mapSchema = (MapSchema)((UnionSchema)schema.Fields[0].Schema)[1];
+        var valueSchema = (RecordSchema)mapSchema.ValueSchema;
+        var value = new GenericRecord(valueSchema);
+        value.Add("code", 1);
+        var map = new Dictionary<string, object> { ["selected"] = value };
+        var record = new GenericRecord(schema);
+        record.Add("value", map);
+        var payload = Serialize(record, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        validator.Validate(payload, 30, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 30, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        value.Add("code", -1);
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 30, failFast: false));
+
+        await Assert.That(allocated).IsEqualTo(0);
+        await Assert.That(exception.Violations.Count).IsEqualTo(2);
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("selected");
+        await Assert.That(exception.Violations[1].Rule.Name).IsEqualTo("positive");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -735,6 +735,36 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_EqualUnionArraysIgnoreBranchOrdering()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "UnionOrderAggregateEqualityRecord",
+              "confluent:rules": [{ "name": "equal", "expr": "this.left == this.right" }],
+              "fields": [
+                { "name": "left", "type": { "type": "array", "items": ["int", "long"] } },
+                { "name": "right", "type": { "type": "array", "items": ["long", "int"] } }
+              ]
+            }
+            """;
+        var validator = new AvroInlineRuleValidator(AvroSchema.Parse(schemaText));
+        ReadOnlyMemory<byte> payload = new byte[]
+        {
+            2, 0, 2, 0,
+            2, 2, 2, 0
+        };
+
+        validator.Validate(payload, 27, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 27, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Validate_BytesLiteralDecodesHexEscapes()
     {
         const string schemaText = """

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -151,6 +151,63 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_RecordUnionFieldRuleResolvesEverySelectedBranch()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "MultiRecordUnionFieldRule",
+              "fields": [{
+                "name": "value",
+                "type": [
+                  { "type": "record", "name": "FirstUnionRuleBranch", "fields": [{ "name": "code", "type": "int" }] },
+                  { "type": "record", "name": "SecondUnionRuleBranch", "fields": [{ "name": "code", "type": "int" }] }
+                ],
+                "confluent:rules": [{ "name": "code", "expr": "this.code > 0" }]
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var union = (UnionSchema)schema.Fields[0].Schema;
+        var record = new GenericRecord(schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        for (var branchIndex = 0; branchIndex < union.Count; branchIndex++)
+        {
+            var branch = (RecordSchema)union[branchIndex];
+            var value = new GenericRecord(branch);
+            value.Add("code", 1);
+            record.Add("value", value);
+            validator.Validate(Serialize(record, schema), 18, failFast: false);
+
+            value.Add("code", -1);
+            Assert.Throws<ValidationRulesFailedException>(() =>
+                validator.Validate(Serialize(record, schema), 18, failFast: false));
+        }
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Validate_LogicalSchemaRetainsInlineRules()
+    {
+        const string schemaText = """
+            {
+              "type": "long",
+              "logicalType": "timestamp-millis",
+              "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+            }
+            """;
+        var validator = new AvroInlineRuleValidator(AvroSchema.Parse(schemaText));
+
+        validator.Validate(new byte[] { 84 }, 18, failFast: false);
+        Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(new byte[] { 1 }, 18, failFast: false));
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
     public async Task Validate_RecordSizeUsesFieldCount()
     {
         const string schemaText = """
@@ -388,6 +445,33 @@ public class AvroInlineRuleValidatorTests
         var schema = (RecordSchema)AvroSchema.Parse(schemaText);
         var record = new GenericRecord(schema);
         record.Add("value", double.NaN);
+
+        new AvroInlineRuleValidator(schema).Validate(
+            Serialize(record, schema),
+            32,
+            failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Validate_IdenticallyEncodedNaNAggregatesUseSemanticEquality()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "NaNAggregateEqualityRecord",
+              "confluent:rules": [{ "name": "not-equal", "expr": "this.left != this.right" }],
+              "fields": [
+                { "name": "left", "type": { "type": "array", "items": "double" } },
+                { "name": "right", "type": { "type": "array", "items": "double" } }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("left", new[] { double.NaN });
+        record.Add("right", new[] { double.NaN });
 
         new AvroInlineRuleValidator(schema).Validate(
             Serialize(record, schema),

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -1,0 +1,598 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using Avro;
+using Avro.Generic;
+using Avro.IO;
+using Avro.Specific;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Avro;
+using Dekaf.SchemaRegistry.Avro.Poco;
+using Dekaf.Serialization;
+using AvroSchema = Avro.Schema;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public class AvroInlineRuleValidatorTests
+{
+    private const string IntegrationSchema = """
+        {
+          "type": "record",
+          "name": "IntegratedRuleRecord",
+          "fields": [{
+            "name": "age",
+            "type": "int",
+            "confluent:rules": [{ "name": "age", "expr": "this >= 0" }]
+          }]
+        }
+        """;
+
+    [Test]
+    public async Task Validate_AggregatesRecordFieldArrayAndMapRules()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "InlineRuleRecord",
+              "confluent:rules": [{ "name": "root", "expr": "this.name != 'forbidden'" }],
+              "fields": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "confluent:rules": [{ "name": "name", "doc": "name required", "expr": "size(this) > 0" }]
+                },
+                {
+                  "name": "items",
+                  "type": {
+                    "type": "array",
+                    "items": {
+                      "type": "int",
+                      "confluent:rules": [{ "name": "positive", "expr": "this >= 0" }]
+                    }
+                  }
+                },
+                {
+                  "name": "labels",
+                  "type": {
+                    "type": "map",
+                    "values": {
+                      "type": "string",
+                      "confluent:rules": [{ "name": "label", "expr": "size(this) > 0" }]
+                    }
+                  }
+                }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("name", "forbidden");
+        record.Add("items", new[] { 1, -1 });
+        record.Add("labels", new Dictionary<string, string> { ["region"] = "" });
+        var validator = new AvroInlineRuleValidator(schema);
+
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 17, failFast: false));
+
+        await Assert.That(exception.Violations.Count).IsEqualTo(3);
+        await Assert.That(exception.Message).Contains("$: root");
+        await Assert.That(exception.Message).Contains("$.items[1]: positive");
+        await Assert.That(exception.Message).Contains("$.labels[\"region\"]: label");
+    }
+
+    [Test]
+    public async Task Validate_RecordMemberAliasesAndNullableNestedRecord()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "AliasRuleRecord",
+              "confluent:rules": [{ "name": "alias", "expr": "this.oldName == 'ok' && this.child.code == 7" }],
+              "fields": [
+                { "name": "name", "aliases": ["oldName"], "type": "string" },
+                {
+                  "name": "child",
+                  "type": ["null", {
+                    "type": "record",
+                    "name": "Child",
+                    "fields": [{ "name": "code", "type": "int" }]
+                  }]
+                }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var childSchema = (RecordSchema)((UnionSchema)schema.Fields[1].Schema)[1];
+        var child = new GenericRecord(childSchema);
+        child.Add("code", 7);
+        var record = new GenericRecord(schema);
+        record.Add("name", "ok");
+        record.Add("child", child);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        validator.Validate(Serialize(record, schema), 18, failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Serializer_EnabledValidationRejectsInvalidGenericRecord()
+    {
+        var schema = (RecordSchema)AvroSchema.Parse(IntegrationSchema);
+        var record = new GenericRecord(schema);
+        record.Add("age", -1);
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(
+            new MockSchemaRegistryClient(),
+            new AvroSerializerConfig
+            {
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
+        var destination = new ArrayBufferWriter<byte>();
+
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            serializer.Serialize(record, ref destination, CreateContext()));
+
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("age");
+        await Assert.That(destination.WrittenCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Deserializer_EnabledValidationRejectsInvalidGenericRecord()
+    {
+        using var registry = new MockSchemaRegistryClient();
+        var registrySchema = new Dekaf.SchemaRegistry.Schema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = IntegrationSchema
+        };
+        var schemaId = await registry.RegisterSchemaAsync("validation-topic-value", registrySchema);
+        var schema = (RecordSchema)AvroSchema.Parse(IntegrationSchema);
+        var record = new GenericRecord(schema);
+        record.Add("age", -1);
+        var payload = Serialize(record, schema);
+        await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(
+            registry,
+            new AvroDeserializerConfig
+            {
+                ValidationRulesExecution = ValidationRulesExecution.AfterDomainRules
+            });
+
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            deserializer.Deserialize(CreateWireBytes(schemaId, payload), CreateContext()));
+
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("age");
+    }
+
+    [Test]
+    public async Task InvalidExecutionModeAndCustomRuleExecutorAreRejected()
+    {
+        var invalidMode = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            _ = new AvroSchemaRegistrySerializer<GenericRecord>(
+                new MockSchemaRegistryClient(),
+                new AvroSerializerConfig
+                {
+                    ValidationRulesExecution = (ValidationRulesExecution)int.MaxValue
+                }));
+        var customExecutor = Assert.Throws<NotSupportedException>(() =>
+            _ = new AvroSchemaRegistryDeserializer<GenericRecord>(
+                new MockSchemaRegistryClient(),
+                new AvroDeserializerConfig
+                {
+                    RuleExecutor = new PassThroughRuleExecutor(),
+                    ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+                }));
+
+        await Assert.That(invalidMode.ParamName).IsEqualTo("execution");
+        await Assert.That(customExecutor.Message).Contains("SchemaRegistryRuleExecutor");
+    }
+
+    [Test]
+    public async Task PocoSerializerAndDeserializer_ApplyInlineRulesToGeneratedBytes()
+    {
+        using var registry = new MockSchemaRegistryClient();
+        var schemaId = await registry.RegisterSchemaAsync(
+            "validation-topic-value",
+            new Dekaf.SchemaRegistry.Schema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = InlineRulePocoCodec.SchemaJson
+            });
+        var serializerConfig = new AvroSerializerConfig
+        {
+            AutoRegisterSchemas = false,
+            ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+        };
+        await using var serializer = new AvroPocoSchemaRegistrySerializer<
+            InlineRulePoco,
+            InlineRulePocoCodec>(registry, serializerConfig);
+        var destination = new ArrayBufferWriter<byte>();
+
+        Assert.Throws<ValidationRulesFailedException>(() =>
+            serializer.Serialize(new InlineRulePoco(-1), ref destination, CreateContext()));
+
+        var payload = new byte[] { 1 };
+        await using var deserializer = new AvroPocoSchemaRegistryDeserializer<
+            InlineRulePoco,
+            InlineRulePocoCodec>(
+                registry,
+                new AvroDeserializerConfig
+                {
+                    ValidationRulesExecution = ValidationRulesExecution.AfterDomainRules
+                });
+        Assert.Throws<ValidationRulesFailedException>(() =>
+            deserializer.Deserialize(CreateWireBytes(schemaId, payload), CreateContext()));
+
+        await Assert.That(destination.WrittenCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task InlineRules_RunAtConfiguredDomainAndEncodingBoundaries()
+    {
+        using var registry = new MockSchemaRegistryClient();
+        var schema = (RecordSchema)AvroSchema.Parse(IntegrationSchema);
+        var validRecord = new GenericRecord(schema);
+        validRecord.Add("age", 1);
+        var invalidRecord = new GenericRecord(schema);
+        invalidRecord.Add("age", -1);
+        var validPayload = Serialize(validRecord, schema);
+        var invalidPayload = Serialize(invalidRecord, schema);
+        var calls = new List<string>();
+        var schemaId = await registry.RegisterSchemaAsync(
+            "validation-topic-value",
+            new Dekaf.SchemaRegistry.Schema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = IntegrationSchema,
+                RuleSet = new SchemaRuleSet
+                {
+                    DomainRules = [CreateRule("domain", "DOMAIN", SchemaRuleMode.WriteRead)],
+                    EncodingRules = [CreateRule("encoding", "ENCODING", SchemaRuleMode.WriteRead)],
+                    HasFixedRuleCollections = true
+                }
+            });
+        var executor = new SchemaRegistryRuleExecutor([
+            new ReplacingRuleHandler("DOMAIN", validPayload, validPayload, calls),
+            new ReplacingRuleHandler("ENCODING", "encoded"u8.ToArray(), invalidPayload, calls)
+        ]);
+        await using var afterSerializer = new AvroSchemaRegistrySerializer<GenericRecord>(
+            registry,
+            new AvroSerializerConfig
+            {
+                AutoRegisterSchemas = false,
+                RuleExecutor = executor,
+                ValidationRulesExecution = ValidationRulesExecution.AfterDomainRules
+            });
+        var destination = new ArrayBufferWriter<byte>();
+
+        afterSerializer.Serialize(invalidRecord, ref destination, CreateContext());
+
+        await Assert.That(calls).IsEquivalentTo(["domain", "encoding"]);
+        calls.Clear();
+        await using var beforeSerializer = new AvroSchemaRegistrySerializer<GenericRecord>(
+            registry,
+            new AvroSerializerConfig
+            {
+                AutoRegisterSchemas = false,
+                RuleExecutor = executor,
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
+        var rejected = new ArrayBufferWriter<byte>();
+        Assert.Throws<ValidationRulesFailedException>(() =>
+            beforeSerializer.Serialize(invalidRecord, ref rejected, CreateContext()));
+        await Assert.That(calls).IsEmpty();
+
+        await using var afterDeserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(
+            registry,
+            new AvroDeserializerConfig
+            {
+                RuleExecutor = executor,
+                ValidationRulesExecution = ValidationRulesExecution.AfterDomainRules
+            });
+        var result = afterDeserializer.Deserialize(
+            CreateWireBytes(schemaId, "encoded"u8),
+            CreateContext());
+        await Assert.That(result["age"]).IsEqualTo(1);
+        await Assert.That(calls).IsEquivalentTo(["encoding", "domain"]);
+        calls.Clear();
+        await using var beforeDeserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(
+            registry,
+            new AvroDeserializerConfig
+            {
+                RuleExecutor = executor,
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
+        Assert.Throws<ValidationRulesFailedException>(() => beforeDeserializer.Deserialize(
+            CreateWireBytes(schemaId, "encoded"u8),
+            CreateContext()));
+        await Assert.That(calls).IsEquivalentTo(["encoding"]);
+    }
+
+    [Test]
+    public async Task Deserializer_InlineRulesHonorMigrationBoundary()
+    {
+        using var registry = new MockSchemaRegistryClient();
+        var schema = (RecordSchema)AvroSchema.Parse(IntegrationSchema);
+        var invalid = new GenericRecord(schema);
+        invalid.Add("age", -1);
+        var valid = new GenericRecord(schema);
+        valid.Add("age", 1);
+        var writerSchemaId = await registry.RegisterSchemaAsync(
+            "validation-topic-value",
+            new Dekaf.SchemaRegistry.Schema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = IntegrationSchema
+            });
+        _ = await registry.RegisterSchemaAsync(
+            "validation-topic-value",
+            new Dekaf.SchemaRegistry.Schema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = IntegrationSchema,
+                RuleSet = new SchemaRuleSet
+                {
+                    MigrationRules = [CreateRule("upgrade", "MIGRATION", SchemaRuleMode.Upgrade)]
+                }
+            });
+        var calls = new List<string>();
+        var executor = new SchemaRegistryRuleExecutor([
+            new ReplacingRuleHandler("MIGRATION", Serialize(valid, schema), Serialize(valid, schema), calls)
+        ]);
+        var wire = CreateWireBytes(writerSchemaId, Serialize(invalid, schema));
+        await using var after = new AvroSchemaRegistryDeserializer<GenericRecord>(
+            registry,
+            new AvroDeserializerConfig
+            {
+                UseLatestVersion = true,
+                RuleExecutor = executor,
+                ValidationRulesExecution = ValidationRulesExecution.AfterDomainRules
+            });
+
+        var result = after.Deserialize(wire, CreateContext());
+
+        await Assert.That(result["age"]).IsEqualTo(1);
+        await Assert.That(calls).IsEquivalentTo(["upgrade"]);
+        calls.Clear();
+        await using var before = new AvroSchemaRegistryDeserializer<GenericRecord>(
+            registry,
+            new AvroDeserializerConfig
+            {
+                UseLatestVersion = true,
+                RuleExecutor = executor,
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
+        Assert.Throws<ValidationRulesFailedException>(() => before.Deserialize(wire, CreateContext()));
+        await Assert.That(calls).IsEmpty();
+    }
+
+    [Test]
+    public async Task Validate_WarmedValidPayloadAllocatesZeroBytes()
+    {
+        var schema = (RecordSchema)AvroSchema.Parse(IntegrationSchema);
+        var record = new GenericRecord(schema);
+        record.Add("age", 42);
+        var payload = Serialize(record, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+        validator.Validate(payload, 23, failFast: false);
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 23, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Validate_UnionBranchWithoutReferencedMemberTreatsItAsMissing()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "UnionMissingRecord",
+              "confluent:rules": [{ "name": "missing", "expr": "!has(this.value.code)" }],
+              "fields": [{
+                "name": "value",
+                "type": [
+                  { "type": "record", "name": "WithCode", "fields": [{ "name": "code", "type": "int" }] },
+                  { "type": "record", "name": "WithoutCode", "fields": [{ "name": "name", "type": "string" }] }
+                ]
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var branch = (RecordSchema)((UnionSchema)schema.Fields[0].Schema)[1];
+        var value = new GenericRecord(branch);
+        value.Add("name", "dekaf");
+        var record = new GenericRecord(schema);
+        record.Add("value", value);
+
+        new AvroInlineRuleValidator(schema).Validate(Serialize(record, schema), 24, failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Validate_ResolvedNamedReferenceUsesReferencedRules()
+    {
+        var names = new SchemaNames();
+        _ = AvroSchema.Parse(
+            """
+            {"type":"record","name":"ReferencedChild","namespace":"Dekaf.Tests","fields":[{"name":"code","type":"int","confluent:rules":[{"name":"code","expr":"this > 0"}]}]}
+            """,
+            names);
+        var schema = (RecordSchema)AvroSchema.Parse(
+            """
+            {"type":"record","name":"ReferenceRoot","namespace":"Dekaf.Tests","fields":[{"name":"child","type":"Dekaf.Tests.ReferencedChild"}]}
+            """,
+            names);
+        var childSchema = (RecordSchema)schema.Fields[0].Schema;
+        var child = new GenericRecord(childSchema);
+        child.Add("code", -1);
+        var record = new GenericRecord(schema);
+        record.Add("child", child);
+
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            new AvroInlineRuleValidator(schema).Validate(Serialize(record, schema), 25, failFast: false));
+
+        await Assert.That(exception.Message).Contains("$.child.code: code");
+    }
+
+    [Test]
+    public async Task SpecificRecordSerializer_UsesSameBinaryValidationPlan()
+    {
+        await using var serializer = new AvroSchemaRegistrySerializer<InlineSpecificRecord>(
+            new MockSchemaRegistryClient(),
+            new AvroSerializerConfig
+            {
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
+        var destination = new ArrayBufferWriter<byte>();
+
+        Assert.Throws<ValidationRulesFailedException>(() =>
+            serializer.Serialize(new InlineSpecificRecord { Age = -1 }, ref destination, CreateContext()));
+
+        await Assert.That(destination.WrittenCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Provider_WarmedRegisteredSchemaLookupAllocatesZeroBytes()
+    {
+        var avroSchema = AvroSchema.Parse(IntegrationSchema);
+        var registrySchema = new Dekaf.SchemaRegistry.Schema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = IntegrationSchema
+        };
+        var provider = new AvroInlineRuleValidatorProvider();
+        _ = provider.Register(registrySchema, avroSchema);
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            _ = provider.Register(registrySchema, avroSchema);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    private static byte[] Serialize(GenericRecord record, RecordSchema schema)
+    {
+        using var stream = new MemoryStream();
+        var encoder = new BinaryEncoder(stream);
+        new GenericDatumWriter<GenericRecord>(schema).Write(record, encoder);
+        encoder.Flush();
+        return stream.ToArray();
+    }
+
+    private static byte[] CreateWireBytes(int schemaId, ReadOnlySpan<byte> payload)
+    {
+        var result = new byte[5 + payload.Length];
+        BinaryPrimitives.WriteInt32BigEndian(result.AsSpan(1, 4), schemaId);
+        payload.CopyTo(result.AsSpan(5));
+        return result;
+    }
+
+    private static SerializationContext CreateContext() => new()
+    {
+        Topic = "validation-topic",
+        Component = SerializationComponent.Value
+    };
+
+    private static SchemaRule CreateRule(string name, string type, SchemaRuleMode mode) => new()
+    {
+        Name = name,
+        Type = type,
+        Kind = SchemaRuleKind.Transform,
+        Mode = mode
+    };
+
+    private sealed class ReplacingRuleHandler(
+        string type,
+        ReadOnlyMemory<byte> serializedReplacement,
+        ReadOnlyMemory<byte> deserializedReplacement,
+        List<string> calls) : ISchemaRegistryRuleHandler
+    {
+        public string Type => type;
+
+        public ReadOnlyMemory<byte> TransformSerializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context)
+        {
+            calls.Add(context.Rule.Name);
+            return serializedReplacement;
+        }
+
+        public ReadOnlyMemory<byte> TransformDeserializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context)
+        {
+            calls.Add(context.Rule.Name);
+            return deserializedReplacement;
+        }
+    }
+
+    private sealed class PassThroughRuleExecutor : ISchemaRegistryRuleExecutor
+    {
+        public ReadOnlyMemory<byte> TransformSerializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleContext context) => payload;
+
+        public ReadOnlyMemory<byte> TransformDeserializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleContext context) => payload;
+    }
+}
+
+internal sealed record InlineRulePoco(int Age);
+
+internal readonly struct InlineRulePocoCodec : IAvroPocoCodec<InlineRulePoco>
+{
+    private static readonly AvroPocoField[] s_fields =
+    [
+        new(
+            "age",
+            ReadOnlyMemory<string>.Empty,
+            defaultJson: null,
+            new AvroPocoType(AvroPocoTypeKind.Int))
+    ];
+
+    public static string SchemaJson =>
+        """
+        {"type":"record","name":"InlineRulePoco","namespace":"Dekaf.Tests","fields":[{"name":"age","type":"int","confluent:rules":[{"name":"age","expr":"this >= 0"}]}]}
+        """;
+
+    public static ReadOnlySpan<byte> SchemaUtf8 =>
+        """{"type":"record","name":"InlineRulePoco","namespace":"Dekaf.Tests","fields":[{"name":"age","type":"int","confluent:rules":[{"name":"age","expr":"this >= 0"}]}]}"""u8;
+
+    public static long ParsingFingerprint64 => 0;
+    public static string FullName => "Dekaf.Tests.InlineRulePoco";
+    public static ReadOnlyMemory<AvroPocoField> Fields => s_fields;
+
+    public static void Write(ref AvroValueWriter writer, InlineRulePoco value) =>
+        writer.WriteInt32(value.Age);
+
+    public static InlineRulePoco Read(ref AvroValueReader reader, AvroPocoReaderPlan plan) =>
+        new(reader.ReadInt32());
+}
+
+internal sealed class InlineSpecificRecord : ISpecificRecord
+{
+    public static readonly AvroSchema _SCHEMA = AvroSchema.Parse(
+        """
+        {"type":"record","name":"InlineSpecificRecord","namespace":"Dekaf.Tests","fields":[{"name":"age","type":"int","confluent:rules":[{"name":"age","expr":"this >= 0"}]}]}
+        """);
+
+    public int Age { get; set; }
+    public AvroSchema Schema => _SCHEMA;
+
+    public object Get(int fieldPos)
+    {
+        ArgumentOutOfRangeException.ThrowIfNotEqual(fieldPos, 0);
+        return Age;
+    }
+
+    public void Put(int fieldPos, object fieldValue)
+    {
+        ArgumentOutOfRangeException.ThrowIfNotEqual(fieldPos, 0);
+        Age = (int)fieldValue;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -482,6 +482,30 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_IdenticallyEncodedRootNaNAggregateUsesSemanticEquality()
+    {
+        const string schemaText = """
+            {
+              "type": "array",
+              "items": "double",
+              "confluent:rules": [{ "name": "not-equal", "expr": "this != this" }]
+            }
+            """;
+        var schema = (ArraySchema)AvroSchema.Parse(schemaText);
+        using var stream = new MemoryStream();
+        var encoder = new BinaryEncoder(stream);
+        new GenericDatumWriter<object>(schema).Write(new[] { double.NaN }, encoder);
+        encoder.Flush();
+
+        new AvroInlineRuleValidator(schema).Validate(
+            stream.ToArray(),
+            36,
+            failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
     public async Task Validate_ArrayRuleWithoutSizeDoesNotRequireSizeStorage()
     {
         const string schemaText = """
@@ -522,12 +546,18 @@ public class AvroInlineRuleValidatorTests
         var record = new GenericRecord(schema);
         var validator = new AvroInlineRuleValidator(schema);
         record.Add("status", new GenericEnum(enumSchema, "OPEN"));
+        var payload = Serialize(record, schema);
 
-        validator.Validate(Serialize(record, schema), 34, failFast: false);
+        validator.Validate(payload, 34, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 34, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
 
         record.Add("status", new GenericEnum(enumSchema, "CLOSED"));
         var exception = Assert.Throws<ValidationRulesFailedException>(() =>
             validator.Validate(Serialize(record, schema), 34, failFast: false));
+        await Assert.That(allocated).IsEqualTo(0);
         await Assert.That(exception.Message).Contains("$.status: open");
     }
 

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -115,6 +115,44 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_RecordSizeUsesFieldCount()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "SizedRecord",
+              "confluent:rules": [{ "name": "record-size", "expr": "size(this) == 2" }],
+              "fields": [
+                { "name": "id", "type": "int" },
+                {
+                  "name": "child",
+                  "type": {
+                    "type": "record",
+                    "name": "SizedChild",
+                    "fields": [{ "name": "name", "type": "string" }]
+                  },
+                  "confluent:rules": [{ "name": "child-size", "expr": "size(this) == 1" }]
+                }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var childSchema = (RecordSchema)schema.Fields[1].Schema;
+        var child = new GenericRecord(childSchema);
+        child.Add("name", "value");
+        var record = new GenericRecord(schema);
+        record.Add("id", 1);
+        record.Add("child", child);
+
+        new AvroInlineRuleValidator(schema).Validate(
+            Serialize(record, schema),
+            18,
+            failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
     public async Task Validate_FloatingArithmeticPreservesFloatingOperands()
     {
         const string schemaText = """
@@ -636,6 +674,89 @@ public class AvroInlineRuleValidatorTests
             });
         Assert.Throws<ValidationRulesFailedException>(() => before.Deserialize(wire, CreateContext()));
         await Assert.That(calls).IsEmpty();
+    }
+
+    [Test]
+    public async Task Deserializer_BeforeDomainMigrationResolvesTargetReferences()
+    {
+        const string childSchemaText = """
+            {"type":"record","name":"ReferencedChild","namespace":"Dekaf.Tests","fields":[{"name":"code","type":"int","confluent:rules":[{"name":"code-positive","expr":"this > 0"}]}]}
+            """;
+        const string writerSchemaText = """
+            {"type":"record","name":"MigrationReferenceRoot","namespace":"Dekaf.Tests","fields":[{"name":"age","type":"int"}]}
+            """;
+        const string targetSchemaText = """
+            {"type":"record","name":"MigrationReferenceRoot","namespace":"Dekaf.Tests","fields":[{"name":"child","type":"Dekaf.Tests.ReferencedChild"}]}
+            """;
+        using var registry = new MockSchemaRegistryClient();
+        _ = await registry.RegisterSchemaAsync(
+            "referenced-child",
+            new Dekaf.SchemaRegistry.Schema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = childSchemaText
+            });
+        var writerSchemaId = await registry.RegisterSchemaAsync(
+            "validation-topic-value",
+            new Dekaf.SchemaRegistry.Schema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = writerSchemaText
+            });
+        _ = await registry.RegisterSchemaAsync(
+            "validation-topic-value",
+            new Dekaf.SchemaRegistry.Schema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = targetSchemaText,
+                References =
+                [
+                    new SchemaReference
+                    {
+                        Name = "Dekaf.Tests.ReferencedChild",
+                        Subject = "referenced-child",
+                        Version = 1
+                    }
+                ],
+                RuleSet = new SchemaRuleSet
+                {
+                    MigrationRules = [CreateRule("upgrade", "MIGRATION", SchemaRuleMode.Upgrade)]
+                }
+            });
+        var names = new SchemaNames();
+        _ = AvroSchema.Parse(childSchemaText, names);
+        var targetSchema = (RecordSchema)AvroSchema.Parse(targetSchemaText, names);
+        var childSchema = (RecordSchema)targetSchema.Fields[0].Schema;
+        var child = new GenericRecord(childSchema);
+        child.Add("code", 1);
+        var target = new GenericRecord(targetSchema);
+        target.Add("child", child);
+        var writerSchema = (RecordSchema)AvroSchema.Parse(writerSchemaText);
+        var writer = new GenericRecord(writerSchema);
+        writer.Add("age", 1);
+        var calls = new List<string>();
+        var executor = new SchemaRegistryRuleExecutor([
+            new ReplacingRuleHandler(
+                "MIGRATION",
+                Serialize(target, targetSchema),
+                Serialize(target, targetSchema),
+                calls)
+        ]);
+        await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(
+            registry,
+            new AvroDeserializerConfig
+            {
+                UseLatestVersion = true,
+                RuleExecutor = executor,
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
+
+        var result = deserializer.Deserialize(
+            CreateWireBytes(writerSchemaId, Serialize(writer, writerSchema)),
+            CreateContext());
+
+        await Assert.That(((GenericRecord)result["child"])["code"]).IsEqualTo(1);
+        await Assert.That(calls).IsEquivalentTo(["upgrade"]);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -1425,6 +1425,53 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_AggregateEqualityRejectsExcessiveRecursionDepth()
+    {
+        var schema = AvroSchema.Parse(
+            """
+            {
+              "type": "record",
+              "name": "RecursiveEqualityNode",
+              "fields": [
+                { "name": "value", "type": "double" },
+                { "name": "children", "type": { "type": "map", "values": "RecursiveEqualityNode" } }
+              ]
+            }
+            """);
+        var comparer = new AvroAggregateEqualityComparerFactory().Create(schema)!;
+        var payload = new ArrayBufferWriter<byte>();
+        for (var depth = 0; depth <= AvroAggregateEqualityComparer.MaximumComparisonDepth; depth++)
+        {
+            var node = payload.GetSpan(sizeof(double));
+            BinaryPrimitives.WriteDoubleLittleEndian(node, 1d);
+            payload.Advance(sizeof(double));
+            if (depth == AvroAggregateEqualityComparer.MaximumComparisonDepth)
+            {
+                payload.GetSpan(1)[0] = 0;
+                payload.Advance(1);
+                continue;
+            }
+            var child = payload.GetSpan(3);
+            child[0] = 2;
+            child[1] = 2;
+            child[2] = (byte)'x';
+            payload.Advance(3);
+        }
+        payload.GetSpan(AvroAggregateEqualityComparer.MaximumComparisonDepth)
+            [..AvroAggregateEqualityComparer.MaximumComparisonDepth]
+            .Clear();
+        payload.Advance(AvroAggregateEqualityComparer.MaximumComparisonDepth);
+
+        var exception = Assert.Throws<SchemaRegistryRuleException>(() =>
+            ((IValidationCelAggregateComparer)comparer).AreEqual(
+                payload.WrittenMemory,
+                comparer,
+                payload.WrittenMemory));
+
+        await Assert.That(exception.Message).Contains("recursion exceeds");
+    }
+
+    [Test]
     public async Task Validate_ConditionalAggregateEqualityUsesSelectedComparer()
     {
         const string schemaText = """

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -74,11 +74,16 @@ public class AvroInlineRuleValidatorTests
 
         var exception = Assert.Throws<ValidationRulesFailedException>(() =>
             validator.Validate(Serialize(record, schema), 17, failFast: false));
+        var failFastException = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 17, failFast: true));
 
         await Assert.That(exception.Violations.Count).IsEqualTo(3);
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("root");
         await Assert.That(exception.Message).Contains("$: root");
         await Assert.That(exception.Message).Contains("$.items[1]: positive");
         await Assert.That(exception.Message).Contains("$.labels[\"region\"]: label");
+        await Assert.That(failFastException.Violations.Count).IsEqualTo(1);
+        await Assert.That(failFastException.Violations[0].Rule.Name).IsEqualTo("root");
     }
 
     [Test]
@@ -1223,6 +1228,36 @@ public class AvroInlineRuleValidatorTests
             validator.Validate(Serialize(record, resolvedSchema), 29, failFast: false));
 
         await Assert.That(exception.Message).Contains("$.child.code: code");
+    }
+
+    [Test]
+    public async Task Provider_RegisteredSchemaIgnoresUnusedReference()
+    {
+        const string rootSchemaText = """
+            {"type":"record","name":"ReferenceRoot","namespace":"Dekaf.Tests","fields":[{"name":"code","type":"int","confluent:rules":[{"name":"code","expr":"this > 0"}]}]}
+            """;
+        var resolvedSchema = (RecordSchema)AvroSchema.Parse(rootSchemaText);
+        var registrySchema = new Dekaf.SchemaRegistry.Schema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = rootSchemaText,
+            References =
+            [
+                new SchemaReference
+                {
+                    Name = "Dekaf.Tests.UnusedChild",
+                    Subject = "unused-child",
+                    Version = 1
+                }
+            ]
+        };
+        var record = new GenericRecord(resolvedSchema);
+        record.Add("code", 1);
+        var validator = new AvroInlineRuleValidatorProvider().Register(registrySchema, resolvedSchema);
+
+        validator.Validate(Serialize(record, resolvedSchema), 30, failFast: false);
+
+        await Assert.That(validator).IsNotNull();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -890,6 +890,37 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_OverlappingUnionComparerGroupsUsePairCompatibility()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "OverlappingUnionAggregateEqualityRecord",
+              "confluent:rules": [{ "name": "equal", "expr": "this.bridge == this.right" }],
+              "fields": [
+                { "name": "left", "type": { "type": "array", "items": "int" } },
+                { "name": "bridge", "type": { "type": "array", "items": ["int", "string"] } },
+                { "name": "right", "type": { "type": "array", "items": "string" } }
+              ]
+            }
+            """;
+        var validator = new AvroInlineRuleValidator(AvroSchema.Parse(schemaText));
+        ReadOnlyMemory<byte> payload = new byte[]
+        {
+            0,
+            2, 2, 2, (byte)'x', 0,
+            2, 2, (byte)'x', 0
+        };
+
+        validator.Validate(payload, 27, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 27, failFast: false);
+
+        await Assert.That(GC.GetAllocatedBytesForCurrentThread() - before).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Validate_BytesLiteralDecodesHexEscapes()
     {
         const string schemaText = """

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -426,6 +426,65 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_ConditionalAggregateEqualityUsesSelectedComparer()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "ConditionalAggregateEqualityRecord",
+              "confluent:rules": [{
+                "name": "equal",
+                "expr": "(true ? this.left : this.right) == this.right"
+              }],
+              "fields": [
+                { "name": "left", "type": { "type": "array", "items": "int" } },
+                { "name": "right", "type": { "type": "array", "items": "int" } }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        ReadOnlyMemory<byte> payload = new byte[]
+        {
+            4, 2, 4, 0,
+            2, 2, 2, 4, 0
+        };
+
+        new AvroInlineRuleValidator(schema).Validate(payload, 37, failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Validate_ConditionalAggregateEqualityPreservesNaNSemantics()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "ConditionalNaNAggregateEqualityRecord",
+              "confluent:rules": [{
+                "name": "not-equal",
+                "expr": "(true ? this.left : this.right) != this.right"
+              }],
+              "fields": [
+                { "name": "left", "type": { "type": "array", "items": "double" } },
+                { "name": "right", "type": { "type": "array", "items": "double" } }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("left", new[] { double.NaN });
+        record.Add("right", new[] { double.NaN });
+
+        new AvroInlineRuleValidator(schema).Validate(
+            Serialize(record, schema),
+            38,
+            failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
     public async Task Validate_NaNIsUnequalAndUnordered()
     {
         const string schemaText = """

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -115,6 +115,85 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_FloatingArithmeticPreservesFloatingOperands()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "FloatingRuleRecord",
+              "fields": [{
+                "name": "value",
+                "type": "double",
+                "confluent:rules": [{ "name": "arithmetic", "expr": "this + 1.0 > 0 && this - 1.0 < 0" }]
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("value", 0.5d);
+
+        new AvroInlineRuleValidator(schema).Validate(
+            Serialize(record, schema),
+            26,
+            failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Validate_EqualAggregateMembersUseAvroValues()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "AggregateEqualityRecord",
+              "confluent:rules": [{ "name": "equal", "expr": "this.left == this.right" }],
+              "fields": [
+                { "name": "left", "type": { "type": "array", "items": "int" } },
+                { "name": "right", "type": { "type": "array", "items": "int" } }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        var left = new[] { 1, 2 };
+        var equalRight = new[] { 1, 2 };
+        record.Add("left", left);
+        record.Add("right", equalRight);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        validator.Validate(Serialize(record, schema), 27, failFast: false);
+
+        var unequalRight = new[] { 1, 3 };
+        record.Add("right", unequalRight);
+        Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 27, failFast: false));
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Validate_ArrayRuleWithoutSizeDoesNotRequireSizeStorage()
+    {
+        const string schemaText = """
+            {
+              "type": "array",
+              "items": "int",
+              "confluent:rules": [{ "name": "always", "expr": "true" }]
+            }
+            """;
+        var schema = (ArraySchema)AvroSchema.Parse(schemaText);
+        using var stream = new MemoryStream();
+        var encoder = new BinaryEncoder(stream);
+        var values = new[] { 1, 2 };
+        new GenericDatumWriter<object>(schema).Write(values, encoder);
+        encoder.Flush();
+
+        new AvroInlineRuleValidator(schema).Validate(stream.ToArray(), 28, failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
     public async Task Serializer_EnabledValidationRejectsInvalidGenericRecord()
     {
         var schema = (RecordSchema)AvroSchema.Parse(IntegrationSchema);
@@ -132,6 +211,43 @@ public class AvroInlineRuleValidatorTests
             serializer.Serialize(record, ref destination, CreateContext()));
 
         await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("age");
+        await Assert.That(destination.WrittenCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Serializer_UsesRulesFromResolvedRegistrySchema()
+    {
+        const string runtimeSchemaText = """
+            {
+              "type": "record",
+              "name": "IntegratedRuleRecord",
+              "fields": [{ "name": "age", "type": "int" }]
+            }
+            """;
+        using var registry = new MockSchemaRegistryClient();
+        _ = await registry.RegisterSchemaAsync(
+            "validation-topic-value",
+            new Dekaf.SchemaRegistry.Schema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = IntegrationSchema
+            });
+        var runtimeSchema = (RecordSchema)AvroSchema.Parse(runtimeSchemaText);
+        var record = new GenericRecord(runtimeSchema);
+        record.Add("age", -1);
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(
+            registry,
+            new AvroSerializerConfig
+            {
+                AutoRegisterSchemas = false,
+                UseLatestVersion = true,
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
+        var destination = new ArrayBufferWriter<byte>();
+
+        Assert.Throws<ValidationRulesFailedException>(() =>
+            serializer.Serialize(record, ref destination, CreateContext()));
+
         await Assert.That(destination.WrittenCount).IsEqualTo(0);
     }
 
@@ -209,6 +325,7 @@ public class AvroInlineRuleValidatorTests
         Assert.Throws<ValidationRulesFailedException>(() =>
             serializer.Serialize(new InlineRulePoco(-1), ref destination, CreateContext()));
 
+        // Avro zigzag varint 0x01 decodes to -1, which violates the age rule.
         var payload = new byte[] { 1 };
         await using var deserializer = new AvroPocoSchemaRegistryDeserializer<
             InlineRulePoco,
@@ -433,6 +550,45 @@ public class AvroInlineRuleValidatorTests
 
         var exception = Assert.Throws<ValidationRulesFailedException>(() =>
             new AvroInlineRuleValidator(schema).Validate(Serialize(record, schema), 25, failFast: false));
+
+        await Assert.That(exception.Message).Contains("$.child.code: code");
+    }
+
+    [Test]
+    public async Task Provider_RegisteredSchemaPreservesResolvedReferenceRules()
+    {
+        const string referenceSchemaText = """
+            {"type":"record","name":"ReferencedChild","namespace":"Dekaf.Tests","fields":[{"name":"code","type":"int","confluent:rules":[{"name":"code","expr":"this > 0"}]}]}
+            """;
+        const string rootSchemaText = """
+            {"type":"record","name":"ReferenceRoot","namespace":"Dekaf.Tests","fields":[{"name":"child","type":"Dekaf.Tests.ReferencedChild"}]}
+            """;
+        var names = new SchemaNames();
+        _ = AvroSchema.Parse(referenceSchemaText, names);
+        var resolvedSchema = (RecordSchema)AvroSchema.Parse(rootSchemaText, names);
+        var registrySchema = new Dekaf.SchemaRegistry.Schema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = rootSchemaText,
+            References =
+            [
+                new SchemaReference
+                {
+                    Name = "Dekaf.Tests.ReferencedChild",
+                    Subject = "referenced-child",
+                    Version = 1
+                }
+            ]
+        };
+        var childSchema = (RecordSchema)resolvedSchema.Fields[0].Schema;
+        var child = new GenericRecord(childSchema);
+        child.Add("code", -1);
+        var record = new GenericRecord(resolvedSchema);
+        record.Add("child", child);
+        var validator = new AvroInlineRuleValidatorProvider().Register(registrySchema, resolvedSchema);
+
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, resolvedSchema), 29, failFast: false));
 
         await Assert.That(exception.Message).Contains("$.child.code: code");
     }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -2165,9 +2165,11 @@ public class AvroInlineRuleValidatorTests
                 ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
             });
 
-        var result = deserializer.Deserialize(
-            CreateWireBytes(writerSchemaId, Serialize(writer, writerSchema)),
-            CreateContext());
+        var wire = CreateWireBytes(writerSchemaId, Serialize(writer, writerSchema));
+        var context = CreateContext();
+        var preparer = (IAsyncDeserializerPreparer<GenericRecord>)deserializer;
+        await preparer.PrepareAsync(wire, context);
+        await Assert.That(preparer.TryDeserialize(wire, context, out var result)).IsTrue();
 
         await Assert.That(((GenericRecord)result["child"])["code"]).IsEqualTo(1);
         await Assert.That(calls).IsEquivalentTo(["upgrade"]);

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -671,6 +671,67 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_EqualRecordsMatchFieldsByName()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "ReorderedRecordEquality",
+              "confluent:rules": [{ "name": "equal", "expr": "this.left == this.right" }],
+              "fields": [
+                {
+                  "name": "left",
+                  "type": {
+                    "type": "record",
+                    "name": "LeftRecord",
+                    "fields": [
+                      { "name": "a", "type": "int" },
+                      { "name": "b", "type": "string" }
+                    ]
+                  }
+                },
+                {
+                  "name": "right",
+                  "type": {
+                    "type": "record",
+                    "name": "RightRecord",
+                    "fields": [
+                      { "name": "b", "type": "string" },
+                      { "name": "a", "type": "int" }
+                    ]
+                  }
+                }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var leftSchema = (RecordSchema)schema.Fields[0].Schema;
+        var rightSchema = (RecordSchema)schema.Fields[1].Schema;
+        var left = new GenericRecord(leftSchema);
+        left.Add("a", 1);
+        left.Add("b", "value");
+        var right = new GenericRecord(rightSchema);
+        right.Add("b", "value");
+        right.Add("a", 1);
+        var record = new GenericRecord(schema);
+        record.Add("left", left);
+        record.Add("right", right);
+        var validator = new AvroInlineRuleValidator(schema);
+        var payload = Serialize(record, schema);
+
+        validator.Validate(payload, 27, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 27, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        right.Add("a", 2);
+        Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 27, failFast: false));
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Validate_IdenticallyEncodedAggregatesRequireCompatibleSchemas()
     {
         const string schemaText = """

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -758,6 +758,39 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_NullableAggregateFieldRuleAndParentSizeAllocateZeroBytes()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "NullableAggregateFieldRuleRecord",
+              "confluent:rules": [{
+                "name": "member-size",
+                "expr": "size(this) == 1 && size(this.items) == 128 && this.items == this.items"
+              }],
+              "fields": [{
+                "name": "items",
+                "type": ["null", { "type": "array", "items": "int" }],
+                "confluent:rules": [{ "name": "field-present", "expr": "this == this" }]
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("items", Enumerable.Range(1, 128).ToArray());
+        var payload = Serialize(record, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+        validator.Validate(payload, 38, failFast: false);
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 38, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Validate_ConditionalSizeCountsOnlySelectedAggregate()
     {
         const string schemaText = """

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -179,6 +179,53 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_AggregateFieldMemberAndNestedRulesShareTraversal()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "FieldMemberNestedRuleRecord",
+              "fields": [{
+                "name": "child",
+                "confluent:rules": [{ "name": "field-member", "expr": "this.code > 0" }],
+                "type": {
+                  "type": "record",
+                  "name": "FieldMemberNestedRuleChild",
+                  "fields": [{
+                    "name": "code",
+                    "type": "int",
+                    "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                  }]
+                }
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var childSchema = (RecordSchema)schema.Fields[0].Schema;
+        var child = new GenericRecord(childSchema);
+        child.Add("code", 1);
+        var record = new GenericRecord(schema);
+        record.Add("child", child);
+        var payload = Serialize(record, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        validator.Validate(payload, 28, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 28, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        child.Add("code", -1);
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 28, failFast: false));
+
+        await Assert.That(allocated).IsEqualTo(0);
+        await Assert.That(exception.Violations.Count).IsEqualTo(2);
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("field-member");
+        await Assert.That(exception.Violations[1].Rule.Name).IsEqualTo("positive");
+    }
+
+    [Test]
     public async Task Validate_MixedParentAndNestedMemberRulesPreserveParentMembers()
     {
         const string schemaText = """
@@ -391,7 +438,11 @@ public class AvroInlineRuleValidatorTests
                 "type": ["null", {
                   "type": "record",
                   "name": "NullableFieldRuleChild",
-                  "fields": [{ "name": "code", "type": "int" }]
+                  "fields": [{
+                    "name": "code",
+                    "type": "int",
+                    "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                  }]
                 }],
                 "confluent:rules": [{ "name": "code", "expr": "this.code == 7" }]
               }]
@@ -405,12 +456,17 @@ public class AvroInlineRuleValidatorTests
         var validator = new AvroInlineRuleValidator(schema);
 
         child.Add("code", 7);
-        validator.Validate(Serialize(record, schema), 18, failFast: false);
+        var payload = Serialize(record, schema);
+        validator.Validate(payload, 18, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 18, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
 
         child.Add("code", 8);
         Assert.Throws<ValidationRulesFailedException>(() =>
             validator.Validate(Serialize(record, schema), 18, failFast: false));
-        await Task.CompletedTask;
+        await Assert.That(allocated).IsEqualTo(0);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -275,6 +275,56 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_EnumRuleUsesSymbolName()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "EnumRuleRecord",
+              "fields": [{
+                "name": "status",
+                "type": { "type": "enum", "name": "Status", "symbols": ["OPEN", "CLOSED"] },
+                "confluent:rules": [{ "name": "open", "expr": "this == 'OPEN'" }]
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var enumSchema = (EnumSchema)schema.Fields[0].Schema;
+        var record = new GenericRecord(schema);
+        var validator = new AvroInlineRuleValidator(schema);
+        record.Add("status", new GenericEnum(enumSchema, "OPEN"));
+
+        validator.Validate(Serialize(record, schema), 34, failFast: false);
+
+        record.Add("status", new GenericEnum(enumSchema, "CLOSED"));
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 34, failFast: false));
+        await Assert.That(exception.Message).Contains("$.status: open");
+    }
+
+    [Test]
+    public async Task Validate_InvalidEnumOrdinalIsRejected()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "InvalidEnumRuleRecord",
+              "fields": [{
+                "name": "status",
+                "type": { "type": "enum", "name": "State", "symbols": ["ON", "OFF"] },
+                "confluent:rules": [{ "name": "known", "expr": "true" }]
+              }]
+            }
+            """;
+        var validator = new AvroInlineRuleValidator(AvroSchema.Parse(schemaText));
+
+        var exception = Assert.Throws<SchemaRegistryRuleException>(() =>
+            validator.Validate(new byte[] { 4 }, 35, failFast: false));
+
+        await Assert.That(exception.Message).Contains("invalid enum index 2");
+    }
+
+    [Test]
     public async Task Serializer_EnabledValidationRejectsInvalidGenericRecord()
     {
         var schema = (RecordSchema)AvroSchema.Parse(IntegrationSchema);
@@ -420,6 +470,32 @@ public class AvroInlineRuleValidatorTests
             deserializer.Deserialize(CreateWireBytes(schemaId, payload), CreateContext()));
 
         await Assert.That(destination.WrittenCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task PocoPreparedDeserializer_AppliesInlineRules()
+    {
+        using var registry = new MockSchemaRegistryClient();
+        var schemaId = await registry.RegisterSchemaAsync(
+            "validation-topic-value",
+            new Dekaf.SchemaRegistry.Schema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = InlineRulePocoCodec.SchemaJson
+            });
+        await using var deserializer = new AvroPocoSchemaRegistryDeserializer<
+            InlineRulePoco,
+            InlineRulePocoCodec>(
+                registry,
+                new AvroDeserializerConfig
+                {
+                    ValidationRulesExecution = ValidationRulesExecution.AfterDomainRules
+                });
+        await deserializer.WarmupAsync(schemaId);
+        var preparer = (IAsyncDeserializerPreparer<InlineRulePoco>)deserializer;
+
+        Assert.Throws<ValidationRulesFailedException>(() =>
+            preparer.TryDeserialize(CreateWireBytes(schemaId, [1]), CreateContext(), out _));
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -1637,6 +1637,51 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_RecursivePayloadRejectsExcessiveValidationDepth()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "RecursiveValidationNode",
+              "fields": [
+                {
+                  "name": "value",
+                  "type": "int",
+                  "confluent:rules": [{ "name": "nonnegative", "expr": "this >= 0" }]
+                },
+                { "name": "next", "type": ["null", "RecursiveValidationNode"] }
+              ]
+            }
+            """;
+        var schema = AvroSchema.Parse(schemaText);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        validator.Validate(
+            CreatePayload(AvroInlineRuleValidator.MaximumValidationDepth),
+            31,
+            failFast: false);
+        var exception = Assert.Throws<SchemaRegistryRuleException>(() =>
+            validator.Validate(
+                CreatePayload(AvroInlineRuleValidator.MaximumValidationDepth + 1),
+                31,
+                failFast: false));
+
+        await Assert.That(exception.Message).Contains(
+            $"recursion exceeds {AvroInlineRuleValidator.MaximumValidationDepth} levels");
+
+        static byte[] CreatePayload(int nodeCount)
+        {
+            var payload = new byte[nodeCount * 2];
+            for (var index = 0; index < nodeCount; index++)
+            {
+                payload[index * 2] = 0;
+                payload[index * 2 + 1] = index == nodeCount - 1 ? (byte)0 : (byte)2;
+            }
+            return payload;
+        }
+    }
+
+    [Test]
     public async Task Validate_RecursiveAndFiniteAggregateSchemasCompareSelectedValues()
     {
         const string schemaText = """

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -571,6 +571,53 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_UnionMemberFailFastRetainsOnlyFirstNestedViolation()
+    {
+        const string schemaText = """
+            {
+              "type": [
+                "null",
+                {
+                  "type": "record",
+                  "name": "UnionFailFastNestedRuleValue",
+                  "fields": [{
+                    "name": "items",
+                    "type": {
+                      "type": "array",
+                      "items": {
+                        "type": "int",
+                        "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                      }
+                    }
+                  }]
+                }
+              ],
+              "confluent:rules": [{ "name": "selected", "expr": "has(this.items)" }]
+            }
+            """;
+        var schema = (UnionSchema)AvroSchema.Parse(schemaText);
+        var valueSchema = (RecordSchema)schema[1];
+        var singleValue = new GenericRecord(valueSchema);
+        singleValue.Add("items", new[] { -1 });
+        var manyValue = new GenericRecord(valueSchema);
+        manyValue.Add("items", Enumerable.Repeat(-1, 128).ToArray());
+        var singlePayload = Serialize(singleValue, schema);
+        var manyPayload = Serialize(manyValue, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(manyPayload, 18, failFast: true));
+        _ = MeasureFailedValidationAllocation(validator, singlePayload);
+        _ = MeasureFailedValidationAllocation(validator, manyPayload);
+        var singleAllocated = MeasureFailedValidationAllocation(validator, singlePayload);
+        var manyAllocated = MeasureFailedValidationAllocation(validator, manyPayload);
+
+        await Assert.That(exception.Violations).HasSingleItem();
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("positive");
+        await Assert.That(manyAllocated).IsLessThanOrEqualTo(singleAllocated + 1024);
+    }
+
+    [Test]
     public async Task Validate_LogicalSchemaRetainsInlineRules()
     {
         const string schemaText = """

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -18,6 +18,8 @@ public class AvroInlineRuleValidatorTests
     private static readonly int[] TwoItems = [1, 2];
     private static readonly float[] OneFloat = [1f];
     private static readonly float[] TwoFloat = [2f];
+    private static readonly string[] OneString = ["a"];
+    private static readonly byte[][] OneBytes = [[(byte)'a']];
 
     private const string IntegrationSchema = """
         {
@@ -575,6 +577,36 @@ public class AvroInlineRuleValidatorTests
         Assert.Throws<ValidationRulesFailedException>(() =>
             validator.Validate(Serialize(record, schema), 27, failFast: false));
         await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Validate_IdenticallyEncodedAggregatesRequireCompatibleSchemas()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "AggregateSchemaEqualityRecord",
+              "confluent:rules": [{ "name": "different", "expr": "this.strings != this.bytes" }],
+              "fields": [
+                { "name": "strings", "type": { "type": "array", "items": "string" } },
+                { "name": "bytes", "type": { "type": "array", "items": "bytes" } }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("strings", OneString);
+        record.Add("bytes", OneBytes);
+        var payload = Serialize(record, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        validator.Validate(payload, 27, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 27, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -670,6 +670,51 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_ConditionalSizeCountsOnlySelectedAggregate()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "ConditionalAggregateSizeRecord",
+              "confluent:rules": [{
+                "name": "selected-size",
+                "expr": "size(this.flag ? this.left : this.right) == 2"
+              }],
+              "fields": [
+                { "name": "flag", "type": "boolean" },
+                { "name": "left", "type": { "type": "array", "items": "int" } },
+                { "name": "right", "type": { "type": "array", "items": "int" } }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var manyItems = Enumerable.Range(0, 128).ToArray();
+        var selectLeft = new GenericRecord(schema);
+        selectLeft.Add("flag", true);
+        selectLeft.Add("left", TwoItems);
+        selectLeft.Add("right", manyItems);
+        var selectRight = new GenericRecord(schema);
+        selectRight.Add("flag", false);
+        selectRight.Add("left", manyItems);
+        selectRight.Add("right", TwoItems);
+        var leftPayload = Serialize(selectLeft, schema);
+        var rightPayload = Serialize(selectRight, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        validator.Validate(leftPayload, 18, failFast: false);
+        validator.Validate(rightPayload, 18, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+        {
+            validator.Validate(leftPayload, 18, failFast: false);
+            validator.Validate(rightPayload, 18, failFast: false);
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Validate_FloatingArithmeticPreservesFloatingOperands()
     {
         const string schemaText = """
@@ -1621,11 +1666,15 @@ public class AvroInlineRuleValidatorTests
             });
         var destination = new ArrayBufferWriter<byte>();
 
+        _ = await serializer.PrepareAsync("validation-topic", record);
+        var schemaCallsAfterPreparation = registry.GetSchemaCallCount;
+
         var exception = Assert.Throws<ValidationRulesFailedException>(() =>
             serializer.Serialize(record, ref destination, CreateContext()));
 
         await Assert.That(exception.Message).Contains("$.child.code: positive");
         await Assert.That(destination.WrittenCount).IsEqualTo(0);
+        await Assert.That(registry.GetSchemaCallCount).IsEqualTo(schemaCallsAfterPreparation);
     }
 
     [Test]
@@ -2287,14 +2336,19 @@ public class AvroInlineRuleValidatorTests
         ReadOnlyMemory<byte> payload)
     {
         var before = GC.GetAllocatedBytesForCurrentThread();
+        var failed = false;
         try
         {
             validator.Validate(payload, 18, failFast: true);
         }
         catch (ValidationRulesFailedException)
         {
+            failed = true;
         }
-        return GC.GetAllocatedBytesForCurrentThread() - before;
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        return failed
+            ? allocated
+            : throw new InvalidOperationException("Expected inline validation to fail.");
     }
 
     private static byte[] CreateWireBytes(int schemaId, ReadOnlySpan<byte> payload)

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -132,6 +132,50 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_MixedRootAndMemberRulesShareNestedTraversal()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "MixedRootMemberNestedRuleRecord",
+              "confluent:rules": [{
+                "name": "root-and-member",
+                "expr": "size(this) == 1 && size(this.items) == 2"
+              }],
+              "fields": [{
+                "name": "items",
+                "confluent:rules": [{ "name": "field-size", "expr": "size(this) == 2" }],
+                "type": {
+                  "type": "array",
+                  "items": {
+                    "type": "int",
+                    "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                  }
+                }
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("items", TwoItems);
+        var payload = Serialize(record, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        validator.Validate(payload, 17, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 17, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        record.Add("items", new[] { 1, -1 });
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 17, failFast: false));
+
+        await Assert.That(allocated).IsEqualTo(0);
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("positive");
+    }
+
+    [Test]
     public async Task Validate_RootArrayAndMapValuesShareNestedTraversal()
     {
         const string arraySchemaText = """
@@ -606,6 +650,112 @@ public class AvroInlineRuleValidatorTests
             validator.Validate(payload, 27, failFast: false);
         var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
 
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Validate_EqualNumericArraysUseCelValueTypes()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "NumericAggregateSchemaEqualityRecord",
+              "confluent:rules": [{ "name": "equal", "expr": "this.ints == this.longs" }],
+              "fields": [
+                { "name": "ints", "type": { "type": "array", "items": "int" } },
+                { "name": "longs", "type": { "type": "array", "items": "long" } }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("ints", TwoItems);
+        record.Add("longs", new long[] { 1, 2 });
+        var payload = Serialize(record, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        validator.Validate(payload, 27, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 27, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        record.Add("longs", new long[] { 1, 3 });
+        Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 27, failFast: false));
+
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Validate_BytesLiteralDecodesHexEscapes()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "BytesLiteralRecord",
+              "confluent:rules": [{ "name": "bytes", "expr": "this.payload == b'\\x00\\xFF'" }],
+              "fields": [{ "name": "payload", "type": "bytes" }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("payload", new byte[] { 0, 255 });
+        var validator = new AvroInlineRuleValidator(schema);
+        var payload = Serialize(record, schema);
+
+        validator.Validate(payload, 27, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 27, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        record.Add("payload", new byte[] { 0, 254 });
+        Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 27, failFast: false));
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Validate_EqualStringLikeArraysUseCelValueTypes()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "StringAggregateSchemaEqualityRecord",
+              "confluent:rules": [{ "name": "equal", "expr": "this.enums == this.strings" }],
+              "fields": [
+                {
+                  "name": "enums",
+                  "type": {
+                    "type": "array",
+                    "items": { "type": "enum", "name": "StringAggregateEnum", "symbols": ["a", "b"] }
+                  }
+                },
+                { "name": "strings", "type": { "type": "array", "items": "string" } }
+              ]
+            }
+            """;
+        var validator = new AvroInlineRuleValidator(AvroSchema.Parse(schemaText));
+        ReadOnlyMemory<byte> equalPayload = new byte[]
+        {
+            4, 0, 2, 0,
+            4, 2, (byte)'a', 2, (byte)'b', 0
+        };
+        ReadOnlyMemory<byte> unequalPayload = new byte[]
+        {
+            4, 0, 2, 0,
+            4, 2, (byte)'a', 2, (byte)'c', 0
+        };
+
+        validator.Validate(equalPayload, 27, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(equalPayload, 27, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(unequalPayload, 27, failFast: false));
         await Assert.That(allocated).IsEqualTo(0);
     }
 

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -14,6 +14,8 @@ namespace Dekaf.Tests.Unit.SchemaRegistry;
 
 public class AvroInlineRuleValidatorTests
 {
+    private static readonly int[] TwoItems = [1, 2];
+
     private const string IntegrationSchema = """
         {
           "type": "record",
@@ -115,6 +117,40 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_NullableRecordFieldRuleResolvesSelectedBranchMembers()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "NullableFieldRuleRecord",
+              "fields": [{
+                "name": "child",
+                "type": ["null", {
+                  "type": "record",
+                  "name": "NullableFieldRuleChild",
+                  "fields": [{ "name": "code", "type": "int" }]
+                }],
+                "confluent:rules": [{ "name": "code", "expr": "this.code == 7" }]
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var childSchema = (RecordSchema)((UnionSchema)schema.Fields[0].Schema)[1];
+        var child = new GenericRecord(childSchema);
+        var record = new GenericRecord(schema);
+        record.Add("child", child);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        child.Add("code", 7);
+        validator.Validate(Serialize(record, schema), 18, failFast: false);
+
+        child.Add("code", 8);
+        Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(Serialize(record, schema), 18, failFast: false));
+        await Task.CompletedTask;
+    }
+
+    [Test]
     public async Task Validate_RecordSizeUsesFieldCount()
     {
         const string schemaText = """
@@ -153,6 +189,48 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_NullableAggregateMemberSizesUseSelectedBranches()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "NullableAggregateSizeRecord",
+              "confluent:rules": [{
+                "name": "sizes",
+                "expr": "size(this.items) == 2 && size(this.labels) == 1 && size(this.child) == 1"
+              }],
+              "fields": [
+                { "name": "items", "type": ["null", { "type": "array", "items": "int" }] },
+                { "name": "labels", "type": ["null", { "type": "map", "values": "int" }] },
+                {
+                  "name": "child",
+                  "type": ["null", {
+                    "type": "record",
+                    "name": "NullableAggregateSizeChild",
+                    "fields": [{ "name": "code", "type": "int" }]
+                  }]
+                }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var childSchema = (RecordSchema)((UnionSchema)schema.Fields[2].Schema)[1];
+        var child = new GenericRecord(childSchema);
+        child.Add("code", 7);
+        var record = new GenericRecord(schema);
+        record.Add("items", TwoItems);
+        record.Add("labels", new Dictionary<string, object> { ["a"] = 1 });
+        record.Add("child", child);
+
+        new AvroInlineRuleValidator(schema).Validate(
+            Serialize(record, schema),
+            18,
+            failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
     public async Task Validate_FloatingArithmeticPreservesFloatingOperands()
     {
         const string schemaText = """
@@ -169,6 +247,35 @@ public class AvroInlineRuleValidatorTests
         var schema = (RecordSchema)AvroSchema.Parse(schemaText);
         var record = new GenericRecord(schema);
         record.Add("value", 0.5d);
+
+        new AvroInlineRuleValidator(schema).Validate(
+            Serialize(record, schema),
+            26,
+            failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Validate_MixedFloatingComparisonPreservesExactIntegerPrecision()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "FloatingPrecisionRuleRecord",
+              "fields": [{
+                "name": "value",
+                "type": "double",
+                "confluent:rules": [{
+                  "name": "precision",
+                  "expr": "this != 9007199254740993 && this < 9007199254740993 && 9007199254740993 > this"
+                }]
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("value", 9007199254740992d);
 
         new AvroInlineRuleValidator(schema).Validate(
             Serialize(record, schema),

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -176,6 +176,53 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_MixedParentAndNestedMemberRulesPreserveParentMembers()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "ParentMemberFrameRecord",
+              "confluent:rules": [{
+                "name": "parent-members",
+                "expr": "size(this) == 2 && this.name == 'allowed' && this.child.value == 1"
+              }],
+              "fields": [
+                { "name": "name", "type": "string" },
+                {
+                  "name": "child",
+                  "type": {
+                    "type": "record",
+                    "name": "NestedMemberFrameRecord",
+                    "confluent:rules": [{
+                      "name": "child-member",
+                      "expr": "size(this) == 1 && this.value == 1"
+                    }],
+                    "fields": [{ "name": "value", "type": "int" }]
+                  }
+                }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var childSchema = (RecordSchema)schema.Fields[1].Schema;
+        var child = new GenericRecord(childSchema);
+        child.Add("value", 1);
+        var record = new GenericRecord(schema);
+        record.Add("name", "allowed");
+        record.Add("child", child);
+        var validator = new AvroInlineRuleValidator(schema);
+        var payload = Serialize(record, schema);
+
+        validator.Validate(payload, 17, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 17, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Validate_RootArrayAndMapValuesShareNestedTraversal()
     {
         const string arraySchemaText = """

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -1087,6 +1087,80 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_UnionBranchWithoutNestedReferencedMemberTreatsItAsMissing()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "NestedUnionMissingRecord",
+              "confluent:rules": [{ "name": "missing", "expr": "!has(this.value.child.code)" }],
+              "fields": [{
+                "name": "value",
+                "type": [
+                  {
+                    "type": "record",
+                    "name": "WithNestedCode",
+                    "fields": [{
+                      "name": "child",
+                      "type": {
+                        "type": "record",
+                        "name": "WithCodeChild",
+                        "fields": [{ "name": "code", "type": "int" }]
+                      }
+                    }]
+                  },
+                  {
+                    "type": "record",
+                    "name": "WithoutNestedCode",
+                    "fields": [{
+                      "name": "child",
+                      "type": {
+                        "type": "record",
+                        "name": "WithoutCodeChild",
+                        "fields": [{ "name": "name", "type": "string" }]
+                      }
+                    }]
+                  }
+                ]
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var branch = (RecordSchema)((UnionSchema)schema.Fields[0].Schema)[1];
+        var childSchema = (RecordSchema)branch.Fields[0].Schema;
+        var child = new GenericRecord(childSchema);
+        child.Add("name", "dekaf");
+        var value = new GenericRecord(branch);
+        value.Add("child", child);
+        var record = new GenericRecord(schema);
+        record.Add("value", value);
+
+        new AvroInlineRuleValidator(schema).Validate(Serialize(record, schema), 32, failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Validate_CanonicalAndAliasReferencesResolveSameField()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "AliasedMemberRecord",
+              "confluent:rules": [{ "name": "alias", "expr": "this.newName == this.oldName" }],
+              "fields": [{ "name": "newName", "aliases": ["oldName"], "type": "string" }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("newName", "dekaf");
+
+        new AvroInlineRuleValidator(schema).Validate(Serialize(record, schema), 33, failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
     public async Task Validate_ResolvedNamedReferenceUsesReferencedRules()
     {
         var names = new SchemaNames();

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -791,6 +791,42 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_SchemaRuledAggregateAndParentSizeAllocateZeroBytes()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "SchemaRuledAggregateSizeRecord",
+              "confluent:rules": [{
+                "name": "member-size",
+                "expr": "size(this) == 1 && size(this.items) == 128"
+              }],
+              "fields": [{
+                "name": "items",
+                "type": {
+                  "type": "array",
+                  "items": "int",
+                  "confluent:rules": [{ "name": "schema-present", "expr": "this == this" }]
+                }
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("items", Enumerable.Range(1, 128).ToArray());
+        var payload = Serialize(record, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+        validator.Validate(payload, 39, failFast: false);
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 39, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Validate_ConditionalSizeCountsOnlySelectedAggregate()
     {
         const string schemaText = """

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -17,6 +17,8 @@ namespace Dekaf.Tests.Unit.SchemaRegistry;
 public class AvroInlineRuleValidatorTests
 {
     private static readonly int[] TwoItems = [1, 2];
+    private static readonly int[] OnePositiveItem = [3];
+    private static readonly int[] ThreePositiveItems = [4, 5, 6];
     private static readonly float[] OneFloat = [1f];
     private static readonly float[] TwoFloat = [2f];
     private static readonly string[] OneString = ["a"];
@@ -445,6 +447,88 @@ public class AvroInlineRuleValidatorTests
         await Assert.That(all.Violations[1].Rule.Name).IsEqualTo("positive");
         await Assert.That(first.Violations).HasSingleItem();
         await Assert.That(first.Violations[0].Rule.Name).IsEqualTo("selected");
+    }
+
+    [Test]
+    public async Task Validate_MapMemberFailFastRetainsOnlyFirstNestedViolation()
+    {
+        const string schemaText = """
+            {
+              "type": "map",
+              "confluent:rules": [{ "name": "selected", "expr": "has(this.selected)" }],
+              "values": {
+                "type": "record",
+                "name": "MapFailFastNestedRuleValue",
+                "fields": [{
+                  "name": "code",
+                  "type": "int",
+                  "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                }]
+              }
+            }
+            """;
+        var schema = (MapSchema)AvroSchema.Parse(schemaText);
+        var valueSchema = (RecordSchema)schema.ValueSchema;
+        var invalidValue = new GenericRecord(valueSchema);
+        invalidValue.Add("code", -1);
+        var singlePayload = Serialize(
+            new Dictionary<string, object> { ["selected"] = invalidValue },
+            schema);
+        var manyValues = new Dictionary<string, object>(128) { ["selected"] = invalidValue };
+        for (var index = 1; index < 128; index++)
+            manyValues.Add($"entry-{index}", invalidValue);
+        var manyPayload = Serialize(manyValues, schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            validator.Validate(manyPayload, 18, failFast: true));
+        _ = MeasureFailedValidationAllocation(validator, singlePayload);
+        _ = MeasureFailedValidationAllocation(validator, manyPayload);
+        var singleAllocated = MeasureFailedValidationAllocation(validator, singlePayload);
+        var manyAllocated = MeasureFailedValidationAllocation(validator, manyPayload);
+
+        await Assert.That(exception.Violations).HasSingleItem();
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("positive");
+        await Assert.That(manyAllocated).IsLessThanOrEqualTo(singleAllocated + 1024);
+    }
+
+    [Test]
+    public async Task Validate_MapMemberSizeDemandUsesMatchedEntrySize()
+    {
+        const string schemaText = """
+            {
+              "type": "map",
+              "confluent:rules": [{
+                "name": "entry-sizes",
+                "expr": "size(this.selected) == 2 && size(this.other) == 1"
+              }],
+              "values": {
+                "type": "array",
+                "items": {
+                  "type": "int",
+                  "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                }
+              }
+            }
+            """;
+        var schema = (MapSchema)AvroSchema.Parse(schemaText);
+        var payload = Serialize(
+            new Dictionary<string, object>
+            {
+                ["selected"] = TwoItems,
+                ["other"] = OnePositiveItem,
+                ["unreferenced"] = ThreePositiveItems
+            },
+            schema);
+        var validator = new AvroInlineRuleValidator(schema);
+
+        validator.Validate(payload, 18, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+            validator.Validate(payload, 18, failFast: false);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
     }
 
     [Test]
@@ -1086,7 +1170,10 @@ public class AvroInlineRuleValidatorTests
         await Task.CompletedTask;
     }
 
+    // The warmup seeds ArrayPool<byte>.Shared for the pooled map index. Keep the
+    // allocation window exclusive so another test cannot rent that buffer.
     [Test]
+    [NotInParallel]
     public async Task Validate_EqualMapsUsePooledIndexWithoutAllocating()
     {
         const string schemaText = """
@@ -2193,6 +2280,21 @@ public class AvroInlineRuleValidatorTests
         new GenericDatumWriter<object>(schema).Write(value, encoder);
         encoder.Flush();
         return stream.ToArray();
+    }
+
+    private static long MeasureFailedValidationAllocation(
+        AvroInlineRuleValidator validator,
+        ReadOnlyMemory<byte> payload)
+    {
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        try
+        {
+            validator.Validate(payload, 18, failFast: true);
+        }
+        catch (ValidationRulesFailedException)
+        {
+        }
+        return GC.GetAllocatedBytesForCurrentThread() - before;
     }
 
     private static byte[] CreateWireBytes(int schemaId, ReadOnlySpan<byte> payload)

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -172,6 +172,87 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_EqualArraysIgnoreAvroBlockSegmentation()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "ArrayBlockEqualityRecord",
+              "confluent:rules": [{ "name": "equal", "expr": "this.left == this.right" }],
+              "fields": [
+                { "name": "left", "type": { "type": "array", "items": "int" } },
+                { "name": "right", "type": { "type": "array", "items": "int" } }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        ReadOnlyMemory<byte> payload = new byte[]
+        {
+            4, 2, 4, 0,       // left: one two-item block [1, 2]
+            2, 2, 2, 4, 0     // right: two one-item blocks [1], [2]
+        };
+
+        new AvroInlineRuleValidator(schema).Validate(payload, 30, failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Validate_EqualMapsIgnoreEntryOrder()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "MapOrderEqualityRecord",
+              "confluent:rules": [{ "name": "equal", "expr": "this.left == this.right" }],
+              "fields": [
+                { "name": "left", "type": { "type": "map", "values": "int" } },
+                { "name": "right", "type": { "type": "map", "values": "int" } }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        ReadOnlyMemory<byte> payload = new byte[]
+        {
+            4, 2, (byte)'a', 2, 2, (byte)'b', 4, 0,
+            4, 2, (byte)'b', 4, 2, (byte)'a', 2, 0
+        };
+
+        new AvroInlineRuleValidator(schema).Validate(payload, 31, failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Validate_NaNIsUnequalAndUnordered()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "NaNComparisonRecord",
+              "fields": [{
+                "name": "value",
+                "type": "double",
+                "confluent:rules": [{
+                  "name": "nan",
+                  "expr": "this != this && !(this < 0) && !(this <= 0) && !(this > 0) && !(this >= 0)"
+                }]
+              }]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("value", double.NaN);
+
+        new AvroInlineRuleValidator(schema).Validate(
+            Serialize(record, schema),
+            32,
+            failFast: false);
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
     public async Task Validate_ArrayRuleWithoutSizeDoesNotRequireSizeStorage()
     {
         const string schemaText = """
@@ -589,6 +670,50 @@ public class AvroInlineRuleValidatorTests
 
         var exception = Assert.Throws<ValidationRulesFailedException>(() =>
             validator.Validate(Serialize(record, resolvedSchema), 29, failFast: false));
+
+        await Assert.That(exception.Message).Contains("$.child.code: code");
+    }
+
+    [Test]
+    public async Task Provider_ExecutorUsesRegisteredResolvedReferenceSchema()
+    {
+        const string referenceSchemaText = """
+            {"type":"record","name":"ReferencedChild","namespace":"Dekaf.Tests","fields":[{"name":"code","type":"int","confluent:rules":[{"name":"code","expr":"this > 0"}]}]}
+            """;
+        const string rootSchemaText = """
+            {"type":"record","name":"ReferenceRoot","namespace":"Dekaf.Tests","fields":[{"name":"child","type":"Dekaf.Tests.ReferencedChild"}]}
+            """;
+        var names = new SchemaNames();
+        _ = AvroSchema.Parse(referenceSchemaText, names);
+        var resolvedSchema = (RecordSchema)AvroSchema.Parse(rootSchemaText, names);
+        var registrySchema = new Dekaf.SchemaRegistry.Schema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = rootSchemaText,
+            References =
+            [
+                new SchemaReference
+                {
+                    Name = "Dekaf.Tests.ReferencedChild",
+                    Subject = "referenced-child",
+                    Version = 1
+                }
+            ]
+        };
+        var childSchema = (RecordSchema)resolvedSchema.Fields[0].Schema;
+        var child = new GenericRecord(childSchema);
+        child.Add("code", -1);
+        var record = new GenericRecord(resolvedSchema);
+        record.Add("child", child);
+        var provider = new AvroInlineRuleValidatorProvider();
+        _ = provider.Register(registrySchema, resolvedSchema);
+
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            ((IInlineValidationRuleExecutor)provider).Validate(
+                Serialize(record, resolvedSchema),
+                33,
+                registrySchema,
+                failFast: false));
 
         await Assert.That(exception.Message).Contains("$.child.code: code");
     }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroInlineRuleValidatorTests.cs
@@ -1682,6 +1682,87 @@ public class AvroInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_RecursiveRecordPrefixRejectsExcessiveValidationDepth()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "RecursivePrefixNode",
+              "confluent:rules": [{ "name": "marker", "expr": "this.marker >= 0" }],
+              "fields": [
+                { "name": "next", "type": ["null", "RecursivePrefixNode"] },
+                { "name": "marker", "type": "int" }
+              ]
+            }
+            """;
+        var validator = new AvroInlineRuleValidator(AvroSchema.Parse(schemaText));
+
+        validator.Validate(
+            CreatePayload(AvroInlineRuleValidator.MaximumValidationDepth),
+            32,
+            failFast: false);
+        var exception = Assert.Throws<SchemaRegistryRuleException>(() =>
+            validator.Validate(
+                CreatePayload(AvroInlineRuleValidator.MaximumValidationDepth + 1),
+                32,
+                failFast: false));
+
+        await Assert.That(exception.Message).Contains(
+            $"recursion exceeds {AvroInlineRuleValidator.MaximumValidationDepth} levels");
+
+        static byte[] CreatePayload(int nodeCount)
+        {
+            var payload = new byte[nodeCount * 2];
+            payload.AsSpan(0, nodeCount - 1).Fill(2);
+            return payload;
+        }
+    }
+
+    [Test]
+    public async Task Validate_RecursiveFieldRuleRejectsExcessiveValidationDepth()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "RecursiveFieldWrapper",
+              "fields": [{
+                "name": "node",
+                "type": {
+                  "type": "record",
+                  "name": "RecursiveFieldNode",
+                  "fields": [
+                    { "name": "next", "type": ["null", "RecursiveFieldNode"] }
+                  ]
+                },
+                "confluent:rules": [{ "name": "self", "expr": "this == this" }]
+              }]
+            }
+            """;
+        var validator = new AvroInlineRuleValidator(AvroSchema.Parse(schemaText));
+        var maximumNodeCount = AvroInlineRuleValidator.MaximumValidationDepth - 1;
+
+        validator.Validate(
+            CreatePayload(maximumNodeCount),
+            33,
+            failFast: false);
+        var exception = Assert.Throws<SchemaRegistryRuleException>(() =>
+            validator.Validate(
+                CreatePayload(maximumNodeCount + 1),
+                33,
+                failFast: false));
+
+        await Assert.That(exception.Message).Contains(
+            $"recursion exceeds {AvroInlineRuleValidator.MaximumValidationDepth} levels");
+
+        static byte[] CreatePayload(int nodeCount)
+        {
+            var payload = new byte[nodeCount];
+            payload.AsSpan(0, nodeCount - 1).Fill(2);
+            return payload;
+        }
+    }
+
+    [Test]
     public async Task Validate_RecursiveAndFiniteAggregateSchemasCompareSelectedValues()
     {
         const string schemaText = """

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroPocoSchemaRegistryTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroPocoSchemaRegistryTests.cs
@@ -1937,7 +1937,10 @@ public sealed class AvroPocoSchemaRegistryTests
         await Assert.That(allocated).IsEqualTo(0);
     }
 
+    // Keep unrelated TUnit work from delaying tier promotion into an exact per-thread
+    // allocation window. The test still creates its own concurrent worker pressure.
     [Test]
+    [NotInParallel]
     public async Task GeneratedCodec_RulesPathSubjectResolutionAllocatesZeroUnderParallelPressure()
     {
         using var registry = new MockSchemaRegistryClient();

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroPocoSchemaRegistryTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroPocoSchemaRegistryTests.cs
@@ -1548,7 +1548,8 @@ public sealed class AvroPocoSchemaRegistryTests
     [Arguments(false)]
     [Arguments(true)]
     [Test]
-    public async Task GeneratedCodec_GuidHeader_SkipsConfiguredAsyncSubjectWithoutRules(bool useWarmup)
+    public async Task GeneratedCodec_GuidHeader_InlineValidationSkipsConfiguredAsyncSubjectWithoutRules(
+        bool useWarmup)
     {
         const string topic = "poco-guid-async-subject";
         var subject = $"{topic}-value";
@@ -1562,7 +1563,9 @@ public sealed class AvroPocoSchemaRegistryTests
             new AvroDeserializerConfig
             {
                 SchemaIdStrategy = SchemaIdDeserializerStrategy.Header,
-                AsyncSubjectNameStrategy = strategy
+                AsyncSubjectNameStrategy = strategy,
+                ValidationRulesExecution =
+                    Dekaf.SchemaRegistry.ValidationRulesExecution.BeforeDomainRules
             });
         var headers = new Headers();
         var context = new SerializationContext

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroPocoSchemaRegistryTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroPocoSchemaRegistryTests.cs
@@ -2878,9 +2878,30 @@ public sealed class AvroPocoSchemaRegistryTests
             });
         await using var serializer = PocoReferencedRoot.CreateAvroSerializer(
             registry,
-            new AvroSerializerConfig { UseLatestVersion = true });
+            new AvroSerializerConfig
+            {
+                UseLatestVersion = true,
+                ValidationRulesExecution =
+                    Dekaf.SchemaRegistry.ValidationRulesExecution.BeforeDomainRules
+            });
 
         await serializer.WarmupAsync("poco-referenced-latest");
+        var schemaCallsAfterPreparation = registry.GetSchemaCallCount;
+        var destination = new ArrayBufferWriter<byte>();
+        serializer.Serialize(
+            new PocoReferencedRoot
+            {
+                Address = new PocoAddress { City = "London", PostCode = "SW1" }
+            },
+            ref destination,
+            new SerializationContext
+            {
+                Topic = "poco-referenced-latest",
+                Component = SerializationComponent.Value
+            });
+
+        await Assert.That(destination.WrittenCount).IsGreaterThan(5);
+        await Assert.That(registry.GetSchemaCallCount).IsEqualTo(schemaCallsAfterPreparation);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroPocoSchemaRegistryTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroPocoSchemaRegistryTests.cs
@@ -1595,9 +1595,12 @@ public sealed class AvroPocoSchemaRegistryTests
         }
 
         var actual = deserializer.Deserialize(destination.WrittenMemory, context);
+        var cachedDecision = deserializer.LastInlineValidationDecision;
 
         await Assert.That(actual.Value).IsEqualTo(expected.Value);
         await Assert.That(strategy.CallCount).IsEqualTo(0);
+        await Assert.That(cachedDecision).IsGreaterThanOrEqualTo(0);
+        await Assert.That((int)(uint)(cachedDecision >> 1)).IsLessThan(0);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -461,6 +461,59 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task HeaderStrategy_InlineValidationCacheDistinguishesGuidSchemas()
+    {
+        const string ruleFreeSchemaText =
+            "{\"type\":\"record\",\"name\":\"GuidValidationRecord\",\"fields\":[{\"name\":\"id\",\"type\":\"int\"}]}";
+        const string ruledSchemaText =
+            "{\"type\":\"record\",\"name\":\"GuidValidationRecord\",\"fields\":[{\"name\":\"id\",\"type\":\"int\",\"confluent:rules\":[{\"name\":\"positive\",\"expr\":\"this > 0\"}]}]}";
+        using var registry = new MockSchemaRegistryClient();
+        var ruleFreeId = await registry.RegisterSchemaAsync("guid-rule-free", new RegistrySchema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = ruleFreeSchemaText
+        });
+        var ruledId = await registry.RegisterSchemaAsync("guid-ruled", new RegistrySchema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = ruledSchemaText
+        });
+        var ruleFreeSchema = (Avro.RecordSchema)AvroSchema.Parse(ruleFreeSchemaText);
+        var ruleFreeRecord = new GenericRecord(ruleFreeSchema);
+        ruleFreeRecord.Add("id", -1);
+        var ruledSchema = (Avro.RecordSchema)AvroSchema.Parse(ruledSchemaText);
+        var ruledRecord = new GenericRecord(ruledSchema);
+        ruledRecord.Add("id", -1);
+        await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(
+            registry,
+            new AvroDeserializerConfig
+            {
+                SchemaIdStrategy = SchemaIdDeserializerStrategy.Header,
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
+
+        _ = deserializer.Deserialize(
+            SerializeAvroRecord(ruleFreeRecord, ruleFreeSchema),
+            CreateGuidContext(ruleFreeId));
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            deserializer.Deserialize(
+                SerializeAvroRecord(ruledRecord, ruledSchema),
+                CreateGuidContext(ruledId)));
+
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("positive");
+
+        static SerializationContext CreateGuidContext(int schemaId) => new()
+        {
+            Topic = "guid-validation",
+            Component = SerializationComponent.Value,
+            Headers = new Headers().Add(new Header(
+                SchemaIdentityHeaderNames.Value,
+                SchemaIdentityFraming.CreateSchemaGuidFrame(
+                    new Guid(schemaId, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))))
+        };
+    }
+
+    [Test]
     [Arguments(SchemaIdDeserializerStrategy.Header)]
     [Arguments(SchemaIdDeserializerStrategy.Dual)]
     public async Task GuidStrategy_ReferencedGenericRecord_ResolvesWriterReferences(

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -2150,6 +2150,64 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Serializer_StandaloneUseLatestValidatesReferencedSchemaWithoutWarmup()
+    {
+        const string addressSchemaJson =
+            """
+            {"type":"record","name":"Address","namespace":"test","fields":[{"name":"city","type":"string"}]}
+            """;
+        const string rootSchemaJson =
+            """
+            {"type":"record","name":"ReferencedRoot","namespace":"test","confluent:rules":[{"name":"london","expr":"this.address.city == 'London'"}],"fields":[{"name":"address","type":"test.Address"}]}
+            """;
+        const string topic = "avro-standalone-referenced-validation";
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        _ = await schemaRegistry.RegisterSchemaAsync(
+            "standalone-address-value",
+            new RegistrySchema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = addressSchemaJson
+            });
+        _ = await schemaRegistry.RegisterSchemaAsync(
+            $"{topic}-value",
+            new RegistrySchema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = rootSchemaJson,
+                References =
+                [
+                    new SchemaReference
+                    {
+                        Name = "test.Address",
+                        Subject = "standalone-address-value",
+                        Version = 1
+                    }
+                ]
+            });
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(
+            schemaRegistry,
+            new AvroSerializerConfig
+            {
+                UseLatestVersion = true,
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
+        var names = new Avro.SchemaNames();
+        var addressSchema = (Avro.RecordSchema)AvroSchema.Parse(addressSchemaJson, names);
+        var rootSchema = (Avro.RecordSchema)AvroSchema.Parse(rootSchemaJson, names);
+        var address = new GenericRecord(addressSchema);
+        address.Add("city", "Paris");
+        var record = new GenericRecord(rootSchema);
+        record.Add("address", address);
+        var destination = new ArrayBufferWriter<byte>();
+
+        var exception = Assert.Throws<ValidationRulesFailedException>(() =>
+            serializer.Serialize(record, ref destination, CreateContext(topic)));
+
+        await Assert.That(exception.Violations[0].Rule.Name).IsEqualTo("london");
+    }
+
+    [Test]
     public async Task Serializer_WarmupAsync_PreCachesSchemaId()
     {
         // Arrange

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufInlineRuleValidatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufInlineRuleValidatorTests.cs
@@ -85,6 +85,30 @@ public sealed class ProtobufInlineRuleValidatorTests
     }
 
     [Test]
+    public async Task Validate_MessageRootSizeCountsExposedFieldsWithoutAllocating()
+    {
+        var validator = new ProtobufInlineRuleValidator(ValidationRootSizeEnvelope.Descriptor);
+        var populated = new ValidationRootSizeEnvelope
+        {
+            Nickname = string.Empty,
+            Email = string.Empty
+        };
+        var populatedPayload = populated.ToByteArray();
+
+        validator.Validate(ReadOnlyMemory<byte>.Empty, schemaId: 17, failFast: false);
+        validator.Validate(populatedPayload, schemaId: 17, failFast: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 100; index++)
+        {
+            validator.Validate(ReadOnlyMemory<byte>.Empty, schemaId: 17, failFast: false);
+            validator.Validate(populatedPayload, schemaId: 17, failFast: false);
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Validate_UnknownClosedEnumValueUsesDeclaredDefault()
     {
         var payload = new ArrayBufferWriter<byte>();

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCelRuleTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCelRuleTests.cs
@@ -7,6 +7,30 @@ namespace Dekaf.Tests.Unit.SchemaRegistry;
 public sealed class SchemaRegistryCelRuleTests
 {
     [Test]
+    public async Task SizeConditional_TracksOnlyValueProducingBranches()
+    {
+        var memberIndexes = new Dictionary<string, int>(StringComparer.Ordinal);
+        var memberPaths = new List<byte[][]>();
+        var usedMemberIndexes = new HashSet<int>();
+        var sizedMemberIndexes = new HashSet<int>();
+
+        _ = CompiledValidationRule.Compile(
+            new ValidationRule
+            {
+                Name = "conditional-size",
+                Expr = "size(has(this.large) ? this.small : this.other) > 0"
+            },
+            memberIndexes,
+            memberPaths,
+            usedMemberIndexes,
+            sizedMemberIndexes);
+
+        await Assert.That(sizedMemberIndexes).DoesNotContain(memberIndexes["large"]);
+        await Assert.That(sizedMemberIndexes).Contains(memberIndexes["small"]);
+        await Assert.That(sizedMemberIndexes).Contains(memberIndexes["other"]);
+    }
+
+    [Test]
     public async Task ConditionRule_AllowsPayload_WhenExpressionIsTrue()
     {
         var executor = new SchemaRegistryRuleExecutor([new CelSchemaRegistryRuleHandler()]);

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCelRuleTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCelRuleTests.cs
@@ -7,7 +7,7 @@ namespace Dekaf.Tests.Unit.SchemaRegistry;
 public sealed class SchemaRegistryCelRuleTests
 {
     [Test]
-    public async Task SizeConditional_TracksOnlyValueProducingBranches()
+    public async Task SizeConditional_DefersValueProducingBranches()
     {
         var memberIndexes = new Dictionary<string, int>(StringComparer.Ordinal);
         var memberPaths = new List<byte[][]>();
@@ -26,8 +26,8 @@ public sealed class SchemaRegistryCelRuleTests
             sizedMemberIndexes);
 
         await Assert.That(sizedMemberIndexes).DoesNotContain(memberIndexes["large"]);
-        await Assert.That(sizedMemberIndexes).Contains(memberIndexes["small"]);
-        await Assert.That(sizedMemberIndexes).Contains(memberIndexes["other"]);
+        await Assert.That(sizedMemberIndexes).DoesNotContain(memberIndexes["small"]);
+        await Assert.That(sizedMemberIndexes).DoesNotContain(memberIndexes["other"]);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCelRuleTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCelRuleTests.cs
@@ -23,7 +23,7 @@ public sealed class SchemaRegistryCelRuleTests
             memberIndexes,
             memberPaths,
             usedMemberIndexes,
-            sizedMemberIndexes);
+            sizedMemberIndexes: sizedMemberIndexes);
 
         await Assert.That(sizedMemberIndexes).DoesNotContain(memberIndexes["large"]);
         await Assert.That(sizedMemberIndexes).DoesNotContain(memberIndexes["small"]);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -43,6 +43,8 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _unionMemberNestedPayload;
     private AvroInlineRuleValidator _mixedRootMemberNestedValidator = null!;
     private ReadOnlyMemory<byte> _mixedRootMemberNestedPayload;
+    private AvroInlineRuleValidator _nestedMemberFrameValidator = null!;
+    private ReadOnlyMemory<byte> _nestedMemberFramePayload;
 
     [GlobalSetup]
     public void Setup()
@@ -421,6 +423,49 @@ public class AvroInlineValidationBenchmarks
             _mixedRootMemberNestedPayload,
             15,
             failFast: false);
+
+        const string nestedMemberFrameSchemaText = """
+            {
+              "type": "record",
+              "name": "NestedMemberFrameBenchmarkRecord",
+              "confluent:rules": [{
+                "name": "parent-members",
+                "expr": "size(this) == 2 && this.name == 'dekaf' && this.child.value == 1"
+              }],
+              "fields": [
+                { "name": "name", "type": "string" },
+                {
+                  "name": "child",
+                  "type": {
+                    "type": "record",
+                    "name": "NestedMemberFrameBenchmarkChild",
+                    "confluent:rules": [{
+                      "name": "child-member",
+                      "expr": "size(this) == 1 && this.value == 1"
+                    }],
+                    "fields": [{ "name": "value", "type": "int" }]
+                  }
+                }
+              ]
+            }
+            """;
+        var nestedMemberFrameSchema = (RecordSchema)AvroSchema.Parse(
+            nestedMemberFrameSchemaText);
+        var nestedMemberFrameChildSchema = (RecordSchema)nestedMemberFrameSchema.Fields[1].Schema;
+        var nestedMemberFrameChild = new GenericRecord(nestedMemberFrameChildSchema);
+        nestedMemberFrameChild.Add("value", 1);
+        var nestedMemberFrameRecord = new GenericRecord(nestedMemberFrameSchema);
+        nestedMemberFrameRecord.Add("name", "dekaf");
+        nestedMemberFrameRecord.Add("child", nestedMemberFrameChild);
+        using var nestedMemberFrameStream = new MemoryStream();
+        var nestedMemberFrameEncoder = new BinaryEncoder(nestedMemberFrameStream);
+        new GenericDatumWriter<GenericRecord>(nestedMemberFrameSchema).Write(
+            nestedMemberFrameRecord,
+            nestedMemberFrameEncoder);
+        nestedMemberFrameEncoder.Flush();
+        _nestedMemberFramePayload = nestedMemberFrameStream.ToArray();
+        _nestedMemberFrameValidator = new AvroInlineRuleValidator(nestedMemberFrameSchema);
+        _nestedMemberFrameValidator.Validate(_nestedMemberFramePayload, 16, failFast: false);
     }
 
     [Benchmark]
@@ -489,4 +534,8 @@ public class AvroInlineValidationBenchmarks
             _mixedRootMemberNestedPayload,
             15,
             failFast: false);
+
+    [Benchmark]
+    public void ValidateNestedMemberFrames() =>
+        _nestedMemberFrameValidator.Validate(_nestedMemberFramePayload, 16, failFast: false);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -825,7 +825,12 @@ public class AvroInlineValidationBenchmarks
         _nestedMemberFrameValidator = new AvroInlineRuleValidator(nestedMemberFrameSchema);
         _nestedMemberFrameValidator.Validate(_nestedMemberFramePayload, 16, failFast: false);
 
-        const string recursiveValidationSchemaText = """
+        SetupRecursiveValidationBenchmark();
+    }
+
+    private void SetupRecursiveValidationBenchmark()
+    {
+        const string schemaText = """
             {
               "type": "record",
               "name": "RecursiveValidationBenchmarkNode",
@@ -839,12 +844,12 @@ public class AvroInlineValidationBenchmarks
               ]
             }
             """;
-        var recursiveValidationSchema = AvroSchema.Parse(recursiveValidationSchemaText);
-        var recursiveValidationPayload = new byte[16];
+        var schema = AvroSchema.Parse(schemaText);
+        var payload = new byte[16];
         for (var index = 0; index < 7; index++)
-            recursiveValidationPayload[index * 2 + 1] = 2;
-        _recursiveValidationPayload = recursiveValidationPayload;
-        _recursiveValidationValidator = new AvroInlineRuleValidator(recursiveValidationSchema);
+            payload[index * 2 + 1] = 2;
+        _recursiveValidationPayload = payload;
+        _recursiveValidationValidator = new AvroInlineRuleValidator(schema);
         _recursiveValidationValidator.Validate(
             _recursiveValidationPayload,
             31,

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -25,6 +25,8 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _nullableAggregatePayload;
     private AvroInlineRuleValidator _mixedFloatingValidator = null!;
     private ReadOnlyMemory<byte> _mixedFloatingPayload;
+    private AvroInlineRuleValidator _nanAggregateValidator = null!;
+    private ReadOnlyMemory<byte> _nanAggregatePayload;
 
     [GlobalSetup]
     public void Setup()
@@ -170,6 +172,29 @@ public class AvroInlineValidationBenchmarks
         _mixedFloatingPayload = floatingStream.ToArray();
         _mixedFloatingValidator = new AvroInlineRuleValidator(floatingSchema);
         _mixedFloatingValidator.Validate(_mixedFloatingPayload, 6, failFast: false);
+
+        const string nanAggregateSchema = """
+            {
+              "type": "record",
+              "name": "NaNAggregateBenchmarkRecord",
+              "confluent:rules": [{ "name": "not-equal", "expr": "this.left != this.right" }],
+              "fields": [
+                { "name": "left", "type": { "type": "array", "items": "double" } },
+                { "name": "right", "type": { "type": "array", "items": "double" } }
+              ]
+            }
+            """;
+        var nanSchema = (RecordSchema)AvroSchema.Parse(nanAggregateSchema);
+        var nanRecord = new GenericRecord(nanSchema);
+        nanRecord.Add("left", new[] { double.NaN });
+        nanRecord.Add("right", new[] { double.NaN });
+        using var nanStream = new MemoryStream();
+        var nanEncoder = new BinaryEncoder(nanStream);
+        new GenericDatumWriter<GenericRecord>(nanSchema).Write(nanRecord, nanEncoder);
+        nanEncoder.Flush();
+        _nanAggregatePayload = nanStream.ToArray();
+        _nanAggregateValidator = new AvroInlineRuleValidator(nanSchema);
+        _nanAggregateValidator.Validate(_nanAggregatePayload, 7, failFast: false);
     }
 
     [Benchmark]
@@ -199,4 +224,8 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateMixedFloatingComparison() =>
         _mixedFloatingValidator.Validate(_mixedFloatingPayload, 6, failFast: false);
+
+    [Benchmark]
+    public void ValidateNaNAggregateInequality() =>
+        _nanAggregateValidator.Validate(_nanAggregatePayload, 7, failFast: false);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -59,6 +59,10 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _mixedRootFieldRulePayload;
     private AvroInlineRuleValidator _fieldMemberNestedValidator = null!;
     private ReadOnlyMemory<byte> _fieldMemberNestedPayload;
+    private AvroInlineRuleValidator _descendantFieldMemberNestedValidator = null!;
+    private ReadOnlyMemory<byte> _descendantFieldMemberNestedPayload;
+    private AvroInlineRuleValidator _unionMapFieldMemberNestedValidator = null!;
+    private ReadOnlyMemory<byte> _unionMapFieldMemberNestedPayload;
     private AvroInlineRuleValidator _schemaRuledFieldSizeValidator = null!;
     private ReadOnlyMemory<byte> _schemaRuledFieldSizePayload;
     private AvroInlineRuleValidator _nestedMemberFrameValidator = null!;
@@ -655,6 +659,96 @@ public class AvroInlineValidationBenchmarks
         _fieldMemberNestedValidator = new AvroInlineRuleValidator(fieldMemberNestedSchema);
         _fieldMemberNestedValidator.Validate(_fieldMemberNestedPayload, 28, failFast: false);
 
+        const string descendantFieldMemberNestedSchemaText = """
+            {
+              "type": "record",
+              "name": "DescendantFieldMemberNestedBenchmarkRecord",
+              "fields": [{
+                "name": "container",
+                "confluent:rules": [{ "name": "selected", "expr": "this.child.code == 1" }],
+                "type": {
+                  "type": "record",
+                  "name": "DescendantFieldMemberNestedBenchmarkContainer",
+                  "fields": [{
+                    "name": "child",
+                    "type": {
+                      "type": "record",
+                      "name": "DescendantFieldMemberNestedBenchmarkChild",
+                      "fields": [
+                        {
+                          "name": "items",
+                          "type": { "type": "array", "items": "int" }
+                        },
+                        { "name": "code", "type": "int" },
+                        {
+                          "name": "guard",
+                          "type": "int",
+                          "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                        }
+                      ]
+                    }
+                  }]
+                }
+              }]
+            }
+            """;
+        var descendantSchema = (RecordSchema)AvroSchema.Parse(
+            descendantFieldMemberNestedSchemaText);
+        var descendantContainerSchema = (RecordSchema)descendantSchema.Fields[0].Schema;
+        var descendantChildSchema = (RecordSchema)descendantContainerSchema.Fields[0].Schema;
+        var descendantChild = new GenericRecord(descendantChildSchema);
+        descendantChild.Add("items", Enumerable.Range(1, 1024).ToArray());
+        descendantChild.Add("code", 1);
+        descendantChild.Add("guard", 1);
+        var descendantContainer = new GenericRecord(descendantContainerSchema);
+        descendantContainer.Add("child", descendantChild);
+        var descendantRecord = new GenericRecord(descendantSchema);
+        descendantRecord.Add("container", descendantContainer);
+        using var descendantStream = new MemoryStream();
+        var descendantEncoder = new BinaryEncoder(descendantStream);
+        new GenericDatumWriter<GenericRecord>(descendantSchema).Write(
+            descendantRecord,
+            descendantEncoder);
+        descendantEncoder.Flush();
+        _descendantFieldMemberNestedPayload = descendantStream.ToArray();
+        _descendantFieldMemberNestedValidator = new AvroInlineRuleValidator(descendantSchema);
+        _descendantFieldMemberNestedValidator.Validate(
+            _descendantFieldMemberNestedPayload,
+            30,
+            failFast: false);
+
+        const string unionMapFieldMemberNestedSchemaText = """
+            {
+              "type": "record",
+              "name": "UnionMapFieldMemberNestedBenchmarkRecord",
+              "fields": [{
+                "name": "value",
+                "type": ["null", {
+                  "type": "map",
+                  "values": "int"
+                }],
+                "confluent:rules": [{ "name": "selected", "expr": "this.selected == 1" }]
+              }]
+            }
+            """;
+        var unionMapSchema = (RecordSchema)AvroSchema.Parse(unionMapFieldMemberNestedSchemaText);
+        var unionMapValues = new Dictionary<string, object>(1024);
+        for (var index = 0; index < 1023; index++)
+            unionMapValues.Add($"item-{index}", 1);
+        unionMapValues.Add("selected", 1);
+        var unionMapRecord = new GenericRecord(unionMapSchema);
+        unionMapRecord.Add("value", unionMapValues);
+        using var unionMapStream = new MemoryStream();
+        var unionMapEncoder = new BinaryEncoder(unionMapStream);
+        new GenericDatumWriter<GenericRecord>(unionMapSchema).Write(unionMapRecord, unionMapEncoder);
+        unionMapEncoder.Flush();
+        _unionMapFieldMemberNestedPayload = unionMapStream.ToArray();
+        _unionMapFieldMemberNestedValidator = new AvroInlineRuleValidator(unionMapSchema);
+        _unionMapFieldMemberNestedValidator.Validate(
+            _unionMapFieldMemberNestedPayload,
+            30,
+            failFast: false);
+
         const string schemaRuledFieldSizeSchemaText = """
             {
               "type": "record",
@@ -851,6 +945,20 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateAggregateFieldMemberWithNestedRules() =>
         _fieldMemberNestedValidator.Validate(_fieldMemberNestedPayload, 28, failFast: false);
+
+    [Benchmark]
+    public void ValidateDescendantFieldMemberWithNestedRules() =>
+        _descendantFieldMemberNestedValidator.Validate(
+            _descendantFieldMemberNestedPayload,
+            30,
+            failFast: false);
+
+    [Benchmark]
+    public void ValidateUnionMapFieldMemberWithNestedRules() =>
+        _unionMapFieldMemberNestedValidator.Validate(
+            _unionMapFieldMemberNestedPayload,
+            30,
+            failFast: false);
 
     [Benchmark]
     public void ValidateSchemaRuledAggregateFieldSize() =>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -22,6 +22,8 @@ public class AvroInlineValidationBenchmarks
     private AvroInlineRuleValidator _unionArrayEqualityValidator = null!;
     private ReadOnlyMemory<byte> _equalUnionArrayControlPayload;
     private ReadOnlyMemory<byte> _equalUnionArrayReorderedPayload;
+    private AvroInlineRuleValidator _unionConcreteArrayEqualityValidator = null!;
+    private ReadOnlyMemory<byte> _equalUnionConcreteArrayPayload;
     private AvroInlineRuleValidator _mapEqualityValidator = null!;
     private ReadOnlyMemory<byte> _reorderedMapPayload;
     private AvroInlineRuleValidator _recordSizeValidator = null!;
@@ -40,6 +42,8 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _enumPayload;
     private AvroInlineRuleValidator _rootArrayNestedValidator = null!;
     private ReadOnlyMemory<byte> _rootArrayNestedPayload;
+    private AvroInlineRuleValidator _rootArrayHasValidator = null!;
+    private AvroInlineRuleValidator _memberArrayHasValidator = null!;
     private AvroInlineRuleValidator _mapMemberNestedValidator = null!;
     private ReadOnlyMemory<byte> _mapMemberNestedPayload;
     private AvroInlineRuleValidator _unionMemberNestedValidator = null!;
@@ -137,6 +141,25 @@ public class AvroInlineValidationBenchmarks
         _unionArrayEqualityValidator.Validate(
             _equalUnionArrayControlPayload,
             17,
+            failFast: false);
+
+        const string unionConcreteArrayEqualitySchema = """
+            {
+              "type": "record",
+              "name": "UnionConcreteArrayEqualityBenchmarkRecord",
+              "confluent:rules": [{ "name": "equal", "expr": "this.left == this.right" }],
+              "fields": [
+                { "name": "left", "type": { "type": "array", "items": ["null", "int"] } },
+                { "name": "right", "type": { "type": "array", "items": "int" } }
+              ]
+            }
+            """;
+        _unionConcreteArrayEqualityValidator = new AvroInlineRuleValidator(
+            AvroSchema.Parse(unionConcreteArrayEqualitySchema));
+        _equalUnionConcreteArrayPayload = new byte[] { 2, 2, 2, 0, 2, 2, 0 };
+        _unionConcreteArrayEqualityValidator.Validate(
+            _equalUnionConcreteArrayPayload,
+            20,
             failFast: false);
 
         const string mapEqualitySchema = """
@@ -341,6 +364,29 @@ public class AvroInlineValidationBenchmarks
         _rootArrayNestedValidator = new AvroInlineRuleValidator(rootArrayNestedSchema);
         _rootArrayNestedValidator.Validate(_rootArrayNestedPayload, 12, failFast: false);
 
+        const string rootArrayHasSchemaText = """
+            {
+              "type": "array",
+              "confluent:rules": [{ "name": "present", "expr": "has(this)" }],
+              "items": "int"
+            }
+            """;
+        _rootArrayHasValidator = new AvroInlineRuleValidator(
+            AvroSchema.Parse(rootArrayHasSchemaText));
+        _rootArrayHasValidator.Validate(_rootArrayNestedPayload, 18, failFast: false);
+
+        const string memberArrayHasSchemaText = """
+            {
+              "type": "record",
+              "name": "MemberArrayHasBenchmarkRecord",
+              "confluent:rules": [{ "name": "present", "expr": "has(this.items)" }],
+              "fields": [{ "name": "items", "type": { "type": "array", "items": "int" } }]
+            }
+            """;
+        _memberArrayHasValidator = new AvroInlineRuleValidator(
+            AvroSchema.Parse(memberArrayHasSchemaText));
+        _memberArrayHasValidator.Validate(_rootArrayNestedPayload, 19, failFast: false);
+
         const string mapMemberNestedSchemaText = """
             {
               "type": "map",
@@ -522,6 +568,13 @@ public class AvroInlineValidationBenchmarks
             failFast: false);
 
     [Benchmark]
+    public void ValidateEqualUnionAndConcreteArrays() =>
+        _unionConcreteArrayEqualityValidator.Validate(
+            _equalUnionConcreteArrayPayload,
+            20,
+            failFast: false);
+
+    [Benchmark]
     public void ValidateEqualMapsWithDifferentOrder() =>
         _mapEqualityValidator.Validate(_reorderedMapPayload, 3, failFast: false);
 
@@ -556,6 +609,14 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateRootArrayWithNestedRules() =>
         _rootArrayNestedValidator.Validate(_rootArrayNestedPayload, 12, failFast: false);
+
+    [Benchmark]
+    public void ValidateRootArrayWithoutSizeDemand() =>
+        _rootArrayHasValidator.Validate(_rootArrayNestedPayload, 18, failFast: false);
+
+    [Benchmark]
+    public void ValidateMemberArrayWithoutSizeDemand() =>
+        _memberArrayHasValidator.Validate(_rootArrayNestedPayload, 19, failFast: false);
 
     [Benchmark]
     public void ValidateMapMemberWithNestedRules() =>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -27,6 +27,10 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _mixedFloatingPayload;
     private AvroInlineRuleValidator _nanAggregateValidator = null!;
     private ReadOnlyMemory<byte> _nanAggregatePayload;
+    private AvroInlineRuleValidator _rootNanAggregateValidator = null!;
+    private ReadOnlyMemory<byte> _rootNanAggregatePayload;
+    private AvroInlineRuleValidator _enumValidator = null!;
+    private ReadOnlyMemory<byte> _enumPayload;
 
     [GlobalSetup]
     public void Setup()
@@ -195,6 +199,45 @@ public class AvroInlineValidationBenchmarks
         _nanAggregatePayload = nanStream.ToArray();
         _nanAggregateValidator = new AvroInlineRuleValidator(nanSchema);
         _nanAggregateValidator.Validate(_nanAggregatePayload, 7, failFast: false);
+
+        const string rootNanAggregateSchema = """
+            {
+              "type": "array",
+              "items": "double",
+              "confluent:rules": [{ "name": "not-equal", "expr": "this != this" }]
+            }
+            """;
+        var rootNanSchema = (ArraySchema)AvroSchema.Parse(rootNanAggregateSchema);
+        using var rootNanStream = new MemoryStream();
+        var rootNanEncoder = new BinaryEncoder(rootNanStream);
+        new GenericDatumWriter<object>(rootNanSchema).Write(new[] { double.NaN }, rootNanEncoder);
+        rootNanEncoder.Flush();
+        _rootNanAggregatePayload = rootNanStream.ToArray();
+        _rootNanAggregateValidator = new AvroInlineRuleValidator(rootNanSchema);
+        _rootNanAggregateValidator.Validate(_rootNanAggregatePayload, 8, failFast: false);
+
+        const string enumSchemaText = """
+            {
+              "type": "record",
+              "name": "EnumBenchmarkRecord",
+              "fields": [{
+                "name": "status",
+                "type": { "type": "enum", "name": "BenchmarkStatus", "symbols": ["OPEN", "CLOSED"] },
+                "confluent:rules": [{ "name": "open", "expr": "this == 'OPEN'" }]
+              }]
+            }
+            """;
+        var enumSchema = (RecordSchema)AvroSchema.Parse(enumSchemaText);
+        var statusSchema = (EnumSchema)enumSchema.Fields[0].Schema;
+        var enumRecord = new GenericRecord(enumSchema);
+        enumRecord.Add("status", new GenericEnum(statusSchema, "OPEN"));
+        using var enumStream = new MemoryStream();
+        var enumEncoder = new BinaryEncoder(enumStream);
+        new GenericDatumWriter<GenericRecord>(enumSchema).Write(enumRecord, enumEncoder);
+        enumEncoder.Flush();
+        _enumPayload = enumStream.ToArray();
+        _enumValidator = new AvroInlineRuleValidator(enumSchema);
+        _enumValidator.Validate(_enumPayload, 9, failFast: false);
     }
 
     [Benchmark]
@@ -228,4 +271,12 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateNaNAggregateInequality() =>
         _nanAggregateValidator.Validate(_nanAggregatePayload, 7, failFast: false);
+
+    [Benchmark]
+    public void ValidateRootNaNAggregateInequality() =>
+        _rootNanAggregateValidator.Validate(_rootNanAggregatePayload, 8, failFast: false);
+
+    [Benchmark]
+    public void ValidateEnumRule() =>
+        _enumValidator.Validate(_enumPayload, 9, failFast: false);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -55,6 +55,8 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _unionMemberNestedPayload;
     private AvroInlineRuleValidator _mixedRootMemberNestedValidator = null!;
     private ReadOnlyMemory<byte> _mixedRootMemberNestedPayload;
+    private AvroInlineRuleValidator _mixedRootFieldRuleValidator = null!;
+    private ReadOnlyMemory<byte> _mixedRootFieldRulePayload;
     private AvroInlineRuleValidator _nestedMemberFrameValidator = null!;
     private ReadOnlyMemory<byte> _nestedMemberFramePayload;
 
@@ -577,6 +579,34 @@ public class AvroInlineValidationBenchmarks
             15,
             failFast: false);
 
+        const string mixedRootFieldRuleSchemaText = """
+            {
+              "type": "record",
+              "name": "MixedRootFieldRuleBenchmarkRecord",
+              "confluent:rules": [{
+                "name": "root-and-member",
+                "expr": "this == this && has(this.items)"
+              }],
+              "fields": [{
+                "name": "items",
+                "confluent:rules": [{ "name": "field-size", "expr": "size(this) == 128" }],
+                "type": { "type": "array", "items": "int" }
+              }]
+            }
+            """;
+        var mixedRootFieldRuleSchema = (RecordSchema)AvroSchema.Parse(mixedRootFieldRuleSchemaText);
+        var mixedRootFieldRuleRecord = new GenericRecord(mixedRootFieldRuleSchema);
+        mixedRootFieldRuleRecord.Add("items", Enumerable.Range(1, 128).ToArray());
+        using var mixedRootFieldRuleStream = new MemoryStream();
+        var mixedRootFieldRuleEncoder = new BinaryEncoder(mixedRootFieldRuleStream);
+        new GenericDatumWriter<GenericRecord>(mixedRootFieldRuleSchema).Write(
+            mixedRootFieldRuleRecord,
+            mixedRootFieldRuleEncoder);
+        mixedRootFieldRuleEncoder.Flush();
+        _mixedRootFieldRulePayload = mixedRootFieldRuleStream.ToArray();
+        _mixedRootFieldRuleValidator = new AvroInlineRuleValidator(mixedRootFieldRuleSchema);
+        _mixedRootFieldRuleValidator.Validate(_mixedRootFieldRulePayload, 21, failFast: false);
+
         const string nestedMemberFrameSchemaText = """
             {
               "type": "record",
@@ -734,6 +764,10 @@ public class AvroInlineValidationBenchmarks
             _mixedRootMemberNestedPayload,
             15,
             failFast: false);
+
+    [Benchmark]
+    public void ValidateMixedRootWithAggregateFieldRule() =>
+        _mixedRootFieldRuleValidator.Validate(_mixedRootFieldRulePayload, 21, failFast: false);
 
     [Benchmark]
     public void ValidateNestedMemberFrames() =>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -34,6 +34,8 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _rootNanAggregatePayload;
     private AvroInlineRuleValidator _enumValidator = null!;
     private ReadOnlyMemory<byte> _enumPayload;
+    private AvroInlineRuleValidator _rootArrayNestedValidator = null!;
+    private ReadOnlyMemory<byte> _rootArrayNestedPayload;
 
     [GlobalSetup]
     public void Setup()
@@ -42,6 +44,7 @@ public class AvroInlineValidationBenchmarks
             {
               "type": "record",
               "name": "ValidationBenchmarkRecord",
+              "confluent:rules": [{ "name": "root-size", "expr": "size(this) == 2" }],
               "fields": [
                 {
                   "name": "name",
@@ -282,6 +285,29 @@ public class AvroInlineValidationBenchmarks
         _enumPayload = enumStream.ToArray();
         _enumValidator = new AvroInlineRuleValidator(enumSchema);
         _enumValidator.Validate(_enumPayload, 9, failFast: false);
+
+        const string rootArrayNestedSchemaText = """
+            {
+              "type": "array",
+              "confluent:rules": [{ "name": "size", "expr": "size(this) == 128" }],
+              "items": {
+                "type": "int",
+                "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+              }
+            }
+            """;
+        var rootArrayNestedSchema = (ArraySchema)AvroSchema.Parse(rootArrayNestedSchemaText);
+        var rootArrayNestedItems = new int[128];
+        Array.Fill(rootArrayNestedItems, 1);
+        using var rootArrayNestedStream = new MemoryStream();
+        var rootArrayNestedEncoder = new BinaryEncoder(rootArrayNestedStream);
+        new GenericDatumWriter<object>(rootArrayNestedSchema).Write(
+            rootArrayNestedItems,
+            rootArrayNestedEncoder);
+        rootArrayNestedEncoder.Flush();
+        _rootArrayNestedPayload = rootArrayNestedStream.ToArray();
+        _rootArrayNestedValidator = new AvroInlineRuleValidator(rootArrayNestedSchema);
+        _rootArrayNestedValidator.Validate(_rootArrayNestedPayload, 12, failFast: false);
     }
 
     [Benchmark]
@@ -331,4 +357,8 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateEnumRule() =>
         _enumValidator.Validate(_enumPayload, 9, failFast: false);
+
+    [Benchmark]
+    public void ValidateRootArrayWithNestedRules() =>
+        _rootArrayNestedValidator.Validate(_rootArrayNestedPayload, 12, failFast: false);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -12,6 +12,11 @@ public class AvroInlineValidationBenchmarks
 {
     private AvroInlineRuleValidator _validator = null!;
     private ReadOnlyMemory<byte> _payload;
+    private AvroInlineRuleValidator _arrayEqualityValidator = null!;
+    private ReadOnlyMemory<byte> _equalArrayPayload;
+    private ReadOnlyMemory<byte> _segmentedArrayPayload;
+    private AvroInlineRuleValidator _mapEqualityValidator = null!;
+    private ReadOnlyMemory<byte> _reorderedMapPayload;
 
     [GlobalSetup]
     public void Setup()
@@ -45,9 +50,58 @@ public class AvroInlineValidationBenchmarks
         _payload = stream.ToArray();
         _validator = new AvroInlineRuleValidator(schema);
         _validator.Validate(_payload, 1, failFast: false);
+
+        const string arrayEqualitySchema = """
+            {
+              "type": "record",
+              "name": "ArrayEqualityBenchmarkRecord",
+              "confluent:rules": [{ "name": "equal", "expr": "this.left == this.right" }],
+              "fields": [
+                { "name": "left", "type": { "type": "array", "items": "int" } },
+                { "name": "right", "type": { "type": "array", "items": "int" } }
+              ]
+            }
+            """;
+        _arrayEqualityValidator = new AvroInlineRuleValidator(
+            AvroSchema.Parse(arrayEqualitySchema));
+        _equalArrayPayload = new byte[] { 4, 2, 4, 0, 4, 2, 4, 0 };
+        _segmentedArrayPayload = new byte[] { 4, 2, 4, 0, 2, 2, 2, 4, 0 };
+        _arrayEqualityValidator.Validate(_equalArrayPayload, 2, failFast: false);
+        _arrayEqualityValidator.Validate(_segmentedArrayPayload, 2, failFast: false);
+
+        const string mapEqualitySchema = """
+            {
+              "type": "record",
+              "name": "MapEqualityBenchmarkRecord",
+              "confluent:rules": [{ "name": "equal", "expr": "this.left == this.right" }],
+              "fields": [
+                { "name": "left", "type": { "type": "map", "values": "int" } },
+                { "name": "right", "type": { "type": "map", "values": "int" } }
+              ]
+            }
+            """;
+        _mapEqualityValidator = new AvroInlineRuleValidator(AvroSchema.Parse(mapEqualitySchema));
+        _reorderedMapPayload = new byte[]
+        {
+            4, 2, (byte)'a', 2, 2, (byte)'b', 4, 0,
+            4, 2, (byte)'b', 4, 2, (byte)'a', 2, 0
+        };
+        _mapEqualityValidator.Validate(_reorderedMapPayload, 3, failFast: false);
     }
 
     [Benchmark]
     public void ValidateWarmedValidPayload() =>
         _validator.Validate(_payload, 1, failFast: false);
+
+    [Benchmark]
+    public void ValidateEqualArraysWithIdenticalEncoding() =>
+        _arrayEqualityValidator.Validate(_equalArrayPayload, 2, failFast: false);
+
+    [Benchmark]
+    public void ValidateEqualArraysWithDifferentBlocks() =>
+        _arrayEqualityValidator.Validate(_segmentedArrayPayload, 2, failFast: false);
+
+    [Benchmark]
+    public void ValidateEqualMapsWithDifferentOrder() =>
+        _mapEqualityValidator.Validate(_reorderedMapPayload, 3, failFast: false);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -34,6 +34,8 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _nullableAggregatePayload;
     private AvroInlineRuleValidator _mixedFloatingValidator = null!;
     private ReadOnlyMemory<byte> _mixedFloatingPayload;
+    private AvroInlineRuleValidator _mixedFloatingArithmeticValidator = null!;
+    private ReadOnlyMemory<byte> _mixedFloatingArithmeticPayload;
     private AvroInlineRuleValidator _nanAggregateValidator = null!;
     private ReadOnlyMemory<byte> _nanAggregatePayload;
     private AvroInlineRuleValidator _rootNanAggregateValidator = null!;
@@ -278,6 +280,35 @@ public class AvroInlineValidationBenchmarks
         _mixedFloatingPayload = floatingStream.ToArray();
         _mixedFloatingValidator = new AvroInlineRuleValidator(floatingSchema);
         _mixedFloatingValidator.Validate(_mixedFloatingPayload, 6, failFast: false);
+
+        const string mixedFloatingArithmeticSchema = """
+            {
+              "type": "record",
+              "name": "MixedFloatingArithmeticBenchmarkRecord",
+              "confluent:rules": [{
+                "name": "arithmetic",
+                "expr": "this.exact + this.floating == 2 && this.exact - this.floating == 0"
+              }],
+              "fields": [
+                { "name": "exact", "type": "long" },
+                { "name": "floating", "type": "double" }
+              ]
+            }
+            """;
+        var arithmeticSchema = (RecordSchema)AvroSchema.Parse(mixedFloatingArithmeticSchema);
+        var arithmeticRecord = new GenericRecord(arithmeticSchema);
+        arithmeticRecord.Add("exact", 1L);
+        arithmeticRecord.Add("floating", 1d);
+        using var arithmeticStream = new MemoryStream();
+        var arithmeticEncoder = new BinaryEncoder(arithmeticStream);
+        new GenericDatumWriter<GenericRecord>(arithmeticSchema).Write(arithmeticRecord, arithmeticEncoder);
+        arithmeticEncoder.Flush();
+        _mixedFloatingArithmeticPayload = arithmeticStream.ToArray();
+        _mixedFloatingArithmeticValidator = new AvroInlineRuleValidator(arithmeticSchema);
+        _mixedFloatingArithmeticValidator.Validate(
+            _mixedFloatingArithmeticPayload,
+            14,
+            failFast: false);
 
         const string nanAggregateSchema = """
             {
@@ -593,6 +624,13 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateMixedFloatingComparison() =>
         _mixedFloatingValidator.Validate(_mixedFloatingPayload, 6, failFast: false);
+
+    [Benchmark]
+    public void ValidateMixedFloatingArithmetic() =>
+        _mixedFloatingArithmeticValidator.Validate(
+            _mixedFloatingArithmeticPayload,
+            14,
+            failFast: false);
 
     [Benchmark]
     public void ValidateNaNAggregateInequality() =>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -47,6 +47,7 @@ public class AvroInlineValidationBenchmarks
     private AvroInlineRuleValidator _rootArrayHasValidator = null!;
     private AvroInlineRuleValidator _memberArrayHasValidator = null!;
     private AvroInlineRuleValidator _mapMemberNestedValidator = null!;
+    private AvroInlineRuleValidator _mapMemberAggregateValidator = null!;
     private ReadOnlyMemory<byte> _mapMemberNestedPayload;
     private AvroInlineRuleValidator _unionMemberNestedValidator = null!;
     private ReadOnlyMemory<byte> _unionMemberNestedPayload;
@@ -455,6 +456,22 @@ public class AvroInlineValidationBenchmarks
         _mapMemberNestedValidator = new AvroInlineRuleValidator(mapMemberNestedSchema);
         _mapMemberNestedValidator.Validate(_mapMemberNestedPayload, 13, failFast: false);
 
+        const string mapMemberAggregateSchemaText = """
+            {
+              "type": "map",
+              "confluent:rules": [{ "name": "selected", "expr": "this.selected.code > 0" }],
+              "values": {
+                "type": "record",
+                "name": "MapMemberAggregateBenchmarkValue",
+                "confluent:rules": [{ "name": "present", "expr": "has(this.code)" }],
+                "fields": [{ "name": "code", "type": "int" }]
+              }
+            }
+            """;
+        _mapMemberAggregateValidator = new AvroInlineRuleValidator(
+            AvroSchema.Parse(mapMemberAggregateSchemaText));
+        _mapMemberAggregateValidator.Validate(_mapMemberNestedPayload, 20, failFast: false);
+
         var unionSchemaText = new StringBuilder(
             "{\"type\":[\"null\",{\"type\":\"record\",\"name\":\"UnionMemberNestedBenchmarkValue\",\"fields\":[");
         for (var index = 0; index < 128; index++)
@@ -659,6 +676,10 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateMapMemberWithNestedRules() =>
         _mapMemberNestedValidator.Validate(_mapMemberNestedPayload, 13, failFast: false);
+
+    [Benchmark]
+    public void ValidateMapMemberWithoutSizeDemand() =>
+        _mapMemberAggregateValidator.Validate(_mapMemberNestedPayload, 20, failFast: false);
 
     [Benchmark]
     public void ValidateUnionMemberWithNestedRules() =>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -19,6 +19,9 @@ public class AvroInlineValidationBenchmarks
     private AvroInlineRuleValidator _conditionalArrayEqualityValidator = null!;
     private ReadOnlyMemory<byte> _equalArrayPayload;
     private ReadOnlyMemory<byte> _segmentedArrayPayload;
+    private AvroInlineRuleValidator _unionArrayEqualityValidator = null!;
+    private ReadOnlyMemory<byte> _equalUnionArrayControlPayload;
+    private ReadOnlyMemory<byte> _equalUnionArrayReorderedPayload;
     private AvroInlineRuleValidator _mapEqualityValidator = null!;
     private ReadOnlyMemory<byte> _reorderedMapPayload;
     private AvroInlineRuleValidator _recordSizeValidator = null!;
@@ -115,6 +118,26 @@ public class AvroInlineValidationBenchmarks
         _conditionalArrayEqualityValidator = new AvroInlineRuleValidator(
             AvroSchema.Parse(conditionalArrayEqualitySchema));
         _conditionalArrayEqualityValidator.Validate(_segmentedArrayPayload, 10, failFast: false);
+
+        const string unionArrayEqualitySchema = """
+            {
+              "type": "record",
+              "name": "UnionArrayEqualityBenchmarkRecord",
+              "confluent:rules": [{ "name": "equal", "expr": "this.left == this.right" }],
+              "fields": [
+                { "name": "left", "type": { "type": "array", "items": ["int", "long"] } },
+                { "name": "right", "type": { "type": "array", "items": ["long", "int"] } }
+              ]
+            }
+            """;
+        _unionArrayEqualityValidator = new AvroInlineRuleValidator(
+            AvroSchema.Parse(unionArrayEqualitySchema));
+        _equalUnionArrayControlPayload = new byte[] { 2, 0, 2, 0, 2, 0, 2, 0 };
+        _equalUnionArrayReorderedPayload = new byte[] { 2, 0, 2, 0, 2, 2, 2, 0 };
+        _unionArrayEqualityValidator.Validate(
+            _equalUnionArrayControlPayload,
+            17,
+            failFast: false);
 
         const string mapEqualitySchema = """
             {
@@ -483,6 +506,20 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateConditionalEqualArraysWithDifferentBlocks() =>
         _conditionalArrayEqualityValidator.Validate(_segmentedArrayPayload, 10, failFast: false);
+
+    [Benchmark]
+    public void ValidateEqualUnionArraysControl() =>
+        _unionArrayEqualityValidator.Validate(
+            _equalUnionArrayControlPayload,
+            17,
+            failFast: false);
+
+    [Benchmark]
+    public void ValidateEqualUnionArraysWithDifferentOrdering() =>
+        _unionArrayEqualityValidator.Validate(
+            _equalUnionArrayReorderedPayload,
+            17,
+            failFast: false);
 
     [Benchmark]
     public void ValidateEqualMapsWithDifferentOrder() =>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -10,6 +10,8 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [MemoryDiagnoser(displayGenColumns: false)]
 public class AvroInlineValidationBenchmarks
 {
+    private static readonly int[] TwoItems = [1, 2];
+
     private AvroInlineRuleValidator _validator = null!;
     private ReadOnlyMemory<byte> _payload;
     private AvroInlineRuleValidator _arrayEqualityValidator = null!;
@@ -19,6 +21,10 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _reorderedMapPayload;
     private AvroInlineRuleValidator _recordSizeValidator = null!;
     private ReadOnlyMemory<byte> _recordSizePayload;
+    private AvroInlineRuleValidator _nullableAggregateValidator = null!;
+    private ReadOnlyMemory<byte> _nullableAggregatePayload;
+    private AvroInlineRuleValidator _mixedFloatingValidator = null!;
+    private ReadOnlyMemory<byte> _mixedFloatingPayload;
 
     [GlobalSetup]
     public void Setup()
@@ -112,6 +118,58 @@ public class AvroInlineValidationBenchmarks
         _recordSizePayload = sizedStream.ToArray();
         _recordSizeValidator = new AvroInlineRuleValidator(sizedSchema);
         _recordSizeValidator.Validate(_recordSizePayload, 4, failFast: false);
+
+        const string nullableAggregateSchema = """
+            {
+              "type": "record",
+              "name": "NullableAggregateBenchmarkRecord",
+              "confluent:rules": [{ "name": "size", "expr": "size(this.items) == 2 && this.child.code == 7" }],
+              "fields": [
+                { "name": "items", "type": ["null", { "type": "array", "items": "int" }] },
+                {
+                  "name": "child",
+                  "type": ["null", {
+                    "type": "record",
+                    "name": "NullableAggregateBenchmarkChild",
+                    "fields": [{ "name": "code", "type": "int" }]
+                  }],
+                  "confluent:rules": [{ "name": "code", "expr": "this.code == 7" }]
+                }
+              ]
+            }
+            """;
+        var nullableSchema = (RecordSchema)AvroSchema.Parse(nullableAggregateSchema);
+        var nullableChildSchema = (RecordSchema)((UnionSchema)nullableSchema.Fields[1].Schema)[1];
+        var nullableChild = new GenericRecord(nullableChildSchema);
+        nullableChild.Add("code", 7);
+        var nullableRecord = new GenericRecord(nullableSchema);
+        nullableRecord.Add("items", TwoItems);
+        nullableRecord.Add("child", nullableChild);
+        using var nullableStream = new MemoryStream();
+        var nullableEncoder = new BinaryEncoder(nullableStream);
+        new GenericDatumWriter<GenericRecord>(nullableSchema).Write(nullableRecord, nullableEncoder);
+        nullableEncoder.Flush();
+        _nullableAggregatePayload = nullableStream.ToArray();
+        _nullableAggregateValidator = new AvroInlineRuleValidator(nullableSchema);
+        _nullableAggregateValidator.Validate(_nullableAggregatePayload, 5, failFast: false);
+
+        const string mixedFloatingSchema = """
+            {
+              "type": "double",
+              "confluent:rules": [{
+                "name": "precision",
+                "expr": "this != 9007199254740993 && this < 9007199254740993"
+              }]
+            }
+            """;
+        var floatingSchema = AvroSchema.Parse(mixedFloatingSchema);
+        using var floatingStream = new MemoryStream();
+        var floatingEncoder = new BinaryEncoder(floatingStream);
+        new GenericDatumWriter<double>(floatingSchema).Write(9007199254740992d, floatingEncoder);
+        floatingEncoder.Flush();
+        _mixedFloatingPayload = floatingStream.ToArray();
+        _mixedFloatingValidator = new AvroInlineRuleValidator(floatingSchema);
+        _mixedFloatingValidator.Validate(_mixedFloatingPayload, 6, failFast: false);
     }
 
     [Benchmark]
@@ -133,4 +191,12 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateRecordSize() =>
         _recordSizeValidator.Validate(_recordSizePayload, 4, failFast: false);
+
+    [Benchmark]
+    public void ValidateNullableAggregateMembers() =>
+        _nullableAggregateValidator.Validate(_nullableAggregatePayload, 5, failFast: false);
+
+    [Benchmark]
+    public void ValidateMixedFloatingComparison() =>
+        _mixedFloatingValidator.Validate(_mixedFloatingPayload, 6, failFast: false);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -22,6 +22,8 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _reorderedMapPayload;
     private AvroInlineRuleValidator _recordSizeValidator = null!;
     private ReadOnlyMemory<byte> _recordSizePayload;
+    private AvroInlineRuleValidator _memberOnlyRecordValidator = null!;
+    private ReadOnlyMemory<byte> _memberOnlyRecordPayload;
     private AvroInlineRuleValidator _nullableAggregateValidator = null!;
     private ReadOnlyMemory<byte> _nullableAggregatePayload;
     private AvroInlineRuleValidator _mixedFloatingValidator = null!;
@@ -143,6 +145,29 @@ public class AvroInlineValidationBenchmarks
         _recordSizePayload = sizedStream.ToArray();
         _recordSizeValidator = new AvroInlineRuleValidator(sizedSchema);
         _recordSizeValidator.Validate(_recordSizePayload, 4, failFast: false);
+
+        const string memberOnlyRecordSchema = """
+            {
+              "type": "record",
+              "name": "MemberOnlyRecordBenchmarkRecord",
+              "confluent:rules": [{ "name": "name", "expr": "this.name == 'dekaf'" }],
+              "fields": [
+                { "name": "name", "type": "string" },
+                { "name": "age", "type": "int" }
+              ]
+            }
+            """;
+        var memberOnlySchema = (RecordSchema)AvroSchema.Parse(memberOnlyRecordSchema);
+        var memberOnlyRecord = new GenericRecord(memberOnlySchema);
+        memberOnlyRecord.Add("name", "dekaf");
+        memberOnlyRecord.Add("age", 42);
+        using var memberOnlyStream = new MemoryStream();
+        var memberOnlyEncoder = new BinaryEncoder(memberOnlyStream);
+        new GenericDatumWriter<GenericRecord>(memberOnlySchema).Write(memberOnlyRecord, memberOnlyEncoder);
+        memberOnlyEncoder.Flush();
+        _memberOnlyRecordPayload = memberOnlyStream.ToArray();
+        _memberOnlyRecordValidator = new AvroInlineRuleValidator(memberOnlySchema);
+        _memberOnlyRecordValidator.Validate(_memberOnlyRecordPayload, 11, failFast: false);
 
         const string nullableAggregateSchema = """
             {
@@ -282,6 +307,10 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateRecordSize() =>
         _recordSizeValidator.Validate(_recordSizePayload, 4, failFast: false);
+
+    [Benchmark]
+    public void ValidateMemberOnlyRecordRule() =>
+        _memberOnlyRecordValidator.Validate(_memberOnlyRecordPayload, 11, failFast: false);
 
     [Benchmark]
     public void ValidateNullableAggregateMembers() =>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -57,6 +57,8 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _mixedRootMemberNestedPayload;
     private AvroInlineRuleValidator _mixedRootFieldRuleValidator = null!;
     private ReadOnlyMemory<byte> _mixedRootFieldRulePayload;
+    private AvroInlineRuleValidator _fieldMemberNestedValidator = null!;
+    private ReadOnlyMemory<byte> _fieldMemberNestedPayload;
     private AvroInlineRuleValidator _schemaRuledFieldSizeValidator = null!;
     private ReadOnlyMemory<byte> _schemaRuledFieldSizePayload;
     private AvroInlineRuleValidator _nestedMemberFrameValidator = null!;
@@ -609,6 +611,50 @@ public class AvroInlineValidationBenchmarks
         _mixedRootFieldRuleValidator = new AvroInlineRuleValidator(mixedRootFieldRuleSchema);
         _mixedRootFieldRuleValidator.Validate(_mixedRootFieldRulePayload, 21, failFast: false);
 
+        const string fieldMemberNestedSchemaText = """
+            {
+              "type": "record",
+              "name": "FieldMemberNestedBenchmarkRecord",
+              "fields": [{
+                "name": "child",
+                "confluent:rules": [{ "name": "selected", "expr": "this.code == 1" }],
+                "type": {
+                  "type": "record",
+                  "name": "FieldMemberNestedBenchmarkChild",
+                  "fields": [
+                    { "name": "code", "type": "int" },
+                    {
+                      "name": "items",
+                      "type": {
+                        "type": "array",
+                        "items": {
+                          "type": "int",
+                          "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }]
+            }
+            """;
+        var fieldMemberNestedSchema = (RecordSchema)AvroSchema.Parse(fieldMemberNestedSchemaText);
+        var fieldMemberNestedChildSchema = (RecordSchema)fieldMemberNestedSchema.Fields[0].Schema;
+        var fieldMemberNestedChild = new GenericRecord(fieldMemberNestedChildSchema);
+        fieldMemberNestedChild.Add("code", 1);
+        fieldMemberNestedChild.Add("items", Enumerable.Range(1, 128).ToArray());
+        var fieldMemberNestedRecord = new GenericRecord(fieldMemberNestedSchema);
+        fieldMemberNestedRecord.Add("child", fieldMemberNestedChild);
+        using var fieldMemberNestedStream = new MemoryStream();
+        var fieldMemberNestedEncoder = new BinaryEncoder(fieldMemberNestedStream);
+        new GenericDatumWriter<GenericRecord>(fieldMemberNestedSchema).Write(
+            fieldMemberNestedRecord,
+            fieldMemberNestedEncoder);
+        fieldMemberNestedEncoder.Flush();
+        _fieldMemberNestedPayload = fieldMemberNestedStream.ToArray();
+        _fieldMemberNestedValidator = new AvroInlineRuleValidator(fieldMemberNestedSchema);
+        _fieldMemberNestedValidator.Validate(_fieldMemberNestedPayload, 28, failFast: false);
+
         const string schemaRuledFieldSizeSchemaText = """
             {
               "type": "record",
@@ -801,6 +847,10 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateMixedRootWithAggregateFieldRule() =>
         _mixedRootFieldRuleValidator.Validate(_mixedRootFieldRulePayload, 21, failFast: false);
+
+    [Benchmark]
+    public void ValidateAggregateFieldMemberWithNestedRules() =>
+        _fieldMemberNestedValidator.Validate(_fieldMemberNestedPayload, 28, failFast: false);
 
     [Benchmark]
     public void ValidateSchemaRuledAggregateFieldSize() =>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -17,6 +17,8 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _payload;
     private AvroInlineRuleValidator _arrayEqualityValidator = null!;
     private AvroInlineRuleValidator _conditionalArrayEqualityValidator = null!;
+    private AvroInlineRuleValidator _conditionalArraySizeValidator = null!;
+    private ReadOnlyMemory<byte> _conditionalArraySizePayload;
     private ReadOnlyMemory<byte> _equalArrayPayload;
     private ReadOnlyMemory<byte> _segmentedArrayPayload;
     private AvroInlineRuleValidator _unionArrayEqualityValidator = null!;
@@ -125,6 +127,40 @@ public class AvroInlineValidationBenchmarks
         _conditionalArrayEqualityValidator = new AvroInlineRuleValidator(
             AvroSchema.Parse(conditionalArrayEqualitySchema));
         _conditionalArrayEqualityValidator.Validate(_segmentedArrayPayload, 10, failFast: false);
+
+        const string conditionalArraySizeSchema = """
+            {
+              "type": "record",
+              "name": "ConditionalArraySizeBenchmarkRecord",
+              "confluent:rules": [{
+                "name": "size",
+                "expr": "size(this.flag ? this.left : this.right) == 128"
+              }],
+              "fields": [
+                { "name": "flag", "type": "boolean" },
+                { "name": "left", "type": { "type": "array", "items": "int" } },
+                { "name": "right", "type": { "type": "array", "items": "int" } }
+              ]
+            }
+            """;
+        var conditionalSizeSchema = (RecordSchema)AvroSchema.Parse(conditionalArraySizeSchema);
+        var conditionalSizeRecord = new GenericRecord(conditionalSizeSchema);
+        var conditionalSizeItems = Enumerable.Range(0, 128).ToArray();
+        conditionalSizeRecord.Add("flag", true);
+        conditionalSizeRecord.Add("left", conditionalSizeItems);
+        conditionalSizeRecord.Add("right", conditionalSizeItems);
+        using var conditionalSizeStream = new MemoryStream();
+        var conditionalSizeEncoder = new BinaryEncoder(conditionalSizeStream);
+        new GenericDatumWriter<GenericRecord>(conditionalSizeSchema).Write(
+            conditionalSizeRecord,
+            conditionalSizeEncoder);
+        conditionalSizeEncoder.Flush();
+        _conditionalArraySizePayload = conditionalSizeStream.ToArray();
+        _conditionalArraySizeValidator = new AvroInlineRuleValidator(conditionalSizeSchema);
+        _conditionalArraySizeValidator.Validate(
+            _conditionalArraySizePayload,
+            21,
+            failFast: false);
 
         const string unionArrayEqualitySchema = """
             {
@@ -600,6 +636,13 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateConditionalEqualArraysWithDifferentBlocks() =>
         _conditionalArrayEqualityValidator.Validate(_segmentedArrayPayload, 10, failFast: false);
+
+    [Benchmark]
+    public void ValidateConditionalArraySize() =>
+        _conditionalArraySizeValidator.Validate(
+            _conditionalArraySizePayload,
+            21,
+            failFast: false);
 
     [Benchmark]
     public void ValidateEqualUnionArraysControl() =>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -69,6 +69,10 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _nestedMemberFramePayload;
     private AvroInlineRuleValidator _recursiveValidationValidator = null!;
     private ReadOnlyMemory<byte> _recursiveValidationPayload;
+    private AvroInlineRuleValidator _recursivePrefixValidator = null!;
+    private ReadOnlyMemory<byte> _recursivePrefixPayload;
+    private AvroInlineRuleValidator _recursiveFieldRuleValidator = null!;
+    private ReadOnlyMemory<byte> _recursiveFieldRulePayload;
 
     [GlobalSetup]
     public void Setup()
@@ -826,6 +830,8 @@ public class AvroInlineValidationBenchmarks
         _nestedMemberFrameValidator.Validate(_nestedMemberFramePayload, 16, failFast: false);
 
         SetupRecursiveValidationBenchmark();
+        SetupRecursivePrefixBenchmark();
+        SetupRecursiveFieldRuleBenchmark();
     }
 
     private void SetupRecursiveValidationBenchmark()
@@ -854,6 +860,52 @@ public class AvroInlineValidationBenchmarks
             _recursiveValidationPayload,
             31,
             failFast: false);
+    }
+
+    private void SetupRecursivePrefixBenchmark()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "RecursivePrefixBenchmarkNode",
+              "confluent:rules": [{ "name": "marker", "expr": "this.marker >= 0" }],
+              "fields": [
+                { "name": "next", "type": ["null", "RecursivePrefixBenchmarkNode"] },
+                { "name": "marker", "type": "int" }
+              ]
+            }
+            """;
+        var payload = new byte[16];
+        payload.AsSpan(0, 7).Fill(2);
+        _recursivePrefixPayload = payload;
+        _recursivePrefixValidator = new AvroInlineRuleValidator(AvroSchema.Parse(schemaText));
+        _recursivePrefixValidator.Validate(_recursivePrefixPayload, 32, failFast: false);
+    }
+
+    private void SetupRecursiveFieldRuleBenchmark()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "RecursiveFieldBenchmarkWrapper",
+              "fields": [{
+                "name": "node",
+                "type": {
+                  "type": "record",
+                  "name": "RecursiveFieldBenchmarkNode",
+                  "fields": [
+                    { "name": "next", "type": ["null", "RecursiveFieldBenchmarkNode"] }
+                  ]
+                },
+                "confluent:rules": [{ "name": "self", "expr": "this == this" }]
+              }]
+            }
+            """;
+        var payload = new byte[8];
+        payload.AsSpan(0, 7).Fill(2);
+        _recursiveFieldRulePayload = payload;
+        _recursiveFieldRuleValidator = new AvroInlineRuleValidator(AvroSchema.Parse(schemaText));
+        _recursiveFieldRuleValidator.Validate(_recursiveFieldRulePayload, 33, failFast: false);
     }
 
     [Benchmark]
@@ -1003,4 +1055,12 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateRecursivePayload() =>
         _recursiveValidationValidator.Validate(_recursiveValidationPayload, 31, failFast: false);
+
+    [Benchmark]
+    public void ValidateRecursivePrefix() =>
+        _recursivePrefixValidator.Validate(_recursivePrefixPayload, 32, failFast: false);
+
+    [Benchmark]
+    public void ValidateRecursiveFieldRule() =>
+        _recursiveFieldRuleValidator.Validate(_recursiveFieldRulePayload, 33, failFast: false);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -20,7 +20,6 @@ public class AvroInlineValidationBenchmarks
             {
               "type": "record",
               "name": "ValidationBenchmarkRecord",
-              "confluent:rules": [{ "name": "root", "expr": "this.name == 'dekaf'" }],
               "fields": [
                 {
                   "name": "name",

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -15,6 +15,7 @@ public class AvroInlineValidationBenchmarks
     private AvroInlineRuleValidator _validator = null!;
     private ReadOnlyMemory<byte> _payload;
     private AvroInlineRuleValidator _arrayEqualityValidator = null!;
+    private AvroInlineRuleValidator _conditionalArrayEqualityValidator = null!;
     private ReadOnlyMemory<byte> _equalArrayPayload;
     private ReadOnlyMemory<byte> _segmentedArrayPayload;
     private AvroInlineRuleValidator _mapEqualityValidator = null!;
@@ -82,6 +83,24 @@ public class AvroInlineValidationBenchmarks
         _segmentedArrayPayload = new byte[] { 4, 2, 4, 0, 2, 2, 2, 4, 0 };
         _arrayEqualityValidator.Validate(_equalArrayPayload, 2, failFast: false);
         _arrayEqualityValidator.Validate(_segmentedArrayPayload, 2, failFast: false);
+
+        const string conditionalArrayEqualitySchema = """
+            {
+              "type": "record",
+              "name": "ConditionalArrayEqualityBenchmarkRecord",
+              "confluent:rules": [{
+                "name": "equal",
+                "expr": "(true ? this.left : this.right) == this.right"
+              }],
+              "fields": [
+                { "name": "left", "type": { "type": "array", "items": "int" } },
+                { "name": "right", "type": { "type": "array", "items": "int" } }
+              ]
+            }
+            """;
+        _conditionalArrayEqualityValidator = new AvroInlineRuleValidator(
+            AvroSchema.Parse(conditionalArrayEqualitySchema));
+        _conditionalArrayEqualityValidator.Validate(_segmentedArrayPayload, 10, failFast: false);
 
         const string mapEqualitySchema = """
             {
@@ -251,6 +270,10 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateEqualArraysWithDifferentBlocks() =>
         _arrayEqualityValidator.Validate(_segmentedArrayPayload, 2, failFast: false);
+
+    [Benchmark]
+    public void ValidateConditionalEqualArraysWithDifferentBlocks() =>
+        _conditionalArrayEqualityValidator.Validate(_segmentedArrayPayload, 10, failFast: false);
 
     [Benchmark]
     public void ValidateEqualMapsWithDifferentOrder() =>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Avro;
 using Avro.Generic;
 using Avro.IO;
@@ -36,6 +37,10 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _enumPayload;
     private AvroInlineRuleValidator _rootArrayNestedValidator = null!;
     private ReadOnlyMemory<byte> _rootArrayNestedPayload;
+    private AvroInlineRuleValidator _mapMemberNestedValidator = null!;
+    private ReadOnlyMemory<byte> _mapMemberNestedPayload;
+    private AvroInlineRuleValidator _unionMemberNestedValidator = null!;
+    private ReadOnlyMemory<byte> _unionMemberNestedPayload;
 
     [GlobalSetup]
     public void Setup()
@@ -308,6 +313,74 @@ public class AvroInlineValidationBenchmarks
         _rootArrayNestedPayload = rootArrayNestedStream.ToArray();
         _rootArrayNestedValidator = new AvroInlineRuleValidator(rootArrayNestedSchema);
         _rootArrayNestedValidator.Validate(_rootArrayNestedPayload, 12, failFast: false);
+
+        const string mapMemberNestedSchemaText = """
+            {
+              "type": "map",
+              "confluent:rules": [{ "name": "selected", "expr": "this.selected.code > 0" }],
+              "values": {
+                "type": "record",
+                "name": "MapMemberNestedBenchmarkValue",
+                "fields": [{
+                  "name": "code",
+                  "type": "int",
+                  "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                }]
+              }
+            }
+            """;
+        var mapMemberNestedSchema = (MapSchema)AvroSchema.Parse(mapMemberNestedSchemaText);
+        var mapMemberNestedValueSchema = (RecordSchema)mapMemberNestedSchema.ValueSchema;
+        var mapMemberNestedValues = new Dictionary<string, object>(128);
+        for (var index = 0; index < 127; index++)
+        {
+            var mapValue = new GenericRecord(mapMemberNestedValueSchema);
+            mapValue.Add("code", 1);
+            mapMemberNestedValues.Add($"entry-{index}", mapValue);
+        }
+        var selectedMapValue = new GenericRecord(mapMemberNestedValueSchema);
+        selectedMapValue.Add("code", 1);
+        mapMemberNestedValues.Add("selected", selectedMapValue);
+        using var mapMemberNestedStream = new MemoryStream();
+        var mapMemberNestedEncoder = new BinaryEncoder(mapMemberNestedStream);
+        new GenericDatumWriter<object>(mapMemberNestedSchema).Write(
+            mapMemberNestedValues,
+            mapMemberNestedEncoder);
+        mapMemberNestedEncoder.Flush();
+        _mapMemberNestedPayload = mapMemberNestedStream.ToArray();
+        _mapMemberNestedValidator = new AvroInlineRuleValidator(mapMemberNestedSchema);
+        _mapMemberNestedValidator.Validate(_mapMemberNestedPayload, 13, failFast: false);
+
+        var unionSchemaText = new StringBuilder(
+            "{\"type\":[\"null\",{\"type\":\"record\",\"name\":\"UnionMemberNestedBenchmarkValue\",\"fields\":[");
+        for (var index = 0; index < 128; index++)
+        {
+            if (index != 0)
+                unionSchemaText.Append(',');
+            unionSchemaText.Append("{\"name\":\"field").Append(index).Append("\",\"type\":\"int\"");
+            if (index == 0)
+            {
+                unionSchemaText.Append(
+                    ",\"confluent:rules\":[{\"name\":\"positive\",\"expr\":\"this > 0\"}]");
+            }
+            unionSchemaText.Append('}');
+        }
+        unionSchemaText.Append(
+            "]}],\"confluent:rules\":[{\"name\":\"selected\",\"expr\":\"this.field127 > 0\"}]}");
+        var unionMemberNestedSchema = (UnionSchema)AvroSchema.Parse(unionSchemaText.ToString());
+        var unionMemberNestedValueSchema = (RecordSchema)unionMemberNestedSchema[1];
+        var unionMemberNestedValue = new GenericRecord(unionMemberNestedValueSchema);
+        for (var index = 0; index < 128; index++)
+            unionMemberNestedValue.Add($"field{index}", 1);
+        using var unionMemberNestedStream = new MemoryStream();
+        var unionMemberNestedEncoder = new BinaryEncoder(unionMemberNestedStream);
+        new GenericDatumWriter<object>(unionMemberNestedSchema).Write(
+            unionMemberNestedValue,
+            unionMemberNestedEncoder);
+        unionMemberNestedEncoder.Flush();
+        _unionMemberNestedPayload = unionMemberNestedStream.ToArray();
+        _unionMemberNestedValidator = new AvroInlineRuleValidator(unionMemberNestedSchema);
+        _unionMemberNestedValidator.Validate(_unionMemberNestedPayload, 14, failFast: false);
     }
 
     [Benchmark]
@@ -361,4 +434,12 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateRootArrayWithNestedRules() =>
         _rootArrayNestedValidator.Validate(_rootArrayNestedPayload, 12, failFast: false);
+
+    [Benchmark]
+    public void ValidateMapMemberWithNestedRules() =>
+        _mapMemberNestedValidator.Validate(_mapMemberNestedPayload, 13, failFast: false);
+
+    [Benchmark]
+    public void ValidateUnionMemberWithNestedRules() =>
+        _unionMemberNestedValidator.Validate(_unionMemberNestedPayload, 14, failFast: false);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -17,6 +17,8 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _segmentedArrayPayload;
     private AvroInlineRuleValidator _mapEqualityValidator = null!;
     private ReadOnlyMemory<byte> _reorderedMapPayload;
+    private AvroInlineRuleValidator _recordSizeValidator = null!;
+    private ReadOnlyMemory<byte> _recordSizePayload;
 
     [GlobalSetup]
     public void Setup()
@@ -87,6 +89,29 @@ public class AvroInlineValidationBenchmarks
             4, 2, (byte)'b', 4, 2, (byte)'a', 2, 0
         };
         _mapEqualityValidator.Validate(_reorderedMapPayload, 3, failFast: false);
+
+        const string recordSizeSchema = """
+            {
+              "type": "record",
+              "name": "RecordSizeBenchmarkRecord",
+              "confluent:rules": [{ "name": "size", "expr": "size(this) == 2" }],
+              "fields": [
+                { "name": "name", "type": "string" },
+                { "name": "age", "type": "int" }
+              ]
+            }
+            """;
+        var sizedSchema = (RecordSchema)AvroSchema.Parse(recordSizeSchema);
+        var sizedRecord = new GenericRecord(sizedSchema);
+        sizedRecord.Add("name", "dekaf");
+        sizedRecord.Add("age", 42);
+        using var sizedStream = new MemoryStream();
+        var sizedEncoder = new BinaryEncoder(sizedStream);
+        new GenericDatumWriter<GenericRecord>(sizedSchema).Write(sizedRecord, sizedEncoder);
+        sizedEncoder.Flush();
+        _recordSizePayload = sizedStream.ToArray();
+        _recordSizeValidator = new AvroInlineRuleValidator(sizedSchema);
+        _recordSizeValidator.Validate(_recordSizePayload, 4, failFast: false);
     }
 
     [Benchmark]
@@ -104,4 +129,8 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateEqualMapsWithDifferentOrder() =>
         _mapEqualityValidator.Validate(_reorderedMapPayload, 3, failFast: false);
+
+    [Benchmark]
+    public void ValidateRecordSize() =>
+        _recordSizeValidator.Validate(_recordSizePayload, 4, failFast: false);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -1,0 +1,54 @@
+using Avro;
+using Avro.Generic;
+using Avro.IO;
+using BenchmarkDotNet.Attributes;
+using Dekaf.SchemaRegistry.Avro;
+using AvroSchema = Avro.Schema;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser(displayGenColumns: false)]
+public class AvroInlineValidationBenchmarks
+{
+    private AvroInlineRuleValidator _validator = null!;
+    private ReadOnlyMemory<byte> _payload;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        const string schemaText = """
+            {
+              "type": "record",
+              "name": "ValidationBenchmarkRecord",
+              "confluent:rules": [{ "name": "root", "expr": "this.name == 'dekaf'" }],
+              "fields": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "confluent:rules": [{ "name": "name", "expr": "size(this) > 0" }]
+                },
+                {
+                  "name": "age",
+                  "type": "int",
+                  "confluent:rules": [{ "name": "age", "expr": "this >= 0" }]
+                }
+              ]
+            }
+            """;
+        var schema = (RecordSchema)AvroSchema.Parse(schemaText);
+        var record = new GenericRecord(schema);
+        record.Add("name", "dekaf");
+        record.Add("age", 42);
+        using var stream = new MemoryStream();
+        var encoder = new BinaryEncoder(stream);
+        new GenericDatumWriter<GenericRecord>(schema).Write(record, encoder);
+        encoder.Flush();
+        _payload = stream.ToArray();
+        _validator = new AvroInlineRuleValidator(schema);
+        _validator.Validate(_payload, 1, failFast: false);
+    }
+
+    [Benchmark]
+    public void ValidateWarmedValidPayload() =>
+        _validator.Validate(_payload, 1, failFast: false);
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -57,8 +57,8 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _mixedRootMemberNestedPayload;
     private AvroInlineRuleValidator _mixedRootFieldRuleValidator = null!;
     private ReadOnlyMemory<byte> _mixedRootFieldRulePayload;
-    private AvroInlineRuleValidator _nullableFieldSizeValidator = null!;
-    private ReadOnlyMemory<byte> _nullableFieldSizePayload;
+    private AvroInlineRuleValidator _schemaRuledFieldSizeValidator = null!;
+    private ReadOnlyMemory<byte> _schemaRuledFieldSizePayload;
     private AvroInlineRuleValidator _nestedMemberFrameValidator = null!;
     private ReadOnlyMemory<byte> _nestedMemberFramePayload;
 
@@ -609,33 +609,36 @@ public class AvroInlineValidationBenchmarks
         _mixedRootFieldRuleValidator = new AvroInlineRuleValidator(mixedRootFieldRuleSchema);
         _mixedRootFieldRuleValidator.Validate(_mixedRootFieldRulePayload, 21, failFast: false);
 
-        const string nullableFieldSizeSchemaText = """
+        const string schemaRuledFieldSizeSchemaText = """
             {
               "type": "record",
-              "name": "NullableFieldSizeBenchmarkRecord",
+              "name": "SchemaRuledFieldSizeBenchmarkRecord",
               "confluent:rules": [{
                 "name": "root-and-member-size",
                 "expr": "size(this) == 1 && size(this.items) == 128"
               }],
               "fields": [{
                 "name": "items",
-                "confluent:rules": [{ "name": "field-present", "expr": "this == this" }],
-                "type": ["null", { "type": "array", "items": "int" }]
+                "type": {
+                  "type": "array",
+                  "items": "int",
+                  "confluent:rules": [{ "name": "schema-present", "expr": "this == this" }]
+                }
               }]
             }
             """;
-        var nullableFieldSizeSchema = (RecordSchema)AvroSchema.Parse(nullableFieldSizeSchemaText);
-        var nullableFieldSizeRecord = new GenericRecord(nullableFieldSizeSchema);
-        nullableFieldSizeRecord.Add("items", Enumerable.Range(1, 128).ToArray());
-        using var nullableFieldSizeStream = new MemoryStream();
-        var nullableFieldSizeEncoder = new BinaryEncoder(nullableFieldSizeStream);
-        new GenericDatumWriter<GenericRecord>(nullableFieldSizeSchema).Write(
-            nullableFieldSizeRecord,
-            nullableFieldSizeEncoder);
-        nullableFieldSizeEncoder.Flush();
-        _nullableFieldSizePayload = nullableFieldSizeStream.ToArray();
-        _nullableFieldSizeValidator = new AvroInlineRuleValidator(nullableFieldSizeSchema);
-        _nullableFieldSizeValidator.Validate(_nullableFieldSizePayload, 22, failFast: false);
+        var schemaRuledFieldSizeSchema = (RecordSchema)AvroSchema.Parse(schemaRuledFieldSizeSchemaText);
+        var schemaRuledFieldSizeRecord = new GenericRecord(schemaRuledFieldSizeSchema);
+        schemaRuledFieldSizeRecord.Add("items", Enumerable.Range(1, 128).ToArray());
+        using var schemaRuledFieldSizeStream = new MemoryStream();
+        var schemaRuledFieldSizeEncoder = new BinaryEncoder(schemaRuledFieldSizeStream);
+        new GenericDatumWriter<GenericRecord>(schemaRuledFieldSizeSchema).Write(
+            schemaRuledFieldSizeRecord,
+            schemaRuledFieldSizeEncoder);
+        schemaRuledFieldSizeEncoder.Flush();
+        _schemaRuledFieldSizePayload = schemaRuledFieldSizeStream.ToArray();
+        _schemaRuledFieldSizeValidator = new AvroInlineRuleValidator(schemaRuledFieldSizeSchema);
+        _schemaRuledFieldSizeValidator.Validate(_schemaRuledFieldSizePayload, 22, failFast: false);
 
         const string nestedMemberFrameSchemaText = """
             {
@@ -800,8 +803,8 @@ public class AvroInlineValidationBenchmarks
         _mixedRootFieldRuleValidator.Validate(_mixedRootFieldRulePayload, 21, failFast: false);
 
     [Benchmark]
-    public void ValidateNullableAggregateFieldSize() =>
-        _nullableFieldSizeValidator.Validate(_nullableFieldSizePayload, 22, failFast: false);
+    public void ValidateSchemaRuledAggregateFieldSize() =>
+        _schemaRuledFieldSizeValidator.Validate(_schemaRuledFieldSizePayload, 22, failFast: false);
 
     [Benchmark]
     public void ValidateNestedMemberFrames() =>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -41,6 +41,8 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _mapMemberNestedPayload;
     private AvroInlineRuleValidator _unionMemberNestedValidator = null!;
     private ReadOnlyMemory<byte> _unionMemberNestedPayload;
+    private AvroInlineRuleValidator _mixedRootMemberNestedValidator = null!;
+    private ReadOnlyMemory<byte> _mixedRootMemberNestedPayload;
 
     [GlobalSetup]
     public void Setup()
@@ -381,6 +383,44 @@ public class AvroInlineValidationBenchmarks
         _unionMemberNestedPayload = unionMemberNestedStream.ToArray();
         _unionMemberNestedValidator = new AvroInlineRuleValidator(unionMemberNestedSchema);
         _unionMemberNestedValidator.Validate(_unionMemberNestedPayload, 14, failFast: false);
+
+        const string mixedRootMemberNestedSchemaText = """
+            {
+              "type": "record",
+              "name": "MixedRootMemberNestedBenchmarkRecord",
+              "confluent:rules": [{
+                "name": "root-and-member",
+                "expr": "size(this) == 1 && size(this.items) == 128"
+              }],
+              "fields": [{
+                "name": "items",
+                "confluent:rules": [{ "name": "field-size", "expr": "size(this) == 128" }],
+                "type": {
+                  "type": "array",
+                  "items": {
+                    "type": "int",
+                    "confluent:rules": [{ "name": "positive", "expr": "this > 0" }]
+                  }
+                }
+              }]
+            }
+            """;
+        var mixedRootMemberNestedSchema = (RecordSchema)AvroSchema.Parse(
+            mixedRootMemberNestedSchemaText);
+        var mixedRootMemberNestedRecord = new GenericRecord(mixedRootMemberNestedSchema);
+        mixedRootMemberNestedRecord.Add("items", Enumerable.Range(1, 128).ToArray());
+        using var mixedRootMemberNestedStream = new MemoryStream();
+        var mixedRootMemberNestedEncoder = new BinaryEncoder(mixedRootMemberNestedStream);
+        new GenericDatumWriter<GenericRecord>(mixedRootMemberNestedSchema).Write(
+            mixedRootMemberNestedRecord,
+            mixedRootMemberNestedEncoder);
+        mixedRootMemberNestedEncoder.Flush();
+        _mixedRootMemberNestedPayload = mixedRootMemberNestedStream.ToArray();
+        _mixedRootMemberNestedValidator = new AvroInlineRuleValidator(mixedRootMemberNestedSchema);
+        _mixedRootMemberNestedValidator.Validate(
+            _mixedRootMemberNestedPayload,
+            15,
+            failFast: false);
     }
 
     [Benchmark]
@@ -442,4 +482,11 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateUnionMemberWithNestedRules() =>
         _unionMemberNestedValidator.Validate(_unionMemberNestedPayload, 14, failFast: false);
+
+    [Benchmark]
+    public void ValidateMixedRootMemberWithNestedRules() =>
+        _mixedRootMemberNestedValidator.Validate(
+            _mixedRootMemberNestedPayload,
+            15,
+            failFast: false);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -67,6 +67,8 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _schemaRuledFieldSizePayload;
     private AvroInlineRuleValidator _nestedMemberFrameValidator = null!;
     private ReadOnlyMemory<byte> _nestedMemberFramePayload;
+    private AvroInlineRuleValidator _recursiveValidationValidator = null!;
+    private ReadOnlyMemory<byte> _recursiveValidationPayload;
 
     [GlobalSetup]
     public void Setup()
@@ -822,6 +824,31 @@ public class AvroInlineValidationBenchmarks
         _nestedMemberFramePayload = nestedMemberFrameStream.ToArray();
         _nestedMemberFrameValidator = new AvroInlineRuleValidator(nestedMemberFrameSchema);
         _nestedMemberFrameValidator.Validate(_nestedMemberFramePayload, 16, failFast: false);
+
+        const string recursiveValidationSchemaText = """
+            {
+              "type": "record",
+              "name": "RecursiveValidationBenchmarkNode",
+              "fields": [
+                {
+                  "name": "value",
+                  "type": "int",
+                  "confluent:rules": [{ "name": "nonnegative", "expr": "this >= 0" }]
+                },
+                { "name": "next", "type": ["null", "RecursiveValidationBenchmarkNode"] }
+              ]
+            }
+            """;
+        var recursiveValidationSchema = AvroSchema.Parse(recursiveValidationSchemaText);
+        var recursiveValidationPayload = new byte[16];
+        for (var index = 0; index < 7; index++)
+            recursiveValidationPayload[index * 2 + 1] = 2;
+        _recursiveValidationPayload = recursiveValidationPayload;
+        _recursiveValidationValidator = new AvroInlineRuleValidator(recursiveValidationSchema);
+        _recursiveValidationValidator.Validate(
+            _recursiveValidationPayload,
+            31,
+            failFast: false);
     }
 
     [Benchmark]
@@ -967,4 +994,8 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateNestedMemberFrames() =>
         _nestedMemberFrameValidator.Validate(_nestedMemberFramePayload, 16, failFast: false);
+
+    [Benchmark]
+    public void ValidateRecursivePayload() =>
+        _recursiveValidationValidator.Validate(_recursiveValidationPayload, 31, failFast: false);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroInlineValidationBenchmarks.cs
@@ -57,6 +57,8 @@ public class AvroInlineValidationBenchmarks
     private ReadOnlyMemory<byte> _mixedRootMemberNestedPayload;
     private AvroInlineRuleValidator _mixedRootFieldRuleValidator = null!;
     private ReadOnlyMemory<byte> _mixedRootFieldRulePayload;
+    private AvroInlineRuleValidator _nullableFieldSizeValidator = null!;
+    private ReadOnlyMemory<byte> _nullableFieldSizePayload;
     private AvroInlineRuleValidator _nestedMemberFrameValidator = null!;
     private ReadOnlyMemory<byte> _nestedMemberFramePayload;
 
@@ -607,6 +609,34 @@ public class AvroInlineValidationBenchmarks
         _mixedRootFieldRuleValidator = new AvroInlineRuleValidator(mixedRootFieldRuleSchema);
         _mixedRootFieldRuleValidator.Validate(_mixedRootFieldRulePayload, 21, failFast: false);
 
+        const string nullableFieldSizeSchemaText = """
+            {
+              "type": "record",
+              "name": "NullableFieldSizeBenchmarkRecord",
+              "confluent:rules": [{
+                "name": "root-and-member-size",
+                "expr": "size(this) == 1 && size(this.items) == 128"
+              }],
+              "fields": [{
+                "name": "items",
+                "confluent:rules": [{ "name": "field-present", "expr": "this == this" }],
+                "type": ["null", { "type": "array", "items": "int" }]
+              }]
+            }
+            """;
+        var nullableFieldSizeSchema = (RecordSchema)AvroSchema.Parse(nullableFieldSizeSchemaText);
+        var nullableFieldSizeRecord = new GenericRecord(nullableFieldSizeSchema);
+        nullableFieldSizeRecord.Add("items", Enumerable.Range(1, 128).ToArray());
+        using var nullableFieldSizeStream = new MemoryStream();
+        var nullableFieldSizeEncoder = new BinaryEncoder(nullableFieldSizeStream);
+        new GenericDatumWriter<GenericRecord>(nullableFieldSizeSchema).Write(
+            nullableFieldSizeRecord,
+            nullableFieldSizeEncoder);
+        nullableFieldSizeEncoder.Flush();
+        _nullableFieldSizePayload = nullableFieldSizeStream.ToArray();
+        _nullableFieldSizeValidator = new AvroInlineRuleValidator(nullableFieldSizeSchema);
+        _nullableFieldSizeValidator.Validate(_nullableFieldSizePayload, 22, failFast: false);
+
         const string nestedMemberFrameSchemaText = """
             {
               "type": "record",
@@ -768,6 +798,10 @@ public class AvroInlineValidationBenchmarks
     [Benchmark]
     public void ValidateMixedRootWithAggregateFieldRule() =>
         _mixedRootFieldRuleValidator.Validate(_mixedRootFieldRulePayload, 21, failFast: false);
+
+    [Benchmark]
+    public void ValidateNullableAggregateFieldSize() =>
+        _nullableFieldSizeValidator.Validate(_nullableFieldSizePayload, 22, failFast: false);
 
     [Benchmark]
     public void ValidateNestedMemberFrames() =>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroPocoSchemaRegistryBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroPocoSchemaRegistryBenchmarks.cs
@@ -233,6 +233,8 @@ public class AvroPocoSchemaRegistryDeserializationBenchmarks
         Component = SerializationComponent.Value
     };
     private AvroPocoSchemaRegistryDeserializer<PocoBenchmarkRecord, PocoBenchmarkRecord.AvroCodec> _poco = null!;
+    private AvroPocoSchemaRegistryDeserializer<PocoBenchmarkRecord, PocoBenchmarkRecord.AvroCodec>
+        _validationEnabledPoco = null!;
     private AvroPocoSchemaRegistryDeserializer<
         PocoWriterUnionBenchmarkRecord,
         PocoWriterUnionBenchmarkRecord.AvroCodec> _rulesValuePoco = null!;
@@ -242,6 +244,7 @@ public class AvroPocoSchemaRegistryDeserializationBenchmarks
     private IAsyncDeserializerPreparer<PocoBenchmarkRecord> _pocoPreparer = null!;
     private AvroSchemaRegistryDeserializer<PocoBenchmarkSpecificRecord> _specific = null!;
     private AvroSchemaRegistryDeserializer<GenericRecord> _generic = null!;
+    private AvroSchemaRegistryDeserializer<GenericRecord> _validationEnabledGeneric = null!;
     private AvroPocoSchemaRegistryDeserializer<PocoBenchmarkDecimalRecord, PocoBenchmarkDecimalRecord.AvroCodec>
         _decimalPoco = null!;
     private AvroPocoSchemaRegistryDeserializer<PocoWriterUnionBenchmarkRecord, PocoWriterUnionBenchmarkRecord.AvroCodec>
@@ -280,6 +283,12 @@ public class AvroPocoSchemaRegistryDeserializationBenchmarks
             SchemaString = SchemaJson
         };
         _poco = PocoBenchmarkRecord.CreateAvroDeserializer(new BenchmarkSchemaRegistryClient(registrySchema));
+        _validationEnabledPoco = PocoBenchmarkRecord.CreateAvroDeserializer(
+            new BenchmarkSchemaRegistryClient(registrySchema),
+            new AvroDeserializerConfig
+            {
+                ValidationRulesExecution = ValidationRulesExecution.AfterDomainRules
+            });
         _pocoPreparer = _poco;
         _rulesValuePoco = PocoWriterUnionBenchmarkRecord.CreateAvroDeserializer(
             new NonCachingBenchmarkSchemaRegistryClient(new global::Dekaf.SchemaRegistry.Schema
@@ -299,6 +308,12 @@ public class AvroPocoSchemaRegistryDeserializationBenchmarks
             new BenchmarkSchemaRegistryClient(registrySchema));
         _generic = new AvroSchemaRegistryDeserializer<GenericRecord>(
             new BenchmarkSchemaRegistryClient(registrySchema));
+        _validationEnabledGeneric = new AvroSchemaRegistryDeserializer<GenericRecord>(
+            new BenchmarkSchemaRegistryClient(registrySchema),
+            new AvroDeserializerConfig
+            {
+                ValidationRulesExecution = ValidationRulesExecution.AfterDomainRules
+            });
         _decimalPoco = PocoBenchmarkDecimalRecord.CreateAvroDeserializer(
             new BenchmarkSchemaRegistryClient(new global::Dekaf.SchemaRegistry.Schema
             {
@@ -372,6 +387,7 @@ public class AvroPocoSchemaRegistryDeserializationBenchmarks
         _timeSpanWireData = CreateTimeSpanWireData();
 
         await _poco.WarmupAsync(SchemaId).ConfigureAwait(false);
+        await _validationEnabledPoco.WarmupAsync(SchemaId).ConfigureAwait(false);
         await ((IAsyncDeserializerPreparer<PocoWriterUnionBenchmarkRecord>)_rulesValuePoco)
             .PrepareAsync(_writerUnionWireData, _context)
             .ConfigureAwait(false);
@@ -380,6 +396,7 @@ public class AvroPocoSchemaRegistryDeserializationBenchmarks
             .ConfigureAwait(false);
         await _specific.WarmupAsync(SchemaId).ConfigureAwait(false);
         await _generic.WarmupAsync(SchemaId).ConfigureAwait(false);
+        await _validationEnabledGeneric.WarmupAsync(SchemaId).ConfigureAwait(false);
         await _decimalPoco.WarmupAsync(SchemaId).ConfigureAwait(false);
         await _writerUnionPoco.WarmupAsync(SchemaId).ConfigureAwait(false);
         await _collectionPoco.WarmupAsync(SchemaId).ConfigureAwait(false);
@@ -395,10 +412,12 @@ public class AvroPocoSchemaRegistryDeserializationBenchmarks
     public async ValueTask Cleanup()
     {
         await _poco.DisposeAsync().ConfigureAwait(false);
+        await _validationEnabledPoco.DisposeAsync().ConfigureAwait(false);
         await _rulesValuePoco.DisposeAsync().ConfigureAwait(false);
         await _cachedRulesValuePoco.DisposeAsync().ConfigureAwait(false);
         await _specific.DisposeAsync().ConfigureAwait(false);
         await _generic.DisposeAsync().ConfigureAwait(false);
+        await _validationEnabledGeneric.DisposeAsync().ConfigureAwait(false);
         await _decimalPoco.DisposeAsync().ConfigureAwait(false);
         await _writerUnionPoco.DisposeAsync().ConfigureAwait(false);
         await _latestWriterUnionPoco.DisposeAsync().ConfigureAwait(false);
@@ -435,6 +454,14 @@ public class AvroPocoSchemaRegistryDeserializationBenchmarks
 
     [Benchmark(Description = "Deserialize GenericRecord")]
     public GenericRecord DeserializeGenericRecord() => _generic.Deserialize(_wireData, _context);
+
+    [Benchmark(Description = "Deserialize rule-free generic record with inline validation enabled")]
+    public GenericRecord DeserializeRuleFreeGenericWithValidationEnabled() =>
+        _validationEnabledGeneric.Deserialize(_wireData, _context);
+
+    [Benchmark(Description = "Deserialize rule-free generated POCO with inline validation enabled")]
+    public PocoBenchmarkRecord DeserializeRuleFreePocoWithValidationEnabled() =>
+        _validationEnabledPoco.Deserialize(_wireData, _context);
 
     [Benchmark(Description = "Deserialize generated decimal POCO")]
     public PocoBenchmarkDecimalRecord DeserializeDecimalPoco() =>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -142,6 +142,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
 
     private AvroSchemaRegistrySerializer<GenericRecord> _serializer = null!;
     private AvroSchemaRegistrySerializer<GenericRecord> _validationEnabledSerializer = null!;
+    private AvroSchemaRegistrySerializer<GenericRecord> _validationWithRuleExecutorSerializer = null!;
     private AvroSchemaRegistrySerializer<GenericRecord> _missSerializer = null!;
     private AvroSchemaRegistrySerializer<GenericRecord> _equivalentOverflowSerializer = null!;
     private AvroSchemaRegistrySerializer<GenericRecord> _alternatingOverflowSerializer = null!;
@@ -170,6 +171,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
     private SpecificBenchmarkRecord _specificRecord = null!;
     private ArrayBufferWriter<byte> _serializeBuffer = null!;
     private ArrayBufferWriter<byte> _validationEnabledBuffer = null!;
+    private ArrayBufferWriter<byte> _validationWithRuleExecutorBuffer = null!;
     private ExactSizeBufferWriter _exactSizeSerializeBuffer = null!;
     private GenericRecord _stableRecord = null!;
     private GenericRecord[] _alternatingGenericRecords = null!;
@@ -188,6 +190,13 @@ public class AvroSchemaRegistrySerializerBenchmarks
             new BenchmarkSchemaRegistryClient(),
             new AvroSerializerConfig
             {
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
+        _validationWithRuleExecutorSerializer = new AvroSchemaRegistrySerializer<GenericRecord>(
+            new BenchmarkSchemaRegistryClient(),
+            new AvroSerializerConfig
+            {
+                RuleExecutor = new SchemaRegistryRuleExecutor([]),
                 ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
             });
         _overflowSerializer = new AvroSchemaRegistrySerializer<GenericRecord>(
@@ -259,11 +268,17 @@ public class AvroSchemaRegistrySerializerBenchmarks
         _specificRecord = new SpecificBenchmarkRecord { Id = 42, Name = "benchmark" };
         _serializeBuffer = new ArrayBufferWriter<byte>();
         _validationEnabledBuffer = new ArrayBufferWriter<byte>();
+        _validationWithRuleExecutorBuffer = new ArrayBufferWriter<byte>();
         _exactSizeSerializeBuffer = new ExactSizeBufferWriter(8192);
         _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _validationEnabledSerializer.Serialize(_stableRecord, ref _validationEnabledBuffer, _context);
         _validationEnabledBuffer.ResetWrittenCount();
+        _validationWithRuleExecutorSerializer.Serialize(
+            _stableRecord,
+            ref _validationWithRuleExecutorBuffer,
+            _context);
+        _validationWithRuleExecutorBuffer.ResetWrittenCount();
         _serializer.Serialize(_intRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_nullableIntArrayRecord, ref _serializeBuffer, _context);
@@ -295,6 +310,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
     {
         _serializer.DisposeAsync().GetAwaiter().GetResult();
         _validationEnabledSerializer.DisposeAsync().GetAwaiter().GetResult();
+        _validationWithRuleExecutorSerializer.DisposeAsync().GetAwaiter().GetResult();
         _overflowSerializer.DisposeAsync().GetAwaiter().GetResult();
         _alternatingGenericSerializer.DisposeAsync().GetAwaiter().GetResult();
         _specificSerializer.DisposeAsync().GetAwaiter().GetResult();
@@ -444,6 +460,16 @@ public class AvroSchemaRegistrySerializerBenchmarks
     {
         _validationEnabledBuffer.ResetWrittenCount();
         _validationEnabledSerializer.Serialize(_stableRecord, ref _validationEnabledBuffer, _context);
+    }
+
+    [Benchmark(Description = "Serialize rule-free record with validation and rule executor")]
+    public void SerializeRuleFreeRecordWithValidationAndRuleExecutor()
+    {
+        _validationWithRuleExecutorBuffer.ResetWrittenCount();
+        _validationWithRuleExecutorSerializer.Serialize(
+            _stableRecord,
+            ref _validationWithRuleExecutorBuffer,
+            _context);
     }
 
     [Benchmark(Description = "Serialize nullable-int array generic Avro record")]
@@ -781,16 +807,27 @@ public class AvroSchemaRegistrySerializerBenchmarks
     internal sealed class BenchmarkSchemaRegistryClient : ISchemaRegistryClient
     {
         private int _registrationCount;
+        private RegistrySchema? _schema;
 
         internal int RegistrationCount => Volatile.Read(ref _registrationCount);
 
         public Task<int> RegisterSchemaAsync(
             string subject,
             RegistrySchema schema,
-            CancellationToken cancellationToken = default) => Task.FromResult(1);
+            CancellationToken cancellationToken = default)
+        {
+            _schema = schema;
+            return Task.FromResult(1);
+        }
 
         public Task<RegistrySchema> GetSchemaAsync(int id, CancellationToken cancellationToken = default) =>
-            throw new NotSupportedException();
+            Task.FromResult(_schema ?? throw new InvalidOperationException("No schema has been registered."));
+
+        public Task<RegistrySchema> GetSchemaAsync(
+            int id,
+            string subject,
+            CancellationToken cancellationToken = default) =>
+            GetSchemaAsync(id, cancellationToken);
 
         public Task<RegisteredSchema> GetSchemaBySubjectAsync(
             string subject,
@@ -800,8 +837,11 @@ public class AvroSchemaRegistrySerializerBenchmarks
         public Task<int> GetOrRegisterSchemaAsync(
             string subject,
             RegistrySchema schema,
-            CancellationToken cancellationToken = default) =>
-            Task.FromResult(Interlocked.Increment(ref _registrationCount));
+            CancellationToken cancellationToken = default)
+        {
+            _schema = schema;
+            return Task.FromResult(Interlocked.Increment(ref _registrationCount));
+        }
 
         public Task<RegisteredSchema> LookupSchemaAsync(
             string subject,

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -141,6 +141,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
         """;
 
     private AvroSchemaRegistrySerializer<GenericRecord> _serializer = null!;
+    private AvroSchemaRegistrySerializer<GenericRecord> _validationEnabledSerializer = null!;
     private AvroSchemaRegistrySerializer<GenericRecord> _missSerializer = null!;
     private AvroSchemaRegistrySerializer<GenericRecord> _equivalentOverflowSerializer = null!;
     private AvroSchemaRegistrySerializer<GenericRecord> _alternatingOverflowSerializer = null!;
@@ -168,6 +169,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
     private GenericRecord[] _variableSizeRecords = null!;
     private SpecificBenchmarkRecord _specificRecord = null!;
     private ArrayBufferWriter<byte> _serializeBuffer = null!;
+    private ArrayBufferWriter<byte> _validationEnabledBuffer = null!;
     private ExactSizeBufferWriter _exactSizeSerializeBuffer = null!;
     private GenericRecord _stableRecord = null!;
     private GenericRecord[] _alternatingGenericRecords = null!;
@@ -182,6 +184,12 @@ public class AvroSchemaRegistrySerializerBenchmarks
         Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkStringBytesLogicalType());
         Avro.Util.LogicalTypeFactory.Instance.Register(new BenchmarkIntBytesLogicalType());
         _serializer = new AvroSchemaRegistrySerializer<GenericRecord>(new BenchmarkSchemaRegistryClient());
+        _validationEnabledSerializer = new AvroSchemaRegistrySerializer<GenericRecord>(
+            new BenchmarkSchemaRegistryClient(),
+            new AvroSerializerConfig
+            {
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
         _overflowSerializer = new AvroSchemaRegistrySerializer<GenericRecord>(
             new BenchmarkSchemaRegistryClient(),
             new AvroSerializerConfig { MaxCachedSchemas = 1 });
@@ -250,9 +258,12 @@ public class AvroSchemaRegistrySerializerBenchmarks
         ];
         _specificRecord = new SpecificBenchmarkRecord { Id = 42, Name = "benchmark" };
         _serializeBuffer = new ArrayBufferWriter<byte>();
+        _validationEnabledBuffer = new ArrayBufferWriter<byte>();
         _exactSizeSerializeBuffer = new ExactSizeBufferWriter(8192);
         _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
+        _validationEnabledSerializer.Serialize(_stableRecord, ref _validationEnabledBuffer, _context);
+        _validationEnabledBuffer.ResetWrittenCount();
         _serializer.Serialize(_intRecord, ref _serializeBuffer, _context);
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_nullableIntArrayRecord, ref _serializeBuffer, _context);
@@ -283,6 +294,7 @@ public class AvroSchemaRegistrySerializerBenchmarks
     public void Cleanup()
     {
         _serializer.DisposeAsync().GetAwaiter().GetResult();
+        _validationEnabledSerializer.DisposeAsync().GetAwaiter().GetResult();
         _overflowSerializer.DisposeAsync().GetAwaiter().GetResult();
         _alternatingGenericSerializer.DisposeAsync().GetAwaiter().GetResult();
         _specificSerializer.DisposeAsync().GetAwaiter().GetResult();
@@ -425,6 +437,13 @@ public class AvroSchemaRegistrySerializerBenchmarks
     {
         _serializeBuffer.ResetWrittenCount();
         _serializer.Serialize(_stableRecord, ref _serializeBuffer, _context);
+    }
+
+    [Benchmark(Description = "Serialize rule-free record with inline validation enabled")]
+    public void SerializeRuleFreeRecordWithValidationEnabled()
+    {
+        _validationEnabledBuffer.ResetWrittenCount();
+        _validationEnabledSerializer.Serialize(_stableRecord, ref _validationEnabledBuffer, _context);
     }
 
     [Benchmark(Description = "Serialize nullable-int array generic Avro record")]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtobufInlineValidationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtobufInlineValidationBenchmarks.cs
@@ -24,6 +24,7 @@ public class ProtobufInlineValidationBenchmarks
     private ProtobufInlineRuleValidator _mapEqualityValidator = null!;
     private ProtobufInlineRuleValidator _collectionEqualityValidator = null!;
     private ProtobufInlineRuleValidator _presenceValidator = null!;
+    private ProtobufInlineRuleValidator _rootSizeValidator = null!;
     private ProtobufInlineRuleValidator _sint32Validator = null!;
     private ProtobufInlineRuleValidator _editionClosedEnumValidator = null!;
     private ProtobufInlineRuleExecutor _alternatingSchemaExecutor = null!;
@@ -41,6 +42,7 @@ public class ProtobufInlineValidationBenchmarks
     private byte[] _mapEqualityPayload = null!;
     private byte[] _collectionEqualityPayload = null!;
     private byte[] _sint32Payload = null!;
+    private byte[] _rootSizePayload = null!;
     private byte[] _simpleLargePayload = null!;
     private byte[] _editionClosedEnumPayload = null!;
     private int _schemaIndex;
@@ -58,6 +60,11 @@ public class ProtobufInlineValidationBenchmarks
         _mapEqualityPayload = CreateMapEqualityPayload();
         _collectionEqualityPayload = CreateCollectionEqualityPayload();
         _sint32Payload = [8, 1];
+        _rootSizePayload = new ValidationRootSizeEnvelope
+        {
+            Nickname = string.Empty,
+            Email = string.Empty
+        }.ToByteArray();
         var simpleLargePayload = new ArrayBufferWriter<byte>(4096);
         simpleLargePayload.Write(_sint32Payload);
         WriteLengthDelimited(simpleLargePayload, fieldNumber: 100, new byte[4096]);
@@ -72,6 +79,8 @@ public class ProtobufInlineValidationBenchmarks
             ValidationCollectionEnvelope.Descriptor);
         _presenceValidator = new ProtobufInlineRuleValidator(
             ValidationPresenceEnvelope.Descriptor);
+        _rootSizeValidator = new ProtobufInlineRuleValidator(
+            ValidationRootSizeEnvelope.Descriptor);
         _sint32Validator = new ProtobufInlineRuleValidator(
             ValidationSint32BenchmarkEnvelope.Descriptor);
         _editionClosedEnumValidator = new ProtobufInlineRuleValidator(
@@ -121,6 +130,7 @@ public class ProtobufInlineValidationBenchmarks
             schemaId: 1,
             failFast: false);
         _presenceValidator.Validate(ReadOnlyMemory<byte>.Empty, schemaId: 1, failFast: false);
+        _rootSizeValidator.Validate(_rootSizePayload, schemaId: 1, failFast: false);
         _sint32Validator.Validate(_sint32Payload, schemaId: 1, failFast: false);
         _sint32Validator.Validate(_simpleLargePayload, schemaId: 1, failFast: false);
         _editionClosedEnumValidator.Validate(
@@ -176,6 +186,10 @@ public class ProtobufInlineValidationBenchmarks
     [Benchmark]
     public void ValidateAbsentWrapper() =>
         _presenceValidator.Validate(ReadOnlyMemory<byte>.Empty, schemaId: 1, failFast: false);
+
+    [Benchmark]
+    public void ValidateMessageRootSize() =>
+        _rootSizeValidator.Validate(_rootSizePayload, schemaId: 1, failFast: false);
 
     [Benchmark]
     public void ValidateSInt32() =>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistryHeaderPreparationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistryHeaderPreparationBenchmarks.cs
@@ -2,6 +2,7 @@ using Avro.Generic;
 using BenchmarkDotNet.Attributes;
 using Dekaf.SchemaRegistry;
 using Dekaf.SchemaRegistry.Avro;
+using Dekaf.SchemaRegistry.Avro.Poco;
 using Dekaf.SchemaRegistry.Protobuf;
 using Dekaf.Serialization;
 using Google.Protobuf.WellKnownTypes;
@@ -15,8 +16,11 @@ public class SchemaRegistryHeaderPreparationBenchmarks
 {
     private const string AvroValidationSchema =
         "{\"type\":\"record\",\"name\":\"ValidatedOrder\",\"fields\":[{\"name\":\"id\",\"type\":\"int\",\"confluent:rules\":[{\"name\":\"nonnegative\",\"expr\":\"this >= 0\"}]}]}";
+    private const string AvroPocoValidationSchema =
+        "{\"type\":\"record\",\"name\":\"PocoWriterUnionBenchmarkRecord\",\"namespace\":\"Dekaf.Benchmarks.Benchmarks.Unit\",\"fields\":[{\"name\":\"value\",\"type\":[\"int\",\"long\"]}]}";
     private static readonly Guid SchemaGuid = new("11111111-2222-3333-4444-555555555555");
     private static readonly byte[] AvroPayload = [84];
+    private static readonly byte[] AvroPocoPayload = [0, 84];
     private static readonly byte[] AvroPrefixPayload = [0, 0, 0, 0, 1, 84];
     private static readonly byte[] ProtobufPayload = [0x0A, 0x01, (byte)'x'];
     private static readonly byte[] ProtobufPrefixPayload = [0, 0, 0, 0, 1, 0, 0x0A, 0x01, (byte)'x'];
@@ -27,6 +31,8 @@ public class SchemaRegistryHeaderPreparationBenchmarks
     private IRecordHeaderAsyncDeserializerPreparer<StringValue> _protobufDualPreparer = null!;
     private IRecordHeaderAsyncDeserializerPreparer<GenericRecord> _avroDoubleReadPreparer = null!;
     private IRecordHeaderAsyncDeserializerPreparer<GenericRecord> _avroValidationPreparer = null!;
+    private IRecordHeaderAsyncDeserializerPreparer<PocoWriterUnionBenchmarkRecord>
+        _avroPocoValidationPreparer = null!;
     private IRecordHeaderAsyncDeserializerPreparer<StringValue> _protobufDoubleReadPreparer = null!;
     private SerializationContext _avroContext;
     private SerializationContext _protobufContext;
@@ -37,10 +43,14 @@ public class SchemaRegistryHeaderPreparationBenchmarks
     private RecordHeaderRoutingLookup _avroPrefixHeaders;
     private RecordHeaderRoutingLookup _protobufPrefixHeaders;
     private RecordHeaderRoutingLookup _avroValidationHeaders;
+    private RecordHeaderRoutingLookup _avroPocoValidationHeaders;
     private AvroSchemaRegistryDeserializer<GenericRecord> _avro = null!;
     private ProtobufSchemaRegistryDeserializer<StringValue> _protobuf = null!;
     private AvroSchemaRegistryDeserializer<GenericRecord> _avroDual = null!;
     private AvroSchemaRegistryDeserializer<GenericRecord> _avroValidation = null!;
+    private AvroPocoSchemaRegistryDeserializer<
+        PocoWriterUnionBenchmarkRecord,
+        PocoWriterUnionBenchmarkRecord.AvroCodec> _avroPocoValidation = null!;
     private Avro.Schema _avroValidationSchema = null!;
     private ProtobufSchemaRegistryDeserializer<StringValue> _protobufDual = null!;
 
@@ -105,6 +115,18 @@ public class SchemaRegistryHeaderPreparationBenchmarks
             });
         _avroValidationPreparer = _avroValidation;
         _avroValidationSchema = Avro.Schema.Parse(AvroValidationSchema);
+        _avroPocoValidation = PocoWriterUnionBenchmarkRecord.CreateAvroDeserializer(
+            new BenchmarkSchemaRegistryClient(new Schema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = AvroPocoValidationSchema
+            }),
+            new AvroDeserializerConfig
+            {
+                SchemaIdStrategy = SchemaIdDeserializerStrategy.Header,
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
+        _avroPocoValidationPreparer = _avroPocoValidation;
 
         var avroHeader = new Header(
             SchemaIdentityHeaderNames.Value,
@@ -122,6 +144,7 @@ public class SchemaRegistryHeaderPreparationBenchmarks
         _avroPrefixHeaders = CreateLookup(_avroDual, identityHeader: null);
         _protobufPrefixHeaders = CreateLookup(_protobufDual, identityHeader: null);
         _avroValidationHeaders = CreateLookup(_avroValidation, avroHeader);
+        _avroPocoValidationHeaders = CreateLookup(_avroPocoValidation, avroHeader);
 
         await PrepareAvroGuidHeaderCached().ConfigureAwait(false);
         await PrepareProtobufGuidHeaderCached().ConfigureAwait(false);
@@ -129,6 +152,12 @@ public class SchemaRegistryHeaderPreparationBenchmarks
                 AvroPayload,
                 _avroContext,
                 _avroValidationHeaders,
+                CancellationToken.None)
+            .ConfigureAwait(false);
+        await _avroPocoValidationPreparer.PrepareAsync(
+                AvroPocoPayload,
+                _avroContext,
+                _avroPocoValidationHeaders,
                 CancellationToken.None)
             .ConfigureAwait(false);
         _ = RecordHeaderDeserializer.Deserialize(
@@ -146,6 +175,7 @@ public class SchemaRegistryHeaderPreparationBenchmarks
         await _avroDual.DisposeAsync().ConfigureAwait(false);
         await _protobufDual.DisposeAsync().ConfigureAwait(false);
         await _avroValidation.DisposeAsync().ConfigureAwait(false);
+        await _avroPocoValidation.DisposeAsync().ConfigureAwait(false);
     }
 
     [Benchmark(Baseline = true)]
@@ -208,6 +238,21 @@ public class SchemaRegistryHeaderPreparationBenchmarks
     [Benchmark(Description = "Avro GUID inline-validator decision cache")]
     public object? ResolveAvroGuidInlineValidationDecision() =>
         _avroValidation.GetInlineValidator(-1, _avroValidationSchema);
+
+    [Benchmark(Description = "Avro POCO GUID header inline-validation cache")]
+    public PocoWriterUnionBenchmarkRecord DeserializeAvroPocoGuidHeaderWithInlineValidation()
+    {
+        if (!_avroPocoValidationPreparer.TryDeserialize(
+                AvroPocoPayload,
+                _avroContext,
+                in _avroPocoValidationHeaders,
+                out var value))
+        {
+            throw new InvalidOperationException("Avro POCO validation deserializer was not prepared.");
+        }
+
+        return value;
+    }
 
     [Benchmark(Description = "Protobuf Dual prefix prepared deserialize")]
     public StringValue DeserializeProtobufDualPrefixRouted()

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistryHeaderPreparationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistryHeaderPreparationBenchmarks.cs
@@ -13,6 +13,8 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [ShortRunJob]
 public class SchemaRegistryHeaderPreparationBenchmarks
 {
+    private const string AvroValidationSchema =
+        "{\"type\":\"record\",\"name\":\"ValidatedOrder\",\"fields\":[{\"name\":\"id\",\"type\":\"int\",\"confluent:rules\":[{\"name\":\"nonnegative\",\"expr\":\"this >= 0\"}]}]}";
     private static readonly Guid SchemaGuid = new("11111111-2222-3333-4444-555555555555");
     private static readonly byte[] AvroPayload = [84];
     private static readonly byte[] AvroPrefixPayload = [0, 0, 0, 0, 1, 84];
@@ -24,6 +26,7 @@ public class SchemaRegistryHeaderPreparationBenchmarks
     private IRecordHeaderAsyncDeserializerPreparer<GenericRecord> _avroDualPreparer = null!;
     private IRecordHeaderAsyncDeserializerPreparer<StringValue> _protobufDualPreparer = null!;
     private IRecordHeaderAsyncDeserializerPreparer<GenericRecord> _avroDoubleReadPreparer = null!;
+    private IRecordHeaderAsyncDeserializerPreparer<GenericRecord> _avroValidationPreparer = null!;
     private IRecordHeaderAsyncDeserializerPreparer<StringValue> _protobufDoubleReadPreparer = null!;
     private SerializationContext _avroContext;
     private SerializationContext _protobufContext;
@@ -33,9 +36,12 @@ public class SchemaRegistryHeaderPreparationBenchmarks
     private RecordHeaderRoutingLookup _protobufHeaders;
     private RecordHeaderRoutingLookup _avroPrefixHeaders;
     private RecordHeaderRoutingLookup _protobufPrefixHeaders;
+    private RecordHeaderRoutingLookup _avroValidationHeaders;
     private AvroSchemaRegistryDeserializer<GenericRecord> _avro = null!;
     private ProtobufSchemaRegistryDeserializer<StringValue> _protobuf = null!;
     private AvroSchemaRegistryDeserializer<GenericRecord> _avroDual = null!;
+    private AvroSchemaRegistryDeserializer<GenericRecord> _avroValidation = null!;
+    private Avro.Schema _avroValidationSchema = null!;
     private ProtobufSchemaRegistryDeserializer<StringValue> _protobufDual = null!;
 
     [GlobalSetup]
@@ -86,6 +92,19 @@ public class SchemaRegistryHeaderPreparationBenchmarks
         _protobufDualPreparer = _protobufDual;
         _avroDoubleReadPreparer = new DoubleReadPrefixPreparer<GenericRecord>(_avroDual);
         _protobufDoubleReadPreparer = new DoubleReadPrefixPreparer<StringValue>(_protobufDual);
+        _avroValidation = new AvroSchemaRegistryDeserializer<GenericRecord>(
+            new BenchmarkSchemaRegistryClient(new Schema
+            {
+                SchemaType = SchemaType.Avro,
+                SchemaString = AvroValidationSchema
+            }),
+            new AvroDeserializerConfig
+            {
+                SchemaIdStrategy = SchemaIdDeserializerStrategy.Header,
+                ValidationRulesExecution = ValidationRulesExecution.BeforeDomainRules
+            });
+        _avroValidationPreparer = _avroValidation;
+        _avroValidationSchema = Avro.Schema.Parse(AvroValidationSchema);
 
         var avroHeader = new Header(
             SchemaIdentityHeaderNames.Value,
@@ -102,9 +121,16 @@ public class SchemaRegistryHeaderPreparationBenchmarks
         _protobufHeaders = CreateLookup(_protobuf, protobufHeader);
         _avroPrefixHeaders = CreateLookup(_avroDual, identityHeader: null);
         _protobufPrefixHeaders = CreateLookup(_protobufDual, identityHeader: null);
+        _avroValidationHeaders = CreateLookup(_avroValidation, avroHeader);
 
         await PrepareAvroGuidHeaderCached().ConfigureAwait(false);
         await PrepareProtobufGuidHeaderCached().ConfigureAwait(false);
+        await _avroValidationPreparer.PrepareAsync(
+                AvroPayload,
+                _avroContext,
+                _avroValidationHeaders,
+                CancellationToken.None)
+            .ConfigureAwait(false);
         _ = RecordHeaderDeserializer.Deserialize(
             _avroDual,
             AvroPrefixPayload,
@@ -119,6 +145,7 @@ public class SchemaRegistryHeaderPreparationBenchmarks
         await _protobuf.DisposeAsync().ConfigureAwait(false);
         await _avroDual.DisposeAsync().ConfigureAwait(false);
         await _protobufDual.DisposeAsync().ConfigureAwait(false);
+        await _avroValidation.DisposeAsync().ConfigureAwait(false);
     }
 
     [Benchmark(Baseline = true)]
@@ -162,6 +189,25 @@ public class SchemaRegistryHeaderPreparationBenchmarks
             out var value);
         return value;
     }
+
+    [Benchmark(Description = "Avro GUID header inline-validation cache")]
+    public GenericRecord DeserializeAvroGuidHeaderWithInlineValidation()
+    {
+        if (!_avroValidationPreparer.TryDeserialize(
+                AvroPayload,
+                _avroContext,
+                in _avroValidationHeaders,
+                out var value))
+        {
+            throw new InvalidOperationException("Avro validation deserializer was not prepared.");
+        }
+
+        return value;
+    }
+
+    [Benchmark(Description = "Avro GUID inline-validator decision cache")]
+    public object? ResolveAvroGuidInlineValidationDecision() =>
+        _avroValidation.GetInlineValidator(-1, _avroValidationSchema);
 
     [Benchmark(Description = "Protobuf Dual prefix prepared deserialize")]
     public StringValue DeserializeProtobufDualPrefixRouted()


### PR DESCRIPTION
Closes #2815

## Summary
- compile Avro schema-level and field-level `confluent:rules` CHECK constraints into cached binary validation plans
- validate generic, specific-record, and POCO payloads without reflection or object materialization per message
- support primitives, records, aliases, nullable unions, arrays, maps, named references, fixed/bytes, enums, and logical base values
- expose configurable before/after-domain execution and fail-fast behavior on Avro serializers/deserializers
- preserve rule ordering through migrations and split built-in domain/encoding transforms at the validation boundary
- reuse registered resolved schemas for referenced roots, compare aggregates by Avro value semantics, and preserve unordered NaN comparisons

## Verification
- full unit suite: net10 8170/8170; net8 8034/8034
- focused Avro inline-rule tests: 22/22 on both net10 and net8
- Kafka + Schema Registry integration: 1/1 valid roundtrip and invalid-payload rejection
- full Release solution build: 0 warnings, 0 errors

## Performance
`[MemoryDiagnoser]` warmed record + field validation:
- mean 330.251 ns; median 322.261 ns; allocated 0 B

Disabled serializer path, BenchmarkDotNet ShortRun, same machine/config:
- exact baseline main `2b9de5116`: mean 40.136 ns; median 38.008 ns; allocated 0 B
- candidate: mean 36.616 ns; median 38.454 ns; allocated 0 B
- delta: mean -8.77%; median +1.17%; allocation unchanged at 0 B

Review-fix BenchmarkDotNet, exact predecessor `3755bfedd` vs candidate `a78ac414b`, same machine/config:
- scalar validation: baseline mean/median 192.718/189.890 ns; candidate 204.209/192.887 ns; 0 B both
- identical aggregate encoding: baseline mean/median 514.075/485.170 ns; candidate 516.829/483.444 ns; 0 B both
- corrected semantic fallbacks: differently blocked arrays 524.326/520.908 ns; reordered maps 881.788/886.141 ns; 0 B

The host showed severe multimodal frequency noise. Medians put the protected scalar path at +1.58% and the exact-encoding aggregate path at -0.36%; neither is material. An intermediate design that stored comparer references in every `ValidationCelValue` measured around 240 ns on the scalar path and was rejected. The final design stores comparers only in thread-local member slots, preserves the original byte fast path, and remains 0 B/op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable inline validation for Avro serialization and deserialization, including execution timing and fail-fast options.
  * Added support for schema identity in record headers, including GUID-based schema resolution.
  * Extended validation for nested records, collections, maps, unions, aggregate values, and root message sizes.
  * Added validation support across migrations, POCO workflows, referenced schemas, and prepared operations.

* **Bug Fixes**
  * Improved schema caching, reference resolution, validation routing, and migration behavior.
  * Added comprehensive coverage for validation, schema headers, nested data, and Protobuf root-size rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->