### PR TITLE
perf(producer): skip wave-coalesce spin for batches sealed as sole demand

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2523,19 +2523,27 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     }
 
     /// <summary>
-    /// Serial transactional ProduceAsync traffic cannot enqueue another record until its sole
-    /// completion resolves, so spinning for a co-temporal batch can never improve coalescing.
+    /// Whether a single-batch wave should spin for siblings. Two shapes prove the spin can
+    /// never improve coalescing because the only producer is awaiting the batch in hand:
+    /// a batch the accumulator sealed as the producer's sole demand (#2510 bypass,
+    /// <see cref="ReadyBatch.SealedAsSoleDemand"/>), and serial transactional ProduceAsync
+    /// traffic, which cannot enqueue another record until its sole completion resolves.
+    /// Skipping here also keeps the wave out of <see cref="WaveCoalesceGate"/> accounting,
+    /// so a skipped wave is counted neither fruitless nor fruitful.
     /// </summary>
     internal static bool ShouldMicroLinger(
         ReadyBatch[] coalescedBatches,
         int coalescedCount,
         bool isTransactional)
     {
-        if (!isTransactional || coalescedCount != 1)
+        if (coalescedCount != 1)
             return true;
 
         var batch = coalescedBatches[0];
-        return batch.RecordCount != 1 || batch.CompletionSourcesCount != 1;
+        if (batch.SealedAsSoleDemand)
+            return false;
+
+        return !isTransactional || batch.RecordCount != 1 || batch.CompletionSourcesCount != 1;
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2541,7 +2541,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         var batch = coalescedBatches[0];
         if (batch.SealedAsSoleDemand)
-            return false;
+            return !batch.HasPendingSoleDemand;
 
         return !isTransactional || batch.RecordCount != 1 || batch.CompletionSourcesCount != 1;
     }

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1340,6 +1340,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // conservative request budget across batches from separate drain passes.
         var coalescedRequestBudgetUsed = 0L;
         var waveCoalesceBounds = SelectWaveCoalesceBounds(_options.LingerMs);
+        var isZeroLinger = _options.LingerMs == 0;
         var waveCoalesceMaxTicks = MicrosecondsToStopwatchTicks(waveCoalesceBounds.MaximumMicroseconds);
         var waveCoalesceQuietTicks = MicrosecondsToStopwatchTicks(waveCoalesceBounds.QuietMicroseconds);
         var waveCoalesceArmed = true;
@@ -1647,10 +1648,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     && coalescedPartitions.Count < _knownPartitions.Count
                     && carryOver.Count == 0
                     && waveCoalesceGate.ShouldSpin(Stopwatch.GetTimestamp())
-                    && ShouldMicroLinger(
-                        coalescedBatches,
-                        coalescedCount,
-                        _options.TransactionalId is not null))
+                    && (isZeroLinger
+                        ? ShouldMicroLingerAtZeroLinger(
+                            coalescedBatches, coalescedCount, _options.TransactionalId is not null)
+                        : ShouldMicroLinger(
+                            coalescedBatches, coalescedCount, _options.TransactionalId is not null)))
                 {
                     waveCoalesceArmed = false;
                     var coalescedCountBeforeSpin = coalescedCount;
@@ -2523,8 +2525,24 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     }
 
     /// <summary>
-    /// Whether a single-batch wave should spin for siblings. Two shapes prove the spin can
-    /// never improve coalescing because the only producer is awaiting the batch in hand:
+    /// The legacy zero-linger decision. Nontransactional traffic returns before touching
+    /// batch state; zero-linger seals never carry a sole-demand proof.
+    /// </summary>
+    internal static bool ShouldMicroLingerAtZeroLinger(
+        ReadyBatch[] coalescedBatches,
+        int coalescedCount,
+        bool isTransactional)
+    {
+        if (!isTransactional || coalescedCount != 1)
+            return true;
+
+        var batch = coalescedBatches[0];
+        return batch.RecordCount != 1 || batch.CompletionSourcesCount != 1;
+    }
+
+    /// <summary>
+    /// Whether a positive-linger single-batch wave should spin for siblings. Two shapes
+    /// prove the spin can never improve coalescing because the only producer is awaiting the batch in hand:
     /// a batch the accumulator sealed as the producer's sole demand (#2510 bypass,
     /// <see cref="ReadyBatch.SealedAsSoleDemand"/>), and serial transactional ProduceAsync
     /// traffic, which cannot enqueue another record until its sole completion resolves.

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3804,6 +3804,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // in forward order, each response's retry must go AFTER earlier responses'
         // retries for the same partition to preserve FIFO ordering.
         batch.IsRetry = true;
+        // The sole-demand proof held at seal time; by the retry, backoff has given other
+        // callers time to enqueue siblings, so the sender must spin for them again.
+        batch.SealedAsSoleDemand = false;
         batch.AppendDiag('H'); // HandleRetriableBatch → carry-over
         carryOver.AddAfterRetries(new BatchReference(batch, generation));
     }
@@ -5231,6 +5234,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 return false;
 
             batch.IsRetry = true;
+            batch.SealedAsSoleDemand = false;
             batch.AppendDiag('Y');
             return batch.IsCurrentIncarnation(expectedGeneration);
         }

--- a/src/Dekaf/Producer/PooledValueTaskSource.cs
+++ b/src/Dekaf/Producer/PooledValueTaskSource.cs
@@ -27,6 +27,12 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
     private CancellationToken _registeredCancellationToken;
 #endif
     private int _hasCompleted; // 0 = not completed, 1 = completed
+    // Never reset on pool return: a batch may still be delivering after its cancelled
+    // caller has consumed the result and rented this source for a different message.
+    private long _cancellationVersion;
+
+    internal long CancellationVersion => Volatile.Read(ref _cancellationVersion);
+    internal bool IsPending => Volatile.Read(ref _hasCompleted) == 0;
 
     /// <summary>
     /// Gets a <see cref="ValueTask{T}"/> bound to this source.
@@ -140,6 +146,7 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
             return false;
         }
 
+        Interlocked.Increment(ref _cancellationVersion);
         _core.SetException(new OperationCanceledException(cancellationToken));
         return true;
     }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4939,8 +4939,17 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (_options.LingerMs == 0)
             return !ShouldDeferPartialBatchSeal(pd, batch);
 
-        return IsAppLimitedAwaitedAppend(batch, completionSource)
-            && !IsMuted(pd);
+        if (!IsAppLimitedAwaitedAppend(batch, completionSource)
+            || IsMuted(pd))
+        {
+            return false;
+        }
+
+        // The gate just proved this record is the producer's only demand. Record that on the
+        // batch so the sender can skip its sibling-wait spin: the sole caller is awaiting this
+        // very batch, so no sibling batch can be appended until it is acknowledged.
+        batch.MarkSealedAsSoleDemand();
+        return true;
     }
 
     /// <summary>
@@ -7788,6 +7797,7 @@ internal sealed class PartitionBatch
     private int _reservedSize;
     private BrokerUnackedByteBudget? _admissionBudget;
     private long _admissionGeneration;
