### PR TITLE
perf(pooling): mark non-throwing reset policies for Reservoir's inline reset path

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -937,7 +937,8 @@ internal sealed class PendingFetchData : IDisposable
     }
 
     private readonly struct PendingFetchDataPolicy(PendingFetchDataPoolState state)
-        : Reservoir.IPooledObjectDestroyPolicy<PendingFetchData>
+        : Reservoir.IPooledObjectDestroyPolicy<PendingFetchData>,
+          Reservoir.INonThrowingResetPolicy
     {
         public PendingFetchData Create() => new();
 

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1479,7 +1479,8 @@ public sealed partial class KafkaConnection :
 
         private readonly struct PoolPolicy
             : Reservoir.IPooledObjectDestroyPolicy<
-                PooledPipelinedResponse<TRequest, TResponse>>
+                PooledPipelinedResponse<TRequest, TResponse>>,
+              Reservoir.INonThrowingResetPolicy
         {
             public PooledPipelinedResponse<TRequest, TResponse> Create()
             {

--- a/src/Dekaf/Networking/PipeMemoryPool.cs
+++ b/src/Dekaf/Networking/PipeMemoryPool.cs
@@ -196,7 +196,7 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
     }
 
     private readonly struct PooledMemoryOwnerPolicy(PipeMemoryPool owner)
-        : Reservoir.IPooledObjectPolicy<PooledMemoryOwner>
+        : Reservoir.IPooledObjectPolicy<PooledMemoryOwner>, Reservoir.INonThrowingResetPolicy
     {
         public PooledMemoryOwner Create() => new(owner);
 

--- a/src/Dekaf/Networking/RentedBufferWriter.cs
+++ b/src/Dekaf/Networking/RentedBufferWriter.cs
@@ -122,7 +122,8 @@ internal sealed class RentedBufferWriter : IBufferWriter<byte>, IDisposable
         _buffer = newBuffer;
     }
 
-    private readonly struct PoolPolicy : Reservoir.IPooledObjectPolicy<RentedBufferWriter>
+    private readonly struct PoolPolicy
+        : Reservoir.IPooledObjectPolicy<RentedBufferWriter>, Reservoir.INonThrowingResetPolicy
     {
         public RentedBufferWriter Create() => new();
 

--- a/src/Dekaf/Producer/ObjectPool.cs
+++ b/src/Dekaf/Producer/ObjectPool.cs
@@ -170,7 +170,7 @@ internal abstract class ObjectPool<T> where T : class
     }
 
     private readonly struct PoolPolicy(PoolState state)
-        : Reservoir.IPooledObjectDestroyPolicy<T>
+        : Reservoir.IPooledObjectDestroyPolicy<T>, Reservoir.INonThrowingResetPolicy
     {
         public T Create()
         {

--- a/src/Dekaf/Producer/PartitionInflightTracker.cs
+++ b/src/Dekaf/Producer/PartitionInflightTracker.cs
@@ -166,7 +166,7 @@ internal sealed class InflightEntryPool
     }
 
     private readonly struct InflightEntryPolicy(InflightEntryPool owner)
-        : Reservoir.IPooledObjectPolicy<InflightEntry>
+        : Reservoir.IPooledObjectPolicy<InflightEntry>, Reservoir.INonThrowingResetPolicy
     {
         public InflightEntry Create()
         {

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -8926,7 +8926,8 @@ internal sealed class BatchArrayReuseQueue
     public void Clear() => _pool.Clear();
 
     private readonly struct CompletionSourceArrayPolicy
-        : Reservoir.IPooledObjectDestroyPolicy<PooledValueTaskSource<RecordMetadata>[]>
+        : Reservoir.IPooledObjectDestroyPolicy<PooledValueTaskSource<RecordMetadata>[]>,
+          Reservoir.INonThrowingResetPolicy
     {
         // Empty singleton represents a cache miss without allocating or renting an unusable array.
         public PooledValueTaskSource<RecordMetadata>[] Create() => [];

--- a/src/Dekaf/Producer/ValueTaskSourcePool.cs
+++ b/src/Dekaf/Producer/ValueTaskSourcePool.cs
@@ -151,7 +151,8 @@ public sealed class ValueTaskSourcePool<T> : IAsyncDisposable
     }
 
     private readonly struct PoolPolicy(ValueTaskSourcePool<T> owner)
-        : Reservoir.IPooledObjectDestroyPolicy<PooledValueTaskSource<T>>
+        : Reservoir.IPooledObjectDestroyPolicy<PooledValueTaskSource<T>>,
+          Reservoir.INonThrowingResetPolicy
     {
         public PooledValueTaskSource<T> Create()
         {

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -388,7 +388,8 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         => s_cachePool.Return(cache);
 
     private readonly struct SerializationCachePolicy
-        : Reservoir.IPooledObjectDestroyPolicy<SerializationCache>
+        : Reservoir.IPooledObjectDestroyPolicy<SerializationCache>,
+          Reservoir.INonThrowingResetPolicy
     {
         public SerializationCache Create() => new();
 


### PR DESCRIPTION
**Draft — sequenced after the Reservoir re-upgrade.** Requires Reservoir ≥ 1.5 (`INonThrowingResetPolicy` doesn't exist in 1.4), so this conflicts with the interim revert #2976 by design: merge order is #2976 now → re-upgrade to the next Reservoir release (fast-path default off + thomhurst/Reservoir#84) → this PR.

## What

Reservoir resets pooled objects through a `NoInlining` destroy-on-throw wrapper unless the policy implements the `INonThrowingResetPolicy` marker, in which case the reset inlines (the type test folds to a constant per instantiation). Reservoir's benchmark shows ~0.6 ns/op off a rent/return pair, and the marked variant is also the code-layout-stable one across builds.

Marks the nine policies whose `TryReset` provably cannot throw — trivial `=> true` bodies (wrapper `PoolPolicy`, `PendingFetchDataPolicy`, `PooledMemoryOwnerPolicy`, `SerializationCachePolicy`, `ValueTaskSourcePool.PoolPolicy`, `CompletionSourceArrayPolicy`), pure field-assignment resets (`RentedBufferWriter.PoolPolicy`, `InflightEntryPolicy`), and `PooledPipelinedResponse.PoolPolicy` (field stores + `ManualResetValueTaskSourceCore.Reset` + bit packing).

**Deliberately not marked**: `PendingRequestPool`'s policy — its reset disposes a `CancellationTokenRegistration` and a response-memory reservation; the marker removes the guard that destroys the object when reset throws, so it stays on the guarded path.

Compile-checked against Reservoir 1.5.0.

https://claude.ai/code/session_01GF8xT4pZXckH3iCGoTPbg6