### PR TITLE
Stabilize Streams Admin timeout tests

### DIFF
--- a/src/Dekaf.Testing/InMemoryAdminClient.StreamsGroupManagement.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.StreamsGroupManagement.cs
@@ -258,14 +258,22 @@ public sealed partial class InMemoryAdminClient
         ErrorCode = ErrorCode.None
     };
 
-    private static async ValueTask<T> ExecuteWithTimeoutAsync<T>(
+    private async ValueTask<T> ExecuteWithTimeoutAsync<T>(
         Func<CancellationToken, ValueTask<T>> operation,
         int timeoutMs,
         string operationName,
         CancellationToken cancellationToken)
     {
         using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeoutSource.CancelAfter(timeoutMs);
+        if (ConfigureTimeoutSourceTestHook is { } configureTimeoutSource)
+        {
+            configureTimeoutSource(timeoutSource);
+        }
+        else
+        {
+            timeoutSource.CancelAfter(timeoutMs);
+        }
+
         try
         {
             return await operation(timeoutSource.Token).ConfigureAwait(false);

--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -19,6 +19,8 @@ public sealed partial class InMemoryAdminClient :
 {
     private static readonly TimeSpan DefaultDelegationTokenLifetime = TimeSpan.FromHours(24);
 
+    internal Action<CancellationTokenSource>? ConfigureTimeoutSourceTestHook;
+
     private readonly InMemoryKafkaCluster _cluster;
     private readonly Dictionary<ClientQuotaEntity, Dictionary<string, double>> _clientQuotas = new();
     private readonly object _delegationTokenGate = new();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryAdminShareFaultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryAdminShareFaultTests.cs
@@ -9,6 +9,8 @@ namespace Dekaf.Tests.Unit.Testing;
 
 public sealed class InMemoryAdminShareFaultTests
 {
+    private const int StreamsAdminTimeoutMs = 20;
+
     [Test]
     public async Task AdminFaults_HonorTopicScopeAndScriptOrderBeforeMutation()
     {
@@ -148,24 +150,24 @@ public sealed class InMemoryAdminShareFaultTests
                 {
                     [groupId] = new() { TopicPartitions = [partition] }
                 },
-                new ListStreamsGroupOffsetsOptions { TimeoutMs = 20 }).AsTask(),
+                new ListStreamsGroupOffsetsOptions { TimeoutMs = StreamsAdminTimeoutMs }).AsTask(),
             partitionScoped: true);
         await AssertStreamsAdminTimeoutAsync(
             static (admin, groupId, partition) => admin.AlterStreamsGroupOffsetsAsync(
                 groupId,
                 [new TopicPartitionOffset(partition.Topic, partition.Partition, 84)],
-                new AlterStreamsGroupOffsetsOptions { TimeoutMs = 20 }).AsTask(),
+                new AlterStreamsGroupOffsetsOptions { TimeoutMs = StreamsAdminTimeoutMs }).AsTask(),
             partitionScoped: true);
         await AssertStreamsAdminTimeoutAsync(
             static (admin, groupId, partition) => admin.DeleteStreamsGroupOffsetsAsync(
                 groupId,
                 [partition],
-                new DeleteStreamsGroupOffsetsOptions { TimeoutMs = 20 }).AsTask(),
+                new DeleteStreamsGroupOffsetsOptions { TimeoutMs = StreamsAdminTimeoutMs }).AsTask(),
             partitionScoped: true);
         await AssertStreamsAdminTimeoutAsync(
             static (admin, groupId, _) => admin.DeleteStreamsGroupsAsync(
                 [groupId],
-                new DeleteStreamsGroupsOptions { TimeoutMs = 20 }).AsTask(),
+                new DeleteStreamsGroupsOptions { TimeoutMs = StreamsAdminTimeoutMs }).AsTask(),
             partitionScoped: false);
     }
 