+    private bool _sealedAsSoleDemand;
     private int _admissionReservedBytes;
     private int _effectiveBatchSizeLimit;
     // Note: _offsetDelta removed - it always equals _recordCount at assignment time
@@ -7914,6 +7924,7 @@ internal sealed class PartitionBatch
         ReleaseAdmissionReservation();
         _isCompleted = 0;  // Only reset here - see remarks
         _completedBatch = null;
+        _sealedAsSoleDemand = false;
     }
 
     /// <summary>
@@ -8735,6 +8746,15 @@ internal sealed class PartitionBatch
         return elapsedMs >= lingerMs;
     }
 
+    /// <summary>
+    /// Records that the app-limited awaited-produce gate (#2510) proved this batch to be the
+    /// producer's only demand at seal time. Called under the deque lock immediately before
+    /// the batch is detached for sealing; <see cref="Complete"/> carries the fact onto the
+    /// <see cref="ReadyBatch"/> so the sender can skip its sibling-wait spin.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void MarkSealedAsSoleDemand() => _sealedAsSoleDemand = true;
+
     public ReadyBatch? Complete()
     {
         // Atomically mark as completed - only first caller proceeds
@@ -8824,6 +8844,7 @@ internal sealed class PartitionBatch
                 completionSourceIndexes: _completionSourceIndexes,
                 callbackDenseCount: _callbackIndexes is null ? _callbackCount : _callbackDenseCount,
                 callbackIndexes: _callbackIndexes);
+            readyBatch.SealedAsSoleDemand = _sealedAsSoleDemand;
 
             if (_admissionBudget is { } admissionBudget)
             {
@@ -9608,6 +9629,19 @@ internal sealed class ReadyBatch
     internal bool IsRetry { get; set; }
 
     /// <summary>
+    /// True when the accumulator's app-limited awaited-produce gate (#2510) proved, at seal
+    /// time, that this batch was the producer's only demand: one awaited record, no other
+    /// unsealed or undelivered batch, no bulk produce scope. The sole caller is awaiting this
+    /// batch, so no sibling batch can arrive while the sender forms the request wave —
+    /// <see cref="BrokerSender.ShouldMicroLinger"/> skips the wave-coalesce spin for it.
+    /// Set only by <see cref="PartitionBatch.Complete"/> on that bypass path; every other
+    /// seal (linger expiry, size-full, flush, zero-linger) leaves it false. It stays with the
+    /// batch object across retry and reroute — the sole caller is still awaiting that batch —
+    /// and is cleared with the rest of the per-lifecycle state in Initialize/Reset.
+    /// </summary>
+    internal bool SealedAsSoleDemand { get; set; }
+
+    /// <summary>
     /// True while this batch owns a crash-recovery mute reference. Kept separate from
     /// <see cref="IsRetry"/> because the reference survives sender-to-sender reroutes and
     /// is released only when the batch reaches a terminal state.
@@ -9904,6 +9938,7 @@ internal sealed class ReadyBatch
         IsSplitBatch = false;
         MaxRecordSize = 0;
         ObservedCompressionRatio = 1.0;
+        SealedAsSoleDemand = false;
     }
 
     /// <summary>
@@ -9984,6 +10019,7 @@ internal sealed class ReadyBatch
         IsSplitBatch = false;
         MaxRecordSize = 0;
         ObservedCompressionRatio = 1.0;
+        SealedAsSoleDemand = false;
         _diagTraceLen = 0;
 
         // NOTE: _cleanedUp, _completed, and _sendCompleted are NOT reset here. They stay

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -9639,9 +9639,32 @@ internal sealed class ReadyBatch
     /// honoured on the first send attempt: marking the batch for retry (sender carry-over,
     /// loop-exit redelivery, <see cref="Reenqueued"/>) clears it, because by then backoff has
     /// given other callers time to enqueue siblings. It is also cleared with the rest of the
-    /// per-lifecycle state in Initialize/Reset.
+    /// per-lifecycle state in Initialize/Reset. The sender additionally checks
+    /// <see cref="HasPendingSoleDemand"/> because cancellation can release the caller
+    /// during the first attempt, before any retry clears this seal-time hint.
     /// </summary>
-    internal bool SealedAsSoleDemand { get; set; }
+    internal bool SealedAsSoleDemand
+    {
+        get => _sealedAsSoleDemand;
+        set
+        {
+            if (value)
+                _soleDemandCancellationVersion = _completionSourcesArray![0].CancellationVersion;
+            _sealedAsSoleDemand = value;
+        }
+    }
+
+    private bool _sealedAsSoleDemand;
+    private long _soleDemandCancellationVersion;
+
+    /// <summary>
+    /// Cancellation releases the sole caller before delivery. Compare the captured version
+    /// even after that caller consumes the cancellation and the completion source is reused.
+    /// Only the sole-demand wave reads this state; no per-message cancellation hook is needed.
+    /// </summary>
+    internal bool HasPendingSoleDemand
+        => _completionSourcesArray![0].IsPending
+            && _completionSourcesArray[0].CancellationVersion == _soleDemandCancellationVersion;
 
     /// <summary>
     /// True while this batch owns a crash-recovery mute reference. Kept separate from

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -9635,9 +9635,11 @@ internal sealed class ReadyBatch
     /// batch, so no sibling batch can arrive while the sender forms the request wave —
     /// <see cref="BrokerSender.ShouldMicroLinger"/> skips the wave-coalesce spin for it.
     /// Set only by <see cref="PartitionBatch.Complete"/> on that bypass path; every other
-    /// seal (linger expiry, size-full, flush, zero-linger) leaves it false. It stays with the
-    /// batch object across retry and reroute — the sole caller is still awaiting that batch —
-    /// and is cleared with the rest of the per-lifecycle state in Initialize/Reset.
+    /// seal (linger expiry, size-full, flush, zero-linger) leaves it false. The proof is only
+    /// honoured on the first send attempt: marking the batch for retry (sender carry-over,
+    /// loop-exit redelivery, <see cref="Reenqueued"/>) clears it, because by then backoff has
+    /// given other callers time to enqueue siblings. It is also cleared with the rest of the
+    /// per-lifecycle state in Initialize/Reset.
     /// </summary>
     internal bool SealedAsSoleDemand { get; set; }
 
@@ -9706,6 +9708,7 @@ internal sealed class ReadyBatch
     {
         _createdTimestamp = Stopwatch.GetTimestamp();
         IsRetry = true;
+        SealedAsSoleDemand = false;
     }
 
     internal void PreserveDeliveryTimeline(ReadyBatch source)

--- a/tests/Dekaf.Tests.Unit/Producer/AppLimitedLingerBypassTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AppLimitedLingerBypassTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Producer;
@@ -417,6 +418,38 @@ public class AppLimitedLingerBypassTests
 
             batch.Reenqueued(nowMs: 0);
 
