### PR TITLE
perf(protocol): parse record bodies in place instead of via a per-record sub-reader

### DIFF
--- a/src/Dekaf/Protocol/KafkaProtocolReader.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolReader.cs
@@ -106,6 +106,14 @@ public ref struct KafkaProtocolReader
     public readonly long Remaining => _isContiguous ? _span.Length - _position : _reader.Remaining;
     public readonly bool End => _isContiguous ? _position >= _span.Length : _reader.End;
 
+    /// <summary>
+    /// True when <see cref="ReadMemorySlice(int)"/> must copy: the reader was constructed
+    /// over a <see cref="ReadOnlySpan{T}"/>, which has no backing memory to slice. Lets a
+    /// caller that would otherwise slice many fields take one copy of the enclosing region
+    /// and slice that instead.
+    /// </summary>
+    internal readonly bool SlicesCopy => _isContiguous && !_hasMemory;
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public sbyte ReadInt8()
     {

--- a/src/Dekaf/Protocol/KafkaProtocolReader.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolReader.cs
@@ -842,6 +842,21 @@ public ref struct KafkaProtocolReader
     }
 
     /// <summary>
+    /// Reads a slice like <see cref="ReadMemorySlice(int)"/>, but fails with
+    /// <see cref="InsufficientDataException"/> when the slice would extend past
+    /// <paramref name="limit"/>, an absolute <see cref="Consumed"/> offset. Lets a
+    /// length-prefixed body be parsed in place with the same bounds a reader sliced to
+    /// that length would enforce, without constructing one.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ReadOnlyMemory<byte> ReadMemorySlice(int count, long limit)
+    {
+        if (count > limit - Consumed)
+            ThrowInsufficientData();
+        return ReadMemorySlice(count);
+    }
+
+    /// <summary>
     /// Reads an array with 4-byte length prefix (legacy format).
     /// </summary>
     public T[] ReadArray<T>(ReadFunc<T> readItem)
@@ -1315,7 +1330,7 @@ public ref struct KafkaProtocolReader
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void ThrowInsufficientData()
+    internal static void ThrowInsufficientData()
     {
         throw new InsufficientDataException();
     }

--- a/src/Dekaf/Protocol/Records/Record.cs
+++ b/src/Dekaf/Protocol/Records/Record.cs
@@ -136,19 +136,16 @@ public readonly record struct Record
         if (length < 0)
             throw new MalformedProtocolDataException($"Invalid record length {length}");
 
+        // The body is parsed in place with the caller's reader rather than through a
+        // per-record sub-reader sliced to the declared length. Every variable-length field
+        // is bounded by the declared body end before it is sliced, so a corrupt interior
+        // field still cannot consume later records or masquerade as truncation (#2065).
         var availableBodyBytes = reader.Remaining;
