### PR TITLE
Revert Reservoir 1.5.0 upgrade (perf regression)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,7 +52,7 @@
     <PackageVersion Include="OpenTelemetry.Api" Version="1.18.0" />
     <PackageVersion Include="Polyfill" Version="11.2.0" />
     <PackageVersion Include="protobuf-net.Reflection" Version="3.4.21" />
-    <PackageVersion Include="Reservoir" Version="1.5.0" />
+    <PackageVersion Include="Reservoir" Version="1.4.0" />
     <PackageVersion Include="SharpFuzz" Version="2.3.0" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="SSH.NET" Version="2026.0.0" />

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -5088,9 +5088,8 @@ internal sealed class PooledResponseMemory : IPooledMemory
 }
 
 /// <summary>
-/// Thread-safe pool for <see cref="PooledPendingRequest"/> instances.
-/// Uses Reservoir's bounded, preallocated shared storage and thread-local fast path for
-/// zero-allocation rent and return.
+/// Thread-safe bounded pool for <see cref="PooledPendingRequest"/> instances.
+/// Uses Reservoir's bounded, preallocated storage for zero-allocation rent and return.
 /// </summary>
 internal sealed class PendingRequestPool
 {
@@ -5123,7 +5122,7 @@ internal sealed class PendingRequestPool
 
     /// <summary>
     /// Returns a <see cref="PooledPendingRequest"/> to the pool for reuse.
-    /// If both the returning thread's slot and the shared tier are full, the instance is discarded.
+    /// If the pool is full, the instance is discarded.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Return(PooledPendingRequest request)

--- a/src/Dekaf/Networking/PipeMemoryPool.cs
+++ b/src/Dekaf/Networking/PipeMemoryPool.cs
@@ -45,11 +45,10 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
     private int _disposed;
 
     /// <summary>
-    /// Maximum number of <see cref="PooledMemoryOwner"/> wrapper objects retained by the shared tier.
+    /// Maximum number of <see cref="PooledMemoryOwner"/> wrapper objects to retain.
     /// Each connection's <see cref="ResponseFrameReader"/> holds one receive buffer for the
     /// connection's lifetime; 64 covers peak connection counts and reconnect churn with
-    /// headroom. Each participating thread may retain one additional wrapper; returned wrappers
-    /// hold no byte array, so the extra thread-local retention is small.
+    /// headroom, while bounding retained wrapper objects to ~2 KB total.
     /// </summary>
     private const int MaxOwnerPoolSize = 64;
 

--- a/src/Dekaf/Producer/ObjectPool.cs
+++ b/src/Dekaf/Producer/ObjectPool.cs
@@ -4,15 +4,14 @@ using Dekaf.Internal;
 namespace Dekaf.Producer;
 
 /// <summary>
-/// Thread-safe object pool backed by Reservoir.
-/// Provides pre-warming, retained-count diagnostics, dynamic shared-capacity ratcheting,
-/// a thread-local fast path, and miss tracking for Dekaf's pooled producer and protocol objects.
+/// Thread-safe bounded object pool backed by Reservoir.
+/// Provides pre-warming, retained-count diagnostics, dynamic capacity ratcheting,
+/// and miss tracking for Dekaf's pooled producer and protocol objects.
 /// </summary>
 /// <remarks>
 /// Subclasses implement <see cref="Create"/> to produce new items and <see cref="Reset"/>
 /// to prepare returned items for reuse. Reservoir supplies fixed-capacity, zero-allocation
-/// shared storage specialized for small and large pools. By default, each participating thread
-/// may retain one additional item for faster same-thread reuse.
+/// storage specialized for small and large pools.
 /// </remarks>
 /// <typeparam name="T">Pooled reference type.</typeparam>
 internal abstract class ObjectPool<T> where T : class
@@ -21,12 +20,11 @@ internal abstract class ObjectPool<T> where T : class
     private PoolState _poolState;
     private PoolState? _retiredPool;
     private readonly Lock _resizeLock = new();
-    private readonly bool _threadLocalFastPath;
     private int _maxPoolSize;
     private int _retainedCount;
     private long _misses;
 
-    /// <summary>Maximum number of items retained by the shared tier.</summary>
+    /// <summary>Maximum number of items retained.</summary>
     public int MaxPoolSize => Volatile.Read(ref _maxPoolSize);
 
     /// <summary>
@@ -34,19 +32,18 @@ internal abstract class ObjectPool<T> where T : class
     /// Reservoir remains the sole authority for retention decisions.
     /// </summary>
     /// <remarks>
-    /// Includes both shared and thread-local retained items. Concurrent rents, returns, and pool
-    /// replacement can make this value transiently inaccurate. Do not use it as a correctness
-    /// gate or expect pre-warming during concurrent use to reach an exact retained count.
+    /// Concurrent rents, returns, and pool replacement can make this value transiently
+    /// inaccurate. Do not use it as a correctness gate or expect pre-warming during concurrent
+    /// use to reach an exact retained count.
     /// </remarks>
     public int ApproximateCount => Volatile.Read(ref _retainedCount);
 
     /// <summary>Number of empty-pool rents that created an item.</summary>
     public long Misses => Volatile.Read(ref _misses);
 
-    protected ObjectPool(int maxPoolSize, bool threadLocalFastPath = true)
+    protected ObjectPool(int maxPoolSize)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxPoolSize);
-        _threadLocalFastPath = threadLocalFastPath;
         _maxPoolSize = maxPoolSize;
         _poolState = CreatePool(maxPoolSize);
         _pool = _poolState.Pool;
