### PR TITLE
Remove MPSC consumer waiter scheduling timeout

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -564,9 +564,12 @@ public class MpscFetchBufferTests
     }
 
     [Test]
-    public async Task WaitToReadAsync_DisposeAfterCancellationRegistration_DoesNotReactivateWaiter()
+    [Timeout(120_000)]
+    public async Task WaitToReadAsync_DisposeAfterCancellationRegistration_DoesNotReactivateWaiter(
+        CancellationToken cancellationToken)
     {
-        using var registrationCompleted = new ManualResetEventSlim();
+        var registrationCompleted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         using var releaseWaiter = new ManualResetEventSlim();
         using var cts = new CancellationTokenSource();
         var buffer = new MpscFetchBuffer(
@@ -574,28 +577,33 @@ public class MpscFetchBufferTests
             afterProducerWaiterCountIncrementedForTesting: null,
             afterConsumerCancellationRegisteredForTesting: () =>
             {
-                registrationCompleted.Set();
-                releaseWaiter.Wait();
+                registrationCompleted.TrySetResult();
+                releaseWaiter.Wait(cancellationToken);
             });
 
-        var waitTask = Task.Run(() =>
-            buffer.WaitToReadAsync(Timeout.Infinite, cts.Token).AsTask());
+        var waitTask = Task.Factory.StartNew(
+            () => buffer.WaitToReadAsync(Timeout.Infinite, cts.Token).AsTask().GetAwaiter().GetResult(),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
 
         try
         {
-            await Assert.That(registrationCompleted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await registrationCompleted.Task.WaitAsync(cancellationToken);
 
             buffer.Dispose();
             releaseWaiter.Set();
 
-            await Assert.That(await waitTask).IsFalse();
+            await Assert.That(await waitTask.WaitAsync(cancellationToken)).IsFalse();
             await Assert.That(GetConsumerWaiting(buffer)).IsEqualTo(0);
             await Assert.That(IsReadWaiterActive(buffer)).IsFalse();
         }
         finally
         {
-            releaseWaiter.Set();
             buffer.Dispose();
+            releaseWaiter.Set();
+            Task waitObservation = waitTask;
+            await waitObservation.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
         }
     }
 


### PR DESCRIPTION
Fixes #2937.

## Summary
- run the cancellation-registration waiter on a dedicated LongRunning task instead of the ThreadPool
- replace the 5-second scheduling assumption with TUnit cancellation-aware synchronization
- always release and observe the blocked waiter during cleanup

## Validation
- Release unit build: 0 warnings, 0 errors
- focused MpscFetchBufferTests: 33/33 net8.0; 33/33 net10.0
- full unit suite: 8,462/8,462 net8.0; 8,598/8,598 net10.0
- /simplify completed

@codex review
@claude review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cancellation and disposal test reliability.
  * Reduced timing-related flakiness by using cancellation-aware asynchronous coordination.
  * Added safeguards to prevent lingering wait operations from affecting subsequent tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->