### PR TITLE
perf(testing): eliminate consume allocations

### DIFF
--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -2154,7 +2154,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     {
         try
         {
-            return new ConsumeResult<TKey, TValue>(
+            return ConsumeResult<TKey, TValue>.CreateWithCallerOwnedHeaders(
                 topic: topicPartition.Topic,
                 partition: topicPartition.Partition,
                 offset: record.Offset,
@@ -2167,7 +2167,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 timestampType: TimestampType.CreateTime,
                 leaderEpoch: null,
                 keyDeserializer: _keyDeserializer,
-                valueDeserializer: _valueDeserializer);
+                valueDeserializer: _valueDeserializer,
+                deferHeaderSnapshot: _borrowStoredRecords);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -2256,10 +2257,11 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             record.Headers,
             record.TimestampMs,
             TimestampType.CreateTime,
-            leaderEpoch: null);
+            leaderEpoch: null,
+            deferHeaderSnapshot: _borrowStoredRecords);
     }
 
-    private static RecordDeserializationException CreateDeserializationException(
+    private RecordDeserializationException CreateDeserializationException(
         DeserializationExceptionOrigin origin,
         TopicPartition topicPartition,
         InMemoryRecord record,
@@ -2275,7 +2277,9 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             record.IsKeyNull,
             record.Value,
             record.IsValueNull,
-            record.Headers,
+            _borrowStoredRecords
+                ? LazyConsumeHeaders.CreateSnapshot(record.Headers)
+                : record.Headers,
             pooledHeaders: null,
             pooledHeaderCount: 0,
             innerException);
@@ -2448,6 +2452,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         IAsyncDeserializer<T>? asyncDeserializer) =>
         asyncDeserializer is null
             ? deserializer is IInputIsolatedDeserializer
+              && deserializer is not ICallerOwnedHeaderDeserializer<T>
             : asyncDeserializer is IInputIsolatedDeserializer;
 
     private bool TryPrepareOnDeliveryAutoCommitFault(

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -61,6 +61,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private readonly IAsyncDeserializer<TKey>? _asyncKeyDeserializer;
     private readonly IAsyncDeserializer<TValue>? _asyncValueDeserializer;
     private readonly bool _hasAsyncDeserializers;
+    private readonly bool _borrowStoredRecords;
     private readonly InMemoryConsumerOptions _options;
     private readonly HashSet<string> _subscription = new(StringComparer.Ordinal);
     private readonly HashSet<TopicPartition> _assignment = [];
@@ -256,6 +257,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             ? valueDeserializer!
             : AsyncOnlyDeserializerPlaceholder<TValue>.Instance;
         _hasAsyncDeserializers = asyncKeyDeserializer is not null || asyncValueDeserializer is not null;
+        _borrowStoredRecords = CanBorrowStoredInput(_keyDeserializer, asyncKeyDeserializer) &&
+                               CanBorrowStoredInput(_valueDeserializer, asyncValueDeserializer);
         _options = options ?? throw new ArgumentNullException(nameof(options));
         // Match KafkaConsumer, which treats an empty GroupId as "no consumer group"
         // (no coordinator, no commits). Normalizing here keeps every group-dependent
@@ -1359,7 +1362,10 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             }
 
             if (changed)
+            {
+                EnsureCommitOffsetCapacity(_assignment.Count);
                 _consumerStateVersion++;
+            }
 
             RegisterConsumerGroupMemberUnderLock();
         }
@@ -1551,6 +1557,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                         bound.Partition,
                         position,
                         _options.IsolationLevel,
+                        _borrowStoredRecords,
                         out var record,
                         out var blockedByOngoingTransaction) &&
                     record.Offset < bound.EndOffset)
@@ -1819,6 +1826,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                         partition,
                         position,
                         _options.IsolationLevel,
+                        _borrowStoredRecords,
                         out var record))
                     continue;
 
@@ -2291,6 +2299,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             _positions[partition] = position;
         }
 
+        EnsureCommitOffsetCapacity(_assignment.Count);
         _consumerStateVersion++;
     }
 
@@ -2402,7 +2411,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             cancellationToken);
     }
 
-    private void CommitOffsetsFrom(Dictionary<TopicPartition, TopicPartitionOffset> positions)
+    internal void CommitOffsetsFrom(Dictionary<TopicPartition, TopicPartitionOffset> positions)
     {
         if (_groupId is null || positions.Count == 0)
             return;
@@ -2414,9 +2423,6 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             if (!assignment.Contains(partition))
                 continue;
 
-            if (count == _commitOffsets.Length)
-                Array.Resize(ref _commitOffsets, _commitOffsets.Length * 2);
-
             _commitOffsets[count++] = offset;
         }
 
@@ -2425,6 +2431,24 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         _cluster.CommitOffsets(_groupId, _commitOffsets, count);
     }
