### PR TITLE
Persist hosted consumer discards in manual mode

### DIFF
--- a/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
+++ b/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
@@ -565,6 +565,18 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
 
         if (disposition == MessageFailureDisposition.Discard)
         {
+            // With automatic offset storage disabled, continuing the loop does not stage the
+            // discarded record. Store it explicitly so the next periodic or final commit makes
+            // the caller's discard decision durable.
+            if (_consumer is IConsumerCommitConfiguration
+                {
+                    EnableAutoOffsetStore: false,
+                    HasConsumerGroup: true
+                })
+            {
+                _consumer.StoreOffset(result);
+            }
+
             LogMessageDiscarded(result.Topic, result.Partition, result.Offset, failureCount, stage);
             return;
         }

--- a/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
+++ b/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
@@ -496,6 +496,7 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
                     .ConfigureAwait(false);
                 if (retryTopicOutcome.Result == RetryTopicRouteResult.Routed)
                 {
+                    StoreResolvedOffsetIfRequired(result);
                     return;
                 }
 
@@ -511,6 +512,7 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
                         .ConfigureAwait(false);
                     if (deadLetterException is null)
                     {
+                        StoreResolvedOffsetIfRequired(result);
                         return;
                     }
 
@@ -565,18 +567,7 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
 
         if (disposition == MessageFailureDisposition.Discard)
         {
-            // With automatic offset storage disabled, continuing the loop does not stage the
-            // discarded record. Store it explicitly so the next periodic or final commit makes
-            // the caller's discard decision durable.
-            if (_consumer is IConsumerCommitConfiguration
-                {
-                    EnableAutoOffsetStore: false,
-                    HasConsumerGroup: true
-                })
-            {
-                _consumer.StoreOffset(result);
-            }
-
+            StoreResolvedOffsetIfRequired(result);
             LogMessageDiscarded(result.Topic, result.Partition, result.Offset, failureCount, stage);
             return;
         }
@@ -587,6 +578,21 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
         }
 
         ExceptionDispatchInfo.Capture(routingException ?? processingException).Throw();
+    }
+
+    private void StoreResolvedOffsetIfRequired(ConsumeResult<TKey, TValue> result)
+    {
+        // Framework-resolved records never return to application code. In strict manual-store
+        // mode, stage them explicitly so the next commit makes the resolution
+        // durable and does not route or discard the same record again after restart.
+        if (_consumer is IConsumerCommitConfiguration
+            {
+                EnableAutoOffsetStore: false,
+                HasConsumerGroup: true
+            })
+        {
+            _consumer.StoreOffset(result);
+        }
     }
 
     private static int GetNextRetryTopicFailureCount(int previousFailureCount) => previousFailureCount + 1;

--- a/tests/Dekaf.Tests.Integration/HostedServiceTests.cs
+++ b/tests/Dekaf.Tests.Integration/HostedServiceTests.cs
@@ -651,6 +651,64 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task RoutedFailure_StrictManualModeNotRedeliveredOnRestart(bool useRetryTopic)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        var groupId = $"hosted-failure-route-{Guid.NewGuid():N}";
+        var attempts = new ConcurrentBag<string>();
+        var retryDelay = TimeSpan.FromHours(1);
+        var retryTopics = useRetryTopic
+            ? new RetryTopicOptions { Delays = [retryDelay] }
+            : null;
+        var deadLetterOptions = new DeadLetterOptions
+        {
+            BootstrapServers = KafkaContainer.BootstrapServers,
+            MaxFailures = useRetryTopic ? 2 : 1,
+            RetryTopics = retryTopics
+        };
+        var routedTopic = retryTopics?.GetRetryTopic(topic, retryDelay) ?? topic + ".DLQ";
+        await KafkaContainer.CreateTopicAsync(routedTopic, partitions: 1);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(topic, "k1", "fail-1", CancellationToken.None);
+        await producer.ProduceAsync(topic, "k2", "ok-1", CancellationToken.None);
+
+        await RunRoutedFailureServiceAsync(
+            topic,
+            groupId,
+            attempts,
+            deadLetterOptions,
+            stopWhen: () => attempts.Contains("ok-1"));
+
+        await using (var offsetProbe = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .BuildAsync())
+        {
+            var committed = await offsetProbe.GetCommittedOffsetAsync(
+                new TopicPartition(topic, 0), CancellationToken.None);
+            await Assert.That(committed).IsEqualTo(1);
+        }
+
+        await producer.ProduceAsync(topic, "k3", "ok-2", CancellationToken.None);
+
+        await RunRoutedFailureServiceAsync(
+            topic,
+            groupId,
+            attempts,
+            deadLetterOptions,
+            stopWhen: () => attempts.Contains("ok-2"));
+
+        await Assert.That(attempts.Count(value => value == "fail-1")).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ManualCommitMode_StoredOffsetsCommitted_DespiteInterruptedRecord()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
@@ -758,6 +816,39 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
             {
                 host.Dispose();
             }
