### PR TITLE
Fix in-memory consumer commit ownership races

### DIFF
--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -461,34 +461,37 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         while (!cancellationToken.IsCancellationRequested)
         {
             var result = await ConsumeOneAsync(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
-            if (result.HasValue)
+            if (result is not { } consumed)
             {
-                yield return result.Value;
+                await WaitForCurrentAutoCommitDeliveryAsync(cancellationToken).ConfigureAwait(false);
+                continue;
+            }
 
-                // Resuming after the yield proves that the caller processed this record.
-                // Do this before the loop observes cancellation, matching KafkaConsumer.
-                ThrowIfDisposed();
-                var capturedProof = await ApplyInDoubtAutoCommitFaultAsync(
-                    CancellationToken.None).ConfigureAwait(false);
-                ThrowIfDisposed();
-                if (capturedProof is { SharedWaiter: true })
+            yield return consumed;
+
+            // Resuming after the yield proves that the caller processed this record.
+            // Do this before the loop observes cancellation, matching KafkaConsumer.
+            ThrowIfDisposed();
+            var capturedProof = await ApplyInDoubtAutoCommitFaultAsync(
+                CancellationToken.None).ConfigureAwait(false);
+            ThrowIfDisposed();
+            if (capturedProof is { SharedWaiter: true })
+            {
+                await WaitForSharedAutoCommitDeliveryAsync(
+                    capturedProof.Value,
+                    cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+            try
+            {
+                lock (_gate)
                 {
-                    await WaitForSharedAutoCommitDeliveryAsync(
-                        capturedProof.Value,
-                        cancellationToken).ConfigureAwait(false);
-                    continue;
+                    ProveInDoubtRecordUnderLock(capturedProof);
                 }
-                try
-                {
-                    lock (_gate)
-                    {
-                        ProveInDoubtRecordUnderLock(capturedProof);
-                    }
-                }
-                finally
-                {
-                    CompleteSharedAutoCommitWaiters(capturedProof);
-                }
+            }
+            finally
+            {
+                CompleteSharedAutoCommitWaiters(capturedProof);
             }
         }
     }
@@ -572,20 +575,14 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                             consumerGroupGeneration);
 
                         ProveInDoubtRecordUnderLock(capturedProof);
-                        if (!TrySelectSnapshotRecordUnderLock(
+                        complete = !TrySelectSnapshotRecordUnderLock(
                                 partitions,
                                 ref activePartitionIndex,
                                 out partition,
                                 out record,
                                 out position,
-                                out pendingAutoCommitAdvancement))
-                        {
-                            complete = !pendingAutoCommitAdvancement;
-                        }
-                        else
-                        {
-                            complete = false;
-                        }
+                                out pendingAutoCommitAdvancement) &&
+                            !pendingAutoCommitAdvancement;
                     }
                 }
                 finally
@@ -884,8 +881,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 ClearInDoubtRecordUnderLock();
             }
 
-            if (_consumerStateVersion == consumerStateVersion)
-                CommitCapturedOffsetsUnderLock(in capturedCommit);
+            CommitCapturedOffsetsUnderLock(in capturedCommit);
         }
     }
 
@@ -2860,6 +2856,39 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 if (_inDoubtNextOffset < 0 ||
                     _inDoubtPartition.Equals(sharedProof.Partition) &&
                     _inDoubtNextOffset == sharedProof.Position)