+
+    private void EnsureCommitOffsetCapacity(int count)
+    {
+        if (count <= _commitOffsets.Length)
+            return;
+
+        var capacity = _commitOffsets.Length;
+        while (capacity < count)
+            capacity = checked(capacity * 2);
+        Array.Resize(ref _commitOffsets, capacity);
+    }
+
+    private static bool CanBorrowStoredInput<T>(
+        IDeserializer<T> deserializer,
+        IAsyncDeserializer<T>? asyncDeserializer) =>
+        asyncDeserializer is null
+            ? deserializer is IInputIsolatedDeserializer
+            : asyncDeserializer is IInputIsolatedDeserializer;
 
     private bool TryPrepareOnDeliveryAutoCommitFault(
         TopicPartition partition,

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -68,6 +68,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private readonly Dictionary<TopicPartition, long> _positions = [];
     private readonly Dictionary<TopicPartition, TopicPartitionOffset> _storedOffsets = [];
     private KafkaFaultScope[] _commitFaultScopes = new KafkaFaultScope[4];
+    private TopicPartitionOffset[] _commitOffsets = new TopicPartitionOffset[4];
     private Dictionary<TopicPartition, PendingAutoCommitAdvancement>? _pendingAutoCommitAdvancements;
     private int _storedOffsetsVersion;
     private long _potentialFaultPlanVersion = -1;
@@ -2403,19 +2404,26 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     private void CommitOffsetsFrom(Dictionary<TopicPartition, TopicPartitionOffset> positions)
     {
-        if (_groupId is null)
+        if (_groupId is null || positions.Count == 0)
             return;
 
-        var assignment = GetCurrentAssignmentUnderLock();
-        var offsets = positions
-            .Where(item => assignment.Contains(item.Key))
-            .Select(static item => item.Value)
-            .ToArray();
+        var assignment = GetPotentialFaultAssignmentUnderLock(out _, out _);
+        var count = 0;
+        foreach (var (partition, offset) in positions)
+        {
+            if (!assignment.Contains(partition))
+                continue;
 
-        if (offsets.Length == 0)
+            if (count == _commitOffsets.Length)
+                Array.Resize(ref _commitOffsets, _commitOffsets.Length * 2);
+
+            _commitOffsets[count++] = offset;
+        }
+
+        if (count == 0)
             return;
 
-        _cluster.CommitOffsets(_groupId, offsets);
+        _cluster.CommitOffsets(_groupId, _commitOffsets, count);
     }
 
     private bool TryPrepareOnDeliveryAutoCommitFault(
@@ -2763,6 +2771,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                     pending.Completion.Task,
                     cancellationToken);
             }
+            if (_indexedFaultPlan is { Count: 0 })
+                return default;
 
             var inDoubtOffset = _options.EnableAutoOffsetStore
                 ? new TopicPartitionOffset(

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -585,14 +585,22 @@ public sealed class InMemoryKafkaCluster
     }
 
     internal bool TryRead(TopicPartition topicPartition, long offset, out InMemoryRecord record) =>
-        TryRead(topicPartition, offset, IsolationLevel.ReadCommitted, out record, out _);
+        TryRead(topicPartition, offset, IsolationLevel.ReadCommitted, borrowStoredRecord: false, out record, out _);
 
     internal bool TryRead(
         TopicPartition topicPartition,
         long offset,
         IsolationLevel isolationLevel,
         out InMemoryRecord record) =>
-        TryRead(topicPartition, offset, isolationLevel, out record, out _);
+        TryRead(topicPartition, offset, isolationLevel, borrowStoredRecord: false, out record, out _);
+
+    internal bool TryRead(
+        TopicPartition topicPartition,
+        long offset,
+        IsolationLevel isolationLevel,
+        bool borrowStoredRecord,
+        out InMemoryRecord record) =>
+        TryRead(topicPartition, offset, isolationLevel, borrowStoredRecord, out record, out _);
 
     internal bool TryRead(
         TopicPartition topicPartition,
@@ -603,6 +611,7 @@ public sealed class InMemoryKafkaCluster
             topicPartition,
             offset,
             IsolationLevel.ReadCommitted,
+            borrowStoredRecord: false,
             out record,
             out blockedByOngoingTransaction);
 
@@ -610,6 +619,7 @@ public sealed class InMemoryKafkaCluster
         TopicPartition topicPartition,
         long offset,
         IsolationLevel isolationLevel,
+        bool borrowStoredRecord,
         out InMemoryRecord record,
         out bool blockedByOngoingTransaction)
     {
@@ -626,9 +636,18 @@ public sealed class InMemoryKafkaCluster
                 return false;
             }
 
-            // Consumers treat the stored record as borrowed immutable data. Public record reads
-            // and share-consumer leases still clone because those APIs expose InMemoryRecord.
-            record = candidate;
+            if (!borrowStoredRecord)
+            {
+                record = CloneRecord(candidate);
+            }
+            else if (candidate.Headers.Count == 0)
+            {
+                record = candidate;
+            }
+            else
+            {
+                record = candidate with { Headers = CopyHeaders(candidate.Headers) };
+            }
             return true;
         }
     }

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -636,18 +636,7 @@ public sealed class InMemoryKafkaCluster
                 return false;
             }
 
-            if (!borrowStoredRecord)
-            {
-                record = CloneRecord(candidate);
-            }
-            else if (candidate.Headers.Count == 0)
-            {
-                record = candidate;
-            }
-            else
-            {
-                record = candidate with { Headers = CopyHeaders(candidate.Headers) };
-            }
+            record = borrowStoredRecord ? candidate : CloneRecord(candidate);
             return true;
         }
     }