+        }
+    }
+
+    private async Task RunRoutedFailureServiceAsync(
+        string topic,
+        string groupId,
+        ConcurrentBag<string> attempts,
+        DeadLetterOptions deadLetterOptions,
+        Func<bool> stopWhen)
+    {
+        var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithAutoOffsetStore(false)
+            .BuildAsync();
+        var service = new RoutingDurabilityConsumerService(
+            consumer,
+            GlobalTestSetup.GetLoggerFactory().CreateLogger<RoutingDurabilityConsumerService>(),
+            attempts,
+            new TestTopicHolder(topic),
+            deadLetterOptions);
+
+        try
+        {
+            await service.StartAsync(CancellationToken.None);
+            await WaitForConditionAsync(stopWhen, TimeSpan.FromSeconds(45));
+            await service.StopAsync(CancellationToken.None);
+        }
+        finally
+        {
+            await service.DisposeAsync();
         }
     }
 
@@ -1066,6 +1157,36 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
 
             _receivedMessages.Add(result.Value!);
             return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class RoutingDurabilityConsumerService : KafkaConsumerService<string, string>
+    {
+        private readonly ConcurrentBag<string> _attempts;
+        private readonly TestTopicHolder _topicHolder;
+
+        public RoutingDurabilityConsumerService(
+            IKafkaConsumer<string, string> consumer,
+            ILogger<RoutingDurabilityConsumerService> logger,
+            ConcurrentBag<string> attempts,
+            TestTopicHolder topicHolder,
+            DeadLetterOptions deadLetterOptions)
+            : base(consumer, logger, deadLetterOptions)
+        {
+            _attempts = attempts;
+            _topicHolder = topicHolder;
+        }
+
+        protected override IEnumerable<string> Topics => [_topicHolder.Topic];
+
+        protected override ValueTask ProcessAsync(
+            ConsumeResult<string, string> result,
+            CancellationToken cancellationToken)
+        {
+            _attempts.Add(result.Value!);
+            return result.Value?.StartsWith("fail-", StringComparison.Ordinal) == true
+                ? ValueTask.FromException(new InvalidOperationException($"Intentional failure for {result.Value}"))
+                : ValueTask.CompletedTask;
         }
     }
 

--- a/tests/Dekaf.Tests.Integration/HostedServiceTests.cs
+++ b/tests/Dekaf.Tests.Integration/HostedServiceTests.cs
@@ -564,7 +564,7 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
     }
 
     [Test]
-    public async Task UnhandledFailure_ExplicitDiscard_CommitsAndContinues()
+    public async Task UnhandledFailure_ExplicitDiscard_StrictManualModeNotRedeliveredOnRestart()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
         var groupId = $"hosted-failure-discard-{Guid.NewGuid():N}";
@@ -579,12 +579,13 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
             .BuildAsync();
 
         await producer.ProduceAsync(topic, "k1", "fail-1", CancellationToken.None);