@@ -70,7 +67,7 @@ internal abstract class ObjectPool<T> where T : class
         return item;
     }
 
-    /// <summary>Returns an item, discarding it when thread-local and shared capacity are full.</summary>
+    /// <summary>Returns an item, discarding it when retained capacity is full.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Return(T item)
     {
@@ -80,7 +77,7 @@ internal abstract class ObjectPool<T> where T : class
         Interlocked.Increment(ref _retainedCount);
     }
 
-    /// <summary>Increases shared retained capacity.</summary>
+    /// <summary>Increases retained capacity.</summary>
     public void RatchetMaxPoolSize(int newSize)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(newSize);
@@ -155,10 +152,7 @@ internal abstract class ObjectPool<T> where T : class
     private PoolState CreatePool(int capacity)
     {
         var state = new PoolState(this);
-        state.Pool = new Reservoir.ObjectPool<T, PoolPolicy>(
-            new PoolPolicy(state),
-            capacity,
-            _threadLocalFastPath);
+        state.Pool = new Reservoir.ObjectPool<T, PoolPolicy>(new PoolPolicy(state), capacity);
         return state;
     }
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -717,8 +717,8 @@ internal readonly struct AppendWorkItem
 /// </remarks>
 internal sealed class BatchArena
 {
-    // Reservoir-backed pool eliminates ConcurrentQueue node allocations. This pool disables
-    // Reservoir's thread-local tier so MaxPoolSizeCap remains a hard POH-retention bound.
+    // Reservoir-backed pool eliminates ConcurrentQueue node allocations and specializes
+    // bounded storage for configured capacity.
     private static readonly BatchArenaPool s_pool = new(DefaultPoolSize);
     // Memory tradeoff: pooling arenas retains POH memory for the pool's lifetime.
     // This is a static/process-wide pool shared across all RecordAccumulator instances.
@@ -877,8 +877,7 @@ internal sealed class BatchArena
         s_pool.Return(arena);
     }
 