+            await Assert.That(batch.IsRetry).IsTrue();
+            await Assert.That(batch.SealedAsSoleDemand).IsFalse();
+            LeakGateHarness.RetireBatch(accumulator, batch, offset: 0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task SoleDemandFlag_IsClearedWhenBatchIsPreparedForLoopExitRedelivery()
+    {
+        // The sender's loop-exit redelivery is the other retry-marking site it owns outright
+        // (HandleRetriableBatch clears the flag on the same line as IsRetry but needs a live
+        // sender to reach). It is static and touches only the batch, so it is driven directly.
+        var prepare = typeof(BrokerSender).GetMethod(
+            "PrepareLoopExitRedelivery",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 5_000));
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            AppendAwaited(accumulator, pool);
+            var batch = DrainSealedBatch(accumulator);
+            await Assert.That(batch.SealedAsSoleDemand).IsTrue();
+
+            var prepared = (bool)prepare.Invoke(null, [batch, batch.Generation])!;
+
+            await Assert.That(prepared).IsTrue();
             await Assert.That(batch.IsRetry).IsTrue();
             await Assert.That(batch.SealedAsSoleDemand).IsFalse();
             LeakGateHarness.RetireBatch(accumulator, batch, offset: 0);

--- a/tests/Dekaf.Tests.Unit/Producer/AppLimitedLingerBypassTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AppLimitedLingerBypassTests.cs
@@ -292,4 +292,119 @@ public class AppLimitedLingerBypassTests
             await pool.DisposeAsync();
         }
     }
