### PR TITLE
perf(producer): fold admission lease decision into the single append lock hold

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -96,6 +96,10 @@ internal ref struct SpinLockGuard
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Dispose()
     {
+        // Keep the full-fence Exit(). Exit(useMemoryBarrier: false) — a plain release store of
+        // the cleared owned bit — saved nothing measurable single-threaded and made four threads
+        // appending to four distinct partitions ~1.7x slower per record
+        // (AccumulatorAdmissionAppendBenchmarks, 4T-split: 92 ns → 154-195 ns).
         if (_taken) _lock.Exit();
     }
 }
@@ -952,7 +956,10 @@ internal sealed class BatchArena
 
     /// <summary>
     /// Tries to allocate space in the arena and returns a span for writing.
-    /// Thread-safe: uses CAS to atomically claim space in the arena.
+    /// Single-writer: the owning <see cref="PartitionBatch"/> only allocates while its
+    /// partition lock is held (see <see cref="PartitionBatch.TryReserveAppendFromSpans"/>),
+    /// so the position advance is a plain read-modify-write. The volatile store keeps the
+    /// lock-free readers (<see cref="Position"/>, <see cref="RemainingCapacity"/>) coherent.
     /// </summary>
     /// <param name="size">Number of bytes needed.</param>
     /// <param name="span">Output span to write to.</param>
@@ -961,30 +968,21 @@ internal sealed class BatchArena
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryAllocate(int size, out Span<byte> span, out int offset)
     {
-        // CAS loop for thread-safe allocation.
-        // Multiple threads may race to allocate space, but each will get a unique region.
-        while (true)
+        var currentPos = _position;
+        var newPos = currentPos + size;
+
+        if (newPos > _buffer.Length)
         {
-            var currentPos = Volatile.Read(ref _position);
-            var newPos = currentPos + size;
-
-            if (newPos > _buffer.Length)
-            {
-                // Not enough space - don't grow, let caller rotate batch
-                span = default;
-                offset = 0;
-                return false;
-            }
-
-            // Atomically claim this region
-            if (Interlocked.CompareExchange(ref _position, newPos, currentPos) == currentPos)
-            {
-                offset = currentPos;
-                span = _buffer.AsSpan(currentPos, size);
-                return true;
-            }
-            // CAS failed - another thread allocated, retry with new position
+            // Not enough space - don't grow, let caller rotate batch
+            span = default;
+            offset = 0;
+            return false;
         }
+
+        Volatile.Write(ref _position, newPos);
+        offset = currentPos;
+        span = _buffer.AsSpan(currentPos, size);
+        return true;
     }
 
     /// <summary>
@@ -1007,12 +1005,17 @@ internal sealed class BatchArena
 
     /// <summary>
     /// Rewinds the last allocation if no later allocation has occurred.
-    /// Used only while the owning partition lock is held to abandon a failed record encode.
+    /// Used only while the owning partition lock is held to abandon a failed record encode,
+    /// so like <see cref="TryAllocate"/> it is a plain single-writer read-modify-write.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryRewindLastAllocation(int offset, int length)
     {
-        return Interlocked.CompareExchange(ref _position, offset, offset + length) == offset + length;
+        if (_position != offset + length)
+            return false;
+
+        Volatile.Write(ref _position, offset);
+        return true;
     }
 
     /// <summary>
@@ -1468,8 +1471,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         public bool AppendInProgress;
 
         /// <summary>
-        /// One append owns the admission-to-commit handoff. This keeps the current batch
-        /// stable while the gate decides whether the append needs a new batch lease.
+        /// One two-phase append owns the admission-to-commit handoff. This keeps the current batch
+        /// stable while the gate decides whether the append needs a new batch lease. The
+        /// single-lock fast path (<see cref="TryAppendFromSpansSingleLock"/>) decides and commits
+        /// under one lock hold, so it never takes the slot; it only refuses to run while a
+        /// two-phase appender holds it.
         /// </summary>
         public int AdmissionInProgress;
 
