### PR TITLE
perf(networking): resume segmented produce writes inline on the socket completion

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -3969,9 +3969,16 @@ public sealed partial class KafkaConnection :
         private readonly SocketAsyncEventArgs _eventArgs = new();
         private int _pendingSegmentIndex;
         private int _pendingSegmentOffset;
+        // The SocketAsyncEventArgs.Completed callback already runs on a ThreadPool thread
+        // (Windows IOCP and Linux SocketAsyncEngine completions are both dispatched through
+        // the pool). Queueing the continuation again would add a second enqueue/dequeue and
+        // a possible worker wake per asynchronous produce write, while the connection's
+        // write lock stays held across the hop. Resume inline, as .NET's own
+        // AwaitableSocketAsyncEventArgs does; CompleteSend resets the event args before it
+        // signals so a continuation that immediately reuses the sender sees clean state.
         private ManualResetValueTaskSourceCore<int> _core = new()
         {
-            RunContinuationsAsynchronously = true
+            RunContinuationsAsynchronously = false
         };
 
         public SocketScatterGatherSender(int pendingSegmentCapacity = MaximumSegmentsPerSend)
@@ -4070,6 +4077,8 @@ public sealed partial class KafkaConnection :
 
         private void CompleteSend(object? sender, SocketAsyncEventArgs eventArgs)
         {
+            // Continuations run inline from here: the event args must be reusable before
+            // the awaiting writer is resumed, because it may call SendAsync again directly.
             eventArgs.BufferList = null;
             if (eventArgs.SocketError == SocketError.Success)
                 _core.SetResult(eventArgs.BytesTransferred);

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -260,6 +260,135 @@ public sealed class KafkaConnectionTests
     }
 
     [Test]
