### PR TITLE
fix(consumer): preserve active read waiter

### DIFF
--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -301,39 +301,52 @@ internal sealed class MpscFetchBuffer
             spin.SpinOnce();
         }
 
-        if (!_readWaiter.TrySetCancellationToken(cancellationToken))
-            return new ValueTask<bool>(false);
+        if (!_readWaiter.TryClaim())
+            throw new InvalidOperationException("MpscFetchBuffer supports only one active reader.");
 
-        _afterConsumerCancellationRegisteredForTesting?.Invoke();
-        Volatile.Write(ref _consumerWaiting, 1);
-        Interlocked.MemoryBarrier();
-
-        lock (_dataAvailableWaiterLock)
+        var waitInstalled = false;
+        try
         {
-            // Re-check after publishing the waiter flag to avoid missed signals.
-            if (HasDataAvailable())
-            {
-                Volatile.Write(ref _consumerWaiting, 0);
-                return new ValueTask<bool>(true);
-            }
-
-            if (_completed)
-            {
-                Volatile.Write(ref _consumerWaiting, 0);
-                if (_completionError is not null)
-                    throw _completionError;
-                return new ValueTask<bool>(HasDataAvailable());
-            }
-
-            if (_readWaiter.IsDisposed)
-            {
-                Volatile.Write(ref _consumerWaiting, 0);
+            if (!_readWaiter.TrySetCancellationToken(cancellationToken))
                 return new ValueTask<bool>(false);
-            }
 
-            Debug.Assert(!_readWaiterActive, "MpscFetchBuffer supports one active reader.");
-            _readWaiterActive = true;
-            return _readWaiter.Prepare(timeoutMs);
+            _afterConsumerCancellationRegisteredForTesting?.Invoke();
+            Volatile.Write(ref _consumerWaiting, 1);
+            Interlocked.MemoryBarrier();
+
+            lock (_dataAvailableWaiterLock)
+            {
+                // Re-check after publishing the waiter flag to avoid missed signals.
+                if (HasDataAvailable())
+                {
+                    Volatile.Write(ref _consumerWaiting, 0);
+                    return new ValueTask<bool>(true);
+                }
+
+                if (_completed)
+                {
+                    Volatile.Write(ref _consumerWaiting, 0);
+                    if (_completionError is not null)
+                        throw _completionError;
+                    return new ValueTask<bool>(HasDataAvailable());
+                }
+
+                if (_readWaiter.IsDisposed)
+                {
+                    Volatile.Write(ref _consumerWaiting, 0);
+                    return new ValueTask<bool>(false);
+                }
+
+                var wait = _readWaiter.Prepare(timeoutMs);
+                _readWaiterActive = true;
+                waitInstalled = true;
+                return wait;
+            }
+        }
+        finally
+        {
+            if (!waitInstalled)
+                _readWaiter.ReleaseClaim();
         }
     }
 
@@ -441,6 +454,7 @@ internal sealed class MpscFetchBuffer
         private bool _queuedResult;
         private Exception? _queuedException;
         private int _cancellationRequested;
+        private int _claimed;
         private bool _disposed;
 
         public ReadWaiter(MpscFetchBuffer owner)
@@ -451,6 +465,10 @@ internal sealed class MpscFetchBuffer
         }
 
         public bool IsDisposed => _disposed;
+
+        public bool TryClaim() => Interlocked.CompareExchange(ref _claimed, 1, 0) == 0;
+
+        public void ReleaseClaim() => Volatile.Write(ref _claimed, 0);
 
         public bool TrySetCancellationToken(CancellationToken cancellationToken)
         {
@@ -617,6 +635,7 @@ internal sealed class MpscFetchBuffer
                 }
 
                 Volatile.Write(ref _owner._consumerWaiting, 0);
+                ReleaseClaim();
             }
         }
 

--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -302,7 +302,7 @@ internal sealed class MpscFetchBuffer
         }
 
         if (!_readWaiter.TryClaim())
-            throw new InvalidOperationException("MpscFetchBuffer supports only one active reader.");
+            return new ValueTask<bool>(false);
 
         var waitInstalled = false;
         try

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -278,10 +278,8 @@ public class MpscFetchBufferTests
 
         try
         {
-            var exception = Assert.Throws<InvalidOperationException>(() =>
-                buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None));
-            await Assert.That(exception.Message)
-                .IsEqualTo("MpscFetchBuffer supports only one active reader.");
+            var overlappingWait = buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None);
+            await Assert.That(await overlappingWait).IsFalse();
             await Assert.That(firstWait.IsCompleted).IsFalse();
 
             await Assert.That(buffer.TryWrite(item)).IsTrue();
@@ -307,10 +305,8 @@ public class MpscFetchBufferTests
             TriggerConsumerTimeout(buffer);
             await TestWait.UntilAsync(() => firstWait.IsCompleted, TimeSpan.FromSeconds(5));
 
-            var exception = Assert.Throws<InvalidOperationException>(() =>
-                buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None));
-            await Assert.That(exception.Message)
-                .IsEqualTo("MpscFetchBuffer supports only one active reader.");
+            var overlappingWait = buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None);
+            await Assert.That(await overlappingWait).IsFalse();
 
             await Assert.That(await firstWait).IsFalse();
 
@@ -335,8 +331,8 @@ public class MpscFetchBufferTests
 
         try
         {
-            _ = Assert.Throws<InvalidOperationException>(() =>
-                buffer.WaitToReadAsync(Timeout.Infinite, secondCts.Token));
+            var overlappingWait = buffer.WaitToReadAsync(Timeout.Infinite, secondCts.Token);
+            await Assert.That(await overlappingWait).IsFalse();
 
             await firstCts.CancelAsync();
             await Assert.That(async () => await firstWait)

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -270,6 +270,85 @@ public class MpscFetchBufferTests
     }
 
     [Test]
