### PR TITLE
test(consumer): preserve reset diagnostics

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -575,14 +575,10 @@ public sealed class ConsumerLeaderDiscoveryTests
                     consumer,
                     CreateDivergingEpochResponse(),
                     GetFetchBufferEpoch(consumer));
-                interceptorInvoked.TrySetResult();
-            }
-            catch (Exception exception)
-            {
-                interceptorInvoked.TrySetException(exception);
             }
             finally
             {
+                interceptorInvoked.TrySetResult();
                 cancellationSource.Cancel();
             }
         };
@@ -601,7 +597,13 @@ public sealed class ConsumerLeaderDiscoveryTests
         {
             cancellationSource.Cancel();
             if (!interceptorWait.IsCompletedSuccessfully)
-                _ = await consumeTask.WaitAsync(TimeSpan.FromSeconds(30));
+            {
+                var completedTask = await Task.WhenAny(
+                    consumeTask,
+                    Task.Delay(TimeSpan.FromSeconds(30)));
+                if (ReferenceEquals(completedTask, consumeTask))
+                    _ = consumeTask.Exception;
+            }
         }
         var result = await consumeTask.WaitAsync(TimeSpan.FromSeconds(30));
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -575,10 +575,15 @@ public sealed class ConsumerLeaderDiscoveryTests
                     consumer,
                     CreateDivergingEpochResponse(),
                     GetFetchBufferEpoch(consumer));
+                interceptorInvoked.TrySetResult();
+            }
+            catch (Exception exception)
+            {
+                interceptorInvoked.TrySetException(exception);
+                throw;
             }
             finally
             {
-                interceptorInvoked.TrySetResult();
                 cancellationSource.Cancel();
             }
         };


### PR DESCRIPTION
Follow-up to #2942. Two exact-head review findings landed after that PR had already merged:

- remove the generic catch while still surfacing interceptor callback failures;
- observe failed synchronization cleanup without allowing cleanup cancellation/faults to replace the original interceptor timeout/failure.

The callback signal now means "invoked". Callback exceptions flow through `consumeTask`; failed interceptor waits cancel and boundedly observe that task with `Task.WhenAny`.

Validation:
- Release unit-test build: 0 warnings, 0 errors
- targeted `ResetToDivergingEpoch_StopsConsumeOneAsyncWhenInterceptorPublishesReset`: 1/1 passed (net10)
- `/simplify`: no further changes

Review context:
- https://github.com/thomhurst/Dekaf/pull/2942#discussion_r3869869323
- https://github.com/thomhurst/Dekaf/pull/2942#discussion_r3869931755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test handling for consumer reset scenarios.
  * Ensured interceptor failures are correctly propagated and recorded.
  * Updated cleanup behavior to avoid unnecessary timeouts while safely handling unfinished consume operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->