-        await producer.ProduceAsync(topic, "k2", "ok-1", CancellationToken.None);
 
         var consumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithGroupId(groupId)
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithAutoOffsetStore(false)
             .BuildAsync();
         var service = new FailureDispositionConsumerService(
             consumer,
@@ -596,9 +597,7 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
         try
         {
             await service.StartAsync(CancellationToken.None);
-            await WaitForConditionAsync(
-                () => processed.Contains("ok-1") && failure.FailureObserved.Task.IsCompleted,
-                TimeSpan.FromSeconds(45));
+            await failure.FailureObserved.Task.WaitAsync(TimeSpan.FromSeconds(45));
             await service.StopAsync(CancellationToken.None);
         }
         finally
@@ -613,11 +612,42 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
         var committed = await offsetProbe.GetCommittedOffsetAsync(
             new TopicPartition(topic, 0), CancellationToken.None);
 
-        await Assert.That(committed).IsEqualTo(2);
+        await Assert.That(committed).IsEqualTo(1);
         await Assert.That(processed).DoesNotContain("fail-1");
-        await Assert.That(processed).Contains("ok-1");
         await Assert.That(failure.Context).IsNotNull();
         await Assert.That(failure.Context!.Value.Result.Offset).IsEqualTo(0);
+
+        await producer.ProduceAsync(topic, "k2", "ok-1", CancellationToken.None);
+
+        var restartFailure = new FailureDispositionHolder(
+            failOnce: false,
+            disposition: MessageFailureDisposition.Discard);
+        var restartConsumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithAutoOffsetStore(false)
+            .BuildAsync();
+        var restartService = new FailureDispositionConsumerService(
+            restartConsumer,
+            GlobalTestSetup.GetLoggerFactory().CreateLogger<FailureDispositionConsumerService>(),
+            processed,
+            new TestTopicHolder(topic),
+            restartFailure);
+
+        try
+        {
+            await restartService.StartAsync(CancellationToken.None);
+            await WaitForConditionAsync(() => processed.Contains("ok-1"), TimeSpan.FromSeconds(45));
+            await restartService.StopAsync(CancellationToken.None);
+        }
+        finally
+        {
+            await restartService.DisposeAsync();
+        }
+
+        await Assert.That(restartFailure.Context).IsNull();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
@@ -160,18 +160,23 @@ public sealed class KafkaConsumerServiceTests
     public async Task ProcessWithRetriesAsync_UnhandledFailure_ExplicitDiscardContinues()
     {
         var consumer = CreateConsumerSubstitute();
+        var configuration = (IConsumerOffsetStoreTimingConfiguration)consumer;
+        configuration.OffsetCommitMode.Returns(OffsetCommitMode.Manual);
+        configuration.EnableAutoOffsetStore.Returns(false);
         var service = new FailingConsumerService(
             consumer,
             ["orders"],
             failureDisposition: MessageFailureDisposition.Discard);
+        var result = CreateResult("orders", partition: 1, offset: 42);
 
         await ProcessWithRetriesAsync(
             service,
-            CreateResult("orders", partition: 1, offset: 42),
+            result,
             CancellationToken.None);
 
         await Assert.That(service.FailureContexts).Count().IsEqualTo(1);
         await Assert.That(service.FailureContexts[0].Stage).IsEqualTo(MessageFailureStage.Processing);
+        consumer.Received(1).StoreOffset(result);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
@@ -160,9 +160,7 @@ public sealed class KafkaConsumerServiceTests
     public async Task ProcessWithRetriesAsync_UnhandledFailure_ExplicitDiscardContinues()
     {
         var consumer = CreateConsumerSubstitute();
-        var configuration = (IConsumerOffsetStoreTimingConfiguration)consumer;
-        configuration.OffsetCommitMode.Returns(OffsetCommitMode.Manual);
-        configuration.EnableAutoOffsetStore.Returns(false);
+        ConfigureStrictManualOffsetStore(consumer);
         var service = new FailingConsumerService(
             consumer,
             ["orders"],
@@ -176,6 +174,53 @@ public sealed class KafkaConsumerServiceTests
 
         await Assert.That(service.FailureContexts).Count().IsEqualTo(1);
         await Assert.That(service.FailureContexts[0].Stage).IsEqualTo(MessageFailureStage.Processing);
+        consumer.Received(1).StoreOffset(result);
+    }
+
+    [Test]
+    public async Task ProcessWithRetriesAsync_DeadLetterRouted_StrictManualModeStoresOffset()
+    {
+        var consumer = CreateConsumerSubstitute();
+        ConfigureStrictManualOffsetStore(consumer);
+        var producer = Substitute.For<IKafkaProducer<byte[]?, byte[]?>>();
+        producer.ProduceAsync(Arg.Any<ProducerMessage<byte[]?, byte[]?>>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<RecordMetadata>(default(RecordMetadata)));
+        var service = new FailingConsumerService(
+            consumer,
+            ["orders"],
+            deadLetterOptions: new DeadLetterOptions());
+        SetDlqProducer(service, producer);
+        var result = CreateResult("orders", partition: 1, offset: 42);
+
+        await ProcessWithRetriesAsync(service, result, CancellationToken.None);
+
+        consumer.Received(1).StoreOffset(result);
+    }
+
+    [Test]
+    public async Task ProcessWithRetriesAsync_RetryTopicRouted_StrictManualModeStoresOffset()
+    {
+        var consumer = CreateConsumerSubstitute();
+        ConfigureStrictManualOffsetStore(consumer);
+        var producer = Substitute.For<IKafkaProducer<byte[]?, byte[]?>>();
+        producer.ProduceAsync(Arg.Any<ProducerMessage<byte[]?, byte[]?>>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<RecordMetadata>(default(RecordMetadata)));
+        var service = new FailingConsumerService(
+            consumer,
+            ["orders"],
+            deadLetterOptions: new DeadLetterOptions
+            {
+                MaxFailures = 2,
+                RetryTopics = new RetryTopicOptions
+                {
+                    Delays = [TimeSpan.FromSeconds(5)]
+                }
+            });
+        SetDlqProducer(service, producer);
+        var result = CreateResult("orders", partition: 1, offset: 42);
+
+        await ProcessWithRetriesAsync(service, result, CancellationToken.None);
+
         consumer.Received(1).StoreOffset(result);
     }
 
@@ -1162,6 +1207,13 @@ public sealed class KafkaConsumerServiceTests
         configuration.HasConsumerGroup.Returns(true);
         configuration.StoresOffsetsOnDelivery.Returns(false);
         return consumer;
+    }
+
+    private static void ConfigureStrictManualOffsetStore(IKafkaConsumer<string, string> consumer)
+    {
+        var configuration = (IConsumerOffsetStoreTimingConfiguration)consumer;
+        configuration.OffsetCommitMode.Returns(OffsetCommitMode.Manual);
+        configuration.EnableAutoOffsetStore.Returns(false);
     }
 
     private static async Task AssertHiddenOffsetTimingRejectedAsync(

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/HostedConsumerProcessingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/HostedConsumerProcessingBenchmarks.cs
@@ -104,3 +104,86 @@ public class HostedConsumerProcessingBenchmarks
         }
     }
 }