+                {
+                    return;
+                }
+            }
+
+            await recordsChanged.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask WaitForCurrentAutoCommitDeliveryAsync(
+        CancellationToken cancellationToken)
+    {
+        TopicPartition partition;
+        long position;
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            if (_inDoubtNextOffset < 0)
+                return;
+
+            partition = _inDoubtPartition;
+            position = _inDoubtNextOffset;
+        }
+
+        while (true)
+        {
+            var recordsChanged = _cluster.ObserveRecordsChanged();
+            lock (_gate)
+            {
+                ThrowIfDisposed();
+                if (_inDoubtNextOffset < 0 ||
+                    !_inDoubtPartition.Equals(partition) ||
+                    _inDoubtNextOffset != position)
                 {
                     return;
                 }

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -840,12 +840,10 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         TopicPartitionOffset? inDoubtRecord;
         CapturedCommitOffsets capturedCommit;
-        int consumerStateVersion;
         bool hasFaultApplication;
         ValueTask faultApplication;
         lock (_gate)
         {
-            consumerStateVersion = _consumerStateVersion;
             inDoubtRecord = _inDoubtNextOffset >= 0
                 ? new TopicPartitionOffset(
                     _inDoubtPartition.Topic,
@@ -872,8 +870,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         lock (_gate)
         {
             ThrowIfDisposed();
-            if (_consumerStateVersion == consumerStateVersion &&
-                IsCapturedCommitCurrentUnderLock(in capturedCommit) &&
+            if (IsCapturedCommitCurrentUnderLock(in capturedCommit) &&
                 inDoubtRecord is { } capturedInDoubt &&
                 _inDoubtNextOffset == capturedInDoubt.Offset &&
                 _inDoubtPartition.Topic == capturedInDoubt.Topic &&

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -91,6 +91,10 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     // proves it; an unwind (or close) leaves it unstaged so it is redelivered.
     private TopicPartition _inDoubtPartition;
     private long _inDoubtNextOffset = -1;
+    // Wakes a shared ConsumeAsync stream after the commit-proof owner aborts. The next
+    // poll consumes this marker and retries the unchanged in-doubt proof.
+    private TopicPartition _retryInDoubtPartition;
+    private long _retryInDoubtNextOffset = -1;
     private int _consumerStateVersion;
     private bool _snapshotActive;
     private readonly string? _groupId;
@@ -2749,6 +2753,11 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
             inDoubtPartition = _inDoubtPartition;
             inDoubtNextOffset = _inDoubtNextOffset;
+            if (_retryInDoubtNextOffset == inDoubtNextOffset &&
+                _retryInDoubtPartition.Equals(inDoubtPartition))
+            {
+                _retryInDoubtNextOffset = -1;
+            }
             if (_pendingAutoCommitAdvancements is not null &&
                 _pendingAutoCommitAdvancements.TryGetValue(inDoubtPartition, out var pending) &&
                 pending.Position == inDoubtNextOffset)
@@ -2807,7 +2816,16 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         }
         catch
         {
-            ClearPendingAutoCommitAdvancement(partition, expectedPosition);
+            lock (_gate)
+            {
+                ClearPendingAutoCommitAdvancementUnderLock(partition, expectedPosition);
+                if (_inDoubtNextOffset == expectedPosition &&
+                    _inDoubtPartition.Equals(partition))
+                {
+                    _retryInDoubtPartition = partition;
+                    _retryInDoubtNextOffset = expectedPosition;
+                }
+            }
             throw;
         }
 
@@ -2878,6 +2896,11 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
             partition = _inDoubtPartition;
             position = _inDoubtNextOffset;
+            if (_retryInDoubtNextOffset == position &&
+                _retryInDoubtPartition.Equals(partition))
+            {
+                return;
+            }
         }
 
         while (true)
@@ -2888,7 +2911,9 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 ThrowIfDisposed();
                 if (_inDoubtNextOffset < 0 ||
                     !_inDoubtPartition.Equals(partition) ||
-                    _inDoubtNextOffset != position)
+                    _inDoubtNextOffset != position ||
+                    _retryInDoubtNextOffset == position &&
+                    _retryInDoubtPartition.Equals(partition))
                 {
                     return;
                 }

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryConsumerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryConsumerFaultTests.cs
@@ -2208,6 +2208,48 @@ public sealed class InMemoryConsumerFaultTests
     }
 
     [Test]
+    public async Task ConsumeAsync_FreshSharedWaiterRetriesAfterOwnerCancellation()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key-0", "value-0");
+        await producer.ProduceAsync(Topic, "key-1", "value-1");
+        var deserializer = new AsyncStringDeserializer();
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            deserializer,
+            deserializer,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                EnableAutoOffsetStore = true,
+                OffsetStoreTiming = OffsetStoreTiming.AfterProcessing
+            });
+        consumer.Subscribe(Topic);
+        _ = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+        using var ownerCancellation = new CancellationTokenSource();
+
+        var ownerConsume = consumer.ConsumeOneAsync(
+            Timeout.InfiniteTimeSpan,
+            ownerCancellation.Token).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        await using var stream = consumer.ConsumeAsync().GetAsyncEnumerator();
+        var sharedMove = stream.MoveNextAsync().AsTask();
+        await Assert.That(sharedMove.IsCompleted).IsFalse();
+        ownerCancellation.Cancel();
+
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => ownerConsume);
+        await Assert.That(barrier.Release()).IsTrue();
+        await Assert.That(await sharedMove.WaitAsync(TimeSpan.FromSeconds(1))).IsTrue();
+        await Assert.That(stream.Current.Key).IsEqualTo("key-1");
+        await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ConsumeAsync_AfterProcessingOwnerCompletesSharedWaiter()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryConsumerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryConsumerFaultTests.cs
@@ -545,6 +545,32 @@ public sealed class InMemoryConsumerFaultTests
     }
 
     [Test]
