### PR TITLE
Honor explicit BenchmarkDotNet jobs

### DIFF
--- a/tests/Dekaf.Tests.Unit/Benchmarks/BenchmarkJobSelectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Benchmarks/BenchmarkJobSelectionTests.cs
@@ -1,0 +1,37 @@
+using Dekaf.Benchmarks.Infrastructure;
+
+namespace Dekaf.Tests.Unit.Benchmarks;
+
+public sealed class BenchmarkJobSelectionTests
+{
+    [Test]
+    public async Task GetExplicitJob_SeparatedOptions_ResolvesJob()
+    {
+        await Assert.That(BenchmarkJobSelection.GetExplicitJob(["--filter", "*Producer*", "--job", "dry"]))
+            .IsEqualTo(BenchmarkJob.Dry);
+        await Assert.That(BenchmarkJobSelection.GetExplicitJob(["-j", "Short"]))
+            .IsEqualTo(BenchmarkJob.Short);
+    }
+
+    [Test]
+    public async Task GetExplicitJob_EqualsOptions_ResolvesJob()
+    {
+        await Assert.That(BenchmarkJobSelection.GetExplicitJob(["--job=Medium"]))
+            .IsEqualTo(BenchmarkJob.Medium);
+        await Assert.That(BenchmarkJobSelection.GetExplicitJob(["-j=Long"]))
+            .IsEqualTo(BenchmarkJob.Long);
+        await Assert.That(BenchmarkJobSelection.GetExplicitJob(["--job=Default"]))
+            .IsEqualTo(BenchmarkJob.Default);
+    }
+
+    [Test]
+    public async Task GetExplicitJob_MissingOrInvalidValue_ReturnsNull()
+    {
+        await Assert.That(BenchmarkJobSelection.GetExplicitJob(["--filter", "*Producer*"]))
+            .IsNull();
+        await Assert.That(BenchmarkJobSelection.GetExplicitJob(["--job"]))
+            .IsNull();
+        await Assert.That(BenchmarkJobSelection.GetExplicitJob(["--job=Unknown"]))
+            .IsNull();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Benchmarks/BenchmarkJobSelectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Benchmarks/BenchmarkJobSelectionTests.cs
@@ -20,6 +20,8 @@ public sealed class BenchmarkJobSelectionTests
             .IsEqualTo(BenchmarkJob.Medium);
         await Assert.That(BenchmarkJobSelection.GetExplicitJob(["-j=Long"]))
             .IsEqualTo(BenchmarkJob.Long);
+        await Assert.That(BenchmarkJobSelection.GetExplicitJob(["--job=VeryLong"]))
+            .IsEqualTo(BenchmarkJob.VeryLong);
         await Assert.That(BenchmarkJobSelection.GetExplicitJob(["--job=Default"]))
             .IsEqualTo(BenchmarkJob.Default);
     }

--- a/tests/Dekaf.Tests.Unit/Benchmarks/BenchmarkJobSelectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Benchmarks/BenchmarkJobSelectionTests.cs
@@ -57,4 +57,24 @@ public sealed class BenchmarkJobSelectionTests
             File.Delete(responseFile);
         }
     }
+
+    [Test]
+    public async Task ExpandResponseFiles_QuotedPath_PreservesBenchmarkDotNetWorkaround()
+    {
+        var responseFile = Path.GetTempFileName();
+        var artifactsPath = Path.Combine(Path.GetTempPath(), "benchmark results");
+        try
+        {
+            await File.WriteAllTextAsync(responseFile, $"--artifacts \"{artifactsPath}\" --job Dry");
+
+            var arguments = BenchmarkJobSelection.ExpandResponseFiles([$"@{responseFile}"]);
+
+            await Assert.That(arguments.SequenceEqual(
+                ["--artifacts", $" {artifactsPath}", "--job", "Dry"])).IsTrue();
+        }
+        finally
+        {
+            File.Delete(responseFile);
+        }
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Benchmarks/BenchmarkJobSelectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Benchmarks/BenchmarkJobSelectionTests.cs
@@ -34,4 +34,25 @@ public sealed class BenchmarkJobSelectionTests
         await Assert.That(BenchmarkJobSelection.GetExplicitJob(["--job=Unknown"]))
             .IsNull();
     }
