### PR TITLE
Harden hosted consumer delivery tests

### DIFF
--- a/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
+++ b/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Condition="'$(PublishAot)' != 'true'" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="protobuf-net.Reflection"
-                      Aliases="protobufnet"
+                      ExcludeAssets="compile"
                       Condition="'$(PublishAot)' != 'true'" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Condition="'$(PublishAot)' != 'true'" />
     <PackageReference Include="SSH.NET" PrivateAssets="All" />

--- a/tests/Dekaf.Tests.Integration/HostedServiceTests.cs
+++ b/tests/Dekaf.Tests.Integration/HostedServiceTests.cs
@@ -55,17 +55,14 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
         builder.Services.AddSingleton<TestTopicHolder>(new TestTopicHolder(topic));
         builder.Services.AddHostedService<TestConsumerService>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
+        await host.StartAsync().ConfigureAwait(false);
 
-        // Start the host
-        using var cts = new CancellationTokenSource();
-        var hostTask = host.RunAsync(cts.Token);
-
-        // Give the consumer service time to start and join the group.
-        // The consumer needs to subscribe, join the group, and receive its partition
-        // assignment before it can receive messages. On CI runners this can take longer
-        // than on local machines due to thread pool contention.
-        await Task.Delay(2000).ConfigureAwait(false);
+        var consumer = host.Services.GetRequiredService<IKafkaConsumer<string, string>>();
+        await WaitForConditionAsync(
+            () => consumer.Assignment.Any(partition => partition.Topic == topic),
+            TimeSpan.FromSeconds(30),
+            description: "hosted consumer partition assignment");
 
         for (var i = 0; i < messageCount; i++)
         {
@@ -84,25 +81,63 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
 
         await Assert.That(receivedMessages.Count).IsGreaterThanOrEqualTo(messageCount);
 
-        // Stop gracefully
-        cts.Cancel();
+        using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await host.StopAsync(stopCts.Token).ConfigureAwait(false);
+    }
 
-        try
+    [Test]
+    public async Task ServiceProviderConfiguredHostedService_ReceivesMessages()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var receivedMessages = new ConcurrentBag<string>();
+        var settings = new HostedConsumerSettings(
+            KafkaContainer.BootstrapServers,
+            $"hosted-service-provider-{Guid.NewGuid():N}");
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.Services.AddSingleton(settings);
+        builder.Services.AddSingleton(receivedMessages);
+        builder.Services.AddSingleton(new TestTopicHolder(topic));
+        builder.Services.AddDekaf(dekaf =>
         {
-            await hostTask.WaitAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
+            dekaf.AddConsumerService<TestConsumerService, string, string>((serviceProvider, consumer) =>
+            {
+                var consumerSettings = serviceProvider.GetRequiredService<HostedConsumerSettings>();
+                consumer
+                    .WithBootstrapServers(consumerSettings.BootstrapServers)
+                    .WithGroupId(consumerSettings.GroupId)
+                    .WithAutoOffsetReset(AutoOffsetReset.Earliest);
+            });
+        });
+
+        using var host = builder.Build();
+        await host.StartAsync().ConfigureAwait(false);
+
+        var consumer = host.Services.GetRequiredService<IKafkaConsumer<string, string>>();
+        await WaitForConditionAsync(
+            () => consumer.Assignment.Any(partition => partition.Topic == topic),
+            TimeSpan.FromSeconds(30),
+            description: "hosted consumer partition assignment");
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
         {
-            // Expected
-        }
-        catch (TimeoutException)
-        {
-            // Host shutdown can be slow on resource-constrained CI runners
-        }
-        finally
-        {
-            host.Dispose();
-        }
+            Topic = topic,
+            Key = "provider-key",
+            Value = "provider-value"
+        }, CancellationToken.None);
+
+        await WaitForConditionAsync(
+            () => receivedMessages.Contains("provider-value"),
+            TimeSpan.FromSeconds(30),
+            description: "hosted consumer message receipt");
+
+        using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await host.StopAsync(stopCts.Token).ConfigureAwait(false);
     }
 
     [Test]