@@ -2449,6 +2455,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         }
 
                         if (!TryReserveForAppend(
+                                GetOrCreateDeque(candidate.Topic, candidate.Partition),
                                 candidate.Topic,
                                 candidate.Partition,
                                 candidate.RecordSize,
@@ -2809,6 +2816,34 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             using var guard = new SpinLockGuard(ref pd.Lock);
             batch = pd.PollFirst();
             return batch is not null;
+        }
+
+        batch = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Test-only sender stand-in that observes the production publication order: a sealed batch
+    /// is visible only through its <see cref="_readyPartitions"/> notification, which the sealing
+    /// thread enqueues after its last touch of the <see cref="ReadyBatch"/>. The deque-polling
+    /// <see cref="TryDrainBatch(out ReadyBatch?)"/> can hand a batch to a concurrent drainer before
+    /// that publication, so recycling it races the sealer's <c>StartPreSerialization</c>. Single
+    /// consumer, like <see cref="Ready"/>; notifications for partitions without a queued batch
+    /// (duplicates) are dropped.
+    /// </summary>
+    internal bool TryDrainPublishedBatch([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out ReadyBatch? batch)
+    {
+        while (_readyPartitions.TryDequeue(out var topicPartition))
+        {
+            if (!_partitionDeques.TryGetValue(topicPartition, out var pd))
+                continue;
+
+            using var guard = new SpinLockGuard(ref pd.Lock);
+            if (pd.Count > 0)
+            {
+                batch = pd.PollFirst()!;
+                return true;
+            }
         }
 
         batch = null;
@@ -3421,7 +3456,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         // Hot path: non-blocking gate check + CAS reservation — no async state machine
         // allocated. An over-budget broker applies the same backpressure as a full buffer.
-        if (TryAdmitAndReserve(topic, partition, recordSize, out var admissionReservation))
+        if (TryAdmitAndReserve(GetOrCreateDeque(topic, partition), topic, partition, recordSize,
+                out var admissionReservation))
             return new ValueTask<bool>(AppendAfterReservation(topic, partition, timestamp, key, value,
                 headers, headerCount, completionSource, callback, recordSize, partitionCount,
                 admissionReservation));
@@ -3825,7 +3861,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // Try the admission gate + non-blocking memory reservation. If the buffer is full
         // or the destination broker is over its unacked-byte budget, return false so the
         // caller (ProduceAsync fast path) falls back to the async path.
-        if (!TryAdmitAndReserve(topic, partition, recordSize, out var admissionReservation))
+        if (!TryAdmitAndReserve(GetOrCreateDeque(topic, partition), topic, partition, recordSize,
+                out var admissionReservation))
             return false;
 
         return AppendPooledAfterReservationCore(topic, partition, timestamp, key, value, headers, headerCount,
@@ -3860,15 +3897,24 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             topic, partition, keyIsNull, keyLength, valueIsNull, valueLength,
             headers, headerCount, recordSize);
 
-        if (!TryAdmitAndReserve(topic, partition, recordSize, out var admissionReservation))
+        var pd = GetOrCreateDeque(topic, partition);
+        if (headers is null && headerCount == 0
+            && TryAppendFromSpansSingleLock(pd, topic, partition, timestamp, keyData, keyIsNull,
+                valueData, valueIsNull, completionSource, callback: null, recordSize, partitionCount))
+        {
+            return true;
+        }
+
+        if (!TryAdmitAndReserve(pd, topic, partition, recordSize, out var admissionReservation))
             return false;
 
-        return AppendFromSpansAfterReservationCore(topic, partition, timestamp, keyData, keyIsNull,
+        return AppendFromSpansAfterReservationCore(pd, topic, partition, timestamp, keyData, keyIsNull,
             valueData, valueIsNull, headers, headerCount, completionSource, callback: null,
             recordSize, partitionCount, returnHeadersOnFailure: false, admissionReservation);
     }
 
     private bool AppendFromSpansAfterReservationCore(
+        PartitionDeque pd,
         string topic,
         int partition,
         long timestamp,
@@ -3885,16 +3931,19 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         bool returnHeadersOnFailure,
         AdmissionReservation admissionReservation)
     {
-        // Headerless records dominate every producer mode. When the current batch has room,
-        // encode and commit under one partition-lock acquisition instead of publishing
-        // AppendInProgress and reacquiring the lock after encoding. Rotation and header paths
-        // retain the two-phase protocol.
+        // Headerless records normally commit in TryAppendFromSpansSingleLock; this path runs
+        // after that attempt yielded (a two-phase appender held the admission slot, rotation or
+        // an encode was in progress, or the batch was full) and the caller took the admission
+        // reservation. When the current batch has room by now, encode and commit under one
+        // partition-lock acquisition instead of publishing AppendInProgress and reacquiring
+        // the lock after encoding. Rotation and header paths retain the two-phase protocol.
         if (headers is null && headerCount == 0)
         {
             var appendCommitted = false;
             try
             {
                 if (TryAppendFromSpansToCurrentBatchFast(
+                    pd,
                     topic,
                     partition,
                     timestamp,
@@ -3924,7 +3973,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
 
         var topicPartition = new TopicPartition(topic, partition);
-        var pd = GetOrCreateDeque(topic, partition);
         ReadyBatch? sealedBatchToEnqueue = null;
         var sealedBatchBytesToRelease = 0;
         PartitionBatch? rentedBatch = null;
@@ -4310,10 +4358,20 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             throw;
         }
 
-        // Hot path: non-blocking gate check + CAS reservation — no async state machine
-        // allocated. An over-budget broker applies the same backpressure as a full buffer.
-        if (TryAdmitAndReserve(topic, partition, recordSize, out var admissionReservation))
-            return new ValueTask<bool>(AppendFromSpansAfterReservation(topic, partition, timestamp,
+        // Hot path: headerless records commit under a single partition-lock hold (lease decision,
+        // encode, commit). Anything it cannot handle in place falls through to the
+        // reservation-based path: non-blocking gate check + CAS reservation — no async state
+        // machine allocated. An over-budget broker applies the same backpressure as a full buffer.
+        var pd = GetOrCreateDeque(topic, partition);
+        if (headers is null && headerCount == 0
+            && TryAppendFromSpansSingleLock(pd, topic, partition, timestamp, keyData, keyIsNull,
+                valueData, valueIsNull, completionSource: null, callback, recordSize, partitionCount))
+        {
+            return new ValueTask<bool>(true);
+        }
+
+        if (TryAdmitAndReserve(pd, topic, partition, recordSize, out var admissionReservation))
+            return new ValueTask<bool>(AppendFromSpansAfterReservation(pd, topic, partition, timestamp,
                 keyData, keyIsNull, valueData, valueIsNull, headers, headerCount, callback, recordSize,
                 partitionCount, admissionReservation));
 
@@ -4413,6 +4471,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// Synchronous append-under-lock logic for span-based append after memory has been reserved.
     /// </summary>
     private bool AppendFromSpansAfterReservation(
+        PartitionDeque pd,
         string topic,
         int partition,
         long timestamp,
@@ -4427,13 +4486,173 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int partitionCount,
         AdmissionReservation admissionReservation)
     {
-        return AppendFromSpansAfterReservationCore(topic, partition, timestamp, keyData, keyIsNull,
+        return AppendFromSpansAfterReservationCore(pd, topic, partition, timestamp, keyData, keyIsNull,
             valueData, valueIsNull, headers, headerCount, completionSource: null, callback,
             recordSize, partitionCount, returnHeadersOnFailure: true, admissionReservation);
     }
 
+    /// <summary>
+    /// Single-lock fast path for headerless span appends. With the admission window enabled
+    /// (the default), a record previously paid two partition-lock acquisitions: one inside
+    /// <see cref="TryReserveForAppend"/> for the lease decision, guarded by the
+    /// <see cref="PartitionDeque.AdmissionInProgress"/> CAS handoff so the batch could not
+    /// rotate before the commit, and a second in <see cref="TryAppendFromSpansToCurrentBatchFast"/>
+    /// for the encode and commit. Here the lease decision, the encode and the commit all run
+    /// under one hold of the partition lock, so the batch is stable by construction and the
+    /// handoff slot is not needed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The BufferMemory reservation is taken before the lock, exactly as the reservation path
+    /// does: <see cref="TryReserveMemory"/> is a contended accumulator-wide atomic, and holding
+    /// the partition lock across it made four threads on four distinct partitions ~55% slower
+    /// per record (AccumulatorAdmissionAppendBenchmarks 4T-split, 64 ns to 100 ns) even though
+    /// nothing else contends for those locks.
+    /// </para>
+    /// <para>
+    /// Every early exit returns whatever it reserved (BufferMemory, and the broker lease when one
+    /// was taken) before the caller continues with the unchanged reservation-based protocol,
+    /// which owns batch rotation, header-bearing records, blocked or re-routed admission,
+    /// BufferMemory backpressure and FIFO behind queued slow-path appends. The two paths
+    /// therefore never double-account a record. Those exits are per batch (rotation) or cold
+    /// (blocked admission, exhausted BufferMemory), so the full <see cref="ReleaseMemory"/>,
+    /// which also drains pending appends, is the right undo.
+    /// </para>
+    /// </remarks>
+    /// <returns>
+    /// <see langword="true"/> when the record was committed to the current batch;
+    /// <see langword="false"/> when the caller must take the reservation-based path.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryAppendFromSpansSingleLock(
+        PartitionDeque pd,
+        string topic,
+        int partition,
+        long timestamp,
+        ReadOnlySpan<byte> keyData,
+        bool keyIsNull,
+        ReadOnlySpan<byte> valueData,
+        bool valueIsNull,
+        PooledValueTaskSource<RecordMetadata>? completionSource,
+        Action<RecordMetadata, Exception?>? callback,
+        int recordSize,
+        int partitionCount)
+    {
+        // Queued slow-path appends own the partition until they drain (FIFO). The reservation
+        // path also records the admission block and requests a flush when the broker is over
+        // budget, so leave that bookkeeping to it.
+        if (Volatile.Read(ref pd.SlowPathAppendCount) != 0)
+            return false;
+
+        // BufferMemory exhausted: the reservation path queues the record behind the same
+        // backpressure.
+        if (!TryReserveMemory(recordSize))
+            return false;
+
+        PartitionBatch? batchToComplete = null;
+        BrokerUnackedByteBudget? leaseBudget = null;
+        var leaseBytes = 0;
+        long leaseGeneration = 0;
+        var committed = false;
+        var actualBytesAdded = 0;
+
+        try
+        {
+            using var guard = new SpinLockGuard(ref pd.Lock);
+
+            // A two-phase appender holding the admission slot has made a lease decision it has
+            // not committed yet; appending ahead of it would invalidate that decision.
+            if (Volatile.Read(ref _disposed) != 0
+                || pd.RotationInProgress
+                || pd.AppendInProgress
+                || Volatile.Read(ref pd.AdmissionInProgress) != 0
+                || pd.CurrentBatch is not { } currentBatch
+                || !currentBatch.CanFitEstimatedRecord(recordSize))
+            {
+                return false;
+            }
+
+            if (_unackedBudgetEnabled)
+            {
+                var budget = GetCachedAdmissionBudget(pd, topic, partition);
+                if (budget is not null && !currentBatch.HasAdmissionCapacity(budget, recordSize))
+                {
+                    // The batch's local credit is exhausted: replenish one fixed-size lease so
+                    // most records keep consuming local credit without touching the broker
+                    // window. A rejected lease (over budget, or a leader that moved) needs the
+                    // refresh and flush-request bookkeeping of the reservation path.
+                    leaseBytes = GetAdmissionLeaseBytes(recordSize);
+                    if (!budget.TryReserve(leaseBytes, out leaseGeneration))
+                        return false;
+
+                    leaseBudget = budget;
+                }
+            }
+
+            var result = currentBatch.TryAppendFromSpans(
+                timestamp,
+                keyData,
+                keyIsNull,
+                valueData,
+                valueIsNull,
+                headers: null,
+                headerCount: 0,
+                completionSource,
+                callback,
+                estimatedSize: recordSize);
+
+            // The estimate fit but the arena could not take the encoded record: rotation belongs
+            // to the two-phase path.
+            if (!result.Success)
+                return false;
+
+            if (leaseBudget is not null)
+                currentBatch.AddAdmissionLease(leaseBudget, leaseGeneration, leaseBytes);
+
+            committed = true;
+            actualBytesAdded = result.ActualSizeAdded;
+            ProducerDebugCounters.RecordMessageAppended(hasCompletionSource: completionSource is not null);
+
+            if (result.FirstCompletionSourceInBatch)
+                TrackPendingAwaitedProduceBatch();
+
+            if (ShouldSealAppendedBatch(pd, currentBatch, completionSource))
+                batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
+        }
+        finally
+        {
+            // Runs after the guard released the lock (ReleaseMemory drains pending appends and
+            // must never run under pd.Lock). Nothing to undo on the committed path: the batch
+            // now owns both the record's BufferMemory and the lease credit.
+            if (!committed)
+            {
+                // Lease first: the drain may need that credit.
+                leaseBudget?.Release(leaseBytes);
+                ReleaseMemory(recordSize);
+            }
+        }
+
+        if (!committed)
+            return false;
+
+        NotifyRecordAppended(topic, partition, actualBytesAdded, partitionCount);
+        if (batchToComplete is not null)
+        {
+            var readyBatch = CompleteDetachedBatchAndEnqueue(pd, batchToComplete);
+            if (readyBatch is not null)
+                StartPreSerialization(readyBatch);
+        }
+        else if (completionSource is not null)
+        {
+            QueueLingerPartition(pd, new TopicPartition(topic, partition), signalLingerLoop: false);
+        }
+
+        return true;
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryAppendFromSpansToCurrentBatchFast(
+        PartitionDeque pd,
         string topic,
         int partition,
         long timestamp,
@@ -4449,7 +4668,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         out bool appendCommitted)
     {
         appendCommitted = false;
-        var pd = GetOrCreateDeque(topic, partition);
         PartitionBatch? batchToComplete = null;
         int actualBytesAdded;
         var drainPendingAfterAppend = false;
@@ -6049,11 +6267,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryAdmitAndReserve(
+        PartitionDeque partitionDeque,
         string topic,
         int partition,
         int recordSize,
         out AdmissionReservation admissionReservation)
         => TryReserveForAppend(
+            partitionDeque,
             topic,
             partition,
             recordSize,
@@ -6063,6 +6283,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryReserveForAppend(
+        PartitionDeque partitionDeque,
         string topic,
         int partition,
         int recordSize,
@@ -6070,7 +6291,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         out AdmissionReservation admissionReservation,
         out bool brokerBlocked)
     {
-        var partitionDeque = GetOrCreateDeque(topic, partition);
         admissionReservation = default;
         brokerBlocked = false;
 

--- a/tests/Dekaf.Tests.Unit/Concurrency/BatchArenaConcurrencyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Concurrency/BatchArenaConcurrencyTests.cs
@@ -4,22 +4,25 @@ using Dekaf.Producer;
 namespace Dekaf.Tests.Unit.Concurrency;
 
 /// <summary>
-/// Concurrency tests for BatchArena verifying thread-safety of the CAS-based
-/// TryAllocate method and the pool's RentOrCreate/ReturnToPool operations.
+/// Tests for BatchArena's single-writer allocation contract and the pool's concurrent
+/// RentOrCreate/ReturnToPool operations. Production only calls <see cref="BatchArena.TryAllocate"/>
+/// and <see cref="BatchArena.TryRewindLastAllocation"/> while the owning partition lock is held,
+/// so the contended tests serialize allocations under a lock exactly like the append path does.
 /// </summary>
 [Repeat(25)]
 public class BatchArenaConcurrencyTests
 {
     [Test]
-    public async Task TryAllocate_ConcurrentAllocations_NoOverlappingRegions()
+    public async Task TryAllocate_SerializedAllocationsFromManyThreads_NoOverlappingRegions()
     {
-        // Multiple threads allocating from the same arena must each get
-        // unique, non-overlapping regions. The CAS loop ensures atomicity.
+        // Threads take turns under a lock (the partition-lock contract) and must each get
+        // unique, non-overlapping regions with the position published to lock-free readers.
 
         const int threadCount = 8;
         const int allocsPerThread = 50;
         const int allocSize = 64;
         var arena = new BatchArena(threadCount * allocsPerThread * allocSize + 1024);
+        var gate = new object();
 
         var allocations = new ConcurrentBag<(int Offset, int Length)>();
 
@@ -27,9 +30,12 @@ public class BatchArenaConcurrencyTests
         {
             for (var j = 0; j < allocsPerThread; j++)
             {
-                if (arena.TryAllocate(allocSize, out _, out var offset))
+                lock (gate)
                 {
-                    allocations.Add((offset, allocSize));
+                    if (arena.TryAllocate(allocSize, out _, out var offset))
+                    {
+                        allocations.Add((offset, allocSize));
+                    }
                 }
             }
         })).ToArray();
@@ -46,18 +52,20 @@ public class BatchArenaConcurrencyTests
 
         // All allocations should have succeeded (arena is large enough)
         await Assert.That(allocations.Count).IsEqualTo(threadCount * allocsPerThread);
+        await Assert.That(arena.Position).IsEqualTo(threadCount * allocsPerThread * allocSize);
     }
 
     [Test]
-    public async Task TryAllocate_ArenaFull_AllThreadsGetConsistentFailure()
+    public async Task TryAllocate_ArenaFull_ReportsFailureWithoutCorruptingPosition()
     {
-        // When the arena is nearly full, concurrent allocations should
-        // cleanly report failure without corrupting internal state.
+        // Once the arena is full every further allocation fails cleanly and the position
+        // stays at capacity, so the caller can rotate the batch.
 
         const int threadCount = 8;
         const int allocSize = 128;
         // Arena that can hold exactly 4 allocations
         var arena = new BatchArena(allocSize * 4);
+        var gate = new object();
 
         var successCount = 0;
         var failCount = 0;
@@ -66,7 +74,13 @@ public class BatchArenaConcurrencyTests
         {
             for (var j = 0; j < 4; j++)
             {
-                if (arena.TryAllocate(allocSize, out _, out _))
+                bool allocated;
+                lock (gate)
+                {
+                    allocated = arena.TryAllocate(allocSize, out _, out _);
+                }
+
+                if (allocated)
                     Interlocked.Increment(ref successCount);
                 else
                     Interlocked.Increment(ref failCount);
@@ -75,28 +89,35 @@ public class BatchArenaConcurrencyTests
 
         await Task.WhenAll(tasks);
 
-        // Exactly 4 allocations should succeed (the arena capacity).
-        // Note: ArrayPool may rent a larger buffer, so we check >= 4
-        await Assert.That(successCount).IsGreaterThanOrEqualTo(4);
-        // Total attempts = threadCount * 4
+        await Assert.That(successCount).IsEqualTo(4);
         await Assert.That(successCount + failCount).IsEqualTo(threadCount * 4);
+        await Assert.That(arena.RemainingCapacity).IsEqualTo(0);
     }
 
     [Test]
     public async Task TryAllocate_WriteToAllocatedSpan_DataIsolated()
     {
-        // Verify that data written to allocated spans doesn't interfere
-        // across threads due to overlapping regions.
+        // Data written to a region allocated under the lock must not be disturbed by
+        // regions other threads allocate afterwards.
 
         const int threadCount = 8;
         const int allocSize = 32;
         var arena = new BatchArena(threadCount * allocSize + 256);
+        var gate = new object();
 
         var offsets = new ConcurrentDictionary<int, byte>();
 
         var tasks = Enumerable.Range(0, threadCount).Select(threadIndex => Task.Run(() =>
         {
-            if (arena.TryAllocate(allocSize, out var span, out var offset))
+            Span<byte> span;
+            int offset;
+            bool allocated;
+            lock (gate)
+            {
+                allocated = arena.TryAllocate(allocSize, out span, out offset);
+            }
+
+            if (allocated)
             {
                 // Fill with a thread-specific byte pattern
                 var pattern = (byte)(threadIndex + 1);
@@ -117,6 +138,27 @@ public class BatchArenaConcurrencyTests
                 await Assert.That((int)data[i]).IsEqualTo((int)pattern);
             }
         }
+    }
+
+    [Test]
+    public async Task TryRewindLastAllocation_OnlyRewindsTheMostRecentAllocation()
+    {
+        var arena = new BatchArena(1024);
+
+        await Assert.That(arena.TryAllocate(100, out _, out var first)).IsTrue();
+        await Assert.That(arena.TryAllocate(50, out _, out var second)).IsTrue();
+        await Assert.That(second).IsEqualTo(first + 100);
+        await Assert.That(arena.Position).IsEqualTo(150);
+
+        // Not the last allocation: refused, position untouched.
+        await Assert.That(arena.TryRewindLastAllocation(first, 100)).IsFalse();
+        await Assert.That(arena.Position).IsEqualTo(150);
+
+        // The last allocation rewinds and its offset is handed out again.
+        await Assert.That(arena.TryRewindLastAllocation(second, 50)).IsTrue();
+        await Assert.That(arena.Position).IsEqualTo(100);
+        await Assert.That(arena.TryAllocate(50, out _, out var reused)).IsTrue();
+        await Assert.That(reused).IsEqualTo(second);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/SingleLockAdmissionAppendTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/SingleLockAdmissionAppendTests.cs
@@ -1,0 +1,383 @@
+using System.Reflection;
+using System.Text;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Covers the single-lock span append fast path (admission-lease decision, BufferMemory
+/// reservation, encode and commit under one partition-lock hold) with the per-broker admission
+/// window enabled — the default configuration. The older admission tests drive the pooled-memory
+/// entry points, which never take this path.
+/// </summary>
+public sealed class SingleLockAdmissionAppendTests
+{
+    private const string Topic = "single-lock-topic";
+    private const int LeaderNodeId = 7;
+
+    private static ProducerOptions CreateOptions(
+        long capOverride,
+        int batchSize,
+        ulong bufferMemory = 64L * 1024 * 1024,
+        int lingerMs = 60_000) => new()
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "single-lock-admission",
+            BufferMemory = bufferMemory,
+            BatchSize = batchSize,
+            LingerMs = lingerMs,
+            MaxBlockMs = 30_000,
+            DeliveryLatencyTargetMs = 10,
+            UnackedByteBudgetCapOverride = capOverride,
+        };
+
+    private static RecordAccumulator CreateAccumulator(ProducerOptions options)
+        => new(options, resolveLeaderId: static (_, _) => LeaderNodeId);
+
+    private static ValueTask<bool> AppendSpansAsync(
+        RecordAccumulator accumulator,
+        ReadOnlySpan<byte> value,
+        int partition = 0,
+        CancellationToken cancellationToken = default)
+        => accumulator.AppendFromSpansAsync(
+            Topic,
+            partition,
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            keyData: default,
+            keyIsNull: true,
+            valueData: value,
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            callback: null,
+            cancellationToken);
+
+    private static async ValueTask SealAllAsync(RecordAccumulator accumulator)
+    {
+        var method = typeof(RecordAccumulator).GetMethod(
+            "SealBatchesAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        await (ValueTask)method.Invoke(accumulator, [true, CancellationToken.None])!;
+    }
+
+    private static List<ReadyBatch> DrainAll(RecordAccumulator accumulator)
+    {
+        var batches = new List<ReadyBatch>();
+        while (accumulator.TryDrainPublishedBatch(out var batch))
+            batches.Add(batch);
+        return batches;
+    }
+
+    private static int CountRecords(IEnumerable<ReadyBatch> batches)
+        => batches.Sum(static batch => batch.RecordBatch.Records.Count);
+
+    private static void RetireAll(RecordAccumulator accumulator, IEnumerable<ReadyBatch> batches)
+    {
+        var offset = 0;
+        foreach (var batch in batches)
+            LeakGateHarness.RetireBatch(accumulator, batch, offset++);
+    }
+
+    [Test]
+    public async Task FastPath_ConsumesOneBatchLease_AndSealRefundsUnusedCredit()
+    {
+        // BatchSize below the 64 KB quantum cap: one lease per batch covers every record in it.
+        const int batchSize = 4_096;
+        var accumulator = CreateAccumulator(CreateOptions(capOverride: 1_000_000, batchSize));
+        var value = new byte[100];
+
+        try
+        {
+            var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+
+            // First record creates the batch on the two-phase path and takes the batch lease.
+            await Assert.That(await AppendSpansAsync(accumulator, value)).IsTrue();
+            await Assert.That(budget.UnackedBytes).IsEqualTo(batchSize);
+
+            // Later records commit on the single-lock path from local credit: no new lease.
+            for (var i = 0; i < 10; i++)
+                await Assert.That(await AppendSpansAsync(accumulator, value)).IsTrue();
+            await Assert.That(budget.UnackedBytes).IsEqualTo(batchSize);
+
+            await SealAllAsync(accumulator);
+            var batches = DrainAll(accumulator);
+            await Assert.That(batches.Count).IsEqualTo(1);
+            await Assert.That(CountRecords(batches)).IsEqualTo(11);
+
+            // Seal charges the bytes actually written and hands the unused credit back.
+            await Assert.That(budget.UnackedBytes).IsEqualTo(batches[0].DataSize);
+            await Assert.That(budget.UnackedBytes).IsLessThan(batchSize);
+
+            RetireAll(accumulator, batches);
+            await Assert.That(budget.UnackedBytes).IsEqualTo(0);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task FastPath_ReplenishesLease_WhenBatchLocalCreditIsExhausted()
+    {
+        // BatchSize above the 64 KB quantum cap: the batch outgrows its first lease and the
+        // single-lock path must reserve the next quantum itself.
+        const int batchSize = 128 * 1024;
+        const int quantum = 64 * 1024;
+        var accumulator = CreateAccumulator(CreateOptions(capOverride: 100_000_000, batchSize));
+        var value = new byte[1_000];
+
+        try
+        {
+            var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+
+            for (var i = 0; i < 100; i++)
+                await Assert.That(await AppendSpansAsync(accumulator, value)).IsTrue();
+
+            // ~100 KB of records: the first lease (64 KB) ran out and exactly one more was taken.
+            await Assert.That(budget.UnackedBytes).IsEqualTo(2L * quantum);
+            await Assert.That(accumulator.TryGetBatch(Topic, 0, out var batch)).IsTrue();
+            await Assert.That(batch!.RecordCount).IsEqualTo(100);
+
+            await SealAllAsync(accumulator);
+            var batches = DrainAll(accumulator);
+            await Assert.That(CountRecords(batches)).IsEqualTo(100);
+            await Assert.That(budget.UnackedBytes).IsEqualTo(batches.Sum(static b => (long)b.DataSize));
+
+            RetireAll(accumulator, batches);
+            await Assert.That(budget.UnackedBytes).IsEqualTo(0);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(60_000)]
+    public async Task ConcurrentFastPathAppends_SamePartition_CommitEveryRecordAndBalanceAccounting(
+        CancellationToken cancellationToken)
+    {
+        // The broker window opens from one BatchSize and only grows with acknowledgements, so a
+        // sender stand-in must retire sealed batches while eight threads contend for one
+        // partition's lock; every record must land exactly once and both ledgers must return
+        // to zero.
+        const int threadCount = 8;
+        const int appendsPerThread = 500;
+        const int batchSize = 16 * 1024;
+        var accumulator = CreateAccumulator(CreateOptions(capOverride: 1_000_000_000, batchSize));
+        var value = Encoding.UTF8.GetBytes(new string('v', 200));
+
+        try
+        {
+            var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+            var retired = 0L;
+            using var drainerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var drainer = Task.Run(() => RetireUntilCancelled(accumulator, drainerCts.Token, ref retired), CancellationToken.None);
+
+            var appended = 0;
+            var tasks = Enumerable.Range(0, threadCount).Select(_ => Task.Run(async () =>
+            {
+                for (var i = 0; i < appendsPerThread; i++)
+                {
+                    if (await AppendSpansAsync(accumulator, value, partition: 0, cancellationToken))
+                        Interlocked.Increment(ref appended);
+                }
+            }, cancellationToken)).ToArray();
+            await Task.WhenAll(tasks);
+
+            await Assert.That(appended).IsEqualTo(threadCount * appendsPerThread);
+
+            await SealAllAsync(accumulator);
+            await WaitForRetiredAsync(threadCount * appendsPerThread, () => Volatile.Read(ref retired), cancellationToken);
+            drainerCts.Cancel();
+            await drainer;
+
+            await Assert.That(Volatile.Read(ref retired)).IsEqualTo(threadCount * appendsPerThread);
+            await Assert.That(budget.UnackedBytes).IsEqualTo(0);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+            await Assert.That(budget.AccountingUnderflowCount).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    /// <summary>Sender stand-in: retires every sealed batch the production way until cancelled.</summary>
+    private static void RetireUntilCancelled(RecordAccumulator accumulator, CancellationToken cancellationToken, ref long retired)
+    {
+        var offset = 0L;
+        var spinner = new SpinWait();
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            if (accumulator.TryDrainPublishedBatch(out var batch))
+            {
+                var recordCount = batch.RecordBatch.Records.Count;
+                LeakGateHarness.RetireBatch(accumulator, batch, offset++);
+                Interlocked.Add(ref retired, recordCount);
+                spinner.Reset();
+            }
+            else
+            {
+                spinner.SpinOnce();
+            }
+        }
+    }
+
+    private static async Task WaitForRetiredAsync(long expected, Func<long> retired, CancellationToken cancellationToken)
+    {
+        while (retired() < expected)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Delay(5, cancellationToken);
+        }
+    }
+
+    [Test]
+    [Timeout(60_000)]
+    public async Task ConcurrentFastPathAppends_TinyBufferMemory_NeverExceedsLimitAndDrainToZero(
+        CancellationToken cancellationToken)
+    {
+        // BufferMemory holds three batches; appends must alternate between the single-lock fast
+        // path and BufferMemory backpressure without losing a record or leaking a refund.
+        const int threadCount = 4;
+        const int appendsPerThread = 400;
+        const int batchSize = 8 * 1024;
+        var options = CreateOptions(
+            capOverride: 1_000_000_000,
+            batchSize,
+            bufferMemory: 3UL * batchSize,
+            lingerMs: 0);
+        var accumulator = CreateAccumulator(options);
+        var value = new byte[300];
+
+        try
+        {
+            var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+            var retired = 0L;
+            using var drainerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var drainer = Task.Run(() => RetireUntilCancelled(accumulator, drainerCts.Token, ref retired), CancellationToken.None);
+
+            var appended = 0;
+            var tasks = Enumerable.Range(0, threadCount).Select(_ => Task.Run(async () =>
+            {
+                for (var i = 0; i < appendsPerThread; i++)
+                {
+                    if (await AppendSpansAsync(accumulator, value, partition: 0, cancellationToken))
+                        Interlocked.Increment(ref appended);
+                }
+            }, cancellationToken)).ToArray();
+            await Task.WhenAll(tasks);
+
+            await Assert.That(appended).IsEqualTo(threadCount * appendsPerThread);
+
+            // Seal the trailing partial batch and let the drainer retire everything.
+            await SealAllAsync(accumulator);
+            await WaitForRetiredAsync(threadCount * appendsPerThread, () => Volatile.Read(ref retired), cancellationToken);
+            drainerCts.Cancel();
+            await drainer;
+
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+            await Assert.That(budget.UnackedBytes).IsEqualTo(0);
+            await Assert.That(budget.AccountingUnderflowCount).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task FastPath_BlockedByBrokerBudget_FallsBackAndRecordsAdmissionBlock()
+    {
+        // Cap of 1 byte: the first sealed batch puts the broker over budget.
+        const int batchSize = 4_096;
+        var accumulator = CreateAccumulator(CreateOptions(capOverride: 1, batchSize));
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var value = new byte[100];
+
+        try
+        {
+            var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+            await Assert.That(await AppendSpansAsync(accumulator, value)).IsTrue();
+            await SealAllAsync(accumulator);
+            await Assert.That(budget.IsOverBudget()).IsTrue();
+
+            var blockEventsBefore = budget.AdmissionBlockEvents;
+            var completion = pool.Rent();
+            var admitted = accumulator.TryAppendFromSpansWithCompletion(
+                Topic, 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                keyData: default, keyIsNull: true, value, valueIsNull: false,
+                headers: null, headerCount: 0, completion);
+
+            await Assert.That(admitted).IsFalse();
+            await Assert.That(budget.AdmissionBlockEvents).IsGreaterThan(blockEventsBefore);
+            pool.Return(completion);
+
+            // Nothing was reserved by the refused attempt.
+            var sealedBatches = DrainAll(accumulator);
+            await Assert.That(accumulator.BufferedBytes)
+                .IsEqualTo(sealedBatches.Sum(static b => (long)b.DataSize));
+
+            RetireAll(accumulator, sealedBatches);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+            await Assert.That(budget.UnackedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task QueuedSpanAppend_LandsInNewBatch_AfterRotationAndChargedBatchExit(
+        CancellationToken cancellationToken)
+    {
+        const int batchSize = 4_096;
+        var accumulator = CreateAccumulator(CreateOptions(capOverride: 1, batchSize));
+        var value = new byte[100];
+
+        try
+        {
+            var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+            await Assert.That(await AppendSpansAsync(accumulator, value, partition: 0, cancellationToken)).IsTrue();
+            await SealAllAsync(accumulator);
+            var charged = DrainAll(accumulator);
+            await Assert.That(charged.Count).IsEqualTo(1);
+            await Assert.That(budget.IsOverBudget()).IsTrue();
+
+            // Over budget: the fast path yields and the record queues behind admission.
+            var blocked = AppendSpansAsync(accumulator, value, partition: 0, cancellationToken);
+            await Assert.That(blocked.IsCompleted).IsFalse();
+
+            // A later fast-path record must not leapfrog the queued one.
+            var later = AppendSpansAsync(accumulator, value, partition: 0, cancellationToken);
+            await Assert.That(later.IsCompleted).IsFalse();
+
+            // Rotation while blocked: the current batch (if any) is sealed away, then the charged
+            // batch exits the pipeline and reopens the window for the queued records.
+            await SealAllAsync(accumulator);
+            RetireAll(accumulator, charged);
+
+            await Assert.That(await blocked).IsTrue();
+            await Assert.That(await later).IsTrue();
+
+            await SealAllAsync(accumulator);
+            var landed = DrainAll(accumulator);
+            await Assert.That(CountRecords(landed)).IsEqualTo(2);
+
+            RetireAll(accumulator, landed);
+            await Assert.That(budget.UnackedBytes).IsEqualTo(0);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AccumulatorAdmissionAppendBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AccumulatorAdmissionAppendBenchmarks.cs
@@ -1,0 +1,264 @@
+using System.Reflection;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Isolates the producer append admission path: <see cref="RecordAccumulator.AppendFromSpansAsync"/>
+/// with the per-broker unacked-byte admission window enabled, which is the
+/// <c>DeliveryLatencyTargetMs &gt; 0</c> default every real producer runs with.
+/// <see cref="AccumulatorAppendBenchmarks"/> constructs its accumulator without a leader resolver
+/// and therefore takes the admission-disabled bypass, so it cannot see this path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Shape"/> covers the uncontended case and the two contended shapes that stress the
+/// partition lock differently: four threads appending to one partition (lock convoy) and four
+/// threads appending to four distinct partitions (only the accumulator-wide counters are shared).
+/// Every invocation appends <see cref="AppendsPerInvoke"/> records in total, split evenly across
+/// the shape's threads, so ns/op is comparable between shapes.
+/// </para>
+/// <para>
+/// No broker: a spinning drainer retires sealed batches the way the sender does
+/// (drained in publication order via <see cref="RecordAccumulator.TryDrainPublishedBatch"/>;
+/// <see cref="RecordAccumulator.OnBatchExitsPipeline"/> returns the broker-window charge,
+/// <see cref="RecordAccumulator.ReleaseMemory"/> returns BufferMemory) so appends stay on the
+/// synchronous hot path. Batches seal on size (16 per invocation), so rotation is amortized
+/// 1:1000 deterministically. Expected allocation: 0 B per append after warmup; a nonzero
+/// Allocated column can only come from the drainer-behind cold path (see AccumulatorAppendBenchmarks).
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 3)]
+public class AccumulatorAdmissionAppendBenchmarks
+{
+    private const string Topic = "bench-topic";
+    private const int MessageSize = 1000;
+    private const int AppendsPerInvoke = 16_000;
+    private const int LeaderNodeId = 0;
+    private const long FixtureCapacityBytes = 1L << 30;
+
+    public const string SingleThread = "1T";
+    public const string FourThreadsSamePartition = "4T-same";
+    public const string FourThreadsDistinctPartitions = "4T-split";
+
+    private RecordAccumulator _accumulator = null!;
+    private byte[] _keyBytes = null!;
+    private byte[] _valueBytes = null!;
+    private CancellationTokenSource _drainerCts = null!;
+    private Thread _drainerThread = null!;
+    private AppendWorker[] _workers = [];
+    private Barrier? _barrier;
+    private volatile bool _stopWorkers;
+
+    [Params(SingleThread, FourThreadsSamePartition, FourThreadsDistinctPartitions)]
+    public string Shape { get; set; } = SingleThread;
+
+    [Params(false, true)]
+    public bool AdmissionEnabled { get; set; }
+
+    private int ThreadCount => Shape == SingleThread ? 1 : 4;
+    private int PartitionCount => Shape == FourThreadsDistinctPartitions ? 4 : 1;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 1_048_576, // 1 MB
+            BufferMemory = 256L * 1024 * 1024,
+            // Seal on size only. With LingerMs = 0 every append seals unless a predecessor batch
+            // is still in the pipeline, so batch size — and the amortized rotation cost per
+            // append — becomes a race between the appender and the drainer instead of a property
+            // of the append path (ProducerFireHotPathBenchmarks pins linger for the same reason).
+            LingerMs = 1_000,
+            // 10 (the default) enables the admission window; 0 disables it.
+            DeliveryLatencyTargetMs = AdmissionEnabled ? 10 : 0,
+            // Keep admission non-blocking so this measures bookkeeping, not drainer scheduling.
+            UnackedByteBudgetCapOverride = FixtureCapacityBytes,
+        };
+
+        _accumulator = AdmissionEnabled
+            ? new RecordAccumulator(options, resolveLeaderId: static (_, _) => LeaderNodeId)
+            : new RecordAccumulator(options);
+
+        if (AdmissionEnabled && _accumulator.GetBrokerUnackedBudget(LeaderNodeId) is { } budget)
+        {
+            // The stopped sender cannot provide acknowledgement pacing, so pin the window at the
+            // fixture cap while the drainer releases every charge (as ProducerFireHotPathBenchmarks does).
+            typeof(BrokerUnackedByteBudget)
+                .GetField("_budgetBytes", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(budget, FixtureCapacityBytes);
+        }
+
+        _keyBytes = Encoding.UTF8.GetBytes("benchmark-key-0");
+        _valueBytes = new byte[MessageSize];
+
+        // Warm the pools (arena, PartitionBatch, ReadyBatch, delivery arrays) by sealing and
+        // retiring complete batches on every partition the shape touches.
+        var msgsPerBatch = options.BatchSize / (MessageSize + 20);
+        var ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        for (var partition = 0; partition < PartitionCount; partition++)
+        {
+            for (var i = 0; i < msgsPerBatch * 4; i++)
+            {
+                Append(partition, ts);
+                if (i % msgsPerBatch == msgsPerBatch - 1)
+                    DrainAll();
+            }
+            DrainAll();
+        }
+
+        _drainerCts = new CancellationTokenSource();
+        _drainerThread = new Thread(() => DrainLoop(_drainerCts.Token))
+        {
+            IsBackground = true,
+            Name = "accumulator-admission-drainer",
+            Priority = ThreadPriority.Highest,
+        };
+        _drainerThread.Start();
+
+        if (ThreadCount > 1)
+        {
+            _barrier = new Barrier(ThreadCount + 1);
+            _workers = new AppendWorker[ThreadCount];
+            for (var i = 0; i < ThreadCount; i++)
+            {
+                var partition = PartitionCount == 1 ? 0 : i;
+                _workers[i] = new AppendWorker(this, partition, AppendsPerInvoke / ThreadCount, _barrier);
+                _workers[i].Start();
+            }
+        }
+
+        AppendBatch();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        foreach (var worker in _workers)
+            worker.Stop();
+        if (_barrier is not null)
+        {
+            // Release workers parked on the start phase so they observe the stop flag.
+            _barrier.SignalAndWait();
+            foreach (var worker in _workers)
+                worker.Join();
+            _barrier.Dispose();
+        }
+
+        _drainerCts.Cancel();
+        _drainerThread.Join();
+        _drainerCts.Dispose();
+        _accumulator.DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Appends <see cref="AppendsPerInvoke"/> headerless records with the shape's thread count.
+    /// Multi-threaded shapes hand the work to persistent workers through a barrier: one phase to
+    /// start, one to finish, so no thread creation is measured.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = AppendsPerInvoke)]
+    public void AppendBatch()
+    {
+        if (_barrier is null)
+        {
+            var ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            for (var i = 0; i < AppendsPerInvoke; i++)
+                Append(partition: 0, ts);
+            return;
+        }
+
+        _barrier.SignalAndWait(); // start
+        _barrier.SignalAndWait(); // finish
+    }
+
+    private void Append(int partition, long ts)
+    {
+        var task = _accumulator.AppendFromSpansAsync(
+            Topic, partition, ts,
+            _keyBytes, false, _valueBytes, false,
+            null, 0, null, CancellationToken.None);
+
+        if (task.IsCompleted)
+        {
+            task.GetAwaiter().GetResult();
+            return;
+        }
+
+        // Cold path (drainer fell behind): a pooled IValueTaskSource is not awaitable via
+        // GetResult until completed, so block on a Task instead.
+        task.AsTask().GetAwaiter().GetResult();
+    }
+
+    private void DrainAll()
+    {
+        while (_accumulator.TryDrainPublishedBatch(out var batch))
+            Retire(batch);
+    }
+
+    private void Retire(ReadyBatch batch)
+    {
+        _accumulator.OnBatchExitsPipeline(batch);
+        _accumulator.ReleaseMemory(batch.DataSize);
+        _accumulator.ReturnReadyBatch(batch);
+    }
+
+    private void DrainLoop(CancellationToken cancellationToken)
+    {
+        var spinner = new SpinWait();
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            if (_accumulator.TryDrainPublishedBatch(out var batch))
+            {
+                Retire(batch);
+                spinner.Reset();
+            }
+            else
+            {
+                spinner.SpinOnce();
+            }
+        }
+    }
+
+    private sealed class AppendWorker(
+        AccumulatorAdmissionAppendBenchmarks owner,
+        int partition,
+        int appendsPerInvoke,
+        Barrier barrier)
+    {
+        private readonly Thread _thread = new(() => Run(owner, partition, appendsPerInvoke, barrier))
+        {
+            IsBackground = true,
+            Name = $"accumulator-admission-append-{partition}",
+        };
+
+        public void Start() => _thread.Start();
+        public void Stop() => owner._stopWorkers = true;
+        public void Join() => _thread.Join();
+
+        private static void Run(
+            AccumulatorAdmissionAppendBenchmarks owner,
+            int partition,
+            int appendsPerInvoke,
+            Barrier barrier)
+        {
+            while (true)
+            {
+                barrier.SignalAndWait(); // start
+                if (owner._stopWorkers)
+                    return;
+
+                var ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                for (var i = 0; i < appendsPerInvoke; i++)
+                    owner.Append(partition, ts);
+
+                barrier.SignalAndWait(); // finish
+            }
+        }
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AccumulatorAdmissionAppendBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AccumulatorAdmissionAppendBenchmarks.cs
@@ -30,6 +30,14 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 /// 1:1000 deterministically. Expected allocation: 0 B per append after warmup; a nonzero
 /// Allocated column can only come from the drainer-behind cold path (see AccumulatorAppendBenchmarks).
 /// </para>
+/// <para>
+/// Allocation accounting on the multi-threaded shapes: BenchmarkDotNet's MemoryDiagnoser reads
+/// <see cref="GC.GetTotalAllocatedBytes(bool)"/>, which is process-wide, so the Allocated
+/// column already includes the append workers (and the drainer). As an independent check
+/// every append thread also snapshots <see cref="GC.GetAllocatedBytesForCurrentThread"/>
+/// around its loop; the summed delta is printed at cleanup (<c>[alloc]</c> line in the run
+/// log, covering every invocation including pilot and warmup).
+/// </para>
 /// </remarks>
 [MemoryDiagnoser]
 [SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 3)]
@@ -53,6 +61,8 @@ public class AccumulatorAdmissionAppendBenchmarks
     private AppendWorker[] _workers = [];
     private Barrier? _barrier;
     private volatile bool _stopWorkers;
+    private long _appendThreadAllocatedBytes;
+    private long _appendThreadAppends;
 
     [Params(SingleThread, FourThreadsSamePartition, FourThreadsDistinctPartitions)]
     public string Shape { get; set; } = SingleThread;
@@ -151,6 +161,13 @@ public class AccumulatorAdmissionAppendBenchmarks
             _barrier.Dispose();
         }
 
+        var appends = Volatile.Read(ref _appendThreadAppends);
+        var allocated = Volatile.Read(ref _appendThreadAllocatedBytes);
+        Console.WriteLine(
+            $"[alloc] Shape={Shape} AdmissionEnabled={AdmissionEnabled} appendThreads={ThreadCount} " +
+            $"appends={appends} appendThreadAllocatedBytes={allocated} " +
+            $"bytesPerAppend={(appends == 0 ? 0 : (double)allocated / appends):F3}");
+
         _drainerCts.Cancel();
         _drainerThread.Join();
         _drainerCts.Dispose();
@@ -167,14 +184,27 @@ public class AccumulatorAdmissionAppendBenchmarks
     {
         if (_barrier is null)
         {
-            var ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            for (var i = 0; i < AppendsPerInvoke; i++)
-                Append(partition: 0, ts);
+            AppendLoop(partition: 0, AppendsPerInvoke);
             return;
         }
 
         _barrier.SignalAndWait(); // start
         _barrier.SignalAndWait(); // finish
+    }
+
+    /// <summary>
+    /// One invocation's appends on the calling thread, with that thread's allocated-byte
+    /// delta folded into the cleanup report.
+    /// </summary>
+    private void AppendLoop(int partition, int appends)
+    {
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        var ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        for (var i = 0; i < appends; i++)
+            Append(partition, ts);
+
+        Interlocked.Add(ref _appendThreadAllocatedBytes, GC.GetAllocatedBytesForCurrentThread() - allocatedBefore);
+        Interlocked.Add(ref _appendThreadAppends, appends);
     }
 
     private void Append(int partition, long ts)
@@ -253,9 +283,7 @@ public class AccumulatorAdmissionAppendBenchmarks
                 if (owner._stopWorkers)
                     return;
 
-                var ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-                for (var i = 0; i < appendsPerInvoke; i++)
-                    owner.Append(partition, ts);
+                owner.AppendLoop(partition, appendsPerInvoke);
 
                 barrier.SignalAndWait(); // finish
             }


### PR DESCRIPTION
## Summary

With the default configuration (`DeliveryLatencyTargetMs = 10` enables the per-broker unacked-byte admission window, `LingerMs = 0`, 1 MB `BatchSize`), every headerless record appended through the span entry points paid two partition-lock acquisitions plus a CAS handoff in `src/Dekaf/Producer/RecordAccumulator.cs` (line numbers at `main` b85eda535):

- `TryReserveForAppend` (6065-6203): a CAS spin on `PartitionDeque.AdmissionInProgress` (6099), then `SpinLockGuard(ref partitionDeque.Lock)` — lock #1 (6120) — for the admission-lease decision (`NeedsAdmissionLease` + `BrokerUnackedByteBudget.TryReserve`), followed by `TryReserveMemory` (6174).
- `TryAppendFromSpansToCurrentBatchFast` (4436-4515): `SpinLockGuard(ref pd.Lock)` — lock #2 (4458) — for the encode and commit; `AdmissionInProgress` is released inside it (6249).
- `BatchArena.TryAllocate` (962-988) and `TryRewindLastAllocation` (1013-1016) ran a CAS loop on `_position` although both only execute under the owning partition lock.
- `GetOrCreateDeque` ran twice per record (6073 and 4452).

## Change

- **`TryAppendFromSpansSingleLock`** (new): for headerless span appends the admission-lease decision, the record encode and the commit run under one hold of `pd.Lock`. Because decision and commit are atomic under the lock, the batch cannot rotate in between and the `AdmissionInProgress` handoff slot is not needed; the fast path only refuses to run while a two-phase appender holds it. The BufferMemory reservation stays *before* the lock, as in the reservation path — see Evidence for why. Every early exit returns whatever it reserved (BufferMemory and, when taken, the broker lease) and the caller falls through to the unchanged reservation-based protocol, which still owns batch rotation, header-bearing records, blocked/re-routed admission, BufferMemory backpressure and FIFO behind queued slow-path appends. Broker-window accounting is unchanged: the batch-local quantum lease (`GetAdmissionLeaseBytes`) is taken exactly when `HasAdmissionCapacity` reports the local credit exhausted, attached with `AddAdmissionLease`, and reconciled at seal as before.
- `AppendFromSpansAsync` and `TryAppendFromSpansWithCompletion` look the deque up once and pass it through `TryAdmitAndReserve` / `TryReserveForAppend` / `AppendFromSpansAfterReservationCore` / `TryAppendFromSpansToCurrentBatchFast` (which keeps its second-chance role after the two-phase path has waited on the admission slot).
- `BatchArena.TryAllocate` / `TryRewindLastAllocation` are plain single-writer read-modify-writes with a `Volatile.Write` publish; the lock-free readers (`Position`, `RemainingCapacity`) are unchanged. `BatchArenaConcurrencyTests` now exercises the documented contract (allocations serialized by a lock, as the append path does) instead of asserting CAS-based concurrent allocation, and gains a `TryRewindLastAllocation` test.
- `RecordAccumulator.TryDrainPublishedBatch` (test-only sender stand-in, like `TryDrainBatch`): drains in publication order via `_readyPartitions`, so a concurrent test drainer cannot recycle a `ReadyBatch` before the sealing thread's `StartPreSerialization` call. The deque-polling `TryDrainBatch` has that race; it crashed one baseline benchmark run (`InvalidOperationException: Pre-serialization task was not created`) and would make the new concurrent unit tests flaky.
- New `AccumulatorAdmissionAppendBenchmarks` (Docker-free, `[MemoryDiagnoser]`): `AppendFromSpansAsync` with the admission window enabled and disabled, in three shapes — one thread, four threads on one partition, four threads on four distinct partitions. The existing `AccumulatorAppendBenchmarks` constructs its accumulator without a leader resolver and therefore never takes the admission path.

**Tried and rejected, with numbers:**
- `SpinLockGuard.Dispose` → `SpinLock.Exit(useMemoryBarrier: false)` (release store instead of the full-fence `Interlocked.Decrement`): no single-thread change (1T 131-135 ns either way) but 4T-split went from 92 ns to 154-195 ns per record. Kept `Exit()`; the reason is recorded in a comment on `Dispose`.
- `TryReserveMemory` *inside* the single lock hold: 1T unchanged (132 ns), but 4T-split regressed from 64-67 ns to 100 ns (pair 1 Medium) even though nothing else contends for those locks — a contended accumulator-wide atomic inside a per-partition critical section is a loss. Moved before the lock (Medium pairs below); rotation/blocked bail-outs undo it with `ReleaseMemory`, which is per batch or cold.

Per record on the default fast path this removes one lock acquisition (enter CAS + exit fence), the `AdmissionInProgress` CAS + release, the arena CAS and the second deque lookup.

## Evidence

Environment: i7-12700K (20 threads), Windows 11, .NET SDK 10.0.400 / .NET 10.0.11, BenchmarkDotNet 0.15.8, `--inProcess`, `--job Medium` (2 × 15 iterations). Other agents were building and running tests on the same machine during these runs (noise noted). Runs were interleaved baseline-1, candidate-1, baseline-2, candidate-2 through a machine-wide benchmark lock. Baseline worktree = `main` @ b85eda535 with the new benchmark file and the test-only `TryDrainPublishedBatch` helper copied in uncommitted so both sides run the same harness (the helper is cold test code; no hot-path line in the baseline differs from `main`).

Harness note: the new benchmark seals on size only (`LingerMs = 1_000`, as `ProducerFireHotPathBenchmarks` does). With `LingerMs = 0` every append seals unless a predecessor batch is still in the drainer's hands, so batch size — and the amortized rotation/CRC cost per append — becomes a race between the appender and the drainer rather than a property of the append path. `AccumulatorAppendBenchmarks` is unchanged and keeps its `LingerMs = 0` regime; both sides ran the same file.

### `AccumulatorAdmissionAppendBenchmarks` (new; 16 000 appends per invocation, 1 000-byte values)

Pair 1 — baseline (`base-adm-1`):

| Method      | Shape    | AdmissionEnabled | Mean        | Error      | StdDev     | Allocated |
|------------ |--------- |----------------- |------------:|-----------:|-----------:|----------:|
| **AppendBatch** | **1T**       | **False**            |   **134.52 ns** |   **1.179 ns** |   **1.690 ns** |         **-** |
| **AppendBatch** | **1T**       | **True**             |   **151.31 ns** |   **0.955 ns** |   **1.339 ns** |         **-** |
| **AppendBatch** | **4T-same**  | **False**            | **2,322.72 ns** | **195.012 ns** | **291.885 ns** |         **-** |
| **AppendBatch** | **4T-same**  | **True**             | **2,673.04 ns** |  **71.299 ns** |  **99.951 ns** |         **-** |
| **AppendBatch** | **4T-split** | **False**            |    **63.94 ns** |   **1.369 ns** |   **2.006 ns** |         **-** |
| **AppendBatch** | **4T-split** | **True**             |    **66.81 ns** |   **1.852 ns** |   **2.772 ns** |         **-** |

Pair 1 — candidate (`cand-adm-1`):

| Method      | Shape    | AdmissionEnabled | Mean        | Error      | StdDev     | Allocated |
|------------ |--------- |----------------- |------------:|-----------:|-----------:|----------:|
| **AppendBatch** | **1T**       | **False**            |   **132.93 ns** |   **1.170 ns** |   **1.678 ns** |         **-** |
| **AppendBatch** | **1T**       | **True**             |   **132.19 ns** |   **0.695 ns** |   **0.928 ns** |         **-** |
| **AppendBatch** | **4T-same**  | **False**            | **2,285.94 ns** | **188.975 ns** | **276.997 ns** |         **-** |
| **AppendBatch** | **4T-same**  | **True**             | **2,403.82 ns** | **155.703 ns** | **233.050 ns** |         **-** |
| **AppendBatch** | **4T-split** | **False**            |    **66.38 ns** |   **1.170 ns** |   **1.715 ns** |         **-** |
| **AppendBatch** | **4T-split** | **True**             |    **65.78 ns** |   **1.406 ns** |   **2.060 ns** |         **-** |

Pair 2 — baseline (`base-adm-2`):

| Method      | Shape    | AdmissionEnabled | Mean        | Error     | StdDev     | Allocated |
|------------ |--------- |----------------- |------------:|----------:|-----------:|----------:|
| **AppendBatch** | **1T**       | **False**            |   **135.41 ns** |  **0.992 ns** |   **1.391 ns** |         **-** |
| **AppendBatch** | **1T**       | **True**             |   **153.37 ns** |  **1.177 ns** |   **1.650 ns** |         **-** |
| **AppendBatch** | **4T-same**  | **False**            | **2,540.94 ns** | **85.817 ns** | **125.790 ns** |         **-** |
| **AppendBatch** | **4T-same**  | **True**             | **2,672.38 ns** | **75.791 ns** | **108.697 ns** |         **-** |
| **AppendBatch** | **4T-split** | **False**            |    **66.54 ns** |  **1.579 ns** |   **2.315 ns** |         **-** |
| **AppendBatch** | **4T-split** | **True**             |    **67.17 ns** |  **2.394 ns** |   **3.583 ns** |         **-** |

Pair 2 — candidate (`cand-adm-2`):

| Method      | Shape    | AdmissionEnabled | Mean        | Error      | StdDev     | Allocated |
|------------ |--------- |----------------- |------------:|-----------:|-----------:|----------:|
| **AppendBatch** | **1T**       | **False**            |   **132.19 ns** |   **1.195 ns** |   **1.714 ns** |         **-** |
| **AppendBatch** | **1T**       | **True**             |   **131.92 ns** |   **1.033 ns** |   **1.414 ns** |         **-** |
| **AppendBatch** | **4T-same**  | **False**            | **2,092.51 ns** | **297.167 ns** | **444.786 ns** |         **-** |
| **AppendBatch** | **4T-same**  | **True**             | **2,471.32 ns** | **103.359 ns** | **154.703 ns** |         **-** |
| **AppendBatch** | **4T-split** | **False**            |    **66.08 ns** |   **1.608 ns** |   **2.407 ns** |         **-** |
| **AppendBatch** | **4T-split** | **True**             |    **66.08 ns** |   **1.476 ns** |   **2.210 ns** |         **-** |

### `AccumulatorAppendBenchmarks` (existing; admission disabled — exercises the arena and single-lock structure only)

Pair 1 — baseline (`base-acc-1`):

| Method                        | MessageSize | Mean      | Error    | StdDev   | Allocated |
|------------------------------ |------------ |----------:|---------:|---------:|----------:|
| **AppendHotPath**                 | **100**         |  **71.96 ns** | **0.247 ns** | **0.347 ns** |         **-** |
| AppendMultiPartition          | 100         |  72.29 ns | 0.370 ns | 0.554 ns |         - |
| AppendAlternatingAccumulators | 100         |  71.94 ns | 0.472 ns | 0.692 ns |         - |
| **AppendHotPath**                 | **1000**        | **144.83 ns** | **2.130 ns** | **3.123 ns** |         **-** |
| AppendMultiPartition          | 1000        | 150.76 ns | 1.354 ns | 1.984 ns |         - |
| AppendAlternatingAccumulators | 1000        | 150.75 ns | 0.855 ns | 1.170 ns |         - |

Pair 1 — candidate (`cand-acc-1`):

| Method                        | MessageSize | Mean      | Error    | StdDev   | Allocated |
|------------------------------ |------------ |----------:|---------:|---------:|----------:|
| **AppendHotPath**                 | **100**         |  **56.70 ns** | **0.235 ns** | **0.322 ns** |         **-** |
| AppendMultiPartition          | 100         |  59.60 ns | 0.451 ns | 0.676 ns |         - |
| AppendAlternatingAccumulators | 100         |  59.58 ns | 0.403 ns | 0.578 ns |         - |
| **AppendHotPath**                 | **1000**        | **136.56 ns** | **1.172 ns** | **1.755 ns** |         **-** |
| AppendMultiPartition          | 1000        | 137.98 ns | 0.964 ns | 1.412 ns |         - |
| AppendAlternatingAccumulators | 1000        | 138.04 ns | 1.652 ns | 2.472 ns |         - |

Pair 2 — baseline (`base-acc-2`):

| Method                        | MessageSize | Mean      | Error    | StdDev   | Allocated |
|------------------------------ |------------ |----------:|---------:|---------:|----------:|
| **AppendHotPath**                 | **100**         |  **71.60 ns** | **0.413 ns** | **0.618 ns** |         **-** |
| AppendMultiPartition          | 100         |  71.84 ns | 0.420 ns | 0.589 ns |         - |
| AppendAlternatingAccumulators | 100         |  74.95 ns | 1.890 ns | 2.828 ns |         - |
| **AppendHotPath**                 | **1000**        | **142.39 ns** | **1.308 ns** | **1.876 ns** |         **-** |
| AppendMultiPartition          | 1000        | 150.56 ns | 1.869 ns | 2.739 ns |         - |
| AppendAlternatingAccumulators | 1000        | 152.15 ns | 1.497 ns | 2.147 ns |         - |

Pair 2 — candidate (`cand-acc-2`):

| Method                        | MessageSize | Mean      | Error    | StdDev   | Allocated |
|------------------------------ |------------ |----------:|---------:|---------:|----------:|
| **AppendHotPath**                 | **100**         |  **58.06 ns** | **0.862 ns** | **1.180 ns** |         **-** |
| AppendMultiPartition          | 100         |  61.12 ns | 0.792 ns | 1.111 ns |         - |
| AppendAlternatingAccumulators | 100         |  60.16 ns | 0.385 ns | 0.539 ns |         - |
| **AppendHotPath**                 | **1000**        | **141.73 ns** | **1.196 ns** | **1.790 ns** |         **-** |
| AppendMultiPartition          | 1000        | 140.22 ns | 2.087 ns | 3.124 ns |         - |
| AppendAlternatingAccumulators | 1000        | 138.62 ns | 1.398 ns | 2.092 ns |         - |

### `ProducerFireHotPathBenchmarks` (existing; full `FireAsync` front-end; `TracingEnabled=false, UsePreparedSerializer=false` rows, filtered so each run fits the runner's time cap — `DeliveryLatencyTargetMs=10` rows take the folded path)

Pair 1 — baseline (`base-fire-1`):

| Method    | MessageSize | DeliveryLatencyTargetMs | PartitionCount | TracingEnabled | UsePreparedSerializer | Mean     | Error   | StdDev  | Allocated |
|---------- |------------ |------------------------ |--------------- |--------------- |---------------------- |---------:|--------:|--------:|----------:|
| **FireBatch** | **1000**        | **0**                       | **1**              | **False**          | **False**                 | **222.7 ns** | **3.06 ns** | **4.48 ns** |         **-** |
| **FireBatch** | **1000**        | **0**                       | **12**             | **False**          | **False**                 | **223.2 ns** | **1.19 ns** | **1.71 ns** |         **-** |
| **FireBatch** | **1000**        | **10**                      | **1**              | **False**          | **False**                 | **252.0 ns** | **3.42 ns** | **4.79 ns** |         **-** |
| **FireBatch** | **1000**        | **10**                      | **12**             | **False**          | **False**                 | **249.2 ns** | **1.77 ns** | **2.65 ns** |         **-** |

Pair 1 — candidate (`cand-fire-1`):

| Method    | MessageSize | DeliveryLatencyTargetMs | PartitionCount | TracingEnabled | UsePreparedSerializer | Mean     | Error   | StdDev  | Allocated |
|---------- |------------ |------------------------ |--------------- |--------------- |---------------------- |---------:|--------:|--------:|----------:|
| **FireBatch** | **1000**        | **0**                       | **1**              | **False**          | **False**                 | **212.1 ns** | **2.53 ns** | **3.78 ns** |         **-** |
| **FireBatch** | **1000**        | **0**                       | **12**             | **False**          | **False**                 | **215.3 ns** | **1.36 ns** | **1.82 ns** |         **-** |
| **FireBatch** | **1000**        | **10**                      | **1**              | **False**          | **False**                 | **212.8 ns** | **2.36 ns** | **3.39 ns** |         **-** |
| **FireBatch** | **1000**        | **10**                      | **12**             | **False**          | **False**                 | **215.9 ns** | **1.61 ns** | **2.36 ns** |         **-** |

Pair 2 — baseline (`base-fire-2`):

| Method    | MessageSize | DeliveryLatencyTargetMs | PartitionCount | TracingEnabled | UsePreparedSerializer | Mean     | Error   | StdDev  | Allocated |
|---------- |------------ |------------------------ |--------------- |--------------- |---------------------- |---------:|--------:|--------:|----------:|
| **FireBatch** | **1000**        | **0**                       | **1**              | **False**          | **False**                 | **220.9 ns** | **2.83 ns** | **4.15 ns** |         **-** |
| **FireBatch** | **1000**        | **0**                       | **12**             | **False**          | **False**                 | **223.3 ns** | **1.67 ns** | **2.44 ns** |         **-** |
| **FireBatch** | **1000**        | **10**                      | **1**              | **False**          | **False**                 | **246.7 ns** | **2.11 ns** | **3.09 ns** |         **-** |
| **FireBatch** | **1000**        | **10**                      | **12**             | **False**          | **False**                 | **241.3 ns** | **1.68 ns** | **2.47 ns** |         **-** |

Pair 2 — candidate (`cand-fire-2`):

| Method    | MessageSize | DeliveryLatencyTargetMs | PartitionCount | TracingEnabled | UsePreparedSerializer | Mean     | Error   | StdDev  | Allocated |
|---------- |------------ |------------------------ |--------------- |--------------- |---------------------- |---------:|--------:|--------:|----------:|
| **FireBatch** | **1000**        | **0**                       | **1**              | **False**          | **False**                 | **212.4 ns** | **1.36 ns** | **1.90 ns** |         **-** |
| **FireBatch** | **1000**        | **0**                       | **12**             | **False**          | **False**                 | **216.1 ns** | **2.27 ns** | **3.25 ns** |         **-** |
| **FireBatch** | **1000**        | **10**                      | **1**              | **False**          | **False**                 | **212.5 ns** | **1.68 ns** | **2.40 ns** |         **-** |
| **FireBatch** | **1000**        | **10**                      | **12**             | **False**          | **False**                 | **216.8 ns** | **2.69 ns** | **3.77 ns** |         **-** |

### Medians and per-pair ratios (candidate / baseline; < 1 is faster)

**AccumulatorAdmissionAppendBenchmarks**

| Case | Baseline p1 | Baseline p2 | Baseline median | Candidate p1 | Candidate p2 | Candidate median | Ratio p1 | Ratio p2 | Median ratio |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| AppendBatch Shape=1T, AdmissionEnabled=False | 134.5 | 135.4 | 135.0 | 132.9 | 132.2 | 132.6 | 0.988 | 0.976 | 0.982 |
| AppendBatch Shape=1T, AdmissionEnabled=True | 151.3 | 153.4 | 152.3 | 132.2 | 131.9 | 132.1 | 0.874 | 0.860 | 0.867 |
| AppendBatch Shape=4T-same, AdmissionEnabled=False | 2322.7 | 2540.9 | 2431.8 | 2285.9 | 2092.5 | 2189.2 | 0.984 | 0.824 | 0.900 |
| AppendBatch Shape=4T-same, AdmissionEnabled=True | 2673.0 | 2672.4 | 2672.7 | 2403.8 | 2471.3 | 2437.6 | 0.899 | 0.925 | 0.912 |
| AppendBatch Shape=4T-split, AdmissionEnabled=False | 63.9 | 66.5 | 65.2 | 66.4 | 66.1 | 66.2 | 1.038 | 0.993 | 1.015 |
| AppendBatch Shape=4T-split, AdmissionEnabled=True | 66.8 | 67.2 | 67.0 | 65.8 | 66.1 | 65.9 | 0.985 | 0.984 | 0.984 |

**AccumulatorAppendBenchmarks**

| Case | Baseline p1 | Baseline p2 | Baseline median | Candidate p1 | Candidate p2 | Candidate median | Ratio p1 | Ratio p2 | Median ratio |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| AppendHotPath MessageSize=100 | 72.0 | 71.6 | 71.8 | 56.7 | 58.1 | 57.4 | 0.788 | 0.811 | 0.799 |
| AppendMultiPartition MessageSize=100 | 72.3 | 71.8 | 72.1 | 59.6 | 61.1 | 60.4 | 0.824 | 0.851 | 0.838 |
| AppendAlternatingAccumulators MessageSize=100 | 71.9 | 75.0 | 73.4 | 59.6 | 60.2 | 59.9 | 0.828 | 0.803 | 0.815 |
| AppendHotPath MessageSize=1000 | 144.8 | 142.4 | 143.6 | 136.6 | 141.7 | 139.1 | 0.943 | 0.995 | 0.969 |
| AppendMultiPartition MessageSize=1000 | 150.8 | 150.6 | 150.7 | 138.0 | 140.2 | 139.1 | 0.915 | 0.931 | 0.923 |
| AppendAlternatingAccumulators MessageSize=1000 | 150.8 | 152.1 | 151.4 | 138.0 | 138.6 | 138.3 | 0.916 | 0.911 | 0.913 |

**ProducerFireHotPathBenchmarks**

| Case | Baseline p1 | Baseline p2 | Baseline median | Candidate p1 | Candidate p2 | Candidate median | Ratio p1 | Ratio p2 | Median ratio |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| FireBatch MessageSize=1000, DeliveryLatencyTargetMs=0, PartitionCount=1,  | 222.7 | 220.9 | 221.8 | 212.1 | 212.4 | 212.2 | 0.952 | 0.961 | 0.957 |
| FireBatch MessageSize=1000, DeliveryLatencyTargetMs=0, PartitionCount=12,  | 223.2 | 223.3 | 223.2 | 215.3 | 216.1 | 215.7 | 0.965 | 0.968 | 0.966 |
| FireBatch MessageSize=1000, DeliveryLatencyTargetMs=10, PartitionCount=1,  | 252.0 | 246.7 | 249.4 | 212.8 | 212.5 | 212.6 | 0.844 | 0.861 | 0.853 |
| FireBatch MessageSize=1000, DeliveryLatencyTargetMs=10, PartitionCount=12,  | 249.2 | 241.3 | 245.3 | 215.9 | 216.8 | 216.4 | 0.866 | 0.899 | 0.882 |

Allocated is `-` (0 B) on every row, before and after, including the four-thread shapes. Throughput/latency-sensitive rows: no pair regresses beyond noise (the only ratio above 1.0 is 4T-split/admission-off pair 1 at 1.038 against a baseline that itself moved from 63.9 to 66.5 ns between pairs; pair 2 is 0.993).

## Risk

- Correctness surface is the interplay of the single-lock path with the two-phase protocol. The fast path reads `RotationInProgress`, `AppendInProgress`, `AdmissionInProgress`, `CurrentBatch` and `CanFitEstimatedRecord` under the lock and bails on any of them, so it never appends during a rotation, an out-of-lock encode, or while another appender's uncommitted lease decision is outstanding. All bail-outs return what was reserved before falling back, so no record is double-accounted (BufferMemory refund stays exactly-once, #2199/#2200).
- FIFO behind queued slow-path appends is preserved by the same `SlowPathAppendCount` check the reservation path uses; the blocked-admission bookkeeping (`RecordAdmissionBlock`, `RequestAdmissionFlush`) still happens exactly once, in the reservation path.
- `DrainPendingAppends` is never called under `pd.Lock` (the undo runs in a `finally` after the guard is disposed), preserving the #2207 rule.
- `BatchArena.TryAllocate` is no longer safe for concurrent callers; every production caller holds the partition lock (documented on the method and in `TryReserveAppendFromSpans`).
- Merge note: PR #2988 (`perf/append-topic-hash-lookups`) also threads `PartitionDeque` through the same append entry points and will conflict here. Suggest #2988 rebases onto this branch once it merges: this PR is the larger change and the stacked PR B (`perf/buffer-memory-batch-lease`) is branched from its final commit, so rebasing this one would cascade; the conflict surface is the two span entry points and the `pd` parameter of `AppendFromSpansAfterReservationCore`, and both PRs pass the deque, so the resolution is mechanical.

## Tests

Unit (TUnit, `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe`):
- `--treenode-filter "/*/*/(SingleLockAdmissionAppendTests|BatchArenaConcurrencyTests|BrokerUnackedAdmissionTests|BufferMemoryTests)/*"` — 199 passed, 0 failed.
- `--treenode-filter "/*/*/(RecordAccumulator*|*Producer*|*BufferMemory*|*Leak*|*Admission*|*Backpressure*|BatchArena*)/*"` — 1128 passed, 0 failed.
- Whole unit suite (no filter) — 8738 passed, 0 failed, 23 s.

Integration (Docker, Testcontainers Kafka 4.3.1, `tests\Dekaf.Tests.Integration\bin\Release\net10.0\Dekaf.Tests.Integration.exe`):
- `--treenode-filter "/*/*/(ProducerTests|*Backpressure*|*BufferMemory*|Idempotent*|Transaction*)/*"` — 91 passed, 0 failed, 2 m 02 s.

New unit tests (`SingleLockAdmissionAppendTests`): one lease per batch consumed locally and refunded at seal; lease replenishment when the batch outgrows the 64 KB quantum; 8 threads on one partition with a sender stand-in (every record lands once, broker and BufferMemory ledgers return to zero, no accounting underflow); 4 threads with BufferMemory sized for three batches (fast path alternating with backpressure, no loss, ledgers to zero); fast path refused while the broker is over budget (block recorded, nothing reserved); queued span appends land in a new batch after rotation and the charged batch's exit, FIFO preserved.

https://claude.ai/code/session_01Suvjuoke4b9o5wuzNU2ThM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved producer append throughput by adding a faster path for eligible span-based appends.
  * Reduced overhead during partition-level append processing while preserving admission limits and backpressure behavior.

* **Bug Fixes**
  * Improved handling of concurrent appends, buffer pressure, batch rotation, and admission limits without record loss.

* **Tests**
  * Added coverage for fast-path appends, concurrency, lease accounting, backpressure, and batch transitions.
  * Strengthened arena allocation and rewind validation.

* **Benchmarks**
  * Added benchmarks for single- and multi-threaded append workloads across shared and separate partitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->