### PR TITLE
Add service provider overload for AddConsumerService

### DIFF
--- a/docs/docs/hosted-services.md
+++ b/docs/docs/hosted-services.md
@@ -64,7 +64,7 @@ builder.Services.AddDekaf(dekaf =>
 });
 ```
 
-This registers the `IKafkaConsumer<string, Order>` singleton and the hosted service together — equivalent to `AddConsumer` followed by `builder.Services.AddHostedService<OrderProcessorService>()`, which remains available when you want to register them separately. Overloads accept a fluent configuration callback, typed `ConsumerOptions`, or an `IConfiguration` section, each with an optional dead-letter-queue callback.
+This registers the `IKafkaConsumer<string, Order>` singleton and the hosted service together — equivalent to `AddConsumer` followed by `builder.Services.AddHostedService<OrderProcessorService>()`, which remains available when you want to register them separately. Overloads accept a fluent configuration callback, typed `ConsumerOptions`, or an `IConfiguration` section, each with an optional dead-letter-queue callback. The fluent callback also has a service-provider-aware form, `(serviceProvider, consumer) => ...`, for resolving registered dependencies when the consumer singleton is created.
 
 To run several hosted services whose consumers share the same `TKey`/`TValue` pair, use the keyed overloads — each takes a `serviceKey` as the first argument and hands the service its own consumer (and dead-letter options) directly, with no `[FromKeyedServices]` attribute needed on the constructor:
 

--- a/src/Dekaf.Extensions.Hosting/DekafBuilderHostingExtensions.cs
+++ b/src/Dekaf.Extensions.Hosting/DekafBuilderHostingExtensions.cs
@@ -14,6 +14,33 @@ namespace Dekaf.Extensions.Hosting;
 public static class DekafBuilderHostingExtensions
 {
     /// <summary>
+    /// Adds a consumer configured using the service provider and a
+    /// <see cref="KafkaConsumerService{TKey, TValue}"/> hosted service that processes it, in one call.
+    /// </summary>
+    /// <typeparam name="TService">The hosted consumer service type.</typeparam>
+    /// <typeparam name="TKey">The message key type.</typeparam>
+    /// <typeparam name="TValue">The message value type.</typeparam>
+    /// <param name="builder">The Dekaf builder.</param>
+    /// <param name="configure">Configures the full consumer builder surface using the service provider.</param>
+    /// <param name="configureDeadLetterQueue">Optional dead letter queue configuration for the service.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    public static DekafBuilder AddConsumerService<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TService,
+        TKey, TValue>(
+        this DekafBuilder builder,
+        Action<IServiceProvider, ConsumerBuilder<TKey, TValue>> configure,
+        Action<DeadLetterQueueBuilder>? configureDeadLetterQueue = null)
+        where TService : KafkaConsumerService<TKey, TValue>
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+        ReserveConsumerServiceRegistration<TService>(builder, serviceKey: null);
+        builder.AddConsumer(configure, configureDeadLetterQueue);
+        return RegisterHostedService<TService, TKey, TValue>(
+            builder, serviceKey: null, configureDeadLetterQueue is not null);
+    }
+
+    /// <summary>
     /// Adds a consumer and a <see cref="KafkaConsumerService{TKey, TValue}"/> hosted service that
     /// processes it, in one call. Equivalent to <c>AddConsumer</c> followed by
     /// <c>services.AddHostedService&lt;TService&gt;()</c>.

--- a/src/Dekaf.Extensions.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.Extensions.Hosting/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+
+static Dekaf.Extensions.Hosting.DekafBuilderHostingExtensions.AddConsumerService<TService, TKey, TValue>(this Dekaf.Extensions.DependencyInjection.DekafBuilder! builder, System.Action<System.IServiceProvider!, Dekaf.ConsumerBuilder<TKey, TValue>!>! configure, System.Action<Dekaf.Consumer.DeadLetter.DeadLetterQueueBuilder!>? configureDeadLetterQueue = null) -> Dekaf.Extensions.DependencyInjection.DekafBuilder!

--- a/tests/Dekaf.Tests.Unit/Hosting/AddConsumerServiceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Hosting/AddConsumerServiceTests.cs
@@ -12,6 +12,36 @@ namespace Dekaf.Tests.Unit.Hosting;
 public class AddConsumerServiceTests
 {
     [Test]
+    public async Task AddConsumerService_ServiceProviderOverload_ConfiguresConsumerAtResolution()
+    {
+        var services = new ServiceCollection();
+        var settings = new ConsumerServiceSettings("localhost:9092", "provider-group");
+        services.AddSingleton(settings);
+        ConsumerServiceSettings? resolvedSettings = null;
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddConsumerService<TestService, string, string>((serviceProvider, consumer) =>
+            {
+                resolvedSettings = serviceProvider.GetRequiredService<ConsumerServiceSettings>();
+                consumer
+                    .WithBootstrapServers(resolvedSettings.BootstrapServers)
+                    .WithGroupId(resolvedSettings.GroupId);
+            });
+        });
+
+        await Assert.That(resolvedSettings).IsNull();
+
+        await using var provider = services.BuildServiceProvider();
+        _ = provider.GetRequiredService<IKafkaConsumer<string, string>>();
+
+        await Assert.That(resolvedSettings).IsSameReferenceAs(settings);
+        await Assert.That(services.Any(d =>
+            d.ServiceType == typeof(IHostedService) &&
+            d.ImplementationType == typeof(TestService))).IsTrue();
+    }
+
+    [Test]
     public async Task AddConsumerService_RegistersConsumerAndHostedService()
     {
         var services = new ServiceCollection();
@@ -341,6 +371,8 @@ public class AddConsumerServiceTests
             ConsumeResult<string, string> result, CancellationToken cancellationToken)
             => ValueTask.CompletedTask;
     }
+
+    private sealed record ConsumerServiceSettings(string BootstrapServers, string GroupId);
 
     private sealed class DlqTestService : KafkaConsumerService<string, string>
     {


### PR DESCRIPTION
## Summary

- add an `IServiceProvider`-aware `AddConsumerService` overload
- defer consumer configuration until singleton resolution while registering the hosted service normally
- document the overload and cover deferred DI resolution

## Testing

- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --no-restore`
- `tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe --treenode-filter '/*/*/AddConsumerServiceTests/*'` (13 passed)
- `tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe` (8,680 passed)

## Performance

No message hot-path code changed. Consumer configuration callback runs once during DI singleton creation, so per-message benchmarks are not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a service-provider-aware configuration option when registering hosted consumer services.
  * Consumer setup can now resolve registered dependencies during creation.
  * Optional dead-letter queue configuration remains supported.

* **Documentation**
  * Updated hosting documentation with the new configuration callback format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->