+    [Timeout(10_000)]
+    public async Task ScatterGatherSender_SynchronousCompletion_ReturnsCompletedValueTaskAndAllowsReuse(
+        CancellationToken cancellationToken)
+    {
+        using var pair = await LoopbackSocketPair.CreateAsync(forceAsynchronousSends: false, cancellationToken);
+        using var sender = new KafkaConnection.SocketScatterGatherSender();
+        var frame = CreateFrame(segmentBytes: 16, sender);
+        var receive = ReceiveExactlyAsync(pair.Server, frame.Length * 2, cancellationToken);
+
+        // A 256-byte frame against default socket buffers is accepted by the kernel immediately.
+        sender.BeginPendingSend();
+        sender.LoadSendWindow();
+        var first = sender.SendAsync(pair.Client);
+        await Assert.That(first.IsCompleted).IsTrue();
+        await Assert.That(first.Result).IsEqualTo(frame.Length);
+
+        // The event args must be free again without a completion callback having run.
+        sender.BeginPendingSend();
+        sender.LoadSendWindow();
+        var second = sender.SendAsync(pair.Client);
+        await Assert.That(second.IsCompleted).IsTrue();
+        await Assert.That(second.Result).IsEqualTo(frame.Length);
+
+        var received = await receive;
+        await Assert.That(received.AsSpan(0, frame.Length).SequenceEqual(frame)).IsTrue();
+        await Assert.That(received.AsSpan(frame.Length).SequenceEqual(frame)).IsTrue();
+    }
+
+    [Test]
+    [Timeout(10_000)]
+    public async Task ScatterGatherSender_AsynchronousCompletion_ContinuationReusesSenderInline(
+        CancellationToken cancellationToken)
+    {
+        using var pair = await LoopbackSocketPair.CreateAsync(forceAsynchronousSends: true, cancellationToken);
+        using var sender = new KafkaConnection.SocketScatterGatherSender();
+        var frame = CreateFrame(segmentBytes: 64 * 1024, sender);
+
+        // Nobody is reading yet and the client has no send buffer, so the 1 MB send stays pending
+        // and its result is produced by the SocketAsyncEventArgs.Completed callback once the
+        // receiver below drains the peer.
+        sender.BeginPendingSend();
+        sender.LoadSendWindow();
+        var first = sender.SendAsync(pair.Client);
+        await Assert.That(first.IsCompleted).IsFalse();
+
+        // Register a raw continuation (no async state machine) that consumes the result and
+        // immediately reuses the sender for a second frame. With inline continuations this
+        // runs inside CompleteSend, so it exercises the reset-before-signal ordering directly.
+        var firstBytes = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondSend = new TaskCompletionSource<Task<int>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        first.GetAwaiter().UnsafeOnCompleted(() =>
+        {
+            try
+            {
+                var bytesSent = first.GetAwaiter().GetResult();
+                sender.ConsumeSentBytes(bytesSent);
+                firstBytes.TrySetResult(bytesSent);
+
+                sender.BeginPendingSend();
+                sender.LoadSendWindow();
+                secondSend.TrySetResult(sender.SendAsync(pair.Client).AsTask());
+            }
+            catch (Exception ex)
+            {
+                firstBytes.TrySetException(ex);
+                secondSend.TrySetException(ex);
+            }
+        });
+
+        var receive = ReceiveExactlyAsync(pair.Server, frame.Length * 2, cancellationToken);
+        await Assert.That(await firstBytes.Task).IsEqualTo(frame.Length);
+        var secondBytes = await await secondSend.Task;
+        await Assert.That(secondBytes).IsEqualTo(frame.Length);
+        sender.ConsumeSentBytes(secondBytes);
+        await Assert.That(sender.HasPendingSegments).IsFalse();
+
+        var received = await receive;
+        await Assert.That(received.AsSpan(0, frame.Length).SequenceEqual(frame)).IsTrue();
+        await Assert.That(received.AsSpan(frame.Length).SequenceEqual(frame)).IsTrue();
+    }
+
+    [Test]
+    [Timeout(10_000)]
+    public async Task ScatterGatherSender_SocketClosedDuringAsynchronousSend_FaultsAwaiter(
+        CancellationToken cancellationToken)
+    {
+        using var pair = await LoopbackSocketPair.CreateAsync(forceAsynchronousSends: true, cancellationToken);
+        using var sender = new KafkaConnection.SocketScatterGatherSender();
+        CreateFrame(segmentBytes: 64 * 1024, sender);
+
+        // Nobody reads the peer, so a 1 MB frame stays pending until the socket is closed.
+        sender.BeginPendingSend();
+        sender.LoadSendWindow();
+        var send = sender.SendAsync(pair.Client);
+        await Assert.That(send.IsCompleted).IsFalse();
+
+        pair.Client.Dispose();
+
+        var act = async () => await send;
+        await Assert.That(act).Throws<SocketException>();
+    }
+
+    private static byte[] CreateFrame(int segmentBytes, KafkaConnection.SocketScatterGatherSender sender)
+    {
+        var frame = new byte[KafkaConnection.SocketScatterGatherSender.MaximumSegmentsPerSend * segmentBytes];
+        Random.Shared.NextBytes(frame);
+        for (var offset = 0; offset < frame.Length; offset += segmentBytes)
+            sender.PendingSegments.Add(new ArraySegment<byte>(frame, offset, segmentBytes));
+
+        return frame;
+    }
+
+    private static async Task<byte[]> ReceiveExactlyAsync(Socket socket, int count, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[count];
+        var received = 0;
+        while (received < count)
+        {
+            var read = await socket.ReceiveAsync(buffer.AsMemory(received), cancellationToken);
+            if (read == 0)
+                throw new IOException("Peer closed before the expected bytes arrived.");
+
+            received += read;
+        }
+
+        return buffer;
+    }
+
+    [Test]
     public async Task SingleBatchProduceSegments_UnpreparedCompressedBatch_FallsBack()
     {
         var batch = new RecordBatch
@@ -2063,6 +2192,68 @@ public sealed class KafkaConnectionTests
                 DisposeCount++;
 
             base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>
+    /// Connected loopback TCP pair for driving <see cref="KafkaConnection.SocketScatterGatherSender"/>
+    /// through its synchronous and asynchronous completion paths deterministically.
+    /// </summary>
+    private sealed class LoopbackSocketPair : IDisposable
+    {
+        private const int AsynchronousReceiveBufferSize = 8 * 1024;
+
+        private LoopbackSocketPair(Socket client, Socket server)
+        {
+            Client = client;
+            Server = server;
+        }
+
+        public Socket Client { get; }
+        public Socket Server { get; }
+
+        /// <param name="forceAsynchronousSends">
+        /// Gives the client a zero-length send buffer so a send completes only once the peer has
+        /// acknowledged the data, i.e. asynchronously on Windows and Linux alike, and caps the peer's
+        /// receive buffer at 8 KB. Windows otherwise accepts an arbitrarily large send synchronously
+        /// whenever the socket's queue is empty, regardless of the configured send buffer size.
+        /// </param>
+        public static async Task<LoopbackSocketPair> CreateAsync(
+            bool forceAsynchronousSends,
+            CancellationToken cancellationToken)
+        {
+            using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listener.Listen(1);
+
+            var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp)
+            {
+                NoDelay = true,
+            };
+            try
+            {
+                if (forceAsynchronousSends)
+                    client.SendBufferSize = 0;
+
+                var acceptTask = listener.AcceptAsync(cancellationToken);
+                await client.ConnectAsync(listener.LocalEndPoint!, cancellationToken);
+                var server = await acceptTask;
+                if (forceAsynchronousSends)
+                    server.ReceiveBufferSize = AsynchronousReceiveBufferSize;
+
+                return new LoopbackSocketPair(client, server);
+            }
+            catch
+            {
+                client.Dispose();
+                throw;
+            }
+        }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            Server.Dispose();
         }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -305,36 +305,108 @@ public sealed class KafkaConnectionTests
         var first = sender.SendAsync(pair.Client);
         await Assert.That(first.IsCompleted).IsFalse();
 
