### PR TITLE
chore(deps): update dependency reservoir to 1.6.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,7 +52,7 @@
     <PackageVersion Include="OpenTelemetry.Api" Version="1.18.0" />
     <PackageVersion Include="Polyfill" Version="11.2.0" />
     <PackageVersion Include="protobuf-net.Reflection" Version="3.4.21" />
-    <PackageVersion Include="Reservoir" Version="1.5.0" />
+    <PackageVersion Include="Reservoir" Version="1.6.0" />
     <PackageVersion Include="SharpFuzz" Version="2.3.0" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="SSH.NET" Version="2026.0.0" />

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -912,9 +912,11 @@ internal sealed class PendingFetchData : IDisposable
     private static PendingFetchDataPoolState CreatePool(int capacity)
     {
         var state = new PendingFetchDataPoolState();
+        // The fetch loop creates entries that the consumer thread later disposes.
         state.Pool = new Reservoir.ObjectPool<PendingFetchData, PendingFetchDataPolicy>(
             new PendingFetchDataPolicy(state),
-            capacity);
+            capacity,
+            threadLocalFastPath: false);
         return state;
     }
 

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -5102,9 +5102,12 @@ internal sealed class PendingRequestPool
     public PendingRequestPool(int maxPoolSize)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxPoolSize);
+        // Requests are rented before asynchronous I/O and returned by response or
+        // failure continuations that commonly run on another thread.
         _pool = new Reservoir.ObjectPool<PooledPendingRequest, PoolPolicy>(
             new PoolPolicy(this),
-            maxPoolSize);
+            maxPoolSize,
+            threadLocalFastPath: false);
     }
 
     public int ApproximateCount => Volatile.Read(ref _poolCount);

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -5088,9 +5088,8 @@ internal sealed class PooledResponseMemory : IPooledMemory
 }
 
 /// <summary>