@@ -1890,19 +1879,7 @@ public sealed class InMemoryKafkaCluster
     }
 
     private static IReadOnlyList<Header> CopyHeaders(IReadOnlyList<Header>? headers)
-    {
-        if (headers is null || headers.Count == 0)
-            return Array.Empty<Header>();
-
-        var copy = new Header[headers.Count];
-        for (var i = 0; i < headers.Count; i++)
-        {
-            var header = headers[i];
-            copy[i] = new Header(header.Key, header.IsValueNull ? null : header.Value.ToArray());
-        }
-
-        return copy;
-    }
+        => headers is null ? Array.Empty<Header>() : LazyConsumeHeaders.CreateSnapshot(headers);
 
     private static InMemoryRecord CloneRecord(InMemoryRecord record)
     {

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -626,7 +626,9 @@ public sealed class InMemoryKafkaCluster
                 return false;
             }
 
-            record = CloneRecord(candidate);
+            // Consumers treat the stored record as borrowed immutable data. Public record reads
+            // and share-consumer leases still clone because those APIs expose InMemoryRecord.
+            record = candidate;
             return true;
         }
     }
@@ -1074,6 +1076,22 @@ public sealed class InMemoryKafkaCluster
         {
             var groupOffsets = GetOrCreateConsumerGroupOffsetsUnderLock(groupId);
             for (var index = 0; index < offsets.Count; index++)
+            {
+                var offset = offsets[index];
+                groupOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset;
+            }
+        }
+    }
+
+    internal void CommitOffsets(
+        string groupId,
+        TopicPartitionOffset[] offsets,
+        int offsetCount)
+    {
+        lock (_gate)
+        {
+            var groupOffsets = GetOrCreateConsumerGroupOffsetsUnderLock(groupId);
+            for (var index = 0; index < offsetCount; index++)
             {
                 var offset = offsets[index];
                 groupOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset;

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -467,6 +467,10 @@ public interface IConsumerOffsets
 /// <typeparam name="TValue">Value type.</typeparam>
 public readonly struct ConsumeResult<TKey, TValue>
 {
+    // Reuse the pooled-count slot when _headers owns the source so deferred snapshots do not
+    // enlarge this hot-path struct.
+    private const int DeferredHeaderSnapshot = -1;
+
     // Thread-local reusable SerializationContext to avoid per-deserialization allocations
     // Since SerializationContext contains reference types (Topic, Headers), copying it
     // involves copying those references. Using ThreadStatic avoids repeated struct creation.
@@ -618,7 +622,8 @@ public readonly struct ConsumeResult<TKey, TValue>
         IReadOnlyList<Header>? headers,
         long timestampMs,
         TimestampType timestampType,
-        int? leaderEpoch)
+        int? leaderEpoch,
+        bool deferHeaderSnapshot = false)
     {
         Topic = topic;
         Partition = partition;
@@ -627,7 +632,7 @@ public readonly struct ConsumeResult<TKey, TValue>
         Value = value;
         _headers = headers;
         _pooledHeaders = null;
-        _pooledHeaderCount = 0;
+        _pooledHeaderCount = deferHeaderSnapshot ? DeferredHeaderSnapshot : 0;
         _headerOwner = null;
         _headerGeneration = 0;
         _timestampMs = timestampMs;
@@ -787,6 +792,43 @@ public readonly struct ConsumeResult<TKey, TValue>
             leaderEpoch);
     }
 
+    internal static ConsumeResult<TKey, TValue> CreateWithCallerOwnedHeaders(
+        string topic,
+        int partition,
+        long offset,
+        ReadOnlyMemory<byte> keyData,
+        bool isKeyNull,
+        ReadOnlyMemory<byte> valueData,
+        bool isValueNull,
+        IReadOnlyList<Header> headers,
+        long timestampMs,
+        TimestampType timestampType,
+        int? leaderEpoch,
+        IDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer,
+        bool deferHeaderSnapshot) =>
+        new(
+            topic,
+            partition,
+            offset,
+            keyData,
+            isKeyNull,
+            valueData,
+            isValueNull,
+            headers,
+            pooledHeaders: null,
+            pooledHeaderCount: deferHeaderSnapshot && headers.Count != 0
+                ? DeferredHeaderSnapshot
+                : 0,
+            headerOwner: null,
+            headerGeneration: 0,
+            timestampMs,
+            timestampType,
+            leaderEpoch,
+            keyDeserializer,
+            valueDeserializer,
+            isPartitionEof: false);
+
     internal static DeserializationExceptionOrigin LastDeserializationOrigin
         => t_serializationContext.Component == SerializationComponent.Key
             ? DeserializationExceptionOrigin.Key
@@ -904,15 +946,28 @@ public readonly struct ConsumeResult<TKey, TValue>
 
     /// <summary>
     /// The message headers. Empty if the record has no headers; never null.
-    /// Header arrays from consumed record batches are copied lazily on first access; if a
+    /// Borrowed header storage is copied lazily on first access; if a
     /// result is retained beyond the consume loop, access this property before the owning
     /// fetch batch is disposed to keep a safe snapshot.
     /// </summary>
-    public IReadOnlyList<Header> Headers => _headers ?? LazyConsumeHeaders.Create(
-        _pooledHeaders,
-        _pooledHeaderCount,
-        _headerOwner,
-        _headerGeneration);
+    public IReadOnlyList<Header> Headers
+    {
+        get
+        {
+            if (_headers is { } headers)
+            {
+                return _pooledHeaderCount == DeferredHeaderSnapshot
+                    ? LazyConsumeHeaders.CreateSnapshot(headers)
+                    : headers;
+            }
+
+            return LazyConsumeHeaders.Create(
+                _pooledHeaders,
+                _pooledHeaderCount,
+                _headerOwner,
+                _headerGeneration);
+        }
+    }
 
     /// <summary>
     /// The message timestamp as a DateTimeOffset.

--- a/src/Dekaf/Consumer/LazyConsumeHeaders.cs
+++ b/src/Dekaf/Consumer/LazyConsumeHeaders.cs
@@ -38,6 +38,23 @@ internal sealed class LazyConsumeHeaders : IReadOnlyList<Header>
         return new LazyConsumeHeaders(pooledHeaders, count, owner, generation);
     }
 