@@ -619,6 +654,8 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
     {
         public string Topic { get; } = topic;
     }
+
+    private sealed record HostedConsumerSettings(string BootstrapServers, string GroupId);
 
     private sealed record RetryTopicInput(
         string Value,

--- a/tests/Dekaf.Tests.Integration/SchemaRegistrySubjectCompatibilityTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistrySubjectCompatibilityTests.cs
@@ -132,12 +132,13 @@ public sealed class SchemaRegistrySubjectCompatibilityTests(KafkaWithSchemaRegis
     {
         var topic = $"protobuf-subject-compat-{Guid.NewGuid():N}";
         using var confluentRegistry = CreateConfluentClient();
-        var confluentSerializer = new Confluent.SchemaRegistry.Serdes.ProtobufSerializer<TestPerson>(
-            confluentRegistry,
-            new Confluent.SchemaRegistry.Serdes.ProtobufSerializerConfig
-            {
-                SubjectNameStrategy = ConfluentSubjectNameStrategy.Record
-            });
+        Confluent.Kafka.IAsyncSerializer<TestPerson> confluentSerializer =
+            new Confluent.SchemaRegistry.Serdes.ProtobufSerializer<TestPerson>(
+                confluentRegistry,
+                new Confluent.SchemaRegistry.Serdes.ProtobufSerializerConfig
+                {
+                    SubjectNameStrategy = ConfluentSubjectNameStrategy.Record
+                });
         var value = new TestPerson { Id = 42, Name = "Compatibility", Email = "compat@example.com" };
 
         await confluentSerializer.SerializeAsync(
@@ -190,7 +191,7 @@ public sealed class SchemaRegistrySubjectCompatibilityTests(KafkaWithSchemaRegis
         await Assert.That(root.Schema.References[0].Version).IsEqualTo(2);
 
         using var confluentRegistry = CreateConfluentClient();
-        var confluentDeserializer =
+        Confluent.Kafka.IAsyncDeserializer<SchemaReferenceEnvelope> confluentDeserializer =
             new Confluent.SchemaRegistry.Serdes.ProtobufDeserializer<SchemaReferenceEnvelope>(confluentRegistry);
         var roundTrip = await confluentDeserializer.DeserializeAsync(
             destination.WrittenMemory,

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -568,8 +568,6 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             enableDeliveryDiagnostics: true);
         var accumulator = new RecordAccumulator(options);
         var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
-        var injectSibling = 0;
-        var expireWaveDeadline = 0;
         var idleWaitCount = 0;
         BrokerSender? sender = null;
         sender = CreateSender(
@@ -579,32 +577,26 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             (_, _, _, _, _) => { },
             onWaveCoalesceStarted: () =>
             {
-                if (Volatile.Read(ref injectSibling) != 0)
-                {
-                    sender!.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 1));
-                    if (Volatile.Read(ref expireWaveDeadline) != 0)
-                    {
-                        // Expire both zero-linger deadlines after the sibling is queued.
-                        var deadline = Stopwatch.GetTimestamp() + Stopwatch.Frequency / 1_000;
-                        while (Stopwatch.GetTimestamp() < deadline)
-                            Thread.SpinWait(32);
-                    }
-                }
+                sender!.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 1));
+
+                // Expire both zero-linger deadlines after the sibling is queued.
+                var deadline = Stopwatch.GetTimestamp() + Stopwatch.Frequency / 1_000;
+                while (Stopwatch.GetTimestamp() < deadline)
+                    Thread.SpinWait(32);
             },
             onIdleWaitStarted: () => Interlocked.Increment(ref idleWaitCount));
+
+        SeedKnownPartitions(
+            sender,
+            new TopicPartition("test-topic", 0),
+            new TopicPartition("test-topic", 1));
 
         try
         {
             await WaitUntilAsync(() => Volatile.Read(ref idleWaitCount) > 0, cancellationToken);
 
-            // Prime both known partitions in one request. The next single-partition event
-            // must enter the wave-coalesce path rather than being fully drained already.
             var expectedIdleWaitCount = Volatile.Read(ref idleWaitCount) + 1;
-            sender.EnqueueBulk(
-            [
-                CreateTestBatch(valueTaskSourcePool, "test-topic", 0),
-                CreateTestBatch(valueTaskSourcePool, "test-topic", 1)
-            ]);
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0));
             await WaitUntilAsync(
                 () => accumulator.GetDeliveryDiagnosticsSnapshot()
                     .ProduceRequestCount == 1
@@ -612,8 +604,7 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
                     && Volatile.Read(ref idleWaitCount) >= expectedIdleWaitCount,
                 cancellationToken);
 