-/// Thread-safe pool for <see cref="PooledPendingRequest"/> instances.
-/// Uses Reservoir's bounded, preallocated shared storage and thread-local fast path for
-/// zero-allocation rent and return.
+/// Thread-safe bounded pool for <see cref="PooledPendingRequest"/> instances.
+/// Uses Reservoir's bounded, preallocated storage for zero-allocation rent and return.
 /// </summary>
 internal sealed class PendingRequestPool
 {
@@ -5123,7 +5122,7 @@ internal sealed class PendingRequestPool
 
     /// <summary>
     /// Returns a <see cref="PooledPendingRequest"/> to the pool for reuse.
-    /// If both the returning thread's slot and the shared tier are full, the instance is discarded.
+    /// If the pool is full, the instance is discarded.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Return(PooledPendingRequest request)

--- a/src/Dekaf/Networking/PipeMemoryPool.cs
+++ b/src/Dekaf/Networking/PipeMemoryPool.cs
@@ -45,11 +45,10 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
     private int _disposed;
 
     /// <summary>
-    /// Maximum number of <see cref="PooledMemoryOwner"/> wrapper objects retained by the shared tier.
+    /// Maximum number of <see cref="PooledMemoryOwner"/> wrapper objects to retain.
     /// Each connection's <see cref="ResponseFrameReader"/> holds one receive buffer for the
     /// connection's lifetime; 64 covers peak connection counts and reconnect churn with
-    /// headroom. Each participating thread may retain one additional wrapper; returned wrappers
-    /// hold no byte array, so the extra thread-local retention is small.
+    /// headroom, while bounding retained wrapper objects to ~2 KB total.
     /// </summary>
     private const int MaxOwnerPoolSize = 64;
 

--- a/src/Dekaf/Networking/PipeMemoryPool.cs
+++ b/src/Dekaf/Networking/PipeMemoryPool.cs
@@ -77,9 +77,12 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
     public PipeMemoryPool(int maxArrayLength = 4 * 1024 * 1024, int maxArraysPerBucket = 32)
     {
         _pool = ArrayPool<byte>.Create(maxArrayLength, maxArraysPerBucket);
+        // Owners are shared across connections and can be disposed on a different
+        // thread from the one that created the response reader.
         _ownerPool = new Reservoir.ObjectPool<PooledMemoryOwner, PooledMemoryOwnerPolicy>(
             new PooledMemoryOwnerPolicy(this),
-            MaxOwnerPoolSize);
+            MaxOwnerPoolSize,
+            threadLocalFastPath: false);
     }
 
     internal static PipeMemoryPool Create(

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -8882,8 +8882,7 @@ internal sealed class ReadyBatchPool(int maxPoolSize = BatchArena.DefaultPoolSiz
 /// Reuse queue for completion source arrays rented by PartitionBatch.
 /// When ReadyBatch finishes cleanup, it pushes the array here instead of returning it to
 /// ArrayPool. PartitionBatch.PrepareForPooling() dequeues from here first, falling back
-/// to ArrayPool on miss. Reservoir may retain one array per participating thread beyond
-/// the configured shared capacity. Fire-only batches retain their array and skip the handoff.
+/// to ArrayPool on miss. Fire-only batches retain their array and skip the handoff.
 /// </summary>
 internal sealed class BatchArrayReuseQueue
 {
@@ -8899,8 +8898,8 @@ internal sealed class BatchArrayReuseQueue
     }
 
     /// <summary>
-    /// Pushes the array for reuse. If the returning thread's slot and shared tier are full,
-    /// the array is returned to the dedicated ArrayPool instead.
+    /// Pushes the array for reuse. If the queue is full, the array is returned
+    /// to the dedicated ArrayPool instead.
     /// </summary>
     public void EnqueueOrReturn(PooledValueTaskSource<RecordMetadata>[] completionSources)
         => _pool.Return(completionSources);

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -877,6 +877,8 @@ internal sealed class BatchArena
         s_pool.Return(arena);
     }
 
+    // Append threads rent arenas that sender cleanup can return. Shared storage also
+    // keeps MaxPoolSize as the hard bound on retained POH buffers.
     private sealed class BatchArenaPool(int maxPoolSize)
         : ObjectPool<BatchArena>(maxPoolSize, threadLocalFastPath: false)
     {

--- a/src/Dekaf/Producer/ValueTaskSourcePool.cs
+++ b/src/Dekaf/Producer/ValueTaskSourcePool.cs
@@ -82,9 +82,12 @@ public sealed class ValueTaskSourcePool<T> : IAsyncDisposable
             throw new ArgumentOutOfRangeException(nameof(maxPoolSize), "Max pool size must be positive.");
 
         _maxPoolSize = maxPoolSize;
+        // GetResult performs the automatic return after an async completion, so the
+        // return commonly runs on a different thread from Rent.
         _pool = new Reservoir.ObjectPool<PooledValueTaskSource<T>, PoolPolicy>(
             new PoolPolicy(this),
-            maxPoolSize);
+            maxPoolSize,
+            threadLocalFastPath: false);
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/ValueTaskSourcePool.cs
+++ b/src/Dekaf/Producer/ValueTaskSourcePool.cs
@@ -35,9 +35,8 @@ public static class ValueTaskSourcePool
 }
 
 /// <summary>
-/// Thread-safe pool for <see cref="PooledValueTaskSource{T}"/> instances.
-/// Uses Reservoir's bounded, preallocated shared storage and thread-local fast path for
-/// zero-allocation Rent/Return.
+/// Thread-safe bounded pool for <see cref="PooledValueTaskSource{T}"/> instances.
+/// Uses Reservoir's bounded, preallocated shared storage for zero-allocation Rent/Return.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -52,10 +51,10 @@ public static class ValueTaskSourcePool
 /// per-operation allocations and specializes storage for configured capacity.
 /// </para>
 /// <para>
-/// The pool has a configurable maximum shared-tier size. Each participating thread may retain
-/// one additional instance for faster same-thread reuse. When both tiers reject a return, the
-/// instance is discarded. This bounds shared retention while reducing allocations in typical
-/// workloads.
+/// The pool has a configurable maximum size. When the pool is empty, new instances are created.
+/// When returning an instance to a full pool, the instance is discarded (let GC handle it).
+/// This bounded approach prevents unbounded memory growth while still reducing allocations
+/// in typical workloads.
 /// </para>
 /// </remarks>
 /// <typeparam name="T">The result type of the value task sources.</typeparam>
@@ -67,16 +66,16 @@ public sealed class ValueTaskSourcePool<T> : IAsyncDisposable
     private int _disposed;
 
     /// <summary>
-    /// Creates a new pool with the default maximum shared-tier size.
+    /// Creates a new pool with the default maximum size.
     /// </summary>
     public ValueTaskSourcePool() : this(ValueTaskSourcePool.FallbackMaxPoolSize)
     {
     }
 
     /// <summary>
