### PR TITLE
Make async wait tests deterministic

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerExtensionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerExtensionsTests.cs
@@ -82,6 +82,7 @@ public sealed class ConsumerExtensionsTests
     }
 
     [Test]
+    [Timeout(120_000)]
     public async Task Where_WithFilteredCallback_AwaitsBeforeRequestingNextItem(
         CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerExtensionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerExtensionsTests.cs
@@ -82,7 +82,6 @@ public sealed class ConsumerExtensionsTests
     }
 
     [Test]
-    [Timeout(10_000)]
     public async Task Where_WithFilteredCallback_AwaitsBeforeRequestingNextItem(
         CancellationToken cancellationToken)
     {
@@ -100,7 +99,7 @@ public sealed class ConsumerExtensionsTests
                 async _ =>
                 {
                     callbackStarted.TrySetResult();
-                    await releaseCallback.Task;
+                    await releaseCallback.Task.WaitAsync(cancellationToken);
                 },
                 cancellationToken))
             {

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -1092,6 +1092,7 @@ public sealed class TransactionTests
     }
 
     [Test]
+    [Timeout(120_000)]
     public async Task TransactionPartitionEnrollment_BatchesCoalescedPartitions(
         CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -1092,9 +1092,14 @@ public sealed class TransactionTests
     }
 
     [Test]
-    public async Task TransactionPartitionEnrollment_BatchesCoalescedPartitions()
+    public async Task TransactionPartitionEnrollment_BatchesCoalescedPartitions(
+        CancellationToken cancellationToken)
     {
-        var requestStarted = new TaskCompletionSource<IReadOnlyList<TopicPartition>>(
+        var firstRequestStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var failFirstRequest = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var retryRequestStarted = new TaskCompletionSource<IReadOnlyList<TopicPartition>>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var completeRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var requestCount = 0;
@@ -1105,11 +1110,15 @@ public sealed class TransactionTests
             CancellationToken cancellationToken)
         {
             if (Interlocked.Increment(ref requestCount) == 1)
+            {
+                firstRequestStarted.TrySetResult();
+                await failFirstRequest.Task.WaitAsync(cancellationToken);
                 throw new IOException("Transient connection failure");
+            }
             if (Interlocked.Exchange(ref failNextEnrollment, 0) == 1)
                 throw new TransactionException("Partition enrollment failed.");
 
-            requestStarted.TrySetResult([.. partitions]);
+            retryRequestStarted.TrySetResult([.. partitions]);
             await completeRequest.Task.WaitAsync(cancellationToken);
         }
 
@@ -1117,7 +1126,9 @@ public sealed class TransactionTests
         {
             BootstrapServers = ["localhost:9092"],
             TransactionalId = "test-txn-id",
-            CloseTimeoutMs = 100
+            CloseTimeoutMs = 100,
+            RetryBackoffMs = 0,
+            RetryBackoffMaxMs = 0
         };
         await using var connectionPool = new ConnectionPool(
             options.ClientId,
@@ -1168,7 +1179,9 @@ public sealed class TransactionTests
         await Assert.That(enrolled.IsEnrolled).IsFalse();
         await Assert.That(enrolled.Error).IsNull();
         await Assert.That(pendingPartitions).IsEquivalentTo(batches.Select(batch => batch.TopicPartition));
-        var requestedPartitions = await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await firstRequestStarted.Task.WaitAsync(cancellationToken);
+        failFirstRequest.SetResult();
+        var requestedPartitions = await retryRequestStarted.Task.WaitAsync(cancellationToken);
         await Assert.That(requestCount).IsEqualTo(2);
         await Assert.That(requestedPartitions).IsEquivalentTo(new[]
         {
@@ -1178,7 +1191,7 @@ public sealed class TransactionTests
         });
 
         completeRequest.SetResult();
-        await Assert.That(await enrollmentCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1))).IsNull();
+        await Assert.That(await enrollmentCompleted.Task.WaitAsync(cancellationToken)).IsNull();
         await Assert.That(producer.TryEnsurePartitionsInTransaction(
             batches,
             batches.Length,
@@ -1200,7 +1213,7 @@ public sealed class TransactionTests
         await Assert.That(mixedResult.IsEnrolled).IsFalse();
         await Assert.That(mixedPendingPartitions).IsEquivalentTo(
             [new TopicPartition("topic-c", 2)]);
-        await Assert.That(await mixedEnrollmentCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1))).IsNull();
+        await Assert.That(await mixedEnrollmentCompleted.Task.WaitAsync(cancellationToken)).IsNull();
 
         Interlocked.Exchange(ref failNextEnrollment, 1);
         var failedBatch = CreateEnrollmentBatch("failed-topic", 0);
@@ -1214,7 +1227,7 @@ public sealed class TransactionTests
             failedPendingPartitions,
             []);
         await Assert.That(pendingFailure.IsEnrolled).IsFalse();
-        await Assert.That(await failedEnrollmentCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1))).IsNull();
+        await Assert.That(await failedEnrollmentCompleted.Task.WaitAsync(cancellationToken)).IsNull();
 
         failedPendingPartitions.Clear();
         var failedResult = producer.TryEnsurePartitionsInTransaction(
@@ -1236,7 +1249,7 @@ public sealed class TransactionTests
             [],
             []);
         await Assert.That(unrelatedResult.Error).IsNull();
-        await Assert.That(await unrelatedEnrollmentCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1))).IsNull();
+        await Assert.That(await unrelatedEnrollmentCompleted.Task.WaitAsync(cancellationToken)).IsNull();
         await Assert.That(producer.TryEnsurePartitionsInTransaction(
             [unrelatedBatch],
             1,


### PR DESCRIPTION
## Summary

- gate the first transaction-enrollment failure explicitly before observing the retry
- set retry backoff to zero in the test and use runner cancellation instead of one-second wall-clock waits
- remove the filtered-callback test's fixed whole-test timeout and propagate runner cancellation through its gate

Closes #2917
Closes #2919

## Validation

- `dotnet build tests/Dekaf.Tests.Unit --configuration Release` — passed, 0 warnings/errors
- `TransactionPartitionEnrollment_BatchesCoalescedPartitions` — 100/100 net10, 100/100 net8
- `Where_WithFilteredCallback_AwaitsBeforeRequestingNextItem` — 100/100 net10, 100/100 net8
- concurrent full suite net10 — 8338/8338 passed twice
- first concurrent full suite net8 — 8201/8202; exposed and fixed #2919
- final concurrent full suite net8 — both changed tests passed; 8201/8202 overall because unrelated `ConsumeAsync_ResumeBeforePrefetchWaitRegistration_WakesRetainedRecord` timed out after reaching its injected pre-wait hook; tracked as #2920 rather than blindly rerun

Tests-only change; no `src/` hot path or benchmark impact.