### PR TITLE
test(consumer): remove diverging-epoch timeout race

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -593,7 +593,7 @@ public sealed class ConsumerLeaderDiscoveryTests
             .ConsumeOneAsync(Timeout.InfiniteTimeSpan, cancellationSource.Token)
             .AsTask();
         await interceptorInvoked.Task.WaitAsync(TimeSpan.FromSeconds(30));
-        var result = await consumeTask;
+        var result = await consumeTask.WaitAsync(TimeSpan.FromSeconds(30));
 
         await Assert.That(result).IsNull();
         InvokeCompleteDivergingEpochResets(consumer);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -592,7 +592,17 @@ public sealed class ConsumerLeaderDiscoveryTests
         var consumeTask = consumer
             .ConsumeOneAsync(Timeout.InfiniteTimeSpan, cancellationSource.Token)
             .AsTask();
-        await interceptorInvoked.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        var interceptorWait = interceptorInvoked.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        try
+        {
+            await interceptorWait;
+        }
+        finally
+        {
+            cancellationSource.Cancel();
+            if (!interceptorWait.IsCompletedSuccessfully)
+                _ = await consumeTask.WaitAsync(TimeSpan.FromSeconds(30));
+        }
         var result = await consumeTask.WaitAsync(TimeSpan.FromSeconds(30));
 
         await Assert.That(result).IsNull();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -569,12 +569,22 @@ public sealed class ConsumerLeaderDiscoveryTests
 
         interceptor.Callback = () =>
         {
-            InvokeResetToDivergingEpoch(
-                consumer,
-                CreateDivergingEpochResponse(),
-                GetFetchBufferEpoch(consumer));
-            interceptorInvoked.TrySetResult();
-            cancellationSource.Cancel();
+            try
+            {
+                InvokeResetToDivergingEpoch(
+                    consumer,
+                    CreateDivergingEpochResponse(),
+                    GetFetchBufferEpoch(consumer));
+                interceptorInvoked.TrySetResult();
+            }
+            catch (Exception exception)
+            {
+                interceptorInvoked.TrySetException(exception);
+            }
+            finally
+            {
+                cancellationSource.Cancel();
+            }
         };
 
         GetPendingFetches(consumer).Enqueue(CreatePendingFetchData());

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -559,6 +559,8 @@ public sealed class ConsumerLeaderDiscoveryTests
     {
         var pool = Substitute.For<IConnectionPool>();
         var interceptor = new CallbackConsumerInterceptor();
+        var interceptorInvoked = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         using var cancellationSource = new CancellationTokenSource();
         await using var metadataManager = CreateMetadataManager(pool);
         await using var consumer = CreateConsumer(pool, metadataManager, interceptor: interceptor);
@@ -571,14 +573,17 @@ public sealed class ConsumerLeaderDiscoveryTests
                 consumer,
                 CreateDivergingEpochResponse(),
                 GetFetchBufferEpoch(consumer));
+            interceptorInvoked.TrySetResult();
             cancellationSource.Cancel();
         };
 
         GetPendingFetches(consumer).Enqueue(CreatePendingFetchData());
 
-        var result = await consumer.ConsumeOneAsync(
-            TimeSpan.FromSeconds(1),
-            cancellationSource.Token);
+        var consumeTask = consumer
+            .ConsumeOneAsync(Timeout.InfiniteTimeSpan, cancellationSource.Token)
+            .AsTask();
+        await interceptorInvoked.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        var result = await consumeTask;
 
         await Assert.That(result).IsNull();
         InvokeCompleteDivergingEpochResets(consumer);


### PR DESCRIPTION
## Summary

- remove the competing one-second `ConsumeOneAsync` timeout from the diverging-epoch interceptor test
- wait for an explicit interceptor-publication signal before checking reset cleanup
- retain a 30-second `WaitAsync` guard that fails diagnostically without acting as synchronization

## Root cause

Under parallel full-suite load, the operation timeout could return `null` before the queued fetch reached the interceptor. The test then completed no diverging-epoch reset and incorrectly expected pending revocations to clear.

## Verification

- net8.0 Release build: 0 warnings, 0 errors
- targeted net8.0 regression: 1/1 passed (413 ms)
- full net8.0 unit suite: 8,462/8,462 passed
- net10.0 Release build: 0 warnings, 0 errors
- full net10.0 unit suite: 8,598/8,598 passed
- `/simplify`: complete; test remains one deterministic signal plus one bounded failure guard

Closes #2941

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved the reliability of consumer leader discovery tests by explicitly synchronizing interceptor activity.
  - Reduced timing-related failures in environments with limited thread-pool availability.
  - Added clear timeout handling while allowing consume operations to complete naturally.
- **Impact**
  - No user-facing functionality or behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->