+
+    [Test]
+    [Arguments("--job Dry")]
+    [Arguments("--job=Dry")]
+    public async Task ExpandResponseFiles_JobOption_ResolvesExplicitJob(string contents)
+    {
+        var responseFile = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(responseFile, contents);
+
+            var arguments = BenchmarkJobSelection.ExpandResponseFiles([$"@{responseFile}"]);
+
+            await Assert.That(BenchmarkJobSelection.GetExplicitJob(arguments))
+                .IsEqualTo(BenchmarkJob.Dry);
+        }
+        finally
+        {
+            File.Delete(responseFile);
+        }
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -6,6 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\tools\Dekaf.Benchmarks\Infrastructure\BenchmarkJobSelection.cs"
+             Link="Benchmarks\BenchmarkJobSelection.cs" />
     <ProjectReference Include="..\..\src\Dekaf\Dekaf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Snappy\Dekaf.Compression.Snappy.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj" />

--- a/tools/Dekaf.Benchmarks/Infrastructure/BenchmarkJobSelection.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/BenchmarkJobSelection.cs
@@ -1,0 +1,42 @@
+namespace Dekaf.Benchmarks.Infrastructure;
+
+internal enum BenchmarkJob
+{
+    Dry,
+    Short,
+    Medium,
+    Long,
+    Default
+}
+
+internal static class BenchmarkJobSelection
+{
+    internal static BenchmarkJob? GetExplicitJob(string[] arguments)
+    {
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var argument = arguments[i];
+            if (argument is "-j" or "--job")
+                return i + 1 < arguments.Length ? Resolve(arguments[i + 1]) : null;
+
+            const string longPrefix = "--job=";
+            const string shortPrefix = "-j=";
+            if (argument.StartsWith(longPrefix, StringComparison.OrdinalIgnoreCase))
+                return Resolve(argument[longPrefix.Length..]);
+            if (argument.StartsWith(shortPrefix, StringComparison.OrdinalIgnoreCase))
+                return Resolve(argument[shortPrefix.Length..]);
+        }
+
+        return null;
+    }
+
+    private static BenchmarkJob? Resolve(string value) => value.ToUpperInvariant() switch
+    {
+        "DRY" => BenchmarkJob.Dry,
+        "SHORT" => BenchmarkJob.Short,
+        "MEDIUM" => BenchmarkJob.Medium,
+        "LONG" => BenchmarkJob.Long,
+        "DEFAULT" => BenchmarkJob.Default,
+        _ => null
+    };
+}

--- a/tools/Dekaf.Benchmarks/Infrastructure/BenchmarkJobSelection.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/BenchmarkJobSelection.cs
@@ -8,6 +8,7 @@ internal enum BenchmarkJob
     Short,
     Medium,
     Long,
+    VeryLong,
     Default
 }
 
@@ -57,6 +58,7 @@ internal static class BenchmarkJobSelection
         "SHORT" => BenchmarkJob.Short,
         "MEDIUM" => BenchmarkJob.Medium,
         "LONG" => BenchmarkJob.Long,
+        "VERYLONG" => BenchmarkJob.VeryLong,
         "DEFAULT" => BenchmarkJob.Default,
         _ => null
     };

--- a/tools/Dekaf.Benchmarks/Infrastructure/BenchmarkJobSelection.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/BenchmarkJobSelection.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace Dekaf.Benchmarks.Infrastructure;
 
 internal enum BenchmarkJob
@@ -11,6 +13,25 @@ internal enum BenchmarkJob
 
 internal static class BenchmarkJobSelection
 {
+    internal static string[] ExpandResponseFiles(string[] arguments)
+    {
+        var expanded = new List<string>(arguments.Length);
+
+        foreach (var argument in arguments)
+        {
+            if (argument is not ['@', .. var path] || !File.Exists(path))
+            {
+                expanded.Add(argument);
+                continue;
+            }
+
+            foreach (var line in File.ReadAllLines(path))
+                expanded.AddRange(ConsumeTokens(line));
+        }
+
+        return expanded.ToArray();
+    }
+
     internal static BenchmarkJob? GetExplicitJob(string[] arguments)
     {
         for (var i = 0; i < arguments.Length; i++)
@@ -39,4 +60,60 @@ internal static class BenchmarkJobSelection
         "DEFAULT" => BenchmarkJob.Default,
         _ => null
     };
+
+    // Mirrors BenchmarkDotNet's ConfigParser response-file tokenization.
+    private static IEnumerable<string> ConsumeTokens(string line)
+    {
+        var insideQuotes = false;
+        var token = new StringBuilder();
+
+        for (var i = 0; i < line.Length; i++)
+        {
+            var character = line[i];
+            if (character == ' ' && !insideQuotes)
+            {
+                if (token.Length > 0)
+                {
+                    yield return GetToken(token);
+                    token.Clear();
+                }
+
+                continue;
+            }
+
+            if (character == '"')
+            {
+                insideQuotes = !insideQuotes;
+                continue;
+            }
+
+            if (character == '\\' && insideQuotes && i + 1 < line.Length)
+            {
+                if (line[i + 1] == '"')
+                {
+                    insideQuotes = false;
+                    i++;
+                    continue;
+                }
+
+                if (line[i + 1] == '\\')
+                {
+                    token.Append('\\');
+                    i++;
+                    continue;
+                }
+            }
+
+            token.Append(character);
+        }
+
+        if (token.Length > 0)
+            yield return GetToken(token);
+
+        static string GetToken(StringBuilder tokenBuilder)
+        {
+            var value = tokenBuilder.ToString();
+            return value.Contains(' ') ? $" {value}" : value;
+        }
+    }
 }