-    /// Creates a new pool with a specified maximum shared-tier size.
+    /// Creates a new pool with a specified maximum size.
     /// </summary>
-    /// <param name="maxPoolSize">Maximum number of instances retained by the shared tier.</param>
+    /// <param name="maxPoolSize">Maximum number of instances to keep in the pool.</param>
     public ValueTaskSourcePool(int maxPoolSize)
     {
         if (maxPoolSize <= 0)
@@ -106,7 +105,7 @@ public sealed class ValueTaskSourcePool<T> : IAsyncDisposable
 
     /// <summary>
     /// Returns a <see cref="PooledValueTaskSource{T}"/> to the pool for reuse.
-    /// If both the returning thread's slot and the shared tier are full, the instance is discarded.
+    /// If the pool is full, the instance is discarded.
     /// </summary>
     /// <remarks>
     /// This method is typically called automatically by <see cref="PooledValueTaskSource{T}"/>
@@ -125,13 +124,13 @@ public sealed class ValueTaskSourcePool<T> : IAsyncDisposable
     }
 
     /// <summary>
-    /// Gets the best-effort number of instances currently retained across shared and thread-local tiers.
+    /// Gets the best-effort number of instances currently in the pool.
     /// Reservoir remains the sole authority for retention decisions.
     /// </summary>
     public int ApproximateCount => Volatile.Read(ref _retainedCount);
 
     /// <summary>
-    /// Gets the maximum shared-tier pool size.
+    /// Gets the maximum pool size.
     /// </summary>
     public int MaxPoolSize => _maxPoolSize;
 

--- a/tests/Dekaf.Tests.Unit/Networking/PendingRequestPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/PendingRequestPoolTests.cs
@@ -146,7 +146,7 @@ public class PendingRequestPoolTests
     }
 
     [Test]
-    public async Task Pool_RetainsThreadLocalItemBeyondCustomSharedMaxSize()
+    public async Task Pool_RespectsCustomMaxPoolSize()
     {
         var pool = new PendingRequestPool(maxPoolSize: 2);
 
@@ -172,9 +172,9 @@ public class PendingRequestPoolTests
 
         pool.Return(r1);
         pool.Return(r2);
-        pool.Return(r3);
+        pool.Return(r3); // Should be discarded (pool full at 2)
 
-        await Assert.That(pool.ApproximateCount).IsEqualTo(3);
+        await Assert.That(pool.ApproximateCount).IsEqualTo(2);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BatchArrayReuseQueueTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BatchArrayReuseQueueTests.cs
@@ -23,27 +23,24 @@ public class BatchArrayReuseQueueTests
     }
 
     [Test]
-    public async Task Enqueue_BeyondThreadLocalAndSharedCapacity_FallsBackToArrayPool()
+    public async Task Enqueue_AtCapacity_FallsBackToArrayPool()
     {
         var queue = new BatchArrayReuseQueue(maxSize: 2);
 
-        // Fill the current thread's slot and the two shared slots.
-        queue.EnqueueOrReturn(CreateTestArray());
+        // Fill the queue to capacity.
         queue.EnqueueOrReturn(CreateTestArray());
         queue.EnqueueOrReturn(CreateTestArray());
 
-        // This one should be returned to ArrayPool because both tiers are full.
+        // This one should be returned to ArrayPool because the queue is full.
         queue.EnqueueOrReturn(CreateTestArray());
 
         var success1 = queue.TryDequeue(out _);
         var success2 = queue.TryDequeue(out _);
         var success3 = queue.TryDequeue(out _);
-        var success4 = queue.TryDequeue(out _);
 
         await Assert.That(success1).IsTrue();
         await Assert.That(success2).IsTrue();
-        await Assert.That(success3).IsTrue();
-        await Assert.That(success4).IsFalse();
+        await Assert.That(success3).IsFalse();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -628,8 +628,8 @@ public class PooledValueTaskSourceTests
         source.SetResult(42);
         source.ObserveForFireAndForget();
 
-        // Already-completed observation returns synchronously, so rent again on the same thread
-        // to exercise Reservoir's thread-local fast path deterministically.
+        // Already-completed observation returns synchronously, so rent again immediately
+        // to verify the returned source is reusable deterministically.
         var retainedCount = pool.ApproximateCount;
         var sameSource = pool.Rent();
 

--- a/tests/Dekaf.Tests.Unit/Producer/ValueTaskSourcePoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ValueTaskSourcePoolTests.cs
@@ -171,7 +171,7 @@ public class ValueTaskSourcePoolTests
     }
 
     [Test]