+    public async Task WaitToReadAsync_ConcurrentWait_DoesNotInvalidateActiveWait()
+    {
+        var buffer = new MpscFetchBuffer(4);
+        var item = CreateDummy();
+        var firstWait = buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None);
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None));
+            await Assert.That(exception.Message)
+                .IsEqualTo("MpscFetchBuffer supports only one active reader.");
+            await Assert.That(firstWait.IsCompleted).IsFalse();
+
+            await Assert.That(buffer.TryWrite(item)).IsTrue();
+            await Assert.That(await firstWait).IsTrue();
+            await Assert.That(buffer.TryRead(out var read)).IsTrue();
+            await Assert.That(read).IsSameReferenceAs(item);
+        }
+        finally
+        {
+            item.Dispose();
+            buffer.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task WaitToReadAsync_ConcurrentWaitAfterCompletion_DoesNotResetUnconsumedWait()
+    {
+        var buffer = new MpscFetchBuffer(4);
+        var firstWait = buffer.WaitToReadAsync(30_000, CancellationToken.None);
+
+        try
+        {
+            TriggerConsumerTimeout(buffer);
+            await TestWait.UntilAsync(() => firstWait.IsCompleted, TimeSpan.FromSeconds(5));
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None));
+            await Assert.That(exception.Message)
+                .IsEqualTo("MpscFetchBuffer supports only one active reader.");
+
+            await Assert.That(await firstWait).IsFalse();
+
+            var nextWait = buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None);
+            await Assert.That(nextWait.IsCompleted).IsFalse();
+            buffer.Complete();
+            await Assert.That(await nextWait).IsFalse();
+        }
+        finally
+        {
+            buffer.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task WaitToReadAsync_ConcurrentWait_DoesNotReplaceActiveCancellation()
+    {
+        var buffer = new MpscFetchBuffer(4);
+        using var firstCts = new CancellationTokenSource();
+        using var secondCts = new CancellationTokenSource();
+        var firstWait = buffer.WaitToReadAsync(Timeout.Infinite, firstCts.Token);
+
+        try
+        {
+            _ = Assert.Throws<InvalidOperationException>(() =>
+                buffer.WaitToReadAsync(Timeout.Infinite, secondCts.Token));
+
+            await firstCts.CancelAsync();
+            await Assert.That(async () => await firstWait)
+                .Throws<OperationCanceledException>();
+        }
+        finally
+        {
+            buffer.Dispose();
+        }
+    }
+
+    [Test]
     public async Task WaitToReadAsync_DataArrivesBeforePark_SkipsWaiter()
     {
         var item = CreateDummy();


### PR DESCRIPTION
## Summary

- claim the reusable fetch-buffer read waiter before cancellation registration
- return an allocation-free non-signaled result for an overlapping slow read instead of resetting the active `ManualResetValueTaskSourceCore`
- retain the claim until the active awaiter consumes completion in `GetResult`
- add deterministic coverage for pending, completed-but-unconsumed, and cancellation-registration races

Closes #2949

## Reproduction

Baseline `6b75383af` deterministically reproduced the report:

1. capture a pending `WaitToReadAsync` value task
2. start a second slow read before the first awaiter registers/consumes completion
3. query the first value task status
4. observe `InvalidOperationException: Operation is not valid due to the current state of the object.` from `ManualResetValueTaskSourceCore.GetStatus`

The second read reset the shared core and advanced its version. The previous `Debug.Assert` did not protect Release builds.

## Performance

BenchmarkDotNet 0.15.8, .NET 10.0.11, Windows 11, i7-12700K. Baseline `6b75383af`; exact final candidate `a66c5531b`. Same existing `[MemoryDiagnoser]` jobs and machine.

| Benchmark | Baseline | Candidate | Delta | Allocated |
|---|---:|---:|---:|---:|
| SignalPendingWait | 13.61 us | 10.88 us | -20.1% | 0 B -> 0 B |
| TimeoutAsync / None | 15.588 ms | 15.635 ms | +0.30% | 0 B -> 0 B |
| TimeoutAsync / Stable token | 15.610 ms | 15.602 ms | -0.05% | 0 B -> 0 B |
| TimeoutAsync / reset token | 15.589 ms | 15.593 ms | +0.03% | 0 B -> 0 B |

All timing confidence intervals overlap. Raw GC counts remain zero. No protected latency or allocation regression is demonstrated.

## Validation

- Release solution build: 0 warnings, 0 errors
- `MpscFetchBufferTests`: 36/36 passed
- full net10 unit suite, sequential: 8,683/8,683 passed on exact final candidate
- Kafka 4.0.2 `HostedServiceTests`: 8/8 passed on exact final candidate
- Kafka 4.0.2 `EmptyTopicConsumerTests`: 5/5 passed on exact final candidate
- `/simplify`: reviewed; retained explicit claim/finally lifecycle because every fast-return and error path must release ownership without changing the measured zero-allocation path

### Parallel-suite audit

The first default-parallel full-suite run passed 8,682 tests and failed unrelated `PooledCompletionSourceMetricsTests.ThrowingInlineContinuation_RecordsReleaseMetric`: its global `MeterListener` observed two producer metric emissions instead of one. The test passes 1/1 in isolation, confirming cross-test metric interference. The full suite then passed 8,683/8,683 with `--maximum-parallel-tests 1`; no failed job was blindly retried.