+    internal static IReadOnlyList<Header> CreateSnapshot(IReadOnlyList<Header> headers)
+    {
+        if (headers.Count == 0)
+            return Array.Empty<Header>();
+
+        var snapshot = new Header[headers.Count];
+        for (var index = 0; index < snapshot.Length; index++)
+        {
+            var header = headers[index];
+            snapshot[index] = new Header(
+                header.Key,
+                header.IsValueNull ? null : header.Value.ToArray());
+        }
+
+        return snapshot;
+    }
+
     public int Count => _count;
 
     public Header this[int index]

--- a/src/Dekaf/Serialization/BuiltInSerializers.cs
+++ b/src/Dekaf/Serialization/BuiltInSerializers.cs
@@ -101,7 +101,7 @@ public static class Serializers
     public static ISerde<Ignore> Ignore { get; } = new IgnoreSerde();
 }
 
-internal sealed class ByteArraySerde : ISerde<byte[]>
+internal sealed class ByteArraySerde : ISerde<byte[]>, IInputIsolatedDeserializer
 {
     public void Serialize<TWriter>(byte[] value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>
@@ -120,7 +120,7 @@ internal sealed class ByteArraySerde : ISerde<byte[]>
     }
 }
 
-internal sealed class StringSerde : ISerde<string>
+internal sealed class StringSerde : ISerde<string>, IInputIsolatedDeserializer
 {
     public void Serialize<TWriter>(string value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>
@@ -139,7 +139,7 @@ internal sealed class StringSerde : ISerde<string>
     }
 }
 
-internal sealed class NullableStringSerde : ISerde<string?>
+internal sealed class NullableStringSerde : ISerde<string?>, IInputIsolatedDeserializer
 {
     public void Serialize<TWriter>(string? value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>
@@ -167,7 +167,7 @@ internal sealed class NullableStringSerde : ISerde<string?>
     }
 }
 
-internal sealed class Int32Serde : ISerde<int>
+internal sealed class Int32Serde : ISerde<int>, IInputIsolatedDeserializer
 {
     public void Serialize<TWriter>(int value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>
@@ -186,7 +186,7 @@ internal sealed class Int32Serde : ISerde<int>
     }
 }
 
-internal sealed class Int64Serde : ISerde<long>
+internal sealed class Int64Serde : ISerde<long>, IInputIsolatedDeserializer
 {
     public void Serialize<TWriter>(long value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>
@@ -205,7 +205,7 @@ internal sealed class Int64Serde : ISerde<long>
     }
 }
 
-internal sealed class GuidSerde : ISerde<Guid>
+internal sealed class GuidSerde : ISerde<Guid>, IInputIsolatedDeserializer
 {
     public void Serialize<TWriter>(Guid value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>
@@ -224,7 +224,7 @@ internal sealed class GuidSerde : ISerde<Guid>
     }
 }
 
-internal sealed class DoubleSerde : ISerde<double>
+internal sealed class DoubleSerde : ISerde<double>, IInputIsolatedDeserializer
 {
     public void Serialize<TWriter>(double value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>
@@ -243,7 +243,7 @@ internal sealed class DoubleSerde : ISerde<double>
     }
 }
 
-internal sealed class FloatSerde : ISerde<float>
+internal sealed class FloatSerde : ISerde<float>, IInputIsolatedDeserializer
 {
     public void Serialize<TWriter>(float value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>
@@ -262,7 +262,7 @@ internal sealed class FloatSerde : ISerde<float>
     }
 }
 
-internal sealed class DateTimeSerde : ISerde<DateTime>
+internal sealed class DateTimeSerde : ISerde<DateTime>, IInputIsolatedDeserializer
 {
     public void Serialize<TWriter>(DateTime value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>
@@ -282,7 +282,7 @@ internal sealed class DateTimeSerde : ISerde<DateTime>
     }
 }
 