+
+    // ── SealedAsSoleDemand: set only by the bypass seal, cleared across pooled reuse ──
+    //
+    // BrokerSender skips its wave-coalesce spin for a single-batch wave carrying the flag,
+    // so the flag must be a faithful record of the bypass proof: every other seal path
+    // (zero-linger, flush, bulk scope) must leave it false, and neither pooled type
+    // (PartitionBatch, ReadyBatch) may carry it into its next lifecycle.
+
+    [Test]
+    public async Task SoleAwaitedProduce_SealsBatchAsSoleDemand()
+    {
+        var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 5_000));
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            AppendAwaited(accumulator, pool);
+
+            var batch = DrainSealedBatch(accumulator);
+            await Assert.That(batch.SealedAsSoleDemand).IsTrue();
+            LeakGateHarness.RetireBatch(accumulator, batch, offset: 0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task ZeroLingerSoleAwaitedProduce_IsNotSealedAsSoleDemand()
+    {
+        // LingerMs == 0 seals on the zero-linger path, which never evaluates the app-limited
+        // gate — the sender keeps its (75 µs) sibling wait for that shape.
+        var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 0));
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            AppendAwaited(accumulator, pool);
+            await Assert.That(accumulator.UnsealedBatchCount).IsEqualTo(0);
+
+            var batch = DrainSealedBatch(accumulator);
+            await Assert.That(batch.SealedAsSoleDemand).IsFalse();
+            LeakGateHarness.RetireBatch(accumulator, batch, offset: 0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task FlushSealOfFireAndForgetBatch_IsNotSealedAsSoleDemand()
+    {
+        var accumulator = new RecordAccumulator(CreateOptions());
+
+        try
+        {
+            await AccumulatorTestHelpers.AppendNullRecordAsync(accumulator, Topic);
+            await AccumulatorTestHelpers.SealAllAsync(accumulator);
+
+            var batch = DrainSealedBatch(accumulator);
+            await Assert.That(batch.SealedAsSoleDemand).IsFalse();
+            LeakGateHarness.RetireBatch(accumulator, batch, offset: 0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task SoleDemandFlag_DoesNotSurvivePooledBatchReuse()
+    {
+        var accumulator = new RecordAccumulator(CreateOptions());
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            // Cycle 1: the bypass seals and flags the batch; retiring it returns both the
+            // PartitionBatch and the ReadyBatch to their pools with the flag still set.
+            AppendAwaited(accumulator, pool);
+            var flagged = DrainSealedBatch(accumulator);
+            await Assert.That(flagged.SealedAsSoleDemand).IsTrue();
+            LeakGateHarness.RetireBatch(accumulator, flagged, offset: 0);
+
+            // Cycle 2: a bulk-scope append re-rents the pooled batch and the flush sweep seals
+            // it without any sole-demand proof — the recycled objects must read false.
+            using (accumulator.EnterBulkProduceScope())
+            {
+                AppendAwaited(accumulator, pool);
+                await Assert.That(accumulator.UnsealedBatchCount).IsEqualTo(1);
+                await AccumulatorTestHelpers.SealAllAsync(accumulator);
+            }
+
+            var recycled = DrainSealedBatch(accumulator);
+            await Assert.That(recycled.SealedAsSoleDemand).IsFalse();
+            LeakGateHarness.RetireBatch(accumulator, recycled, offset: 1);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    private static ReadyBatch DrainSealedBatch(RecordAccumulator accumulator)
+    {
+        if (!accumulator.TryDrainBatch(new TopicPartition(Topic, 0), out var batch))
+            throw new InvalidOperationException("Expected a sealed batch in the partition deque.");
+
+        return batch;
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/AppLimitedLingerBypassTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AppLimitedLingerBypassTests.cs
@@ -400,6 +400,34 @@ public class AppLimitedLingerBypassTests
         }
     }
 
+    [Test]
+    public async Task SoleDemandFlag_IsClearedWhenBatchIsReenqueuedForRetry()
+    {
+        // The proof only covers the first send attempt: once a batch is marked for retry,
+        // backoff has given other callers time to enqueue siblings, so the sender must spin
+        // for them again on the retry wave.
+        var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 5_000));
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            AppendAwaited(accumulator, pool);
+            var batch = DrainSealedBatch(accumulator);
+            await Assert.That(batch.SealedAsSoleDemand).IsTrue();
+
+            batch.Reenqueued(nowMs: 0);
+
+            await Assert.That(batch.IsRetry).IsTrue();
+            await Assert.That(batch.SealedAsSoleDemand).IsFalse();
+            LeakGateHarness.RetireBatch(accumulator, batch, offset: 0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
     private static ReadyBatch DrainSealedBatch(RecordAccumulator accumulator)
     {
         if (!accumulator.TryDrainBatch(new TopicPartition(Topic, 0), out var batch))

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSoleDemandWaveTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSoleDemandWaveTests.cs
@@ -20,6 +20,36 @@ public sealed class BrokerSenderSoleDemandWaveTests : ScriptedProduceResponseFix
     private const string Topic = "sole-demand-topic";
 
     [Test]
+    public async Task ShouldMicroLinger_CancelledSoleWaiter_KeepsSpinningAfterSourceReuse()
+    {
+        var source = new PooledValueTaskSource<RecordMetadata>();
+        var delivery = source.Task;
+        var batch = new ReadyBatch();
+        batch.Initialize(new TopicPartition(Topic, 0), new RecordBatch { Records = [] },
+            [source], completionSourcesCount: 1, recordCount: 1, dataSize: 100);
+        batch.SealedAsSoleDemand = true;
+        using var cancellation = new CancellationTokenSource();
+        source.RegisterCancellation(cancellation.Token);
+
+        await Assert.That(BrokerSender.ShouldMicroLinger([batch], 1, isTransactional: false)).IsFalse();
+        cancellation.Cancel();
+        await Assert.That(BrokerSender.ShouldMicroLinger([batch], 1, isTransactional: false)).IsTrue();
+        await Assert.That(BrokerSender.ShouldMicroLinger([batch], 1, isTransactional: true)).IsTrue();
+
+        await Assert.That(async () => await delivery).Throws<OperationCanceledException>();
+        // GetResult resets the source to Pending. The original batch must not mistake
+        // this new incarnation for its own still-waiting caller.
+        await Assert.That(source.Task.IsCompleted).IsFalse();
+        await Assert.That(BrokerSender.ShouldMicroLinger([batch], 1, isTransactional: false)).IsTrue();
+
+        var nextBatch = new ReadyBatch();
+        nextBatch.Initialize(new TopicPartition(Topic, 1), new RecordBatch { Records = [] },
+            [source], completionSourcesCount: 1, recordCount: 1, dataSize: 100);
+        nextBatch.SealedAsSoleDemand = true;
+        await Assert.That(BrokerSender.ShouldMicroLinger([nextBatch], 1, isTransactional: false)).IsFalse();
+    }
+
+    [Test]
     public async Task ShouldMicroLinger_SoleDemandSingleBatchWave_SkipsSpin()
     {
         var pool = new ValueTaskSourcePool<RecordMetadata>();

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSoleDemandWaveTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSoleDemandWaveTests.cs
@@ -20,6 +20,35 @@ public sealed class BrokerSenderSoleDemandWaveTests : ScriptedProduceResponseFix
     private const string Topic = "sole-demand-topic";
 
     [Test]
+    public async Task ZeroLinger_NontransactionalWave_DoesNotReadBatchState()
+    {
+        // A missing batch is intentional: the legacy nontransactional decision needs
+        // only configuration and must not read sole-demand or completion state.
+        await Assert.That(BrokerSender.ShouldMicroLingerAtZeroLinger([], 1, isTransactional: false)).IsTrue();
+        await Assert.That(BrokerSender.ShouldMicroLingerAtZeroLinger([], 2, isTransactional: true)).IsTrue();
+    }
+
+    [Test]
+    public async Task ZeroLinger_TransactionalSingleRecord_KeepsLegacySkip()
+    {
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        try
+        {
+            var (batch, _) = CreateBatch(pool, partition: 0, soleDemand: false);
+            await Assert.That(BrokerSender.ShouldMicroLingerAtZeroLinger([batch], 1, isTransactional: true)).IsFalse();
+
+            var multiRecordBatch = new ReadyBatch();
+            multiRecordBatch.Initialize(new TopicPartition(Topic, 0), new RecordBatch { Records = [] },
+                completionSourcesArray: null, completionSourcesCount: 0, recordCount: 2, dataSize: 100);
+            await Assert.That(BrokerSender.ShouldMicroLingerAtZeroLinger([multiRecordBatch], 1, isTransactional: true)).IsTrue();
+        }
+        finally
+        {
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task ShouldMicroLinger_CancelledSoleWaiter_KeepsSpinningAfterSourceReuse()
     {
         var source = new PooledValueTaskSource<RecordMetadata>();
@@ -103,8 +132,12 @@ public sealed class BrokerSenderSoleDemandWaveTests : ScriptedProduceResponseFix
     }
 
     [Test]
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(5)]
     [Timeout(60_000)]
-    public async Task SendLoop_SoleDemandBatch_SkipsWaveCoalesceSpin_UnflaggedBatchStillSpins(
+    public async Task SendLoop_ZeroLingerUsesLegacySpin_PositiveLingerSkipsSoleDemand(
+        int lingerMs,
         CancellationToken cancellationToken)
     {
         var responses = new Queue<TaskCompletionSource<ProduceResponse>>(
@@ -115,7 +148,7 @@ public sealed class BrokerSenderSoleDemandWaveTests : ScriptedProduceResponseFix
         var (pool, connection) = CreateMockConnection(responses);
         connection.CaptureProduceRequests = true;
         cancellationToken = GuardUnscriptedSends(cancellationToken);
-        var options = CreateOptions();
+        var options = CreateOptions(lingerMs);
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
         var spinsStarted = 0;
@@ -137,14 +170,15 @@ public sealed class BrokerSenderSoleDemandWaveTests : ScriptedProduceResponseFix
             var metadata = await soleDemandDelivery.WaitAsync(cancellationToken);
 
             await Assert.That(metadata.Offset).IsEqualTo(10);
-            await Assert.That(Volatile.Read(ref spinsStarted)).IsEqualTo(0);
+            var expectedFlaggedSpins = lingerMs == 0 ? 1 : 0;
+            await Assert.That(Volatile.Read(ref spinsStarted)).IsEqualTo(expectedFlaggedSpins);
 
             var (unflagged, unflaggedDelivery) = CreateBatch(vtPool, partition: 0, soleDemand: false);
             sender.Enqueue(unflagged);
             metadata = await unflaggedDelivery.WaitAsync(cancellationToken);
 
             await Assert.That(metadata.Offset).IsEqualTo(11);
-            await Assert.That(Volatile.Read(ref spinsStarted)).IsEqualTo(1);
+            await Assert.That(Volatile.Read(ref spinsStarted)).IsEqualTo(expectedFlaggedSpins + 1);
             int capturedRequestCount;
             lock (connection.CapturedProduceRequests)
             {
@@ -219,14 +253,14 @@ public sealed class BrokerSenderSoleDemandWaveTests : ScriptedProduceResponseFix
         }
     }
 
-    private static ProducerOptions CreateOptions() => new()
+    private static ProducerOptions CreateOptions(int lingerMs = 5) => new()
     {
         BootstrapServers = ["localhost:9092"],
         MaxInFlightRequestsPerConnection = 1,
         ConnectionsPerBroker = 1,
         EnableIdempotence = true,
         Acks = Acks.All,
-        LingerMs = 5,
+        LingerMs = lingerMs,
         RetryBackoffMs = 100,
         RetryBackoffMaxMs = 1000,
         DeliveryTimeoutMs = 30_000,

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSoleDemandWaveTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSoleDemandWaveTests.cs
@@ -1,0 +1,253 @@
+using System.Buffers;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// The send loop's wave-coalesce spin waits up to a quiet window for sibling batches before
+/// writing a request. A batch the accumulator sealed as the producer's sole demand (#2510
+/// bypass) cannot gain a sibling during that wait — its only caller is awaiting it — so a
+/// single-batch wave carrying <see cref="ReadyBatch.SealedAsSoleDemand"/> skips the spin
+/// without entering <see cref="WaveCoalesceGate"/> accounting. Unflagged waves keep spinning.
+/// </summary>
+public sealed class BrokerSenderSoleDemandWaveTests : ScriptedProduceResponseFixture
+{
+    private const string Topic = "sole-demand-topic";
+
+    [Test]
+    public async Task ShouldMicroLinger_SoleDemandSingleBatchWave_SkipsSpin()
+    {
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        try
+        {
+            var (batch, _) = CreateBatch(pool, partition: 0, soleDemand: true);
+
+            await Assert.That(BrokerSender.ShouldMicroLinger([batch], 1, isTransactional: false)).IsFalse();
+            await Assert.That(BrokerSender.ShouldMicroLinger([batch], 1, isTransactional: true)).IsFalse();
+        }
+        finally
+        {
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task ShouldMicroLinger_UnflaggedSingleBatchWave_KeepsSpinning()
+    {
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        try
+        {
+            var (batch, _) = CreateBatch(pool, partition: 0, soleDemand: false);
+
+            await Assert.That(BrokerSender.ShouldMicroLinger([batch], 1, isTransactional: false)).IsTrue();
+            // Pre-existing skip: serial transactional produce is the same shape, proven by
+            // the transaction's single-caller protocol rather than the accumulator gate.
+            await Assert.That(BrokerSender.ShouldMicroLinger([batch], 1, isTransactional: true)).IsFalse();
+        }
+        finally
+        {
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task ShouldMicroLinger_MultiBatchWave_KeepsSpinningEvenWhenFlagged()
+    {
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        try
+        {
+            var (first, _) = CreateBatch(pool, partition: 0, soleDemand: true);
+            var (second, _) = CreateBatch(pool, partition: 1, soleDemand: true);
+
+            await Assert.That(BrokerSender.ShouldMicroLinger([first, second], 2, isTransactional: false)).IsTrue();
+        }
+        finally
+        {
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(60_000)]
+    public async Task SendLoop_SoleDemandBatch_SkipsWaveCoalesceSpin_UnflaggedBatchStillSpins(
+        CancellationToken cancellationToken)
+    {
+        var responses = new Queue<TaskCompletionSource<ProduceResponse>>(
+        [
+            CompletedResponse(partition: 0, baseOffset: 10),
+            CompletedResponse(partition: 0, baseOffset: 11),
+        ]);
+        var (pool, connection) = CreateMockConnection(responses);
+        connection.CaptureProduceRequests = true;
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
+        var options = CreateOptions();
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var spinsStarted = 0;
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            static (_, _, _, _, _) => { },
+            onWaveCoalesceStarted: () => Interlocked.Increment(ref spinsStarted));
+
+        try
+        {
+            // Two known partitions with one coalesced: the only remaining spin gate is the
+            // per-wave predicate under test.
+            SeedKnownPartitions(sender, new TopicPartition(Topic, 0), new TopicPartition(Topic, 1));
+
+            var (soleDemand, soleDemandDelivery) = CreateBatch(vtPool, partition: 0, soleDemand: true);
+            sender.Enqueue(soleDemand);
+            var metadata = await soleDemandDelivery.WaitAsync(cancellationToken);
+
+            await Assert.That(metadata.Offset).IsEqualTo(10);
+            await Assert.That(Volatile.Read(ref spinsStarted)).IsEqualTo(0);
+
+            var (unflagged, unflaggedDelivery) = CreateBatch(vtPool, partition: 0, soleDemand: false);
+            sender.Enqueue(unflagged);
+            metadata = await unflaggedDelivery.WaitAsync(cancellationToken);
+
+            await Assert.That(metadata.Offset).IsEqualTo(11);
+            await Assert.That(Volatile.Read(ref spinsStarted)).IsEqualTo(1);
+            int capturedRequestCount;
+            lock (connection.CapturedProduceRequests)
+            {
+                capturedRequestCount = connection.CapturedProduceRequests.Count;
+            }
+
+            await Assert.That(capturedRequestCount).IsEqualTo(2);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// A skipped wave must not be booked as a fruitless spin: after more skipped waves than
+    /// <see cref="WaveCoalesceGate.FruitlessSpinSuppressThreshold"/>, the next unflagged wave
+    /// still spins. (The gate re-probes on a 50 ms clock, so a regression here is only
+    /// masked if the flagged cycles themselves take longer than that — far above what this
+    /// in-process script needs.)
+    /// </summary>
+    [Test]
+    [Timeout(60_000)]
+    public async Task SendLoop_SkippedSoleDemandWaves_DoNotConsumeWaveCoalesceGateBudget(
+        CancellationToken cancellationToken)
+    {
+        const int flaggedWaves = WaveCoalesceGate.FruitlessSpinSuppressThreshold + 2;
+        var responses = new Queue<TaskCompletionSource<ProduceResponse>>();
+        for (var i = 0; i < flaggedWaves; i++)
+            responses.Enqueue(CompletedResponse(partition: i % 2, baseOffset: i));
+        responses.Enqueue(CompletedResponse(partition: 0, baseOffset: flaggedWaves));
+
+        var (pool, _) = CreateMockConnection(responses);
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
+        var options = CreateOptions();
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var spinsStarted = 0;
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            static (_, _, _, _, _) => { },
+            onWaveCoalesceStarted: () => Interlocked.Increment(ref spinsStarted));
+
+        try
+        {
+            SeedKnownPartitions(sender, new TopicPartition(Topic, 0), new TopicPartition(Topic, 1));
+
+            for (var i = 0; i < flaggedWaves; i++)
+            {
+                var (batch, delivery) = CreateBatch(vtPool, partition: i % 2, soleDemand: true);
+                sender.Enqueue(batch);
+                await delivery.WaitAsync(cancellationToken);
+            }
+
+            await Assert.That(Volatile.Read(ref spinsStarted)).IsEqualTo(0);
+
+            var (unflagged, unflaggedDelivery) = CreateBatch(vtPool, partition: 0, soleDemand: false);
+            sender.Enqueue(unflagged);
+            await unflaggedDelivery.WaitAsync(cancellationToken);
+
+            await Assert.That(Volatile.Read(ref spinsStarted)).IsEqualTo(1);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    private static ProducerOptions CreateOptions() => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        MaxInFlightRequestsPerConnection = 1,
+        ConnectionsPerBroker = 1,
+        EnableIdempotence = true,
+        Acks = Acks.All,
+        LingerMs = 5,
+        RetryBackoffMs = 100,
+        RetryBackoffMaxMs = 1000,
+        DeliveryTimeoutMs = 30_000,
+        RequestTimeoutMs = 30_000,
+    };
+
+    private (IConnectionPool pool, TestKafkaConnection connection) CreateMockConnection(
+        Queue<TaskCompletionSource<ProduceResponse>> responseQueue)
+    {
+        var connection = new TestKafkaConnection();
+        var scripted = RegisterScript(responseQueue);
+        connection.SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(scripted.Dequeue());
+
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+        pool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+        return (pool, connection);
+    }
+
+    private static TaskCompletionSource<ProduceResponse> CompletedResponse(int partition, long baseOffset)
+    {
+        var response = new TaskCompletionSource<ProduceResponse>();
+        response.SetResult(CreateSuccessResponse(Topic, partition, baseOffset));
+        return response;
+    }
+
+    /// <summary>
+    /// One awaited record, mirroring the shape the #2510 bypass seals; <paramref name="soleDemand"/>
+    /// stands in for the accumulator having proven it the producer's only demand.
+    /// </summary>
+    private static (ReadyBatch Batch, Task<RecordMetadata> Delivery) CreateBatch(
+        ValueTaskSourcePool<RecordMetadata> pool,
+        int partition,
+        bool soleDemand)
+    {
+        var batch = new ReadyBatch();
+        var source = pool.Rent();
+        var delivery = source.Task.AsTask();
+        var sources = ArrayPool<PooledValueTaskSource<RecordMetadata>>.Shared.Rent(1);
+        sources[0] = source;
+        batch.Initialize(
+            new TopicPartition(Topic, partition),
+            new RecordBatch { Records = Array.Empty<Record>() },
+            sources,
+            completionSourcesCount: 1,
+            recordCount: 1,
+            dataSize: 100);
+        batch.TrySetMemoryReleased();
+        batch.SealedAsSoleDemand = soleDemand;
+        return (batch, delivery);
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerSingleTailBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerSingleTailBenchmarks.cs
@@ -28,6 +28,11 @@ public class ProducerSingleTailBenchmarks
     private const int MaxSamples = 1 << 20;
     private const int MessageSize = 100;
 
+    // BenchmarkDotNet also invokes the benchmark during its pilot and warmup stages, and those
+    // calls carry JIT, first metadata fetch, and connection setup. The sample array cannot tell
+    // stages apart, so the distribution drops a fixed leading prefix and reports how many.
+    private const int WarmupSamplesDiscarded = OperationsPerInvoke * 5;
+
     private KafkaTestEnvironment _kafka = null!;
     private DekafProducer.IKafkaProducer<string, string> _producer = null!;
     private string _messageValue = null!;
@@ -106,22 +111,23 @@ public class ProducerSingleTailBenchmarks
 
     private void PrintDistribution()
     {
-        var count = _sampleCount;
+        var skipped = Math.Min(_sampleCount, WarmupSamplesDiscarded);
+        var count = _sampleCount - skipped;
         if (count == 0)
         {
-            Console.WriteLine($"[tail] LingerMs={LingerMs} no samples");
+            Console.WriteLine($"[tail] LingerMs={LingerMs} no samples after skipping {skipped}");
             return;
         }
 
         var sorted = new long[count];
-        Array.Copy(_samples, sorted, count);
+        Array.Copy(_samples, skipped, sorted, 0, count);
         Array.Sort(sorted);
         var ticksPerMicrosecond = Stopwatch.Frequency / 1_000_000.0;
         var over500Us = count - LowerBound(sorted, (long)(500 * ticksPerMicrosecond));
         var over1Ms = count - LowerBound(sorted, (long)(1_000 * ticksPerMicrosecond));
 
         Console.WriteLine(
-            $"[tail] LingerMs={LingerMs} n={count} " +
+            $"[tail] LingerMs={LingerMs} n={count} skipped={skipped} " +
             $"p50={Percentile(sorted, 0.50) / ticksPerMicrosecond:F1}us " +
             $"p90={Percentile(sorted, 0.90) / ticksPerMicrosecond:F1}us " +
             $"p99={Percentile(sorted, 0.99) / ticksPerMicrosecond:F1}us " +

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerSingleTailBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerSingleTailBenchmarks.cs
@@ -1,0 +1,148 @@
+using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Benchmarks.Infrastructure;
+using Dekaf.Tooling;
+using DekafProducer = Dekaf.Producer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Client;
+
+/// <summary>
+/// Per-operation latency distribution of serial awaited produce (one message in flight at a
+/// time, keyed so the sender knows more than one partition). BenchmarkDotNet's percentile
+/// columns describe iteration means, which cannot surface a rare per-call stall — the
+/// send loop's wave-coalesce probe, for example, costs a full quiet window on roughly one
+/// call per 50 ms — so every call's latency is recorded into a preallocated array and the
+/// distribution is printed at cleanup (<c>[tail]</c> lines in the run log).
+/// </summary>
+/// <remarks>
+/// Evidence harness, not a published table: the async loop allocates one state machine per
+/// invocation (amortised over <see cref="OperationsPerInvoke"/> calls), so its Allocated
+/// column is not a hot-path gate.
+/// </remarks>
+[MemoryDiagnoser]
+[ThroughputJob]
+public class ProducerSingleTailBenchmarks
+{
+    private const string Topic = "benchmark-producer-single-tail";
+    private const int OperationsPerInvoke = 1_000;
+    private const int MaxSamples = 1 << 20;
+    private const int MessageSize = 100;
+
+    private KafkaTestEnvironment _kafka = null!;
+    private DekafProducer.IKafkaProducer<string, string> _producer = null!;
+    private string _messageValue = null!;
+    private long[] _samples = null!;
+    private int _sampleCount;
+
+    [Params(0, 5)]
+    public int LingerMs { get; set; }
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        _kafka = await KafkaTestEnvironment.CreateAsync().ConfigureAwait(false);
+        await _kafka.CreateTopicAsync(Topic, 3).ConfigureAwait(false);
+
+        _messageValue = new string('x', MessageSize);
+        _samples = new long[MaxSamples];
+        _sampleCount = 0;
+
+        _producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(_kafka.BootstrapServers)
+            .WithClientId($"dekaf-single-tail-linger-{LingerMs}")
+            .WithAcks(DekafProducer.Acks.All)
+            .WithLinger(TimeSpan.FromMilliseconds(LingerMs))
+            .WithBatchSize(16384)
+            .BuildAsync()
+            .ConfigureAwait(false);
+
+        // Same two keys as ProducerSingleBenchmarks: "warmup" and "key" hash to different
+        // partitions, so the sender's known-partition set is wider than each single-batch
+        // wave and the wave-coalesce spin gate is open for every request.
+        for (var i = 0; i < 10; i++)
+        {
+            await _producer.ProduceAsync(Topic, "warmup", "warmup", CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+    }
+
+    [GlobalCleanup]
+    public async Task CleanupAsync()
+    {
+        PrintDistribution();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        try
+        {
+            await _producer.FlushAsync(cts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            // Ignore the bounded cleanup flush timeout.
+        }
+        finally
+        {
+            await _producer.DisposeAsync().ConfigureAwait(false);
+            await _kafka.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public async ValueTask Dekaf_ProduceSingleSerial()
+    {
+        var producer = _producer;
+        var samples = _samples;
+        var count = _sampleCount;
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            var started = Stopwatch.GetTimestamp();
+            await producer.ProduceAsync(Topic, "key", _messageValue, CancellationToken.None)
+                .ConfigureAwait(false);
+            if (count < samples.Length)
+                samples[count++] = Stopwatch.GetTimestamp() - started;
+        }
+
+        _sampleCount = count;
+    }
+
+    private void PrintDistribution()
+    {
+        var count = _sampleCount;
+        if (count == 0)
+        {
+            Console.WriteLine($"[tail] LingerMs={LingerMs} no samples");
+            return;
+        }
+
+        var sorted = new long[count];
+        Array.Copy(_samples, sorted, count);
+        Array.Sort(sorted);
+        var ticksPerMicrosecond = Stopwatch.Frequency / 1_000_000.0;
+        var over500Us = count - LowerBound(sorted, (long)(500 * ticksPerMicrosecond));
+        var over1Ms = count - LowerBound(sorted, (long)(1_000 * ticksPerMicrosecond));
+
+        Console.WriteLine(
+            $"[tail] LingerMs={LingerMs} n={count} " +
+            $"p50={Percentile(sorted, 0.50) / ticksPerMicrosecond:F1}us " +
+            $"p90={Percentile(sorted, 0.90) / ticksPerMicrosecond:F1}us " +
+            $"p99={Percentile(sorted, 0.99) / ticksPerMicrosecond:F1}us " +
+            $"p99.9={Percentile(sorted, 0.999) / ticksPerMicrosecond:F1}us " +
+            $"max={sorted[count - 1] / ticksPerMicrosecond:F1}us " +
+            $"over500us={over500Us} over1ms={over1Ms}");
+    }
+
+    private static long Percentile(long[] sorted, double fraction)
+        => sorted[Math.Min(sorted.Length - 1, (int)Math.Ceiling(fraction * sorted.Length) - 1)];
+
+    private static int LowerBound(long[] sorted, long value)
+    {
+        var index = Array.BinarySearch(sorted, value);
+        if (index >= 0)
+        {
+            while (index > 0 && sorted[index - 1] == value)
+                index--;
+            return index;
+        }
+
+        return ~index;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerSingleTailBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerSingleTailBenchmarks.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
+using System.Diagnostics.Tracing;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
 using Dekaf.Benchmarks.Infrastructure;
 using Dekaf.Tooling;
 using DekafProducer = Dekaf.Producer;
@@ -29,15 +31,17 @@ public class ProducerSingleTailBenchmarks
     private const int MessageSize = 100;
 
     // BenchmarkDotNet also invokes the benchmark during its pilot and warmup stages, and those
-    // calls carry JIT, first metadata fetch, and connection setup. The sample array cannot tell
-    // stages apart, so the distribution drops a fixed leading prefix and reports how many.
-    private const int WarmupSamplesDiscarded = OperationsPerInvoke * 5;
-
+    // calls carry JIT, first metadata fetch, and connection setup. The engine announces each
+    // stage on its EventSource, so the listener flags the measured (Workload/Actual)
+    // iterations and only their calls are recorded; the rest are counted and reported so the
+    // discard can be cross-checked against the job's pilot and warmup invocation counts.
+    private MeasuredStageListener _stageListener = null!;
     private KafkaTestEnvironment _kafka = null!;
     private DekafProducer.IKafkaProducer<string, string> _producer = null!;
     private string _messageValue = null!;
     private long[] _samples = null!;
     private int _sampleCount;
+    private int _unmeasuredSamples;
 
     [Params(0, 5)]
     public int LingerMs { get; set; }
@@ -45,12 +49,14 @@ public class ProducerSingleTailBenchmarks
     [GlobalSetup]
     public async Task SetupAsync()
     {
+        _stageListener = new MeasuredStageListener();
         _kafka = await KafkaTestEnvironment.CreateAsync().ConfigureAwait(false);
         await _kafka.CreateTopicAsync(Topic, 3).ConfigureAwait(false);
 
         _messageValue = new string('x', MessageSize);
         _samples = new long[MaxSamples];
         _sampleCount = 0;
+        _unmeasuredSamples = 0;
 
         _producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(_kafka.BootstrapServers)
@@ -75,6 +81,7 @@ public class ProducerSingleTailBenchmarks
     public async Task CleanupAsync()
     {
         PrintDistribution();
+        _stageListener.Dispose();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         try
         {
@@ -95,6 +102,18 @@ public class ProducerSingleTailBenchmarks
     public async ValueTask Dekaf_ProduceSingleSerial()
     {
         var producer = _producer;
+        if (!_stageListener.IsMeasuring)
+        {
+            for (var i = 0; i < OperationsPerInvoke; i++)
+            {
+                await producer.ProduceAsync(Topic, "key", _messageValue, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+
+            _unmeasuredSamples += OperationsPerInvoke;
+            return;
+        }
+
         var samples = _samples;
         var count = _sampleCount;
         for (var i = 0; i < OperationsPerInvoke; i++)
@@ -111,23 +130,23 @@ public class ProducerSingleTailBenchmarks
 
     private void PrintDistribution()
     {
-        var skipped = Math.Min(_sampleCount, WarmupSamplesDiscarded);
-        var count = _sampleCount - skipped;
+        var count = _sampleCount;
         if (count == 0)
         {
-            Console.WriteLine($"[tail] LingerMs={LingerMs} no samples after skipping {skipped}");
+            Console.WriteLine(
+                $"[tail] LingerMs={LingerMs} no measured samples (unmeasured={_unmeasuredSamples})");
             return;
         }
 
         var sorted = new long[count];
-        Array.Copy(_samples, skipped, sorted, 0, count);
+        Array.Copy(_samples, 0, sorted, 0, count);
         Array.Sort(sorted);
         var ticksPerMicrosecond = Stopwatch.Frequency / 1_000_000.0;
         var over500Us = count - LowerBound(sorted, (long)(500 * ticksPerMicrosecond));
         var over1Ms = count - LowerBound(sorted, (long)(1_000 * ticksPerMicrosecond));
 
         Console.WriteLine(
-            $"[tail] LingerMs={LingerMs} n={count} skipped={skipped} " +
+            $"[tail] LingerMs={LingerMs} n={count} unmeasured={_unmeasuredSamples} " +
             $"p50={Percentile(sorted, 0.50) / ticksPerMicrosecond:F1}us " +
             $"p90={Percentile(sorted, 0.90) / ticksPerMicrosecond:F1}us " +
             $"p99={Percentile(sorted, 0.99) / ticksPerMicrosecond:F1}us " +
@@ -150,5 +169,33 @@ public class ProducerSingleTailBenchmarks
         }
 
         return ~index;
+    }
+
+    /// <summary>
+    /// Tracks whether the engine is inside a measured workload iteration by listening to
+    /// BenchmarkDotNet's <see cref="EngineEventSource"/>: <c>WorkloadActualStart</c> and
+    /// <c>WorkloadActualStop</c> bracket exactly the iterations that feed the reported
+    /// statistics, so jitting, pilot, warmup and overhead invocations are excluded whatever
+    /// counts the selected job uses.
+    /// </summary>
+    private sealed class MeasuredStageListener : EventListener
+    {
+        private volatile bool _measuring;
+
+        public bool IsMeasuring => _measuring;
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name == EngineEventSource.SourceName)
+                EnableEvents(eventSource, EventLevel.Informational);
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.EventId == EngineEventSource.WorkloadActualStartEventId)
+                _measuring = true;
+            else if (eventData.EventId == EngineEventSource.WorkloadActualStopEventId)
+                _measuring = false;
+        }
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/WaveCoalesceProbeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/WaveCoalesceProbeBenchmarks.cs
@@ -101,7 +101,7 @@ public class WaveCoalesceSoleDemandBenchmarks
         batch.Initialize(
             new TopicPartition("wave-coalesce", partition),
             new RecordBatch { Records = Array.Empty<Record>() },
-            new PooledValueTaskSource<RecordMetadata>[1],
+            [new PooledValueTaskSource<RecordMetadata>()],
             completionSourcesCount: 1,
             recordCount: 1,
             dataSize: 100);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/WaveCoalesceProbeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/WaveCoalesceProbeBenchmarks.cs
@@ -95,6 +95,18 @@ public class WaveCoalesceSoleDemandBenchmarks
     public bool SoleDemandWave()
         => BrokerSender.ShouldMicroLinger(_soleDemandWave, 1, isTransactional: false);
 
+    [Benchmark]
+    public bool ZeroLingerMultiBatchWave()
+        => BrokerSender.ShouldMicroLingerAtZeroLinger(_multiBatchWave, 2, isTransactional: false);
+
+    [Benchmark]
+    public bool ZeroLingerUnflaggedSingleBatchWave()
+        => BrokerSender.ShouldMicroLingerAtZeroLinger(_unflaggedWave, 1, isTransactional: false);
+
+    [Benchmark]
+    public bool ZeroLingerTransactionalSerialWave()
+        => BrokerSender.ShouldMicroLingerAtZeroLinger(_unflaggedWave, 1, isTransactional: true);
+
     private static ReadyBatch CreateSingleAwaitedRecordBatch(int partition)
     {
         var batch = new ReadyBatch();

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/WaveCoalesceProbeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/WaveCoalesceProbeBenchmarks.cs
@@ -3,6 +3,7 @@ using System.Threading.Channels;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
 using Dekaf.Producer;
+using Dekaf.Protocol.Records;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
@@ -51,4 +52,59 @@ public class WaveCoalesceTailBenchmarks
         _configuredQuietTicks,
         _maximumArrivalGapTicks,
         _additionalBatchCount);
+}
+
+/// <summary>
+/// Per-wave cost of the single-batch spin decision (<see cref="BrokerSender.ShouldMicroLinger"/>).
+/// The loaded shapes (multi-batch wave, unflagged single-batch wave) must not move; the two
+/// skip shapes show what proving the spin unnecessary costs. The spin these decisions avoid
+/// is a full quiet window (75 µs at zero linger, 1 ms at the default) and is measured
+/// end-to-end by the Docker-based ProducerSingleBenchmarks.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class WaveCoalesceSoleDemandBenchmarks
+{
+    private readonly ReadyBatch[] _multiBatchWave = new ReadyBatch[2];
+    private readonly ReadyBatch[] _unflaggedWave = new ReadyBatch[1];
+    private readonly ReadyBatch[] _soleDemandWave = new ReadyBatch[1];
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _multiBatchWave[0] = CreateSingleAwaitedRecordBatch(partition: 0);
+        _multiBatchWave[1] = CreateSingleAwaitedRecordBatch(partition: 1);
+        _unflaggedWave[0] = CreateSingleAwaitedRecordBatch(partition: 0);
+        _soleDemandWave[0] = CreateSingleAwaitedRecordBatch(partition: 0);
+        _soleDemandWave[0].SealedAsSoleDemand = true;
+    }
+
+    [Benchmark(Baseline = true)]
+    public bool MultiBatchWave()
+        => BrokerSender.ShouldMicroLinger(_multiBatchWave, 2, isTransactional: false);
+
+    [Benchmark]
+    public bool UnflaggedSingleBatchWave()
+        => BrokerSender.ShouldMicroLinger(_unflaggedWave, 1, isTransactional: false);
+
+    [Benchmark]
+    public bool TransactionalSerialWave()
+        => BrokerSender.ShouldMicroLinger(_unflaggedWave, 1, isTransactional: true);
+
+    [Benchmark]
+    public bool SoleDemandWave()
+        => BrokerSender.ShouldMicroLinger(_soleDemandWave, 1, isTransactional: false);
+
+    private static ReadyBatch CreateSingleAwaitedRecordBatch(int partition)
+    {
+        var batch = new ReadyBatch();
+        batch.Initialize(
+            new TopicPartition("wave-coalesce", partition),
+            new RecordBatch { Records = Array.Empty<Record>() },
+            new PooledValueTaskSource<RecordMetadata>[1],
+            completionSourcesCount: 1,
+            recordCount: 1,
+            dataSize: 100);
+        return batch;
+    }
 }


### PR DESCRIPTION
Serial awaited production can pay a wave-coalesce spin while its only caller is waiting for the batch already in hand. This PR records the accumulator's sole-demand proof and skips that spin for positive linger while the original waiter remains pending.

At **0 ms linger**, the sender keeps the legacy coalescing predicate. At **positive linger**, a flagged single-batch wave skips coalescing only while its original sole waiter remains pending. Cancellation-version checks prevent pooled completion-source reuse from reviving stale proof. Retries, carry-over, redelivery and pooled reset clear the hint. Unflagged and multi-batch waves retain existing decisions; skipped waves do not consume the gate's probe budget. No public API change.

Current head is **`9778462c0d380e331684eb0ae9cd4d8f392c089c`**, restored after the subsequent waiter experiments failed performance gates. Ordinary channel waits and the response-wait wrapper retain their pre-experiment implementations. The experimental reusable-wait changes are not part of this PR.

Validation and performance evidence:

- The restored head previously passed Release builds, focused sender/accumulator tests, 32 Kafka producer integration tests and all CI checks. Predicate benchmarks reported 0 B/op; these isolated checks do not imply zero whole-producer allocation.
- [Five-minute main/PR/main comparison](https://github.com/thomhurst/Dekaf/pull/2990#issuecomment-5546813055): at 5 ms, throughput improved 3.80–4.57% and p99 fell 19.35%; zero-linger results remained inconclusive/adverse under control drift. Full metrics and limitations are in the linked comment.
- Subsequent waiter experiments demonstrated large allocation savings but failed protected performance metrics. Their [complete results and rollback decision](https://github.com/thomhurst/Dekaf/pull/2990#issuecomment-5547975588) are recorded. They do not establish acceptance of the restored PR.

**Final recommendation: close this proposal.** Positive-linger screening gains do not justify the added lifecycle complexity with unresolved zero-linger allocation/stability and failed waiter follow-ups. [Complete merge-or-close decision](https://github.com/thomhurst/Dekaf/pull/2990#issuecomment-5548282741). Correctness risks center on stale sole-demand proof and pooled completion-source reuse, covered by pending/version checks and focused tests.