-    public async Task Pool_RetainsThreadLocalItemBeyondSharedMaxSize()
+    public async Task Pool_RespectsMaxSize()
     {
         const int maxSize = 5;
         var pool = new ValueTaskSourcePool<int>(maxPoolSize: maxSize);
@@ -190,8 +190,7 @@ public class ValueTaskSourcePoolTests
             await source.Task.ConfigureAwait(false);
         }
 
-        // One current-thread item is retained in addition to the bounded shared tier.
-        await Assert.That(pool.ApproximateCount).IsEqualTo(maxSize + 1);
+        await Assert.That(pool.ApproximateCount).IsEqualTo(maxSize);
     }
 
     [Test]
@@ -427,7 +426,7 @@ public class ValueTaskSourcePoolTests
         var barrier = new Barrier(workerCount);
         var tasks = new List<Task>();
 
-        // Concurrent workers exercise both shared storage and their thread-local slots.
+        // Concurrent workers exercise the shared storage.
         for (var t = 0; t < workerCount; t++)
         {
             tasks.Add(Task.Run(async () =>
@@ -447,7 +446,7 @@ public class ValueTaskSourcePoolTests
         await Task.WhenAll(tasks).ConfigureAwait(false);
 
         // Pool should be in a consistent state
-        await Assert.That(pool.ApproximateCount).IsLessThanOrEqualTo(maxPoolSize + workerCount);
+        await Assert.That(pool.ApproximateCount).IsLessThanOrEqualTo(maxPoolSize);
         await Assert.That(pool.ApproximateCount).IsGreaterThanOrEqualTo(0);
     }
 }


### PR DESCRIPTION
## Summary

- update Reservoir from 1.5.0 to 1.6.0
- align pool documentation and tests with Reservoir 1.6's bounded shared default for manual rentals
- retain Dekaf's existing explicit thread-local choices for pools that intentionally opt in or out

Reservoir 1.6 changes manual Rent/Return pools to use the bounded shared tier by default. This targets the cross-thread handoff behavior that caused Dekaf's measured Reservoir 1.5 regression: https://github.com/thomhurst/Reservoir/pull/84

## Validation

- `dotnet restore`
- `dotnet build tests/Dekaf.Tests.Unit --configuration Release --framework net10.0 --no-restore` — 0 warnings, 0 errors
- `tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe` — 8,704 passed
- BenchmarkDotNet Dry validation — 14/14 pool benchmark cases executed
- `git diff --check`

## Performance

BenchmarkDotNet 0.15.8 ShortRun, .NET 10.0.11, Windows 11, Intel Core Ultra 9 185H. All measured paths remained at 0 B allocated.

| Hot path | Reservoir 1.5 | Reservoir 1.6 | Delta |
| --- | ---: | ---: | ---: |
| ValueTaskSource rent/complete/return | 89.87 ns | 75.72 ns | -15.74% |
| PendingFetchData rent/return | 89.60 ns | 68.78 ns | -23.24% |
| BatchArena rent/return (strict-pool control) | 79.83 ns | 131.22 ns | +64.37% |
| PendingRequest rent/return | 71.69 ns | 125.36 ns | +74.86% |
| PipeMemoryOwner rent/return | 119.84 ns | 87.07 ns | -27.34% |

The sequential ShortRun timing comparison is inconclusive: the unchanged strict-pool control moved by +64.37%, indicating substantial run-to-run noise. The allocation hard gate stayed at 0 B throughout. The relevant upstream cross-thread investigation measured Reservoir 1.5 at -8.13% throughput and +11.17% CPU in Dekaf and motivated the 1.6 default change linked above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified pooling behavior, capacity limits, and fallback handling across networking and producer components.
* **Bug Fixes**
  * Corrected pool capacity behavior so configured maximum sizes are respected and excess items are discarded or returned to shared pools.
* **Chores**
  * Updated the centrally managed Reservoir package version to 1.6.0.
* **Tests**
  * Updated coverage to verify exact pool limits, overflow handling, and reusable pooled resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->