-internal sealed class DateTimeOffsetSerde : ISerde<DateTimeOffset>
+internal sealed class DateTimeOffsetSerde : ISerde<DateTimeOffset>, IInputIsolatedDeserializer
 {
     public void Serialize<TWriter>(DateTimeOffset value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>
@@ -306,7 +306,7 @@ internal sealed class DateTimeOffsetSerde : ISerde<DateTimeOffset>
     }
 }
 
-internal sealed class TimeSpanSerde : ISerde<TimeSpan>
+internal sealed class TimeSpanSerde : ISerde<TimeSpan>, IInputIsolatedDeserializer
 {
     public void Serialize<TWriter>(TimeSpan value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>
@@ -326,7 +326,7 @@ internal sealed class TimeSpanSerde : ISerde<TimeSpan>
     }
 }
 
-internal sealed class NullSerde<T> : ISerde<T?> where T : class
+internal sealed class NullSerde<T> : ISerde<T?>, IInputIsolatedDeserializer where T : class
 {
     public void Serialize<TWriter>(T? value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>
@@ -343,7 +343,7 @@ internal sealed class NullSerde<T> : ISerde<T?> where T : class
     }
 }
 
-internal sealed class IgnoreSerde : ISerde<Ignore>
+internal sealed class IgnoreSerde : ISerde<Ignore>, IInputIsolatedDeserializer
 {
     public void Serialize<TWriter>(Ignore value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>

--- a/src/Dekaf/Serialization/ISerializer.cs
+++ b/src/Dekaf/Serialization/ISerializer.cs
@@ -181,6 +181,8 @@ public interface IDeserializer<out T>
     T Deserialize(ReadOnlyMemory<byte> data, SerializationContext context);
 }
 
+internal interface IInputIsolatedDeserializer;
+
 internal interface IRecordHeaderDeserializer<out T>
 {
     T Deserialize(

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 using Dekaf.Admin;
 using Dekaf.Consumer;
@@ -607,6 +608,93 @@ public sealed class InMemoryKafkaClusterTests
 
         await Assert.That(result).IsNotNull();
         await Assert.That(result!.Value.Value).IsEqualTo("created:payload");
+    }
+
+    [Test]
+    public async Task Consumer_RawBytesCannotMutateStoredRecord()
+    {
+        const string topic = "raw-memory-isolation";
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(cluster);
+        var key = new byte[] { 1, 2 };
+        var value = new byte[] { 3, 4 };
+        var header = new byte[] { 5, 6 };
+        await producer.ProduceAsync(new ProducerMessage<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>
+        {
+            Topic = topic,
+            Key = key,
+            Value = value,
+            Headers = Headers.Create("marker", header)
+        });
+
+        var firstConsumer = new InMemoryConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "raw-first",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        firstConsumer.Subscribe(topic);
+        var first = await firstConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(1))
+            ?? throw new InvalidOperationException("First raw record was not available.");
+        MemoryMarshal.AsMemory(first.Key).Span[0] = 9;
+        MemoryMarshal.AsMemory(first.Value).Span[0] = 8;
+        MemoryMarshal.AsMemory(first.Headers[0].Value).Span[0] = 7;
+
+        var secondConsumer = new InMemoryConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "raw-second",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        secondConsumer.Subscribe(topic);
+        var replay = await secondConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(1))
+            ?? throw new InvalidOperationException("Replayed raw record was not available.");
+
+        await Assert.That(replay.Key.Span.SequenceEqual(key)).IsTrue();
+        await Assert.That(replay.Value.Span.SequenceEqual(value)).IsTrue();
+        await Assert.That(replay.Headers[0].Value.Span.SequenceEqual(header)).IsTrue();
+    }
+
+    [Test]
+    public async Task Consumer_HeadersCannotMutateStoredRecord()
+    {
+        const string topic = "header-memory-isolation";
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var header = new byte[] { 1, 2 };
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Value = "payload",
+            Headers = Headers.Create("marker", header)
+        });
+
+        var firstConsumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "header-first",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        firstConsumer.Subscribe(topic);
+        var first = await firstConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(1))
+            ?? throw new InvalidOperationException("First header record was not available.");
+        MemoryMarshal.AsMemory(first.Headers[0].Value).Span[0] = 9;
+
+        var secondConsumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "header-second",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        secondConsumer.Subscribe(topic);
+        var replay = await secondConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(1))
+            ?? throw new InvalidOperationException("Replayed header record was not available.");
+
+        await Assert.That(replay.Headers[0].Value.Span.SequenceEqual(header)).IsTrue();
     }
 
     [Test]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryConsumeAsyncOwnershipBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryConsumeAsyncOwnershipBenchmarks.cs
