### PR TITLE
Synchronize retired lease disposal test

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
@@ -433,7 +433,9 @@ public sealed class ConsumerConnectionOwnershipTests
     }
 
     [Test]
-    public async Task StandaloneConsumer_Dispose_KeepsPoolAliveUntilRetiredLeaseReleases()
+    [Timeout(30_000)]
+    public async Task StandaloneConsumer_Dispose_KeepsPoolAliveUntilRetiredLeaseReleases(
+        CancellationToken cancellationToken)
     {
         var pool = CreatePool();
         var removedConnection = new TrackedConnection(
@@ -449,12 +451,14 @@ public sealed class ConsumerConnectionOwnershipTests
 
         try
         {
-            await Task.Delay(TimeSpan.FromSeconds(5.2));
+            await removedConnection.RetirementLeaseObserved.WaitAsync(cancellationToken);
+            await Assert.That(disposeTask.IsCompleted).IsFalse();
             _ = pool.DidNotReceive().DisposeAsync();
 
             removedConnection.ReleaseLease();
             leaseReleased = true;
-            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+            await removedConnection.DisposalStarted.WaitAsync(cancellationToken);
+            await disposeTask.WaitAsync(cancellationToken);
         }
         finally
         {


### PR DESCRIPTION
## Summary

- replace the 5.2-second wall-clock delay with the existing retired-lease observation signal
- prove the pool remains alive while the lease is held
- wait for the disposal-start signal before completing consumer disposal

## Validation

- Release unit build: 0 warnings, 0 errors (net10/net8)
- focused test: 1/1 passed on net10 and net8 (~0.4 s each)
- full net8 unit suite: 8,462/8,462 passed under suite load
- `/simplify`: completed
- `git diff --check`: clean

Closes #2939