### PR TITLE
perf(producer): read append-path topic state from PartitionDeque instead of hashing

### DIFF
--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -169,7 +169,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     /// <summary>
     /// Claims ownership of this operation (CAS from pending to completed).
     /// Called by <see cref="RecordAccumulator.DrainPendingAppends"/> BEFORE calling
-    /// <see cref="RecordAccumulator.AppendAfterReservation"/> to prevent timeout/cancel
+    /// <see cref="RecordAccumulator.AppendPooledAfterReservationCore"/> to prevent timeout/cancel
     /// from cleaning up resources while the drain is using them.
     /// </summary>
     /// <returns>True if this call won the race; false if timeout/cancel/dispose already completed it.</returns>
@@ -189,16 +189,16 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     internal void ReleasePendingCountAfterClaim() => ReleasePendingCount();
 
     /// <summary>
-    /// Sets the successful result after <see cref="TryClaim"/> + AppendAfterReservation.
+    /// Sets the successful result after <see cref="TryClaim"/> + AppendPooledAfterReservationCore.
     /// Must only be called after <see cref="TryClaim"/> returned true.
-    /// Resources are consumed by AppendAfterReservation — no cleanup needed.
+    /// Resources are consumed by AppendPooledAfterReservationCore — no cleanup needed.
     /// </summary>
     public void CompleteResult(bool result) => _core.SetResult(result);
 
     /// <summary>
-    /// Sets an exception result after <see cref="TryClaim"/> + failed AppendAfterReservation.
+    /// Sets an exception result after <see cref="TryClaim"/> + failed AppendPooledAfterReservationCore.
     /// Must only be called after <see cref="TryClaim"/> returned true.
-    /// AppendAfterReservation handles its own resource cleanup on throw.
+    /// AppendPooledAfterReservationCore handles its own resource cleanup on throw.
     /// </summary>
     public void CompleteException(Exception exception) => _core.SetException(exception);
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1081,8 +1081,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly ProducerOptions _options;
     private readonly bool _serializeBatchesPerPartition;
     private readonly CompressionCodecRegistry? _compressionCodecs;
-    private readonly ConcurrentDictionary<string, int> _singleBatchRequestFixedSizes =
-        new(StringComparer.Ordinal);
 
     /// <summary>
     /// Per-partition deques of sealed ReadyBatches, matching Java's
@@ -1107,12 +1105,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly int _admissionLeaseQuantumBytes;
 
     /// <summary>
-    /// Muted partitions — skipped by Ready() and Drain(). The value is a reference count:
-    /// independent BrokerSenders and crash-recovery barriers may overlap for the same partition.
-    /// Updates are serialized by <see cref="_partitionMuteLock"/>, while Ready/Drain perform
-    /// lock-free presence checks.
+    /// Serializes the read-modify-write of <see cref="PartitionDeque.MuteCount"/>. Readers
+    /// (Ready, Drain, and the append seal decision) never take it.
     /// </summary>
-    private readonly ConcurrentDictionary<TopicPartition, int> _mutedPartitions = new();
     private readonly System.Threading.Lock _partitionMuteLock = new();
 
     /// <summary>
@@ -1419,6 +1414,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     private readonly record struct DrainablePendingAppend(
         PendingAppend Operation,
+        PartitionDeque Deque,
         AdmissionReservation AdmissionReservation);
 
     /// <summary>
@@ -1438,6 +1434,25 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         public readonly string Topic = topicPartition.Topic;
         public readonly int Partition = topicPartition.Partition;
         public readonly RecordAccumulator Owner = owner;
+
+        /// <summary>
+        /// Conservative fixed ProduceRequest body size for a single-batch request to this
+        /// topic — a pure function of (TransactionalId, Topic), computed once per deque so
+        /// the per-record MaxRequestSize guard is a field read.
+        /// </summary>
+        public readonly int SingleBatchRequestFixedSize =
+            ProduceRequestSizeCalculator.GetConservativeSingleBatchFixedSize(
+                owner._options.TransactionalId,
+                topicPartition.Topic);
+
+        /// <summary>
+        /// Mute reference count — a muted partition is skipped by Ready() and Drain(), and
+        /// LingerMs == 0 appends keep its partial batch open. Independent BrokerSenders and
+        /// crash-recovery barriers may overlap for the same partition, hence a count rather
+        /// than a flag. Updates are serialized by <see cref="_partitionMuteLock"/>; readers
+        /// perform a lock-free volatile read.
+        /// </summary>
+        public int MuteCount;
 
         /// <summary>Per-partition lock for deque access (matches Java's synchronized(deque)).
         /// SpinLock avoids kernel transitions for the brief critical sections in append/drain paths.</summary>
@@ -1671,17 +1686,17 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             var dequeued = _readyPartitions.TryDequeue(out var tp);
             Debug.Assert(dequeued, "TryDequeue failed despite being the sole consumer of _readyPartitions");
 
-            if (_mutedPartitions.ContainsKey(tp))
+            var pd = _partitionDeques.GetValueOrDefault(tp);
+            if (pd is null)
+                continue;
+
+            if (IsMuted(pd))
             {
                 // Drop the notification; UnmutePartition() will re-enqueue if the
                 // partition still has sealed batches. This avoids unbounded queue
                 // growth while a partition stays muted across many sender cycles.
                 continue;
             }
