### PR TITLE
Pool suspended consumer serde state machines

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -5383,6 +5383,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                && coordinator.IsAssignmentSyncCurrent(assignmentVersion);
     }
 
+#if NET
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneCoreAsync(
         bool pollRecorded,
         PreparedDeserializerKey? preparedKey,
@@ -6017,6 +6020,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             ? ConsumeOneFromPendingFetchesCoreAsync<NoRecordFilterMode>(preparedKey, cancellationToken)
             : ConsumeOneFromPendingFetchesCoreAsync<RecordFilterMode>(preparedKey, cancellationToken);
 
+#if NET
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneFromPendingFetchesCoreAsync<TRecordFilterMode>(
         PreparedDeserializerKey? preparedKey,
         CancellationToken cancellationToken)
@@ -6680,6 +6686,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
+#if NET
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private async ValueTask<ConsumeResult<TKey, TValue>> CreateResultWithAsyncDeserializationAsync(
         PendingFetchData pending,
         long offset,

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AsyncConsumerSerdePoolingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AsyncConsumerSerdePoolingBenchmarks.cs
@@ -34,23 +34,28 @@ public class AsyncConsumerSerdePoolingBenchmarks
                 .WithLaunchCount(1)
                 .WithWarmupCount(3)
                 .WithIterationCount(10)
-                .WithInvocationCount(PollsPerIteration)
+                .WithInvocationCount(1)
                 .WithUnrollFactor(1));
         }
     }
 
     private Record[][] _batchRecords = null!;
+    private Record[][] _headerBatchRecords = null!;
     private KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _completedConsumer = null!;
     private KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _yieldingConsumer = null!;
+    private KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _completedKeyHeaderValueConsumer = null!;
+    private KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _yieldingKeyHeaderValueConsumer = null!;
 
     [GlobalSetup]
     public void Setup()
     {
         var value = new byte[100];
         _batchRecords = new Record[10][];
+        _headerBatchRecords = new Record[10][];
         for (var b = 0; b < _batchRecords.Length; b++)
         {
             var records = new Record[RecordsPerBatch];
+            var headerRecords = new Record[RecordsPerBatch];
             for (var i = 0; i < records.Length; i++)
             {
                 records[i] = new Record
@@ -60,13 +65,28 @@ public class AsyncConsumerSerdePoolingBenchmarks
                     Key = value,
                     Value = value
                 };
+                headerRecords[i] = new Record
+                {
+                    OffsetDelta = i,
+                    TimestampDelta = i,
+                    Key = value,
+                    Value = value,
+                    Headers = [new Header("record-id", value)]
+                };
             }
 
             _batchRecords[b] = records;
+            _headerBatchRecords[b] = headerRecords;
         }
 
         _completedConsumer = CreateConsumer(new CompletedDeserializer());
         _yieldingConsumer = CreateConsumer(new YieldingDeserializer());
+        _completedKeyHeaderValueConsumer = CreateConsumer(
+            new CompletedDeserializer(),
+            new HeaderDeserializer());
+        _yieldingKeyHeaderValueConsumer = CreateConsumer(
+            new YieldingDeserializer(),
+            new HeaderDeserializer());
     }
 
     [IterationSetup(Target = nameof(Completed))]
@@ -75,21 +95,55 @@ public class AsyncConsumerSerdePoolingBenchmarks
     [IterationSetup(Target = nameof(Yielding))]
     public void YieldingSetup() => Reseed(_yieldingConsumer);
 
-    [Benchmark]
-    public ValueTask<ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>?> Completed()
-        => _completedConsumer.ConsumeOneAsync(PollTimeout);
+    [IterationSetup(Target = nameof(CompletedKeySyncHeaderValue))]
+    public void CompletedKeySyncHeaderValueSetup() =>
+        Reseed(_completedKeyHeaderValueConsumer, _headerBatchRecords);
 