--- a/tools/Dekaf.Benchmarks/Program.cs
+++ b/tools/Dekaf.Benchmarks/Program.cs
@@ -9,18 +9,19 @@ var config = DefaultConfig.Instance
 
 if (BenchmarkJobSelection.GetExplicitJob(args) is { } selectedJob)
 {
-    var jobId = selectedJob switch
+    var job = selectedJob switch
     {
-        BenchmarkJob.Dry => Job.Dry.ResolvedId,
-        BenchmarkJob.Short => Job.ShortRun.ResolvedId,
-        BenchmarkJob.Medium => Job.MediumRun.ResolvedId,
-        BenchmarkJob.Long => Job.LongRun.ResolvedId,
-        BenchmarkJob.Default => Job.Default.ResolvedId,
+        BenchmarkJob.Dry => Job.Dry,
+        BenchmarkJob.Short => Job.ShortRun,
+        BenchmarkJob.Medium => Job.MediumRun,
+        BenchmarkJob.Long => Job.LongRun,
+        BenchmarkJob.Default => Job.Default,
         _ => throw new System.Diagnostics.UnreachableException()
     };
 
+    config = config.AddJob(job);
     config = config.AddFilter(new SimpleFilter(benchmarkCase =>
-        string.Equals(benchmarkCase.Job.ResolvedId, jobId, StringComparison.Ordinal)));
+        string.Equals(benchmarkCase.Job.ResolvedId, job.ResolvedId, StringComparison.Ordinal)));
 }
 
 // Pass all arguments to BenchmarkSwitcher for flexible filtering

--- a/tools/Dekaf.Benchmarks/Program.cs
+++ b/tools/Dekaf.Benchmarks/Program.cs
@@ -1,6 +1,8 @@
+using BenchmarkDotNet.ConsoleArguments;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Filters;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
 using Dekaf.Benchmarks.Infrastructure;
 
@@ -10,19 +12,31 @@ var benchmarkArguments = BenchmarkJobSelection.ExpandResponseFiles(args);
 
 if (BenchmarkJobSelection.GetExplicitJob(benchmarkArguments) is { } selectedJob)
 {
-    var job = selectedJob switch
+    var baseJob = selectedJob switch
     {
         BenchmarkJob.Dry => Job.Dry,
         BenchmarkJob.Short => Job.ShortRun,
         BenchmarkJob.Medium => Job.MediumRun,
         BenchmarkJob.Long => Job.LongRun,
+        BenchmarkJob.VeryLong => Job.VeryLongRun,
         BenchmarkJob.Default => Job.Default,
         _ => throw new System.Diagnostics.UnreachableException()
     };
 
-    config = config.AddJob(job);
-    config = config.AddFilter(new SimpleFilter(benchmarkCase =>
-        string.Equals(benchmarkCase.Job.ResolvedId, job.ResolvedId, StringComparison.Ordinal)));
+    var (parsed, commandLineConfig, _) = ConfigParser.Parse(benchmarkArguments, NullLogger.Instance);
+    var configuredJobs = parsed ? commandLineConfig.GetJobs().ToArray() : [];
+
+    // BenchmarkDotNet applies customized CLI jobs as mutators to class jobs, so injecting the
+    // unmodified preset in that case would duplicate cases and discard the requested settings.
+    if (parsed && configuredJobs.All(job => !job.Meta.IsMutator))
+    {
+        var jobs = configuredJobs.Length == 0 ? [baseJob] : configuredJobs;
+        var jobIds = jobs.Select(job => job.ResolvedId).ToHashSet(StringComparer.Ordinal);
+
+        config = config.AddJob(jobs);
+        config = config.AddFilter(new SimpleFilter(benchmarkCase =>
+            jobIds.Contains(benchmarkCase.Job.ResolvedId)));
+    }
 }
 
 // Pass all arguments to BenchmarkSwitcher for flexible filtering

--- a/tools/Dekaf.Benchmarks/Program.cs
+++ b/tools/Dekaf.Benchmarks/Program.cs
@@ -1,14 +1,34 @@
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Filters;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
+using Dekaf.Benchmarks.Infrastructure;
 
 var config = DefaultConfig.Instance
     .WithOptions(ConfigOptions.DisableOptimizationsValidator);