-        var bodyReader = reader;
-        var bodyStart = bodyReader.Consumed;
-        if (length <= availableBodyBytes)
-        {
-            bodyReader = new KafkaProtocolReader(reader.GetRemainingSequence().Slice(0, length));
-            bodyStart = 0;
-            reader.Skip(length);
-        }
+        var bodyStart = reader.Consumed;
 
         try
         {
-            return ReadBody(ref bodyReader, length, bodyStart, headerRoutingPlan);
+            return ReadBody(ref reader, length, bodyStart, headerRoutingPlan);
         }
         catch (RecordBodyLengthMismatchException ex)
         {
@@ -170,17 +167,19 @@ public readonly record struct Record
         long bodyStart,
         RecordHeaderRoutingPlan? headerRoutingPlan)
     {
+        var bodyEnd = bodyStart + length;
+
         var attributes = (byte)reader.ReadInt8();
         var timestampDelta = reader.ReadVarLong();
         var offsetDelta = reader.ReadVarInt();
 
         var keyLength = reader.ReadVarInt();
         var isKeyNull = keyLength < 0;
-        var key = isKeyNull ? ReadOnlyMemory<byte>.Empty : reader.ReadMemorySlice(keyLength);
+        var key = isKeyNull ? ReadOnlyMemory<byte>.Empty : reader.ReadMemorySlice(keyLength, bodyEnd);
 
         var valueLength = reader.ReadVarInt();
         var isValueNull = valueLength < 0;
-        var value = isValueNull ? ReadOnlyMemory<byte>.Empty : reader.ReadMemorySlice(valueLength);
+        var value = isValueNull ? ReadOnlyMemory<byte>.Empty : reader.ReadMemorySlice(valueLength, bodyEnd);
 
         var headerCount = reader.ReadVarInt();
         ValidateHeaderCount(headerCount, length, reader.Consumed - bodyStart, reader.Remaining);
@@ -209,7 +208,7 @@ public readonly record struct Record
             {
                 for (var i = 0; i < headerCount; i++)
                 {
-                    var header = HeaderProtocol.Read(ref reader);
+                    var header = HeaderProtocol.Read(ref reader, bodyEnd);
                     headers[i] = header;
                     if (headerRoutingPlan is not null
                         && headerRoutingPlan.TryGetSlot(header.Key, out var slot))
@@ -384,11 +383,24 @@ public readonly record struct Record
         };
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void ValidateBodyLength(int declaredLength, long consumedLength)
     {
         if (consumedLength != declaredLength)
-            throw new RecordBodyLengthMismatchException(
-                $"Record body length mismatch: declared {declaredLength}, consumed {consumedLength}");
+            ThrowBodyLengthMismatch(declaredLength, consumedLength);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowBodyLengthMismatch(int declaredLength, long consumedLength)
+    {
+        // Fixed-width fields and varints are not pre-bounded, so a corrupt body can run past
+        // its declared end before the mismatch is observed. That is the same condition a
+        // reader bounded to the declared length would have reported as exhausted.
+        if (consumedLength > declaredLength)
+            KafkaProtocolReader.ThrowInsufficientData();
+
+        throw new RecordBodyLengthMismatchException(
+            $"Record body length mismatch: declared {declaredLength}, consumed {consumedLength}");
     }
 
     private sealed class RecordBodyLengthMismatchException(string message) : Exception(message);
@@ -396,7 +408,9 @@ public readonly record struct Record
     private static void ValidateHeaderCount(int headerCount, int recordBodyLength, long bodyBytesRead, long readerRemaining)
     {
         var remainingInRecord = recordBodyLength - bodyBytesRead;
-        if (remainingInRecord < 0 || headerCount < 0 || headerCount > MaxReasonableHeaderCount)
+        if (remainingInRecord < 0)
+            KafkaProtocolReader.ThrowInsufficientData();
+        if (headerCount < 0 || headerCount > MaxReasonableHeaderCount)
             throw new MalformedProtocolDataException($"Invalid record header count {headerCount}");
 
         // A header needs at least one byte for key length and one byte for value length.

--- a/src/Dekaf/Protocol/Records/Record.cs
+++ b/src/Dekaf/Protocol/Records/Record.cs
@@ -145,6 +145,15 @@ public readonly record struct Record
 
         try
         {
+            if (reader.SlicesCopy && length <= availableBodyBytes)
+            {
+                // A span-backed reader copies on every ReadMemorySlice, so parsing in place
+                // would cost one array per key, value, and header field. Copy the body once
+                // and slice that array instead, as the former sub-reader path did.
+                var bodyReader = new KafkaProtocolReader(reader.ReadMemorySlice(length));
+                return ReadBody(ref bodyReader, length, bodyStart: 0, headerRoutingPlan);
+            }
+
             return ReadBody(ref reader, length, bodyStart, headerRoutingPlan);
         }
         catch (RecordBodyLengthMismatchException ex)

--- a/src/Dekaf/Serialization/HeaderProtocol.cs
+++ b/src/Dekaf/Serialization/HeaderProtocol.cs
@@ -79,14 +79,19 @@ internal static class HeaderProtocol
         writer.AddBytesWritten(keyByteCount);
     }
 
-    internal static Header Read(ref KafkaProtocolReader reader)
+    /// <summary>
+    /// Reads a header whose key and value must lie within the enclosing record body ending at
+    /// <paramref name="bodyEnd"/> (a reader offset). Bounding the slices here keeps a corrupt
+    /// header length from interning or exposing bytes that belong to later records.
+    /// </summary>
+    internal static Header Read(ref KafkaProtocolReader reader, long bodyEnd)
     {
         var keyLength = reader.ReadVarInt();
-        var key = s_keyCache.Intern(reader.ReadMemorySlice(keyLength));
+        var key = s_keyCache.Intern(reader.ReadMemorySlice(keyLength, bodyEnd));
 
         var valueLength = reader.ReadVarInt();
         var isValueNull = valueLength < 0;
-        var value = isValueNull ? ReadOnlyMemory<byte>.Empty : reader.ReadMemorySlice(valueLength);
+        var value = isValueNull ? ReadOnlyMemory<byte>.Empty : reader.ReadMemorySlice(valueLength, bodyEnd);
 
         return new Header(key, value, isNull: isValueNull);
     }

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -1898,6 +1898,69 @@ public class RecordBatchTests
         await Assert.That(readerAtEnd).IsTrue();
     }
 
+    [Test]
+    public async Task Record_Read_SpanBackedReader_ParsesFieldsAndConsumesExactlyDeclaredLength()
+    {
+        // A span-backed reader has no memory to slice, so Record.Read copies the body once and
+        // parses that copy; the fields must still come back intact and the outer reader must
+        // land exactly on the next record.
+        var first = new Record
+        {
+            Key = "key"u8.ToArray(),
+            Value = "value"u8.ToArray(),
+            Headers = [new Header("h", "hv"u8.ToArray())],
+            HeaderCount = 1
+        };
+        var second = new Record { OffsetDelta = 1, IsKeyNull = true, Value = "second"u8.ToArray() };
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        first.Write(ref writer);
+        second.Write(ref writer);
+        var reader = new KafkaProtocolReader(buffer.WrittenSpan);
+
+        var parsedFirst = Record.Read(ref reader);
+        var parsedSecond = Record.Read(ref reader);
+        var readerAtEnd = reader.End;
+
+        await Assert.That(parsedFirst.Key.ToArray()).IsEquivalentTo("key"u8.ToArray());
+        await Assert.That(parsedFirst.Value.ToArray()).IsEquivalentTo("value"u8.ToArray());
+        await Assert.That(parsedFirst.HeaderCount).IsEqualTo(1);
+        await Assert.That(parsedFirst.Headers![0].Key).IsEqualTo("h");
+        await Assert.That(parsedFirst.Headers[0].Value.ToArray()).IsEquivalentTo("hv"u8.ToArray());
+        await Assert.That(parsedSecond.OffsetDelta).IsEqualTo(1);
+        await Assert.That(parsedSecond.IsKeyNull).IsTrue();
+        await Assert.That(parsedSecond.Value.ToArray()).IsEquivalentTo("second"u8.ToArray());
+        await Assert.That(readerAtEnd).IsTrue();
+    }
+
+    [Test]
+    public async Task Record_Read_SpanBackedReader_KeyLengthOverrunsDeclaredBody_ThrowsMalformedProtocolData()
+    {
+        var body = new ArrayBufferWriter<byte>();
+        var bodyWriter = new KafkaProtocolWriter(body);
+        bodyWriter.WriteInt8(0); // attributes
+        bodyWriter.WriteVarLong(0); // timestamp delta
+        bodyWriter.WriteVarInt(0); // offset delta
+        bodyWriter.WriteVarInt(40); // key length: only 4 body bytes follow
+        bodyWriter.WriteRawBytes(new byte[] { 1, 2, 3, 4 });
+        var framed = FrameRecordBody(body.WrittenSpan, trailingBytes: 128);
+
+        MalformedProtocolDataException? exception = null;
+        try
+        {
+            var reader = new KafkaProtocolReader(framed.Span);
+            Record.Read(ref reader);
+        }
+        catch (MalformedProtocolDataException ex)
+        {
+            exception = ex;
+        }
+
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.Message).Contains("declared length");
+        await Assert.That(exception.InnerException).IsTypeOf<InsufficientDataException>();
+    }
+
     /// <summary>
     /// Frames a hand-encoded record body as it appears on the wire: the length varint, the
     /// body, and optionally trailing bytes standing in for the records that follow it.

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -1741,7 +1741,6 @@ public class RecordBatchTests
     [Test]
     public async Task Record_Read_HeaderCountExceedsRemainingRecordBody_ThrowsMalformedProtocolData()
     {
-        var buffer = new ArrayBufferWriter<byte>();
         var body = new ArrayBufferWriter<byte>();
         var bodyWriter = new KafkaProtocolWriter(body);
         bodyWriter.WriteInt8(0); // attributes
@@ -1751,21 +1750,9 @@ public class RecordBatchTests
         bodyWriter.WriteVarInt(-1); // null value
         bodyWriter.WriteVarInt(1024); // impossible: no bytes remain for headers
 
-        var writer = new KafkaProtocolWriter(buffer);
-        writer.WriteVarInt(bodyWriter.BytesWritten);
-        writer.WriteRawBytes(body.WrittenSpan);
+        var exception = ReadRecordExpectingMalformedData(FrameRecordBody(body.WrittenSpan));
 
-        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
-
-        try
-        {
-            Record.Read(ref reader);
-            throw new InvalidOperationException("Expected MalformedProtocolDataException was not thrown");
-        }
-        catch (MalformedProtocolDataException ex)
-        {
-            await Assert.That(ex.Message).Contains("header count");
-        }
+        await Assert.That(exception.Message).Contains("header count");
     }
 
     [Test]
@@ -1782,21 +1769,9 @@ public class RecordBatchTests
         bodyWriter.WriteVarInt(headerCount);
         bodyWriter.WriteRawBytes(new byte[headerCount * 2]); // minimal empty key/value headers
 
-        var buffer = new ArrayBufferWriter<byte>();
-        var writer = new KafkaProtocolWriter(buffer);
-        writer.WriteVarInt(bodyWriter.BytesWritten);
-        writer.WriteRawBytes(body.WrittenSpan);
-        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var exception = ReadRecordExpectingMalformedData(FrameRecordBody(body.WrittenSpan));
 
-        try
-        {
-            Record.Read(ref reader);
-            throw new InvalidOperationException("Expected MalformedProtocolDataException was not thrown");
-        }
-        catch (MalformedProtocolDataException ex)
-        {
-            await Assert.That(ex.Message).Contains("header count");
-        }
+        await Assert.That(exception.Message).Contains("header count");
     }
 
     [Test]