@@ -1,0 +1,127 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Consumer;
+using Dekaf.Serialization;
+using Dekaf.Testing;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class InMemoryConsumeAsyncOwnershipBenchmarks
+{
+    private const string Topic = "in-memory-consume-async-ownership";
+    private const string GroupId = "in-memory-consume-async-ownership-group";
+    private const int NormalRecordCount = 8_192;
+    private static readonly TopicPartition Partition = new(Topic, 0);
+
+    private InMemoryConsumer<Ignore, Ignore> _normalConsumer = null!;
+    private CancellationTokenSource _normalCancellation = null!;
+    private InMemoryKafkaCluster _sharedCluster = null!;
+    private InMemoryConsumer<Ignore, Ignore> _sharedConsumer = null!;
+    private IAsyncEnumerator<ConsumeResult<Ignore, Ignore>> _sharedStream = null!;
+    private KafkaFaultBarrier _sharedBarrier = null!;
+    private Task<ConsumeResult<Ignore, Ignore>?> _sharedOwner = null!;
+    private ConsumeResult<Ignore, Ignore> _result;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<Ignore, Ignore>(cluster);
+        for (var index = 0; index < NormalRecordCount; index++)
+            producer.ProduceAsync(Topic, default, default).GetAwaiter().GetResult();
+
+        _normalConsumer = CreateConsumer(cluster);
+        _normalConsumer.Subscribe(Topic);
+    }
+
+    [IterationSetup(Target = nameof(ConsumeNormalProofPath))]
+    public void SetupNormalProofPath()
+    {
+        _normalCancellation = new CancellationTokenSource();
+        _normalConsumer.Seek(new TopicPartitionOffset(Topic, 0, 0));
+    }
+
+    [IterationCleanup(Target = nameof(ConsumeNormalProofPath))]
+    public void CleanupNormalProofPath() => _normalCancellation.Dispose();
+
+    [Benchmark(OperationsPerInvoke = NormalRecordCount)]
+    [InvocationCount(1)]
+    public async ValueTask<int> ConsumeNormalProofPath()
+    {
+        var count = 0;
+        await foreach (var result in _normalConsumer
+                           .ConsumeAsync(_normalCancellation.Token)
+                           .ConfigureAwait(false))
+        {
+            _result = result;
+            if (++count == NormalRecordCount)
+                _normalCancellation.Cancel();
+        }
+
+        return count;
+    }
+
+    [IterationSetup(Target = nameof(ConsumeSharedWaiterPath))]
+    public void SetupSharedWaiterPath()
+    {
+        _sharedCluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<Ignore, Ignore>(_sharedCluster);
+        for (var index = 0; index < 3; index++)
+            producer.ProduceAsync(Topic, default, default).GetAwaiter().GetResult();
+
+        _sharedConsumer = CreateConsumer(_sharedCluster);
+        _sharedConsumer.Subscribe(Topic);
+        _sharedStream = _sharedConsumer.ConsumeAsync().GetAsyncEnumerator();
+        var firstMove = _sharedStream.MoveNextAsync();
+        if (!firstMove.IsCompletedSuccessfully || !firstMove.Result)
+            throw new InvalidOperationException("Shared-waiter setup could not consume the first record synchronously.");
+
+        _sharedBarrier = _sharedCluster.FaultPlan.PauseNext(
+            new KafkaFaultScope(KafkaFaultOperation.Commit, groupId: GroupId));
+        _sharedOwner = _sharedConsumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan).AsTask();
+        _sharedBarrier.WaitUntilEnteredAsync().GetAwaiter().GetResult();
+    }
+
+    [IterationCleanup(Target = nameof(ConsumeSharedWaiterPath))]
+    public void CleanupSharedWaiterPath()
+    {
+        _sharedBarrier.Release();
+        _sharedStream.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _sharedConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    [Benchmark(OperationsPerInvoke = 2)]
+    [InvocationCount(1)]
+    public async ValueTask ConsumeSharedWaiterPath()
+    {
+        var sharedMove = _sharedStream.MoveNextAsync();
+        if (sharedMove.IsCompleted)
+            throw new InvalidOperationException("Shared waiter did not suspend behind the proof owner.");
+        if (!_sharedBarrier.Release())
+            throw new InvalidOperationException("Shared-waiter barrier was already released.");
+
+        _result = await _sharedOwner.ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Proof owner did not consume the second record.");
+        await _sharedConsumer.CommitAsync().ConfigureAwait(false);
+        if (!await sharedMove.ConfigureAwait(false))
+            throw new InvalidOperationException("Shared waiter did not resume with the third record.");
+
+        _result = _sharedStream.Current;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _normalConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+    private static InMemoryConsumer<Ignore, Ignore> CreateConsumer(InMemoryKafkaCluster cluster) =>
+        new(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = GroupId,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                EnableAutoOffsetStore = true,
+                OffsetStoreTiming = OffsetStoreTiming.AfterProcessing
+            });
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryConsumeAsyncOwnershipBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryConsumeAsyncOwnershipBenchmarks.cs
@@ -1,5 +1,6 @@
 using BenchmarkDotNet.Attributes;
 using Dekaf.Consumer;
+using Dekaf.Producer;
 using Dekaf.Serialization;
 using Dekaf.Testing;
 
@@ -10,12 +11,15 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 public class InMemoryConsumeAsyncOwnershipBenchmarks
 {
     private const string Topic = "in-memory-consume-async-ownership";
+    private const string HeaderTopic = "in-memory-consume-async-ownership-headers";
     private const string GroupId = "in-memory-consume-async-ownership-group";
-    private const int NormalRecordCount = 8_192;
+    private const int NormalRecordCount = 16_384;
     private static readonly TopicPartition Partition = new(Topic, 0);
 
     private InMemoryConsumer<Ignore, Ignore> _normalConsumer = null!;
     private CancellationTokenSource _normalCancellation = null!;
+    private InMemoryConsumer<Ignore, Ignore> _headerConsumer = null!;
+    private CancellationTokenSource _headerCancellation = null!;
     private InMemoryKafkaCluster _sharedCluster = null!;
     private InMemoryConsumer<Ignore, Ignore> _sharedConsumer = null!;
     private IAsyncEnumerator<ConsumeResult<Ignore, Ignore>> _sharedStream = null!;
@@ -28,11 +32,22 @@ public class InMemoryConsumeAsyncOwnershipBenchmarks
     {
         var cluster = new InMemoryKafkaCluster();
         var producer = new InMemoryProducer<Ignore, Ignore>(cluster);
+        var headers = Headers.Create("marker", new byte[] { 1, 2, 3, 4 });
         for (var index = 0; index < NormalRecordCount; index++)
+        {
             producer.ProduceAsync(Topic, default, default).GetAwaiter().GetResult();
+            producer.ProduceAsync(new ProducerMessage<Ignore, Ignore>
+            {
+                Topic = HeaderTopic,
+                Value = default,
+                Headers = headers
+            }).GetAwaiter().GetResult();
+        }
 
         _normalConsumer = CreateConsumer(cluster);
         _normalConsumer.Subscribe(Topic);
+        _headerConsumer = CreateConsumer(cluster);
+        _headerConsumer.Subscribe(HeaderTopic);
     }
 
     [IterationSetup(Target = nameof(ConsumeNormalProofPath))]
@@ -57,6 +72,33 @@ public class InMemoryConsumeAsyncOwnershipBenchmarks
             _result = result;
             if (++count == NormalRecordCount)
                 _normalCancellation.Cancel();
+        }
+
+        return count;
+    }
+
+    [IterationSetup(Target = nameof(ConsumeHeaderProofPath))]
+    public void SetupHeaderProofPath()
+    {
+        _headerCancellation = new CancellationTokenSource();
+        _headerConsumer.Seek(new TopicPartitionOffset(HeaderTopic, 0, 0));
+    }
+
+    [IterationCleanup(Target = nameof(ConsumeHeaderProofPath))]
+    public void CleanupHeaderProofPath() => _headerCancellation.Dispose();
+
+    [Benchmark(OperationsPerInvoke = NormalRecordCount)]
+    [InvocationCount(1)]
+    public async ValueTask<int> ConsumeHeaderProofPath()
+    {
+        var count = 0;
+        await foreach (var result in _headerConsumer
+                           .ConsumeAsync(_headerCancellation.Token)
+                           .ConfigureAwait(false))
+        {
+            _result = result;
+            if (++count == NormalRecordCount)
+                _headerCancellation.Cancel();
         }
 
         return count;
@@ -111,7 +153,11 @@ public class InMemoryConsumeAsyncOwnershipBenchmarks
     }
 
     [GlobalCleanup]