+    public async Task CommitAsync_PauseChangeDuringBarrierCommitsCapturedOffsets()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(Topic, partitionCount: 2);
+        await using var consumer = CreateConsumer(cluster, enableAutoOffsetStore: false);
+        var secondPartition = new TopicPartition(Topic, 1);
+        consumer.Assign(Partition, secondPartition);
+        consumer.StoreOffsets([
+            new TopicPartitionOffset(Topic, 0, 1),
+            new TopicPartitionOffset(Topic, 1, 1)
+        ]);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId));
+
+        var commit = consumer.CommitAsync().AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        consumer.Pause(secondPartition);
+        consumer.Resume(secondPartition);
+        await Assert.That(barrier.Release()).IsTrue();
+        await commit;
+
+        await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsEqualTo(1);
+        await Assert.That(cluster.GetCommittedOffset(GroupId, secondPartition)).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task CommitAsync_GroupChangeDuringBarrierDoesNotOverwriteNewOwnerOffset()
     {
         var cluster = new InMemoryKafkaCluster();
@@ -2130,6 +2156,50 @@ public sealed class InMemoryConsumerFaultTests
         await Assert.That(concurrent!.Value.Key).IsEqualTo("key-1");
         await Assert.That(sharedMove.IsCompleted).IsFalse();
         await Assert.That(await consumer.GetCommittedOffsetAsync(Partition)).IsEqualTo(1);
+
+        await consumer.CommitAsync();
+
+        await Assert.That(await sharedMove).IsTrue();
+        await Assert.That(stream.Current.Key).IsEqualTo("key-2");
+    }
+
+    [Test]
+    public async Task ConsumeAsync_FreshSharedWaiterAwaitsOwnerDelivery()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(Topic, "key-0", "value-0");
+        await producer.ProduceAsync(Topic, "key-1", "value-1");
+        await producer.ProduceAsync(Topic, "key-2", "value-2");
+        var deserializer = new AsyncStringDeserializer();
+        await using var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            deserializer,
+            deserializer,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                EnableAutoOffsetStore = true,
+                OffsetStoreTiming = OffsetStoreTiming.AfterProcessing
+            });
+        consumer.Subscribe(Topic);
+        _ = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        var barrier = cluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+
+        var ownerConsume = consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        await using var stream = consumer.ConsumeAsync().GetAsyncEnumerator();
+        var sharedMove = stream.MoveNextAsync().AsTask();
+        await Assert.That(sharedMove.IsCompleted).IsFalse();
+        await Assert.That(barrier.Release()).IsTrue();
+
+        var ownerResult = await ownerConsume;
+        await Assert.That(ownerResult).IsNotNull();
+        await Assert.That(ownerResult!.Value.Key).IsEqualTo("key-1");
+        await Assert.That(sharedMove.IsCompleted).IsFalse();
 
         await consumer.CommitAsync();
 

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryConsumerFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryConsumerFaultTests.cs
@@ -549,13 +549,32 @@ public sealed class InMemoryConsumerFaultTests
     {
         var cluster = new InMemoryKafkaCluster();
         cluster.CreateTopic(Topic, partitionCount: 2);
-        await using var consumer = CreateConsumer(cluster, enableAutoOffsetStore: false);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 0,
+            Key = "key-0",
+            Value = "value-0"
+        });
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Partition = 0,
+            Key = "key-1",
+            Value = "value-1"
+        });
+        await using var consumer = CreateConsumer(
+            cluster,
+            enableAutoOffsetStore: true,
+            offsetCommitMode: OffsetCommitMode.Auto,
+            offsetStoreTiming: OffsetStoreTiming.AfterProcessing);
         var secondPartition = new TopicPartition(Topic, 1);
         consumer.Assign(Partition, secondPartition);