@@ -1084,6 +1086,8 @@ public sealed class InMemoryAdminShareFaultTests
     {
         var cluster = new InMemoryKafkaCluster();
         var admin = new InMemoryAdminClient(cluster);
+        CancellationTokenSource? timeoutSource = null;
+        admin.ConfigureTimeoutSourceTestHook = source => timeoutSource = source;
         const string groupId = "streams-timeout";
         var partition = new TopicPartition("input", 0);
         cluster.CreateTopic(partition.Topic);
@@ -1102,10 +1106,14 @@ public sealed class InMemoryAdminShareFaultTests
 
         try
         {
-            await barrier.WaitUntilEnteredAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+            var entered = barrier.WaitUntilEnteredAsync();
+            await Assert.That(entered.IsCompletedSuccessfully).IsTrue();
+            await entered;
+            timeoutSource!.Cancel();
             var exception = await Assert.ThrowsAsync<KafkaTimeoutException>(() => pending);
             await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Api);
-            await Assert.That(exception.Configured).IsEqualTo(TimeSpan.FromMilliseconds(20));
+            await Assert.That(exception.Configured)
+                .IsEqualTo(TimeSpan.FromMilliseconds(StreamsAdminTimeoutMs));
         }
         finally
         {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryAdminTimeoutBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryAdminTimeoutBenchmarks.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Admin;
+using Dekaf.Testing;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser(displayGenColumns: false)]
+[ShortRunJob]
+public class InMemoryAdminTimeoutBenchmarks
+{
+    private const string GroupId = "streams-benchmark";
+    private readonly InMemoryAdminClient _admin;
+    private readonly IReadOnlyDictionary<string, ListStreamsGroupOffsetsSpec> _groupSpecs;
+
+    public InMemoryAdminTimeoutBenchmarks()
+    {
+        var partition = new TopicPartition("input", 0);
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic(partition.Topic);
+        _admin = new InMemoryAdminClient(cluster);
+        _admin.AlterStreamsGroupOffsetsAsync(
+                GroupId,
+                [new TopicPartitionOffset(partition.Topic, partition.Partition, 42)])
+            .GetAwaiter()
+            .GetResult();
+        _groupSpecs = new Dictionary<string, ListStreamsGroupOffsetsSpec>
+        {
+            [GroupId] = new() { TopicPartitions = [partition] }
+        };
+    }
+
+    [Benchmark]
+    public ValueTask<IReadOnlyDictionary<string, StreamsGroupOffsetsResult>> ListOffsets() =>
+        _admin.ListStreamsGroupOffsetsAsync(_groupSpecs);
+}


### PR DESCRIPTION
## Summary

- add an internal timeout-source configuration hook to InMemoryAdminClient
- make Streams Admin timeout tests cancel the API timeout deterministically after the fault barrier is entered
- remove the wall-clock WaitAsync guard and preserve timeout classification/state assertions
- add InMemoryAdminTimeoutBenchmarks allocation coverage for the default public path

## Root cause

The 20 ms production timer started before the pause barrier was proven entered. A GC or scheduler stall could cancel the operation before the fault plan consumed the pause, so WaitUntilEnteredAsync().WaitAsync(5s) timed out. The test now supplies an unarmed timeout source, verifies the barrier completed synchronously, then cancels that exact API timeout source.

## Validation

- net8 build: 0 warnings, 0 errors
- net10 build: 0 warnings, 0 errors
- net8 unit: 8199/8199
- net10 unit: 8335/8335
- focused InMemoryAdminShareFaultTests: 37/37 on net8 and net10
- git diff --check
- /simplify

## Performance

BenchmarkDotNet ShortRun, .NET 10.0.11, ListStreamsGroupOffsetsAsync successful default path:

- exact base ^[651b76ed4dcb85daad153b65abe5c8d6734396b: 256.9 ns and 472.8 ns controls, 1.41 KB allocated
- final candidate 51e1955b4: 304.5 ns, 1.41 KB allocated

Host timing varied substantially across unchanged-base controls. The final candidate is inside that control envelope and allocation is unchanged.

Closes #2915

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of in-memory administration timeout handling.
  * Timeout behavior can now be controlled more consistently during testing.

* **Tests**
  * Strengthened timeout tests to verify cancellation and configured timeout values.

* **Benchmarks**
  * Added benchmarking coverage for listing stream-group offsets in an in-memory administration scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Runtime note

`tools/Dekaf.Benchmarks` targets net10.0. An explicit BenchmarkDotNet `Net80` job failed with `NU1201`; a temporary project multi-target attempt then failed on existing `RoutingSerdeBenchmarks` by-ref-like generics (`CS9240`), which .NET 8 cannot compile. Therefore this repository cannot produce a net8 MemoryDiagnoser result without a broad, unrelated benchmark-project retarget. Runtime correctness remains covered by the full net8 unit suite (8199/8199). The committed benchmark uses the public constructor, leaves `ConfigureTimeoutSourceTestHook` null, and measures the default `CancelAfter(timeoutMs)` branch.