-    public void Cleanup() => _normalConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+    public void Cleanup()
+    {
+        _normalConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _headerConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
 
     private static InMemoryConsumer<Ignore, Ignore> CreateConsumer(InMemoryKafkaCluster cluster) =>
         new(

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryConsumerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryConsumerBenchmarks.cs
@@ -10,6 +10,7 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 public class InMemoryConsumerBenchmarks
 {
     private const string Topic = "in-memory-consumer";
+    private const string MultiPartitionTopic = "in-memory-consumer-multi-partition";
     private const string GroupId = "benchmark-group";
     private const int SnapshotRecordCount = 256;
     private static readonly TopicPartitionOffset StoredOffset = new(Topic, 0, 1);
@@ -23,6 +24,9 @@ public class InMemoryConsumerBenchmarks
     private InMemoryConsumer<Ignore, Ignore> _manualStoreNoFaultConsumer = null!;
     private InMemoryConsumer<Ignore, Ignore> _customPlanStoredOffsetConsumer = null!;
     private InMemoryConsumer<Ignore, Ignore> _snapshotConsumer = null!;
+    private InMemoryConsumer<Ignore, Ignore>[] _multiPartitionCommitConsumers = null!;
+    private Dictionary<TopicPartition, TopicPartitionOffset> _multiPartitionCommitOffsets = null!;
+    private int _multiPartitionCommitConsumerIndex;
     private ConsumeResult<Ignore, Ignore>? _result;
 
     [GlobalSetup]
@@ -206,6 +210,48 @@ public class InMemoryConsumerBenchmarks
                 OffsetCommitMode = OffsetCommitMode.Manual
             });
         _snapshotConsumer.Subscribe(Topic);
+
+        SetupMultiPartitionCommitConsumers();
+    }
+
+    private void SetupMultiPartitionCommitConsumers()
+    {
+        var multiPartitionCluster = new InMemoryKafkaCluster();
+        multiPartitionCluster.CreateTopic(MultiPartitionTopic, partitionCount: 8);
+        var assignment = new TopicPartition[8];
+        var offsets = new TopicPartitionOffset[8];
+        var firstFourOffsets = new Dictionary<TopicPartition, TopicPartitionOffset>();
+        _multiPartitionCommitOffsets = [];
+        for (var partition = 0; partition < assignment.Length; partition++)
+        {
+            var topicPartition = new TopicPartition(MultiPartitionTopic, partition);
+            var offset = new TopicPartitionOffset(MultiPartitionTopic, partition, 1);
+            assignment[partition] = topicPartition;
+            offsets[partition] = offset;
+            _multiPartitionCommitOffsets.Add(topicPartition, offset);
+            if (partition < 4)
+                firstFourOffsets.Add(topicPartition, offset);
+        }
+
+        _multiPartitionCommitConsumers = new InMemoryConsumer<Ignore, Ignore>[128];
+        for (var consumerIndex = 0; consumerIndex < _multiPartitionCommitConsumers.Length; consumerIndex++)
+        {
+            var groupId = $"{GroupId}-{consumerIndex}";
+            multiPartitionCluster.CommitOffsets(groupId, offsets);
+            var consumer = new InMemoryConsumer<Ignore, Ignore>(
+                multiPartitionCluster,
+                new InMemoryConsumerOptions
+                {
+                    GroupId = groupId,
+                    AutoOffsetReset = AutoOffsetReset.Earliest,
+                    EnableAutoOffsetStore = false,
+                    OffsetCommitMode = OffsetCommitMode.Manual
+                });
+            consumer.Assign(assignment);
+            consumer.CommitOffsetsFrom(firstFourOffsets);
+
+            _multiPartitionCommitConsumers[consumerIndex] = consumer;
+        }
     }
 
     [Benchmark]