-    [Benchmark]
-    public ValueTask<ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>?> Yielding()
-        => _yieldingConsumer.ConsumeOneAsync(PollTimeout);
+    [IterationSetup(Target = nameof(YieldingKeySyncHeaderValue))]
+    public void YieldingKeySyncHeaderValueSetup() =>
+        Reseed(_yieldingKeyHeaderValueConsumer, _headerBatchRecords);
+
+    [Benchmark(OperationsPerInvoke = PollsPerIteration)]
+    public ValueTask Completed() => ConsumeAllAsync(_completedConsumer);
+
+    [Benchmark(OperationsPerInvoke = PollsPerIteration)]
+    public ValueTask Yielding() => ConsumeAllAsync(_yieldingConsumer);
+
+    [Benchmark(OperationsPerInvoke = PollsPerIteration)]
+    public ValueTask CompletedKeySyncHeaderValue() =>
+        ConsumeAllAsync(_completedKeyHeaderValueConsumer);
+
+    [Benchmark(OperationsPerInvoke = PollsPerIteration)]
+    public ValueTask YieldingKeySyncHeaderValue() =>
+        ConsumeAllAsync(_yieldingKeyHeaderValueConsumer);
 
     [GlobalCleanup]
     public void Cleanup()
     {
         BufferedConsumerHarness.DrainPendingFetches(_completedConsumer);
         BufferedConsumerHarness.DrainPendingFetches(_yieldingConsumer);
+        BufferedConsumerHarness.DrainPendingFetches(_completedKeyHeaderValueConsumer);
+        BufferedConsumerHarness.DrainPendingFetches(_yieldingKeyHeaderValueConsumer);
         _completedConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
         _yieldingConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _completedKeyHeaderValueConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _yieldingKeyHeaderValueConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    // BenchmarkDotNet synchronously waits for an async operation between invocations. Running a
+    // full consumer loop per invocation keeps successive polls on the async continuation thread,
+    // matching application usage and measuring steady-state allocations per consumed record.
+#if NET
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+#endif
+    private static async ValueTask ConsumeAllAsync(
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
+    {
+        for (var i = 0; i < PollsPerIteration; i++)
+        {
+            if (await consumer.ConsumeOneAsync(PollTimeout).ConfigureAwait(false) is null)
+                throw new InvalidOperationException("Buffered benchmark record was unavailable.");
+        }
     }
 
     private static KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> CreateConsumer(
@@ -109,9 +163,32 @@ public class AsyncConsumerSerdePoolingBenchmarks
         return consumer;
     }
 
+    private static KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> CreateConsumer(
+        IAsyncDeserializer<ReadOnlyMemory<byte>> asyncKeyDeserializer,
+        IDeserializer<ReadOnlyMemory<byte>> valueDeserializer)
+    {
+        var consumer = new KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                QueuedMinMessages = 1
+            },
+            Serializers.RawBytes,
+            valueDeserializer,
+            asyncKeyDeserializer: asyncKeyDeserializer);
+        BufferedConsumerHarness.InitializeForBufferedFastPath(consumer, Topic, Partition);
+        return consumer;
+    }
+
     private void Reseed(KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
+        => Reseed(consumer, _batchRecords);
+
+    private static void Reseed(
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer,
+        Record[][] records)
         => BufferedConsumerHarness.ReseedPendingFetches(
-            consumer, Topic, Partition, _batchRecords, BatchCount, RecordsPerBatch);
+            consumer, Topic, Partition, records, BatchCount, RecordsPerBatch);
 
     private sealed class CompletedDeserializer : IAsyncDeserializer<ReadOnlyMemory<byte>>
     {
@@ -133,5 +210,26 @@ public class AsyncConsumerSerdePoolingBenchmarks
             await Task.Yield();
             return data;
         }
+    }
+
+    private sealed class HeaderDeserializer :
+        IDeserializer<ReadOnlyMemory<byte>>,
+        IRecordHeaderDeserializer<ReadOnlyMemory<byte>>,
+        IRecordHeaderRoutingProvider
+    {
+        private const string HeaderName = "record-id";
+
+        public ReadOnlyMemory<byte> Deserialize(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context) =>
+            data;
+
+        public ReadOnlyMemory<byte> Deserialize(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            in RecordHeaderRoutingLookup headers) =>
+            headers.TryGetLast(HeaderName, out _) ? data : ReadOnlyMemory<byte>.Empty;
+
+        public void CollectHeaderNames(List<string> names) => names.Add(HeaderName);
     }
 }


### PR DESCRIPTION
Closes #2923.

## What changed

- use `PoolingAsyncValueTaskMethodBuilder<T>` for the three nested `ConsumeOneAsync` state machines that suspend during async deserialization
- benchmark a full steady-state consumer loop so BenchmarkDotNet's synchronous async harness does not turn a cross-thread cold-cache handoff into a false per-record allocation
- add completed/yielding key + synchronous record-header value lanes

## Performance

Exact source baseline: `dbd6cfef4`
Candidate: `c07cc17ad`
Command:

```powershell
dotnet run --project tools/Dekaf.Benchmarks --configuration Release -- --filter '*AsyncConsumerSerdePoolingBenchmarks*'
```

| Lane | Baseline | Candidate repeat | Delta |
|---|---:|---:|---:|
| Completed | 543.2 ns / 0 B | 528.1 ns / 0 B | -2.8% |
| Yielding | 1,931.2 ns / 1,845 B | 1,801.2 ns / 0 B | -6.7% |
| CompletedKeySyncHeaderValue | 728.6 ns / 0 B | 743.5 ns / 0 B | +2.1%, overlapping intervals |
| YieldingKeySyncHeaderValue | 2,125.7 ns / 1,843 B | 1,796.5 ns / 0 B | -15.5% |

The completed-header control was noisy across processes. A 3-launch follow-up also encountered machine-wide bimodal load (baseline control MValue 3.6), so its means were rejected; medians showed 733.1 ns candidate vs 739.5 ns baseline. No protected allocation or timing regression remains supported by the evidence.

## Validation

- `ConsumeOneFastPathTests`: 46/46 on net10.0 and net8.0
- full unit suite after current-main merge: 8,340/8,340 net10.0; 8,204/8,204 net8.0
- Release build: 0 warnings, 0 errors
- `/simplify` completed; no hot-path work added beyond compiler-selected pooled builders