### PR TITLE
test(consumer): remove revocation wait timeout

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -765,19 +765,21 @@ public sealed class ConsumerPauseResumeCacheTests
     }
 
     [Test]
-    public async Task ConsumeAsync_RevocationDuringPrefetchWait_SuppressesRevokedPartition()
+    [Timeout(120_000)]
+    public async Task ConsumeAsync_RevocationDuringPrefetchWait_SuppressesRevokedPartition(
+        CancellationToken cancellationToken)
     {
         var revokedPartition = new TopicPartition(PrefetchedTopic, 0);
         var activePartition = new TopicPartition(PrefetchedTopic, 1);
-        using var waitEntered = new ManualResetEventSlim();
+        var waitEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using var releaseWait = new ManualResetEventSlim();
         var prefetchBuffer = new MpscFetchBuffer(
             4,
             afterProducerWaiterCountIncrementedForTesting: null,
             beforeConsumerWaitSpinForTesting: () =>
             {
-                waitEntered.Set();
-                releaseWait.Wait();
+                waitEntered.TrySetResult();
+                releaseWait.Wait(cancellationToken);
             });
         var consumer = new KafkaConsumer<string, string>(
             new ConsumerOptions
@@ -807,20 +809,21 @@ public sealed class ConsumerPauseResumeCacheTests
 
         try
         {
-            records = consumer.ConsumeAsync(consumeCancellation.Token).GetAsyncEnumerator();
+            records = consumer.ConsumeAsync(consumeCancellation.Token)
+                .GetAsyncEnumerator(CancellationToken.None);
             moveNext = StartDedicatedMoveNext(records);
             var stagePendingClear = typeof(KafkaConsumer<string, string>).GetMethod(
                 "StagePendingFetchClear",
                 BindingFlags.Instance | BindingFlags.NonPublic)
                 ?? throw new InvalidOperationException("StagePendingFetchClear method not found");
 
-            await Assert.That(waitEntered.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await waitEntered.Task.WaitAsync(cancellationToken);
             stagePendingClear.Invoke(consumer, [revokedPartition]);
             await Assert.That(prefetchBuffer.TryWrite(CreatePendingFetch(revokedPartition, 10, 1))).IsTrue();
             await Assert.That(prefetchBuffer.TryWrite(CreatePendingFetch(activePartition, 20, 1))).IsTrue();
             releaseWait.Set();
 
-            await Assert.That(await moveNext.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(await moveNext.WaitAsync(cancellationToken)).IsTrue();
             await Assert.That(records.Current.Topic).IsEqualTo(activePartition.Topic);
             await Assert.That(records.Current.Partition).IsEqualTo(activePartition.Partition);
             await Assert.That(records.Current.Offset).IsEqualTo(20);


### PR DESCRIPTION
Closes #2824.

Root cause: the dedicated `MoveNextAsync` thread enters deterministically, but the test still imposed two arbitrary five-second deadlines. Under concurrent full-suite load, valid active-partition delivery could exceed that wall-clock budget and produce a false failure.

Changes:
- coordinate prefetch-wait entry asynchronously with `TaskCompletionSource`
- use the TUnit 120-second timeout cancellation token for both coordination waits
- keep consumer cancellation separate so failure cleanup always releases and observes the in-flight move
- mirror the established deterministic pattern from #2922

Validation:
- Release unit build: 0 warnings, 0 errors
- focused test: net10.0 25/25; net8.0 25/25
- concurrent full unit suites: net10.0 exit 0; net8.0 exit 0

Test-only change; benchmark gate does not apply.