@@ -1812,22 +1787,148 @@ public class RecordBatchTests
         bodyWriter.WriteVarInt(2); // header count
         bodyWriter.WriteRawBytes(new byte[] { 0, 0, 0x80, 0x80 });
 
+        var exception = ReadRecordExpectingMalformedData(FrameRecordBody(body.WrittenSpan));
+
+        // Expected: the rented Header[] is returned before the exception escapes.
+        await Assert.That(exception.InnerException).IsTypeOf<InsufficientDataException>();
+    }
+
+    [Test]
+    public async Task Record_Read_KeyLengthOverrunsDeclaredBody_ThrowsMalformedProtocolData()
+    {
+        // The key claims more bytes than the declared body holds, but the buffer continues
+        // (as it would with a following record). The body is parsed in place with the outer
+        // reader, so the overrun must be caught against the declared length, not the buffer.
+        var body = new ArrayBufferWriter<byte>();
+        var bodyWriter = new KafkaProtocolWriter(body);
+        bodyWriter.WriteInt8(0); // attributes
+        bodyWriter.WriteVarLong(0); // timestamp delta
+        bodyWriter.WriteVarInt(0); // offset delta
+        bodyWriter.WriteVarInt(40); // key length: only 4 body bytes follow
+        bodyWriter.WriteRawBytes(new byte[] { 1, 2, 3, 4 });
+
+        var exception = ReadRecordExpectingMalformedData(
+            FrameRecordBody(body.WrittenSpan, trailingBytes: 128));
+
+        await Assert.That(exception.Message).Contains("declared length");
+        await Assert.That(exception.InnerException).IsTypeOf<InsufficientDataException>();
+    }
+
+    [Test]
+    public async Task Record_Read_HeaderValueLengthOverrunsDeclaredBody_ThrowsMalformedProtocolData()
+    {
+        var body = new ArrayBufferWriter<byte>();
+        var bodyWriter = new KafkaProtocolWriter(body);
+        bodyWriter.WriteInt8(0); // attributes
+        bodyWriter.WriteVarLong(0); // timestamp delta
+        bodyWriter.WriteVarInt(0); // offset delta
+        bodyWriter.WriteVarInt(-1); // null key
+        bodyWriter.WriteVarInt(-1); // null value
+        bodyWriter.WriteVarInt(1); // header count
+        bodyWriter.WriteVarInt(1); // header key length
+        bodyWriter.WriteRawBytes("k"u8);
+        bodyWriter.WriteVarInt(64); // header value length: no body bytes remain
+
+        var exception = ReadRecordExpectingMalformedData(
+            FrameRecordBody(body.WrittenSpan, trailingBytes: 128));
+
+        await Assert.That(exception.Message).Contains("declared length");
+        await Assert.That(exception.InnerException).IsTypeOf<InsufficientDataException>();
+    }
+
+    [Test]
+    public async Task Record_Read_VarIntFieldsOverrunDeclaredBody_ThrowsMalformedProtocolData()
+    {
+        // A non-canonical three-byte varlong makes the body longer than its declared length
+        // without any slice exceeding the bound; the overrun is observed after the fact.
+        var body = new ArrayBufferWriter<byte>();
+        var bodyWriter = new KafkaProtocolWriter(body);
+        bodyWriter.WriteInt8(0); // attributes
+        bodyWriter.WriteRawBytes(new byte[] { 0x80, 0x80, 0x00 }); // timestamp delta 0, 3 bytes
+        bodyWriter.WriteVarInt(0); // offset delta
+        bodyWriter.WriteVarInt(-1); // null key
+        bodyWriter.WriteVarInt(-1); // null value
+        bodyWriter.WriteVarInt(0); // header count
+
+        var exception = ReadRecordExpectingMalformedData(
+            FrameRecordBody(body.WrittenSpan, declaredLength: body.WrittenCount - 2, trailingBytes: 128));
+
+        await Assert.That(exception.Message).Contains("declared length");
+        await Assert.That(exception.InnerException).IsTypeOf<InsufficientDataException>();
+    }
+
+    [Test]
+    public async Task Record_Read_DeclaredLengthExceedsEncodedBody_ThrowsMalformedProtocolData()
+    {
+        var body = new ArrayBufferWriter<byte>();
+        var bodyWriter = new KafkaProtocolWriter(body);
+        bodyWriter.WriteInt8(0); // attributes
+        bodyWriter.WriteVarLong(0); // timestamp delta
+        bodyWriter.WriteVarInt(0); // offset delta
+        bodyWriter.WriteVarInt(-1); // null key
+        bodyWriter.WriteVarInt(-1); // null value
+        bodyWriter.WriteVarInt(0); // header count
+
+        var exception = ReadRecordExpectingMalformedData(
+            FrameRecordBody(body.WrittenSpan, declaredLength: body.WrittenCount + 3, trailingBytes: 128));
+
+        await Assert.That(exception.Message).Contains("length mismatch");
+    }
+
+    [Test]
+    public async Task Record_Read_ValidRecordFollowedByMoreData_ConsumesExactlyDeclaredLength()
+    {
+        var first = new Record { Key = "key"u8.ToArray(), Value = "value"u8.ToArray() };
+        var second = new Record { OffsetDelta = 1, IsKeyNull = true, Value = "second"u8.ToArray() };
         var buffer = new ArrayBufferWriter<byte>();
         var writer = new KafkaProtocolWriter(buffer);
-        writer.WriteVarInt(bodyWriter.BytesWritten);
-        writer.WriteRawBytes(body.WrittenSpan);
+        first.Write(ref writer);
+        second.Write(ref writer);
         var reader = new KafkaProtocolReader(buffer.WrittenMemory);
 
+        var parsedFirst = Record.Read(ref reader);
+        var parsedSecond = Record.Read(ref reader);
+        var readerAtEnd = reader.End;
+
+        await Assert.That(parsedFirst.Key.ToArray()).IsEquivalentTo("key"u8.ToArray());
+        await Assert.That(parsedFirst.Value.ToArray()).IsEquivalentTo("value"u8.ToArray());
+        await Assert.That(parsedSecond.OffsetDelta).IsEqualTo(1);
+        await Assert.That(parsedSecond.IsKeyNull).IsTrue();
+        await Assert.That(parsedSecond.Value.ToArray()).IsEquivalentTo("second"u8.ToArray());
+        await Assert.That(readerAtEnd).IsTrue();
+    }
+
+    /// <summary>
+    /// Frames a hand-encoded record body as it appears on the wire: the length varint, the
+    /// body, and optionally trailing bytes standing in for the records that follow it.
+    /// </summary>
+    private static ReadOnlyMemory<byte> FrameRecordBody(
+        ReadOnlySpan<byte> body,
+        int? declaredLength = null,
+        int trailingBytes = 0)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteVarInt(declaredLength ?? body.Length);
+        writer.WriteRawBytes(body);
+        if (trailingBytes > 0)
+            writer.WriteRawBytes(new byte[trailingBytes]);
+        return buffer.WrittenMemory;
+    }
+
+    private static MalformedProtocolDataException ReadRecordExpectingMalformedData(ReadOnlyMemory<byte> bytes)
+    {
+        var reader = new KafkaProtocolReader(bytes);
         try
         {
             Record.Read(ref reader);
-            throw new InvalidOperationException("Expected MalformedProtocolDataException was not thrown");
         }
         catch (MalformedProtocolDataException ex)
         {
-            // Expected: the rented Header[] is returned before the exception escapes.
-            await Assert.That(ex.InnerException).IsTypeOf<InsufficientDataException>();
+            return ex;
         }
+
+        throw new InvalidOperationException("Expected MalformedProtocolDataException was not thrown");
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Serialization/HeaderRecordStructTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/HeaderRecordStructTests.cs
@@ -183,7 +183,7 @@ public class HeaderRecordStructTests
         HeaderProtocol.Write(in header, ref writer);
 
         var reader = new KafkaProtocolReader(buffer.WrittenMemory);
-        return HeaderProtocol.Read(ref reader);
+        return HeaderProtocol.Read(ref reader, bodyEnd: buffer.WrittenCount);
     }
 
     private sealed class NonArrayMemoryManager(byte[] bytes) : MemoryManager<byte>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtocolBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtocolBenchmarks.cs