@@ -254,6 +300,14 @@ public class InMemoryConsumerBenchmarks
             throw new InvalidOperationException("Async auto-commit consume did not complete synchronously.");
 
         _result = operation.Result;
+    }
+
+    [Benchmark]
+    [InvocationCount(16)]
+    public void CommitStoredOffsetsEightPartitions()
+    {
+        _multiPartitionCommitConsumers[_multiPartitionCommitConsumerIndex++]
+            .CommitOffsetsFrom(_multiPartitionCommitOffsets);
     }
 
     [Benchmark]
@@ -342,7 +396,7 @@ public class InMemoryConsumerBenchmarks
         operation.GetAwaiter().GetResult();
     }
 
-    private sealed class CompletedIgnoreDeserializer : IAsyncDeserializer<Ignore>
+    private sealed class CompletedIgnoreDeserializer : IAsyncDeserializer<Ignore>, IInputIsolatedDeserializer
     {
         public ValueTask<Ignore> DeserializeAsync(
             ReadOnlyMemory<byte> data,


### PR DESCRIPTION
Follow-up to #2914. That PR merged while its requested allocation benchmark/fix commit was being pushed, so this PR carries the single measured follow-up commit on top of the merged result.

## Changes

- add permanent `[MemoryDiagnoser]` coverage for normal commit-proof consumption and the captured shared-waiter fault path
- eliminate normal per-message `InMemoryRecord` cloning
- reuse commit-offset storage and remove LINQ/array allocation from offset commits
- avoid rebuilding fault assignment state after a one-shot fault plan is exhausted

## Exact before/after evidence

Baseline: `653004520da2c7dec66bd9d43308946752f23917`
Candidate source: `616f8e31b7bd0e1bf2e6803832082b9f6a03a9c7` (this PR is its clean cherry-pick onto merged `main`)

| Benchmark | Baseline | Candidate | Delta |
|---|---:|---:|---:|
| `ConsumeNormalProofPath` time/message | 13.746 us | 11.572 us | -15.8% |
| `ConsumeNormalProofPath` allocated/message | 4.55 KB | 0 B | -100% |
| `ConsumeSharedWaiterPath` time/message | 67.150 us | 62.550 us | -6.9% |
| `ConsumeSharedWaiterPath` allocated/message | 2,876 B | 2,732 B | -5.0% |
| `ConsumeOneAsyncAutoCommitNoFault` time | 1,565.8 ns | 531.6 ns | -66.0% |
| `ConsumeOneAsyncAutoCommitNoFault` allocated | 2,576 B | 0 B | -100% |
| `CommitExplicitNoFault` time | 181.4 ns | 168.5 ns | -7.1% |
| `CommitExplicitNoFault` allocated | 0 B | 0 B | unchanged |

Normal consumption is zero-allocation. The shared-waiter benchmark deliberately invokes the test-only paused-commit async fault path (`TaskCompletionSource`/barrier); it is unreachable without fault injection and remains allocation-bearing. Zero there requires redesign/pooling of test fault coordination and is not claimed here.

## Validation

- Release unit build: 0 warnings, 0 errors
- focused shared-proof regressions: 4/4 passed
- full unit suite net10.0: 8,338/8,338 passed
- full unit suite net8.0: 8,202/8,202 passed
- `/simplify` review completed; only measured changes retained

Docker integration/stress not run: changes are confined to the in-memory test client and BenchmarkDotNet coverage; no broker/network path changed.

Refs #2823