-
-            var pd = _partitionDeques.GetValueOrDefault(tp);
-            if (pd is null)
-                continue;
 
             ReadyBatch? head;
             {
@@ -1799,7 +1814,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         foreach (var (topicPartition, pd) in _partitionDeques)
         {
-            if (_mutedPartitions.ContainsKey(topicPartition))
+            if (IsMuted(pd))
                 continue;
 
             ReadyBatch? head;
@@ -1927,11 +1942,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 }
             }
 
-            if (_mutedPartitions.ContainsKey(tp))
-                continue;
-
             var pd = _partitionDeques.GetValueOrDefault(tp);
-            if (pd is null)
+            if (pd is null || IsMuted(pd))
                 continue;
 
             ReadyBatch? batch;
@@ -1957,7 +1969,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     continue;
 
                 batchRequestSize = ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
-                    GetSingleBatchRequestFixedSize(tp.Topic),
+                    pd.SingleBatchRequestFixedSize,
                     batch.EncodedSize);
                 oversizedBatch = batchRequestSize > maxRequestSize;
                 if (!oversizedBatch && ready.Count > 0 && size + batchRequestSize > maxRequestSize)
@@ -2243,13 +2255,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     internal void MutePartition(TopicPartition tp)
     {
+        var pd = GetOrCreateDeque(tp);
         lock (_partitionMuteLock)
-        {
-            if (_mutedPartitions.TryGetValue(tp, out var count))
-                _mutedPartitions[tp] = count + 1;
-            else
-                _mutedPartitions[tp] = 1;
-        }
+            Volatile.Write(ref pd.MuteCount, pd.MuteCount + 1);
     }
 
     /// <summary>
@@ -2290,38 +2298,42 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     internal void UnmutePartition(TopicPartition tp)
     {
+        if (!_partitionDeques.TryGetValue(tp, out var pd))
+            return;
+
         lock (_partitionMuteLock)
         {
-            if (!_mutedPartitions.TryGetValue(tp, out var count))
+            var count = pd.MuteCount;
+            if (count == 0)
                 return;
 
+            // The count must reach zero before notification so Ready() cannot consume the
+            // notification while the partition still appears muted.
+            Volatile.Write(ref pd.MuteCount, count - 1);
             if (count > 1)
-            {
-                _mutedPartitions[tp] = count - 1;
                 return;
-            }
-
-            // Remove must precede notification so Ready() cannot consume the notification
-            // while the partition still appears muted.
-            _mutedPartitions.TryRemove(tp, out _);
         }
 
         // Re-notify so Ready() picks up any sealed batches that were skipped while muted.
-        if (HasQueuedBatches(tp))
+        if (HasQueuedBatches(pd))
             _readyPartitions.Enqueue(tp);
 
-        if (_partitionDeques.TryGetValue(tp, out var pd))
-            ReactivateDeferredLinger(tp, pd);
+        ReactivateDeferredLinger(tp, pd);
 
         SignalWakeup(); // Wake sender loop so it can drain the newly-unmuted partition
     }
-    internal bool IsMuted(TopicPartition tp) => _mutedPartitions.ContainsKey(tp);
+
+    internal bool IsMuted(TopicPartition tp)
+        => _partitionDeques.TryGetValue(tp, out var pd) && IsMuted(pd);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsMuted(PartitionDeque pd) => Volatile.Read(ref pd.MuteCount) != 0;
 
     internal bool HasQueuedBatches(TopicPartition tp)
-    {
-        if (!_partitionDeques.TryGetValue(tp, out var pd))
-            return false;
+        => _partitionDeques.TryGetValue(tp, out var pd) && HasQueuedBatches(pd);
 
+    private static bool HasQueuedBatches(PartitionDeque pd)
+    {
         using var guard = new SpinLockGuard(ref pd.Lock);
         return pd.PeekFirst() is not null;
     }
@@ -2448,7 +2460,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             continue;
                         }
 