-        consumer.StoreOffsets([
-            new TopicPartitionOffset(Topic, 0, 1),
-            new TopicPartitionOffset(Topic, 1, 1)
-        ]);
+        consumer.StoreOffset(new TopicPartitionOffset(Topic, 1, 1));
+        var first = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        await Assert.That(first).IsNotNull();
+        await Assert.That(first!.Value.Offset).IsEqualTo(0);
         var barrier = cluster.FaultPlan.PauseNext(
             new KafkaFaultScope(KafkaFaultOperation.Commit, Topic, 0, GroupId));
 
@@ -568,6 +587,15 @@ public sealed class InMemoryConsumerFaultTests
 
         await Assert.That(cluster.GetCommittedOffset(GroupId, Partition)).IsEqualTo(1);
         await Assert.That(cluster.GetCommittedOffset(GroupId, secondPartition)).IsEqualTo(1);
+
+        cluster.FaultPlan.Fail(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId),
+            new InvalidOperationException("already committed record was retried"));
+        var second = await consumer.ConsumeOneAsync(TimeSpan.Zero);
+        cluster.FaultPlan.Clear();
+
+        await Assert.That(second).IsNotNull();
+        await Assert.That(second!.Value.Offset).IsEqualTo(1);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- prevent a fresh ConsumeAsync stream from proving another caller's AfterProcessing delivery before that caller processes it
- let shared streams retry when the pending commit-proof owner aborts without a new delivery
- commit immutable parameterless CommitAsync snapshots across unrelated pause/resume state changes while retaining group-generation ownership fencing
- simplify snapshot completion branching flagged during review

Follow-up to #2823 and its post-merge review findings.

## Validation
- candidate: `7ac161e70`, rebased onto exact main `45521850b`
- Release solution build: 0 warnings, 0 errors
- full unit tests net10.0: 8,338/8,338 passed
- full unit tests net8.0: 8,202/8,202 passed
- focused `InMemoryConsumerFaultTests`: 111/111 passed on each target framework
- deterministic cancellation regression proves a fresh shared stream repolls after its commit-proof owner aborts`n- pause/resume commit regression injects a subsequent commit failure and proves the explicitly committed in-doubt record is not retried
- `/simplify`: retained the partition/position retry marker under `_gate`; normal proof structure/helper and no-fault call sites remain unchanged

## Performance
Initial BenchmarkDotNet ShortRun, .NET 10.0.11, 131,072 invocations, MemoryDiagnoser, exact main e651b76 -> candidate consumer source -> exact main e651b76:

| Benchmark | Main before | Candidate | Main after | Allocated |
|---|---:|---:|---:|---:|
| ConsumeOneNoFault | 530.2 ns | 497.8 ns | 523.1 ns | 80 B unchanged |
| ConsumeOneAsyncAutoCommitNoFault | 1.268 us | 1.244 us | 1.272 us | 2,576 B unchanged |

Review-fix experiment against exact preceding head `78eaa218`:

| Run | Mean | Median | Allocated |
|---|---:|---:|---:|
| baseline before | 1.237 us | 1.241 us | 2,576 B |
| final candidate | 1.317 us | 1.265 us | 2,576 B |
| baseline after | 1.261 us | 1.265 us | 2,576 B |

The candidate mean contains one 1.438 us outlier; its other iterations were 1.249/1.265 us and its median equals the baseline-after median. A longer diagnostic run was explicitly inconclusive/multimodal (mValue 2.83), so it is not relabeled as a pass. Earlier candidate shapes that enlarged the hot async state were rejected. The final design restores the benchmarked proof struct, pending-wait helper signature, and no-fault consume call sites exactly; retry checks execute only after an owner actually aborts a pending commit proof. Allocations remain unchanged.

The original final design leaves public ConsumeOneAsync unchanged and moves ownership waiting to the rare shared-stream path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message consumption when deliveries are pending, ensuring consumers wait appropriately before polling for additional records.
  * Shared consumers now coordinate delivery processing correctly and can recover when the owning consumption operation is canceled.
  * Improved auto-commit fault handling, allowing affected records to be retried safely.
  * Explicit commits now consistently validate the offsets captured during the commit operation.
* **Tests**
  * Added coverage for shared-consumer waiting, cancellation recovery, and commit behavior during state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