-        // Register a raw continuation (no async state machine) that consumes the result and
-        // immediately reuses the sender for a second frame. With inline continuations this
+        // Drive the same loop the production writer runs (LoadSendWindow -> SendAsync ->
+        // ConsumeSentBytes until no segments remain) from raw continuations, with no async state
+        // machine in between: every asynchronous completion consumes its byte count and reuses the
+        // sender for the next send directly inside the callback. With inline continuations that
         // runs inside CompleteSend, so it exercises the reset-before-signal ordering directly.
-        var firstBytes = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var secondSend = new TaskCompletionSource<Task<int>>(TaskCreationOptions.RunContinuationsAsynchronously);
-        first.GetAwaiter().UnsafeOnCompleted(() =>
+        // Linux completes large loopback sends in pieces, so the loop must tolerate partial counts;
+        // the frame is sent twice (two passes) to prove the args are reusable after a completion.
+        var firstPass = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondPass = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pass = 0;
+        var passBytes = 0;
+        var inlineReuses = 0;
+
+        void Fail(Exception ex)
+        {
+            firstPass.TrySetException(ex);
+            secondPass.TrySetException(ex);
+        }
+
+        void OnSent(int bytesSent)
+        {
+            sender.ConsumeSentBytes(bytesSent);
+            passBytes += bytesSent;
+        }
+
+        void Continue()
         {
             try
             {
-                var bytesSent = first.GetAwaiter().GetResult();
-                sender.ConsumeSentBytes(bytesSent);
-                firstBytes.TrySetResult(bytesSent);
+                while (true)
+                {
+                    if (!sender.HasPendingSegments)
+                    {
+                        var completed = pass == 0 ? firstPass : secondPass;
+                        var bytes = passBytes;
+                        if (pass == 0)
+                        {
+                            pass = 1;
+                            passBytes = 0;
+                            sender.BeginPendingSend();
+                            completed.TrySetResult(bytes);
+                            continue;
+                        }
 
-                sender.BeginPendingSend();
-                sender.LoadSendWindow();
-                secondSend.TrySetResult(sender.SendAsync(pair.Client).AsTask());
+                        completed.TrySetResult(bytes);
+                        return;
+                    }
+
+                    sender.LoadSendWindow();
+                    inlineReuses++;
+                    var send = sender.SendAsync(pair.Client);
+                    if (!send.IsCompleted)
+                    {
+                        var awaiter = send.GetAwaiter();
+                        awaiter.UnsafeOnCompleted(() =>
+                        {
+                            try
+                            {
+                                OnSent(awaiter.GetResult());
+                            }
+                            catch (Exception ex)
+                            {
+                                Fail(ex);
+                                return;
+                            }
+
+                            Continue();
+                        });
+                        return;
+                    }
+
+                    OnSent(send.GetAwaiter().GetResult());
+                }
             }
             catch (Exception ex)
             {
-                firstBytes.TrySetException(ex);
-                secondSend.TrySetException(ex);
+                Fail(ex);
             }
+        }
+
+        var firstAwaiter = first.GetAwaiter();
+        firstAwaiter.UnsafeOnCompleted(() =>
+        {
+            try
+            {
+                OnSent(firstAwaiter.GetResult());
+            }
+            catch (Exception ex)
+            {
+                Fail(ex);
+                return;
+            }
+
+            Continue();
         });
 
         var receive = ReceiveExactlyAsync(pair.Server, frame.Length * 2, cancellationToken);
-        await Assert.That(await firstBytes.Task).IsEqualTo(frame.Length);
-        var secondBytes = await await secondSend.Task;
-        await Assert.That(secondBytes).IsEqualTo(frame.Length);
-        sender.ConsumeSentBytes(secondBytes);
+        await Assert.That(await firstPass.Task).IsEqualTo(frame.Length);
+        await Assert.That(await secondPass.Task).IsEqualTo(frame.Length);
         await Assert.That(sender.HasPendingSegments).IsFalse();
+        // At least the second pass issued a SendAsync from inside a completion callback.
+        await Assert.That(inlineReuses).IsGreaterThanOrEqualTo(1);
 
         var received = await receive;
         await Assert.That(received.AsSpan(0, frame.Length).SequenceEqual(frame)).IsTrue();

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -295,11 +295,15 @@ public sealed class KafkaConnectionTests
     {
         using var pair = await LoopbackSocketPair.CreateAsync(forceAsynchronousSends: true, cancellationToken);
         using var sender = new KafkaConnection.SocketScatterGatherSender();
-        var frame = CreateFrame(segmentBytes: 64 * 1024, sender);
+        // 64 KB: large enough that the peer's 8 KB receive buffer plus the client's minimal send
+        // buffer cannot absorb it, so the send is guaranteed to pend on both platforms, yet small
+        // enough that Linux loopback (which paces such tiny-buffer transfers at ~150 KB/s via
+        // delayed ACKs) moves both passes well inside the test timeout.
+        var frame = CreateFrame(segmentBytes: 4 * 1024, sender);
 
-        // Nobody is reading yet and the client has no send buffer, so the 1 MB send stays pending
-        // and its result is produced by the SocketAsyncEventArgs.Completed callback once the
-        // receiver below drains the peer.
+        // Nobody is reading yet and the client has no send buffer, so the send stays pending and
+        // its result is produced by the SocketAsyncEventArgs.Completed callback once the receiver
+        // below drains the peer.
         sender.BeginPendingSend();
         sender.LoadSendWindow();
         var first = sender.SendAsync(pair.Client);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SocketScatterGatherSenderBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SocketScatterGatherSenderBenchmarks.cs
@@ -1,0 +1,142 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading.Tasks.Sources;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Networking;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures one asynchronous scatter/gather produce write through
+/// <see cref="KafkaConnection.SocketScatterGatherSender"/>: a 64 KB frame in 16 segments,
+/// the shape <c>KafkaConnection.WriteSegmentedFrameHoldingLockAsync</c> sends per zero-copy
+/// produce request. The loopback pair is configured so the send cannot complete synchronously
+/// (zero send buffer: the kernel only completes once the peer has acknowledged the data, on
+/// Windows as well as Linux; an 8 KB receive buffer keeps the peer's window small) while a
+/// dedicated thread drains the peer, so every operation exercises the
+/// <see cref="SocketAsyncEventArgs.Completed"/> path whose continuation policy is under test.
+/// <c>RunContinuationsAsynchronously</c> is flipped on the sender's
+/// <see cref="ManualResetValueTaskSourceCore{TResult}"/> so both policies run in the same
+/// process; the production sender constructs with <c>false</c>. The <c>Completed Work Items</c>
+/// column (ThreadingDiagnoser) counts ThreadPool dispatches per send: the redundant hop shows up
+/// as one extra work item per operation.
+/// </summary>
+[MemoryDiagnoser]
+[ThreadingDiagnoser]
+public class SocketScatterGatherSenderBenchmarks
+{
+    private const int SegmentCount = KafkaConnection.SocketScatterGatherSender.MaximumSegmentsPerSend;
+    private const int SegmentBytes = 4 * 1024;
+    private const int FrameBytes = SegmentCount * SegmentBytes;
+    private const int ReceiveBufferSize = 8 * 1024;
+
+    private TcpListener _listener = null!;
+    private Socket _client = null!;
+    private Socket _server = null!;
+    private Thread _drainThread = null!;
+    private KafkaConnection.SocketScatterGatherSender _sender = null!;
+    private long _sends;
+    private long _synchronousCompletions;
+
+    [Params(true, false)]
+    public bool RunContinuationsAsynchronously { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        _client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp)
+        {
+            NoDelay = true,
+            SendBufferSize = 0,
+        };
+        _client.Connect((IPEndPoint)_listener.LocalEndpoint);
+        _server = _listener.AcceptSocket();
+        _server.ReceiveBufferSize = ReceiveBufferSize;
+
+        _drainThread = new Thread(Drain) { IsBackground = true, Name = "scatter-gather-drain" };
+        _drainThread.Start(_server);
+
+        _sender = new KafkaConnection.SocketScatterGatherSender(SegmentCount);
+        SetRunContinuationsAsynchronously(_sender, RunContinuationsAsynchronously);
+        for (var i = 0; i < SegmentCount; i++)
+        {
+            var segment = new byte[SegmentBytes];
+            segment.AsSpan().Fill((byte)i);
+            _sender.PendingSegments.Add(new ArraySegment<byte>(segment));
+        }
+    }
+
+    /// <summary>
+    /// One 16-segment window, i.e. one <see cref="Socket.SendAsync(SocketAsyncEventArgs)"/>: the
+    /// loop <c>KafkaConnection.WriteSegmentedFrameHoldingLockAsync</c> runs per zero-copy produce
+    /// request has exactly one iteration for frames of up to 16 segments. The sender's
+    /// <see cref="ValueTask{TResult}"/> is returned directly so the only continuation is
+    /// BenchmarkDotNet's allocation-free awaiter and the Allocated column reflects the sender alone.
+    /// </summary>
+    [Benchmark]
+    public ValueTask<int> SendFrame()
+    {
+        var sender = _sender;
+        sender.BeginPendingSend();
+        sender.LoadSendWindow();
+        var send = sender.SendAsync(_client);
+        _sends++;
+        if (send.IsCompleted)
+            _synchronousCompletions++;
+
+        return send;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        // Validity check for the run log: the hop under test only exists on asynchronous
+        // completions, so nearly every send must have gone asynchronous.
+        Console.WriteLine(
+            $"// SocketScatterGatherSenderBenchmarks RunContinuationsAsynchronously={RunContinuationsAsynchronously}: "
+            + $"{_synchronousCompletions}/{_sends} sends completed synchronously");
+
+        _client.Shutdown(SocketShutdown.Both);
+        _client.Dispose();
+        _drainThread.Join();
+        _server.Dispose();
+        _listener.Stop();
+        _sender.Dispose();
+    }
+
+    private static void Drain(object? state)
+    {
+        var socket = (Socket)state!;
+        // Smaller than a frame: Windows can hand a send straight to a pending receive that has
+        // room for all of it, which would let that send complete synchronously.
+        var buffer = new byte[FrameBytes / 4];
+        try
+        {
+            while (socket.Receive(buffer) > 0)
+            {
+            }
+        }
+        catch (SocketException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    private static void SetRunContinuationsAsynchronously(
+        KafkaConnection.SocketScatterGatherSender sender,
+        bool value)
+    {
+        var coreField = typeof(KafkaConnection.SocketScatterGatherSender).GetField(
+                "_core",
+                BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("SocketScatterGatherSender._core field not found.");
+        var core = (ManualResetValueTaskSourceCore<int>)coreField.GetValue(sender)!;
+        core.RunContinuationsAsynchronously = value;
+        coreField.SetValue(sender, core);
+    }
+}


### PR DESCRIPTION
## Summary

`src/Dekaf/Networking/KafkaConnection.cs` — nested `SocketScatterGatherSender` (the zero-copy single-batch produce writer used by `WriteSegmentedFrameHoldingLockAsync`, ~L1969-2038) initialised its `ManualResetValueTaskSourceCore<int>` with `RunContinuationsAsynchronously = true` (~L3972 at `b85eda535`).

When a segmented produce write does not complete synchronously (socket send buffer full, i.e. the throughput-bound regime), the `SocketAsyncEventArgs.Completed` callback already runs on a ThreadPool thread on every platform (.NET dispatches Windows IOCP completions and Linux `SocketAsyncEngine` completions through the pool). `RunContinuationsAsynchronously = true` then queued the awaiting writer a *second* time before `WriteSegmentedFrameHoldingLockAsync` could resume, release `_scatterGatherSenderLock`/`_writeLock`, return the metadata buffer and let `BrokerSender` continue. Cost per asynchronous produce request: one extra enqueue/dequeue plus a possible worker wake, with the connection write lock held across the hop so the next request's write is serialised behind it. The generic `NetworkStream.WriteAsync` path and .NET's own `AwaitableSocketAsyncEventArgs` both resume inline for exactly this reason.

## Change

- `SocketScatterGatherSender._core`: `RunContinuationsAsynchronously = false`, with the rationale in a comment. Safety argument, verified by reading the whole sender:
  - `CompleteSend` already reads `BytesTransferred`/`SocketError` and nulls `BufferList` *before* `SetResult`/`SetException`, and the SAEA has already returned to its `Free` state when `Completed` fires, so a continuation that immediately calls `SendAsync` again (the writer's `while (HasPendingSegments)` loop for >16-segment frames) sees a reusable event args. `_core.Reset()` happens inside that next `SendAsync`; `ManualResetValueTaskSourceCore.SignalCompletion` touches no state after invoking the continuation, so re-entrant reset is safe.
  - The synchronous path (`Socket.SendAsync` returning `false`) never raises `Completed`, so there is no recursion.
  - Exceptions still flow through `_core.SetException` → `GetResult`, identical for both policies.
  - The other two `RunContinuationsAsynchronously` sites in the file are untouched: the pipelined response source (~L1044) is already `false` by design; `PooledPendingRequest` (~L5175) is deliberately `true`.
- New Docker-free benchmark `tools/Dekaf.Benchmarks/Benchmarks/Unit/SocketScatterGatherSenderBenchmarks.cs`: loopback pair with a zero send buffer / 8 KB receive buffer so every 64 KB, 16-segment send completes on the `Completed` callback, a dedicated drain thread, `[ThreadingDiagnoser]` to count pool dispatches per send, and the policy flipped via reflection on the private `_core` field so both settings run in one process (same reflection seam as `AsyncProducerSerdePoolingBenchmarks`).
- New unit tests in `KafkaConnectionTests`: synchronous completion + immediate reuse; asynchronous completion with a raw continuation that reuses the sender from *inside* the completion callback (exercises the reset-before-signal ordering the inline policy relies on); exception propagation when the socket is closed under a pending send.

Windows note: SO_SNDBUF is only an "is the queue empty now" check on Windows — a 1 MB overlapped send with an 8 KB send buffer completes synchronously on an idle socket — so the harness and tests use `SendBufferSize = 0` (complete on peer ACK) to reach the asynchronous path deterministically on both OSes.

## Evidence

Environment: i7-12700K (20 threads), Windows 11, .NET SDK 10.0.400 / runtime 10.0.11, BenchmarkDotNet 0.15.8 `--inProcess`, `--job Medium` (2 launches × 15 iterations). Other agents were building and running tests on the same machine during these runs (noise noted); benchmark processes were serialised by a machine-wide lock and interleaved baseline → candidate per pair.

### 1. Micro: `SocketScatterGatherSenderBenchmarks` (primary mechanism evidence)

Both worktrees compile the same harness file. `RunContinuationsAsynchronously=True` rows are `main`'s policy, `False` rows are this PR's. "Completed Work Items" = ThreadPool work items per send.

<details><summary>Pair 1 — baseline <code>main</code> b85eda535 (<code>micro-base-1</code>)</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
LaunchCount=2  WarmupCount=10  

```
| Method    | RunContinuationsAsynchronously | Mean     | Error    | StdDev   | Completed Work Items | Lock Contentions | Allocated |
|---------- |------------------------------- |---------:|---------:|---------:|---------------------:|-----------------:|----------:|
| **SendFrame** | **False**                          | **39.62 μs** | **1.349 μs** | **1.934 μs** |               **1.0000** |           **0.0032** |         **-** |
| **SendFrame** | **True**                           | **41.11 μs** | **1.407 μs** | **1.973 μs** |               **1.9999** |           **0.0051** |      **32 B** |

</details>

<details><summary>Pair 1 — candidate aef0e8ec6 (<code>micro-cand-1</code>)</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
LaunchCount=2  WarmupCount=10  

```
| Method    | RunContinuationsAsynchronously | Mean     | Error    | StdDev   | Completed Work Items | Lock Contentions | Allocated |
|---------- |------------------------------- |---------:|---------:|---------:|---------------------:|-----------------:|----------:|
| **SendFrame** | **False**                          | **37.71 μs** | **0.683 μs** | **0.888 μs** |               **1.0000** |           **0.0005** |         **-** |
| **SendFrame** | **True**                           | **38.37 μs** | **0.514 μs** | **0.668 μs** |               **1.9999** |           **0.0012** |      **32 B** |

</details>

<details><summary>Pair 2 — baseline <code>main</code> b85eda535 (<code>micro-base-2</code>)</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
LaunchCount=2  WarmupCount=10  

```
| Method    | RunContinuationsAsynchronously | Mean     | Error    | StdDev   | Completed Work Items | Lock Contentions | Allocated |
|---------- |------------------------------- |---------:|---------:|---------:|---------------------:|-----------------:|----------:|
| **SendFrame** | **False**                          | **33.38 μs** | **0.457 μs** | **0.626 μs** |               **1.0000** |           **0.0005** |         **-** |
| **SendFrame** | **True**                           | **37.99 μs** | **0.816 μs** | **1.117 μs** |               **1.9999** |           **0.0013** |      **32 B** |

</details>

<details><summary>Pair 2 — candidate aef0e8ec6 (<code>micro-cand-2</code>)</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
LaunchCount=2  WarmupCount=10  

```
| Method    | RunContinuationsAsynchronously | Mean     | Error    | StdDev   | Completed Work Items | Lock Contentions | Allocated |
|---------- |------------------------------- |---------:|---------:|---------:|---------------------:|-----------------:|----------:|
| **SendFrame** | **False**                          | **37.72 μs** | **0.856 μs** | **1.172 μs** |               **1.0000** |           **0.0024** |         **-** |
| **SendFrame** | **True**                           | **38.59 μs** | **0.599 μs** | **0.800 μs** |               **2.0000** |           **0.0058** |      **32 B** |

</details>

<details><summary>Pair 3 — baseline <code>main</code> b85eda535 (<code>micro-base-3</code>)</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
LaunchCount=2  WarmupCount=10  

```
| Method    | RunContinuationsAsynchronously | Mean     | Error    | StdDev   | Completed Work Items | Lock Contentions | Allocated |
|---------- |------------------------------- |---------:|---------:|---------:|---------------------:|-----------------:|----------:|
| **SendFrame** | **False**                          | **37.04 μs** | **0.635 μs** | **0.869 μs** |               **1.0000** |           **0.0032** |         **-** |
| **SendFrame** | **True**                           | **37.48 μs** | **0.267 μs** | **0.356 μs** |               **1.9999** |           **0.0040** |      **32 B** |

</details>

<details><summary>Pair 3 — candidate aef0e8ec6 (<code>micro-cand-3</code>)</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
LaunchCount=2  WarmupCount=10  

```
| Method    | RunContinuationsAsynchronously | Mean     | Error    | StdDev   | Completed Work Items | Lock Contentions | Allocated |
|---------- |------------------------------- |---------:|---------:|---------:|---------------------:|-----------------:|----------:|
| **SendFrame** | **False**                          | **38.59 μs** | **1.261 μs** | **1.726 μs** |               **1.0000** |           **0.0038** |         **-** |
| **SendFrame** | **True**                           | **37.76 μs** | **0.510 μs** | **0.662 μs** |               **1.9999** |           **0.0057** |      **32 B** |

</details>


Median summary:

Same-process A/B (the primary comparison: the only difference between the two rows of a run is the policy flag). Means in µs:

| Run | `True` (main policy) | `False` (this PR) | ratio | Completed Work Items `True` → `False` | Lock Contentions `True` → `False` | Allocated `True` → `False` |
|---|---:|---:|---:|---|---|---|
| micro-base-1 | 41.11 | 39.62 | 0.964 | 1.9999 → 1.0000 | 0.0051 → 0.0032 | 32 B → 0 |
| micro-cand-1 | 38.37 | 37.71 | 0.983 | 1.9999 → 1.0000 | 0.0012 → 0.0005 | 32 B → 0 |
| micro-base-2 | 37.99 | 33.38 | 0.879 | 1.9999 → 1.0000 | 0.0013 → 0.0005 | 32 B → 0 |
| micro-cand-2 | 38.59 | 37.72 | 0.977 | 2.0000 → 1.0000 | 0.0058 → 0.0024 | 32 B → 0 |
| micro-base-3 | 37.48 | 37.04 | 0.988 | 1.9999 → 1.0000 | 0.0040 → 0.0032 | 32 B → 0 |
| micro-cand-3 | 37.76 | 38.59 | 1.022 | 1.9999 → 1.0000 | 0.0057 → 0.0038 | 32 B → 0 |
| **median** | **38.18** | **37.72** | **0.988** | **2.0 → 1.0** | lower in 6/6 | **32 B → 0 B** |

Shipped-vs-shipped across worktrees (`True` row on baseline vs `False` row on candidate): pair 1 41.11 → 37.71 µs (0.917), pair 2 37.99 → 37.72 µs (0.993), pair 3 37.48 → 38.59 µs (1.030); medians 37.99 → 37.72 µs (0.993). Same-row cross-worktree ratios (identical code, i.e. the noise floor): `False` 0.952 / 1.130 / 1.042, `True` 0.933 / 1.016 / 1.008 — ±5-13 % run-to-run on this shared machine, which is why the in-process A/B above is the primary read.

What the numbers say:
- **ThreadPool dispatches per asynchronous send: 2.0 → 1.0, in all six runs.** This is the mechanism claim; it is a count, not a timing.
- **Allocated 32 B → 0 B.** The 32 B is the `QueueUserWorkItemCallback` wrapper `ThreadPool.UnsafeQueueUserWorkItem` allocates for the benchmark's awaiter continuation on the `True` path. The production awaiter is an async-state-machine box, which the runtime queues without a wrapper, so in production the saving is the dispatch and wake, not heap bytes. `False` rows are 0 B on both worktrees: the sender itself allocates nothing per send.
- **Time: −1.2 % at the median, faster in 5 of 6 in-process comparisons, slower in one (+2.2 %, inside its error bar).** A ~37 µs loopback ACK round trip dominates each operation, so a ~1 µs hop cannot show as more than a few percent here. Directionally consistent but not statistically strong on Windows; it is not the basis of the claim.
- Validity: 25-71 of 458,753 sends per case (≤ 0.015 %) completed synchronously, so effectively every measured operation went through the `Completed` callback whose continuation policy is under test.


### 2. Docker: `ProducerBenchmarks` `Dekaf_*` at MessageSize=1000 / BatchSize=1000 (supporting only — end-to-end against a Testcontainers broker on loopback, very noisy)

<details><summary>Pair 1 — baseline <code>main</code> b85eda535 (<code>docker-base-1</code>)</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
LaunchCount=2  WarmupCount=10  

```
| Method                           | Categories    | MessageSize | BatchSize | Mean      | Error     | StdDev    | Allocated |
|--------------------------------- |-------------- |------------ |---------- |----------:|----------:|----------:|----------:|
| Dekaf_ProduceBatchAllIdempotent  | BatchProduce  | 1000        | 1000      | 15.551 ms | 0.0953 ms | 0.1336 ms |   51092 B |
|                                  |               |             |           |           |           |           |           |
| Dekaf_FireAndForgetAllIdempotent | FireAndForget | 1000        | 1000      |  8.466 ms | 0.1659 ms | 0.2432 ms |     864 B |

</details>

<details><summary>Pair 1 — candidate aef0e8ec6 (<code>docker-cand-1</code>)</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
LaunchCount=2  WarmupCount=10  

```
| Method                           | Categories    | MessageSize | BatchSize | Mean      | Error     | StdDev    | Allocated |
|--------------------------------- |-------------- |------------ |---------- |----------:|----------:|----------:|----------:|
| Dekaf_ProduceBatchAllIdempotent  | BatchProduce  | 1000        | 1000      | 15.555 ms | 0.0624 ms | 0.0895 ms |   51533 B |
|                                  |               |             |           |           |           |           |           |
| Dekaf_FireAndForgetAllIdempotent | FireAndForget | 1000        | 1000      |  8.564 ms | 0.2123 ms | 0.3112 ms |     769 B |

</details>

<details><summary>Pair 2 — baseline <code>main</code> b85eda535 (<code>docker-base-2</code>)</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
LaunchCount=2  WarmupCount=10  

```
| Method                           | Categories    | MessageSize | BatchSize | Mean      | Error     | StdDev    | Allocated |
|--------------------------------- |-------------- |------------ |---------- |----------:|----------:|----------:|----------:|
| Dekaf_ProduceBatchAllIdempotent  | BatchProduce  | 1000        | 1000      | 15.559 ms | 0.0656 ms | 0.0940 ms |   50347 B |
|                                  |               |             |           |           |           |           |           |
| Dekaf_FireAndForgetAllIdempotent | FireAndForget | 1000        | 1000      |  8.494 ms | 0.1476 ms | 0.2163 ms |     810 B |

</details>

<details><summary>Pair 2 — candidate aef0e8ec6 (<code>docker-cand-2</code>)</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
LaunchCount=2  WarmupCount=10  

```
| Method                           | Categories    | MessageSize | BatchSize | Mean      | Error     | StdDev    | Allocated |
|--------------------------------- |-------------- |------------ |---------- |----------:|----------:|----------:|----------:|
| Dekaf_ProduceBatchAllIdempotent  | BatchProduce  | 1000        | 1000      | 15.650 ms | 0.1303 ms | 0.1826 ms |   50335 B |
|                                  |               |             |           |           |           |           |           |
| Dekaf_FireAndForgetAllIdempotent | FireAndForget | 1000        | 1000      |  8.613 ms | 0.1698 ms | 0.2542 ms |     821 B |

</details>


Median summary:

| Benchmark (MessageSize=1000, BatchSize=1000) | main median | PR median | ratio | per-pair ratios | Allocated main → PR |
|---|---:|---:|---:|---|---|
| `Dekaf_ProduceBatchAllIdempotent` | 15.555 ms | 15.603 ms | 1.003 | 1.000, 1.006 | 51092 / 50347 B → 51533 / 50335 B |
| `Dekaf_FireAndForgetAllIdempotent` | 8.480 ms | 8.588 ms | 1.013 | 1.012, 1.014 | 864 / 810 B → 769 / 821 B |

Flat within the reported error (`Error` ±0.06-0.13 ms for ProduceBatch, ±0.15-0.21 ms for FireAndForget; the FnF deltas are 0.10-0.12 ms). This harness is expected to be insensitive to the change on Windows: the broker is a loopback container and Windows completes an overlapped send synchronously whenever the socket queue is empty, so these 16 KB batches almost never take the asynchronous path that was changed. Reported as supporting/no-regression evidence only.


### 3. Linux stress A-B-A

**Pending.** The definitive test is the Linux stress A-B-A on lane `producer-1b` with `baseline_sha=b85eda535` (the immediately preceding product SHA), which exercises the throughput-bound regime where produce writes actually complete asynchronously. It will be dispatched by the maintainer; nothing was dispatched from this PR.

## Risk

- Continuations now run on the socket completion thread. Everything downstream of the await in `WriteSegmentedFrameHoldingLockAsync` is non-blocking (`SemaphoreHelper.ReleaseSafely`, pool returns, `Task` completion; `SemaphoreSlim` still resumes its own async waiters via the pool), so no blocking work moves onto the completion thread and there is no new deadlock path.
- A continuation that throws would now propagate into the SAEA callback; the only production awaiter is an async state machine, which never throws out of `MoveNext`.
- No behavioural change on the synchronous path, the TLS path (`NetworkStream.WriteAsync`) or the non-segmented path.

## Tests

Unit (TUnit, Release, `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe`, run on the committed code):
- `--treenode-filter "/*/*/KafkaConnection*/*"` — 120 total, 120 succeeded, 0 failed
- `--treenode-filter "/*/*/*/*ScatterGather*"` — 5 total, 5 succeeded, 0 failed (also 5/5 on three consecutive earlier runs; `/*/*/*ScatterGather*/*` matches no class — the tests live in `KafkaConnectionTests`)
- `--treenode-filter "/*/*/*Producer*/*"` — 567 total, 567 succeeded, 0 failed
- `--treenode-filter "/*/*/*Segment*/*"` — no matching classes (0 tests)

Integration (Docker, Testcontainers Kafka, `KAFKA_TEST_IMAGE_TAG` default 4.3.1; `dotnet build tests/Dekaf.Tests.Integration -c Release`, then `tests\Dekaf.Tests.Integrationin\Release
et10.0\Dekaf.Tests.Integration.exe --treenode-filter ...`):
- `/*/*/ProducerTests/*` — 32 total, 32 succeeded, 0 failed
- `/*/*/LargeMessageTests/*` (both namespaces) — 14 total, 14 succeeded, 0 failed
- `/*/*/ProducerLimitBoundaryTests/*` — 2 total, 2 succeeded, 0 failed
- `/*/*/ProducerOrderingTests/*` — 17 total, 17 succeeded, 0 failed

Benchmarks: `dotnet run -c Release --project tools/Dekaf.Benchmarks -- --filter "*SocketScatterGatherSender*" --inProcess --job Medium --exporters json github` × 3 interleaved pairs, and `--filter "*ProducerBenchmarks*Dekaf*(MessageSize: 1000, BatchSize: 1000)*"` × 2 interleaved pairs, serialised by a machine-wide lock.


https://claude.ai/code/session_01Suvjuoke4b9o5wuzNU2ThM
