### PR TITLE
test(schema-registry): validate identity interop

### DIFF
--- a/docs/docs/migrating-from-confluent-kafka.md
+++ b/docs/docs/migrating-from-confluent-kafka.md
@@ -306,7 +306,7 @@ Port custom serializers to those contracts instead of allocating an intermediate
 For Schema Registry, configure Dekaf's Avro or Protobuf serializer with the same registry and
 subject-naming strategy. Validate existing payloads and subjects in staging before switching
 writers. See [Schema Registry](./serialization/schema-registry.md), especially its subject naming
-and compatibility guidance.
+and [identity-framing migration guidance](./serialization/schema-registry.md#schema-identity-framing-and-confluent-interoperability).
 
 ## Migrate transactions
 

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -930,7 +930,7 @@ The serializer and deserializer strategies are intentionally separate:
 | --- | --- | --- | --- |
 | `SchemaIdSerializerStrategy.Prefix` | Writes | — | Confluent-compatible default; payload carries the global integer ID. |
 | `SchemaIdSerializerStrategy.Header` | — | Writes | Payload is unprefixed; a `Headers` collection is required. |
-| `SchemaIdDeserializerStrategy.Prefix` | Reads | Rejects | Ignores identity headers and requires a valid prefix. |
+| `SchemaIdDeserializerStrategy.Prefix` | Reads | Header ignored | Parses the raw payload as a prefix without inspecting identity headers. |
 | `SchemaIdDeserializerStrategy.Header` | Rejects | Reads | Requires the reserved key/value identity header. |
 | `SchemaIdDeserializerStrategy.Dual` | Reads | Reads | Header wins when present; otherwise falls back to the prefix. This is the default reader strategy. |
 
@@ -938,6 +938,11 @@ The serializer and deserializer strategies are intentionally separate:
 GUID header into one record: when the header is present, `Dual` treats byte zero as application
 payload. A malformed reserved header never falls back to a valid prefix. Duplicate reserved headers
 follow Kafka header conventions: the last matching key/value identity is authoritative.
+
+`Prefix` is not a strict guard against header-framed records. It ignores identity headers and parses
+the first five payload bytes as a prefix. If those bytes happen to contain magic byte `0` and a
+registered nonnegative schema ID, the reader can decode the remaining bytes under an unintended
+schema instead of rejecting the record.
 
 For a rolling migration, deploy `Dual` readers first, switch writers from `Prefix` to `Header`, then
 optionally tighten readers to `Header` after all prefixed records have aged out. Keep `Dual` when a
@@ -979,7 +984,7 @@ deserializers reuse bounded caches. The registry must return a non-empty GUID an
 lookup. The checked-in interoperability vectors are generated with Confluent Schema Registry
 SerDes 2.15.0 and `confluentinc/cp-schema-registry:8.2.0` for all three schema formats.
 
-Identity failures are deterministic:
+Within the framing selected by the reader strategy, identity failures are deterministic:
 
 - Missing, null, empty, truncated, or unknown-magic headers fail instead of falling back.
 - Negative, truncated, or unknown-magic prefix IDs fail before payload decoding.

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -915,3 +915,80 @@ constructor/builder-extension argument for JSON Schema and generic Schema Regist
 It affects only the enum-based `RecordName` and `TopicRecordName` strategies; `TopicName` and custom
 `ISubjectNameStrategy` implementations are unchanged. Disable the option after every producer and
 schema has moved to the standard subject.
+
+## Schema identity framing and Confluent interoperability
+
+Dekaf reads and writes the Confluent Schema Registry identity framing used by Avro, JSON Schema,
+and Protobuf serializers. Prefix framing places magic byte `0` and the big-endian global schema ID
+before the payload. Header framing leaves the payload unprefixed and writes magic byte `1` plus the
+network-order schema GUID to `__key_schema_id` or `__value_schema_id`. Protobuf appends its message
+index data to that identity header.
+
+The serializer and deserializer strategies are intentionally separate:
+
+| Writer / reader strategy | Prefix record | Header record | Behavior |
+| --- | --- | --- | --- |
+| `SchemaIdSerializerStrategy.Prefix` | Writes | — | Confluent-compatible default; payload carries the global integer ID. |
+| `SchemaIdSerializerStrategy.Header` | — | Writes | Payload is unprefixed; a `Headers` collection is required. |
+| `SchemaIdDeserializerStrategy.Prefix` | Reads | Rejects | Ignores identity headers and requires a valid prefix. |
+| `SchemaIdDeserializerStrategy.Header` | Rejects | Reads | Requires the reserved key/value identity header. |
+| `SchemaIdDeserializerStrategy.Dual` | Reads | Reads | Header wins when present; otherwise falls back to the prefix. This is the default reader strategy. |
+
+`Dual` is a reader migration mode, not a serializer mode. Do not combine a prefixed payload and a
+GUID header into one record: when the header is present, `Dual` treats byte zero as application
+payload. A malformed reserved header never falls back to a valid prefix. Duplicate reserved headers
+follow Kafka header conventions: the last matching key/value identity is authoritative.
+
+For a rolling migration, deploy `Dual` readers first, switch writers from `Prefix` to `Header`, then
+optionally tighten readers to `Header` after all prefixed records have aged out. Keep `Dual` when a
+topic deliberately accepts both writer generations.
+
+<!-- doc-test-ignore: Uses application-specific registry and Order types. -->
+```csharp
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Avro;
+
+var writer = new AvroSchemaRegistrySerializer<Order>(
+    registry,
+    new AvroSerializerConfig
+    {
+        // Use an already registered schema and emit its GUID as a Kafka header.
+        UseSchemaId = 123,
+        AutoRegisterSchemas = false,
+        SchemaIdStrategy = SchemaIdSerializerStrategy.Header
+    });
+
+var reader = new AvroSchemaRegistryDeserializer<Order>(
+    registry,
+    new AvroDeserializerConfig
+    {
+        // Accept existing prefix records and newly written header records.
+        SchemaIdStrategy = SchemaIdDeserializerStrategy.Dual
+    });
+```
+
+`UseSchemaId` has precedence over `UseLatestVersion` and `AutoRegisterSchemas`. Dekaf fetches the
+selected schema and validates that its format, root type, and Protobuf reference graph match the
+serializer type before emitting any bytes. `UseLatestVersion` takes precedence over auto-register
+or lookup when no explicit ID is set. Otherwise `AutoRegisterSchemas = true` registers or reuses
+the schema; `false` performs exact lookup.
+
+Header serialization resolves the registered schema GUID during preparation and caches the encoded
+frame. Header deserialization resolves GUIDs through Schema Registry; warm serializers and
+deserializers reuse bounded caches. The registry must return a non-empty GUID and support GUID
+lookup. The checked-in interoperability vectors are generated with Confluent Schema Registry
+SerDes 2.15.0 and `confluentinc/cp-schema-registry:8.2.0` for all three schema formats.
+
+Identity failures are deterministic:
+
+- Missing, null, empty, truncated, or unknown-magic headers fail instead of falling back.
+- Negative, truncated, or unknown-magic prefix IDs fail before payload decoding.
+- A GUID resolving to the wrong schema format or an explicit ID resolving to the wrong record type
+  fails before serialization/deserialization completes.
+- If subject-scoped lookup returns a different GUID or ID than the identity being processed, Dekaf
+  reports the conflict; it does not silently select either schema.
+- Protobuf rejects malformed or trailing message-index data after the GUID frame.
+
+Cross-client rollout tests should cover both key and value header names, every schema format, old
+prefix records, new header records, and malformed reserved headers. Do not strip the reserved
+identity header in middleware or copy it between key and value components.

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -58,6 +58,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Protocol\ResponseFixtures\*.bin" />
+    <EmbeddedResource Include="SchemaRegistry\IdentityFixtures\*.json" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/IdentityFixtures/confluent-schema-identity-v2.15.0.json
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/IdentityFixtures/confluent-schema-identity-v2.15.0.json
@@ -1,0 +1,38 @@
+[
+  {
+    "format": "avro",
+    "producerPackage": "Confluent.SchemaRegistry.Serdes.Avro 2.15.0",
+    "registryImage": "confluentinc/cp-schema-registry:8.2.0",
+    "schemaId": 1,
+    "schemaGuid": "474592cf-579b-9e89-83fc-d0d5263f2b70",
+    "schema": "{\"type\":\"record\",\"name\":\"IdentityFixtureRecord\",\"namespace\":\"dekaf.interop\",\"fields\":[{\"name\":\"id\",\"type\":\"int\"},{\"name\":\"name\",\"type\":\"string\"}]}",
+    "prefixPayloadHex": "0000000001541c636f6e666c75656e742d6176726f",
+    "headerPayloadHex": "541c636f6e666c75656e742d6176726f",
+    "headerName": "__value_schema_id",
+    "headerValueHex": "01474592cf579b9e8983fcd0d5263f2b70"
+  },
+  {
+    "format": "json",
+    "producerPackage": "Confluent.SchemaRegistry.Serdes.Json 2.15.0",
+    "registryImage": "confluentinc/cp-schema-registry:8.2.0",
+    "schemaId": 2,
+    "schemaGuid": "a8219e01-7a65-080d-6da3-31e4d1ebc00c",
+    "schema": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"IdentityFixtureJsonRecord\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"Id\":{\"type\":\"integer\",\"format\":\"int32\"},\"Name\":{\"type\":\"string\"}}}",
+    "prefixPayloadHex": "00000000027b224964223a34332c224e616d65223a22636f6e666c75656e742d6a736f6e227d",
+    "headerPayloadHex": "7b224964223a34332c224e616d65223a22636f6e666c75656e742d6a736f6e227d",
+    "headerName": "__value_schema_id",
+    "headerValueHex": "01a8219e017a65080d6da331e4d1ebc00c"
+  },
+  {
+    "format": "protobuf",
+    "producerPackage": "Confluent.SchemaRegistry.Serdes.Protobuf 2.15.0",
+    "registryImage": "confluentinc/cp-schema-registry:8.2.0",
+    "schemaId": 1,
+    "schemaGuid": "3449adb9-8f17-05cd-b0b2-d5e7e0a1c819",
+    "schema": "ChJ0ZXN0X21lc3NhZ2UucHJvdG8SC2Rla2FmLnRlc3RzIjYKC1Rlc3RNZXNzYWdlEgoKAmlkGAEgASgFEgwKBG5hbWUYAiABKAkSDQoFdmFsdWUYAyABKAFiBnByb3RvMw==",
+    "prefixPayloadHex": "000000000100082c1212636f6e666c75656e742d70726f746f627566190000000000002940",
+    "headerPayloadHex": "082c1212636f6e666c75656e742d70726f746f627566190000000000002940",
+    "headerName": "__value_schema_id",
+    "headerValueHex": "013449adb98f1705cdb0b2d5e7e0a1c81900"
+  }
+]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/MockSchemaRegistryClient.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/MockSchemaRegistryClient.cs
@@ -448,21 +448,35 @@ internal sealed class MockSchemaRegistryClient : IFormattedSchemaRegistryClient,
             throw new SchemaRegistryException(40401, $"Subject '{subject}' not found");
 
         var versions = list.Select(e => e.Version).ToList();
+        _schemasBySubject.Remove(subject);
 
         foreach (var entry in list)
         {
+            if (IsSchemaIdReferenced(entry.Id))
+                continue;
+
             _schemasById.Remove(entry.Id);
-            var guid = _schemaGuidsById[entry.Id];
-            _schemaGuidsById.Remove(entry.Id);
+            if (!_schemaGuidsById.Remove(entry.Id, out var guid))
+                continue;
             foreach (var key in _schemasByGuid.Keys.Where(key => key.Guid == guid).ToArray())
-            {
                 _schemasByGuid.Remove(key);
+        }
+
+        return Task.FromResult<IReadOnlyList<int>>(versions);
+    }
+
+    private bool IsSchemaIdReferenced(int id)
+    {
+        foreach (var schemas in _schemasBySubject.Values)
+        {
+            for (var index = 0; index < schemas.Count; index++)
+            {
+                if (schemas[index].Id == id)
+                    return true;
             }
         }
 
-        _schemasBySubject.Remove(subject);
-
-        return Task.FromResult<IReadOnlyList<int>>(versions);
+        return false;
     }
 
     public async Task<IReadOnlyList<Association>> GetAssociationsByResourceNameAsync(

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/MockSchemaRegistryClient.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/MockSchemaRegistryClient.cs
@@ -9,6 +9,7 @@ namespace Dekaf.Tests.Unit.SchemaRegistry;
 internal sealed class MockSchemaRegistryClient : IFormattedSchemaRegistryClient, ISchemaRegistryCache
 {
     private readonly Dictionary<int, Schema> _schemasById = new();
+    private readonly Dictionary<int, Guid> _schemaGuidsById = new();
     private readonly Dictionary<(Guid Guid, string? Format), Schema> _schemasByGuid = new();
     private readonly Dictionary<string, List<(int Version, int Id, Schema Schema)>> _schemasBySubject = new();
     private readonly Dictionary<(string Namespace, string Name), List<Association>> _associationsByResource = new();
@@ -131,8 +132,10 @@ internal sealed class MockSchemaRegistryClient : IFormattedSchemaRegistryClient,
         ThrowIfDisposed();
 
         var id = _nextId++;
+        var guid = GuidFromId(id);
         _schemasById[id] = schema;
-        _schemasByGuid[(GuidFromId(id), null)] = schema;
+        _schemaGuidsById[id] = guid;
+        _schemasByGuid[(guid, null)] = schema;
 
         if (!_schemasBySubject.TryGetValue(subject, out var list))
         {
@@ -144,6 +147,19 @@ internal sealed class MockSchemaRegistryClient : IFormattedSchemaRegistryClient,
         list.Add((version, id, schema));
 
         return Task.FromResult(id);
+    }
+
+    internal void AddRegisteredSchema(
+        int id,
+        Guid guid,
+        string subject,
+        Schema schema)
+    {
+        _schemasById.Add(id, schema);
+        _schemaGuidsById.Add(id, guid);
+        _schemasByGuid.Add((guid, null), schema);
+        _schemasBySubject.Add(subject, [(1, id, schema)]);
+        _nextId = Math.Max(_nextId, id + 1);
     }
 
     internal void AddSchemaSubject(int id, string subject)
@@ -284,7 +300,7 @@ internal sealed class MockSchemaRegistryClient : IFormattedSchemaRegistryClient,
         return Task.FromResult(new RegisteredSchema
         {
             Id = entry.Id,
-            Guid = GuidFromId(entry.Id).ToString(),
+            Guid = _schemaGuidsById[entry.Id].ToString(),
             Subject = subject,
             Version = entry.Version,
             Schema = entry.Schema
@@ -337,7 +353,7 @@ internal sealed class MockSchemaRegistryClient : IFormattedSchemaRegistryClient,
         return Task.FromResult(new RegisteredSchema
         {
             Id = entry.Id,
-            Guid = GuidFromId(entry.Id).ToString(),
+            Guid = _schemaGuidsById[entry.Id].ToString(),
             Subject = subject,
             Version = entry.Version,
             Schema = entry.Schema
@@ -436,7 +452,8 @@ internal sealed class MockSchemaRegistryClient : IFormattedSchemaRegistryClient,
         foreach (var entry in list)
         {
             _schemasById.Remove(entry.Id);
-            var guid = GuidFromId(entry.Id);
+            var guid = _schemaGuidsById[entry.Id];
+            _schemaGuidsById.Remove(entry.Id);
             foreach (var key in _schemasByGuid.Keys.Where(key => key.Guid == guid).ToArray())
             {
                 _schemasByGuid.Remove(key);

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaIdentityInteroperabilityFixtureTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaIdentityInteroperabilityFixtureTests.cs
@@ -1,0 +1,343 @@
+using System.Buffers;
+using System.Text.Json;
+using Avro.Generic;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Avro;
+using Dekaf.SchemaRegistry.Protobuf;
+using Dekaf.Serialization;
+using AvroSchema = Avro.Schema;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public sealed class SchemaIdentityInteroperabilityFixtureTests
+{
+    private const string TopicSuffix = "-fixture";
+    private const string FixtureResource =
+        "Dekaf.Tests.Unit.SchemaRegistry.IdentityFixtures.confluent-schema-identity-v2.15.0.json";
+
+    private static readonly JsonSerializerOptions FixtureJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+    private static readonly JsonSerializerOptions PayloadJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private static readonly IdentityFixture[] Fixtures = LoadFixtures();
+
+    [Test]
+    public async Task Avro_ConfluentPrefixHeaderAndDualFixtures_Deserialize()
+    {
+        var fixture = GetFixture("avro");
+        using var registry = CreateRegistry(fixture);
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(fixture.Schema);
+
+        await AssertAvroFixtureAsync(fixture, registry, SchemaIdDeserializerStrategy.Prefix, useHeader: false);
+        await AssertAvroFixtureAsync(fixture, registry, SchemaIdDeserializerStrategy.Header, useHeader: true);
+        await AssertAvroFixtureAsync(fixture, registry, SchemaIdDeserializerStrategy.Dual, useHeader: false);
+        await AssertAvroFixtureAsync(fixture, registry, SchemaIdDeserializerStrategy.Dual, useHeader: true);
+
+        var record = new GenericRecord(schema);
+        record.Add("id", 42);
+        record.Add("name", "confluent-avro");
+        await AssertAvroEmissionAsync(fixture, registry, record, SchemaIdSerializerStrategy.Prefix);
+        await AssertAvroEmissionAsync(fixture, registry, record, SchemaIdSerializerStrategy.Header);
+    }
+
+    [Test]
+    public async Task Json_ConfluentPrefixHeaderAndDualFixtures_Deserialize()
+    {
+        var fixture = GetFixture("json");
+        using var registry = CreateRegistry(fixture);
+
+        await AssertJsonFixtureAsync(fixture, registry, SchemaIdDeserializerStrategy.Prefix, useHeader: false);
+        await AssertJsonFixtureAsync(fixture, registry, SchemaIdDeserializerStrategy.Header, useHeader: true);
+        await AssertJsonFixtureAsync(fixture, registry, SchemaIdDeserializerStrategy.Dual, useHeader: false);
+        await AssertJsonFixtureAsync(fixture, registry, SchemaIdDeserializerStrategy.Dual, useHeader: true);
+
+        var value = new IdentityFixtureJsonRecord { Id = 43, Name = "confluent-json" };
+        await AssertJsonEmissionAsync(fixture, registry, value, SchemaIdSerializerStrategy.Prefix);
+        await AssertJsonEmissionAsync(fixture, registry, value, SchemaIdSerializerStrategy.Header);
+    }
+
+    [Test]
+    public async Task Protobuf_ConfluentPrefixHeaderAndDualFixtures_Deserialize()
+    {
+        var fixture = GetFixture("protobuf");
+        using var registry = CreateRegistry(fixture);
+
+        await AssertProtobufFixtureAsync(fixture, registry, SchemaIdDeserializerStrategy.Prefix, useHeader: false);
+        await AssertProtobufFixtureAsync(fixture, registry, SchemaIdDeserializerStrategy.Header, useHeader: true);
+        await AssertProtobufFixtureAsync(fixture, registry, SchemaIdDeserializerStrategy.Dual, useHeader: false);
+        await AssertProtobufFixtureAsync(fixture, registry, SchemaIdDeserializerStrategy.Dual, useHeader: true);
+
+        var value = new TestMessage
+        {
+            Id = 44,
+            Name = "confluent-protobuf",
+            Value = 12.5
+        };
+        await AssertProtobufEmissionAsync(fixture, registry, value, SchemaIdSerializerStrategy.Prefix);
+        await AssertProtobufEmissionAsync(fixture, registry, value, SchemaIdSerializerStrategy.Header);
+    }
+
+    [Test]
+    public async Task DualFixture_MalformedHeader_DoesNotFallBackToValidPrefix()
+    {
+        var fixture = GetFixture("json");
+        using var registry = CreateRegistry(fixture);
+        await using var deserializer = new JsonSchemaRegistryDeserializer<IdentityFixtureJsonRecord>(
+            registry,
+            PayloadJsonOptions,
+            new SchemaRegistryDeserializerConfig
+            {
+                SchemaIdStrategy = SchemaIdDeserializerStrategy.Dual
+            });
+        var context = CreateContext(fixture, useHeader: false);
+        context.Headers!.Add(new Header(fixture.HeaderName, new byte[] { 1, 2, 3 }));
+
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(() => Task.FromResult(
+            deserializer.Deserialize(Convert.FromHexString(fixture.PrefixPayloadHex), context)));
+
+        await Assert.That(exception!.Message).Contains("GUID frame is truncated");
+    }
+
+    [Test]
+    public async Task DualFixture_ConflictingHeaderIdentity_RejectsWrongSchemaFormat()
+    {
+        var avro = GetFixture("avro");
+        var json = GetFixture("json");
+        using var registry = CreateRegistry(avro, json);
+        await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(
+            registry,
+            new AvroDeserializerConfig
+            {
+                SchemaIdStrategy = SchemaIdDeserializerStrategy.Dual
+            });
+        var context = CreateContext(json, useHeader: true);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => Task.FromResult(
+            deserializer.Deserialize(Convert.FromHexString(avro.PrefixPayloadHex), context)));
+
+        await Assert.That(exception!.Message).Contains("not an Avro schema");
+    }
+
+    private static async Task AssertAvroFixtureAsync(
+        IdentityFixture fixture,
+        MockSchemaRegistryClient registry,
+        SchemaIdDeserializerStrategy strategy,
+        bool useHeader)
+    {
+        await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(
+            registry,
+            new AvroDeserializerConfig { SchemaIdStrategy = strategy });
+
+        var record = deserializer.Deserialize(GetPayload(fixture, useHeader), CreateContext(fixture, useHeader));
+
+        await Assert.That(record["id"]).IsEqualTo(42);
+        await Assert.That(record["name"].ToString()).IsEqualTo("confluent-avro");
+    }
+
+    private static async Task AssertJsonFixtureAsync(
+        IdentityFixture fixture,
+        MockSchemaRegistryClient registry,
+        SchemaIdDeserializerStrategy strategy,
+        bool useHeader)
+    {
+        await using var deserializer = new JsonSchemaRegistryDeserializer<IdentityFixtureJsonRecord>(
+            registry,
+            PayloadJsonOptions,
+            new SchemaRegistryDeserializerConfig { SchemaIdStrategy = strategy });
+
+        var value = deserializer.Deserialize(GetPayload(fixture, useHeader), CreateContext(fixture, useHeader));
+
+        await Assert.That(value.Id).IsEqualTo(43);
+        await Assert.That(value.Name).IsEqualTo("confluent-json");
+    }
+
+    private static async Task AssertProtobufFixtureAsync(
+        IdentityFixture fixture,
+        MockSchemaRegistryClient registry,
+        SchemaIdDeserializerStrategy strategy,
+        bool useHeader)
+    {
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(
+            registry,
+            new ProtobufDeserializerConfig { SchemaIdStrategy = strategy });
+
+        var value = deserializer.Deserialize(GetPayload(fixture, useHeader), CreateContext(fixture, useHeader));
+
+        await Assert.That(value.Id).IsEqualTo(44);
+        await Assert.That(value.Name).IsEqualTo("confluent-protobuf");
+        await Assert.That(value.Value).IsEqualTo(12.5);
+    }
+
+    private static async Task AssertAvroEmissionAsync(
+        IdentityFixture fixture,
+        MockSchemaRegistryClient registry,
+        GenericRecord value,
+        SchemaIdSerializerStrategy strategy)
+    {
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(
+            registry,
+            new AvroSerializerConfig
+            {
+                AutoRegisterSchemas = false,
+                SchemaIdStrategy = strategy
+            });
+        await AssertEmissionAsync(fixture, strategy, (ref ArrayBufferWriter<byte> destination, SerializationContext context) =>
+            serializer.Serialize(value, ref destination, context));
+    }
+
+    private static async Task AssertJsonEmissionAsync(
+        IdentityFixture fixture,
+        MockSchemaRegistryClient registry,
+        IdentityFixtureJsonRecord value,
+        SchemaIdSerializerStrategy strategy)
+    {
+        await using var serializer = new JsonSchemaRegistrySerializer<IdentityFixtureJsonRecord>(
+            registry,
+            fixture.Schema,
+            PayloadJsonOptions,
+            new JsonSchemaSerializerConfig
+            {
+                AutoRegisterSchemas = false,
+                SchemaIdStrategy = strategy
+            });
+        await AssertEmissionAsync(fixture, strategy, (ref ArrayBufferWriter<byte> destination, SerializationContext context) =>
+            serializer.Serialize(value, ref destination, context));
+    }
+
+    private static async Task AssertProtobufEmissionAsync(
+        IdentityFixture fixture,
+        MockSchemaRegistryClient registry,
+        TestMessage value,
+        SchemaIdSerializerStrategy strategy)
+    {
+        await using var serializer = new ProtobufSchemaRegistrySerializer<TestMessage>(
+            registry,
+            new ProtobufSerializerConfig
+            {
+                AutoRegisterSchemas = false,
+                SchemaIdStrategy = strategy
+            });
+        await AssertEmissionAsync(fixture, strategy, (ref ArrayBufferWriter<byte> destination, SerializationContext context) =>
+            serializer.Serialize(value, ref destination, context));
+    }
+
+    private static async Task AssertEmissionAsync(
+        IdentityFixture fixture,
+        SchemaIdSerializerStrategy strategy,
+        SerializeFixture serialize)
+    {
+        var destination = new ArrayBufferWriter<byte>();
+        var context = CreateContext(fixture, useHeader: false);
+
+        serialize(ref destination, context);
+
+        var expectedPayload = Convert.FromHexString(
+            strategy == SchemaIdSerializerStrategy.Prefix
+                ? fixture.PrefixPayloadHex
+                : fixture.HeaderPayloadHex);
+        await Assert.That(destination.WrittenSpan.SequenceEqual(expectedPayload)).IsTrue();
+        if (strategy == SchemaIdSerializerStrategy.Prefix)
+        {
+            await Assert.That(context.Headers!.Count).IsEqualTo(0);
+            return;
+        }
+
+        await Assert.That(context.Headers!.Count).IsEqualTo(1);
+        await Assert.That(context.Headers[0].Key).IsEqualTo(fixture.HeaderName);
+        await Assert.That(context.Headers[0].Value.Span.SequenceEqual(
+            Convert.FromHexString(fixture.HeaderValueHex))).IsTrue();
+    }
+
+    private static MockSchemaRegistryClient CreateRegistry(params IdentityFixture[] fixtures)
+    {
+        var registry = new MockSchemaRegistryClient();
+        for (var index = 0; index < fixtures.Length; index++)
+        {
+            var fixture = fixtures[index];
+            registry.AddRegisteredSchema(
+                fixture.SchemaId,
+                Guid.Parse(fixture.SchemaGuid),
+                GetSubject(fixture),
+                new Schema
+                {
+                    SchemaType = GetSchemaType(fixture.Format),
+                    SchemaString = fixture.Schema
+                });
+        }
+
+        return registry;
+    }
+
+    private static SerializationContext CreateContext(IdentityFixture fixture, bool useHeader)
+    {
+        var headers = new Headers();
+        if (useHeader)
+        {
+            headers.Add(new Header(
+                fixture.HeaderName,
+                Convert.FromHexString(fixture.HeaderValueHex)));
+        }
+
+        return new SerializationContext
+        {
+            Topic = GetTopic(fixture),
+            Component = SerializationComponent.Value,
+            Headers = headers
+        };
+    }
+
+    private static ReadOnlyMemory<byte> GetPayload(IdentityFixture fixture, bool useHeader) =>
+        Convert.FromHexString(useHeader ? fixture.HeaderPayloadHex : fixture.PrefixPayloadHex);
+
+    private static string GetTopic(IdentityFixture fixture) => fixture.Format + TopicSuffix;
+
+    private static string GetSubject(IdentityFixture fixture) => GetTopic(fixture) + "-value";
+
+    private static SchemaType GetSchemaType(string format) => format switch
+    {
+        "avro" => SchemaType.Avro,
+        "json" => SchemaType.Json,
+        "protobuf" => SchemaType.Protobuf,
+        _ => throw new InvalidDataException($"Unknown fixture schema format '{format}'.")
+    };
+
+    private static IdentityFixture GetFixture(string format) =>
+        Fixtures.Single(fixture => fixture.Format == format);
+
+    private static IdentityFixture[] LoadFixtures()
+    {
+        using var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream(FixtureResource)
+                           ?? throw new InvalidOperationException($"Missing fixture resource '{FixtureResource}'.");
+        return JsonSerializer.Deserialize<IdentityFixture[]>(stream, FixtureJsonOptions)
+               ?? throw new InvalidDataException("The Confluent schema identity fixture is empty.");
+    }
+
+    private delegate void SerializeFixture(
+        ref ArrayBufferWriter<byte> destination,
+        SerializationContext context);
+
+    private sealed class IdentityFixture
+    {
+        public required string Format { get; init; }
+        public required string ProducerPackage { get; init; }
+        public required string RegistryImage { get; init; }
+        public required int SchemaId { get; init; }
+        public required string SchemaGuid { get; init; }
+        public required string Schema { get; init; }
+        public required string PrefixPayloadHex { get; init; }
+        public required string HeaderPayloadHex { get; init; }
+        public required string HeaderName { get; init; }
+        public required string HeaderValueHex { get; init; }
+    }
+
+    private sealed class IdentityFixtureJsonRecord
+    {
+        public int Id { get; init; }
+        public required string Name { get; init; }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaIdentityInteroperabilityFixtureTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaIdentityInteroperabilityFixtureTests.cs
@@ -83,6 +83,34 @@ public sealed class SchemaIdentityInteroperabilityFixtureTests
     }
 
     [Test]
+    public async Task MockRegistry_DeleteSharedSubject_PreservesIdentityUntilLastAlias()
+    {
+        const int schemaId = 41;
+        var schemaGuid = Guid.Parse("bc703644-6486-4f78-98d3-c531c5c5a147");
+        var schema = new Schema
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = "{}"
+        };
+        using var registry = new MockSchemaRegistryClient();
+        registry.AddRegisteredSchema(schemaId, schemaGuid, "first-value", schema);
+        registry.AddSchemaSubject(schemaId, "second-value");
+
+        _ = await registry.DeleteSubjectAsync("first-value");
+
+        await Assert.That(await registry.GetSchemaAsync(schemaId)).IsSameReferenceAs(schema);
+        await Assert.That(await registry.GetSchemaByGuidAsync(schemaGuid.ToString())).IsSameReferenceAs(schema);
+        await Assert.That((await registry.GetSchemaBySubjectAsync("second-value")).Guid)
+            .IsEqualTo(schemaGuid.ToString());
+        await Assert.That((await registry.LookupSchemaAsync("second-value", schema)).Guid)
+            .IsEqualTo(schemaGuid.ToString());
+
+        var deletedVersions = await registry.DeleteSubjectAsync("second-value");
+
+        await Assert.That(deletedVersions).IsEquivalentTo([1]);
+    }
+
+    [Test]
     public async Task DualFixture_MalformedHeader_DoesNotFallBackToValidPrefix()
     {
         var fixture = GetFixture("json");


### PR DESCRIPTION
## Summary
- add checked-in Avro, JSON Schema, and Protobuf identity vectors generated by Confluent Schema Registry SerDes 2.15.0 against `confluentinc/cp-schema-registry:8.2.0`
- verify Dekaf reads Prefix, Header, and Dual records and emits byte-exact Prefix/Header records for every format
- cover malformed Dual headers and conflicting schema identities deterministically
- document strategy behavior, precedence, failure modes, and rolling migration order

## Test plan
- [x] unit tests: net10.0 (8,482 passed)
- [x] unit tests: net8.0 (8,346 passed)
- [x] focused identity fixture tests: 5/5 on both TFMs
- [x] SchemaIdentityFramingIntegrationTests: 5/5 with Testcontainers
- [x] documentation snippet validator (299 compiled, 4 excluded, known-failure fingerprint matched)
- [x] `npm run build --prefix docs`
- [x] Release builds: 0 warnings, 0 errors

## Performance
Same machine, ShortRun, 1 launch, 5 warmups, 10 iterations. This PR changes only tests/docs; `src/` and benchmark code are byte-identical, so deltas are reported as measurement variance, not claimed gains.

| Warm serialization path | Base | Candidate | Allocated before/after |
| --- | ---: | ---: | ---: |
| Avro Prefix | 24.066 ns | 18.672 ns | 0 B / 0 B |
| Avro Header | 31.852 ns | 31.089 ns | 0 B / 0 B |
| Protobuf Prefix | 29.032 ns | 26.097 ns | 0 B / 0 B |
| Protobuf Header | 37.869 ns | 37.730 ns | 0 B / 0 B |
| JSON prepared | 55.557 ns | 54.960 ns | 0 B / 0 B |

All protected measurements remain Pareto-safe; every measured hot path stays at 0 B.

Closes #2782