+
+/// <summary>Measures durable discard handling in strict manual offset-store mode.</summary>
+[MemoryDiagnoser(displayGenColumns: false)]
+[ShortRunJob]
+[InvocationCount(256)]
+public class HostedConsumerDiscardBenchmarks
+{
+    private const int Operations = 1024;
+    private readonly ConsumeResult<string, string> _result = new(
+        topic: "orders",
+        partition: 1,
+        offset: 42,
+        keyData: default,
+        isKeyNull: true,
+        valueData: default,
+        isValueNull: true,
+        headers: null,
+        timestampMs: 0,
+        timestampType: TimestampType.NotAvailable,
+        leaderEpoch: null,
+        keyDeserializer: null,
+        valueDeserializer: null);
+    private DiscardingConsumerService _before = null!;
+    private DiscardingConsumerService _after = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _before = CreateService(enableAutoOffsetStore: true);
+        _after = CreateService(enableAutoOffsetStore: false);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = Operations)]
+    public async ValueTask Before_DiscardWithoutExplicitStore()
+    {
+        for (var index = 0; index < Operations; index++)
+            await _before.ProcessWithRetriesAsync(_result, CancellationToken.None).ConfigureAwait(false);
+    }
+
+    [Benchmark(OperationsPerInvoke = Operations)]
+    public async ValueTask After_StrictManualDiscardWithStore()
+    {
+        for (var index = 0; index < Operations; index++)
+            await _after.ProcessWithRetriesAsync(_result, CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private static DiscardingConsumerService CreateService(bool enableAutoOffsetStore)
+    {
+        var consumer = new InMemoryConsumer<string, string>(
+            new InMemoryKafkaCluster(),
+            new InMemoryConsumerOptions
+            {
+                GroupId = "hosted-discard-benchmark",
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                EnableAutoOffsetStore = enableAutoOffsetStore
+            });
+        return new DiscardingConsumerService(consumer);
+    }
+
+    private sealed class DiscardingConsumerService(IKafkaConsumer<string, string> consumer)
+        : KafkaConsumerService<string, string>(consumer, NullLogger.Instance)
+    {
+        private static readonly InvalidOperationException Failure = new("Invalid record");
+
+        protected override IEnumerable<string> Topics => ["orders"];
+
+        protected override ValueTask ProcessAsync(
+            ConsumeResult<string, string> result,
+            CancellationToken cancellationToken)
+            => throw Failure;
+
+        protected override ValueTask OnErrorAsync(
+            Exception exception,
+            ConsumeResult<string, string>? result,
+            CancellationToken cancellationToken)
+            => ValueTask.CompletedTask;
+
+        protected override ValueTask<MessageFailureDisposition> GetFailureDispositionAsync(
+            MessageFailureContext<string, string> context,
+            CancellationToken cancellationToken)
+            => new(MessageFailureDisposition.Discard);
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/HostedConsumerProcessingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/HostedConsumerProcessingBenchmarks.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
-/// <summary>Measures the complete hosted-consumer processing chain for asynchronously completed handlers.</summary>
+/// <summary>Measures the complete hosted-consumer processing chain before and after wrapper removal.</summary>
 [MemoryDiagnoser(displayGenColumns: false)]
 [ShortRunJob]
 public class HostedConsumerProcessingBenchmarks
@@ -26,8 +26,11 @@ public class HostedConsumerProcessingBenchmarks
         leaderEpoch: null,
         keyDeserializer: null,
         valueDeserializer: null);
-    private AsyncConsumerService _service = null!;
+    private ConsumerService _service = null!;
     private bool _hasInDoubtFailedRecord;
+
+    [Params(false, true)]
+    public bool HandlerSuspends { get; set; }
 
     [GlobalSetup]
     public void Setup()
@@ -39,11 +42,11 @@ public class HostedConsumerProcessingBenchmarks
                 OffsetCommitMode = OffsetCommitMode.Manual,
                 EnableAutoOffsetStore = false
             });