+
+if (BenchmarkJobSelection.GetExplicitJob(args) is { } selectedJob)
+{
+    var jobId = selectedJob switch
+    {
+        BenchmarkJob.Dry => Job.Dry.ResolvedId,
+        BenchmarkJob.Short => Job.ShortRun.ResolvedId,
+        BenchmarkJob.Medium => Job.MediumRun.ResolvedId,
+        BenchmarkJob.Long => Job.LongRun.ResolvedId,
+        BenchmarkJob.Default => Job.Default.ResolvedId,
+        _ => throw new System.Diagnostics.UnreachableException()
+    };
+
+    config = config.AddFilter(new SimpleFilter(benchmarkCase =>
+        string.Equals(benchmarkCase.Job.ResolvedId, jobId, StringComparison.Ordinal)));
+}
 
 // Pass all arguments to BenchmarkSwitcher for flexible filtering
 // Examples:
 //   dotnet run -c Release -- --filter "*Unit*"     (run unit benchmarks)
 //   dotnet run -c Release -- --filter "*Client*"   (run client benchmarks)
 //   dotnet run -c Release -- --filter "*Producer*" (run producer benchmarks)
+//   dotnet run -c Release -- --filter "*Producer*" --job Dry (override class jobs)
 //   dotnet run -c Release                          (run all benchmarks)
 
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly)

--- a/tools/Dekaf.Benchmarks/Program.cs
+++ b/tools/Dekaf.Benchmarks/Program.cs
@@ -6,8 +6,9 @@ using Dekaf.Benchmarks.Infrastructure;
 
 var config = DefaultConfig.Instance
     .WithOptions(ConfigOptions.DisableOptimizationsValidator);
+var benchmarkArguments = BenchmarkJobSelection.ExpandResponseFiles(args);
 
-if (BenchmarkJobSelection.GetExplicitJob(args) is { } selectedJob)
+if (BenchmarkJobSelection.GetExplicitJob(benchmarkArguments) is { } selectedJob)
 {
     var job = selectedJob switch
     {
@@ -33,4 +34,4 @@ if (BenchmarkJobSelection.GetExplicitJob(args) is { } selectedJob)
 //   dotnet run -c Release                          (run all benchmarks)
 
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly)
-    .Run(args, config);
+    .Run(benchmarkArguments, config);


### PR DESCRIPTION
## Summary

- make explicit BenchmarkDotNet `-j` / `--job` presets override class-level jobs
- support direct and `@response-file` arguments in separated and `=` forms
- support Default, Dry, Short, Medium, Long, and VeryLong
- preserve CLI job customizations and class diagnosers, including `MemoryDiagnoser`
- preserve existing class jobs when no CLI job is supplied

## Why

BenchmarkDotNet unions an explicit preset with `[SimpleJob]` and `[Config]` jobs. A diagnostic command such as `--job Dry` therefore also ran the class's normal job, doubling cases, mixing result shapes, and wasting iteration time.

## Performance evidence

Exact local A/B on Windows 11, .NET SDK 10.0.400, BenchmarkDotNet 0.15.8:

```text
dotnet run --project tools/Dekaf.Benchmarks --configuration Release -- \
  --filter '*ValueTaskContinuationBenchmarks*' --job Dry
```

| Metric | Baseline `eaa54e575` | Candidate `fc5bf1402` | Delta |
|---|---:|---:|---:|
| Discovered/executed cases | 4 | 2 | -50.0% |
| Wall time | 51.849 s | 33.370 s | -35.6% |
| Unrequested class-job cases | 2 | 0 | -100% |
| Requested Dry cases | 2 | 2 | unchanged |
| `MemoryDiagnoser` output | present | present | unchanged |

Additional controls:

- config-backed `TransactionalProduceAllocationBenchmarks --job Dry`: 32 cases (16 class + 16 Dry) -> 16 Dry-only; allocation columns retained
- `@jobs.rsp` containing `--job Dry`: 4 cases / 47.20 s -> 2 Dry cases / 36.18 s; `MemoryDiagnoser` retained
- `--job Dry --iterationCount 5 --warmupCount 1`: 4 duplicate cases before modifier fix -> 2 cases; executed job retained `IterationCount=5`, `RunStrategy=ColdStart`, and `WarmupCount=1`
- `--job=Short`: 2 ShortRun cases only
- no-job control: original 2 class-job cases only

## Validation

- benchmark and unit builds: 0 warnings, 0 errors
- focused job-selection tests: 5/5 passed
- full unit suite: 8,702/8,702 passed
- `git diff --check`: clean

No `src/` code changes; producer stress validation is not applicable.