### PR TITLE
perf(networking): size response buffer pools from connection topology

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1690,7 +1690,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private TimeSpan? _metadataMaxAge;
     private IsolationLevel _isolationLevel = IsolationLevel.ReadUncommitted;
     private IRetryPolicy? _retryPolicy;
-    private int _prefetchPipelineDepth = 3;
+    private int _prefetchPipelineDepth = ConsumerOptions.DefaultPrefetchPipelineDepth;
     private int _connectionsPerBroker = 2;
     private bool _enableAdaptiveConnections = true;
     private int _maxConnectionsPerBroker = ConsumerOptions.DefaultMaxConnectionsPerBroker;
@@ -2622,14 +2622,14 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// which would saturate broker connections and increase memory usage from buffered
     /// responses without proportional throughput gain.
     /// </summary>
-    /// <param name="depth">The pipeline depth (1-8). Default is 2.</param>
+    /// <param name="depth">The pipeline depth (1-8). Default is 3.</param>
     /// <returns>The builder instance for method chaining.</returns>
     public ConsumerBuilder<TKey, TValue> WithPrefetchPipelineDepth(int depth)
     {
         // Capped at 8: beyond this, additional in-flight fetches saturate broker
         // connections and buffer memory without meaningful throughput improvement.
-        if (depth is < 1 or > 8)
-            throw new ArgumentOutOfRangeException(nameof(depth), "Prefetch pipeline depth must be between 1 and 8");
+        if (depth is < 1 or > ConsumerOptions.MaxPrefetchPipelineDepth)
+            throw new ArgumentOutOfRangeException(nameof(depth), $"Prefetch pipeline depth must be between 1 and {ConsumerOptions.MaxPrefetchPipelineDepth}");
         _prefetchPipelineDepth = depth;
         return this;
     }

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -44,6 +44,8 @@ public sealed class ConsumerOptions
     private bool _isReconnectBackoffMaxMsConfigured;
     private TimeSpan? _connectionTimeoutMax;
     internal const int DefaultMaxConnectionsPerBroker = 4;
+    internal const int DefaultPrefetchPipelineDepth = 3;
+    internal const int MaxPrefetchPipelineDepth = 8;
 
     /// <summary>
     /// Bootstrap servers (host:port,host:port).
@@ -526,7 +528,7 @@ public sealed class ConsumerOptions
     /// Higher values (up to 8) allow more overlapping fetches, which can improve
     /// throughput for single-broker setups by hiding network latency. Default is 3.
     /// </summary>
-    public int PrefetchPipelineDepth { get; init; } = 3;
+    public int PrefetchPipelineDepth { get; init; } = DefaultPrefetchPipelineDepth;
 
     /// <summary>
     /// Number of TCP connections to maintain per broker.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1288,6 +1288,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly Diagnostics.ConsumerFetchBufferStateSource _fetchBufferMetricSource;
     private readonly IDekafMemoryBudget _memoryBudget;
     private readonly bool _ownsInfrastructure;
+    private readonly IDisposable? _brokerCountDiscoveredRegistration;
     private readonly ConsumerCoordinator? _coordinator;
     private readonly Func<bool> _tryRecordPollFast;
     private readonly CompressionCodecRegistry _compressionCodecs;
@@ -1873,6 +1874,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         _metadataManager = infrastructure.Metadata;
         _ownsInfrastructure = ownsInfrastructure;
         _memoryBudget = memoryBudget;
+
+        // The response pool was sized from the bootstrap seed count; grow it to the prefetch
+        // working set of the broker count metadata actually reports. Ratchets only grow.
+        if (infrastructure.Pool is ConnectionPool ratchetableConnectionPool)
+        {
+            var prefetchPipelineDepth = options.PrefetchPipelineDepth;
+            var maxConnectionsPerBroker = options.MaxConnectionsPerBroker;
+            _brokerCountDiscoveredRegistration = _metadataManager.AddBrokerCountDiscoveredCallback(brokerCount =>
+            {
+                var depth = PoolSizing.ForConsumerResponseBuffers(brokerCount, prefetchPipelineDepth, maxConnectionsPerBroker);
+                ratchetableConnectionPool.RatchetResponseBufferRetention(depth, depth);
+            });
+        }
         _telemetryMetricCollector = infrastructure.TelemetryMetricCollector;
         _telemetryMetricCollector.RegisterMetricsForSubscription(options.ApplicationMetrics);
         _loggerFactory = loggerFactory;
@@ -13131,6 +13145,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             await _coordinator.DisposeAsync().ConfigureAwait(false);
 
         await _telemetryManager.DisposeAsync().ConfigureAwait(false);
+        _brokerCountDiscoveredRegistration?.Dispose();
         if (_ownsInfrastructure)
         {
             await _metadataManager.DisposeAsync().ConfigureAwait(false);

--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -26,7 +26,7 @@ internal static class PoolSizing
     private const int MinConsumerPrefetchBufferCapacity = 16;
     private const int MaxConsumerPrefetchBufferCapacity = 1024;
     private const int MinResponseBuffers = 16;
-    private const int MaxResponseBuffers = 256;
+    internal const int MaxResponseBuffers = 256;
     private const int MinConsumerParsedRecordSlabsPerBucket = 16;
     private const int MaxConsumerParsedRecordSlabsPerBucket = 64;
 

--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -1,3 +1,5 @@
+using Dekaf.Consumer;
+
 namespace Dekaf.Internal;
 
 /// <summary>
@@ -23,8 +25,8 @@ internal static class PoolSizing
     private const int MaxValueTaskSources = 65536;
     private const int MinConsumerPrefetchBufferCapacity = 16;
     private const int MaxConsumerPrefetchBufferCapacity = 1024;
-    private const int MinConsumerResponseBuffers = 16;
-    private const int MaxConsumerResponseBuffers = 256;
+    private const int MinResponseBuffers = 16;
+    private const int MaxResponseBuffers = 256;
     private const int MinConsumerParsedRecordSlabsPerBucket = 16;
     private const int MaxConsumerParsedRecordSlabsPerBucket = 64;
 
@@ -188,9 +190,22 @@ internal static class PoolSizing
 
         return ClampPoolDepth(
             liveResponseBuffers,
-            MinConsumerResponseBuffers,
-            MaxConsumerResponseBuffers);
+            MinResponseBuffers,
+            MaxResponseBuffers);
     }
+
+    /// <summary>
+    /// Response-buffer depth for the consumer-role pool of a shared <c>KafkaClient</c>. The
+    /// pool exists before any consumer does and cannot be resized, so it is sized for the
+    /// deepest prefetch pipeline a consumer built from the client can configure. A cap above
+    /// the live working set costs nothing: dormant buffers never exceed the peak live count,
+    /// so a default-depth consumer retains exactly what its standalone pool would.
+    /// </summary>
+    internal static int ForSharedClientConsumerResponseBuffers(int brokerCount, int maxConnectionsPerBroker)
+        => ForConsumerResponseBuffers(
+            brokerCount,
+            ConsumerOptions.MaxPrefetchPipelineDepth,
+            maxConnectionsPerBroker);
 
     private static long CeilingDivide(long value, long divisor) =>
         (value + divisor - 1L) / divisor;
@@ -236,6 +251,13 @@ internal static class PoolSizing
         /// hold enough responses to avoid allocation under concurrent load.
         /// </summary>
         public required int ProduceResponsePoolSize { get; init; }
+
+        /// <summary>
+        /// Depth for the shared <see cref="Networking.ResponseBufferPool"/> that receives
+        /// producer, admin, and coordination responses (managed arrays per size bucket and
+        /// native buffers in total): peak in-flight requests across peak connections, x2.
+        /// </summary>
+        public required int ResponseBuffersPerBucket { get; init; }
     }
 
     /// <summary>
@@ -307,6 +329,16 @@ internal static class PoolSizing
             floor: 64,
             ceiling: ProduceResponsePoolSizeCeiling);
 
+        // ResponseBufferPool: one live response frame per in-flight request per peak
+        // connection, with 2x headroom because a completed request's in-flight slot is
+        // reused before its response frame is parsed and disposed. Peak (not configured)
+        // connections matter because adaptive scaling multiplies concurrent receive loops
+        // that all rent from this one shared pool.
+        var responseBuffers = ClampPoolDepth(
+            SaturatingMultiply(peakInFlightBatches, 2L),
+            MinResponseBuffers,
+            MaxResponseBuffers);
+
         return new SharedPoolSizes
         {
             ProducerDataArraysPerBucket = producerDataArrays,
@@ -314,6 +346,7 @@ internal static class PoolSizing
             PipeMemoryArraysPerBucket = pipeMemoryArrays,
             SerializationArraysPerBucket = serializationArrays,
             ProduceResponsePoolSize = responsePoolSize,
+            ResponseBuffersPerBucket = responseBuffers,
         };
     }
 

--- a/src/Dekaf/Internal/RatchetableArrayPool.cs
+++ b/src/Dekaf/Internal/RatchetableArrayPool.cs
@@ -6,7 +6,8 @@ namespace Dekaf.Internal;
 /// An <see cref="ArrayPool{T}"/> wrapper that supports monotonically-increasing bucket depth.
 /// When <see cref="RatchetBucketCapacity"/> is called with a value greater than the current depth,
 /// a new <c>ConfigurableArrayPool</c> is created and atomically swapped in. The old pool instance
-/// becomes GC-eligible once outstanding rentals are returned.
+/// becomes GC-eligible once callers release their references to it. Outstanding arrays
+/// can be returned to the replacement pool; arrays do not retain their originating pool.
 /// </summary>
 internal sealed class RatchetableArrayPool<T>
 {

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -714,6 +714,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
 {
     private const int SharedResponseBufferFetchMaxBytes = 200 * 1024 * 1024;
 
+    private readonly IDisposable _brokerCountDiscoveredRegistration;
     private int _disposed;
 
     private KafkaClientInfrastructure(
@@ -721,6 +722,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         ConnectionPool connectionPool,
         ConnectionPool consumerConnectionPool,
         MetadataManager metadataManager,
+        IDisposable brokerCountDiscoveredRegistration,
         IDekafMemoryBudget memoryBudget,
         ILoggerFactory? loggerFactory,
         int connectionsPerBroker,
@@ -736,6 +738,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         ConnectionPool = connectionPool;
         ConsumerConnectionPool = consumerConnectionPool;
         MetadataManager = metadataManager;
+        _brokerCountDiscoveredRegistration = brokerCountDiscoveredRegistration;
         MemoryBudget = memoryBudget;
         LoggerFactory = loggerFactory;
         ConnectionsPerBroker = connectionsPerBroker;
@@ -777,19 +780,25 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             maxConnectionsPerBroker: options.MaxConnectionsPerBroker);
 
         var connectionOptions = CreateConnectionOptions(options);
+        var producerResponseBufferPool = ResponseBufferPool.Create(
+            SharedResponseBufferFetchMaxBytes,
+            poolSizes.ResponseBuffersPerBucket);
+        var consumerResponseBufferPool = ResponseBufferPool.Create(
+            SharedResponseBufferFetchMaxBytes,
+            consumerResponseBuffers);
         var connectionPool = new ConnectionPool(
             options.ClientId,
             connectionOptions,
             options.LoggerFactory,
             options.ConnectionsPerBroker,
-            ResponseBufferPool.Create(SharedResponseBufferFetchMaxBytes, poolSizes.ResponseBuffersPerBucket),
+            producerResponseBufferPool,
             pipeMemoryBucketCapacity: poolSizes.PipeMemoryArraysPerBucket);
         var consumerConnectionPool = new ConnectionPool(
             options.ClientId,
             connectionOptions,
             options.LoggerFactory,
             options.ConnectionsPerBroker,
-            ResponseBufferPool.Create(SharedResponseBufferFetchMaxBytes, consumerResponseBuffers),
+            consumerResponseBufferPool,
             pipeMemoryBucketCapacity: poolSizes.PipeMemoryArraysPerBucket,
             responseMemoryAdmissionsEnabled: true);
 
@@ -812,11 +821,31 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             logger: options.LoggerFactory?.CreateLogger<MetadataManager>());
         metadataManager.SetAdditionalBrokerRegistrationTarget(consumerConnectionPool);
 
+        // Both response pools were sized from the seed count; grow them to the working set of
+        // the topology metadata actually reports. Every client built from this
+        // infrastructure shares these pools, so the ratchet lives with the metadata manager.
+        var connectionsPerBroker = options.ConnectionsPerBroker;
+        var maxInFlight = options.MaxInFlightRequestsPerConnection;
+        var maxConnectionsPerBroker = options.MaxConnectionsPerBroker;
+        var brokerCountDiscoveredRegistration = metadataManager.AddBrokerCountDiscoveredCallback(brokerCount =>
+        {
+            var producerDepth = PoolSizing.ForSharedPools(
+                brokerCount,
+                connectionsPerBroker,
+                maxInFlight,
+                batchSize: 1048576,
+                maxConnectionsPerBroker).ResponseBuffersPerBucket;
+            producerResponseBufferPool.RatchetRetention(producerDepth, producerDepth);
+            var consumerDepth = PoolSizing.ForSharedClientConsumerResponseBuffers(brokerCount, maxConnectionsPerBroker);
+            consumerResponseBufferPool.RatchetRetention(consumerDepth, consumerDepth);
+        });
+
         return new KafkaClientInfrastructure(
             options.BootstrapServers,
             connectionPool,
             consumerConnectionPool,
             metadataManager,
+            brokerCountDiscoveredRegistration,
             new ClientMemoryBudget(options.MemoryBudgetBytes),
             options.LoggerFactory,
             options.ConnectionsPerBroker,
@@ -864,6 +893,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
+        _brokerCountDiscoveredRegistration.Dispose();
         await MetadataManager.DisposeAsync().ConfigureAwait(false);
         await ConsumerConnectionPool.DisposeAsync().ConfigureAwait(false);
         await ConnectionPool.DisposeAsync().ConfigureAwait(false);

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -772,20 +772,24 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             batchSize: 1048576,
             maxConnectionsPerBroker: options.MaxConnectionsPerBroker);
 
+        var consumerResponseBuffers = PoolSizing.ForSharedClientConsumerResponseBuffers(
+            brokerCount: options.BootstrapServers.Count,
+            maxConnectionsPerBroker: options.MaxConnectionsPerBroker);
+
         var connectionOptions = CreateConnectionOptions(options);
         var connectionPool = new ConnectionPool(
             options.ClientId,
             connectionOptions,
             options.LoggerFactory,
             options.ConnectionsPerBroker,
-            ResponseBufferPool.Create(SharedResponseBufferFetchMaxBytes),
+            ResponseBufferPool.Create(SharedResponseBufferFetchMaxBytes, poolSizes.ResponseBuffersPerBucket),
             pipeMemoryBucketCapacity: poolSizes.PipeMemoryArraysPerBucket);
         var consumerConnectionPool = new ConnectionPool(
             options.ClientId,
             connectionOptions,
             options.LoggerFactory,
             options.ConnectionsPerBroker,
-            ResponseBufferPool.Create(SharedResponseBufferFetchMaxBytes),
+            ResponseBufferPool.Create(SharedResponseBufferFetchMaxBytes, consumerResponseBuffers),
             pipeMemoryBucketCapacity: poolSizes.PipeMemoryArraysPerBucket,
             responseMemoryAdmissionsEnabled: true);
 

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -332,6 +332,10 @@ public sealed partial class ConnectionPool :
         }
     }
 
