### PR TITLE
fix(consumer): bound retained watermark snapshots

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="ToxiproxyNetCore" Version="1.0.50" />
     <PackageVersion Include="TUnit" Version="1.65.63" />
     <PackageVersion Include="TUnit.Logging.Microsoft" Version="1.65.63" />
-    <PackageVersion Include="Verify.TUnit" Version="31.28.0" />
+    <PackageVersion Include="Verify.TUnit" Version="32.0.0" />
     <PackageVersion Include="ZstdSharp.Port" Version="0.8.8" />
   </ItemGroup>
 

--- a/docs/docs/consumer/offset-management.md
+++ b/docs/docs/consumer/offset-management.md
@@ -237,6 +237,12 @@ watermark for `ReadUncommitted` and the last stable offset for `ReadCommitted`; 
 from the latest fetch or explicit query, so newly appended or newly committed records can make the
 result stale.
 
+`GetWatermarkOffsets` preserves a partition's last broker watermark after unassignment. The
+snapshot remains observable until the consumer retains 256 newer unassigned snapshots; assigning
+that partition again invalidates it immediately. This bounds cache growth for long-lived consumers
+that sweep across many manual assignments. Call `QueryWatermarkOffsetsAsync` when a current broker
+value is required.
+
 Refresh the isolation-visible end offset when the caller needs a current broker value:
 
 ```csharp

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -475,6 +475,11 @@ public interface IConsumerOffsets
     /// The watermarks are updated from fetch responses as records are consumed.
     /// Returns null if no watermark data is cached for the partition.
     /// </summary>
+    /// <remarks>
+    /// After unassignment, the last snapshot remains available until 256 newer
+    /// unassigned snapshots are retained. Assigning the partition again invalidates
+    /// its retained snapshot immediately.
+    /// </remarks>
     /// <param name="topicPartition">The topic partition to get watermarks for.</param>
     /// <returns>The cached watermark offsets, or null if not available.</returns>
     WatermarkOffsets? GetWatermarkOffsets(TopicPartition topicPartition);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -5454,6 +5454,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                && coordinator.IsAssignmentSyncCurrent(assignmentVersion);
     }
 
+#if NET
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneCoreAsync(
         bool pollRecorded,
         PreparedDeserializerKey? preparedKey,
@@ -6088,6 +6091,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             ? ConsumeOneFromPendingFetchesCoreAsync<NoRecordFilterMode>(preparedKey, cancellationToken)
             : ConsumeOneFromPendingFetchesCoreAsync<RecordFilterMode>(preparedKey, cancellationToken);
 
+#if NET
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneFromPendingFetchesCoreAsync<TRecordFilterMode>(
         PreparedDeserializerKey? preparedKey,
         CancellationToken cancellationToken)
@@ -6751,6 +6757,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
+#if NET
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private async ValueTask<ConsumeResult<TKey, TValue>> CreateResultWithAsyncDeserializationAsync(
         PendingFetchData pending,
         long offset,

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -11187,7 +11187,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     continue;
                 }
 
-                var latestUpdateSequence = _watermarkUpdateState & long.MaxValue;
+                var updateState = _watermarkUpdateState;
+                var latestUpdateSequence = updateState;
+                if (updateState < 0)
+                {
+                    var lagEndOffsetUpdateSequence = updateState & long.MaxValue;
+                    latestUpdateSequence = (lagEndOffsetUpdateSequence & ~uint.MaxValue)
+                        | (uint)_watermarkOffsetsUpdateSequenceLow;
+                    if (latestUpdateSequence > lagEndOffsetUpdateSequence)
+                        latestUpdateSequence -= 1L << 32;
+                }
                 var replaced = replacement._watermarkUpdateState >= latestUpdateSequence
                     && watermarks.TryUpdate(partition, replacement, this);
                 Volatile.Write(ref _version, version + 2);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1511,10 +1511,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly object _snapshotStateGate = new();
     // Captured before each fetch/ListOffsets request so delayed responses cannot regress the cache.
     private long _watermarkUpdateSequence;
+    // Cold-path FIFO for bounding snapshots retained after unassignment or direct queries.
+    private Queue<RetainedWatermarkSnapshot>? _retainedWatermarkSnapshots;
 
     private static readonly long s_preferredReadReplicaMaxAgeTimestampDelta =
         (long)(TimeSpan.FromMinutes(5).TotalSeconds * Stopwatch.Frequency);
     private const long NoPreferredReplicaExpiry = long.MaxValue;
+    private const int MaxRetainedUnassignedWatermarkSnapshots = 256;
 
     private readonly record struct PartitionBrokerCacheEntry(
         Dictionary<int, List<TopicPartition>> PartitionsByBroker,
@@ -8756,6 +8759,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 return;
             }
 
+            if (assignmentGeneration is null)
+            {
+                var retainedEntry = new WatermarkCacheEntry(
+                    low,
+                    high,
+                    lagEndOffset,
+                    watermarkUpdateSequence);
+                _watermarks[partition] = retainedEntry;
+                RetainUnassignedWatermarkSnapshot(partition, retainedEntry, _assignmentSnapshot);
+                return;
+            }
+
             if (_watermarks.TryGetValue(partition, out var entry))
             {
                 entry.Update(low, high, lagEndOffset, watermarkUpdateSequence);
@@ -8767,6 +8782,34 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 new WatermarkCacheEntry(low, high, lagEndOffset, watermarkUpdateSequence));
         }
     }
+
+    // Must run under _snapshotStateGate. Every unassigned cache entry owns a current
+    // ticket. Refreshes replace the entry, so stale tickets cannot remove newer values.
+    private void RetainUnassignedWatermarkSnapshot(
+        TopicPartition partition,
+        WatermarkCacheEntry entry,
+        TopicPartitionSet assignmentSnapshot)
+    {
+        var retained = _retainedWatermarkSnapshots ??=
+            new Queue<RetainedWatermarkSnapshot>(MaxRetainedUnassignedWatermarkSnapshots + 1);
+        retained.Enqueue(new RetainedWatermarkSnapshot(partition, entry));
+
+        while (retained.Count > MaxRetainedUnassignedWatermarkSnapshots)
+        {
+            var expired = retained.Dequeue();
+            if (!assignmentSnapshot.Contains(expired.Partition))
+            {
+                _watermarks.TryRemove(
+                    new KeyValuePair<TopicPartition, WatermarkCacheEntry>(
+                        expired.Partition,
+                        expired.Entry));
+            }
+        }
+    }
+
+    private readonly record struct RetainedWatermarkSnapshot(
+        TopicPartition Partition,
+        WatermarkCacheEntry Entry);
 
     /// <inheritdoc />
     public async ValueTask InitializeAsync(CancellationToken cancellationToken = default)
@@ -9684,6 +9727,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     continue;
 
                 _watermarkAssignmentVersions.TryRemove(partition, out _);
+                if (_watermarks.TryGetValue(partition, out var entry))
+                    RetainUnassignedWatermarkSnapshot(partition, entry, assignmentSnapshot);
             }
 
             foreach (var partition in assignmentSnapshot)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -8766,7 +8766,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     high,
                     lagEndOffset,
                     watermarkUpdateSequence);
-                _watermarks[partition] = retainedEntry;
+                if (_watermarks.TryGetValue(partition, out var existingEntry))
+                {
+                    if (!existingEntry.TryReplaceWithNewerSnapshot(
+                            _watermarks,
+                            partition,
+                            retainedEntry))
+                    {
+                        return;
+                    }
+                }
+                else
+                {
+                    _watermarks[partition] = retainedEntry;
+                }
+
                 RetainUnassignedWatermarkSnapshot(partition, retainedEntry, _assignmentSnapshot);
                 return;
             }
@@ -11155,6 +11169,30 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             Volatile.Write(ref _low, low);
             Volatile.Write(ref _high, high);
             _watermarkOffsetsUpdateSequenceLow = (int)watermarkUpdateSequence;
+        }
+
+        public bool TryReplaceWithNewerSnapshot(
+            ConcurrentDictionary<TopicPartition, WatermarkCacheEntry> watermarks,
+            TopicPartition partition,
+            WatermarkCacheEntry replacement)
+        {
+            var spinner = new SpinWait();
+            while (true)
+            {
+                var version = Volatile.Read(ref _version);
+                if ((version & 1) != 0
+                    || Interlocked.CompareExchange(ref _version, version + 1, version) != version)
+                {
+                    spinner.SpinOnce();
+                    continue;
+                }
+
+                var latestUpdateSequence = _watermarkUpdateState & long.MaxValue;
+                var replaced = replacement._watermarkUpdateState >= latestUpdateSequence
+                    && watermarks.TryUpdate(partition, replacement, this);
+                Volatile.Write(ref _version, version + 2);
+                return replaced;
+            }
         }
 
         public WatermarkOffsets? ReadWatermarks()

--- a/tests/Dekaf.Tests.Integration/WatermarkOffsetsTests.cs
+++ b/tests/Dekaf.Tests.Integration/WatermarkOffsetsTests.cs
@@ -232,6 +232,41 @@ public class WatermarkOffsetsTests(KafkaTestContainer kafka) : KafkaIntegrationT
     }
 
     [Test]
+    [Timeout(60_000)]
+    public async Task AssignedQuery_RetainsWatermarksAfterUnassignAndInvalidatesOnReassign(
+        CancellationToken testTimeout)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var partition = new TopicPartition(topic, 0);
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("retained-watermark-producer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(testTimeout);
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "key",
+            Value = "value"
+        }, testTimeout);
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("retained-watermark-consumer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(testTimeout);
+        consumer.Assign(partition);
+
+        var queried = await consumer.QueryWatermarkOffsetsAsync(partition, testTimeout);
+        consumer.Unassign();
+
+        await Assert.That(consumer.GetWatermarkOffsets(partition)).IsEqualTo(queried);
+
+        consumer.Assign(partition);
+
+        await Assert.That(consumer.GetWatermarkOffsets(partition)).IsNull();
+    }
+
+    [Test]
     public async Task GetWatermarkOffsets_MultiplePartitions_ReturnsSeparateValues()
     {
         // Arrange - create topic with multiple partitions

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLagTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLagTests.cs
@@ -9,6 +9,7 @@ namespace Dekaf.Tests.Unit.Consumer;
 [NotInParallel]
 public sealed class ConsumerLagTests
 {
+    private const int RetainedWatermarkLimit = 256;
     private static readonly TopicPartition Partition = new("lag-topic", 0);
 
     [Test]
@@ -55,6 +56,62 @@ public sealed class ConsumerLagTests
 
         await Assert.That(consumer.GetWatermarkOffsets(Partition)).IsEqualTo(new WatermarkOffsets(0, 25));
         await Assert.That(consumer.GetCurrentLag(Partition)).IsNull();
+    }
+
+    [Test]
+    public async Task UnassignedWatermarks_RetainOnlyNewest256Snapshots()
+    {
+        await using var consumer = CreateConsumer();
+
+        RetainWatermarksForPartitions(consumer, firstPartition: 0, RetainedWatermarkLimit + 1);
+
+        await Assert.That(consumer.GetWatermarkOffsets(Partition)).IsNull();
+        await Assert.That(consumer.GetWatermarkOffsets(new TopicPartition(Partition.Topic, 1)))
+            .IsEqualTo(new WatermarkOffsets(1, 101));
+        await Assert.That(consumer.GetWatermarkOffsets(
+                new TopicPartition(Partition.Topic, RetainedWatermarkLimit)))
+            .IsEqualTo(new WatermarkOffsets(RetainedWatermarkLimit, RetainedWatermarkLimit + 100));
+        await Assert.That(GetWatermarkCacheCount(consumer)).IsEqualTo(RetainedWatermarkLimit);
+    }
+
+    [Test]
+    public async Task UnassignedWatermarks_ExpiredTicketDoesNotRemoveReassignedEntry()
+    {
+        await using var consumer = CreateConsumer();
+        consumer.IncrementalAssign([new TopicPartitionOffset(Partition.Topic, Partition.Partition, 10)]);
+        SetCachedWatermarks(consumer, new WatermarkOffsets(0, 25));
+        consumer.IncrementalUnassign([Partition]);
+
+        consumer.IncrementalAssign([new TopicPartitionOffset(Partition.Topic, Partition.Partition, 20)]);
+        SetCachedWatermarks(consumer, new WatermarkOffsets(10, 50));
+
+        RetainWatermarksForPartitions(consumer, firstPartition: 1, RetainedWatermarkLimit);
+
+        await Assert.That(consumer.GetWatermarkOffsets(Partition))
+            .IsEqualTo(new WatermarkOffsets(10, 50));
+        await Assert.That(consumer.GetCurrentLag(Partition)).IsEqualTo(30);
+        await Assert.That(GetWatermarkCacheCount(consumer)).IsEqualTo(RetainedWatermarkLimit + 1);
+    }
+
+    [Test]
+    public async Task UnassignedWatermarks_ExpiredTicketDoesNotRemoveRefreshedEntry()
+    {
+        await using var consumer = CreateConsumer();
+        consumer.IncrementalAssign([new TopicPartitionOffset(Partition.Topic, Partition.Partition, 10)]);
+        SetCachedWatermarks(consumer, new WatermarkOffsets(0, 25));
+        consumer.IncrementalUnassign([Partition]);
+        SetQueriedCachedWatermarks(consumer, Partition, new WatermarkOffsets(10, 50), updateSequence: 1);
+
+        RetainWatermarksForPartitions(consumer, firstPartition: 1, RetainedWatermarkLimit - 1);
+
+        await Assert.That(consumer.GetWatermarkOffsets(Partition))
+            .IsEqualTo(new WatermarkOffsets(10, 50));
+        await Assert.That(GetWatermarkCacheCount(consumer)).IsEqualTo(RetainedWatermarkLimit);
+
+        RetainWatermarksForPartitions(consumer, firstPartition: RetainedWatermarkLimit, count: 1);
+
+        await Assert.That(consumer.GetWatermarkOffsets(Partition)).IsNull();
+        await Assert.That(GetWatermarkCacheCount(consumer)).IsEqualTo(RetainedWatermarkLimit);
     }
 
     [Test]
@@ -403,11 +460,35 @@ public sealed class ConsumerLagTests
 
     private static void SetCachedWatermarks(
         KafkaConsumer<string, string> consumer,
+        WatermarkOffsets watermarks) => SetCachedWatermarks(consumer, Partition, watermarks);
+
+    private static void RetainWatermarksForPartitions(
+        KafkaConsumer<string, string> consumer,
+        int firstPartition,
+        int count)
+    {
+        for (var partitionIndex = firstPartition; partitionIndex < firstPartition + count; partitionIndex++)
+        {
+            var partition = new TopicPartition(Partition.Topic, partitionIndex);
+            consumer.IncrementalAssign([
+                new TopicPartitionOffset(partition.Topic, partition.Partition, partitionIndex)
+            ]);
+            SetCachedWatermarks(
+                consumer,
+                partition,
+                new WatermarkOffsets(partitionIndex, partitionIndex + 100));
+            consumer.IncrementalUnassign([partition]);
+        }
+    }
+
+    private static void SetCachedWatermarks(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition partition,
         WatermarkOffsets watermarks)
     {
-        UpdateWatermarksFromFetchResponse(consumer, new FetchResponsePartition
+        UpdateWatermarksFromFetchResponse(consumer, partition, new FetchResponsePartition
         {
-            PartitionIndex = Partition.Partition,
+            PartitionIndex = partition.Partition,
             HighWatermark = watermarks.High,
             LastStableOffset = watermarks.High,
             LogStartOffset = watermarks.Low
@@ -418,6 +499,18 @@ public sealed class ConsumerLagTests
         KafkaConsumer<string, string> consumer,
         FetchResponsePartition response,
         int? assignmentVersion = null,
+        long watermarkUpdateSequence = 0) => UpdateWatermarksFromFetchResponse(
+            consumer,
+            Partition,
+            response,
+            assignmentVersion,
+            watermarkUpdateSequence);
+
+    private static void UpdateWatermarksFromFetchResponse(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition partition,
+        FetchResponsePartition response,
+        int? assignmentVersion = null,
         long watermarkUpdateSequence = 0)
     {
         var method = typeof(KafkaConsumer<string, string>).GetMethod(
@@ -425,10 +518,30 @@ public sealed class ConsumerLagTests
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("UpdateWatermarksFromFetchResponse method not found");
         method.Invoke(consumer, [
-            Partition,
+            partition,
             response,
             assignmentVersion ?? GetAssignmentVersion(consumer),
             watermarkUpdateSequence
+        ]);
+    }
+
+    private static void SetQueriedCachedWatermarks(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition partition,
+        WatermarkOffsets watermarks,
+        long updateSequence)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "UpdateQueriedCachedWatermarks",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("UpdateQueriedCachedWatermarks method not found");
+        method.Invoke(consumer, [
+            partition,
+            watermarks.Low,
+            watermarks.High,
+            watermarks.High,
+            null,
+            updateSequence
         ]);
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLagTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLagTests.cs
@@ -115,6 +115,18 @@ public sealed class ConsumerLagTests
     }
 
     [Test]
+    public async Task UnassignedWatermarks_OlderQueryCannotOverwriteNewerSnapshot()
+    {
+        await using var consumer = CreateConsumer();
+
+        SetQueriedCachedWatermarks(consumer, Partition, new WatermarkOffsets(10, 50), updateSequence: 2);
+        SetQueriedCachedWatermarks(consumer, Partition, new WatermarkOffsets(0, 25), updateSequence: 1);
+
+        await Assert.That(consumer.GetWatermarkOffsets(Partition))
+            .IsEqualTo(new WatermarkOffsets(10, 50));
+    }
+
+    [Test]
     public async Task UnassignAndAssign_PublicApisClearPartitionState()
     {
         await using var consumer = CreateConsumer();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLagTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLagTests.cs
@@ -127,6 +127,24 @@ public sealed class ConsumerLagTests
     }
 
     [Test]
+    public async Task UnassignedWatermarks_NewerQueryReplacesDivergentSnapshot()
+    {
+        await using var consumer = CreateConsumer();
+        consumer.IncrementalAssign([new TopicPartitionOffset(Partition.Topic, Partition.Partition, 10)]);
+        UpdateWatermarksFromFetchResponse(
+            consumer,
+            CreateFetchResponse(25),
+            watermarkUpdateSequence: 5);
+        UpdateCachedLagEndOffset(consumer, lagEndOffset: 30, watermarkUpdateSequence: 10);
+        consumer.IncrementalUnassign([Partition]);
+
+        SetQueriedCachedWatermarks(consumer, Partition, new WatermarkOffsets(10, 50), updateSequence: 7);
+
+        await Assert.That(consumer.GetWatermarkOffsets(Partition))
+            .IsEqualTo(new WatermarkOffsets(10, 50));
+    }
+
+    [Test]
     public async Task UnassignAndAssign_PublicApisClearPartitionState()
     {
         await using var consumer = CreateConsumer();

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AsyncConsumerSerdePoolingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AsyncConsumerSerdePoolingBenchmarks.cs
@@ -34,23 +34,28 @@ public class AsyncConsumerSerdePoolingBenchmarks
                 .WithLaunchCount(1)
                 .WithWarmupCount(3)
                 .WithIterationCount(10)
-                .WithInvocationCount(PollsPerIteration)
+                .WithInvocationCount(1)
                 .WithUnrollFactor(1));
         }
     }
 
     private Record[][] _batchRecords = null!;
+    private Record[][] _headerBatchRecords = null!;
     private KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _completedConsumer = null!;
     private KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _yieldingConsumer = null!;
+    private KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _completedKeyHeaderValueConsumer = null!;
+    private KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _yieldingKeyHeaderValueConsumer = null!;
 
     [GlobalSetup]
     public void Setup()
     {
         var value = new byte[100];
         _batchRecords = new Record[10][];
+        _headerBatchRecords = new Record[10][];
         for (var b = 0; b < _batchRecords.Length; b++)
         {
             var records = new Record[RecordsPerBatch];
+            var headerRecords = new Record[RecordsPerBatch];
             for (var i = 0; i < records.Length; i++)
             {
                 records[i] = new Record
@@ -60,13 +65,28 @@ public class AsyncConsumerSerdePoolingBenchmarks
                     Key = value,
                     Value = value
                 };
+                headerRecords[i] = new Record
+                {
+                    OffsetDelta = i,
+                    TimestampDelta = i,
+                    Key = value,
+                    Value = value,
+                    Headers = [new Header("record-id", value)]
+                };
             }
 
             _batchRecords[b] = records;
+            _headerBatchRecords[b] = headerRecords;
         }
 
         _completedConsumer = CreateConsumer(new CompletedDeserializer());
         _yieldingConsumer = CreateConsumer(new YieldingDeserializer());
+        _completedKeyHeaderValueConsumer = CreateConsumer(
+            new CompletedDeserializer(),
+            new HeaderDeserializer());
+        _yieldingKeyHeaderValueConsumer = CreateConsumer(
+            new YieldingDeserializer(),
+            new HeaderDeserializer());
     }
 
     [IterationSetup(Target = nameof(Completed))]
@@ -75,21 +95,55 @@ public class AsyncConsumerSerdePoolingBenchmarks
     [IterationSetup(Target = nameof(Yielding))]
     public void YieldingSetup() => Reseed(_yieldingConsumer);
 
-    [Benchmark]
-    public ValueTask<ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>?> Completed()
-        => _completedConsumer.ConsumeOneAsync(PollTimeout);
+    [IterationSetup(Target = nameof(CompletedKeySyncHeaderValue))]
+    public void CompletedKeySyncHeaderValueSetup() =>
+        Reseed(_completedKeyHeaderValueConsumer, _headerBatchRecords);
 
-    [Benchmark]
-    public ValueTask<ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>?> Yielding()
-        => _yieldingConsumer.ConsumeOneAsync(PollTimeout);
+    [IterationSetup(Target = nameof(YieldingKeySyncHeaderValue))]
+    public void YieldingKeySyncHeaderValueSetup() =>
+        Reseed(_yieldingKeyHeaderValueConsumer, _headerBatchRecords);
+
+    [Benchmark(OperationsPerInvoke = PollsPerIteration)]
+    public ValueTask Completed() => ConsumeAllAsync(_completedConsumer);
+
+    [Benchmark(OperationsPerInvoke = PollsPerIteration)]
+    public ValueTask Yielding() => ConsumeAllAsync(_yieldingConsumer);
+
+    [Benchmark(OperationsPerInvoke = PollsPerIteration)]
+    public ValueTask CompletedKeySyncHeaderValue() =>
+        ConsumeAllAsync(_completedKeyHeaderValueConsumer);
+
+    [Benchmark(OperationsPerInvoke = PollsPerIteration)]
+    public ValueTask YieldingKeySyncHeaderValue() =>
+        ConsumeAllAsync(_yieldingKeyHeaderValueConsumer);
 
     [GlobalCleanup]
     public void Cleanup()
     {
         BufferedConsumerHarness.DrainPendingFetches(_completedConsumer);
         BufferedConsumerHarness.DrainPendingFetches(_yieldingConsumer);
+        BufferedConsumerHarness.DrainPendingFetches(_completedKeyHeaderValueConsumer);
+        BufferedConsumerHarness.DrainPendingFetches(_yieldingKeyHeaderValueConsumer);
         _completedConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
         _yieldingConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _completedKeyHeaderValueConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _yieldingKeyHeaderValueConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    // BenchmarkDotNet synchronously waits for an async operation between invocations. Running a
+    // full consumer loop per invocation keeps successive polls on the async continuation thread,
+    // matching application usage and measuring steady-state allocations per consumed record.
+#if NET
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+#endif
+    private static async ValueTask ConsumeAllAsync(
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
+    {
+        for (var i = 0; i < PollsPerIteration; i++)
+        {
+            if (await consumer.ConsumeOneAsync(PollTimeout).ConfigureAwait(false) is null)
+                throw new InvalidOperationException("Buffered benchmark record was unavailable.");
+        }
     }
 
     private static KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> CreateConsumer(
@@ -109,9 +163,32 @@ public class AsyncConsumerSerdePoolingBenchmarks
         return consumer;
     }
 
+    private static KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> CreateConsumer(
+        IAsyncDeserializer<ReadOnlyMemory<byte>> asyncKeyDeserializer,
+        IDeserializer<ReadOnlyMemory<byte>> valueDeserializer)
+    {
+        var consumer = new KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                QueuedMinMessages = 1
+            },
+            Serializers.RawBytes,
+            valueDeserializer,
+            asyncKeyDeserializer: asyncKeyDeserializer);
+        BufferedConsumerHarness.InitializeForBufferedFastPath(consumer, Topic, Partition);
+        return consumer;
+    }
+
     private void Reseed(KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
+        => Reseed(consumer, _batchRecords);
+
+    private static void Reseed(
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer,
+        Record[][] records)
         => BufferedConsumerHarness.ReseedPendingFetches(
-            consumer, Topic, Partition, _batchRecords, BatchCount, RecordsPerBatch);
+            consumer, Topic, Partition, records, BatchCount, RecordsPerBatch);
 
     private sealed class CompletedDeserializer : IAsyncDeserializer<ReadOnlyMemory<byte>>
     {
@@ -133,5 +210,26 @@ public class AsyncConsumerSerdePoolingBenchmarks
             await Task.Yield();
             return data;
         }
+    }
+
+    private sealed class HeaderDeserializer :
+        IDeserializer<ReadOnlyMemory<byte>>,
+        IRecordHeaderDeserializer<ReadOnlyMemory<byte>>,
+        IRecordHeaderRoutingProvider
+    {
+        private const string HeaderName = "record-id";
+
+        public ReadOnlyMemory<byte> Deserialize(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context) =>
+            data;
+
+        public ReadOnlyMemory<byte> Deserialize(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            in RecordHeaderRoutingLookup headers) =>
+            headers.TryGetLast(HeaderName, out _) ? data : ReadOnlyMemory<byte>.Empty;
+
+        public void CollectHeaderNames(List<string> names) => names.Add(HeaderName);
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerFetchWatermarkBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerFetchWatermarkBenchmarks.cs
@@ -13,6 +13,7 @@ public class ConsumerFetchWatermarkBenchmarks
     private KafkaConsumer<byte[], byte[]> _consumer = null!;
     private TopicPartition _partition;
     private FetchResponsePartition _response = null!;
+    private UpdateLagEndOffset _updateLagEndOffset = null!;
     private UpdateWatermarks _updateWatermarks = null!;
     private int _assignmentVersion;
 
@@ -35,6 +36,9 @@ public class ConsumerFetchWatermarkBenchmarks
         _updateWatermarks = typeof(KafkaConsumer<byte[], byte[]>)
             .GetMethod("UpdateWatermarksFromFetchResponse", BindingFlags.Instance | BindingFlags.NonPublic)!
             .CreateDelegate<UpdateWatermarks>();
+        _updateLagEndOffset = typeof(KafkaConsumer<byte[], byte[]>)
+            .GetMethod("UpdateCachedLagEndOffset", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .CreateDelegate<UpdateLagEndOffset>();
         _assignmentVersion = (int)typeof(KafkaConsumer<byte[], byte[]>)
             .GetField("_assignmentEnsureVersion", BindingFlags.Instance | BindingFlags.NonPublic)!
             .GetValue(_consumer)!;
@@ -46,6 +50,13 @@ public class ConsumerFetchWatermarkBenchmarks
     public void UpdateFromFetchResponse() =>
         _updateWatermarks(_consumer, _partition, _response, _assignmentVersion, 0);
 
+    [Benchmark]
+    public void UpdateDivergentFromFetchResponse()
+    {
+        _updateLagEndOffset(_consumer, _partition, 1_100, 2);
+        _updateWatermarks(_consumer, _partition, _response, _assignmentVersion, 1);
+    }
+
     [GlobalCleanup]
     public ValueTask Cleanup() => _consumer.DisposeAsync();
 
@@ -54,5 +65,11 @@ public class ConsumerFetchWatermarkBenchmarks
         TopicPartition partition,
         FetchResponsePartition response,
         int assignmentVersion,
+        long watermarkUpdateSequence);
+
+    private delegate void UpdateLagEndOffset(
+        KafkaConsumer<byte[], byte[]> consumer,
+        TopicPartition partition,
+        long lagEndOffset,
         long watermarkUpdateSequence);
 }


### PR DESCRIPTION
Closes #2924.

Stacked on #2910 because this bounds the watermark cache introduced there.

## Summary
- retain at most 256 unassigned watermark snapshots using a cold-path FIFO
- fence stale tickets by cache-entry identity; unassigned refreshes replace entries
- preserve current assignments and invalidate retained state immediately on reassignment
- document the observable retention contract
- add deterministic bound, reassignment ABA, and refreshed-entry lifecycle tests

## Verification
- Build: 0 warnings, 0 errors
- ConsumerLagTests: 21/21 on net10.0 and net8.0
- Full unit: 8373/8373 on net10.0; 8237/8237 on net8.0
- Exact-head benchmark base 300ac9f2c, BenchmarkDotNet MemoryDiagnoser:
  - fetch watermark update: 11.24 ns / 0 B -> 10.73 ns / 0 B (-4.6%)
  - cached lag: 29.41 ns / 0 B -> 27.66 ns / 0 B (-5.9%)