@@ -28,6 +28,7 @@ public class ProtocolBenchmarks
     private byte[] _compressedRecordBatchBytes = null!;
     private byte[] _largeRecordBatchBytes = null!;
     private byte[] _largeRecordBatchWithHeadersBytes = null!;
+    private byte[] _largeRecordsBytes = null!;
     private RecordBatch _writeBatch = null!;
     private string _testString = null!;
     private string _longString = null!;
@@ -89,6 +90,9 @@ public class ProtocolBenchmarks
             new Header("content-type", "application/json"u8.ToArray())
         ]));
 
+        // The same 1000 records without the batch envelope, for the direct Record.Read rows.
+        _largeRecordsBytes = WriteRecords(tempBuffer, CreateThousandRecordBatch(headers: null).Records);
+
         _writeBatch = CreateTenRecordBatch();
     }
 
@@ -96,6 +100,15 @@ public class ProtocolBenchmarks
     {
         buffer.Clear();
         batch.Write(buffer);
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    private static byte[] WriteRecords(ArrayBufferWriter<byte> buffer, IReadOnlyList<Record> records)
+    {
+        buffer.Clear();
+        var writer = new KafkaProtocolWriter(buffer);
+        for (var i = 0; i < records.Count; i++)
+            records[i].Write(ref writer);
         return buffer.WrittenSpan.ToArray();
     }
 
@@ -304,6 +317,36 @@ public class ProtocolBenchmarks
 
     [Benchmark(Description = "Read + Iterate RecordBatch (1000 records, 1 KB, 2 headers)")]
     public int ReadAndIterateLargeRecordBatchWithHeaders() => ReadAndIterate(_largeRecordBatchWithHeadersBytes);
+
+    /// <summary>
+    /// Direct <see cref="Record.Read(ref KafkaProtocolReader)"/> over a memory-backed reader:
+    /// key and value are zero-copy slices of the buffer.
+    /// </summary>
+    [Benchmark(Description = "Read Records, memory-backed reader (1000 records, 1 KB)")]
+    public int ReadRecordsFromMemoryReader()
+    {
+        var reader = new KafkaProtocolReader(_largeRecordsBytes);
+        return ReadRecords(ref reader);
+    }
+
+    /// <summary>
+    /// Same records over a span-backed reader, which cannot hand out memory slices: expected
+    /// cost is one body copy per record, never one array per field.
+    /// </summary>
+    [Benchmark(Description = "Read Records, span-backed reader (1000 records, 1 KB)")]
+    public int ReadRecordsFromSpanReader()
+    {
+        var reader = new KafkaProtocolReader(_largeRecordsBytes.AsSpan());
+        return ReadRecords(ref reader);
+    }
+
+    private static int ReadRecords(ref KafkaProtocolReader reader)
+    {
+        var sum = 0;
+        while (!reader.End)
+            sum += Record.Read(ref reader).OffsetDelta;
+        return sum;
+    }
 
     private static int ReadAndIterate(byte[] batchBytes)
     {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtocolBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtocolBenchmarks.cs
@@ -3,6 +3,7 @@ using BenchmarkDotNet.Attributes;
 using Dekaf.Benchmarks.Infrastructure;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
@@ -25,6 +26,8 @@ public class ProtocolBenchmarks
     private byte[] _varIntData = null!;
     private byte[] _recordBatchBytes = null!;
     private byte[] _compressedRecordBatchBytes = null!;
+    private byte[] _largeRecordBatchBytes = null!;
+    private byte[] _largeRecordBatchWithHeadersBytes = null!;
     private RecordBatch _writeBatch = null!;
     private string _testString = null!;
     private string _longString = null!;
@@ -77,7 +80,45 @@ public class ProtocolBenchmarks
         batch.Write(tempBuffer, CompressionType.Gzip);
         _compressedRecordBatchBytes = tempBuffer.WrittenSpan.ToArray();
 
+        // Consumer-shaped batches: 1000 records of 1 KB so per-record parse cost dominates
+        // the fixed batch-header cost, with and without headers.
+        _largeRecordBatchBytes = WriteBatch(tempBuffer, CreateThousandRecordBatch(headers: null));
+        _largeRecordBatchWithHeadersBytes = WriteBatch(tempBuffer, CreateThousandRecordBatch(
+        [
+            new Header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"u8.ToArray()),
+            new Header("content-type", "application/json"u8.ToArray())
+        ]));
+
         _writeBatch = CreateTenRecordBatch();
+    }
+
+    private static byte[] WriteBatch(ArrayBufferWriter<byte> buffer, RecordBatch batch)
+    {
+        buffer.Clear();
+        batch.Write(buffer);
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    private static RecordBatch CreateThousandRecordBatch(Header[]? headers)
+    {
+        var value = new byte[1024];
+        Random.Shared.NextBytes(value);
+        return new RecordBatch
+        {
+            BaseOffset = 0,
+            BaseTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            MaxTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            LastOffsetDelta = 999,
+            Records = Enumerable.Range(0, 1000).Select(i => new Record
+            {
+                TimestampDelta = i,
+                OffsetDelta = i,
+                Key = System.Text.Encoding.UTF8.GetBytes($"key-{i}"),
+                Value = value,
+                Headers = headers,
+                HeaderCount = headers?.Length ?? 0
+            }).ToList()
+        };
     }
 
     // No [IterationSetup]: its presence would force single-invocation iterations
@@ -256,9 +297,17 @@ public class ProtocolBenchmarks
     }
 
     [Benchmark(Description = "Read + Iterate RecordBatch (10 records)")]
-    public int ReadAndIterateRecordBatch()
+    public int ReadAndIterateRecordBatch() => ReadAndIterate(_recordBatchBytes);
+
+    [Benchmark(Description = "Read + Iterate RecordBatch (1000 records, 1 KB)")]
+    public int ReadAndIterateLargeRecordBatch() => ReadAndIterate(_largeRecordBatchBytes);
+
+    [Benchmark(Description = "Read + Iterate RecordBatch (1000 records, 1 KB, 2 headers)")]
+    public int ReadAndIterateLargeRecordBatchWithHeaders() => ReadAndIterate(_largeRecordBatchWithHeadersBytes);
+
+    private static int ReadAndIterate(byte[] batchBytes)
     {
-        var reader = new KafkaProtocolReader(_recordBatchBytes);
+        var reader = new KafkaProtocolReader(batchBytes);
         var batch = RecordBatch.Read(ref reader);
         var sum = 0;
         for (var i = 0; i < batch.Records.Count; i++)


### PR DESCRIPTION
## Summary

`Record.Read` (`src/Dekaf/Protocol/Records/Record.cs:139-147` at `b85eda535`) built a fresh sub-reader for every consumed record whenever the declared body fit in the frame:

```csharp
bodyReader = new KafkaProtocolReader(reader.GetRemainingSequence().Slice(0, length));
reader.Skip(length);
```

Per record that is a full `KafkaProtocolReader` struct copy (`var bodyReader = reader`; the struct embeds a `SequenceReader<byte>`), `GetRemainingSequence()` (a `ReadOnlySequence<byte>` built from `_memory`, with type dispatch on the backing object), `ReadOnlySequence.Slice`, and the `ReadOnlySequence` constructor of `KafkaProtocolReader` (`IsSingleSegment`, `.First`, `.Span` — a virtual `GetSpan()` with a disposed check on `NativeResponseBuffer`-backed frames). None of it is needed to parse the body; it existed only to bound the record's variable-length fields to the declared length (#2065).

## Change

- Parse the body in place with the caller's reader. `ReadBody` computes `bodyEnd = bodyStart + length`, and every variable-length slice (key, value, header key, header value) goes through a new internal `KafkaProtocolReader.ReadMemorySlice(int count, long limit)` that throws `InsufficientDataException` when the slice would cross `bodyEnd` — exactly what the sub-reader raised when it ran out — before any bytes are sliced or interned.
- `HeaderProtocol.Read(ref reader, long bodyEnd)` bounds header key/value slices the same way, so a corrupt header length cannot intern or expose bytes belonging to later records. The unbounded overload had no remaining production caller and was removed; its one test caller passes the buffer end.
- `ValidateHeaderCount` / `ValidateBodyLength` report "consumed past the declared body" (reachable only now that fixed-width fields and varints are not pre-bounded) as `InsufficientDataException`, so the unchanged `catch` clauses in `Record.Read` classify every failure exactly as before: an in-bounds body that cannot be parsed within its declared length surfaces as `MalformedProtocolDataException` (inner `InsufficientDataException`, same message), a frame cut short still surfaces as `InsufficientDataException`, and a body shorter than its declared length keeps its "length mismatch" message.
- The `length > availableBodyBytes` (frame truncated) path already parsed with the outer reader; it is unchanged apart from the new bound checks, which can only fire where the frame-length check would have failed anyway (same final exception type).

Not changed: control-record parsing; `HeaderProtocol.Read` has no other `src/` callers.

## Evidence

Environment: i7-12700K (20 threads), Windows 11, .NET SDK 10.0.400, BenchmarkDotNet `--inProcess --job Medium`, `[MemoryDiagnoser]`. Other agents were building and running tests on the same machine throughout, so absolute numbers are noisy (pair 1 in particular ran under heavy load — note its error bands); runs were interleaved baseline → candidate → baseline → candidate → baseline → candidate through a machine-wide benchmark lock so no two benchmark processes overlapped. The two `1000 records, 1 KB` cases were added by this PR (`ProtocolBenchmarks`) so per-record cost dominates; the same benchmark file was compiled into the baseline worktree. candidate-1/2 were measured with the bound check as a `Record`-local static helper; candidate-3 is the committed code (bound check moved onto `KafkaProtocolReader` after `/simplify`, same instructions).

### baseline-1 (`b85eda535`)

| Method                                                       | Mean          | Error         | StdDev        | Median        | Gen0    | Gen1   | Allocated |
|------------------------------------------------------------- |--------------:|--------------:|--------------:|--------------:|--------:|-------:|----------:|
| 'Read RecordBatch (10 records)'                              |      85.34 ns |      4.234 ns |      5.936 ns |      81.10 ns |       - |      - |         - |
| 'Read Gzip RecordBatch (10 records)'                         |   1,002.65 ns |     20.584 ns |     28.856 ns |     996.24 ns |  0.0229 |      - |     312 B |
| 'Read + Iterate RecordBatch (10 records)'                    |     914.63 ns |    151.009 ns |    216.573 ns |     934.88 ns |       - |      - |         - |
| 'Read + Iterate RecordBatch (1000 records, 1 KB)'            |  97,841.35 ns |  4,411.549 ns |  6,602.999 ns |  94,222.74 ns |       - |      - |       1 B |
| 'Read + Iterate RecordBatch (1000 records, 1 KB, 2 headers)' | 660,584.05 ns | 62,656.762 ns | 93,781.699 ns | 654,409.81 ns | 17.5781 | 4.8828 |  240510 B |

### candidate-1

| Method                                                       | Mean         | Error       | StdDev       | Median       | Gen0    | Gen1   | Allocated |
|------------------------------------------------------------- |-------------:|------------:|-------------:|-------------:|--------:|-------:|----------:|
| 'Read RecordBatch (10 records)'                              |     113.5 ns |     9.69 ns |     14.50 ns |     120.1 ns |       - |      - |         - |
| 'Read Gzip RecordBatch (10 records)'                         |   1,061.6 ns |    68.60 ns |    100.56 ns |   1,013.2 ns |  0.0229 |      - |     312 B |
| 'Read + Iterate RecordBatch (10 records)'                    |     577.9 ns |    43.88 ns |     62.93 ns |     557.5 ns |       - |      - |         - |
| 'Read + Iterate RecordBatch (1000 records, 1 KB)'            |  86,235.8 ns | 7,872.80 ns | 11,783.64 ns |  80,083.8 ns |       - |      - |       1 B |
| 'Read + Iterate RecordBatch (1000 records, 1 KB, 2 headers)' | 519,879.0 ns | 8,134.04 ns | 10,858.71 ns | 516,131.5 ns | 17.5781 | 4.8828 |  238382 B |

### baseline-2 (`b85eda535`)

| Method                                                       | Mean          | Error        | StdDev       | Gen0    | Gen1   | Allocated |
|------------------------------------------------------------- |--------------:|-------------:|-------------:|--------:|-------:|----------:|
| 'Read RecordBatch (10 records)'                              |      78.77 ns |     0.660 ns |     0.947 ns |       - |      - |         - |
| 'Read Gzip RecordBatch (10 records)'                         |     954.52 ns |     6.120 ns |     8.971 ns |  0.0229 |      - |     312 B |
| 'Read + Iterate RecordBatch (10 records)'                    |     658.83 ns |     2.478 ns |     3.554 ns |       - |      - |         - |
| 'Read + Iterate RecordBatch (1000 records, 1 KB)'            |  91,044.58 ns |   462.116 ns |   647.822 ns |       - |      - |       1 B |
| 'Read + Iterate RecordBatch (1000 records, 1 KB, 2 headers)' | 534,114.83 ns | 2,808.448 ns | 3,937.052 ns | 17.5781 | 4.8828 |  238379 B |

### candidate-2

| Method                                                       | Mean          | Error        | StdDev       | Median        | Gen0    | Gen1   | Allocated |
|------------------------------------------------------------- |--------------:|-------------:|-------------:|--------------:|--------:|-------:|----------:|
| 'Read RecordBatch (10 records)'                              |      77.56 ns |     0.696 ns |     0.929 ns |      78.10 ns |       - |      - |         - |
| 'Read Gzip RecordBatch (10 records)'                         |     956.44 ns |     5.606 ns |     8.040 ns |     954.02 ns |  0.0229 |      - |     312 B |
| 'Read + Iterate RecordBatch (10 records)'                    |     519.58 ns |     3.629 ns |     5.088 ns |     518.77 ns |       - |      - |         - |
| 'Read + Iterate RecordBatch (1000 records, 1 KB)'            |  77,152.42 ns |   590.203 ns |   827.383 ns |  76,793.25 ns |       - |      - |       1 B |
| 'Read + Iterate RecordBatch (1000 records, 1 KB, 2 headers)' | 505,322.90 ns | 2,974.742 ns | 4,266.287 ns | 504,720.65 ns | 17.5781 | 4.8828 |  238381 B |

### baseline-3 (`b85eda535`)

| Method                                                       | Mean          | Error        | StdDev       | Gen0    | Gen1   | Allocated |
|------------------------------------------------------------- |--------------:|-------------:|-------------:|--------:|-------:|----------:|
| 'Read RecordBatch (10 records)'                              |      80.04 ns |     2.213 ns |     2.878 ns |       - |      - |         - |
| 'Read Gzip RecordBatch (10 records)'                         |     950.17 ns |     5.119 ns |     7.503 ns |  0.0229 |      - |     312 B |
| 'Read + Iterate RecordBatch (10 records)'                    |     664.23 ns |     2.616 ns |     3.668 ns |       - |      - |         - |
| 'Read + Iterate RecordBatch (1000 records, 1 KB)'            |  89,555.51 ns |   453.795 ns |   636.157 ns |       - |      - |       1 B |
| 'Read + Iterate RecordBatch (1000 records, 1 KB, 2 headers)' | 536,708.82 ns | 2,024.053 ns | 2,770.546 ns | 17.5781 | 4.8828 |  238380 B |

### candidate-3 (committed code)

| Method                                                       | Mean          | Error        | StdDev       | Median        | Gen0    | Gen1   | Allocated |
|------------------------------------------------------------- |--------------:|-------------:|-------------:|--------------:|--------:|-------:|----------:|
| 'Read RecordBatch (10 records)'                              |      77.94 ns |     0.713 ns |     0.976 ns |      78.50 ns |       - |      - |         - |
| 'Read Gzip RecordBatch (10 records)'                         |     963.67 ns |     5.334 ns |     7.477 ns |     960.88 ns |  0.0229 |      - |     312 B |
| 'Read + Iterate RecordBatch (10 records)'                    |     516.05 ns |     1.981 ns |     2.712 ns |     516.47 ns |       - |      - |         - |
| 'Read + Iterate RecordBatch (1000 records, 1 KB)'            |  77,071.56 ns |   323.069 ns |   452.897 ns |  76,963.72 ns |       - |      - |       1 B |
| 'Read + Iterate RecordBatch (1000 records, 1 KB, 2 headers)' | 505,288.20 ns | 3,483.200 ns | 5,213.491 ns | 503,245.70 ns | 17.5781 | 4.8828 |  238381 B |

### Medians of the three runs per side (Mean column) and per-pair ratios

| Case | Baseline median | Candidate median | Ratio | Pair 1 | Pair 2 | Pair 3 | Allocated (both sides) |
|---|---:|---:|---:|---:|---:|---:|---|
| Read RecordBatch (10 records) — lazy, no record parsed | 80.04 ns | 77.94 ns | 0.974 | 1.330 | 0.985 | 0.974 | - |
| Read Gzip RecordBatch (10 records) — lazy, no record parsed | 954.52 ns | 963.67 ns | 1.010 | 1.059 | 1.002 | 1.014 | 312 B |
| Read + Iterate RecordBatch (10 records) | 664.23 ns | 519.58 ns | 0.782 | 0.632 | 0.789 | 0.777 | - |
| Read + Iterate RecordBatch (1000 records, 1 KB) | 91,044.58 ns | 77,152.42 ns | 0.847 | 0.881 | 0.847 | 0.861 | 1 B |
| Read + Iterate RecordBatch (1000 records, 1 KB, 2 headers) | 536,708.82 ns | 505,322.90 ns | 0.942 | 0.787 | 0.946 | 0.941 | ~238 KB |

- Per-record saving is consistent across shapes: (664.23 − 519.58) / 10 = 14.5 ns and (91,044.58 − 77,152.42) / 1000 = 13.9 ns per record, i.e. 15-22 % of the parse-and-iterate cost depending on record size.
- The two lazy `Read RecordBatch` cases never call `Record.Read`. Pair 1's +33 % on the 10-record case came with a 14.5 ns StdDev on an ~80 ns operation under external load and did not reproduce: pairs 2 and 3 (errors under 1 %) show 0.985 and 0.974. The Gzip case moves +0.2 % / +1.4 % in the clean pairs, inside its own baseline-to-baseline spread (950-1003 ns); its 312 B is the pre-existing decompression allocation.
- Allocated is identical on both sides for every case. The `1 B` on the 1000-record case is diagnoser rounding of an occasional `ArrayPool<Record>` re-rent and appears on the baseline too. The `2 headers` case allocates ~238 KB/op on **both** sides: `ArrayPool<Header>.Shared` keeps at most ~33 arrays per bucket per core, so 1000 header-carrying records in one batch overflow the pool and rent fresh `Header[]` for the remainder. Pre-existing and unrelated to this change; worth a follow-up (per-batch header slab).

## Risk

- `Dekaf.Protocol` change on the consumer per-record path. Malformed-vs-truncated classification is covered by the existing `RecordBatchTests` truncation/corruption suite (#2065 cases), `FetchResponseBatchBoundaryTests`, the fuzz-corpus replay tests (`RecordBatchFuzzCorpusTests`, `ResponseParserFuzzCorpusTests`, `ProtocolReaderFuzzCorpusTests`), and five new `Record.Read` tests that overrun key, header value, and varint fields into a following record and assert the exact exception type, message, and inner exception.
- On a parse failure the caller's reader is no longer positioned after the record (it was, via `Skip(length)`). Both callers (`RecordBatch.EnsureLazyRecordsParsedUpTo`, `LazyRecordList.EnsureParsedUpTo`) read `reader.Consumed` only after a successful `Record.Read`, so this is unobservable.
- Fixed-width fields and varints are bounded retroactively (at header-count and body-length validation) rather than eagerly; at most ~20 bytes of the following record can be read before the overrun is detected, and nothing is allocated or interned from them. Slices (key, value, header key/value) are bounded before they are taken.
- Readers constructed over a `ReadOnlySpan<byte>` (no backing memory) previously copied the whole record body once via `GetRemainingSequence()` and then sliced the copy; they now copy per key/value slice through the existing `ReadMemorySlice` span fallback. Neither path is used by the consumer, which always parses from `ReadOnlyMemory<byte>`.

## Tests

- `dotnet build tests/Dekaf.Tests.Unit -c Release`; `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe` (full suite): 8711 total, 8711 passed, 0 failed.
- Same exe with `--treenode-filter`: `/*/*/*FuzzCorpus*/*` 30/30, `/*/*/RecordBatchTests/*` 63/63 (5 new), `/*/*/HeaderRecordStructTests/*` 19/19, `/*/*/FetchResponse*/*` 25/25, `/*/*/LazyRecordListTests/*` 14/14, `/*/*/*Consumer*/*` 1231/1231 — all passed.
- `dotnet build tests/Dekaf.Tests.Integration -c Release`; `tests\Dekaf.Tests.Integration\bin\Release\net10.0\Dekaf.Tests.Integration.exe --treenode-filter "/*/*/ConsumerTests/*"` (Docker, `KAFKA_TEST_IMAGE_TAG` default 4.3.1): 38 total, 38 passed, 0 failed.
- Benchmarks: `dotnet run -c Release --project tools/Dekaf.Benchmarks -- --filter "*ProtocolBenchmarks.Read*RecordBatch*" --inProcess --job Medium --exporters json github`, six runs as tabled above.

https://claude.ai/code/session_01Suvjuoke4b9o5wuzNU2ThM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of record and header boundaries when parsing Kafka protocol data.
  * Malformed, truncated, or inconsistent record bodies now produce appropriate insufficient-data or malformed-data errors.
  * Prevented corrupted length fields from reading bytes beyond the current record.
  * Ensured valid records consume exactly their declared length, including span-backed readers.

* **Tests**
  * Added coverage for malformed headers, length overruns, truncated data, and record-boundary handling.

* **Performance**
  * Added benchmarks for reading and iterating large record batches, including batches with headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->