-    private sealed class BatchArenaPool(int maxPoolSize)
-        : ObjectPool<BatchArena>(maxPoolSize, threadLocalFastPath: false)
+    private sealed class BatchArenaPool(int maxPoolSize) : ObjectPool<BatchArena>(maxPoolSize)
     {
         protected override BatchArena Create()
         {
@@ -8882,8 +8881,7 @@ internal sealed class ReadyBatchPool(int maxPoolSize = BatchArena.DefaultPoolSiz
 /// Reuse queue for completion source arrays rented by PartitionBatch.
 /// When ReadyBatch finishes cleanup, it pushes the array here instead of returning it to
 /// ArrayPool. PartitionBatch.PrepareForPooling() dequeues from here first, falling back
-/// to ArrayPool on miss. Reservoir may retain one array per participating thread beyond
-/// the configured shared capacity. Fire-only batches retain their array and skip the handoff.
+/// to ArrayPool on miss. Fire-only batches retain their array and skip the handoff.
 /// </summary>
 internal sealed class BatchArrayReuseQueue
 {
@@ -8899,8 +8897,8 @@ internal sealed class BatchArrayReuseQueue
     }
 
     /// <summary>
-    /// Pushes the array for reuse. If the returning thread's slot and shared tier are full,
-    /// the array is returned to the dedicated ArrayPool instead.
+    /// Pushes the array for reuse. If the queue is full, the array is returned
+    /// to the dedicated ArrayPool instead.
     /// </summary>
     public void EnqueueOrReturn(PooledValueTaskSource<RecordMetadata>[] completionSources)
         => _pool.Return(completionSources);

--- a/src/Dekaf/Producer/ValueTaskSourcePool.cs
+++ b/src/Dekaf/Producer/ValueTaskSourcePool.cs
@@ -35,9 +35,8 @@ public static class ValueTaskSourcePool
 }
 
 /// <summary>
-/// Thread-safe pool for <see cref="PooledValueTaskSource{T}"/> instances.
-/// Uses Reservoir's bounded, preallocated shared storage and thread-local fast path for
-/// zero-allocation Rent/Return.
+/// Thread-safe bounded pool for <see cref="PooledValueTaskSource{T}"/> instances.
+/// Uses Reservoir's bounded, preallocated striped storage for zero-allocation Rent/Return.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -52,10 +51,10 @@ public static class ValueTaskSourcePool
 /// per-operation allocations and specializes storage for configured capacity.
 /// </para>
 /// <para>
-/// The pool has a configurable maximum shared-tier size. Each participating thread may retain
-/// one additional instance for faster same-thread reuse. When both tiers reject a return, the
-/// instance is discarded. This bounds shared retention while reducing allocations in typical
-/// workloads.
+/// The pool has a configurable maximum size. When the pool is empty, new instances are created.
+/// When returning an instance to a full pool, the instance is discarded (let GC handle it).
+/// This bounded approach prevents unbounded memory growth while still reducing allocations
+/// in typical workloads.
 /// </para>
 /// </remarks>
 /// <typeparam name="T">The result type of the value task sources.</typeparam>
@@ -67,16 +66,16 @@ public sealed class ValueTaskSourcePool<T> : IAsyncDisposable
     private int _disposed;
 
     /// <summary>
-    /// Creates a new pool with the default maximum shared-tier size.
+    /// Creates a new pool with the default maximum size.
     /// </summary>
     public ValueTaskSourcePool() : this(ValueTaskSourcePool.FallbackMaxPoolSize)
     {
     }
 
     /// <summary>
-    /// Creates a new pool with a specified maximum shared-tier size.
+    /// Creates a new pool with a specified maximum size.
     /// </summary>
-    /// <param name="maxPoolSize">Maximum number of instances retained by the shared tier.</param>
+    /// <param name="maxPoolSize">Maximum number of instances to keep in the pool.</param>
     public ValueTaskSourcePool(int maxPoolSize)
     {
         if (maxPoolSize <= 0)
@@ -106,7 +105,7 @@ public sealed class ValueTaskSourcePool<T> : IAsyncDisposable
 
     /// <summary>
     /// Returns a <see cref="PooledValueTaskSource{T}"/> to the pool for reuse.
-    /// If both the returning thread's slot and the shared tier are full, the instance is discarded.
+    /// If the pool is full, the instance is discarded.
     /// </summary>
     /// <remarks>
     /// This method is typically called automatically by <see cref="PooledValueTaskSource{T}"/>
@@ -125,13 +124,13 @@ public sealed class ValueTaskSourcePool<T> : IAsyncDisposable
     }
 
     /// <summary>
-    /// Gets the best-effort number of instances currently retained across shared and thread-local tiers.
+    /// Gets the best-effort number of instances currently in the pool.
     /// Reservoir remains the sole authority for retention decisions.
     /// </summary>
     public int ApproximateCount => Volatile.Read(ref _retainedCount);
 
     /// <summary>
-    /// Gets the maximum shared-tier pool size.
+    /// Gets the maximum pool size.
     /// </summary>
     public int MaxPoolSize => _maxPoolSize;
 

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -348,14 +348,14 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
     /// </summary>
     internal const int TotalBatchHeaderSize = BatchBodyOffset + BatchHeaderSize;
 
-    // Strictly bounded pool of scratch buffer caches for RecordBatch serialization/deserialization.
+    // Bounded pool of scratch buffer caches for RecordBatch serialization/deserialization.
     // Previously [ThreadStatic], but ConfigureAwait(false) in BrokerSender send loops causes
     // thread migration — each unique thread that handled serialization retained a permanent
     // ~1MB buffer rented from DekafPools.SerializationBuffers. With 3+ brokers, dozens of
     // threads accumulated caches over time, depleting the pool and driving Gen2 GC pressure.
     private const int MaxPooledCaches = 16;
     private static readonly Reservoir.ObjectPool<SerializationCache, SerializationCachePolicy>
-        s_cachePool = new(default, MaxPooledCaches, threadLocalFastPath: false);
+        s_cachePool = new(MaxPooledCaches);
 
     /// <summary>
     /// Holds scratch buffer state for a single RecordBatch serialization/deserialization operation.

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -432,6 +432,10 @@ public sealed class KafkaConnectionTests
 
         try
         {
+            var baseline = KafkaConnection.GetPipelinedResponsePoolCount<
+                ApiVersionsRequest,
+                ApiVersionsResponse>();
+            var expectedAfterReturn = Math.Max(1, baseline);
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
             var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(
@@ -447,9 +451,6 @@ public sealed class KafkaConnectionTests
                     new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
                     apiVersion: 3,
                     callerTimeout.Token);
-            var expectedAfterReturn = KafkaConnection.GetPipelinedResponsePoolCount<
-                ApiVersionsRequest,
-                ApiVersionsResponse>() + 1;
             await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
 
             if (abandonBeforeCompletion)
@@ -495,6 +496,10 @@ public sealed class KafkaConnectionTests
 
         try
         {
+            var baseline = KafkaConnection.GetPipelinedResponsePoolCount<
+                ApiVersionsRequest,
+                ApiVersionsResponse>();
+            var expectedAfterReturn = Math.Max(1, baseline);
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
             var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(
@@ -510,9 +515,6 @@ public sealed class KafkaConnectionTests
                     new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
                     apiVersion: 3,
                     callerTimeout.Token);
-            var expectedAfterReturn = KafkaConnection.GetPipelinedResponsePoolCount<
-                ApiVersionsRequest,
-                ApiVersionsResponse>() + 1;
             await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
 
             var cancelTask = callerTimeout.CancelAsync();
@@ -608,6 +610,10 @@ public sealed class KafkaConnectionTests
 
         try
         {
+            var baseline = KafkaConnection.GetPipelinedResponsePoolCount<
+                ApiVersionsRequest,
+                ApiVersionsResponse>();
+            var expectedAfterReturn = Math.Max(1, baseline);
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
             var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
@@ -619,9 +625,6 @@ public sealed class KafkaConnectionTests
                     new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
                     apiVersion: 3,
                     cancellationToken);
-            var expectedAfterReturn = KafkaConnection.GetPipelinedResponsePoolCount<
-                ApiVersionsRequest,
-                ApiVersionsResponse>() + 1;
             var requestFrame = await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
             var correlationId = BinaryPrimitives.ReadInt32BigEndian(requestFrame.AsSpan(4, 4));
             await serverClient.GetStream().WriteAsync(
@@ -655,6 +658,11 @@ public sealed class KafkaConnectionTests
 
         try
         {
+            var baseline = KafkaConnection.GetPipelinedResponsePoolCount<
+                ApiVersionsRequest,
+                ApiVersionsResponse>();
+            var expectedWhileRetained = Math.Max(0, baseline - 1);
+            var expectedAfterReturn = Math.Max(1, baseline);
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
             var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
@@ -666,10 +674,6 @@ public sealed class KafkaConnectionTests
                     new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
                     apiVersion: 3,
                     cancellationToken);
-            var expectedWhileRetained = KafkaConnection.GetPipelinedResponsePoolCount<
-                ApiVersionsRequest,
-                ApiVersionsResponse>();
-            var expectedAfterReturn = expectedWhileRetained + 1;
             await Assert.That(response.TryRetainExternalOwner())
                 .IsEqualTo(ExternalOwnershipClaimResult.Retained);
             await Assert.That(response.TryRetainExternalOwner())

--- a/tests/Dekaf.Tests.Unit/Networking/PendingRequestPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/PendingRequestPoolTests.cs
@@ -146,7 +146,7 @@ public class PendingRequestPoolTests
     }
 
     [Test]
-    public async Task Pool_RetainsThreadLocalItemBeyondCustomSharedMaxSize()
+    public async Task Pool_RespectsCustomMaxPoolSize()
     {
         var pool = new PendingRequestPool(maxPoolSize: 2);
 
@@ -172,9 +172,9 @@ public class PendingRequestPoolTests
 
         pool.Return(r1);
         pool.Return(r2);
-        pool.Return(r3);
+        pool.Return(r3); // Should be discarded (pool full at 2)
 
-        await Assert.That(pool.ApproximateCount).IsEqualTo(3);
+        await Assert.That(pool.ApproximateCount).IsEqualTo(2);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BatchArrayReuseQueueTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BatchArrayReuseQueueTests.cs
@@ -23,27 +23,25 @@ public class BatchArrayReuseQueueTests
     }
 
     [Test]
-    public async Task Enqueue_BeyondThreadLocalAndSharedCapacity_FallsBackToArrayPool()
+    public async Task Enqueue_AtCapacity_FallsBackToArrayPool()
     {
         var queue = new BatchArrayReuseQueue(maxSize: 2);
 
-        // Fill the current thread's slot and the two shared slots.
-        queue.EnqueueOrReturn(CreateTestArray());
+        // Fill the queue to capacity
         queue.EnqueueOrReturn(CreateTestArray());
         queue.EnqueueOrReturn(CreateTestArray());
 
-        // This one should be returned to ArrayPool because both tiers are full.
+        // This one should be returned to ArrayPool (queue is full)
         queue.EnqueueOrReturn(CreateTestArray());
 
+        // Should only be able to dequeue the 2 that fit
         var success1 = queue.TryDequeue(out _);
         var success2 = queue.TryDequeue(out _);
         var success3 = queue.TryDequeue(out _);
-        var success4 = queue.TryDequeue(out _);
 
         await Assert.That(success1).IsTrue();
         await Assert.That(success2).IsTrue();
-        await Assert.That(success3).IsTrue();
-        await Assert.That(success4).IsFalse();
+        await Assert.That(success3).IsFalse();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/ObjectPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ObjectPoolTests.cs
@@ -15,8 +15,7 @@ public class ObjectPoolTests
         public bool WasDestroyed { get; set; }
     }
 
-    private sealed class TestPool(int maxPoolSize, bool threadLocalFastPath = true)
-        : ObjectPool<TestItem>(maxPoolSize, threadLocalFastPath)
+    private sealed class TestPool(int maxPoolSize) : ObjectPool<TestItem>(maxPoolSize)
     {
         private int _nextId;
 
@@ -91,7 +90,7 @@ public class ObjectPoolTests
     }
 
     [Test]
-    public async Task Return_RetainsOneThreadLocalItemBeyondSharedCapacity()
+    public async Task Return_WhenPoolFull_DiscardsResetItem()
     {
         var pool = new TestPool(2);
         var item1 = pool.Rent();
@@ -99,31 +98,12 @@ public class ObjectPoolTests
         var item3 = pool.Rent();
         pool.Return(item1);
         pool.Return(item2);
-        pool.Return(item3);
-
-        var retainedCount = pool.ApproximateCount;
-
-        await Assert.That(retainedCount).IsEqualTo(3);
-        await Assert.That(item1.WasDestroyed).IsFalse();
-        await Assert.That(item2.WasDestroyed).IsFalse();
-        await Assert.That(item3.WasDestroyed).IsFalse();
-    }
-
-    [Test]
-    public async Task Return_WhenStrictPoolFull_DiscardsResetItem()
-    {
-        var pool = new TestPool(2, threadLocalFastPath: false);
-        var item1 = pool.Rent();
-        var item2 = pool.Rent();
-        var item3 = pool.Rent();
-        pool.Return(item1);
-        pool.Return(item2);
-        pool.Return(item3);
+        pool.Return(item3); // Pool is full (max 2), this should be discarded
 
         await Assert.That(pool.ApproximateCount).IsEqualTo(2);
-        await Assert.That(item3.WasReset).IsTrue();
+        await Assert.That(item3.WasReset).IsTrue(); // Reset runs before TryPush capacity check
         var rented = pool.Rent();
-        await Assert.That(rented).IsNotSameReferenceAs(item3);
+        await Assert.That(rented).IsNotSameReferenceAs(item3); // Discarded item is not returned
     }
 
     [Test]
@@ -280,6 +260,6 @@ public class ObjectPoolTests
         await Task.WhenAll(tasks);
 
         await Assert.That(corruptedRents).IsEqualTo(0);
-        await Assert.That(pool.ApproximateCount).IsBetween(0, threadCount + 1);
+        await Assert.That(pool.ApproximateCount).IsBetween(0, 1);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -628,12 +628,14 @@ public class PooledValueTaskSourceTests
         source.SetResult(42);
         source.ObserveForFireAndForget();
 
-        // Already-completed observation returns synchronously, so rent again on the same thread
-        // to exercise Reservoir's thread-local fast path deterministically.
-        var retainedCount = pool.ApproximateCount;
-        var sameSource = pool.Rent();
+        // Give a tiny bit of time for the callback to execute
+        await Task.Yield();
 
-        await Assert.That(retainedCount).IsEqualTo(1);
+        // Source should have been returned to pool
+        await Assert.That(pool.ApproximateCount).IsEqualTo(1);
+
+        // Should be able to rent the same instance again
+        var sameSource = pool.Rent();
         await Assert.That(source).IsSameReferenceAs(sameSource);
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/ValueTaskSourcePoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ValueTaskSourcePoolTests.cs
@@ -171,7 +171,7 @@ public class ValueTaskSourcePoolTests
     }
 
     [Test]
-    public async Task Pool_RetainsThreadLocalItemBeyondSharedMaxSize()
+    public async Task Pool_RespectsMaxSize()
     {
         const int maxSize = 5;
         var pool = new ValueTaskSourcePool<int>(maxPoolSize: maxSize);
@@ -190,8 +190,8 @@ public class ValueTaskSourcePoolTests
             await source.Task.ConfigureAwait(false);
         }
 
-        // One current-thread item is retained in addition to the bounded shared tier.
-        await Assert.That(pool.ApproximateCount).IsEqualTo(maxSize + 1);
+        // Pool should only contain maxSize items (extras are discarded)
+        await Assert.That(pool.ApproximateCount).IsLessThanOrEqualTo(maxSize);
     }
 
     [Test]
@@ -421,14 +421,12 @@ public class ValueTaskSourcePoolTests
     [Test]
     public async Task ConcurrentRentAndReturn_MaintainsConsistency()
     {
-        const int maxPoolSize = 100;
-        const int workerCount = 10;
-        var pool = new ValueTaskSourcePool<int>(maxPoolSize);
-        var barrier = new Barrier(workerCount);
+        var pool = new ValueTaskSourcePool<int>(maxPoolSize: 100);
+        var barrier = new Barrier(10);
         var tasks = new List<Task>();
 
-        // Concurrent workers exercise both shared storage and their thread-local slots.
-        for (var t = 0; t < workerCount; t++)
+        // 10 threads doing concurrent rent/complete/return cycles
+        for (int t = 0; t < 10; t++)
         {
             tasks.Add(Task.Run(async () =>
             {
@@ -447,7 +445,7 @@ public class ValueTaskSourcePoolTests
         await Task.WhenAll(tasks).ConfigureAwait(false);
 
         // Pool should be in a consistent state
-        await Assert.That(pool.ApproximateCount).IsLessThanOrEqualTo(maxPoolSize + workerCount);
+        await Assert.That(pool.ApproximateCount).IsLessThanOrEqualTo(100);
         await Assert.That(pool.ApproximateCount).IsGreaterThanOrEqualTo(0);
     }
 }


### PR DESCRIPTION
Reverts #2975 (353086ffe), restoring Reservoir 1.4.0.

## Why

Reservoir 1.5.0 regressed Dekaf: **throughput −8.13%, CPU +11.17%** with defaults; **−3.58% / +7.45%** with the wrapper-exposed `threadLocalFastPath` flags off. The auto-merge landed before benchmarks finished, so main carries the regressed configuration.

Root causes (full investigation in thomhurst/Reservoir#84):
- 1.5.0 enables Reservoir's thread-local fast path by default. Dekaf's pools are cross-thread handoff shaped (rent on the producer thread, return on the IO/completion thread) — the fast path's adversarial workload: returns park objects on threads that never rent them.
- The "disabled everywhere" configuration was incomplete: six direct 2-arg `Reservoir.ObjectPool` constructions silently kept the fast path on — `PendingRequestPool`'s inner pool, static `PooledPipelinedResponse.Pool`, `PartitionInflightTracker`, `KafkaConsumer.PendingFetchData`, static `RentedBufferWriter.Pool`, and `PipeMemoryPool`'s owner pool. That explains the residual regression.

## Path forward

The next Reservoir release flips the fast-path default back off (thomhurst/Reservoir#82, merged) and gates thread-local parking to renting threads (thomhurst/Reservoir#84), so re-upgrading will need no Dekaf changes and heals all six hidden pools automatically.

https://claude.ai/code/session_01GF8xT4pZXckH3iCGoTPbg6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved bounded pooling behavior so pools no longer retain items beyond their configured capacity.
- Excess returned items are now discarded and reset correctly.
- Updated connection, batching, and asynchronous pooling behavior for more consistent resource reuse.
- Corrected pool-count handling when pools start empty or operate under concurrent load.

## Chores
- Downgraded the centrally managed Reservoir package version to 1.4.0.
- Updated internal documentation and validation coverage to reflect bounded pool behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->