-        _service = new AsyncConsumerService(consumer);
+        _service = new ConsumerService(consumer, HandlerSuspends);
     }
 
     [Benchmark(Baseline = true, OperationsPerInvoke = Operations)]
-    public async ValueTask<bool> AdditionalAsyncWrapper()
+    public async ValueTask<bool> Before_AdditionalAsyncWrapper()
     {
         for (var index = 0; index < Operations; index++)
             await ProcessTrackingInDoubtAsync(_result).ConfigureAwait(false);
@@ -52,7 +55,7 @@ public class HostedConsumerProcessingBenchmarks
     }
 
     [Benchmark(OperationsPerInvoke = Operations)]
-    public async ValueTask<bool> ExistingLoopStateMachine()
+    public async ValueTask<bool> After_ExistingLoopStateMachine()
     {
         for (var index = 0; index < Operations; index++)
         {
@@ -83,14 +86,19 @@ public class HostedConsumerProcessingBenchmarks
         }
     }
 
-    private sealed class AsyncConsumerService(IKafkaConsumer<string, string> consumer)
+    private sealed class ConsumerService(
+        IKafkaConsumer<string, string> consumer,
+        bool handlerSuspends)
         : KafkaConsumerService<string, string>(consumer, NullLogger.Instance)
     {
         protected override IEnumerable<string> Topics => ["orders"];
 
-        protected override async ValueTask ProcessAsync(
+        protected override ValueTask ProcessAsync(
             ConsumeResult<string, string> result,
             CancellationToken cancellationToken)
+            => handlerSuspends ? SuspendAsync() : ValueTask.CompletedTask;
+
+        private static async ValueTask SuspendAsync()
         {
             await Task.Yield();
         }


### PR DESCRIPTION
Follow-up to #2956 after a late CodeRabbit review identified that explicit MessageFailureDisposition.Discard was not durable when automatic offset storage was disabled.

- Stage the discarded record offset for grouped consumers with automatic storage disabled.
- Add unit coverage for strict manual mode.
- Add a real-Kafka restart regression proving the failed record is not redelivered.
- Extend the hosted processing MemoryDiagnoser benchmark to cover the synchronous 0 B fast path and genuinely suspending handlers.

Validation:
- Unit tests: 8,690/8,690 passed.
- Hosted unhandled-failure integration tests: 2/2 passed.
- Builds: unit, integration, and benchmark projects; 0 warnings/errors.
- 15-iteration benchmark: sync 36.39 ns / 0 B before -> 27.07 ns / 0 B after; suspended 943.17 ns / 621 B before -> 782.30 ns / 414 B after.

Addresses the late review at thomhurst/Dekaf#2956.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved messages routed to retry topics, sent to the dead-letter queue, or explicitly discarded are now committed correctly in strict manual offset mode.
  * Prevented resolved messages from being redelivered after a service restart.

* **Tests**
  * Added coverage for durable offset handling across retry, dead-letter, and discard scenarios.

* **Benchmarks**
  * Added performance comparisons for consumer processing and discard handling under different offset-store configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->