### PR TITLE
test(consumer): use suite timeout for dispose

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/FetchBufferMemoryPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/FetchBufferMemoryPoolTests.cs
@@ -148,7 +148,8 @@ public sealed class FetchBufferMemoryPoolTests
     }
 
     [Test]
-    public async Task Dispose_WakesAllWaitingReservations()
+    [Timeout(120_000)]
+    public async Task Dispose_WakesAllWaitingReservations(CancellationToken cancellationToken)
     {
         var pool = new FetchBufferMemoryPool(100);
         using var retained = await pool.ReserveAsync(100, CancellationToken.None);
@@ -157,9 +158,9 @@ public sealed class FetchBufferMemoryPoolTests
 
         pool.Dispose();
 
-        await Assert.That(async () => await first.WaitAsync(TimeSpan.FromSeconds(5)))
+        await Assert.That(async () => await first.WaitAsync(cancellationToken))
             .Throws<ObjectDisposedException>();
-        await Assert.That(async () => await second.WaitAsync(TimeSpan.FromSeconds(5)))
+        await Assert.That(async () => await second.WaitAsync(cancellationToken))
             .Throws<ObjectDisposedException>();
     }
 }


### PR DESCRIPTION
## Summary

- replace two independent 5-second continuation deadlines with the TUnit test cancellation token
- keep a 120-second suite-owned timeout as the bounded failure gate
- retain both `ObjectDisposedException` assertions

The original failure was scheduler delay under full-suite load, not a product-code waiter-registration gap. This matches the deterministic timeout pattern merged in #2929.

## Validation

- Release unit build: 0 warnings, 0 errors
- focused `Dispose_WakesAllWaitingReservations`: 1/1 net10, 1/1 net8
- full unit net10: 8477/8477
- full unit net8: 8341/8341
- final `/simplify`: minimal test-only change retained

No `src/` files changed; performance benchmarks are not applicable.

Closes #2930