+                        var candidateDeque = GetOrCreateDeque(candidate.Topic, candidate.Partition);
                         if (!TryReserveForAppend(
+                                candidateDeque,
                                 candidate.Topic,
                                 candidate.Partition,
                                 candidate.RecordSize,
@@ -2466,6 +2480,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
                         _drainablePendingAppends.Add(new DrainablePendingAppend(
                             candidate,
+                            candidateDeque,
                             admissionReservation));
                     }
 
@@ -2478,7 +2493,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     var op = drainable.Operation;
                     // Claim the operation with CAS BEFORE touching resources.
                     // This prevents timeout/cancel from cleaning up key/value/headers
-                    // while AppendAfterReservation is using them.
+                    // while AppendPooledAfterReservationCore is using them.
                     if (!op.TryClaim())
                     {
                         // Timeout/cancel won the race and already cleaned up resources.
@@ -2492,7 +2507,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
                     try
                     {
-                        var result = AppendAfterReservation(
+                        var result = AppendPooledAfterReservationCore(
+                            drainable.Deque,
                             op.Topic, op.Partition, op.Timestamp,
                             op.Key, op.Value, op.Headers, op.HeaderCount,
                             op.CompletionSource, op.Callback, op.RecordSize, op.PartitionCount,
@@ -2503,7 +2519,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     }
                     catch (Exception ex)
                     {
-                        // AppendAfterReservation handles its own resource cleanup on throw
+                        // AppendPooledAfterReservationCore handles its own resource cleanup on throw
                         op.ReleasePendingCountAfterClaim();
                         op.CompleteException(ex);
                     }
@@ -3371,7 +3387,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         if (Volatile.Read(ref pd.LingerDeferred) == 0
             || Volatile.Read(ref pd.QueueBytes) > 0
-            || _mutedPartitions.ContainsKey(topicPartition)
+            || IsMuted(pd)
             || Interlocked.CompareExchange(ref pd.LingerDeferred, 0, 1) != 1)
         {
             return;
@@ -3403,12 +3419,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (Volatile.Read(ref _disposed) != 0)
             return new ValueTask<bool>(false);
 
+        var pd = GetOrCreateDeque(topic, partition);
         int recordSize;
         try
         {
             recordSize = PartitionBatch.EstimateRecordSize(key.Length, value.Length, headers, headerCount);
             ThrowIfRecordExceedsMaxRequestSize(
-                topic, partition, key.IsNull, key.Length, value.IsNull, value.Length,
+                pd, topic, partition, key.IsNull, key.Length, value.IsNull, value.Length,
                 headers, headerCount, recordSize);
         }
         catch
@@ -3421,8 +3438,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         // Hot path: non-blocking gate check + CAS reservation — no async state machine
         // allocated. An over-budget broker applies the same backpressure as a full buffer.
-        if (TryAdmitAndReserve(topic, partition, recordSize, out var admissionReservation))
-            return new ValueTask<bool>(AppendAfterReservation(topic, partition, timestamp, key, value,
+        if (TryAdmitAndReserve(pd, topic, partition, recordSize, out var admissionReservation))
+            return new ValueTask<bool>(AppendPooledAfterReservationCore(pd, topic, partition, timestamp, key, value,
                 headers, headerCount, completionSource, callback, recordSize, partitionCount,
                 admissionReservation));
 
@@ -3432,25 +3449,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             headers, headerCount, completionSource, callback, recordSize, cancellationToken, partitionCount);
     }
 
-    private bool AppendAfterReservation(
-        string topic,
-        int partition,
-        long timestamp,
-        PooledMemory key,
-        PooledMemory value,
-        Header[]? headers,
-        int headerCount,
-        PooledValueTaskSource<RecordMetadata>? completionSource,
-        Action<RecordMetadata, Exception?>? callback,
-        int recordSize,
-        int partitionCount,
-        AdmissionReservation admissionReservation)
-    {
-        return AppendPooledAfterReservationCore(topic, partition, timestamp, key, value, headers, headerCount,
-            completionSource, callback, recordSize, partitionCount, admissionReservation);
-    }
-
     private bool AppendPooledAfterReservationCore(
+        PartitionDeque pd,
         string topic,
         int partition,
         long timestamp,
@@ -3465,7 +3465,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         AdmissionReservation admissionReservation)
     {
         var topicPartition = new TopicPartition(topic, partition);
-        var pd = GetOrCreateDeque(topic, partition);
         ReadyBatch? sealedBatchToEnqueue = null;
         var sealedBatchBytesToRelease = 0;
         PartitionBatch? rentedBatch = null;
@@ -3806,12 +3805,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (Volatile.Read(ref _disposed) != 0)
             return false;
 
+        var pd = GetOrCreateDeque(topic, partition);
         int recordSize;
         try
         {
             recordSize = PartitionBatch.EstimateRecordSize(key.Length, value.Length, headers, headerCount);
             ThrowIfRecordExceedsMaxRequestSize(
-                topic, partition, key.IsNull, key.Length, value.IsNull, value.Length,
+                pd, topic, partition, key.IsNull, key.Length, value.IsNull, value.Length,
                 headers, headerCount, recordSize);
         }
         catch
@@ -3825,10 +3825,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // Try the admission gate + non-blocking memory reservation. If the buffer is full
         // or the destination broker is over its unacked-byte budget, return false so the
         // caller (ProduceAsync fast path) falls back to the async path.
-        if (!TryAdmitAndReserve(topic, partition, recordSize, out var admissionReservation))
+        if (!TryAdmitAndReserve(pd, topic, partition, recordSize, out var admissionReservation))
             return false;
 
-        return AppendPooledAfterReservationCore(topic, partition, timestamp, key, value, headers, headerCount,
+        return AppendPooledAfterReservationCore(pd, topic, partition, timestamp, key, value, headers, headerCount,
             completionSource, callback: null, recordSize, partitionCount, admissionReservation);
     }
 
@@ -3853,22 +3853,27 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (Volatile.Read(ref _disposed) != 0)
             return false;
 
+        var pd = GetOrCreateDeque(topic, partition);
         var keyLength = keyIsNull ? 0 : keyData.Length;
         var valueLength = valueIsNull ? 0 : valueData.Length;
         var recordSize = PartitionBatch.EstimateRecordSize(keyLength, valueLength, headers, headerCount);
         ThrowIfRecordExceedsMaxRequestSize(
-            topic, partition, keyIsNull, keyLength, valueIsNull, valueLength,
+            pd, topic, partition, keyIsNull, keyLength, valueIsNull, valueLength,
             headers, headerCount, recordSize);
 
-        if (!TryAdmitAndReserve(topic, partition, recordSize, out var admissionReservation))
+        if (!TryAdmitAndReserve(pd, topic, partition, recordSize, out var admissionReservation))
             return false;
 
-        return AppendFromSpansAfterReservationCore(topic, partition, timestamp, keyData, keyIsNull,
+        return AppendFromSpansAfterReservationCore(pd, topic, partition, timestamp, keyData, keyIsNull,
             valueData, valueIsNull, headers, headerCount, completionSource, callback: null,
             recordSize, partitionCount, returnHeadersOnFailure: false, admissionReservation);
     }
 
+    /// <summary>
+    /// Synchronous append-under-lock logic for span-based append after memory has been reserved.
+    /// </summary>
     private bool AppendFromSpansAfterReservationCore(
+        PartitionDeque pd,
         string topic,
         int partition,
         long timestamp,
@@ -3895,6 +3900,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             try
             {
                 if (TryAppendFromSpansToCurrentBatchFast(
+                    pd,
                     topic,
                     partition,
                     timestamp,
@@ -3924,7 +3930,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
 
         var topicPartition = new TopicPartition(topic, partition);
-        var pd = GetOrCreateDeque(topic, partition);
         ReadyBatch? sealedBatchToEnqueue = null;
         var sealedBatchBytesToRelease = 0;
         PartitionBatch? rentedBatch = null;
@@ -4294,6 +4299,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (Volatile.Read(ref _disposed) != 0)
             return new ValueTask<bool>(false);
 
+        var pd = GetOrCreateDeque(topic, partition);
         var keyLength = keyIsNull ? 0 : keyData.Length;
         var valueLength = valueIsNull ? 0 : valueData.Length;
         int recordSize;
@@ -4301,7 +4307,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             recordSize = PartitionBatch.EstimateRecordSize(keyLength, valueLength, headers, headerCount);
             ThrowIfRecordExceedsMaxRequestSize(
-                topic, partition, keyIsNull, keyLength, valueIsNull, valueLength,
+                pd, topic, partition, keyIsNull, keyLength, valueIsNull, valueLength,
                 headers, headerCount, recordSize);
         }
         catch
@@ -4312,10 +4318,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         // Hot path: non-blocking gate check + CAS reservation — no async state machine
         // allocated. An over-budget broker applies the same backpressure as a full buffer.
-        if (TryAdmitAndReserve(topic, partition, recordSize, out var admissionReservation))
-            return new ValueTask<bool>(AppendFromSpansAfterReservation(topic, partition, timestamp,
-                keyData, keyIsNull, valueData, valueIsNull, headers, headerCount, callback, recordSize,
-                partitionCount, admissionReservation));
+        if (TryAdmitAndReserve(pd, topic, partition, recordSize, out var admissionReservation))
+            return new ValueTask<bool>(AppendFromSpansAfterReservationCore(pd, topic, partition, timestamp,
+                keyData, keyIsNull, valueData, valueIsNull, headers, headerCount, completionSource: null,
+                callback, recordSize, partitionCount, returnHeadersOnFailure: true, admissionReservation));
 
         // Cold path: buffer full. Copy spans to PooledMemory BEFORE the await boundary
         // (ReadOnlySpan<byte> cannot survive across async suspension points).
@@ -4328,6 +4334,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ThrowIfRecordExceedsMaxRequestSize(
+        PartitionDeque pd,
         string topic,
         int partition,
         bool keyIsNull,
@@ -4341,7 +4348,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var maxRequestSize = _options.MaxRequestSize > 0
             ? _options.MaxRequestSize
             : ProduceRequestSizeCalculator.DefaultMaxRequestSize;
-        var fixedSize = GetSingleBatchRequestFixedSize(topic);
+        var fixedSize = pd.SingleBatchRequestFixedSize;
         var estimatedBatchSize = (long)RecordBatch.TotalBatchHeaderSize + estimatedRecordSize;
         if (estimatedBatchSize <= int.MaxValue)
         {
@@ -4398,42 +4405,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int GetSingleBatchRequestFixedSize(string topic)
-    {
-        if (_singleBatchRequestFixedSizes.TryGetValue(topic, out var fixedSize))
-            return fixedSize;
-
-        fixedSize = ProduceRequestSizeCalculator.GetConservativeSingleBatchFixedSize(
-            _options.TransactionalId,
-            topic);
-        return _singleBatchRequestFixedSizes.GetOrAdd(topic, fixedSize);
-    }
-
-    /// <summary>
-    /// Synchronous append-under-lock logic for span-based append after memory has been reserved.
-    /// </summary>
-    private bool AppendFromSpansAfterReservation(
-        string topic,
-        int partition,
-        long timestamp,
-        ReadOnlySpan<byte> keyData,
-        bool keyIsNull,
-        ReadOnlySpan<byte> valueData,
-        bool valueIsNull,
-        Header[]? headers,
-        int headerCount,
-        Action<RecordMetadata, Exception?>? callback,
-        int recordSize,
-        int partitionCount,
-        AdmissionReservation admissionReservation)
-    {
-        return AppendFromSpansAfterReservationCore(topic, partition, timestamp, keyData, keyIsNull,
-            valueData, valueIsNull, headers, headerCount, completionSource: null, callback,
-            recordSize, partitionCount, returnHeadersOnFailure: true, admissionReservation);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryAppendFromSpansToCurrentBatchFast(
+        PartitionDeque pd,
         string topic,
         int partition,
         long timestamp,
@@ -4449,7 +4422,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         out bool appendCommitted)
     {
         appendCommitted = false;
-        var pd = GetOrCreateDeque(topic, partition);
         PartitionBatch? batchToComplete = null;
         int actualBytesAdded;
         var drainPendingAfterAppend = false;
@@ -4751,7 +4723,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             return !ShouldDeferPartialBatchSeal(pd, batch);
 
         return IsAppLimitedAwaitedAppend(batch, completionSource)
-            && !_mutedPartitions.ContainsKey(batch.TopicPartition);
+            && !IsMuted(pd);
     }
 
     /// <summary>
@@ -4811,10 +4783,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldDeferPartialBatchSeal(PartitionDeque pd, PartitionBatch batch)
     {
-        var topicPartition = batch.TopicPartition;
         var hasPipelineBatch = Volatile.Read(ref pd.QueueBytes) > 0;
         return ShouldDeferPartialBatchSeal(
-            _mutedPartitions.ContainsKey(topicPartition),
+            IsMuted(pd),
             _serializeBatchesPerPartition,
             hasPipelineBatch,
             batch.EstimatedSize,
@@ -6049,11 +6020,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryAdmitAndReserve(
+        PartitionDeque partitionDeque,
         string topic,
         int partition,
         int recordSize,
         out AdmissionReservation admissionReservation)
         => TryReserveForAppend(
+            partitionDeque,
             topic,
             partition,
             recordSize,
@@ -6063,6 +6036,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryReserveForAppend(
+        PartitionDeque partitionDeque,
         string topic,
         int partition,
         int recordSize,
@@ -6070,7 +6044,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         out AdmissionReservation admissionReservation,
         out bool brokerBlocked)
     {
-        var partitionDeque = GetOrCreateDeque(topic, partition);
         admissionReservation = default;
         brokerBlocked = false;
 
@@ -6745,7 +6718,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             var elapsed = Stopwatch.GetElapsedTime(batch.StopwatchCreatedTicks);
 
             // Diagnostic: capture partition state to help identify why batch was orphaned
-            var isMuted = _mutedPartitions.ContainsKey(batch.TopicPartition);
+            var isMuted = IsMuted(batch.TopicPartition);
             var inDeque = false;
             var dequeCount = 0;
             if (_partitionDeques.TryGetValue(batch.TopicPartition, out var pd))

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -683,6 +683,54 @@ public class RecordAccumulatorReadyTests
     }
 
     [Test]
+    public async Task MutePartition_IsReferenceCounted_ReadyResumesOnlyAfterLastUnmute()
+    {
+        // Overlapping mute holders (independent BrokerSenders, crash-recovery barriers) must
+        // each release before Ready() may drain the partition again. Muting a partition that
+        // has never been appended to must be honored once appends arrive.
+        var options = CreateTestOptions(batchSize: 50);
+        var accumulator = new RecordAccumulator(options);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var metadataManager = CreateMetadataManager("test-topic", 1, nodeId: 1);
+        var tp = new TopicPartition("test-topic", 0);
+
+        try
+        {
+            await Assert.That(accumulator.IsMuted(tp)).IsFalse();
+
+            accumulator.MutePartition(tp);
+            accumulator.MutePartition(tp);
+            await Assert.That(accumulator.IsMuted(tp)).IsTrue();
+
+            for (var i = 0; i < 10; i++)
+                AccumulatorTestHelpers.AppendAwaitedNullRecord(accumulator, pool, "test-topic");
+
+            // One holder releasing leaves the partition muted: Ready() drops the notification.
+            accumulator.UnmutePartition(tp);
+            await Assert.That(accumulator.IsMuted(tp)).IsTrue();
+            var readyNodes = new HashSet<int>();
+            accumulator.Ready(metadataManager, readyNodes);
+            await Assert.That(readyNodes).IsEmpty();
+
+            // The last holder releasing re-notifies the sealed batches.
+            accumulator.UnmutePartition(tp);
+            await Assert.That(accumulator.IsMuted(tp)).IsFalse();
+            accumulator.Ready(metadataManager, readyNodes);
+            await Assert.That(readyNodes).Contains(1);
+
+            // An unbalanced release is a no-op, not an underflow into a muted state.
+            accumulator.UnmutePartition(tp);
+            await Assert.That(accumulator.IsMuted(tp)).IsFalse();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task Ready_MultiplePartitions_OnlyReportsReadyOnes()
     {
         // Verifies that with many partitions, only the ones with sealed batches are reported.


### PR DESCRIPTION
## SummaryTwo per-record topic-string hash lookups sat on the producer append path at main `b85eda535` (`src/Dekaf/Producer/RecordAccumulator.cs`):1. **MaxRequestSize guard.** `GetSingleBatchRequestFixedSize(string topic)` (:4401-4410) probed `_singleBatchRequestFixedSizes` — a `ConcurrentDictionary<string,int>` (:1084) — on every record, from `ThrowIfRecordExceedsMaxRequestSize` (:4330), which every append entry point runs (`AppendAsync` :3410, `TryAppendWithCompletion` :3813, `TryAppendFromSpansWithCompletion` :3859, `AppendFromSpansAsync` :4303). The value is a pure function of `(TransactionalId, topic)` (`ProduceRequestSizeCalculator.GetConservativeSingleBatchFixedSize`, `ProduceRequestSizeCalculator.cs:101-117`), so the Marvin hash of the topic string plus bucket probe bought nothing per record.2. **Mute check in the seal decision.** `ShouldDeferPartialBatchSeal(pd, batch)` (:4812-4821) called `_mutedPartitions.ContainsKey(topicPartition)` — a `ConcurrentDictionary<TopicPartition,int>` (:1115), where `TopicPartition` hashes its topic string — on every append when `LingerMs == 0`, the library default (`ProducerOptions.cs:154`), via `ShouldSealAppendedBatch` (:4750). The awaited-linger branch (:4754) did the same probe whenever the app-limited bypass was armed.In addition, the `PartitionDeque` was resolved twice per append: once inside `TryReserveForAppend` (:6072) and again inside `Append*AfterReservationCore` (:3468 / :3927) or `TryAppendFromSpansToCurrentBatchFast` (:4452).## Change- `PartitionDeque` gains two fields: `SingleBatchRequestFixedSize` (readonly, computed once per deque in the field initializer) and `MuteCount` (the mute reference count).- Each append entry point resolves the deque once via the existing `GetOrCreateDeque` (direct-mapped L1 + per-thread cache) and threads `pd` through `ThrowIfRecordExceedsMaxRequestSize` → `TryAdmitAndReserve` / `TryReserveForAppend` → `Append*AfterReservationCore` → `TryAppendFromSpansToCurrentBatchFast`. The size guard is now a field read; the duplicate deque resolutions are gone.- `_singleBatchRequestFixedSizes` is deleted. `Drain` uses `pd.SingleBatchRequestFixedSize` for its per-batch request-size accounting.- `_mutedPartitions` is deleted. `MutePartition` / `UnmutePartition` maintain `pd.MuteCount` under the existing `_partitionMuteLock` — same refcount semantics, same "count reaches zero before re-notification" ordering. Every reader (`Ready`, `Drain`, `RecoverStrandedSealedBatches`, `ReactivateDeferredLinger`, `ShouldSealAppendedBatch`, `ShouldDeferPartialBatchSeal`, the orphan-batch diagnostic) uses a lock-free `Volatile.Read` through `IsMuted(pd)`. `Ready` / `Drain` now do one `_partitionDeques` lookup per ready partition instead of `_mutedPartitions.ContainsKey` + `_partitionDeques.GetValueOrDefault` (two topic-string hashes).- Cold pending-append drain: the deque resolved during the reservation scan rides along in `DrainablePendingAppend` instead of being resolved again per drained op.- Two 14-parameter pass-through wrappers (`AppendAfterReservation`, `AppendFromSpansAfterReservation`) are removed; entry points call the Core methods directly. `PendingAppend.cs` doc comments updated to the surviving name.- Test: `MutePartition_IsReferenceCounted_ReadyResumesOnlyAfterLastUnmute` covers mute-before-first-append, two overlapping holders, and an unbalanced release.## Evidence**Environment:** i7-12700K (20 threads), Windows 11 10.0.26200, .NET SDK 10.0.400 / runtime 10.0.11, BenchmarkDotNet 0.15.8, `--inProcess --job Medium` (InProcessEmitToolchain, WarmupCount=10, IterationCount=15, LaunchCount=2), `[MemoryDiagnoser]`. Other agents were building concurrently on the same machine throughout; the noise shows up as two wide-StdDev samples called out below, which is why the runs are interleaved pairs (baseline then candidate, back to back) and the summary uses medians.**Benchmark:** `AccumulatorAppendBenchmarks` (Docker-free), `LingerMs = 0`, so both removed lookups and the duplicate deque resolution are on the measured path. Baseline worktree = detached `b85eda535`; candidate = this branch. Pair 1 ran the full class per side. Pairs 2 and 3 ran the class per method (`--filter *AccumulatorAppendBenchmarks.<Method>*`), interleaved baseline → candidate per method, because the resumed session's foreground command cap is 10 minutes and a full-class Medium run takes ~12; BDN measures each case independently with its own warmup, so per-case numbers are directly comparable. A third pair was run for `AppendHotPath` only, because pairs 1 and 2 disagreed by more than 10% on `AppendHotPath/1000` (pair 2's baseline sample is the outlier: StdDev 25.5 ns vs ~1.7 ns everywhere else).`Allocated` is `-` (0 B) on every case in every run, both sides. (A `-Job Short` sanity run of the candidate earlier showed 7 B on `AppendMultiPartition/1000` — the known stochastic drainer-behind cold path noted in CLAUDE.md; it did not recur in any of the ten Medium runs on either side.)### Pair 1 — baseline `acc-base-1` (started 10:09:40)| Method                        | MessageSize | Mean      | Error    | StdDev   | Allocated ||------------------------------ |------------ |----------:|---------:|---------:|----------:|| **AppendHotPath**                 | **100**         |  **71.62 ns** | **0.436 ns** | **0.626 ns** |         **-** || AppendMultiPartition          | 100         |  71.82 ns | 0.644 ns | 0.964 ns |         - || AppendAlternatingAccumulators | 100         |  71.05 ns | 0.293 ns | 0.421 ns |         - || **AppendHotPath**                 | **1000**        | **141.52 ns** | **1.198 ns** | **1.719 ns** |         **-** || AppendMultiPartition          | 1000        | 148.30 ns | 1.226 ns | 1.797 ns |         - || AppendAlternatingAccumulators | 1000        | 146.95 ns | 1.313 ns | 1.884 ns |         - |### Pair 1 — candidate `acc-cand-1` (started 10:21:31)| Method                        | MessageSize | Mean      | Error    | StdDev   | Allocated ||------------------------------ |------------ |----------:|---------:|---------:|----------:|| **AppendHotPath**                 | **100**         |  **65.36 ns** | **0.354 ns** | **0.530 ns** |         **-** || AppendMultiPartition          | 100         |  66.59 ns | 0.576 ns | 0.844 ns |         - || AppendAlternatingAccumulators | 100         |  66.95 ns | 0.280 ns | 0.419 ns |         - || **AppendHotPath**                 | **1000**        | **140.22 ns** | **1.022 ns** | **1.497 ns** |         **-** || AppendMultiPartition          | 1000        | 144.18 ns | 1.112 ns | 1.595 ns |         - || AppendAlternatingAccumulators | 1000        | 144.77 ns | 0.920 ns | 1.348 ns |         - |### Pair 2 — baseline `acc-base-2-hot` (13:05:49)| Method        | MessageSize | Mean      | Error     | StdDev    | Allocated ||-------------- |------------ |----------:|----------:|----------:|----------:|| AppendHotPath | 100         |  71.07 ns |  0.465 ns |  0.667 ns |         - || AppendHotPath | 1000        | 180.96 ns | 17.049 ns | 25.519 ns |         - |(The 1000 B row is the noisy outlier referenced above.)### Pair 2 — candidate `acc-cand-2-hot` (13:08:37)| Method        | MessageSize | Mean      | Error    | StdDev   | Allocated ||-------------- |------------ |----------:|---------:|---------:|----------:|| AppendHotPath | 100         |  65.89 ns | 0.536 ns | 0.802 ns |         - || AppendHotPath | 1000        | 140.07 ns | 1.520 ns | 2.179 ns |         - |### Pair 2 — baseline `acc-base-2-multi` (13:10:50)| Method               | MessageSize | Mean      | Error    | StdDev   | Allocated ||--------------------- |------------ |----------:|---------:|---------:|----------:|| AppendMultiPartition | 100         |  71.82 ns | 0.399 ns | 0.586 ns |         - || AppendMultiPartition | 1000        | 148.20 ns | 1.354 ns | 2.026 ns |         - |### Pair 2 — candidate `acc-cand-2-multi` (13:13:29)| Method               | MessageSize | Mean      | Error    | StdDev   | Allocated ||--------------------- |------------ |----------:|---------:|---------:|----------:|| AppendMultiPartition | 100         |  67.37 ns | 0.620 ns | 0.909 ns |         - || AppendMultiPartition | 1000        | 146.75 ns | 1.671 ns | 2.449 ns |         - |### Pair 2 — baseline `acc-base-2-alt` (13:15:57)| Method                        | MessageSize | Mean      | Error    | StdDev   | Allocated ||------------------------------ |------------ |----------:|---------:|---------:|----------:|| AppendAlternatingAccumulators | 100         |  71.75 ns | 0.583 ns | 0.854 ns |         - || AppendAlternatingAccumulators | 1000        | 151.37 ns | 3.530 ns | 5.284 ns |         - |### Pair 2 — candidate `acc-cand-2-alt` (13:18:32)| Method                        | MessageSize | Mean      | Error    | StdDev   | Allocated ||------------------------------ |------------ |----------:|---------:|---------:|----------:|| AppendAlternatingAccumulators | 100         |  67.10 ns | 0.454 ns | 0.651 ns |         - || AppendAlternatingAccumulators | 1000        | 145.73 ns | 1.389 ns | 2.079 ns |         - |### Pair 3 (AppendHotPath only) — baseline `acc-base-3-hot` (13:21:00)| Method        | MessageSize | Mean      | Error    | StdDev   | Allocated ||-------------- |------------ |----------:|---------:|---------:|----------:|| AppendHotPath | 100         |  71.83 ns | 0.552 ns | 0.827 ns |         - || AppendHotPath | 1000        | 142.40 ns | 1.466 ns | 2.194 ns |         - |### Pair 3 (AppendHotPath only) — candidate `acc-cand-3-hot` (13:23:32)| Method        | MessageSize | Mean      | Error    | StdDev   | Allocated ||-------------- |------------ |----------:|---------:|---------:|----------:|| AppendHotPath | 100         |  70.39 ns | 3.188 ns | 4.674 ns |         - || AppendHotPath | 1000        | 138.31 ns | 1.319 ns | 1.974 ns |         - |(The 100 B row here is the second wide-StdDev sample: 4.7 ns vs ~0.5-0.8 ns in the other five HotPath/100 samples.)### Median summaryMedian of the per-side samples (three samples for `AppendHotPath`, two for the others — for two samples the median is their mean). Per-pair ratio = candidate / baseline within the same pair.| Case | Baseline median | Candidate median | Ratio | Per-pair ratios ||---|---:|---:|---:|---|| AppendHotPath / 100 B | 71.62 ns | 65.89 ns | **0.920** | 0.913, 0.927, 0.980 || AppendHotPath / 1000 B | 142.40 ns | 140.07 ns | **0.984** | 0.991, 0.774 (noisy baseline), 0.971 || AppendMultiPartition / 100 B | 71.82 ns | 66.98 ns | **0.933** | 0.927, 0.938 || AppendMultiPartition / 1000 B | 148.25 ns | 145.47 ns | **0.981** | 0.972, 0.990 || AppendAlternatingAccumulators / 100 B | 71.40 ns | 67.03 ns | **0.939** | 0.942, 0.935 || AppendAlternatingAccumulators / 1000 B | 149.16 ns | 145.25 ns | **0.974** | 0.985, 0.963 |The candidate is faster in all 12 pair-case comparisons. The absolute saving is ~4.4-5.7 ns per append at 100 B (6-8%) and ~2.3-4 ns at 1000 B (2-3%, diluted by the record memcpy) — consistent with removing two dictionary probes (each a Marvin hash over the topic string plus a bucket walk) and one L1 deque-cache re-resolution. These benchmarks are single-threaded and CPU-bound, so time here is CPU per message. No metric regressed: allocations are 0 B before and after on every case.**FireAsync path:** `ProducerFireHotPathBenchmarks` (16 parameter cases, `LingerMs = 1000`, so only the size-guard lookup and the duplicate deque resolution are on its path) was measured afterwards in two interleaved pairs: ratios 0.957-1.030 with the pairs disagreeing in sign on six of eight hot-path rows, 0 B allocated on both sides, i.e. no measurable change. Full tables in https://github.com/thomhurst/Dekaf/pull/2988#issuecomment-5515363542. The `producer-fnf` stress lane with `baseline_sha` remains a maintainer call (paid run).## Risk- **Semantics preserved.** The mute refcount is updated under the same lock at the same sites; only its storage moved. `MutePartition` now creates the deque if absent (previously `_mutedPartitions` could hold a partition that had no deque yet). `_partitionDeques` never evicts, so this is bounded by partition count and is exactly what the first append to that partition would have done. Both production mute callers in `BrokerSender` pass partitions that already have batches, so the create branch is effectively never taken in production.- **Ordering.** The deque is now created before the MaxRequestSize guard can throw, so an oversized record to a never-seen partition leaves an empty deque behind (one `PartitionDeque` + `ReadyBatch?[4]`, roughly 180 B, exception path only, once per partition).- **Per-partition vs per-topic cache.** `SingleBatchRequestFixedSize` is computed once per partition rather than once per topic: N× a ~50-100 ns allocation-free computation at deque creation, 4 bytes per deque.- **`IsMuted(TopicPartition)`** (used per batch by `BrokerSender`) now probes `_partitionDeques` instead of `_mutedPartitions` — same cost class (one topic-string hash), per batch.- The L1 / per-thread deque caches were already on the append path inside `TryReserveForAppend`; hoisting the call to the entry point does not change cache behaviour. `pd` becomes one extra argument to the two non-inlined Core methods (one stack slot); the other threaded methods are `AggressiveInlining`.## TestsBuilt with `dotnet build -c Release` in the worktree (`TreatWarningsAsErrors` on; clean). Unit tests (TUnit / Microsoft.Testing.Platform), run against the final code:    tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "<filter>"| Filter | Total | Failed ||---|---:|---:|| `/*/*/RecordAccumulator*/*` | 350 | 0 || `/*/*/*Producer*/*` | 567 | 0 || `/*/*/BrokerSender*/*` | 113 | 0 || `/*/*/AdaptiveScaleDown*/*` | 43 | 0 || `/*/*/Kip126*/*` | 13 | 0 || `/*/*/ShouldFlush*/*` | 20 | 0 || `/*/*/StrandedBatch*/*` | 5 | 0 |The last five filters are every unit-test class that references partition muting (`grep -rln Mute tests/Dekaf.Tests.Unit`). `RecordAccumulator*` includes the new `MutePartition_IsReferenceCounted_ReadyResumesOnlyAfterLastUnmute`.Integration (Docker, Testcontainers Kafka, default `KAFKA_TEST_IMAGE_TAG` 4.3.1):    tests\Dekaf.Tests.Integration\bin\Release\net10.0\Dekaf.Tests.Integration.exe --treenode-filter "/*/*/ProducerTests/*"Passed: 32 total, 0 failed, 0 skipped.`/simplify` was run on the diff; three of its four review angles (reuse, simplification, efficiency) reported before the session was interrupted, and their zero-cost findings were applied (pass-through wrapper removal, single deque resolution in the pending-append drain, doc wording, shared test helper). Deliberately skipped: replacing `_partitionMuteLock` with `Interlocked` (cold path; kept the exact existing semantics) and dropping the `topic`/`partition` parameters that now travel alongside `pd` (pre-existing convention across ~13 signatures; the register-vs-field-load effect would need its own measurement — follow-up).https://claude.ai/code/session_01Suvjuoke4b9o5wuzNU2ThM<!-- This is an auto-generated comment: release notes by coderabbit.ai -->## Summary by CodeRabbit* **Bug Fixes**  * Improved partition muting behavior when multiple mute requests overlap.  * Ensured readiness notifications are correctly suppressed while a partition is muted and restored after the final unmute.  * Prevented unmatched unmute operations from changing partition state.* **Refactor**  * Improved internal handling of partition append and batching state without changing public APIs.<!-- end of auto-generated comment: release notes by coderabbit.ai -->