-            Volatile.Write(ref injectSibling, 1);
-            Volatile.Write(ref expireWaveDeadline, 1);
+            // Sender is fully idle again. Next event must re-arm wave coalescing.
             expectedIdleWaitCount = Volatile.Read(ref idleWaitCount) + 1;
             sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0));
             await WaitUntilAsync(
@@ -623,21 +614,11 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
                     && Volatile.Read(ref idleWaitCount) >= expectedIdleWaitCount,
                 cancellationToken);
 
-            // The sender is fully idle again. Waiting for this event must re-arm the wave.
-            expectedIdleWaitCount = Volatile.Read(ref idleWaitCount) + 1;
-            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0));
-            await WaitUntilAsync(
-                () => accumulator.GetDeliveryDiagnosticsSnapshot()
-                    .ProduceRequestCount == 3
-                    && Volatile.Read(ref connection.SendFireAndForgetWithCallerTimeoutCalls) == 3
-                    && Volatile.Read(ref idleWaitCount) >= expectedIdleWaitCount,
-                cancellationToken);
-
             var diagnostic = accumulator.GetDeliveryDiagnosticsSnapshot();
-            await Assert.That(connection.SendFireAndForgetWithCallerTimeoutCalls).IsEqualTo(3);
+            await Assert.That(connection.SendFireAndForgetWithCallerTimeoutCalls).IsEqualTo(2);
             await Assert.That(diagnostic.CoalesceWidthHistogram
                     .Single(bucket => bucket.MinimumWidth == 2).RequestCount)
-                .IsEqualTo(3);
+                .IsEqualTo(2);
         }
         finally
         {


### PR DESCRIPTION
## Summary

- exclude `protobuf-net.Reflection` compile assets to resolve duplicate `Google.Protobuf.Reflection` generated-code types while retaining runtime interop
- add real-broker coverage proving the service-provider `AddConsumerService` overload receives messages
- replace fixed hosted-consumer startup delay with deterministic partition-assignment synchronization
- require graceful shutdown instead of swallowing timeout failures

## CI coverage

Both hosted-service receive tests inherit `[Category("Messaging")]`. PR CI runs the `Messaging` category in the net10.0 integration group; release CI runs it for net8.0 and net10.0 across the supported Kafka matrix.

Verified locally with the exact CI category filter: both test names are selected by `/**[Category=Messaging]`.

## Testing

- `dotnet build tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj --configuration Release --no-restore` (net8.0 + net10.0, 0 warnings/errors)
- `HostedServiceTests`: 8 passed
- `Protobuf_ConfluentRegisteredSubject_CanBeLookedUpByDekaf`: passed
- `Protobuf_DekafRegisteredReferences_CanBeConsumedByConfluent`: passed
- hosting unit suites: 41 passed

## Performance

Test/project asset changes only. No `src/` or message hot-path changes; benchmarks not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hosted service integration tests by waiting for consumer readiness before processing messages, reducing timing-related failures.
  * Added coverage for configuring hosted consumers through a service provider.
  * Improved graceful hosted service shutdown handling with timeout support.

* **Tests**
  * Clarified serializer and deserializer type handling in schema registry integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->