+    /// <inheritdoc cref="ResponseBufferPool.RatchetRetention"/>
+    internal void RatchetResponseBufferRetention(int managedArraysPerBucket, int maxRetainedNativeBuffers) =>
+        _responseBufferPool.RatchetRetention(managedArraysPerBucket, maxRetainedNativeBuffers);
+
     /// <summary>
     /// Increases the shared PipeMemoryPool bucket capacity if <paramref name="bucketCapacity"/>
     /// exceeds the current value. New connections will use the larger pool; existing connections

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -4885,32 +4885,37 @@ internal sealed class ResponseBufferPool
     /// with interlocked exchanges (<see cref="IntPtr.Zero"/> marks an empty slot), so
     /// retaining a frame allocates nothing; a <c>ConcurrentStack</c> pushed a 32 B node per
     /// retained frame. The slot count is the pool's global allowance, which the caller
-    /// enforces before returning, and the occupancy hint lets rent skip an empty bucket
-    /// without scanning.
+    /// enforces before returning. Returns fill upward from a top hint and rents take the
+    /// slot just below it, so the bucket behaves as a stack (the most recently returned,
+    /// cache-warm frame is rented first) and both scans are one step long in steady state.
+    /// The hint is written plainly: a stale value only lengthens a scan, which wraps over
+    /// the whole array before giving up.
     /// </summary>
     private sealed class NativeBufferBucket(int capacity, int slotCount)
     {
         private readonly IntPtr[] _slots = new IntPtr[slotCount];
-        private int _occupied;
+        private int _top;
 
         internal int Capacity => capacity;
 
         internal bool TryRent(out IntPtr pointer)
         {
-            if (Volatile.Read(ref _occupied) > 0)
+            var slots = _slots;
+            var start = Math.Min(Volatile.Read(ref _top), slots.Length) - 1;
+            for (var n = 0; n < slots.Length; n++)
             {
-                var slots = _slots;
-                for (var i = 0; i < slots.Length; i++)
-                {
-                    if (Volatile.Read(ref slots[i]) == IntPtr.Zero)
-                        continue;
+                var i = start - n;
+                if (i < 0)
+                    i += slots.Length;
 
-                    pointer = Interlocked.Exchange(ref slots[i], IntPtr.Zero);
-                    if (pointer != IntPtr.Zero)
-                    {
-                        Interlocked.Decrement(ref _occupied);
-                        return true;
-                    }
+                if (Volatile.Read(ref slots[i]) == IntPtr.Zero)
+                    continue;
+
+                pointer = Interlocked.Exchange(ref slots[i], IntPtr.Zero);
+                if (pointer != IntPtr.Zero)
+                {
+                    Volatile.Write(ref _top, i);
+                    return true;
                 }
             }
 
@@ -4921,14 +4926,19 @@ internal sealed class ResponseBufferPool
         internal bool TryReturn(IntPtr pointer)
         {
             var slots = _slots;
-            for (var i = 0; i < slots.Length; i++)
+            var start = Math.Min(Volatile.Read(ref _top), slots.Length - 1);
+            for (var n = 0; n < slots.Length; n++)
             {
+                var i = start + n;
+                if (i >= slots.Length)
+                    i -= slots.Length;
+
                 if (Volatile.Read(ref slots[i]) != IntPtr.Zero)
                     continue;
 
                 if (Interlocked.CompareExchange(ref slots[i], pointer, IntPtr.Zero) == IntPtr.Zero)
                 {
-                    Interlocked.Increment(ref _occupied);
+                    Volatile.Write(ref _top, i + 1);
                     return true;
                 }
             }

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -4634,7 +4634,8 @@ internal sealed class ResponseBufferPool
     /// </summary>
     private readonly NativeBufferBucket[] _nativeBuckets = new NativeBufferBucket[NativeBucketSlotCount];
     // Availability hint updated on empty/nonempty transitions. An overflow return probes
-    // one indicated alternative, never scans capacity slots. Concurrent renters may win it.
+    // an indicated alternative, never scans capacity slots. Retry only when a concurrent
+    // renter wins that buffer, as with the bucket's own lock-free stack operations.
     private int _nativeBucketsWithBuffers;
     private readonly RatchetableArrayPool<byte> _managedArrays;
     /// <summary>
@@ -4822,27 +4823,29 @@ internal sealed class ResponseBufferPool
     /// </summary>
     private bool TryEvictDormantBuffer(int capacity)
     {
-        var alternatives = (uint)Volatile.Read(ref _nativeBucketsWithBuffers)
-            & ~(1u << NativeBucketIndex(capacity));
-        if (alternatives == 0)
-            return false;
-
-        var index = BitOperations.Log2(alternatives);
-        var bucket = _nativeBuckets[index];
-        if (!bucket.TryRent(out var pointer))
+        var excludedCapacity = 1u << NativeBucketIndex(capacity);
+        while (true)
         {
-            // A renter consumed this bucket since its last return. Repair just this hint;
-            // under contention the incoming buffer may be freed even if another tier is
-            // available. Retention is opportunistic and the global allowance stays exact.
-            ClearEmptyNativeBucket(index);
-            return false;
-        }
+            var alternatives = (uint)Volatile.Read(ref _nativeBucketsWithBuffers) & ~excludedCapacity;
+            if (alternatives == 0)
+                return false;
 
-        Marshal.FreeHGlobal(pointer);
-        Interlocked.Decrement(ref _retainedNativeBufferCount);
-        if (!bucket.HasRetainedBuffers)
-            ClearEmptyNativeBucket(index);
-        return true;
+            var index = BitOperations.Log2(alternatives);
+            var bucket = _nativeBuckets[index];
+            if (!bucket.TryRent(out var pointer))
+            {
+                // A concurrent renter won the indicated capacity. Repair its bit and
+                // retry from the current mask so another available tier is not discarded.
+                ClearEmptyNativeBucket(index);
+                continue;
+            }
+
+            Marshal.FreeHGlobal(pointer);
+            Interlocked.Decrement(ref _retainedNativeBufferCount);
+            if (!bucket.HasRetainedBuffers)
+                ClearEmptyNativeBucket(index);
+            return true;
+        }
     }
 
     private void MarkNativeBucketAvailable(int index)

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
@@ -4610,6 +4611,9 @@ internal sealed class ResponseBufferPool
     /// no longer rounds, so every distinct frame size would need its own bucket.
     /// </summary>
     private const int MaxPooledNativeCapacity = 1 << 30;
+
+    /// <summary>One slot per power of two from 1 to <see cref="MaxPooledNativeCapacity"/>.</summary>
+    private const int NativeBucketSlotCount = 31;
 #if !NETSTANDARD2_0
     private const long NativeMemoryPressureRefreshMilliseconds = 1_000;
 #endif
@@ -4622,9 +4626,14 @@ internal sealed class ResponseBufferPool
         (int MaxArrayLength, int ManagedArraysPerBucket, int MaxRetainedNativeBuffers),
         ResponseBufferPool>
         s_sharedPools = new();
-    // Copy-on-write: buckets are only ever added (one per power-of-two capacity seen), so
-    // rent, return, eviction, and trim can walk the array without enumerator allocations.
-    private NativeBufferBucket[] _nativeBuckets = [];
+    /// <summary>
+    /// Bucket slots for every retainable power-of-two capacity, indexed by
+    /// <see cref="NativeBucketIndex"/> (log2 of the capacity), so rent and return resolve
+    /// their bucket in O(1) regardless of how many capacities adaptive fetch sizing has
+    /// visited. Slots are filled lazily and never cleared; eviction and trim walk the
+    /// fixed array without enumerator allocations.
+    /// </summary>
+    private readonly NativeBufferBucket?[] _nativeBuckets = new NativeBufferBucket?[NativeBucketSlotCount];
     private int _retainedNativeBufferCount;
     private int _highNativeMemoryPressure;
 #if !NETSTANDARD2_0
@@ -4718,10 +4727,9 @@ internal sealed class ResponseBufferPool
     internal NativeResponseBuffer RentNative(int minimumLength)
     {
         var capacity = RoundUpToPowerOfTwo(minimumLength);
-        var bucket = capacity <= MaxPooledNativeCapacity
-            ? FindNativeBucket(Volatile.Read(ref _nativeBuckets), capacity)
-            : null;
-        if (bucket is not null && bucket.TryRent(out var pointer))
+        if (capacity <= MaxPooledNativeCapacity
+            && Volatile.Read(ref _nativeBuckets[NativeBucketIndex(capacity)]) is { } bucket
+            && bucket.TryRent(out var pointer))
         {
             Interlocked.Decrement(ref _retainedNativeBufferCount);
             return NativeResponseBuffer.Rent(this, pointer, capacity);
@@ -4750,7 +4758,15 @@ internal sealed class ResponseBufferPool
             return;
         }
 
-        GetOrAddNativeBucket(capacity).Return(pointer);
+        if (!GetOrAddNativeBucket(capacity).TryReturn(pointer))
+        {
+            // Every slot of this capacity is occupied. The global count admits at most one
+            // buffer per slot, so this is only reachable while a concurrent trim has popped a
+            // slot but not yet given back its allowance; freeing keeps the bound exact.
+            Interlocked.Decrement(ref _retainedNativeBufferCount);
+            Marshal.FreeHGlobal(pointer);
+            return;
+        }
 
         // Pressure can begin after the first check but before this buffer is published.
         if (Volatile.Read(ref _highNativeMemoryPressure) != 0)
@@ -4767,9 +4783,11 @@ internal sealed class ResponseBufferPool
     /// </summary>
     private bool TryEvictDormantBuffer(int capacity)
     {
-        foreach (var bucket in Volatile.Read(ref _nativeBuckets))
+        var buckets = _nativeBuckets;
+        for (var i = 0; i < buckets.Length; i++)
         {
-            if (bucket.Capacity == capacity || !bucket.TryRent(out var pointer))
+            var bucket = Volatile.Read(ref buckets[i]);
+            if (bucket is null || bucket.Capacity == capacity || !bucket.TryRent(out var pointer))
                 continue;
 
             Marshal.FreeHGlobal(pointer);
@@ -4782,38 +4800,28 @@ internal sealed class ResponseBufferPool
 
     private NativeBufferBucket GetOrAddNativeBucket(int capacity)
     {
-        while (true)
-        {
-            var buckets = Volatile.Read(ref _nativeBuckets);
-            var existing = FindNativeBucket(buckets, capacity);
-            if (existing is not null)
-                return existing;
+        ref var slot = ref _nativeBuckets[NativeBucketIndex(capacity)];
+        var existing = Volatile.Read(ref slot);
+        if (existing is not null)
+            return existing;
 
-            var added = new NativeBufferBucket[buckets.Length + 1];
-            buckets.AsSpan().CopyTo(added);
-            var bucket = new NativeBufferBucket(capacity);
-            added[buckets.Length] = bucket;
-            if (Interlocked.CompareExchange(ref _nativeBuckets, added, buckets) == buckets)
-                return bucket;
-        }
+        var created = new NativeBufferBucket(capacity, MaxRetainedNativeBuffers);
+        return Interlocked.CompareExchange(ref slot, created, null) ?? created;
     }
 
-    private static NativeBufferBucket? FindNativeBucket(NativeBufferBucket[] buckets, int capacity)
-    {
-        foreach (var bucket in buckets)
-        {
-            if (bucket.Capacity == capacity)
-                return bucket;
-        }
-
-        return null;
-    }
+    /// <summary>Slot of a power-of-two <paramref name="capacity"/> in <see cref="_nativeBuckets"/>.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int NativeBucketIndex(int capacity) => BitOperations.Log2((uint)capacity);
 
     internal int TrimNativeBuffers()
     {
         var released = 0;
-        foreach (var bucket in Volatile.Read(ref _nativeBuckets))
-            released += bucket.Trim();
+        var buckets = _nativeBuckets;
+        for (var i = 0; i < buckets.Length; i++)
+        {
+            if (Volatile.Read(ref buckets[i]) is { } bucket)
+                released += bucket.Trim();
+        }
 
         if (released > 0)
             Interlocked.Add(ref _retainedNativeBufferCount, -released);
@@ -4872,20 +4880,66 @@ internal sealed class ResponseBufferPool
         return (int)rounded;
     }
 
-    private sealed class NativeBufferBucket(int capacity)
+    /// <summary>
+    /// Retained buffers of one capacity. Pointers live in fixed slots claimed and released
+    /// with interlocked exchanges (<see cref="IntPtr.Zero"/> marks an empty slot), so
+    /// retaining a frame allocates nothing; a <c>ConcurrentStack</c> pushed a 32 B node per
+    /// retained frame. The slot count is the pool's global allowance, which the caller
+    /// enforces before returning, and the occupancy hint lets rent skip an empty bucket
+    /// without scanning.
+    /// </summary>
+    private sealed class NativeBufferBucket(int capacity, int slotCount)
     {
-        private readonly ConcurrentStack<IntPtr> _buffers = new();
+        private readonly IntPtr[] _slots = new IntPtr[slotCount];
+        private int _occupied;
 
         internal int Capacity => capacity;
 
-        internal bool TryRent(out IntPtr pointer) => _buffers.TryPop(out pointer);
+        internal bool TryRent(out IntPtr pointer)
+        {
+            if (Volatile.Read(ref _occupied) > 0)
+            {
+                var slots = _slots;
+                for (var i = 0; i < slots.Length; i++)
+                {
+                    if (Volatile.Read(ref slots[i]) == IntPtr.Zero)
+                        continue;
 
-        internal void Return(IntPtr pointer) => _buffers.Push(pointer);
+                    pointer = Interlocked.Exchange(ref slots[i], IntPtr.Zero);
+                    if (pointer != IntPtr.Zero)
+                    {
+                        Interlocked.Decrement(ref _occupied);
+                        return true;
+                    }
+                }
+            }
+
+            pointer = IntPtr.Zero;
+            return false;
+        }
+
+        internal bool TryReturn(IntPtr pointer)
+        {
+            var slots = _slots;
+            for (var i = 0; i < slots.Length; i++)
+            {
+                if (Volatile.Read(ref slots[i]) != IntPtr.Zero)
+                    continue;
+
+                if (Interlocked.CompareExchange(ref slots[i], pointer, IntPtr.Zero) == IntPtr.Zero)
+                {
+                    Interlocked.Increment(ref _occupied);
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         internal int Trim()
         {
             var released = 0;
-            while (_buffers.TryPop(out var pointer))
+            while (TryRent(out var pointer))
             {
                 Marshal.FreeHGlobal(pointer);
                 released++;

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -4881,70 +4881,108 @@ internal sealed class ResponseBufferPool
     }
 
     /// <summary>
-    /// Retained buffers of one capacity. Pointers live in fixed slots claimed and released
-    /// with interlocked exchanges (<see cref="IntPtr.Zero"/> marks an empty slot), so
-    /// retaining a frame allocates nothing; a <c>ConcurrentStack</c> pushed a 32 B node per
-    /// retained frame. The slot count is the pool's global allowance, which the caller
-    /// enforces before returning. Returns fill upward from a top hint and rents take the
-    /// slot just below it, so the bucket behaves as a stack (the most recently returned,
-    /// cache-warm frame is rented first) and both scans are one step long in steady state.
-    /// The hint is written plainly: a stale value only lengthens a scan, which wraps over
-    /// the whole array before giving up.
+    /// Retained buffers of one capacity. Pointers live in a fixed slot array threaded by two
+    /// index-linked Treiber stacks: the retained chain links the slots holding a buffer and
+    /// the free chain links the empty ones. A return pops a free slot, stores the pointer,
+    /// and pushes the slot onto the retained chain; a rent does the reverse. Each is one CAS
+    /// per chain operation with no slot scan, whatever the slot count or occupancy pattern,
+    /// and retaining a frame allocates nothing (the two arrays are allocated once per
+    /// capacity tier). Each chain head packs a 32-bit version above the slot index and every
+    /// successful CAS bumps it, so a pop whose <c>next</c> read went stale because the slot
+    /// was popped and pushed back meanwhile fails its CAS instead of corrupting the chain
+    /// (the ABA case of pointer-only stacks). Rents take the most recently returned,
+    /// cache-warm frame first.
     /// </summary>
-    private sealed class NativeBufferBucket(int capacity, int slotCount)
+    private sealed class NativeBufferBucket
     {
-        private readonly IntPtr[] _slots = new IntPtr[slotCount];
-        private int _top;
+        private const int None = -1;
+        private const long VersionIncrement = 1L << 32;
+        private const long VersionMask = unchecked((long)0xFFFF_FFFF_0000_0000);
 
-        internal int Capacity => capacity;
+        private readonly IntPtr[] _slots;
+        private readonly int[] _next;
+        private long _retainedHead;
+        private long _freeHead;
+
+        internal NativeBufferBucket(int capacity, int slotCount)
+        {
+            Capacity = capacity;
+            _slots = new IntPtr[slotCount];
+            _next = new int[slotCount];
+            for (var i = 0; i < slotCount - 1; i++)
+                _next[i] = i + 1;
+            _next[slotCount - 1] = None;
+            _freeHead = Pack(0L, 0);
+            _retainedHead = Pack(0L, None);
+        }
+
+        internal int Capacity { get; }
 
         internal bool TryRent(out IntPtr pointer)
         {
-            var slots = _slots;
-            var start = Math.Min(Volatile.Read(ref _top), slots.Length) - 1;
-            for (var n = 0; n < slots.Length; n++)
+            var index = Pop(ref _retainedHead);
+            if (index < 0)
             {
-                var i = start - n;
-                if (i < 0)
-                    i += slots.Length;
-
-                if (Volatile.Read(ref slots[i]) == IntPtr.Zero)
-                    continue;
-
-                pointer = Interlocked.Exchange(ref slots[i], IntPtr.Zero);
-                if (pointer != IntPtr.Zero)
-                {
-                    Volatile.Write(ref _top, i);
-                    return true;
-                }
+                pointer = IntPtr.Zero;
+                return false;
             }
 
-            pointer = IntPtr.Zero;
-            return false;
+            // The pop's CAS orders this read after the returner's store, which preceded its
+            // push. The slot is private to this thread until it is pushed onto the free chain.
+            pointer = _slots[index];
+            _slots[index] = IntPtr.Zero;
+            Push(ref _freeHead, index);
+            return true;
         }
 
         internal bool TryReturn(IntPtr pointer)
         {
-            var slots = _slots;
-            var start = Math.Min(Volatile.Read(ref _top), slots.Length - 1);
-            for (var n = 0; n < slots.Length; n++)
-            {
-                var i = start + n;
-                if (i >= slots.Length)
-                    i -= slots.Length;
+            var index = Pop(ref _freeHead);
+            if (index < 0)
+                return false;
 
-                if (Volatile.Read(ref slots[i]) != IntPtr.Zero)
-                    continue;
-
-                if (Interlocked.CompareExchange(ref slots[i], pointer, IntPtr.Zero) == IntPtr.Zero)
-                {
-                    Volatile.Write(ref _top, i + 1);
-                    return true;
-                }
-            }
-
-            return false;
+            _slots[index] = pointer;
+            Push(ref _retainedHead, index);
+            return true;
         }
+
+        private int Pop(ref long head)
+        {
+            var next = _next;
+            while (true)
+            {
+                var current = Volatile.Read(ref head);
+                var index = unchecked((int)current);
+                if (index < 0)
+                    return None;
+
+                // A stale successor is harmless: the version guarantees the CAS below fails
+                // if this index left and re-entered the chain since the head was read.
+                var updated = Pack(NextVersion(current), Volatile.Read(ref next[index]));
+                if (Interlocked.CompareExchange(ref head, updated, current) == current)
+                    return index;
+            }
+        }
+
+        private void Push(ref long head, int index)
+        {
+            var next = _next;
+            while (true)
+            {
+                var current = Volatile.Read(ref head);
+                Volatile.Write(ref next[index], unchecked((int)current));
+                var updated = Pack(NextVersion(current), index);
+                if (Interlocked.CompareExchange(ref head, updated, current) == current)
+                    return;
+            }
+        }
+
+        /// <summary>Head word: <paramref name="version"/> in the high 32 bits, the slot index (or <see cref="None"/>) in the low 32.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static long Pack(long version, int index) => version | (uint)index;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static long NextVersion(long head) => unchecked((head & VersionMask) + VersionIncrement);
 
         internal int Trim()
         {

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -4634,6 +4634,13 @@ internal sealed class ResponseBufferPool
     /// fixed array without enumerator allocations.
     /// </summary>
     private readonly NativeBufferBucket?[] _nativeBuckets = new NativeBufferBucket?[NativeBucketSlotCount];
+    private readonly RatchetableArrayPool<byte> _managedArrays;
+    /// <summary>
+    /// Slots allocated per native bucket: the retention ceiling, so a later
+    /// <see cref="RatchetRetention"/> never has to resize a bucket under live rents.
+    /// </summary>
+    private readonly int _nativeSlotCapacity;
+    private int _maxRetainedNativeBuffers;
     private int _retainedNativeBufferCount;
     private int _highNativeMemoryPressure;
 #if !NETSTANDARD2_0
@@ -4641,10 +4648,10 @@ internal sealed class ResponseBufferPool
     private readonly bool _monitorNativeMemoryPressure;
 #endif
 
-    internal ArrayPool<byte> Pool { get; }
+    internal ArrayPool<byte> Pool => _managedArrays.Pool;
     internal int MaxArrayLength { get; }
-    internal int ManagedArraysPerBucket { get; }
-    internal int MaxRetainedNativeBuffers { get; }
+    internal int ManagedArraysPerBucket => _managedArrays.CurrentArraysPerBucket;
+    internal int MaxRetainedNativeBuffers => Volatile.Read(ref _maxRetainedNativeBuffers);
     internal int RetainedNativeBufferCount => Volatile.Read(ref _retainedNativeBufferCount);
 
     internal ResponseBufferPool(
@@ -4657,14 +4664,31 @@ internal sealed class ResponseBufferPool
         var nativeRetentionLimit = maxRetainedNativeBuffers ?? managedArraysPerBucket;
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(nativeRetentionLimit);
         MaxArrayLength = maxArrayLength;
-        ManagedArraysPerBucket = managedArraysPerBucket;
-        MaxRetainedNativeBuffers = nativeRetentionLimit;
+        _maxRetainedNativeBuffers = nativeRetentionLimit;
+        _nativeSlotCapacity = Math.Max(nativeRetentionLimit, PoolSizing.MaxResponseBuffers);
 #if !NETSTANDARD2_0
         _monitorNativeMemoryPressure = monitorNativeMemoryPressure;
 #endif
-        Pool = ArrayPool<byte>.Create(
-            maxArrayLength: maxArrayLength,
-            maxArraysPerBucket: managedArraysPerBucket);
+        _managedArrays = new RatchetableArrayPool<byte>(maxArrayLength, managedArraysPerBucket);
+    }
+
+    /// <summary>
+    /// Raises the retention depth to the working set of a newly discovered topology. Pools are
+    /// sized from the bootstrap seed count before metadata reports the real broker count, so
+    /// producers, consumers, and shared clients call this from the broker-count-discovered
+    /// callback; like every other Dekaf pool ratchet it only ever grows. The managed side
+    /// swaps in a deeper <see cref="ArrayPool{T}"/> (arrays rented from the previous instance
+    /// return into the new one); the native allowance is a monotonic counter bound, capped at
+    /// the slot capacity every bucket was allocated with, so no bucket is ever resized.
+    /// </summary>
+    internal void RatchetRetention(int managedArraysPerBucket, int maxRetainedNativeBuffers)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(managedArraysPerBucket);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxRetainedNativeBuffers);
+        _managedArrays.RatchetBucketCapacity(managedArraysPerBucket);
+        InterlockedHelper.RatchetUp(
+            ref _maxRetainedNativeBuffers,
+            Math.Min(maxRetainedNativeBuffers, _nativeSlotCapacity));
     }
 
     /// <summary>
@@ -4691,6 +4715,12 @@ internal sealed class ResponseBufferPool
     internal static ResponseBufferPool CreateDefaultSized(int responseBuffersPerBucket)
         => GetOrAddShared(DefaultMaxArrayLength, responseBuffersPerBucket, responseBuffersPerBucket);
 
+    /// <summary>
+    /// Shared instances are keyed by their construction-time sizing. A pool that has since
+    /// grown through <see cref="RatchetRetention"/> stays under its original key: a later
+    /// caller asking for the shallower configuration receives the deeper pool, which retains
+    /// at most the peak live working set either way.
+    /// </summary>
     private static ResponseBufferPool GetOrAddShared(
         int maxArrayLength,
         int managedArraysPerBucket,
@@ -4805,7 +4835,7 @@ internal sealed class ResponseBufferPool
         if (existing is not null)
             return existing;
 
-        var created = new NativeBufferBucket(capacity, MaxRetainedNativeBuffers);
+        var created = new NativeBufferBucket(capacity, _nativeSlotCapacity);
         return Interlocked.CompareExchange(ref slot, created, null) ?? created;
     }
 

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -4569,6 +4569,16 @@ public sealed class ConnectionOptions
 /// <c>ArrayPool&lt;byte&gt;</c> so that large multi-partition fetch responses are pooled
 /// instead of falling through to unpooled LOH allocations.
 /// </summary>
+/// <remarks>
+/// Retention depth must cover the live response working set (in-flight requests x peak
+/// connections for producers; prefetch pipeline slots x brokers x connections for
+/// consumers). Below that depth the managed buckets allocate a fresh array and the native
+/// path pays <c>AllocHGlobal</c>/<c>FreeHGlobal</c> plus first-touch page faults on every
+/// frame. Dormant memory is bounded by <see cref="ManagedArraysPerBucket"/> arrays per
+/// managed size bucket in use, plus <see cref="MaxRetainedNativeBuffers"/> native buffers
+/// in total across all native capacities (at most that many times the largest native
+/// capacity in use); native retention is released under high memory load.
+/// </remarks>
 internal sealed class ResponseBufferPool
 {
     // Managed arrays at or above this size enter the LOH and force full collections while
@@ -4589,10 +4599,17 @@ internal sealed class ResponseBufferPool
     private const int SizeTierBytes = 1024 * 1024;
 
     /// <summary>
-    /// Default shared instance used by producers, admin clients, and connections
-    /// that don't have consumer-specific configuration.
+    /// Depth of <see cref="Default"/>, the shared instance for admin clients, share consumers,
+    /// direct connections, and tests. Producers and consumers size their pools from topology
+    /// via <see cref="Internal.PoolSizing"/>.
     /// </summary>
     private const int DefaultManagedArraysPerBucket = 4;
+
+    /// <summary>
+    /// Largest native capacity that is retained. Above this, <see cref="RoundUpToPowerOfTwo"/>
+    /// no longer rounds, so every distinct frame size would need its own bucket.
+    /// </summary>
+    private const int MaxPooledNativeCapacity = 1 << 30;
 #if !NETSTANDARD2_0
     private const long NativeMemoryPressureRefreshMilliseconds = 1_000;
 #endif
@@ -4605,7 +4622,9 @@ internal sealed class ResponseBufferPool
         (int MaxArrayLength, int ManagedArraysPerBucket, int MaxRetainedNativeBuffers),
         ResponseBufferPool>
         s_sharedPools = new();
-    private readonly ConcurrentDictionary<int, NativeBufferBucket> _nativeBuckets = new();
+    // Copy-on-write: buckets are only ever added (one per power-of-two capacity seen), so
+    // rent, return, eviction, and trim can walk the array without enumerator allocations.
+    private NativeBufferBucket[] _nativeBuckets = [];
     private int _retainedNativeBufferCount;
     private int _highNativeMemoryPressure;
 #if !NETSTANDARD2_0
@@ -4648,21 +4667,36 @@ internal sealed class ResponseBufferPool
         int fetchMaxBytes,
         int managedArraysPerBucket = DefaultManagedArraysPerBucket,
         int? maxRetainedNativeBuffers = null)
-    {
-        var maxArrayLength = ComputeMaxArrayLength(fetchMaxBytes);
-        var nativeRetentionLimit = maxRetainedNativeBuffers ?? managedArraysPerBucket;
-        return maxArrayLength == DefaultMaxArrayLength
+        => GetOrAddShared(
+            ComputeMaxArrayLength(fetchMaxBytes),
+            managedArraysPerBucket,
+            maxRetainedNativeBuffers ?? managedArraysPerBucket);
+
+    /// <summary>
+    /// Returns a process-shared <see cref="ResponseBufferPool"/> with the
+    /// <see cref="DefaultMaxArrayLength"/> ceiling used for producer, admin, and coordination
+    /// traffic, retaining <paramref name="responseBuffersPerBucket"/> managed arrays per size
+    /// bucket and the same number of native buffers in total (see
+    /// <see cref="Internal.PoolSizing.SharedPoolSizes.ResponseBuffersPerBucket"/>).
+    /// </summary>
+    internal static ResponseBufferPool CreateDefaultSized(int responseBuffersPerBucket)
+        => GetOrAddShared(DefaultMaxArrayLength, responseBuffersPerBucket, responseBuffersPerBucket);
+
+    private static ResponseBufferPool GetOrAddShared(
+        int maxArrayLength,
+        int managedArraysPerBucket,
+        int maxRetainedNativeBuffers)
+        => maxArrayLength == DefaultMaxArrayLength
             && managedArraysPerBucket == DefaultManagedArraysPerBucket
-            && nativeRetentionLimit == DefaultManagedArraysPerBucket
+            && maxRetainedNativeBuffers == DefaultManagedArraysPerBucket
             ? Default
             : s_sharedPools.GetOrAdd(
-                (maxArrayLength, managedArraysPerBucket, nativeRetentionLimit),
+                (maxArrayLength, managedArraysPerBucket, maxRetainedNativeBuffers),
                 static configuration => new ResponseBufferPool(
                     configuration.MaxArrayLength,
                     configuration.ManagedArraysPerBucket,
                     configuration.MaxRetainedNativeBuffers,
                     monitorNativeMemoryPressure: true));
-    }
 
     internal static int ComputeMaxArrayLength(int fetchMaxBytes)
     {
@@ -4684,10 +4718,10 @@ internal sealed class ResponseBufferPool
     internal NativeResponseBuffer RentNative(int minimumLength)
     {
         var capacity = RoundUpToPowerOfTwo(minimumLength);
-        var bucket = _nativeBuckets.GetOrAdd(
-            capacity,
-            static _ => new NativeBufferBucket());
-        if (bucket.TryRent(out var pointer))
+        var bucket = capacity <= MaxPooledNativeCapacity
+            ? FindNativeBucket(Volatile.Read(ref _nativeBuckets), capacity)
+            : null;
+        if (bucket is not null && bucket.TryRent(out var pointer))
         {
             Interlocked.Decrement(ref _retainedNativeBufferCount);
             return NativeResponseBuffer.Rent(this, pointer, capacity);
@@ -4701,33 +4735,84 @@ internal sealed class ResponseBufferPool
 #if !NETSTANDARD2_0
         RefreshNativeMemoryPressure();
 #endif
-        if (Volatile.Read(ref _highNativeMemoryPressure) != 0)
+        if (Volatile.Read(ref _highNativeMemoryPressure) != 0 || capacity > MaxPooledNativeCapacity)
         {
             Marshal.FreeHGlobal(pointer);
             return;
         }
 
-        if (Interlocked.Increment(ref _retainedNativeBufferCount) > MaxRetainedNativeBuffers)
+        if (Interlocked.Increment(ref _retainedNativeBufferCount) > MaxRetainedNativeBuffers
+            && !TryEvictDormantBuffer(capacity))
         {
+            // Nothing of another capacity to evict: this size alone exceeds the allowance.
             Interlocked.Decrement(ref _retainedNativeBufferCount);
             Marshal.FreeHGlobal(pointer);
             return;
         }
 
-        var bucket = _nativeBuckets.GetOrAdd(
-            capacity,
-            static _ => new NativeBufferBucket());
-        bucket.Return(pointer);
+        GetOrAddNativeBucket(capacity).Return(pointer);
 
         // Pressure can begin after the first check but before this buffer is published.
         if (Volatile.Read(ref _highNativeMemoryPressure) != 0)
             TrimNativeBuffers();
     }
 
+    /// <summary>
+    /// Frees one dormant buffer whose capacity differs from <paramref name="capacity"/> so the
+    /// retained set follows the live response size. Fetch frames move between power-of-two
+    /// capacities as consumer lag or adaptive fetch sizing changes; without eviction the
+    /// stale capacity's dormant buffers hold the global allowance and every frame of the new
+    /// size is freed on return and re-allocated on rent. The global bound is unchanged: the
+    /// evicted buffer's allowance is what the returned buffer takes.
+    /// </summary>
+    private bool TryEvictDormantBuffer(int capacity)
+    {
+        foreach (var bucket in Volatile.Read(ref _nativeBuckets))
+        {
+            if (bucket.Capacity == capacity || !bucket.TryRent(out var pointer))
+                continue;
+
+            Marshal.FreeHGlobal(pointer);
+            Interlocked.Decrement(ref _retainedNativeBufferCount);
+            return true;
+        }
+
+        return false;
+    }
+
+    private NativeBufferBucket GetOrAddNativeBucket(int capacity)
+    {
+        while (true)
+        {
+            var buckets = Volatile.Read(ref _nativeBuckets);
+            var existing = FindNativeBucket(buckets, capacity);
+            if (existing is not null)
+                return existing;
+
+            var added = new NativeBufferBucket[buckets.Length + 1];
+            buckets.AsSpan().CopyTo(added);
+            var bucket = new NativeBufferBucket(capacity);
+            added[buckets.Length] = bucket;
+            if (Interlocked.CompareExchange(ref _nativeBuckets, added, buckets) == buckets)
+                return bucket;
+        }
+    }
+
+    private static NativeBufferBucket? FindNativeBucket(NativeBufferBucket[] buckets, int capacity)
+    {
+        foreach (var bucket in buckets)
+        {
+            if (bucket.Capacity == capacity)
+                return bucket;
+        }
+
+        return null;
+    }
+
     internal int TrimNativeBuffers()
     {
         var released = 0;
-        foreach (var bucket in _nativeBuckets.Values)
+        foreach (var bucket in Volatile.Read(ref _nativeBuckets))
             released += bucket.Trim();
 
         if (released > 0)
@@ -4774,7 +4859,7 @@ internal sealed class ResponseBufferPool
 
     private static int RoundUpToPowerOfTwo(int value)
     {
-        if (value > 1 << 30)
+        if (value > MaxPooledNativeCapacity)
             return value;
 
         var rounded = (uint)(value - 1);
@@ -4787,9 +4872,11 @@ internal sealed class ResponseBufferPool
         return (int)rounded;
     }
 
-    private sealed class NativeBufferBucket
+    private sealed class NativeBufferBucket(int capacity)
     {
         private readonly ConcurrentStack<IntPtr> _buffers = new();
+
+        internal int Capacity => capacity;
 
         internal bool TryRent(out IntPtr pointer) => _buffers.TryPop(out pointer);
 

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -4630,10 +4630,12 @@ internal sealed class ResponseBufferPool
     /// Bucket slots for every retainable power-of-two capacity, indexed by
     /// <see cref="NativeBucketIndex"/> (log2 of the capacity), so rent and return resolve
     /// their bucket in O(1) regardless of how many capacities adaptive fetch sizing has
-    /// visited. Slots are filled lazily and never cleared; eviction and trim walk the
-    /// fixed array without enumerator allocations.
+    /// visited. Storage is allocated during construction, before any response is returned.
     /// </summary>
-    private readonly NativeBufferBucket?[] _nativeBuckets = new NativeBufferBucket?[NativeBucketSlotCount];
+    private readonly NativeBufferBucket[] _nativeBuckets = new NativeBufferBucket[NativeBucketSlotCount];
+    // Availability hint updated on empty/nonempty transitions. An overflow return probes
+    // one indicated alternative, never scans capacity slots. Concurrent renters may win it.
+    private int _nativeBucketsWithBuffers;
     private readonly RatchetableArrayPool<byte> _managedArrays;
     /// <summary>
     /// Slots allocated per native bucket: the retention ceiling, so a later
@@ -4666,6 +4668,8 @@ internal sealed class ResponseBufferPool
         MaxArrayLength = maxArrayLength;
         _maxRetainedNativeBuffers = nativeRetentionLimit;
         _nativeSlotCapacity = Math.Max(nativeRetentionLimit, PoolSizing.MaxResponseBuffers);
+        for (var i = 0; i < _nativeBuckets.Length; i++)
+            _nativeBuckets[i] = new NativeBufferBucket(_nativeSlotCapacity);
 #if !NETSTANDARD2_0
         _monitorNativeMemoryPressure = monitorNativeMemoryPressure;
 #endif
@@ -4758,10 +4762,12 @@ internal sealed class ResponseBufferPool
     {
         var capacity = RoundUpToPowerOfTwo(minimumLength);
         if (capacity <= MaxPooledNativeCapacity
-            && Volatile.Read(ref _nativeBuckets[NativeBucketIndex(capacity)]) is { } bucket
-            && bucket.TryRent(out var pointer))
+            && _nativeBuckets[NativeBucketIndex(capacity)].TryRent(out var pointer))
         {
             Interlocked.Decrement(ref _retainedNativeBufferCount);
+            var index = NativeBucketIndex(capacity);
+            if (!_nativeBuckets[index].HasRetainedBuffers)
+                ClearEmptyNativeBucket(index);
             return NativeResponseBuffer.Rent(this, pointer, capacity);
         }
 
@@ -4788,7 +4794,8 @@ internal sealed class ResponseBufferPool
             return;
         }
 
-        if (!GetOrAddNativeBucket(capacity).TryReturn(pointer))
+        var bucketIndex = NativeBucketIndex(capacity);
+        if (!_nativeBuckets[bucketIndex].TryReturn(pointer))
         {
             // Every slot of this capacity is occupied. The global count admits at most one
             // buffer per slot, so this is only reachable while a concurrent trim has popped a
@@ -4797,6 +4804,8 @@ internal sealed class ResponseBufferPool
             Marshal.FreeHGlobal(pointer);
             return;
         }
+
+        MarkNativeBucketAvailable(bucketIndex);
 
         // Pressure can begin after the first check but before this buffer is published.
         if (Volatile.Read(ref _highNativeMemoryPressure) != 0)
@@ -4813,30 +4822,43 @@ internal sealed class ResponseBufferPool
     /// </summary>
     private bool TryEvictDormantBuffer(int capacity)
     {
-        var buckets = _nativeBuckets;
-        for (var i = 0; i < buckets.Length; i++)
-        {
-            var bucket = Volatile.Read(ref buckets[i]);
-            if (bucket is null || bucket.Capacity == capacity || !bucket.TryRent(out var pointer))
-                continue;
+        var alternatives = (uint)Volatile.Read(ref _nativeBucketsWithBuffers)
+            & ~(1u << NativeBucketIndex(capacity));
+        if (alternatives == 0)
+            return false;
 
-            Marshal.FreeHGlobal(pointer);
-            Interlocked.Decrement(ref _retainedNativeBufferCount);
-            return true;
+        var index = BitOperations.Log2(alternatives);
+        var bucket = _nativeBuckets[index];
+        if (!bucket.TryRent(out var pointer))
+        {
+            // A renter consumed this bucket since its last return. Repair just this hint;
+            // under contention the incoming buffer may be freed even if another tier is
+            // available. Retention is opportunistic and the global allowance stays exact.
+            ClearEmptyNativeBucket(index);
+            return false;
         }
 
-        return false;
+        Marshal.FreeHGlobal(pointer);
+        Interlocked.Decrement(ref _retainedNativeBufferCount);
+        if (!bucket.HasRetainedBuffers)
+            ClearEmptyNativeBucket(index);
+        return true;
     }
 
-    private NativeBufferBucket GetOrAddNativeBucket(int capacity)
+    private void MarkNativeBucketAvailable(int index)
     {
-        ref var slot = ref _nativeBuckets[NativeBucketIndex(capacity)];
-        var existing = Volatile.Read(ref slot);
-        if (existing is not null)
-            return existing;
+        var bit = 1 << index;
+        if ((Volatile.Read(ref _nativeBucketsWithBuffers) & bit) == 0)
+            Interlocked.Or(ref _nativeBucketsWithBuffers, bit);
+    }
 
-        var created = new NativeBufferBucket(capacity, _nativeSlotCapacity);
-        return Interlocked.CompareExchange(ref slot, created, null) ?? created;
+    private void ClearEmptyNativeBucket(int index)
+    {
+        Interlocked.And(ref _nativeBucketsWithBuffers, ~(1 << index));
+        // A concurrent return may have observed the old set bit after publishing its
+        // pointer. Recheck after clearing so that publication cannot be hidden forever.
+        if (_nativeBuckets[index].HasRetainedBuffers)
+            MarkNativeBucketAvailable(index);
     }
 
     /// <summary>Slot of a power-of-two <paramref name="capacity"/> in <see cref="_nativeBuckets"/>.</summary>
@@ -4849,8 +4871,8 @@ internal sealed class ResponseBufferPool
         var buckets = _nativeBuckets;
         for (var i = 0; i < buckets.Length; i++)
         {
-            if (Volatile.Read(ref buckets[i]) is { } bucket)
-                released += bucket.Trim();
+            released += buckets[i].Trim();
+            ClearEmptyNativeBucket(i);
         }
 
         if (released > 0)
@@ -4934,9 +4956,8 @@ internal sealed class ResponseBufferPool
         private long _retainedHead;
         private long _freeHead;
 
-        internal NativeBufferBucket(int capacity, int slotCount)
+        internal NativeBufferBucket(int slotCount)
         {
-            Capacity = capacity;
             _slots = new IntPtr[slotCount];
             _next = new int[slotCount];
             for (var i = 0; i < slotCount - 1; i++)
@@ -4946,7 +4967,7 @@ internal sealed class ResponseBufferPool
             _retainedHead = Pack(0L, None);
         }
 
-        internal int Capacity { get; }
+        internal bool HasRetainedBuffers => unchecked((int)Volatile.Read(ref _retainedHead)) >= 0;
 
         internal bool TryRent(out IntPtr pointer)
         {

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -542,7 +542,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             },
             loggerFactory,
             options.ConnectionsPerBroker,
-            ResponseBufferPool.Default,
+            ResponseBufferPool.CreateDefaultSized(sharedPoolSizes.ResponseBuffersPerBucket),
             pipeMemoryBucketCapacity: sharedPoolSizes.PipeMemoryArraysPerBucket,
             telemetryMetricCollector: telemetryMetricCollector);
 

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -704,6 +704,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
             DekafPools.RatchetSerializationBucketCapacity(sizes.SerializationArraysPerBucket);
             ProduceResponse.RatchetPoolSize(sizes.ProduceResponsePoolSize);
             connectionPool.RatchetPipeMemoryBucketCapacity(sizes.PipeMemoryArraysPerBucket);
+            connectionPool.RatchetResponseBufferRetention(sizes.ResponseBuffersPerBucket, sizes.ResponseBuffersPerBucket);
         });
 
         _compressionCodecs = CreateCompressionCodecRegistry(options);

--- a/src/Dekaf/Protocol/Messages/ProduceResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ProduceResponse.cs
@@ -47,8 +47,8 @@ public sealed class ProduceResponse : IKafkaResponse
     private const int MinRequestBytesPerRecord = 4;
 
     // Absolute ceilings for the ratchet, chosen independently of any single connection's
-    // actual frame size (standalone producers read responses through the 16 MiB
-    // ResponseBufferPool.Default frame; producers sharing a KafkaClient read through a
+    // actual frame size (standalone producers read responses through a 16 MiB
+    // ResponseBufferPool.DefaultMaxArrayLength frame; producers sharing a KafkaClient read through a
     // pool sized by the client's SharedResponseBufferFetchMaxBytes constant, a ~201 MiB
     // tier). The ceiling budget is what a 16 MiB frame can encode at each entry's minimum
     // legitimate response encoding — deliberately conservative so one producer's huge

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -452,6 +452,56 @@ public sealed class KafkaClientBuilderTests
     }
 
     [Test]
+    public async Task RootClient_ResponseBufferPools_RatchetWhenMetadataDiscoversMoreBrokers()
+    {
+        // A single seed endpoint for a nine-broker cluster: both shared pools are sized from
+        // the seed count at construction and must grow once metadata reports the topology.
+        await using var client = Kafka.Connect("broker1:9092", builder => builder
+            .WithMaxConnectionsPerBroker(6)
+            .WithMaxInFlightRequestsPerConnection(5));
+        await using var producer = client.CreateProducer<string, string>().Build();
+        await using var consumer = client.CreateConsumer<string, string>().Build();
+
+        var producerResponsePool = GetField<ResponseBufferPool>(
+            GetField<ConnectionPool>(producer, "_connectionPool"),
+            "_responseBufferPool");
+        var consumerResponsePool = GetField<ResponseBufferPool>(
+            GetField<ConnectionPool>(consumer, "_connectionPool"),
+            "_responseBufferPool");
+        var infrastructure = GetField<KafkaClientInfrastructure>(client, "_infrastructure");
+        var seededProducer = PoolSizing.ForSharedPools(
+            brokerCount: 1,
+            connectionsPerBroker: 1,
+            maxInFlightRequestsPerConnection: 5,
+            batchSize: 1048576,
+            maxConnectionsPerBroker: 6).ResponseBuffersPerBucket;
+        var seededConsumer = PoolSizing.ForSharedClientConsumerResponseBuffers(
+            brokerCount: 1,
+            maxConnectionsPerBroker: 6);
+        await Assert.That(producerResponsePool.MaxRetainedNativeBuffers).IsEqualTo(seededProducer);
+        await Assert.That(consumerResponsePool.MaxRetainedNativeBuffers).IsEqualTo(seededConsumer);
+
+        const int discoveredBrokers = 9;
+        infrastructure.MetadataManager.NotifyBrokerCountDiscovered(discoveredBrokers);
+
+        var expectedProducer = PoolSizing.ForSharedPools(
+            brokerCount: discoveredBrokers,
+            connectionsPerBroker: 1,
+            maxInFlightRequestsPerConnection: 5,
+            batchSize: 1048576,
+            maxConnectionsPerBroker: 6).ResponseBuffersPerBucket;
+        var expectedConsumer = PoolSizing.ForSharedClientConsumerResponseBuffers(
+            brokerCount: discoveredBrokers,
+            maxConnectionsPerBroker: 6);
+        await Assert.That(expectedProducer).IsGreaterThan(seededProducer);
+        await Assert.That(expectedConsumer).IsGreaterThan(seededConsumer);
+        await Assert.That(producerResponsePool.ManagedArraysPerBucket).IsEqualTo(expectedProducer);
+        await Assert.That(producerResponsePool.MaxRetainedNativeBuffers).IsEqualTo(expectedProducer);
+        await Assert.That(consumerResponsePool.ManagedArraysPerBucket).IsEqualTo(expectedConsumer);
+        await Assert.That(consumerResponsePool.MaxRetainedNativeBuffers).IsEqualTo(expectedConsumer);
+    }
+
+    [Test]
     public async Task MetadataManager_BrokerCountCallbacks_AreMulticast()
     {
         await using var metadataManager = new MetadataManager(
@@ -472,14 +522,19 @@ public sealed class KafkaClientBuilderTests
     public async Task RootClient_CreatedProducer_DisposeRemovesBrokerCountCallback()
     {
         await using var client = Kafka.Connect("localhost:9092");
+        var infrastructure = GetField<KafkaClientInfrastructure>(client, "_infrastructure");
+        // The shared client holds its own registration (response-pool ratchet) for its lifetime.
+        var clientOwnedCallbacks = infrastructure.MetadataManager.BrokerCountDiscoveredCallbackCount;
+        await Assert.That(clientOwnedCallbacks).IsEqualTo(1);
+
         var producer = client.CreateProducer<string, string>().Build();
         var metadataManager = GetField<MetadataManager>(producer, "_metadataManager");
 
-        await Assert.That(metadataManager.BrokerCountDiscoveredCallbackCount).IsEqualTo(1);
+        await Assert.That(metadataManager.BrokerCountDiscoveredCallbackCount).IsEqualTo(clientOwnedCallbacks + 1);
 
         await producer.DisposeAsync();
 
-        await Assert.That(metadataManager.BrokerCountDiscoveredCallbackCount).IsEqualTo(0);
+        await Assert.That(metadataManager.BrokerCountDiscoveredCallbackCount).IsEqualTo(clientOwnedCallbacks);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -3,6 +3,7 @@ using System.Net.Security;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Consumer;
+using Dekaf.Internal;
 using Dekaf.Producer;
 using Dekaf.Security.Sasl;
 using Dekaf.Streams;
@@ -406,6 +407,46 @@ public sealed class KafkaClientBuilderTests
         var pool = GetField<ConnectionPool>(consumer, "_connectionPool");
         var responseBufferPool = GetField<ResponseBufferPool>(pool, "_responseBufferPool");
 
+        await Assert.That(responseBufferPool.MaxArrayLength)
+            .IsEqualTo(200 * 1024 * 1024 + ResponseBufferPool.ProtocolOverheadBytes);
+    }
+
+    [Test]
+    public async Task RootClient_ConsumerConnectionPool_RetainsDeepestPrefetchWorkingSet()
+    {
+        await using var client = Kafka.Connect("broker1:9092,broker2:9092", builder => builder
+            .WithMaxConnectionsPerBroker(4));
+        await using var consumer = client.CreateConsumer<string, string>().Build();
+
+        var pool = GetField<ConnectionPool>(consumer, "_connectionPool");
+        var responseBufferPool = GetField<ResponseBufferPool>(pool, "_responseBufferPool");
+
+        var expected = PoolSizing.ForSharedClientConsumerResponseBuffers(
+            brokerCount: 2,
+            maxConnectionsPerBroker: 4);
+        await Assert.That(responseBufferPool.ManagedArraysPerBucket).IsEqualTo(expected);
+        await Assert.That(responseBufferPool.MaxRetainedNativeBuffers).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task RootClient_ProducerConnectionPool_RetainsPeakInFlightWorkingSet()
+    {
+        await using var client = Kafka.Connect("broker1:9092,broker2:9092", builder => builder
+            .WithMaxConnectionsPerBroker(4)
+            .WithMaxInFlightRequestsPerConnection(5));
+        await using var producer = client.CreateProducer<string, string>().Build();
+
+        var pool = GetField<ConnectionPool>(producer, "_connectionPool");
+        var responseBufferPool = GetField<ResponseBufferPool>(pool, "_responseBufferPool");
+
+        var expected = PoolSizing.ForSharedPools(
+            brokerCount: 2,
+            connectionsPerBroker: 1,
+            maxInFlightRequestsPerConnection: 5,
+            batchSize: 1048576,
+            maxConnectionsPerBroker: 4).ResponseBuffersPerBucket;
+        await Assert.That(responseBufferPool.ManagedArraysPerBucket).IsEqualTo(expected);
+        await Assert.That(responseBufferPool.MaxRetainedNativeBuffers).IsEqualTo(expected);
         await Assert.That(responseBufferPool.MaxArrayLength)
             .IsEqualTo(200 * 1024 * 1024 + ResponseBufferPool.ProtocolOverheadBytes);
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerResponseBufferSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerResponseBufferSizingTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Internal;
+using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Serialization;
 
@@ -103,6 +104,48 @@ public sealed class ConsumerResponseBufferSizingTests
 
         await Assert.That(responsePool.ManagedArraysPerBucket).IsEqualTo(expectedWorkingSet);
         await Assert.That(responsePool.MaxRetainedNativeBuffers).IsEqualTo(expectedWorkingSet);
+    }
+
+    [Test]
+    public async Task ConsumerInfrastructure_RatchetsResponsePoolWhenMetadataDiscoversMoreBrokers()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ConnectionsPerBroker = 1,
+            MaxConnectionsPerBroker = 5,
+            EnableAdaptiveConnections = true,
+            PrefetchPipelineDepth = 4
+        };
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+
+        var connectionPool = GetField<ConnectionPool>(consumer, "_connectionPool");
+        var responsePool = GetField<ResponseBufferPool>(connectionPool, "_responseBufferPool");
+        var metadataManager = GetField<MetadataManager>(consumer, "_metadataManager");
+        var seeded = PoolSizing.ForConsumerResponseBuffers(
+            brokerCount: 1,
+            options.PrefetchPipelineDepth,
+            options.MaxConnectionsPerBroker);
+        await Assert.That(responsePool.MaxRetainedNativeBuffers).IsEqualTo(seeded);
+
+        const int discoveredBrokers = 12;
+        metadataManager.NotifyBrokerCountDiscovered(discoveredBrokers);
+
+        var expected = PoolSizing.ForConsumerResponseBuffers(
+            discoveredBrokers,
+            options.PrefetchPipelineDepth,
+            options.MaxConnectionsPerBroker);
+        await Assert.That(expected).IsGreaterThan(seeded);
+        await Assert.That(responsePool.ManagedArraysPerBucket).IsEqualTo(expected);
+        await Assert.That(responsePool.MaxRetainedNativeBuffers).IsEqualTo(expected);
+
+        metadataManager.NotifyBrokerCountDiscovered(1);
+
+        await Assert.That(responsePool.MaxRetainedNativeBuffers).IsEqualTo(expected)
+            .Because("a smaller metadata response never shrinks the pool");
     }
 
     private static T GetField<T>(object target, string name) =>

--- a/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
@@ -1,3 +1,4 @@
+using Dekaf.Consumer;
 using Dekaf.Internal;
 using Dekaf.Producer;
 
@@ -265,7 +266,48 @@ public class PoolSizingTests
         await Assert.That(capacity).IsEqualTo(expected);
     }
 
+    [Test]
+    [Arguments(1, 4, 40)] // 1 broker x (8 + 2 slots) x 4 connections
+    [Arguments(2, 4, 80)]
+    [Arguments(1, 1, 16)]
+    public async Task ForSharedClientConsumerResponseBuffers_SizesForDeepestPipeline(
+        int brokerCount,
+        int maxConnectionsPerBroker,
+        int expected)
+    {
+        var capacity = PoolSizing.ForSharedClientConsumerResponseBuffers(brokerCount, maxConnectionsPerBroker);
+
+        await Assert.That(capacity).IsEqualTo(expected);
+        await Assert.That(capacity).IsEqualTo(PoolSizing.ForConsumerResponseBuffers(
+            brokerCount,
+            ConsumerOptions.MaxPrefetchPipelineDepth,
+            maxConnectionsPerBroker));
+    }
+
     // --- ForSharedPools tests ---
+
+    [Test]
+    [Arguments(1, 1, 1, 16)]
+    [Arguments(1, 3, 5, 30)] // default standalone producer: 1 x 3 peak connections x 5 in flight, x2
+    [Arguments(2, 4, 5, 80)]
+    [Arguments(3, 4, 5, 120)]
+    [Arguments(16, 10, 5, 256)]
+    [Arguments(int.MaxValue, int.MaxValue, int.MaxValue, 256)]
+    public async Task ForSharedPools_ResponseBuffers_CoverPeakInFlightWorkingSetWithinBounds(
+        int brokerCount,
+        int maxConnectionsPerBroker,
+        int maxInFlightRequestsPerConnection,
+        int expected)
+    {
+        var sizes = PoolSizing.ForSharedPools(
+            brokerCount,
+            connectionsPerBroker: 1,
+            maxInFlightRequestsPerConnection,
+            batchSize: 1048576,
+            maxConnectionsPerBroker);
+
+        await Assert.That(sizes.ResponseBuffersPerBucket).IsEqualTo(expected);
+    }
 
     [Test]
     public async Task ForSharedPools_SingleBroker_DefaultBatch_ReturnsDepthForAdaptiveScaling()

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
@@ -152,6 +152,70 @@ public class ResponseBufferPoolTests
     }
 
     [Test]
+    public async Task NativePool_OverAllowanceReturnEvictsStaleCapacityInsteadOfFreeingLiveSize()
+    {
+        // The consumer was caught up (small frames) and then fell behind (large frames). The
+        // small frames sit dormant in their bucket; retaining the large frames must evict
+        // them rather than leave the live size permanently over the allowance.
+        const int allowance = 4;
+        const int smallCapacity = ResponseBufferPool.NativeMemoryThresholdBytes;
+        const int largeCapacity = ResponseBufferPool.NativeMemoryThresholdBytes * 8;
+        var pool = new ResponseBufferPool(
+            16 * 1024 * 1024,
+            managedArraysPerBucket: allowance,
+            maxRetainedNativeBuffers: allowance);
+        var frames = new NativeResponseBuffer[allowance];
+        for (var i = 0; i < allowance; i++)
+            frames[i] = pool.RentNative(smallCapacity);
+        for (var i = 0; i < allowance; i++)
+            frames[i].Return();
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(allowance);
+
+        for (var i = 0; i < allowance; i++)
+            frames[i] = pool.RentNative(largeCapacity);
+
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(allowance)
+            .Because("renting a new capacity leaves the stale capacity's buffers dormant");
+
+        for (var i = 0; i < allowance; i++)
+            frames[i].Return();
+
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(allowance)
+            .Because("the global allowance is preserved while its contents migrate");
+
+        for (var i = 0; i < allowance; i++)
+            frames[i] = pool.RentNative(largeCapacity);
+
+        // The count only decrements on a hit, so reaching zero proves every large rent
+        // reused a retained buffer and every stale small buffer was evicted to make room.
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(0);
+
+        for (var i = 0; i < allowance; i++)
+            frames[i].Return();
+        pool.TrimNativeBuffers();
+    }
+
+    [Test]
+    public async Task NativePool_OverAllowanceReturnOfLiveCapacityStillFreesSurplus()
+    {
+        var pool = new ResponseBufferPool(
+            1024 * 1024,
+            managedArraysPerBucket: 2,
+            maxRetainedNativeBuffers: 2);
+        var first = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        var second = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        var third = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+
+        first.Return();
+        second.Return();
+        third.Return();
+
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(2)
+            .Because("with no other capacity to evict, the surplus of the live size is freed");
+        pool.TrimNativeBuffers();
+    }
+
+    [Test]
     public async Task NativePool_TrimReleasesAllDormantBuffers()
     {
         var pool = new ResponseBufferPool(1024 * 1024, managedArraysPerBucket: 4);
@@ -349,6 +413,25 @@ public class ResponseBufferPoolTests
         var default2 = ResponseBufferPool.Default;
 
         await Assert.That(default1).IsSameReferenceAs(default2);
+    }
+
+    [Test]
+    public async Task CreateDefaultSized_UsesDefaultCeilingWithRequestedDepth()
+    {
+        var pool = ResponseBufferPool.CreateDefaultSized(30);
+
+        await Assert.That(pool.MaxArrayLength).IsEqualTo(ResponseBufferPool.DefaultMaxArrayLength);
+        await Assert.That(pool.ManagedArraysPerBucket).IsEqualTo(30);
+        await Assert.That(pool.MaxRetainedNativeBuffers).IsEqualTo(30);
+        await Assert.That(pool).IsNotSameReferenceAs(ResponseBufferPool.Default);
+        await Assert.That(ResponseBufferPool.CreateDefaultSized(30)).IsSameReferenceAs(pool);
+    }
+
+    [Test]
+    public async Task CreateDefaultSized_WithDefaultDepth_ReturnsDefaultInstance()
+    {
+        await Assert.That(ResponseBufferPool.CreateDefaultSized(4))
+            .IsSameReferenceAs(ResponseBufferPool.Default);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using Dekaf.Internal;
 using Dekaf.Networking;
 
 namespace Dekaf.Tests.Unit.Networking;
@@ -458,5 +460,124 @@ public class ResponseBufferPoolTests
         await Assert.That(nativeShallow.MaxRetainedNativeBuffers).IsEqualTo(4);
         await Assert.That(ResponseBufferPool.Create(20 * 1024 * 1024, 16))
             .IsSameReferenceAs(consumer);
+    }
+
+    [Test]
+    public async Task NativePool_RentsMostRecentlyReturnedBufferFirst()
+    {
+        var pool = new ResponseBufferPool(1024 * 1024, managedArraysPerBucket: 4);
+        var first = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        var second = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        var firstAddress = first.Address;
+        var secondAddress = second.Address;
+
+        first.Return();
+        second.Return();
+
+        var warm = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        var cold = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+
+        await Assert.That(warm.Address).IsEqualTo(secondAddress)
+            .Because("the most recently returned frame is the cache-warm one");
+        await Assert.That(cold.Address).IsEqualTo(firstAddress);
+        warm.Return();
+        cold.Return();
+        pool.TrimNativeBuffers();
+    }
+
+    [Test]
+    public async Task NativePool_ConcurrentRentAndReturn_NeverHandsOutOneBufferTwiceOrLosesOne()
+    {
+        const int allowance = 8;
+        const int threads = 8;
+        const int iterations = 20_000;
+        var pool = new ResponseBufferPool(
+            1024 * 1024,
+            managedArraysPerBucket: allowance,
+            maxRetainedNativeBuffers: allowance);
+        var live = new ConcurrentDictionary<IntPtr, byte>();
+        var duplicates = 0;
+        var workers = new Task[threads];
+        for (var t = 0; t < threads; t++)
+        {
+            workers[t] = Task.Run(() =>
+            {
+                for (var i = 0; i < iterations; i++)
+                {
+                    var buffer = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+                    if (!live.TryAdd(buffer.Address, 0))
+                        Interlocked.Increment(ref duplicates);
+                    buffer.GetSpan()[0] = (byte)i;
+                    live.TryRemove(buffer.Address, out _);
+                    buffer.Return();
+                }
+            });
+        }
+
+        await Task.WhenAll(workers);
+
+        await Assert.That(duplicates).IsEqualTo(0)
+            .Because("a retained slot must be popped by exactly one renter");
+        var retained = pool.RetainedNativeBufferCount;
+        await Assert.That(retained).IsLessThanOrEqualTo(allowance);
+        await Assert.That(pool.TrimNativeBuffers()).IsEqualTo(retained)
+            .Because("every counted buffer is reachable from the retained chain");
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task RatchetRetention_RaisesAllowanceAndRetainsBeyondSeedDepth()
+    {
+        var pool = new ResponseBufferPool(
+            1024 * 1024,
+            managedArraysPerBucket: 2,
+            maxRetainedNativeBuffers: 2);
+        var frames = new NativeResponseBuffer[4];
+        for (var i = 0; i < frames.Length; i++)
+            frames[i] = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        for (var i = 0; i < frames.Length; i++)
+            frames[i].Return();
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(2)
+            .Because("the seed-count allowance frees the surplus");
+
+        var managedBeforeRatchet = pool.Pool;
+        var rentedBeforeRatchet = pool.Pool.Rent(8 * 1024);
+        pool.RatchetRetention(4, 4);
+
+        await Assert.That(pool.MaxRetainedNativeBuffers).IsEqualTo(4);
+        await Assert.That(pool.ManagedArraysPerBucket).IsEqualTo(4);
+        await Assert.That(pool.Pool).IsNotSameReferenceAs(managedBeforeRatchet);
+        pool.Pool.Return(rentedBeforeRatchet);
+
+        for (var i = 0; i < frames.Length; i++)
+            frames[i] = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        for (var i = 0; i < frames.Length; i++)
+            frames[i].Return();
+
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(4)
+            .Because("the discovered topology's working set is retained in full");
+        pool.TrimNativeBuffers();
+    }
+
+    [Test]
+    public async Task RatchetRetention_NeverLowersAndCapsAtSizingCeiling()
+    {
+        var pool = new ResponseBufferPool(
+            1024 * 1024,
+            managedArraysPerBucket: 8,
+            maxRetainedNativeBuffers: 8);
+        var managed = pool.Pool;
+
+        pool.RatchetRetention(2, 2);
+
+        await Assert.That(pool.ManagedArraysPerBucket).IsEqualTo(8);
+        await Assert.That(pool.MaxRetainedNativeBuffers).IsEqualTo(8);
+        await Assert.That(pool.Pool).IsSameReferenceAs(managed);
+
+        pool.RatchetRetention(PoolSizing.MaxResponseBuffers, PoolSizing.MaxResponseBuffers * 4);
+
+        await Assert.That(pool.ManagedArraysPerBucket).IsEqualTo(PoolSizing.MaxResponseBuffers);
+        await Assert.That(pool.MaxRetainedNativeBuffers).IsEqualTo(PoolSizing.MaxResponseBuffers)
+            .Because("buckets are allocated with the sizing ceiling's slot count, so the allowance cannot exceed it");
     }
 }

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
@@ -486,7 +486,9 @@ public class ResponseBufferPoolTests
     }
 
     [Test]
-    public async Task NativePool_ConcurrentRentAndReturn_NeverHandsOutOneBufferTwiceOrLosesOne()
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task NativePool_ConcurrentRentAndReturn_NeverHandsOutOneBufferTwiceOrLosesOne(bool varyCapacity)
     {
         const int allowance = 8;
         const int threads = 8;
@@ -504,7 +506,10 @@ public class ResponseBufferPoolTests
             {
                 for (var i = 0; i < iterations; i++)
                 {
-                    var buffer = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+                    var capacity = varyCapacity && (i & 1) != 0
+                        ? 256 * 1024
+                        : ResponseBufferPool.NativeMemoryThresholdBytes;
+                    var buffer = pool.RentNative(capacity);
                     if (!live.TryAdd(buffer.Address, 0))
                         Interlocked.Increment(ref duplicates);
                     buffer.GetSpan()[0] = (byte)i;
@@ -533,10 +538,7 @@ public class ResponseBufferPoolTests
             managedArraysPerBucket: 2,
             maxRetainedNativeBuffers: 2);
         var frames = new NativeResponseBuffer[4];
-        for (var i = 0; i < frames.Length; i++)
-            frames[i] = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
-        for (var i = 0; i < frames.Length; i++)
-            frames[i].Return();
+        RentAndReturnFrames(pool, frames);
         await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(2)
             .Because("the seed-count allowance frees the surplus");
 
@@ -549,14 +551,50 @@ public class ResponseBufferPoolTests
         await Assert.That(pool.Pool).IsNotSameReferenceAs(managedBeforeRatchet);
         pool.Pool.Return(rentedBeforeRatchet);
 
-        for (var i = 0; i < frames.Length; i++)
-            frames[i] = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
-        for (var i = 0; i < frames.Length; i++)
-            frames[i].Return();
+        RentAndReturnFrames(pool, frames);
 
         await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(4)
             .Because("the discovered topology's working set is retained in full");
         pool.TrimNativeBuffers();
+    }
+
+    private static void RentAndReturnFrames(ResponseBufferPool pool, NativeResponseBuffer[] frames)
+    {
+        for (var i = 0; i < frames.Length; i++)
+            frames[i] = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        for (var i = 0; i < frames.Length; i++)
+            frames[i].Return();
+    }
+
+    [Test]
+    public async Task ReturnNative_FirstCapacity_DoesNotAllocateBucketStorage()
+    {
+        var pool = new ResponseBufferPool(1024 * 1024);
+        var frame = pool.RentNative(128 * 1024);
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        frame.Return();
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        pool.TrimNativeBuffers();
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task NativePool_SurplusReturns_AfterCapacityEmpties_PreserveBoundAndReuse()
+    {
+        var pool = new ResponseBufferPool(1024 * 1024, maxRetainedNativeBuffers: 2);
+        var old = pool.RentNative(128 * 1024);
+        old.Return();
+        old = pool.RentNative(128 * 1024); // Clears the empty capacity hint.
+        var frames = new NativeResponseBuffer[4];
+        for (var i = 0; i < frames.Length; i++)
+            frames[i] = pool.RentNative(256 * 1024);
+        for (var i = 0; i < frames.Length; i++)
+            frames[i].Return();
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(2);
+        old.Return(); // Evicts one dormant 256 KB frame.
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(2);
+        await Assert.That(pool.TrimNativeBuffers()).IsEqualTo(2);
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(0);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerResponseBufferSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerResponseBufferSizingTests.cs
@@ -1,0 +1,39 @@
+using Dekaf.Internal;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public sealed class ProducerResponseBufferSizingTests
+{
+    [Test]
+    public async Task ProducerInfrastructure_SizesResponsePoolForPeakInFlightWorkingSet()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092", "localhost:9093"],
+            ConnectionsPerBroker = 1,
+            MaxConnectionsPerBroker = 3,
+            MaxInFlightRequestsPerConnection = 5
+        };
+        await using var producer = new KafkaProducer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+
+        var connectionPool = AccumulatorTestHelpers.GetPrivateField<ConnectionPool>(producer, "_connectionPool");
+        var responsePool = AccumulatorTestHelpers.GetPrivateField<ResponseBufferPool>(connectionPool, "_responseBufferPool");
+
+        var expected = PoolSizing.ForSharedPools(
+            brokerCount: options.BootstrapServers.Count,
+            connectionsPerBroker: options.ConnectionsPerBroker,
+            maxInFlightRequestsPerConnection: options.MaxInFlightRequestsPerConnection,
+            batchSize: options.BatchSize,
+            maxConnectionsPerBroker: options.MaxConnectionsPerBroker).ResponseBuffersPerBucket;
+        await Assert.That(responsePool.ManagedArraysPerBucket).IsEqualTo(expected);
+        await Assert.That(responsePool.MaxRetainedNativeBuffers).IsEqualTo(expected);
+        await Assert.That(responsePool.MaxArrayLength).IsEqualTo(ResponseBufferPool.DefaultMaxArrayLength);
+        await Assert.That(responsePool).IsNotSameReferenceAs(ResponseBufferPool.Default);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerResponseBufferSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerResponseBufferSizingTests.cs
@@ -1,4 +1,5 @@
 using Dekaf.Internal;
+using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Producer;
 using Dekaf.Serialization;
@@ -35,5 +36,52 @@ public sealed class ProducerResponseBufferSizingTests
         await Assert.That(responsePool.MaxRetainedNativeBuffers).IsEqualTo(expected);
         await Assert.That(responsePool.MaxArrayLength).IsEqualTo(ResponseBufferPool.DefaultMaxArrayLength);
         await Assert.That(responsePool).IsNotSameReferenceAs(ResponseBufferPool.Default);
+    }
+
+    [Test]
+    public async Task ProducerInfrastructure_RatchetsResponsePoolWhenMetadataDiscoversMoreBrokers()
+    {
+        // One seed endpoint for a larger cluster: the pool is sized from the seed count and
+        // must grow to the discovered topology's working set, never shrink.
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ConnectionsPerBroker = 1,
+            MaxConnectionsPerBroker = 9,
+            MaxInFlightRequestsPerConnection = 5
+        };
+        await using var producer = new KafkaProducer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+
+        var connectionPool = AccumulatorTestHelpers.GetPrivateField<ConnectionPool>(producer, "_connectionPool");
+        var responsePool = AccumulatorTestHelpers.GetPrivateField<ResponseBufferPool>(connectionPool, "_responseBufferPool");
+        var metadataManager = AccumulatorTestHelpers.GetPrivateField<MetadataManager>(producer, "_metadataManager");
+        var seeded = PoolSizing.ForSharedPools(
+            brokerCount: 1,
+            connectionsPerBroker: options.ConnectionsPerBroker,
+            maxInFlightRequestsPerConnection: options.MaxInFlightRequestsPerConnection,
+            batchSize: options.BatchSize,
+            maxConnectionsPerBroker: options.MaxConnectionsPerBroker).ResponseBuffersPerBucket;
+        await Assert.That(responsePool.MaxRetainedNativeBuffers).IsEqualTo(seeded);
+
+        const int discoveredBrokers = 10;
+        metadataManager.NotifyBrokerCountDiscovered(discoveredBrokers);
+
+        var expected = PoolSizing.ForSharedPools(
+            brokerCount: discoveredBrokers,
+            connectionsPerBroker: options.ConnectionsPerBroker,
+            maxInFlightRequestsPerConnection: options.MaxInFlightRequestsPerConnection,
+            batchSize: options.BatchSize,
+            maxConnectionsPerBroker: options.MaxConnectionsPerBroker).ResponseBuffersPerBucket;
+        await Assert.That(expected).IsGreaterThan(seeded);
+        await Assert.That(responsePool.ManagedArraysPerBucket).IsEqualTo(expected);
+        await Assert.That(responsePool.MaxRetainedNativeBuffers).IsEqualTo(expected);
+
+        metadataManager.NotifyBrokerCountDiscovered(1);
+
+        await Assert.That(responsePool.MaxRetainedNativeBuffers).IsEqualTo(expected)
+            .Because("a smaller metadata response never shrinks the pool");
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseBufferPoolBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseBufferPoolBenchmarks.cs
@@ -25,6 +25,9 @@ public class ResponseBufferOverflowBenchmarks
             _pool.ReturnNative(Marshal.AllocHGlobal(FrameBytes), FrameBytes);
     }
 
+    [Benchmark(Baseline = true)]
+    public void AllocateAndFree() => Marshal.FreeHGlobal(Marshal.AllocHGlobal(FrameBytes));
+
     [Benchmark]
     public void SurplusReturn() => _pool.ReturnNative(Marshal.AllocHGlobal(FrameBytes), FrameBytes);
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseBufferPoolBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseBufferPoolBenchmarks.cs
@@ -15,19 +15,24 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 public class ResponseBufferPoolBenchmarks
 {
     private const int LiveResponses = 16;
+    private const int CeilingWaveResponses = 256;
     private const int FetchFrameBytes = 1024 * 1024;
     private const int CaughtUpFrameBytes = 256 * 1024;
+    private const int CeilingWaveFrameBytes = 128 * 1024;
     private const int ProduceFrameBytes = 8 * 1024;
     private const int PageBytes = 4096;
 
-    // 4 = ResponseBufferPool.Default; 20 = PoolSizing.ForConsumerResponseBuffers(1 broker, depth 3, 4 connections).
-    [Params(4, 20)]
+    // 4 = ResponseBufferPool.Default; 20 = PoolSizing.ForConsumerResponseBuffers(1 broker, depth 3, 4 connections);
+    // 256 = PoolSizing.MaxResponseBuffers, the retention ceiling every native bucket allocates slots for.
+    [Params(4, 20, 256)]
     public int Depth { get; set; }
 
     private ResponseBufferPool _pool = null!;
     private ResponseBufferPool _grownPool = null!;
+    private ResponseBufferPool _ceilingWavePool = null!;
     private NativeResponseBuffer[] _nativeLive = null!;
     private NativeResponseBuffer[] _grownLive = null!;
+    private NativeResponseBuffer[] _ceilingWaveLive = null!;
     private byte[][] _managedLive = null!;
 
     [GlobalSetup]
@@ -55,6 +60,13 @@ public class ResponseBufferPoolBenchmarks
             _grownLive[i].Return();
         for (var i = 0; i < LiveResponses; i++)
             _grownLive[i] = _grownPool.RentNative(FetchFrameBytes);
+
+        // A wave the size of the retention ceiling, so a covering pool's bucket sweeps its
+        // whole slot range every invocation.
+        _ceilingWavePool = CreatePool();
+        _ceilingWaveLive = new NativeResponseBuffer[CeilingWaveResponses];
+        for (var i = 0; i < CeilingWaveResponses; i++)
+            _ceilingWaveLive[i] = _ceilingWavePool.RentNative(CeilingWaveFrameBytes);
     }
 
     [GlobalCleanup]
@@ -67,8 +79,12 @@ public class ResponseBufferPoolBenchmarks
             _pool.Pool.Return(_managedLive[i]);
         }
 
+        for (var i = 0; i < CeilingWaveResponses; i++)
+            _ceilingWaveLive[i].Return();
+
         _pool.TrimNativeBuffers();
         _grownPool.TrimNativeBuffers();
+        _ceilingWavePool.TrimNativeBuffers();
     }
 
     /// <summary>
@@ -84,14 +100,23 @@ public class ResponseBufferPoolBenchmarks
 
     /// <summary>Fetch-sized frames through the native path.</summary>
     [Benchmark(OperationsPerInvoke = LiveResponses)]
-    public void NativeFetchFrames_1MB() => ReturnAndRefillWave(_pool, _nativeLive);
+    public void NativeFetchFrames_1MB() => ReturnAndRefillWave(_pool, _nativeLive, FetchFrameBytes);
 
     /// <summary>
     /// Same wave on a pool whose allowance is partly held by dormant frames of the previous,
     /// smaller capacity: shows whether the retained set follows the live frame size.
     /// </summary>
     [Benchmark(OperationsPerInvoke = LiveResponses)]
-    public void NativeFetchFrames_1MB_AfterFrameSizeGrowth() => ReturnAndRefillWave(_grownPool, _grownLive);
+    public void NativeFetchFrames_1MB_AfterFrameSizeGrowth() => ReturnAndRefillWave(_grownPool, _grownLive, FetchFrameBytes);
+
+    /// <summary>
+    /// A wave the size of the retention ceiling (256 frames) released and refilled. On a
+    /// covering pool the bucket's occupancy sweeps its entire slot range twice per invocation,
+    /// which is where a slot scan degrades to O(depth) per frame; the per-frame time here
+    /// should match the 16-frame rows at the same depth.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = CeilingWaveResponses)]
+    public void NativeCeilingWave_128KB() => ReturnAndRefillWave(_ceilingWavePool, _ceilingWaveLive, CeilingWaveFrameBytes);
 
     /// <summary>Produce-response-sized frames through the managed array pool.</summary>
     [Benchmark(OperationsPerInvoke = LiveResponses)]
@@ -118,14 +143,14 @@ public class ResponseBufferPoolBenchmarks
     /// touched once, as a socket receive would, so a freshly allocated buffer pays its
     /// page faults here.
     /// </summary>
-    private static void ReturnAndRefillWave(ResponseBufferPool pool, NativeResponseBuffer[] live)
+    private static void ReturnAndRefillWave(ResponseBufferPool pool, NativeResponseBuffer[] live, int frameBytes)
     {
         for (var i = 0; i < live.Length; i++)
             live[i].Return();
 
         for (var i = 0; i < live.Length; i++)
         {
-            var buffer = pool.RentNative(FetchFrameBytes);
+            var buffer = pool.RentNative(frameBytes);
             TouchPages(buffer.GetSpan());
             live[i] = buffer;
         }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseBufferPoolBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseBufferPoolBenchmarks.cs
@@ -1,0 +1,139 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Networking;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures <see cref="ResponseBufferPool"/> rent/return when a wave of live response frames
+/// (prefetch depth x brokers x connections) is released by the application and immediately
+/// refilled by the receive loops. A pool shallower than the wave frees the surplus on return
+/// and re-allocates it on rent: for native frames that is <c>AllocHGlobal</c>/<c>FreeHGlobal</c>
+/// plus first-touch page faults (visible as time), for managed frames a fresh array (visible
+/// in <c>Allocated</c>). See the <see cref="ResponseBufferPool"/> remarks for the sizing rule.
+/// </summary>
+[MemoryDiagnoser]
+public class ResponseBufferPoolBenchmarks
+{
+    private const int LiveResponses = 16;
+    private const int FetchFrameBytes = 1024 * 1024;
+    private const int CaughtUpFrameBytes = 256 * 1024;
+    private const int ProduceFrameBytes = 8 * 1024;
+    private const int PageBytes = 4096;
+
+    // 4 = ResponseBufferPool.Default; 20 = PoolSizing.ForConsumerResponseBuffers(1 broker, depth 3, 4 connections).
+    [Params(4, 20)]
+    public int Depth { get; set; }
+
+    private ResponseBufferPool _pool = null!;
+    private ResponseBufferPool _grownPool = null!;
+    private NativeResponseBuffer[] _nativeLive = null!;
+    private NativeResponseBuffer[] _grownLive = null!;
+    private byte[][] _managedLive = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Direct construction keeps benchmark pools out of the process-wide shared-pool cache
+        // and disables the once-per-second memory-pressure sample so only pool mechanics are timed.
+        _pool = CreatePool();
+        _nativeLive = new NativeResponseBuffer[LiveResponses];
+        _managedLive = new byte[LiveResponses][];
+        for (var i = 0; i < LiveResponses; i++)
+        {
+            _nativeLive[i] = _pool.RentNative(FetchFrameBytes);
+            _managedLive[i] = _pool.Pool.Rent(ProduceFrameBytes);
+        }
+
+        // A consumer that was caught up (256 KB frames) and then fell behind (1 MB frames):
+        // the caught-up frames sit dormant in their own capacity bucket while the live
+        // working set has moved to the larger one.
+        _grownPool = CreatePool();
+        _grownLive = new NativeResponseBuffer[LiveResponses];
+        for (var i = 0; i < LiveResponses; i++)
+            _grownLive[i] = _grownPool.RentNative(CaughtUpFrameBytes);
+        for (var i = 0; i < LiveResponses; i++)
+            _grownLive[i].Return();
+        for (var i = 0; i < LiveResponses; i++)
+            _grownLive[i] = _grownPool.RentNative(FetchFrameBytes);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        for (var i = 0; i < LiveResponses; i++)
+        {
+            _nativeLive[i].Return();
+            _grownLive[i].Return();
+            _pool.Pool.Return(_managedLive[i]);
+        }
+
+        _pool.TrimNativeBuffers();
+        _grownPool.TrimNativeBuffers();
+    }
+
+    /// <summary>
+    /// Page-touch cost alone on frames that stay live, so the Ratio column of the other
+    /// native rows isolates what the pool adds.
+    /// </summary>
+    [Benchmark(Baseline = true, OperationsPerInvoke = LiveResponses)]
+    public void TouchLiveFrames_1MB()
+    {
+        for (var i = 0; i < LiveResponses; i++)
+            TouchPages(_nativeLive[i].GetSpan());
+    }
+
+    /// <summary>Fetch-sized frames through the native path.</summary>
+    [Benchmark(OperationsPerInvoke = LiveResponses)]
+    public void NativeFetchFrames_1MB() => ReturnAndRefillWave(_pool, _nativeLive);
+
+    /// <summary>
+    /// Same wave on a pool whose allowance is partly held by dormant frames of the previous,
+    /// smaller capacity: shows whether the retained set follows the live frame size.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = LiveResponses)]
+    public void NativeFetchFrames_1MB_AfterFrameSizeGrowth() => ReturnAndRefillWave(_grownPool, _grownLive);
+
+    /// <summary>Produce-response-sized frames through the managed array pool.</summary>
+    [Benchmark(OperationsPerInvoke = LiveResponses)]
+    public void ManagedProduceFrames_8KB()
+    {
+        for (var i = 0; i < LiveResponses; i++)
+            _pool.Pool.Return(_managedLive[i]);
+
+        for (var i = 0; i < LiveResponses; i++)
+        {
+            var array = _pool.Pool.Rent(ProduceFrameBytes);
+            array[0] = 1;
+            _managedLive[i] = array;
+        }
+    }
+
+    private ResponseBufferPool CreatePool() => new(
+        ResponseBufferPool.DefaultMaxArrayLength,
+        managedArraysPerBucket: Depth,
+        maxRetainedNativeBuffers: Depth);
+
+    /// <summary>
+    /// Returns every live frame, then re-rents the wave. Each rented frame's pages are
+    /// touched once, as a socket receive would, so a freshly allocated buffer pays its
+    /// page faults here.
+    /// </summary>
+    private static void ReturnAndRefillWave(ResponseBufferPool pool, NativeResponseBuffer[] live)
+    {
+        for (var i = 0; i < live.Length; i++)
+            live[i].Return();
+
+        for (var i = 0; i < live.Length; i++)
+        {
+            var buffer = pool.RentNative(FetchFrameBytes);
+            TouchPages(buffer.GetSpan());
+            live[i] = buffer;
+        }
+    }
+
+    private static void TouchPages(Span<byte> span)
+    {
+        for (var offset = 0; offset < span.Length; offset += PageBytes)
+            span[offset] = 1;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseBufferPoolBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseBufferPoolBenchmarks.cs
@@ -1,7 +1,36 @@
+using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using Dekaf.Networking;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Surplus native returns above the 256-buffer retention ceiling. Keep the retained set
+/// full and allocate the incoming native pointer directly, excluding the separate
+/// NativeResponseBuffer wrapper pool's own 256-object ceiling from this measurement.
+/// </summary>
+[MemoryDiagnoser]
+public class ResponseBufferOverflowBenchmarks
+{
+    private const int RetainedBuffers = 256;
+    private const int FrameBytes = 128 * 1024;
+    private ResponseBufferPool _pool = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _pool = new ResponseBufferPool(ResponseBufferPool.DefaultMaxArrayLength,
+            managedArraysPerBucket: 256, maxRetainedNativeBuffers: 256);
+        for (var i = 0; i < RetainedBuffers; i++)
+            _pool.ReturnNative(Marshal.AllocHGlobal(FrameBytes), FrameBytes);
+    }
+
+    [Benchmark]
+    public void SurplusReturn() => _pool.ReturnNative(Marshal.AllocHGlobal(FrameBytes), FrameBytes);
+
+    [GlobalCleanup]
+    public void Cleanup() => _pool.TrimNativeBuffers();
+}
 
 /// <summary>
 /// Measures <see cref="ResponseBufferPool"/> rent/return when a wave of live response frames


### PR DESCRIPTION
Response-buffer retention was too shallow for shared-client consumers and standalone producers. More live responses than retained buffers caused repeated native allocation/page faults or managed array allocation; a frame-size increase could also leave the retention allowance occupied by dormant buffers of the old size.

This PR sizes retention from peak connection/in-flight or prefetch topology, and ratchets it upward when metadata discovers more brokers. Native overflow returns can evict one dormant buffer of another capacity so the retained set follows the live frame size. Managed pool growth replaces the underlying configurable ArrayPool; outstanding arrays return into the current pool.

Native buffers use 31 fixed capacity buckets, selected by log2(capacity). Each bucket has preallocated slots and versioned index stacks for retained/free slots; an availability bitmask selects an eviction candidate. Ordinary rent/return and overflow selection do not scan the buckets or allocate stack nodes. Trimming still walks buckets, and high-memory-pressure handling still releases retained native memory. Capacities above 1 GiB are not retained. There is no public API change.

Dormant native memory remains bounded by the global retention count times the largest retained capacity; managed retention is bounded per size bucket. Increasing topology limits can retain more dormant memory. Concurrent return/rent/trim accounting, slot reuse and monotonic growth are the main correctness risks.

Current head: `3d12aeef9dd45e196c7700230801ed7b821b17bc`.

**Final recommendation: close this implementation.** The [warmed raw-consumer A/B/A comparison](https://github.com/thomhurst/Dekaf/pull/2992#issuecomment-5548476435) reports REGRESSION: allocation 0.098715 B/message versus main 0.095562/0.094488, +3.883% versus the bracketing mean and above all three same-VM main controls. CPU is inconclusive under control drift; candidate and one control also breach the separate throughput-slope limit. Full metrics, uncertainty, exact SHAs and configuration are in the linked verdict.

Current PR CI passed. Every new comparison segment completed with zero errors, matching message/latency sample counts and validated partition offsets; only the performance gate failed. The [isolated frame-growth benefit](https://github.com/thomhurst/Dekaf/pull/2992#issuecomment-5547269977) remains large: about 238-280 us/frame -> 1.40 us/frame, 8 -> 0 B/frame. The extra surplus-return candidate was rejected and is absent from this PR.

The new end-to-end lane uses standalone consumers as a regression control; it does not measure the primary shared-client depth-four fix. A shared-client harness was prepared and compiled but not dispatched: a gain there cannot justify the failing standalone control without approval of that trade. The allocation source needs isolation before a future redesign. This decision rejects the current implementation, not topology-sized pooling in general.

No further paid run or merge is planned. Earlier experiments and all raw results remain linked in the PR history.
