### PR TITLE
perf(consumer): re-issue fetches from the completing broker task

### DIFF
--- a/src/Dekaf/Consumer/AdaptiveFetchSizer.cs
+++ b/src/Dekaf/Consumer/AdaptiveFetchSizer.cs
@@ -37,7 +37,9 @@ internal sealed class AdaptiveFetchSizer
     private int _consecutiveGrowSignals;
     private int _consecutiveShrinkSignals;
     private long _lastFetchStartTimestamp;
-    private long _lastFetchEndTimestamp;
+    // Published as one atomic value so a fetch latency is never assembled from the start of one
+    // fetch and the end of another when several broker tasks record concurrently.
+    private long _lastFetchDurationTicks;
 
     /// <summary>
     /// The current adaptive MaxPartitionFetchBytes value.
@@ -111,12 +113,27 @@ internal sealed class AdaptiveFetchSizer
     }
 
     /// <summary>
-    /// Records the completion of a fetch operation. Call after the fetch response is received.
+    /// Records the completion of the fetch started by <see cref="RecordFetchStart"/>.
+    /// Call after the fetch response is received.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void RecordFetchEnd()
     {
-        _lastFetchEndTimestamp = Stopwatch.GetTimestamp();
+        if (_lastFetchStartTimestamp != 0)
+            RecordFetchCompleted(_lastFetchStartTimestamp);
+    }
+
+    /// <summary>
+    /// Publishes the latency of a fetch that started at <paramref name="fetchStartTimestamp"/>
+    /// (a <see cref="Stopwatch.GetTimestamp"/> value). Safe to call from concurrent broker
+    /// prefetch tasks; the most recently completed fetch wins.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void RecordFetchCompleted(long fetchStartTimestamp)
+    {
+        var elapsedTicks = Stopwatch.GetTimestamp() - fetchStartTimestamp;
+        if (elapsedTicks > 0)
+            Volatile.Write(ref _lastFetchDurationTicks, elapsedTicks);
     }
 
     /// <summary>
@@ -127,13 +144,11 @@ internal sealed class AdaptiveFetchSizer
     /// <param name="processingDuration">Time spent processing the fetched records.</param>
     public void ReportProcessingComplete(TimeSpan processingDuration)
     {
-        if (_lastFetchStartTimestamp == 0 || _lastFetchEndTimestamp == 0)
+        var fetchDurationTicks = Volatile.Read(ref _lastFetchDurationTicks);
+        if (fetchDurationTicks <= 0)
             return;
 
-        var fetchDuration = Stopwatch.GetElapsedTime(_lastFetchStartTimestamp, _lastFetchEndTimestamp);
-
-        if (fetchDuration <= TimeSpan.Zero)
-            return;
+        var fetchDuration = Stopwatch.GetElapsedTime(0, fetchDurationTicks);
 
         var ratio = processingDuration.TotalSeconds / fetchDuration.TotalSeconds;
         EvaluateAndAdjust(ratio);

--- a/src/Dekaf/Consumer/BrokerPrefetchScheduler.cs
+++ b/src/Dekaf/Consumer/BrokerPrefetchScheduler.cs
@@ -1,11 +1,49 @@
+using Dekaf.Internal;
+
 namespace Dekaf.Consumer;
 
-internal sealed class BrokerPrefetchScheduler
+/// <summary>
+/// Tracks the single in-flight prefetch task per <c>(broker, connection)</c> key on behalf of
+/// the central prefetch loop and wakes that loop when any task returns.
+/// </summary>
+/// <remarks>
+/// <para><b>Loop ownership.</b> The central prefetch loop (<c>KafkaConsumer.PrefetchLoopAsync</c>)
+/// owns everything that decides <em>which</em> partitions are fetched from <em>where</em>:
+/// assignment changes and rebalances, pause/resume, seeks and fetch-buffer epochs, connection
+/// routing width and its transitions, fetch-session cleanup for keys that left the plan, error
+/// backoff, and prefetch-memory admission. It starts exactly one task for every planned key
+/// that has no running task.</para>
+/// <para>Each task owns its connection for as long as the plan it was started with stays valid.
+/// After publishing a response it re-validates that plan with a handful of volatile reads
+/// (<c>KafkaConsumer.CanReissueBrokerPrefetch</c>) and, when nothing changed, immediately
+/// issues the next fetch on the same leased connection without returning here. It hands
+/// control back to the loop only when that validation fails, when a response carries anything
+/// the loop must react to (session or partition errors, epoch resets, topic identity or
+/// preferred-replica changes, stale partitions), when memory admission is exhausted, or when it
+/// is cancelled. KIP-227 semantics hold because a key never has more than one task and a task
+/// never has more than one request in flight on its fetch session.</para>
+/// <para><b>Wake-up.</b> Completion of any task fires one reusable
+/// <see cref="AsyncAutoResetSignal"/>; <see cref="WaitForAnyAsync"/> awaits that signal instead
+/// of snapshotting the in-flight tasks into a <c>Task.WhenAny</c>, so waking the loop allocates
+/// nothing after the first wait. The signal is bound to the first cancellation token it waits
+/// with, which is the prefetch loop's lifetime token.</para>
+/// <para>Apart from the completion callback, every member is called only by the loop that owns
+/// this scheduler, so no other synchronization is needed.</para>
+/// </remarks>
+internal sealed class BrokerPrefetchScheduler : IDisposable
 {
     private readonly Dictionary<(int BrokerId, int ConnectionIndex), Task> _inFlight = [];
     private readonly List<KeyValuePair<(int BrokerId, int ConnectionIndex), Task>> _completed = [];
-    // Populated only while the scheduler has remained single-task since becoming non-empty.
-    private Task? _singleInFlightTask;
+    // A completed task signals from its own continuation and has nothing left to do, so the loop
+    // resumes inline on that thread instead of paying a thread-pool hop per wake, exactly as the
+    // former Task.WhenAny/WaitAsync promises resumed it.
+    private readonly AsyncAutoResetSignal _completionSignal = new(inlineSignalContinuations: true);
+    private readonly Action _signalCompletion;
+
+    public BrokerPrefetchScheduler()
+    {
+        _signalCompletion = _completionSignal.Signal;
+    }
 
     public int InFlightCount => _inFlight.Count;
 
@@ -20,7 +58,10 @@ internal sealed class BrokerPrefetchScheduler
 
         var task = taskFactory();
         _inFlight.Add(key, task);
-        _singleInFlightTask = _inFlight.Count == 1 ? task : null;
+        // Completion only wakes the loop; the task's result and any exception are harvested
+        // by DrainCompletedAsync. A first continuation on a task stores the delegate directly,
+        // so this registration does not allocate.
+        task.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(_signalCompletion);
         return true;
     }
 
@@ -49,27 +90,35 @@ internal sealed class BrokerPrefetchScheduler
         }
     }
 
+    /// <summary>
+    /// Returns once at least one tracked task has completed. Returns immediately when a
+    /// completed task is already waiting to be drained; otherwise awaits the completion signal.
+    /// A signal left over from a task that was drained before this wait is re-checked against
+    /// the tracked set, so it never produces a wake-up with nothing to drain.
+    /// </summary>
     public async ValueTask WaitForAnyAsync(CancellationToken cancellationToken)
     {
         if (_inFlight.Count == 0)
             return;
 
-        if (_inFlight.Count == 1 && _singleInFlightTask is { } task)
+        _completionSignal.RegisterShutdownToken(cancellationToken);
+
+        while (!HasCompletedInFlight())
         {
-            if (!task.IsCompleted)
-            {
-                var waitTask = task.WaitAsync(cancellationToken);
-                await waitTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+            cancellationToken.ThrowIfCancellationRequested();
+            await _completionSignal.WaitAsync(Timeout.Infinite).ConfigureAwait(false);
+        }
+    }
 
-                if (waitTask.IsCanceled && cancellationToken.IsCancellationRequested)
-                    cancellationToken.ThrowIfCancellationRequested();
-            }
-
-            return;
+    private bool HasCompletedInFlight()
+    {
+        foreach (var task in _inFlight.Values)
+        {
+            if (task.IsCompleted)
+                return true;
         }
 
-        var tasks = _inFlight.Values.ToArray();
-        await Task.WhenAny(tasks).WaitAsync(cancellationToken).ConfigureAwait(false);
+        return false;
     }
 
     public async ValueTask<Exception?> DrainAllSafelyAsync(
@@ -81,7 +130,6 @@ internal sealed class BrokerPrefetchScheduler
 
         var tasks = _inFlight.Values.ToArray();
         _inFlight.Clear();
-        _singleInFlightTask = null;
         Exception? firstFailure = null;
 
         for (var i = 0; i < tasks.Length; i++)
@@ -103,4 +151,6 @@ internal sealed class BrokerPrefetchScheduler
 
         return firstFailure;
     }
+
+    public void Dispose() => _completionSignal.Dispose();
 }

--- a/src/Dekaf/Consumer/BrokerPrefetchScheduler.cs
+++ b/src/Dekaf/Consumer/BrokerPrefetchScheduler.cs
@@ -39,10 +39,15 @@ internal sealed class BrokerPrefetchScheduler : IDisposable
     // former Task.WhenAny/WaitAsync promises resumed it.
     private readonly AsyncAutoResetSignal _completionSignal = new(inlineSignalContinuations: true);
     private readonly Action _signalCompletion;
+    // Only callbacks share the completion counter; removals belong to the loop, so
+    // draining needs no atomic write. Removals may lead queued callbacks temporarily:
+    // those callbacks repay the difference instead of waking a reused key spuriously.
+    private long _completedTaskCount;
+    private long _removedTaskCount;
 
     public BrokerPrefetchScheduler()
     {
-        _signalCompletion = _completionSignal.Signal;
+        _signalCompletion = OnTaskCompleted;
     }
 
     public int InFlightCount => _inFlight.Count;
@@ -61,8 +66,17 @@ internal sealed class BrokerPrefetchScheduler : IDisposable
         // Completion only wakes the loop; the task's result and any exception are harvested
         // by DrainCompletedAsync. A first continuation on a task stores the delegate directly,
         // so this registration does not allocate.
-        task.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(_signalCompletion);
+        if (task.IsCompleted)
+            Interlocked.Increment(ref _completedTaskCount);
+        else
+            task.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(_signalCompletion);
         return true;
+    }
+
+    private void OnTaskCompleted()
+    {
+        Interlocked.Increment(ref _completedTaskCount);
+        _completionSignal.Signal();
     }
 
     public async ValueTask<int> DrainCompletedAsync()
@@ -79,7 +93,10 @@ internal sealed class BrokerPrefetchScheduler : IDisposable
             {
                 var (key, task) = _completed[i];
                 if (_inFlight.Remove(key))
+                {
+                    _removedTaskCount++;
                     await task.ConfigureAwait(false);
+                }
             }
 
             return _completed.Count;
@@ -93,8 +110,8 @@ internal sealed class BrokerPrefetchScheduler : IDisposable
     /// <summary>
     /// Returns once at least one tracked task has completed. Returns immediately when a
     /// completed task is already waiting to be drained; otherwise awaits the completion signal.
-    /// A signal left over from a task that was drained before this wait is re-checked against
-    /// the tracked set, so it never produces a wake-up with nothing to drain.
+    /// A signal left over from a drained task is checked against the completion balance,
+    /// so it never produces a wake-up with nothing to drain. The check is O(1).
     /// </summary>
     public async ValueTask WaitForAnyAsync(CancellationToken cancellationToken)
     {
@@ -103,22 +120,11 @@ internal sealed class BrokerPrefetchScheduler : IDisposable
 
         _completionSignal.RegisterShutdownToken(cancellationToken);
 
-        while (!HasCompletedInFlight())
+        while (Volatile.Read(ref _completedTaskCount) <= _removedTaskCount)
         {
             cancellationToken.ThrowIfCancellationRequested();
             await _completionSignal.WaitAsync(Timeout.Infinite).ConfigureAwait(false);
         }
-    }
-
-    private bool HasCompletedInFlight()
-    {
-        foreach (var task in _inFlight.Values)
-        {
-            if (task.IsCompleted)
-                return true;
-        }
-
-        return false;
     }
 
     public async ValueTask<Exception?> DrainAllSafelyAsync(
@@ -130,6 +136,7 @@ internal sealed class BrokerPrefetchScheduler : IDisposable
 
         var tasks = _inFlight.Values.ToArray();
         _inFlight.Clear();
+        _removedTaskCount += tasks.Length;
         Exception? firstFailure = null;
 
         for (var i = 0; i < tasks.Length; i++)

--- a/src/Dekaf/Consumer/BrokerPrefetchScheduler.cs
+++ b/src/Dekaf/Consumer/BrokerPrefetchScheduler.cs
@@ -57,11 +57,17 @@ internal sealed class BrokerPrefetchScheduler : IDisposable
     public bool TryStart(
         (int BrokerId, int ConnectionIndex) key,
         Func<Task> taskFactory)
+        => TryStart(key, taskFactory, static factory => factory());
+
+    public bool TryStart<TState>(
+        (int BrokerId, int ConnectionIndex) key,
+        TState state,
+        Func<TState, Task> taskFactory)
     {
         if (_inFlight.ContainsKey(key))
             return false;
 
-        var task = taskFactory();
+        var task = taskFactory(state);
         _inFlight.Add(key, task);
         // Completion only wakes the loop; the task's result and any exception are harvested
         // by DrainCompletedAsync. A first continuation on a task stores the delegate directly,

--- a/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
+++ b/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
@@ -59,34 +59,104 @@ internal sealed class ConsumerConnectionScaler : IDisposable
 
     /// <summary>
     /// Reports current pipeline utilization. Call this each time a fetch completes or is dispatched.
+    /// The utilization windows are read and cleared by <see cref="MaybeScale"/> under
+    /// <see cref="_operationLock"/>, and broker prefetch tasks report concurrently with the loop
+    /// (see <see cref="ReportFetchReissue"/>), so the update takes the same lock. This runs once
+    /// per loop iteration or per fetch, never per message.
     /// </summary>
     public void ReportPipelineUtilization(int inFlightCount, int pipelineDepth)
     {
         var now = GetTimestamp();
         var isSaturated = inFlightCount >= pipelineDepth;
 
-        if (isSaturated)
-        {
-            if (_saturationStartTimestamp == 0)
-                _saturationStartTimestamp = now;
-        }
-        else if (_saturationStartTimestamp != 0)
-        {
-            _saturationStartTimestamp = 0;
-        }
-
         // Integer comparison equivalent to: (inFlightCount / pipelineDepth) < 0.3
         var isLowUtilization = pipelineDepth > 0 && inFlightCount * 10 < pipelineDepth * 3;
 
-        if (isLowUtilization)
+        lock (_operationLock)
         {
-            if (_lowUtilizationStartTimestamp == 0)
-                _lowUtilizationStartTimestamp = now;
+            if (isSaturated)
+            {
+                if (_saturationStartTimestamp == 0)
+                    _saturationStartTimestamp = now;
+            }
+            else if (_saturationStartTimestamp != 0)
+            {
+                _saturationStartTimestamp = 0;
+            }
+
+            if (isLowUtilization)
+            {
+                if (_lowUtilizationStartTimestamp == 0)
+                    _lowUtilizationStartTimestamp = now;
+            }
+            else if (_lowUtilizationStartTimestamp != 0)
+            {
+                _lowUtilizationStartTimestamp = 0;
+            }
         }
-        else if (_lowUtilizationStartTimestamp != 0)
+    }
+
+    /// <summary>
+    /// Reports, from a broker prefetch task about to re-issue a fetch on its own lease, the
+    /// completion the loop would otherwise have observed for that key. The loop-owned path
+    /// restarts the saturation window at every completion (re-dispatching the key reports its
+    /// slot idle, and the next backlogged wait reports it busy again), so that window has always
+    /// measured a single fetch; this mirrors it exactly, and keeps the low-utilization window
+    /// clear because the slot is busy again immediately.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> when <see cref="MaybeScale"/> would act now. The caller must then
+    /// hand control back to the loop, which owns <see cref="MaybeScale"/>, instead of
+    /// re-issuing; the windows are left intact for it. Once per fetch, never per message.
+    /// </returns>
+    public bool ReportFetchReissue()
+    {
+        var now = GetTimestamp();
+        lock (_operationLock)
         {
+            if (SelectScaleDirectionLocked(now) != ScaleDirection.None)
+                return true;
+
+            _saturationStartTimestamp = now;
             _lowUtilizationStartTimestamp = 0;
+            return false;
         }
+    }
+
+    private enum ScaleDirection
+    {
+        None,
+        Up,
+        Down
+    }
+
+    /// <summary>
+    /// The decision <see cref="MaybeScale"/> would take at <paramref name="now"/>, without
+    /// applying it. Must be called under <see cref="_operationLock"/>.
+    /// </summary>
+    private ScaleDirection SelectScaleDirectionLocked(long now)
+    {
+        if (_stopping != 0)
+            return ScaleDirection.None;
+
+        if (_lastScaleTimestamp != 0 && Stopwatch.GetElapsedTime(_lastScaleTimestamp, now) < Cooldown)
+            return ScaleDirection.None;
+
+        if (_saturationStartTimestamp != 0
+            && _currentConnectionCount < _maxConnectionCount
+            && Stopwatch.GetElapsedTime(_saturationStartTimestamp, now) >= ScaleUpSustained)
+        {
+            return ScaleDirection.Up;
+        }
+
+        if (_lowUtilizationStartTimestamp != 0
+            && _currentConnectionCount > _initialConnectionCount
+            && Stopwatch.GetElapsedTime(_lowUtilizationStartTimestamp, now) >= ScaleDownSustained)
+        {
+            return ScaleDirection.Down;
+        }
+
+        return ScaleDirection.None;
     }
 
     /// <summary>
@@ -101,37 +171,27 @@ internal sealed class ConsumerConnectionScaler : IDisposable
         TaskCompletionSource? operationReservation = null;
         lock (_operationLock)
         {
-            if (_stopping != 0)
-                return;
-
-            if (_lastScaleTimestamp != 0 && Stopwatch.GetElapsedTime(_lastScaleTimestamp, now) < Cooldown)
-                return;
-
-            if (_saturationStartTimestamp != 0
-                && _currentConnectionCount < _maxConnectionCount
-                && Stopwatch.GetElapsedTime(_saturationStartTimestamp, now) >= ScaleUpSustained)
+            switch (SelectScaleDirectionLocked(now))
             {
-                Interlocked.Increment(ref _currentConnectionCount);
-                _saturationStartTimestamp = 0;
-                _lastScaleTimestamp = now;
-                operation = _scaleUpAsync;
-            }
-            else if (_lowUtilizationStartTimestamp != 0
-                && _currentConnectionCount > _initialConnectionCount
-                && Stopwatch.GetElapsedTime(_lowUtilizationStartTimestamp, now) >= ScaleDownSustained)
-            {
-                Interlocked.Decrement(ref _currentConnectionCount);
-                _lowUtilizationStartTimestamp = 0;
-                _lastScaleTimestamp = now;
-                operation = _scaleDownAsync;
+                case ScaleDirection.Up:
+                    Interlocked.Increment(ref _currentConnectionCount);
+                    _saturationStartTimestamp = 0;
+                    _lastScaleTimestamp = now;
+                    operation = _scaleUpAsync;
+                    break;
+                case ScaleDirection.Down:
+                    Interlocked.Decrement(ref _currentConnectionCount);
+                    _lowUtilizationStartTimestamp = 0;
+                    _lastScaleTimestamp = now;
+                    operation = _scaleDownAsync;
+                    break;
+                default:
+                    return;
             }
 
-            if (operation is not null)
-            {
-                operationReservation = new TaskCompletionSource(
-                    TaskCreationOptions.RunContinuationsAsynchronously);
-                _pendingOperations.Add(operationReservation.Task);
-            }
+            operationReservation = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _pendingOperations.Add(operationReservation.Task);
         }
 
         if (operationReservation is not null)

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -383,6 +383,18 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         && Volatile.Read(ref _fatalHeartbeatException) is null
         && Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0;
 
+    /// <summary>
+    /// True when <see cref="EnsureActiveGroupAsync(StringSet, string?, CancellationToken)"/>
+    /// would return on its lock-free fast path: the member is stable in the group for exactly
+    /// this subscription, is not disposed, and no fatal heartbeat failure is waiting to surface.
+    /// Mirrors that method's early-return conditions and must be kept in sync with them.
+    /// </summary>
+    internal bool IsEnsureActiveGroupCurrent(StringSet topics, string? subscribedTopicRegex) =>
+        Volatile.Read(ref _disposed) == 0
+        && _state == CoordinatorState.Stable
+        && Volatile.Read(ref _fatalHeartbeatException) is null
+        && SubscriptionMatches(topics, subscribedTopicRegex);
+
     internal bool TryRecordPollFast() => TryRecordPollFast(out _);
 
     /// <summary>

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4216,13 +4216,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     /// <summary>
-    /// Reports what the loop would report when re-dispatching a completed fetch: at this instant
-    /// the key's single pipeline slot is free. Only the loop may call
+    /// Reports the completed fetch the task is about to re-issue, exactly as the loop would have
+    /// reported it (see <see cref="ConsumerConnectionScaler.ReportFetchReissue"/>), and returns
+    /// whether a scale decision is now due. Only the loop may call
     /// <see cref="ConsumerConnectionScaler.MaybeScale"/>, because a scale operation drains the
-    /// scheduler and the scheduler is single-threaded to the loop.
+    /// scheduler and the scheduler is single-threaded to the loop; a due decision therefore ends
+    /// the task, and the loop's <see cref="ReportBrokerPrefetchBacklog"/> on wake-up acts on it.
     /// </summary>
-    private void ReportBrokerPrefetchReissue() =>
-        _connectionScaler?.ReportPipelineUtilization(0, pipelineDepth: 1);
+    private bool IsScaleDecisionDueOnReissue() =>
+        _connectionScaler is { } scaler && scaler.ReportFetchReissue();
 
     private async Task RunBrokerPrefetchAsync(
         int brokerId,
@@ -4451,12 +4453,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 || partitionCount == 0
                 || !plan.CanReissue
                 || cancellationToken.IsCancellationRequested
-                || !CanReissueBrokerPrefetch(in plan, fetchBufferEpoch))
+                || !CanReissueBrokerPrefetch(in plan, fetchBufferEpoch)
+                || IsScaleDecisionDueOnReissue())
             {
                 return;
             }
-
-            ReportBrokerPrefetchReissue();
         }
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1136,8 +1136,11 @@ internal static class ConsumerFetchPools
 /// <list type="bullet">
 ///   <item><description><b>Prefetch loop</b> (<see cref="PrefetchLoopAsync"/>): Runs on a background
 ///     thread when <c>QueuedMinMessages &gt; 1</c>, fetching records ahead of the consume loop.
-///     Coordinates with the user thread via the bounded <see cref="_prefetchBuffer"/> and
-///     lock-free <see cref="_eofEmitted"/> for EOF state.</description></item>
+///     It plans which partitions each <c>(broker, connection)</c> fetches and starts one
+///     self-continuing task per key; the task re-issues fetches on its leased connection while
+///     that plan stays valid (see <see cref="BrokerPrefetchScheduler"/>). Coordinates with the
+///     user thread via the bounded <see cref="_prefetchBuffer"/> and lock-free
+///     <see cref="_eofEmitted"/> for EOF state.</description></item>
 ///   <item><description><b>Heartbeat</b> (managed by <see cref="ConsumerCoordinator"/>): Sends
 ///     periodic heartbeats to the group coordinator on a background thread to keep the consumer
 ///     alive in the group.</description></item>
@@ -3913,11 +3916,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     if (decision.Action == PrefetchLoopAction.WaitForAny)
                     {
                         ReportBrokerPrefetchBacklog(decision.ReportBacklog);
-                        if (decision.RecordFetchWait)
-                            _adaptiveFetchSizer?.RecordFetchStart();
                         await _brokerPrefetchScheduler.WaitForAnyAsync(cancellationToken).ConfigureAwait(false);
-                        if (decision.RecordFetchWait)
-                            _adaptiveFetchSizer?.RecordFetchEnd();
                         ReportBrokerPrefetchBacklog(decision.ReportBacklog);
                     }
                     else if (decision.Action == PrefetchLoopAction.DelayNoWork)
@@ -3997,6 +3996,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         var partitionsByBroker = await GroupPartitionsByBrokerAsync(cancellationToken).ConfigureAwait(false);
         partitionsByBroker = ExcludePartitionsPendingFetchClear(partitionsByBroker);
+        var plan = CapturePrefetchPlanStamp(partitionsByBroker);
         var fetchSessionSnapshot = ShouldUseFetchSessions && !_fetchSessions.IsEmpty
             ? _fetchSessions.ToArray()
             : Array.Empty<KeyValuePair<(int BrokerId, int ConnectionIndex), FetchSessionHandler>>();
@@ -4039,6 +4039,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     startIndex,
                     count,
                     connectionIndex,
+                    plan,
                     cancellationToken))
                 {
                     started++;
@@ -4081,6 +4082,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 0,
                 0,
                 key.ConnectionIndex,
+                PrefetchPlanStamp.SingleFetch,
                 cancellationToken))
             {
                 started++;
@@ -4120,6 +4122,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         int partitionStartIndex,
         int partitionCount,
         int connectionIndex,
+        PrefetchPlanStamp plan,
         CancellationToken cancellationToken)
     {
         var fetchBufferEpoch = Volatile.Read(ref _fetchBufferEpoch);
@@ -4132,8 +4135,83 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 partitionCount,
                 connectionIndex,
                 fetchBufferEpoch,
+                plan,
                 cancellationToken));
     }
+
+    /// <summary>
+    /// Stamps the plan the loop is about to dispatch. Only a plan served straight from the
+    /// partition cache can be re-validated by version later; anything else (an uncached result
+    /// or a revocation-filtered copy) is dispatched as single fetches, as before.
+    /// </summary>
+    private PrefetchPlanStamp CapturePrefetchPlanStamp(Dictionary<int, List<TopicPartition>> partitionsByBroker)
+    {
+        lock (_partitionCacheLock)
+        {
+            if (_cachedPartitionsByBroker is not { } cached
+                || !ReferenceEquals(cached.PartitionsByBroker, partitionsByBroker))
+            {
+                return PrefetchPlanStamp.SingleFetch;
+            }
+
+            return new PrefetchPlanStamp(
+                CanReissue: true,
+                Volatile.Read(ref _assignmentVersion),
+                Volatile.Read(ref _appliedConnectionCount),
+                _metadataManager.Metadata.CaptureSnapshot(),
+                cached.PreferredReplicaExpiresAtTimestamp);
+        }
+    }
+
+    /// <summary>
+    /// Lock-free check, run by a broker prefetch task between fetches, that the plan it was
+    /// started with is still what <see cref="DispatchReadyBrokerPrefetchesAsync"/> would compute
+    /// now and that the central loop has nothing else pending. Every input the loop consults is
+    /// covered: the partition-cache version (assignment, pause/resume, preferred replicas,
+    /// snapshots), the fetch-buffer epoch (seeks, resets, revocations), routing width and
+    /// in-progress transitions, pending coordinator revocations, metadata refreshes (leader and
+    /// topic identity changes), preferred-replica expiry, prefetch-memory admission, and
+    /// coordinator/assignment currency.
+    /// </summary>
+    private bool CanReissueBrokerPrefetch(in PrefetchPlanStamp plan, int fetchBufferEpoch)
+    {
+        if (Volatile.Read(ref _assignmentVersion) != plan.AssignmentVersion
+            || Volatile.Read(ref _fetchBufferEpoch) != fetchBufferEpoch
+            || Volatile.Read(ref _appliedConnectionCount) != plan.ConnectionCount
+            || Volatile.Read(ref _connectionRoutingTransitionTask) is not null
+            || Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0
+            || HasPendingCoordinatorRevocations()
+            || !ReferenceEquals(_metadataManager.Metadata.CaptureSnapshot(), plan.MetadataSnapshot)
+            || Volatile.Read(ref _consumerDisposed) != 0
+            || Volatile.Read(ref _closed) != 0)
+        {
+            return false;
+        }
+
+        if (plan.PreferredReplicaExpiresAtTimestamp != NoPreferredReplicaExpiry
+            && plan.PreferredReplicaExpiresAtTimestamp <= Stopwatch.GetTimestamp())
+        {
+            return false;
+        }
+
+        if (PrefetchLoopControl.ShouldWaitForMemory(
+                Interlocked.Read(ref _prefetchedBytes),
+                CalculatePrefetchMaxBytes(CurrentQueuedMaxBytes)))
+        {
+            return false;
+        }
+
+        return IsEnsureAssignmentCurrent();
+    }
+
+    /// <summary>
+    /// Reports what the loop would report when re-dispatching a completed fetch: at this instant
+    /// the key's single pipeline slot is free. Only the loop may call
+    /// <see cref="ConsumerConnectionScaler.MaybeScale"/>, because a scale operation drains the
+    /// scheduler and the scheduler is single-threaded to the loop.
+    /// </summary>
+    private void ReportBrokerPrefetchReissue() =>
+        _connectionScaler?.ReportPipelineUtilization(0, pipelineDepth: 1);
 
     private async Task RunBrokerPrefetchAsync(
         int brokerId,
@@ -4142,6 +4220,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         int partitionCount,
         int connectionIndex,
         int fetchBufferEpoch,
+        PrefetchPlanStamp plan,
         CancellationToken cancellationToken)
     {
         // Rent a CTS from the pool for the combined consume cancellation source
@@ -4165,6 +4244,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 partitionCount,
                 connectionIndex,
                 fetchBufferEpoch,
+                plan,
                 consumeCts.Token,
                 consumeCts.Token).ConfigureAwait(false);
         }
@@ -4193,6 +4273,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         int partitionCount,
         int connectionIndex,
         int fetchBufferEpoch,
+        PrefetchPlanStamp plan,
         CancellationToken linkedToken,
         CancellationToken consumeCancellationToken)
     {
@@ -4200,6 +4281,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         try
         {
+            // PrefetchFromBrokerAsync clears this key's failure streak after its first success.
             await PrefetchFromBrokerAsync(
                 brokerId,
                 partitions,
@@ -4207,8 +4289,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 partitionCount,
                 connectionIndex,
                 fetchBufferEpoch,
+                plan,
                 linkedToken).ConfigureAwait(false);
-            _prefetchFailureTracker.Reset(failureKey);
         }
         catch (OperationCanceledException) when (consumeCancellationToken.IsCancellationRequested)
         {
@@ -4313,6 +4395,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         int partitionCount,
         int connectionIndex,
         int fetchBufferEpoch,
+        PrefetchPlanStamp plan,
         CancellationToken cancellationToken)
     {
         using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
@@ -4326,7 +4409,65 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             ApiKey.Fetch,
             FetchRequest.LowestSupportedVersion,
             FetchRequest.HighestSupportedVersion);
+        var failureKey = new PrefetchFailureKey(brokerId, connectionIndex);
+        var failureStreakCleared = false;
 
+        // Self-continuing fetch loop; loop ownership is documented on BrokerPrefetchScheduler.
+        // Every iteration issues exactly one request on this connection's fetch session, and the
+        // task keeps the leased connection until the plan it was started with can no longer be
+        // trusted, at which point control returns to the central prefetch loop.
+        while (true)
+        {
+            var canReissue = await FetchOnceFromBrokerAsync(
+                connection,
+                apiVersion,
+                brokerId,
+                partitions,
+                partitionStartIndex,
+                partitionCount,
+                connectionIndex,
+                fetchBufferEpoch,
+                cancellationToken).ConfigureAwait(false);
+
+            // A failure always ends the task, so only the first success has a streak to clear.
+            if (!failureStreakCleared)
+            {
+                _prefetchFailureTracker.Reset(failureKey);
+                failureStreakCleared = true;
+            }
+
+            if (!canReissue
+                || partitionCount == 0
+                || !plan.CanReissue
+                || cancellationToken.IsCancellationRequested
+                || !CanReissueBrokerPrefetch(in plan, fetchBufferEpoch))
+            {
+                return;
+            }
+
+            ReportBrokerPrefetchReissue();
+        }
+    }
+
+    /// <summary>
+    /// Issues one fetch on <paramref name="connection"/> and publishes its records to the
+    /// prefetch buffer. Returns <see langword="true"/> when every partition in the response was
+    /// plain data (records, or an empty poll), so the caller may immediately issue the next
+    /// fetch with the same plan; <see langword="false"/> when the response carried anything the
+    /// central prefetch loop must react to first: a session-level error, a partition error or
+    /// diverging epoch, a topic identity refresh, or a partition that went stale mid-fetch.
+    /// </summary>
+    private async ValueTask<bool> FetchOnceFromBrokerAsync(
+        IKafkaConnection connection,
+        short apiVersion,
+        int brokerId,
+        List<TopicPartition> partitions,
+        int partitionStartIndex,
+        int partitionCount,
+        int connectionIndex,
+        int fetchBufferEpoch,
+        CancellationToken cancellationToken)
+    {
         // Resolve any special offset values — pass index range to avoid GetRange allocation
         await ResolveSpecialOffsetsAsync(partitions, partitionStartIndex, partitionCount, cancellationToken).ConfigureAwait(false);
 
@@ -4390,6 +4531,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
 
             RecordFetchDuration(fetchStarted, brokerId);
+            _adaptiveFetchSizer?.RecordFetchCompleted(fetchStarted);
 
             // Take ownership of pooled memory from the response (if zero-copy was used)
             var memoryOwner = response.PooledMemoryOwner;
@@ -4402,7 +4544,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 LogFetchSessionError(brokerId, response.ErrorCode);
                 response.ReturnToPool();
                 memoryOwner?.Dispose();
-                return;
+                return false;
             }
 
             fetchSessionHandler?.HandleResponse(response);
@@ -4415,6 +4557,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             var pendingItems = _prefetchPendingItemsByBroker.GetOrAdd((brokerId, connectionIndex), static _ => []);
             pendingItems.Clear();
             var queuedDivergingEpochReset = false;
+            var canReissue = true;
             Dictionary<string, Guid>? topicIdentityRefreshes = null;
 
             // Write to prefetch channel
@@ -4435,7 +4578,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     {
                         var tp = new TopicPartition(topic, partitionResponse.PartitionIndex);
                         if (ShouldDropStaleFetchPartition(tp, fetchBufferEpoch))
+                        {
+                            canReissue = false;
                             continue;
+                        }
 
                         // Update watermark cache from fetch response (even on errors, watermarks may be valid)
                         UpdateWatermarksFromFetchResponse(
@@ -4448,6 +4594,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                         if (partitionResponse.RecordParseError is { } parseError)
                         {
+                            canReissue = false;
                             pendingItems.Add(PendingFetchData.CreateError(
                                 topic,
                                 partitionResponse.PartitionIndex,
@@ -4459,6 +4606,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                         if (partitionResponse.DivergingEpoch is not null)
                         {
+                            canReissue = false;
                             _stuckFetchPositionTracker.Reset(tp);
                             if (ResetToDivergingEpoch(
                                 topic,
@@ -4473,6 +4621,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                         if (partitionResponse.ErrorCode != ErrorCode.None)
                         {
+                            canReissue = false;
                             _stuckFetchPositionTracker.Reset(tp);
                             if (partitionResponse.ErrorCode == ErrorCode.OffsetOutOfRange)
                             {
@@ -4577,6 +4726,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
 
             memoryOwner?.Dispose();
+            return canReissue;
         }
         finally
         {
@@ -9189,6 +9339,30 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
+    /// <summary>
+    /// True when <see cref="EnsureAssignmentAsync"/> would return on its lock-free fast path: no
+    /// pattern refresh is due, the group member is stable with its assignment already applied
+    /// (or the manual assignment is unchanged). Mirrors that method's early returns and must be
+    /// kept in sync with them; broker prefetch tasks use it to decide whether the central loop
+    /// needs to run before the next fetch.
+    /// </summary>
+    private bool IsEnsureAssignmentCurrent()
+    {
+        if (_topicFilter is not null && IsFilterRefreshDue())
+            return false;
+
+        var subscriptionSnapshot = _subscriptionSnapshot;
+        var topicPattern = _topicPattern;
+        var coordinator = _coordinator;
+        if ((subscriptionSnapshot.Count != 0 || topicPattern is not null) && coordinator is not null)
+        {
+            return coordinator.IsEnsureActiveGroupCurrent(subscriptionSnapshot, topicPattern)
+                && IsCoordinatorAssignmentSyncCurrent(coordinator, out _);
+        }
+
+        return IsManualAssignmentEnsureCurrent();
+    }
+
     internal async ValueTask EnsureAssignmentAsync(CancellationToken cancellationToken)
     {
         // Refresh pattern subscription BEFORE acquiring the lock — RefreshFilteredTopicsAsync
@@ -10026,26 +10200,31 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// <summary>
     /// Invalidates the cached partition grouping. Called whenever _assignment or _paused changes.
     /// </summary>
+    /// <remarks>
+    /// <see cref="_assignmentVersion"/> changes only under <see cref="_partitionCacheLock"/>, in
+    /// the same critical section as the cache it describes (here and in the paused/resumed cache
+    /// patches). <see cref="CapturePrefetchPlanStamp"/> relies on this: a version read under the
+    /// lock while the cache is populated is exactly the version that cached plan was built for,
+    /// so a broker prefetch task can detect any later change with one volatile read.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void InvalidatePartitionCache()
     {
-        Interlocked.Increment(ref _assignmentVersion);
         lock (_partitionCacheLock)
         {
+            Interlocked.Increment(ref _assignmentVersion);
             _cachedPartitionsByBroker = null;
         }
     }
 
     private void UpdateCachesForPausedPartitions(IReadOnlyList<TopicPartition> partitions)
     {
-        Interlocked.Increment(ref _assignmentVersion);
         RemovePausedPartitionsFromPartitionCache(partitions);
         InvalidateFetchRequestCache();
     }
 
     private void UpdateCachesForResumedPartitions(IReadOnlyList<TopicPartition> partitions)
     {
-        Interlocked.Increment(ref _assignmentVersion);
         AddResumedPartitionsToPartitionCache(partitions);
         InvalidateFetchRequestCache();
     }
@@ -10054,6 +10233,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         lock (_partitionCacheLock)
         {
+            Interlocked.Increment(ref _assignmentVersion);
             var cachedEntry = _cachedPartitionsByBroker;
             if (cachedEntry is null)
                 return;
@@ -10092,6 +10272,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         lock (_partitionCacheLock)
         {
+            Interlocked.Increment(ref _assignmentVersion);
             var cachedEntry = _cachedPartitionsByBroker;
             if (cachedEntry is null)
                 return;
@@ -13126,6 +13307,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         _initLock.Dispose();
         _topicIdentityLock.Dispose();
         _prefetchMemoryAvailable.Dispose();
+        _brokerPrefetchScheduler.Dispose();
 
         if (_coordinator is not null)
             await _coordinator.DisposeAsync().ConfigureAwait(false);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4142,10 +4142,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// <summary>
     /// Stamps the plan the loop is about to dispatch. Only a plan served straight from the
     /// partition cache can be re-validated by version later; anything else (an uncached result
-    /// or a revocation-filtered copy) is dispatched as single fetches, as before.
+    /// or a revocation-filtered copy) is dispatched as single fetches, as before. The stamped
+    /// metadata snapshot must be the one whose topic identities
+    /// <see cref="GroupPartitionsByBrokerAsync"/> processed (published as
+    /// <see cref="_observedTopicIdentityMarker"/>); a refresh that landed after that pass is
+    /// left for the loop's next iteration, otherwise a re-issuing task would keep accepting a
+    /// snapshot whose topic identity changes were never applied to its fetch positions.
     /// </summary>
     private PrefetchPlanStamp CapturePrefetchPlanStamp(Dictionary<int, List<TopicPartition>> partitionsByBroker)
     {
+        var metadataSnapshot = _metadataManager.Metadata.CaptureSnapshot();
+        if (!ReferenceEquals(metadataSnapshot, Volatile.Read(ref _observedTopicIdentityMarker)))
+            return PrefetchPlanStamp.SingleFetch;
+
         lock (_partitionCacheLock)
         {
             if (_cachedPartitionsByBroker is not { } cached
@@ -4158,7 +4167,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 CanReissue: true,
                 Volatile.Read(ref _assignmentVersion),
                 Volatile.Read(ref _appliedConnectionCount),
-                _metadataManager.Metadata.CaptureSnapshot(),
+                metadataSnapshot,
                 cached.PreferredReplicaExpiresAtTimestamp);
         }
     }
@@ -4170,8 +4179,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// covered: the partition-cache version (assignment, pause/resume, preferred replicas,
     /// snapshots), the fetch-buffer epoch (seeks, resets, revocations), routing width and
     /// in-progress transitions, pending coordinator revocations, metadata refreshes (leader and
-    /// topic identity changes), preferred-replica expiry, prefetch-memory admission, and
-    /// coordinator/assignment currency.
+    /// topic identity changes: the current snapshot must be the stamped one, and the stamped one
+    /// must still be the snapshot whose topic identities were last processed), preferred-replica
+    /// expiry, prefetch-memory admission, and coordinator/assignment currency.
     /// </summary>
     private bool CanReissueBrokerPrefetch(in PrefetchPlanStamp plan, int fetchBufferEpoch)
     {
@@ -4182,6 +4192,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             || Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0
             || HasPendingCoordinatorRevocations()
             || !ReferenceEquals(_metadataManager.Metadata.CaptureSnapshot(), plan.MetadataSnapshot)
+            || !ReferenceEquals(Volatile.Read(ref _observedTopicIdentityMarker), plan.MetadataSnapshot)
             || Volatile.Read(ref _consumerDisposed) != 0
             || Volatile.Read(ref _closed) != 0)
         {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4128,15 +4128,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var fetchBufferEpoch = Volatile.Read(ref _fetchBufferEpoch);
         return _brokerPrefetchScheduler.TryStart(
             (brokerId, connectionIndex),
-            () => RunBrokerPrefetchAsync(
-                brokerId,
-                partitions,
-                partitionStartIndex,
-                partitionCount,
-                connectionIndex,
-                fetchBufferEpoch,
-                plan,
-                cancellationToken));
+            (Consumer: this, BrokerId: brokerId, Partitions: partitions,
+                PartitionStartIndex: partitionStartIndex, PartitionCount: partitionCount,
+                ConnectionIndex: connectionIndex, FetchBufferEpoch: fetchBufferEpoch,
+                Plan: plan, CancellationToken: cancellationToken),
+            static state => state.Consumer.RunBrokerPrefetchAsync(
+                state.BrokerId,
+                state.Partitions,
+                state.PartitionStartIndex,
+                state.PartitionCount,
+                state.ConnectionIndex,
+                state.FetchBufferEpoch,
+                state.Plan,
+                state.CancellationToken));
     }
 
     /// <summary>

--- a/src/Dekaf/Consumer/PrefetchLoopControl.cs
+++ b/src/Dekaf/Consumer/PrefetchLoopControl.cs
@@ -11,8 +11,7 @@ internal enum PrefetchLoopAction
 
 internal readonly record struct PrefetchLoopDecision(
     PrefetchLoopAction Action,
-    bool ReportBacklog,
-    bool RecordFetchWait);
+    bool ReportBacklog);
 
 internal static class PrefetchLoopControl
 {
@@ -36,14 +35,14 @@ internal static class PrefetchLoopControl
         bool hasInFlight)
     {
         if (started > 0)
-            return new PrefetchLoopDecision(PrefetchLoopAction.Continue, ReportBacklog: false, RecordFetchWait: false);
+            return new PrefetchLoopDecision(PrefetchLoopAction.Continue, ReportBacklog: false);
 
         if (hasInFlight)
         {
             var hasBacklog = targetCount > 0;
-            return new PrefetchLoopDecision(PrefetchLoopAction.WaitForAny, hasBacklog, RecordFetchWait: true);
+            return new PrefetchLoopDecision(PrefetchLoopAction.WaitForAny, hasBacklog);
         }
 
-        return new PrefetchLoopDecision(PrefetchLoopAction.DelayNoWork, ReportBacklog: false, RecordFetchWait: false);
+        return new PrefetchLoopDecision(PrefetchLoopAction.DelayNoWork, ReportBacklog: false);
     }
 }

--- a/src/Dekaf/Consumer/PrefetchPlanStamp.cs
+++ b/src/Dekaf/Consumer/PrefetchPlanStamp.cs
@@ -17,8 +17,9 @@ namespace Dekaf.Consumer;
 /// </param>
 /// <param name="ConnectionCount">Applied routing width the plan split partitions across.</param>
 /// <param name="MetadataSnapshot">
-/// Cluster metadata snapshot current when the plan was stamped; any refresh (leader or topic
-/// identity changes) hands control back to the loop.
+/// Cluster metadata snapshot the plan was grouped against, i.e. the one whose topic identities
+/// had been processed when the plan was stamped; any refresh (leader or topic identity changes)
+/// hands control back to the loop.
 /// </param>
 /// <param name="PreferredReplicaExpiresAtTimestamp">
 /// Earliest preferred-replica expiry in the plan, or <c>long.MaxValue</c> when none applies.

--- a/src/Dekaf/Consumer/PrefetchPlanStamp.cs
+++ b/src/Dekaf/Consumer/PrefetchPlanStamp.cs
@@ -1,0 +1,35 @@
+using Dekaf.Metadata;
+
+namespace Dekaf.Consumer;
+
+/// <summary>
+/// Identifies the fetch plan a broker prefetch task was started with, so the task can verify
+/// that the plan is still current before re-issuing a fetch without returning to the central
+/// prefetch loop (see <see cref="BrokerPrefetchScheduler"/>).
+/// </summary>
+/// <param name="CanReissue">
+/// False when the plan was not served from the partition cache (uncached result or a
+/// revocation-filtered copy); such tasks always perform a single fetch.
+/// </param>
+/// <param name="AssignmentVersion">
+/// Partition-cache version the plan was built for; bumped by assignment, pause/resume,
+/// preferred-replica and snapshot changes.
+/// </param>
+/// <param name="ConnectionCount">Applied routing width the plan split partitions across.</param>
+/// <param name="MetadataSnapshot">
+/// Cluster metadata snapshot current when the plan was stamped; any refresh (leader or topic
+/// identity changes) hands control back to the loop.
+/// </param>
+/// <param name="PreferredReplicaExpiresAtTimestamp">
+/// Earliest preferred-replica expiry in the plan, or <c>long.MaxValue</c> when none applies.
+/// </param>
+internal readonly record struct PrefetchPlanStamp(
+    bool CanReissue,
+    int AssignmentVersion,
+    int ConnectionCount,
+    ClusterMetadataSnapshot? MetadataSnapshot,
+    long PreferredReplicaExpiresAtTimestamp)
+{
+    /// <summary>A plan that must not be re-issued by the task; the loop re-dispatches it.</summary>
+    public static PrefetchPlanStamp SingleFetch => default;
+}

--- a/src/Dekaf/Internal/AsyncAutoResetSignal.cs
+++ b/src/Dekaf/Internal/AsyncAutoResetSignal.cs
@@ -25,7 +25,7 @@ internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>,
     private const int QueuedShutdown = 2;
 
     private ManualResetValueTaskSourceCore<bool> _core;
-    private readonly bool _inlineTimeoutContinuations;
+    private readonly bool _inlineSignalContinuations;
     private int _queuedCompletion;
 
     /// <summary>
@@ -63,10 +63,19 @@ internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>,
     private int _shutdownRequested; // 0 = running, 1 = shutdown requested — terminal once set
     private CancellationToken _shutdownToken;
 
-    public AsyncAutoResetSignal(bool inlineTimeoutContinuations = false)
+    /// <param name="inlineTimeoutContinuations">
+    /// Run the waiter inline on the timer thread when a timeout fires; <see cref="Signal"/> and
+    /// shutdown then hop through the thread pool so their callers never run the waiter.
+    /// </param>
+    /// <param name="inlineSignalContinuations">
+    /// Run the waiter inline on the thread that calls <see cref="Signal"/> (and, as above, on
+    /// the timer thread); shutdown still hops through the thread pool. Use when the signaler
+    /// has nothing left to do, so a hop would only add wake-up latency.
+    /// </param>
+    public AsyncAutoResetSignal(bool inlineTimeoutContinuations = false, bool inlineSignalContinuations = false)
     {
-        _inlineTimeoutContinuations = inlineTimeoutContinuations;
-        _core.RunContinuationsAsynchronously = !inlineTimeoutContinuations;
+        _inlineSignalContinuations = inlineSignalContinuations;
+        _core.RunContinuationsAsynchronously = !inlineTimeoutContinuations && !inlineSignalContinuations;
         _timeoutCallback = static state =>
         {
             var self = (AsyncAutoResetSignal)state!;
@@ -233,7 +242,9 @@ internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>,
 
     private void CompleteSignal()
     {
-        if (!_inlineTimeoutContinuations)
+        // Default mode: the core queues the continuation. Inline-signal mode: the signaler runs
+        // it. Inline-timeout mode: only the timer may run the waiter inline, so hop via the pool.
+        if (_core.RunContinuationsAsynchronously || _inlineSignalContinuations)
         {
             _core.SetResult(true);
             return;
@@ -245,7 +256,7 @@ internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>,
 
     private void CompleteShutdown()
     {
-        if (!_inlineTimeoutContinuations)
+        if (_core.RunContinuationsAsynchronously)
         {
             _core.SetException(new OperationCanceledException(_shutdownToken));
             return;

--- a/src/Dekaf/Internal/AsyncAutoResetSignal.cs
+++ b/src/Dekaf/Internal/AsyncAutoResetSignal.cs
@@ -63,6 +63,10 @@ internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>,
     private int _shutdownRequested; // 0 = running, 1 = shutdown requested — terminal once set
     private CancellationToken _shutdownToken;
 
+    /// <summary>
+    /// Creates a signal. By default every continuation hops through the thread pool; the flags
+    /// select which completing thread may run the waiter inline instead.
+    /// </summary>
     /// <param name="inlineTimeoutContinuations">
     /// Run the waiter inline on the timer thread when a timeout fires; <see cref="Signal"/> and
     /// shutdown then hop through the thread pool so their callers never run the waiter.

--- a/tests/Dekaf.Tests.Unit/Consumer/AdaptiveFetchSizerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/AdaptiveFetchSizerTests.cs
@@ -321,6 +321,32 @@ public class AdaptiveFetchSizerTests
         await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(initial);
     }
 
+    [Test]
+    public async Task RecordFetchEnd_WithoutStart_IsIgnored()
+    {
+        var sizer = CreateSizerWithWindowOne();
+        var initial = sizer.CurrentPartitionFetchBytes;
+
+        sizer.RecordFetchEnd();
+        sizer.ReportProcessingComplete(TimeSpan.FromMilliseconds(100));
+
+        await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(initial);
+    }
+
+    [Test]
+    public async Task RecordFetchCompleted_PublishesFetchLatencyForProcessingRatio()
+    {
+        var sizer = CreateSizerWithWindowOne();
+        var initial = sizer.CurrentPartitionFetchBytes;
+
+        // A fetch that took ~1s against 10ms of processing is a keeping-up (grow) signal.
+        var oneSecondAgo = System.Diagnostics.Stopwatch.GetTimestamp() - System.Diagnostics.Stopwatch.Frequency;
+        sizer.RecordFetchCompleted(oneSecondAgo);
+        sizer.ReportProcessingComplete(TimeSpan.FromMilliseconds(10));
+
+        await Assert.That(sizer.CurrentPartitionFetchBytes).IsGreaterThan(initial);
+    }
+
     #endregion
 
     #region Configuration defaults

--- a/tests/Dekaf.Tests.Unit/Consumer/BrokerPrefetchSchedulerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/BrokerPrefetchSchedulerTests.cs
@@ -92,6 +92,76 @@ public sealed class BrokerPrefetchSchedulerTests
     }
 
     [Test]
+    public async Task WaitForAny_MultiplePendingTasks_WakesWhenAnyOneCompletes()
+    {
+        var scheduler = new BrokerPrefetchScheduler();
+        var completions = new TaskCompletionSource[4];
+        for (var broker = 0; broker < completions.Length; broker++)
+        {
+            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            completions[broker] = completion;
+            scheduler.TryStart((BrokerId: broker, ConnectionIndex: 0), () => completion.Task);
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var waitTask = scheduler.WaitForAnyAsync(cts.Token).AsTask();
+        await Assert.That(waitTask.IsCompleted).IsFalse();
+
+        completions[2].SetResult();
+        await waitTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        await Assert.That(await scheduler.DrainCompletedAsync()).IsEqualTo(1);
+        await Assert.That(scheduler.InFlightCount).IsEqualTo(3);
+        await Assert.That(scheduler.TryStart((BrokerId: 2, ConnectionIndex: 0), () => completions[2].Task)).IsTrue();
+
+        foreach (var completion in completions)
+            completion.TrySetResult();
+        await scheduler.DrainAllSafelyAsync(static _ => { }, static _ => false);
+    }
+
+    [Test]
+    public async Task WaitForAny_RepeatedWaits_WakeForEachSuccessiveCompletion()
+    {
+        var scheduler = new BrokerPrefetchScheduler();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        for (var round = 0; round < 3; round++)
+        {
+            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            await Assert.That(scheduler.TryStart((BrokerId: 1, ConnectionIndex: 0), () => completion.Task)).IsTrue();
+
+            var waitTask = scheduler.WaitForAnyAsync(cts.Token).AsTask();
+            await Assert.That(waitTask.IsCompleted).IsFalse();
+
+            completion.SetResult();
+            await waitTask.WaitAsync(TimeSpan.FromSeconds(10));
+            await Assert.That(await scheduler.DrainCompletedAsync()).IsEqualTo(1);
+        }
+
+        await Assert.That(scheduler.HasInFlight).IsFalse();
+    }
+
+    [Test]
+    public async Task WaitForAny_CancelledDuringWait_Throws()
+    {
+        var scheduler = new BrokerPrefetchScheduler();
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        scheduler.TryStart((BrokerId: 1, ConnectionIndex: 0), () => completion.Task);
+
+        using var cts = new CancellationTokenSource();
+        var waitTask = scheduler.WaitForAnyAsync(cts.Token).AsTask();
+        await Assert.That(waitTask.IsCompleted).IsFalse();
+
+        cts.Cancel();
+
+        await Assert.That(async () => await waitTask.WaitAsync(TimeSpan.FromSeconds(10)))
+            .Throws<OperationCanceledException>();
+
+        completion.SetResult();
+        await scheduler.DrainAllSafelyAsync(static _ => { }, static _ => false);
+    }
+
+    [Test]
     public async Task DrainAllSafely_ReturnsFirstMatchingFailureAndObservesAll()
     {
         var scheduler = new BrokerPrefetchScheduler();

--- a/tests/Dekaf.Tests.Unit/Consumer/BrokerPrefetchSchedulerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/BrokerPrefetchSchedulerTests.cs
@@ -5,6 +5,31 @@ namespace Dekaf.Tests.Unit.Consumer;
 public sealed class BrokerPrefetchSchedulerTests
 {
     [Test]
+    public async Task TryStart_StateFactory_DuplicateKeyDoesNotInvokeFactory()
+    {
+        using var scheduler = new BrokerPrefetchScheduler();
+        var completion = new TaskCompletionSource();
+        await Assert.That(scheduler.TryStart((1, 0), completion, static state => state.Task)).IsTrue();
+        await Assert.That(scheduler.TryStart((1, 0), 42,
+            static _ => throw new InvalidOperationException("Duplicate factory invoked"))).IsFalse();
+        completion.SetResult();
+        await Assert.That(await scheduler.DrainCompletedAsync()).IsEqualTo(1);
+        await Assert.That(scheduler.TryStart((1, 0), Task.CompletedTask, static state => state)).IsTrue();
+        await Assert.That(await scheduler.DrainCompletedAsync()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TryStart_StateFactory_ThrowDoesNotReserveKey()
+    {
+        using var scheduler = new BrokerPrefetchScheduler();
+        await Assert.That(() => scheduler.TryStart((1, 0), 42,
+            static _ => throw new InvalidOperationException("Factory failed"))).Throws<InvalidOperationException>();
+        await Assert.That(scheduler.InFlightCount).IsEqualTo(0);
+        await Assert.That(scheduler.TryStart((1, 0), Task.CompletedTask, static state => state)).IsTrue();
+        await Assert.That(await scheduler.DrainCompletedAsync()).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task WaitForAny_DrainedSignal_DoesNotCompleteWaitForReusedKey()
     {
         using var scheduler = new BrokerPrefetchScheduler();

--- a/tests/Dekaf.Tests.Unit/Consumer/BrokerPrefetchSchedulerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/BrokerPrefetchSchedulerTests.cs
@@ -5,6 +5,56 @@ namespace Dekaf.Tests.Unit.Consumer;
 public sealed class BrokerPrefetchSchedulerTests
 {
     [Test]
+    public async Task WaitForAny_DrainedSignal_DoesNotCompleteWaitForReusedKey()
+    {
+        using var scheduler = new BrokerPrefetchScheduler();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var first = new TaskCompletionSource();
+        scheduler.TryStart((1, 0), () => first.Task);
+        first.SetResult(); // Inline notification leaves a signal with no waiter.
+        await Assert.That(await scheduler.DrainCompletedAsync()).IsEqualTo(1);
+
+        var next = new TaskCompletionSource();
+        scheduler.TryStart((1, 0), () => next.Task);
+        var wait = scheduler.WaitForAnyAsync(timeout.Token);
+        await Assert.That(wait.IsCompleted).IsFalse();
+        next.SetResult();
+        await wait;
+        await Assert.That(await scheduler.DrainCompletedAsync()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task WaitForAny_AfterDrainAll_DoesNotCountPreviousTasks()
+    {
+        using var scheduler = new BrokerPrefetchScheduler();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var first = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        scheduler.TryStart((1, 0), () => first.Task);
+        var drain = scheduler.DrainAllSafelyAsync(static _ => { }, static _ => false);
+        first.SetResult();
+        await drain;
+
+        var next = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        scheduler.TryStart((1, 0), () => next.Task);
+        var wait = scheduler.WaitForAnyAsync(timeout.Token);
+        await Assert.That(wait.IsCompleted).IsFalse();
+        next.SetResult();
+        await wait;
+        await Assert.That(await scheduler.DrainCompletedAsync()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task DrainCompleted_FaultLeavesRemainingCompletionAvailable()
+    {
+        using var scheduler = new BrokerPrefetchScheduler();
+        scheduler.TryStart((1, 0), static () => Task.FromException(new InvalidOperationException()));
+        scheduler.TryStart((2, 0), static () => Task.CompletedTask);
+        await Assert.That(async () => await scheduler.DrainCompletedAsync()).Throws<InvalidOperationException>();
+        await Assert.That(scheduler.WaitForAnyAsync(CancellationToken.None).IsCompletedSuccessfully).IsTrue();
+        await Assert.That(await scheduler.DrainCompletedAsync()).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task DrainCompleted_AllowsFastBrokerRestartWhileSlowBrokerRemainsInFlight()
     {
         var scheduler = new BrokerPrefetchScheduler();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
@@ -371,6 +371,153 @@ public sealed class ConsumerConnectionScalerTests
     }
 
     [Test]
+    public async Task ReportFetchReissue_FetchBelowThreshold_NotDue_AndRestartsSaturationWindow()
+    {
+        var scaleUpCount = 0;
+        var scaler = new ConsumerConnectionScaler(
+            initialConnectionCount: 2,
+            maxConnectionCount: 4,
+            scaleUpAsync: ct => { scaleUpCount++; return ValueTask.CompletedTask; },
+            scaleDownAsync: ct => { return ValueTask.CompletedTask; });
+
+        // The loop's backlogged wait opens the window; the task then re-issues after two 3 s
+        // fetches. The loop-owned path reset the window at every completion, so back-to-back
+        // fetches must not read as one 6 s saturation window.
+        scaler.ReportPipelineUtilization(1, 1);
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(3));
+        await Assert.That(scaler.ReportFetchReissue()).IsFalse();
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(3));
+        await Assert.That(scaler.ReportFetchReissue()).IsFalse();
+
+        scaler.ReportPipelineUtilization(1, 1);
+        scaler.MaybeScale();
+        await Assert.That(scaleUpCount).IsEqualTo(0);
+        await Assert.That(scaler.CurrentConnectionCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ReportFetchReissue_FetchAboveThreshold_Due_AndLoopScalesUp()
+    {
+        var scaleUpCount = 0;
+        var scaler = new ConsumerConnectionScaler(
+            initialConnectionCount: 2,
+            maxConnectionCount: 4,
+            scaleUpAsync: ct => { scaleUpCount++; return ValueTask.CompletedTask; },
+            scaleDownAsync: ct => { return ValueTask.CompletedTask; });
+
+        scaler.ReportPipelineUtilization(1, 1);
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(6));
+        await Assert.That(scaler.ReportFetchReissue()).IsTrue();
+        // The window is left for the loop, so the decision stays due until the loop acts.
+        await Assert.That(scaler.ReportFetchReissue()).IsTrue();
+
+        // The loop's wake-up sequence after the task hands control back.
+        scaler.ReportPipelineUtilization(1, 1);
+        scaler.MaybeScale();
+        await Assert.That(scaleUpCount).IsEqualTo(1);
+        await Assert.That(scaler.CurrentConnectionCount).IsEqualTo(3);
+
+        // Re-dispatch, then a long fetch inside the cooldown: not due, window restarted.
+        scaler.ReportPipelineUtilization(0, 1);
+        scaler.ReportPipelineUtilization(1, 1);
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(4));
+        await Assert.That(scaler.ReportFetchReissue()).IsFalse();
+
+        // Past the cooldown, the next over-threshold fetch is due again.
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(6));
+        await Assert.That(scaler.ReportFetchReissue()).IsTrue();
+        scaler.ReportPipelineUtilization(1, 1);
+        scaler.MaybeScale();
+        await Assert.That(scaleUpCount).IsEqualTo(2);
+        await Assert.That(scaler.CurrentConnectionCount).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task ReportFetchReissue_AtMaxConnections_NeverDue()
+    {
+        var scaler = new ConsumerConnectionScaler(
+            initialConnectionCount: 2,
+            maxConnectionCount: 2,
+            scaleUpAsync: ct => { return ValueTask.CompletedTask; },
+            scaleDownAsync: ct => { return ValueTask.CompletedTask; });
+
+        scaler.ReportPipelineUtilization(1, 1);
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(6));
+        await Assert.That(scaler.ReportFetchReissue()).IsFalse();
+    }
+
+    [Test]
+    public async Task ReportFetchReissue_SustainedReissue_DoesNotAccumulateLowUtilization()
+    {
+        var scaleDownCount = 0;
+        var scaler = new ConsumerConnectionScaler(
+            initialConnectionCount: 2,
+            maxConnectionCount: 3,
+            scaleUpAsync: ct => { return ValueTask.CompletedTask; },
+            scaleDownAsync: ct => { scaleDownCount++; return ValueTask.CompletedTask; });
+        scaler.TestSetConnectionCount(3);
+
+        // Loop re-dispatch (slot idle for an instant) then the backlogged wait, as before the
+        // first re-issue; then 160 s of back-to-back fetches on the busy slot.
+        scaler.ReportPipelineUtilization(0, 1);
+        scaler.ReportPipelineUtilization(1, 1);
+        for (var i = 0; i < 40; i++)
+        {
+            scaler.TestAdvanceTime(TimeSpan.FromSeconds(4));
+            await Assert.That(scaler.ReportFetchReissue()).IsFalse();
+        }
+
+        scaler.ReportPipelineUtilization(1, 1);
+        scaler.MaybeScale();
+        await Assert.That(scaleDownCount).IsEqualTo(0);
+        await Assert.That(scaler.CurrentConnectionCount).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task ReportPipelineUtilization_ConcurrentWithReissueAndMaybeScale_ScalesOnce()
+    {
+        var scaleUpCount = 0;
+        var scaler = new ConsumerConnectionScaler(
+            initialConnectionCount: 2,
+            maxConnectionCount: 4,
+            scaleUpAsync: ct => { Interlocked.Increment(ref scaleUpCount); return ValueTask.CompletedTask; },
+            scaleDownAsync: ct => { return ValueTask.CompletedTask; });
+
+        scaler.ReportPipelineUtilization(1, 1);
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(6));
+
+        // Broker tasks report re-issues while the loop reports and evaluates: every window
+        // update and decision is serialized, so exactly one scale-up is taken for the one
+        // over-threshold window and the cooldown holds after it.
+        const int threadCount = 8;
+        using var barrier = new Barrier(threadCount);
+        var workers = new Task[threadCount];
+        for (var t = 0; t < threadCount; t++)
+        {
+            var isBrokerTask = (t & 1) == 0;
+            workers[t] = Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                for (var i = 0; i < 2_000; i++)
+                {
+                    if (isBrokerTask)
+                        scaler.ReportFetchReissue();
+                    else
+                        scaler.ReportPipelineUtilization(1, 1);
+
+                    if ((i & 63) == 0)
+                        scaler.MaybeScale();
+                }
+            });
+        }
+
+        await Task.WhenAll(workers);
+        scaler.MaybeScale();
+        await Assert.That(scaleUpCount).IsEqualTo(1);
+        await Assert.That(scaler.CurrentConnectionCount).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task SplitPartitions_SingleConnection_ReturnsSingleGroup()
     {
         var groups = new (int StartIndex, int Count)[1];

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchMemorySignalTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchMemorySignalTests.cs
@@ -218,14 +218,10 @@ public sealed class KafkaConsumerPrefetchMemorySignalTests
 
     private static void SetFetchTiming(AdaptiveFetchSizer sizer, TimeSpan duration)
     {
-        var startField = typeof(AdaptiveFetchSizer)
-            .GetField("_lastFetchStartTimestamp", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        var endField = typeof(AdaptiveFetchSizer)
-            .GetField("_lastFetchEndTimestamp", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        var end = Stopwatch.GetTimestamp();
-        var start = end - (long)(duration.TotalSeconds * Stopwatch.Frequency);
-        startField.SetValue(sizer, start);
-        endField.SetValue(sizer, end);
+        var durationField = typeof(AdaptiveFetchSizer)
+            .GetField("_lastFetchDurationTicks", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_lastFetchDurationTicks field not found - was it renamed?");
+        durationField.SetValue(sizer, (long)(duration.TotalSeconds * Stopwatch.Frequency));
     }
 
     private static MethodInfo GetReportAdaptiveProcessingComplete()

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchReissueTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchReissueTests.cs
@@ -1,0 +1,291 @@
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+/// <summary>
+/// Verifies that a broker prefetch task re-issues fetches on its own leased connection while the
+/// fetch plan is stable, and hands control back to the central prefetch loop (which acquires a
+/// fresh lease) when the plan changes.
+/// </summary>
+[NotInParallel]
+public sealed class KafkaConsumerPrefetchReissueTests
+{
+    private const string Topic = "reissue-topic";
+    private static readonly Guid TopicId = Guid.Parse("00000000-0000-0000-0000-000000000042");
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TopicPartition Partition = new(Topic, 0);
+
+    [Test]
+    [Timeout(60_000)]
+    public async Task StablePlan_ReissuesConsecutiveFetchesOnOneLease(CancellationToken cancellationToken)
+    {
+        var connection = new FetchServingConnection();
+        await using var metadataManager = CreateMetadataManager(connection);
+        await using var consumer = CreateConsumer(connection, metadataManager);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 10)]);
+
+        await StartPrefetchAsync(consumer, cancellationToken);
+        await TestWait.UntilAsync(() => connection.FetchCount >= 8, WaitTimeout);
+
+        // Eight consecutive fetches on a stable plan must not have gone back through the loop:
+        // the task keeps re-issuing on the single connection lease it started with.
+        await Assert.That(connection.LeaseAcquisitionCount).IsEqualTo(1);
+        await Assert.That(connection.LeaseCount).IsEqualTo(1);
+        await Assert.That(connection.MaxConcurrentFetches).IsEqualTo(1);
+        await Assert.That(connection.LastFetchOffset).IsEqualTo(10L);
+    }
+
+    [Test]
+    [Timeout(60_000)]
+    public async Task Pause_EndsTaskAndReleasesLease_ResumeStartsFreshTask(CancellationToken cancellationToken)
+    {
+        var connection = new FetchServingConnection();
+        await using var metadataManager = CreateMetadataManager(connection);
+        await using var consumer = CreateConsumer(connection, metadataManager);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 10)]);
+
+        await StartPrefetchAsync(consumer, cancellationToken);
+        await TestWait.UntilAsync(() => connection.FetchCount >= 3, WaitTimeout);
+        await Assert.That(connection.LeaseAcquisitionCount).IsEqualTo(1);
+
+        consumer.Pause(Partition);
+
+        await TestWait.UntilAsync(() => connection.LeaseCount == 0, WaitTimeout);
+        var fetchesAtPause = connection.FetchCount;
+        await Task.Delay(TimeSpan.FromMilliseconds(200), cancellationToken);
+        await Assert.That(connection.FetchCount).IsEqualTo(fetchesAtPause);
+
+        consumer.Resume(Partition);
+
+        await TestWait.UntilAsync(() => connection.FetchCount >= fetchesAtPause + 3, WaitTimeout);
+        await Assert.That(connection.LeaseAcquisitionCount).IsEqualTo(2);
+    }
+
+    [Test]
+    [Timeout(60_000)]
+    public async Task Seek_EndsTaskAndNextTaskFetchesFromNewPosition(CancellationToken cancellationToken)
+    {
+        var connection = new FetchServingConnection();
+        await using var metadataManager = CreateMetadataManager(connection);
+        await using var consumer = CreateConsumer(connection, metadataManager);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 10)]);
+
+        await StartPrefetchAsync(consumer, cancellationToken);
+        await TestWait.UntilAsync(() => connection.FetchCount >= 3, WaitTimeout);
+        await Assert.That(connection.LeaseAcquisitionCount).IsEqualTo(1);
+
+        consumer.Seek(new TopicPartitionOffset(Topic, 0, 500));
+
+        await TestWait.UntilAsync(() => connection.LastFetchOffset == 500L, WaitTimeout);
+        await Assert.That(connection.LeaseAcquisitionCount).IsEqualTo(2);
+    }
+
+    private static async Task StartPrefetchAsync(
+        KafkaConsumer<string, string> consumer,
+        CancellationToken cancellationToken)
+    {
+        // The prefetch loop is a lifetime loop started by the first consume call; the poll
+        // itself times out because the fake broker never returns records.
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(50), cancellationToken);
+        await Assert.That(result).IsNull();
+    }
+
+    private static KafkaConsumer<string, string> CreateConsumer(
+        FetchServingConnection connection,
+        MetadataManager metadataManager)
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        pool.DisposeAsync().Returns(ValueTask.CompletedTask);
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection>(connection));
+        pool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection>(connection));
+
+        var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = "prefetch-reissue-test",
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                EnableAdaptiveConnections = false,
+                IsAutoTuned = false
+            },
+            Serializers.String,
+            Serializers.String,
+            pool,
+            metadataManager);
+
+        var initialized = typeof(KafkaConsumer<string, string>).GetField(
+            "_initialized",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_initialized field not found.");
+        initialized.SetValue(consumer, true);
+        return consumer;
+    }
+
+    private static MetadataManager CreateMetadataManager(FetchServingConnection connection)
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection>(connection));
+        var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        metadataManager.SetApiVersion(
+            ApiKey.Fetch,
+            FetchRequest.LowestSupportedVersion,
+            FetchRequest.HighestSupportedVersion);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    Name = Topic,
+                    TopicId = TopicId,
+                    ErrorCode = ErrorCode.None,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            PartitionIndex = 0,
+                            LeaderId = 1,
+                            ErrorCode = ErrorCode.None,
+                            ReplicaNodes = [1],
+                            IsrNodes = [1]
+                        }
+                    ]
+                }
+            ]
+        });
+        return metadataManager;
+    }
+
+    /// <summary>
+    /// Answers every fetch with an empty response after a short broker-like wait, and counts
+    /// lease acquisitions so tests can tell a re-issued fetch from a loop re-dispatch.
+    /// </summary>
+    private sealed class FetchServingConnection : IKafkaConnection, IRetirableKafkaConnection
+    {
+        private static readonly TimeSpan FetchWait = TimeSpan.FromMilliseconds(5);
+        private int _leaseCount;
+        private int _leaseAcquisitionCount;
+        private int _fetchCount;
+        private int _fetchesInFlight;
+        private int _maxConcurrentFetches;
+        private long _lastFetchOffset = -1;
+
+        public int BrokerId => 1;
+        public string Host => "localhost";
+        public int Port => 9092;
+        public bool IsConnected => true;
+        public int LeaseCount => Volatile.Read(ref _leaseCount);
+        public int LeaseAcquisitionCount => Volatile.Read(ref _leaseAcquisitionCount);
+        public int ActiveOperationCount => 0;
+        public int FetchCount => Volatile.Read(ref _fetchCount);
+        public int MaxConcurrentFetches => Volatile.Read(ref _maxConcurrentFetches);
+        public long LastFetchOffset => Interlocked.Read(ref _lastFetchOffset);
+
+        public bool TryAcquireLease()
+        {
+            Interlocked.Increment(ref _leaseAcquisitionCount);
+            Interlocked.Increment(ref _leaseCount);
+            return true;
+        }
+
+        public void ReleaseLease() => Interlocked.Decrement(ref _leaseCount);
+
+        public void BeginRetirement()
+        {
+        }
+
+        public void CompleteRetirement()
+        {
+        }
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.CompletedTask;
+
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            if (request is not FetchRequest fetchRequest || typeof(TResponse) != typeof(FetchResponse))
+                throw new NotSupportedException($"Unexpected request {typeof(TRequest).Name}");
+
+            if (fetchRequest.Topics is { Count: > 0 } topics && topics[0].Partitions is { Count: > 0 } partitions)
+                Interlocked.Exchange(ref _lastFetchOffset, partitions[0].FetchOffset);
+
+            return ServeFetchAsync<TResponse>(cancellationToken);
+        }
+
+        private async ValueTask<TResponse> ServeFetchAsync<TResponse>(CancellationToken cancellationToken)
+        {
+            var inFlight = Interlocked.Increment(ref _fetchesInFlight);
+            var observedMax = Volatile.Read(ref _maxConcurrentFetches);
+            while (inFlight > observedMax
+                   && Interlocked.CompareExchange(ref _maxConcurrentFetches, inFlight, observedMax) != observedMax)
+            {
+                observedMax = Volatile.Read(ref _maxConcurrentFetches);
+            }
+
+            try
+            {
+                await Task.Delay(FetchWait, cancellationToken);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _fetchesInFlight);
+                Interlocked.Increment(ref _fetchCount);
+            }
+
+            return (TResponse)(object)new FetchResponse { ErrorCode = ErrorCode.None };
+        }
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            throw new NotSupportedException();
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchReissueTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchReissueTests.cs
@@ -251,7 +251,8 @@ public sealed class KafkaConsumerPrefetchReissueTests
                 Interlocked.Increment(ref _fetchCount);
             }
 
-            return (TResponse)(object)new FetchResponse { ErrorCode = ErrorCode.None };
+            object response = new FetchResponse { ErrorCode = ErrorCode.None };
+            return (TResponse)response;
         }
 
         public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchReissueTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchReissueTests.cs
@@ -87,6 +87,65 @@ public sealed class KafkaConsumerPrefetchReissueTests
         await Assert.That(connection.LeaseAcquisitionCount).IsEqualTo(2);
     }
 
+    [Test]
+    [Timeout(60_000)]
+    public async Task MetadataRefresh_EndsTaskAndNextTaskReissuesOnRefreshedSnapshot(CancellationToken cancellationToken)
+    {
+        var connection = new FetchServingConnection();
+        await using var metadataManager = CreateMetadataManager(connection);
+        await using var consumer = CreateConsumer(connection, metadataManager);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 10)]);
+
+        await StartPrefetchAsync(consumer, cancellationToken);
+        await TestWait.UntilAsync(() => connection.FetchCount >= 3, WaitTimeout);
+        await Assert.That(connection.LeaseAcquisitionCount).IsEqualTo(1);
+
+        // Any refresh publishes a new snapshot, even with identical content; the plan is stamped
+        // with the snapshot it was grouped against, so the task hands back to the loop.
+        metadataManager.Metadata.Update(CreateMetadataResponse());
+
+        await TestWait.UntilAsync(() => connection.LeaseAcquisitionCount == 2, WaitTimeout);
+        var fetchesAtRefresh = connection.FetchCount;
+        await TestWait.UntilAsync(() => connection.FetchCount >= fetchesAtRefresh + 3, WaitTimeout);
+        await Assert.That(connection.LeaseAcquisitionCount).IsEqualTo(2);
+    }
+
+    [Test]
+    [Timeout(60_000)]
+    public async Task TopicIdentityMarkerBehindPlan_EndsTaskUntilLoopReprocessesSnapshot(CancellationToken cancellationToken)
+    {
+        var connection = new FetchServingConnection();
+        await using var metadataManager = CreateMetadataManager(connection);
+        await using var consumer = CreateConsumer(connection, metadataManager);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 10)]);
+
+        await StartPrefetchAsync(consumer, cancellationToken);
+        await TestWait.UntilAsync(() => connection.FetchCount >= 3, WaitTimeout);
+        await Assert.That(connection.LeaseAcquisitionCount).IsEqualTo(1);
+
+        // The current snapshot still matches the plan, but the topic-identity pass no longer
+        // vouches for it (an assignment publish replaces the marker the same way). The task must
+        // stop re-issuing; the loop reprocesses the snapshot, restamps, and a fresh task resumes.
+        SetObservedTopicIdentityMarker(consumer, new object());
+
+        await TestWait.UntilAsync(() => connection.LeaseAcquisitionCount == 2, WaitTimeout);
+        var fetchesAtRestamp = connection.FetchCount;
+        await TestWait.UntilAsync(() => connection.FetchCount >= fetchesAtRestamp + 3, WaitTimeout);
+        await Assert.That(connection.LeaseAcquisitionCount).IsEqualTo(2);
+        await Assert.That(GetObservedTopicIdentityMarker(consumer))
+            .IsSameReferenceAs(metadataManager.Metadata.CaptureSnapshot());
+    }
+
+    private static object? GetObservedTopicIdentityMarker(KafkaConsumer<string, string> consumer) =>
+        GetPrivateField("_observedTopicIdentityMarker").GetValue(consumer);
+
+    private static void SetObservedTopicIdentityMarker(KafkaConsumer<string, string> consumer, object marker) =>
+        GetPrivateField("_observedTopicIdentityMarker").SetValue(consumer, marker);
+
+    private static FieldInfo GetPrivateField(string name) =>
+        typeof(KafkaConsumer<string, string>).GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException($"{name} field not found.");
+
     private static async Task StartPrefetchAsync(
         KafkaConsumer<string, string> consumer,
         CancellationToken cancellationToken)
@@ -122,11 +181,7 @@ public sealed class KafkaConsumerPrefetchReissueTests
             pool,
             metadataManager);
 
-        var initialized = typeof(KafkaConsumer<string, string>).GetField(
-            "_initialized",
-            BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("_initialized field not found.");
-        initialized.SetValue(consumer, true);
+        GetPrivateField("_initialized").SetValue(consumer, true);
         return consumer;
     }
 
@@ -140,35 +195,37 @@ public sealed class KafkaConsumerPrefetchReissueTests
             ApiKey.Fetch,
             FetchRequest.LowestSupportedVersion,
             FetchRequest.HighestSupportedVersion);
-        metadataManager.Metadata.Update(new MetadataResponse
-        {
-            Brokers =
-            [
-                new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }
-            ],
-            Topics =
-            [
-                new TopicMetadata
-                {
-                    Name = Topic,
-                    TopicId = TopicId,
-                    ErrorCode = ErrorCode.None,
-                    Partitions =
-                    [
-                        new PartitionMetadata
-                        {
-                            PartitionIndex = 0,
-                            LeaderId = 1,
-                            ErrorCode = ErrorCode.None,
-                            ReplicaNodes = [1],
-                            IsrNodes = [1]
-                        }
-                    ]
-                }
-            ]
-        });
+        metadataManager.Metadata.Update(CreateMetadataResponse());
         return metadataManager;
     }
+
+    private static MetadataResponse CreateMetadataResponse() => new()
+    {
+        Brokers =
+        [
+            new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }
+        ],
+        Topics =
+        [
+            new TopicMetadata
+            {
+                Name = Topic,
+                TopicId = TopicId,
+                ErrorCode = ErrorCode.None,
+                Partitions =
+                [
+                    new PartitionMetadata
+                    {
+                        PartitionIndex = 0,
+                        LeaderId = 1,
+                        ErrorCode = ErrorCode.None,
+                        ReplicaNodes = [1],
+                        IsrNodes = [1]
+                    }
+                ]
+            }
+        ]
+    };
 
     /// <summary>
     /// Answers every fetch with an empty response after a short broker-like wait, and counts

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchReissueTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchReissueTests.cs
@@ -136,6 +136,38 @@ public sealed class KafkaConsumerPrefetchReissueTests
             .IsSameReferenceAs(metadataManager.Metadata.CaptureSnapshot());
     }
 
+    [Test]
+    [Timeout(60_000)]
+    public async Task ScaleDecisionDue_EndsTaskSoLoopCanScaleUp(CancellationToken cancellationToken)
+    {
+        var connection = new FetchServingConnection();
+        await using var metadataManager = CreateMetadataManager(connection);
+        await using var consumer = CreateConsumer(connection, metadataManager, adaptiveConnections: true);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 10)]);
+
+        await StartPrefetchAsync(consumer, cancellationToken);
+        await TestWait.UntilAsync(() => connection.FetchCount >= 3, WaitTimeout);
+        await Assert.That(connection.LeaseAcquisitionCount).IsEqualTo(1);
+
+        var scaler = GetConnectionScaler(consumer);
+        await Assert.That(scaler.CurrentConnectionCount).IsEqualTo(1);
+
+        // Steady re-issuing never accumulates saturation (each fetch restarts the window, as the
+        // loop-owned path did). A fetch that outlasts the scale-up threshold is a due decision:
+        // the task must end so the loop, the only MaybeScale caller, can act on it.
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(6));
+
+        await TestWait.UntilAsync(() => scaler.CurrentConnectionCount == 2, WaitTimeout);
+        await TestWait.UntilAsync(() => connection.LeaseAcquisitionCount >= 2, WaitTimeout);
+        var fetchesAtScale = connection.FetchCount;
+        await TestWait.UntilAsync(() => connection.FetchCount >= fetchesAtScale + 3, WaitTimeout);
+        await Assert.That(scaler.CurrentConnectionCount).IsEqualTo(2);
+    }
+
+    private static ConsumerConnectionScaler GetConnectionScaler(KafkaConsumer<string, string> consumer) =>
+        (ConsumerConnectionScaler?)GetPrivateField("_connectionScaler").GetValue(consumer)
+        ?? throw new InvalidOperationException("Adaptive connection scaler not created.");
+
     private static object? GetObservedTopicIdentityMarker(KafkaConsumer<string, string> consumer) =>
         GetPrivateField("_observedTopicIdentityMarker").GetValue(consumer);
 
@@ -158,7 +190,8 @@ public sealed class KafkaConsumerPrefetchReissueTests
 
     private static KafkaConsumer<string, string> CreateConsumer(
         FetchServingConnection connection,
-        MetadataManager metadataManager)
+        MetadataManager metadataManager,
+        bool adaptiveConnections = false)
     {
         var pool = Substitute.For<IConnectionPool>();
         pool.DisposeAsync().Returns(ValueTask.CompletedTask);
@@ -173,7 +206,10 @@ public sealed class KafkaConsumerPrefetchReissueTests
                 BootstrapServers = ["localhost:9092"],
                 ClientId = "prefetch-reissue-test",
                 OffsetCommitMode = OffsetCommitMode.Manual,
-                EnableAdaptiveConnections = false,
+                // One fetch connection either way; adaptive mode may add the coordination one.
+                ConnectionsPerBroker = 1,
+                MaxConnectionsPerBroker = adaptiveConnections ? 2 : 1,
+                EnableAdaptiveConnections = adaptiveConnections,
                 IsAutoTuned = false
             },
             Serializers.String,

--- a/tests/Dekaf.Tests.Unit/Consumer/PrefetchLoopControlTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PrefetchLoopControlTests.cs
@@ -23,7 +23,6 @@ public sealed class PrefetchLoopControlTests
 
         await Assert.That(decision.Action).IsEqualTo(PrefetchLoopAction.WaitForAny);
         await Assert.That(decision.ReportBacklog).IsTrue();
-        await Assert.That(decision.RecordFetchWait).IsTrue();
     }
 
     [Test]
@@ -36,7 +35,6 @@ public sealed class PrefetchLoopControlTests
 
         await Assert.That(decision.Action).IsEqualTo(PrefetchLoopAction.WaitForAny);
         await Assert.That(decision.ReportBacklog).IsFalse();
-        await Assert.That(decision.RecordFetchWait).IsTrue();
     }
 
     [Test]
@@ -49,7 +47,6 @@ public sealed class PrefetchLoopControlTests
 
         await Assert.That(decision.Action).IsEqualTo(PrefetchLoopAction.DelayNoWork);
         await Assert.That(decision.ReportBacklog).IsFalse();
-        await Assert.That(decision.RecordFetchWait).IsFalse();
     }
 
     [Test]
@@ -62,7 +59,6 @@ public sealed class PrefetchLoopControlTests
 
         await Assert.That(decision.Action).IsEqualTo(PrefetchLoopAction.Continue);
         await Assert.That(decision.ReportBacklog).IsFalse();
-        await Assert.That(decision.RecordFetchWait).IsFalse();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Internal/AsyncAutoResetSignalTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/AsyncAutoResetSignalTests.cs
@@ -61,4 +61,46 @@ public class AsyncAutoResetSignalTests
                 await signal.WaitAsync(Timeout.Infinite).AsTask().WaitAsync(TimeSpan.FromSeconds(1)))
             .Throws<OperationCanceledException>();
     }
+
+    [Test]
+    public async Task InlineSignalContinuations_ResumeWaiterOnSignalerThreadAndRearm()
+    {
+        using var signal = new AsyncAutoResetSignal(inlineSignalContinuations: true);
+
+        for (var i = 0; i < 100; i++)
+        {
+            var resumedOnThread = 0;
+            var waiter = ObserveResumeThreadAsync(signal, thread => Volatile.Write(ref resumedOnThread, thread));
+
+            signal.Signal();
+
+            // The waiter's continuation ran inside Signal(), on this thread, before it returned.
+            await Assert.That(Volatile.Read(ref resumedOnThread)).IsEqualTo(Environment.CurrentManagedThreadId);
+            await waiter;
+        }
+
+        // A signal with no waiter is stored and consumed by the next wait.
+        signal.Signal();
+        await Assert.That(await signal.WaitAsync(Timeout.Infinite)).IsTrue();
+    }
+
+    [Test]
+    public async Task InlineSignalContinuations_ShutdownStillCompletesWaiter()
+    {
+        using var signal = new AsyncAutoResetSignal(inlineSignalContinuations: true);
+        using var cancellation = new CancellationTokenSource();
+        signal.RegisterShutdownToken(cancellation.Token);
+
+        var wait = signal.WaitAsync(Timeout.Infinite).AsTask();
+        cancellation.Cancel();
+
+        await Assert.That(async () => await wait.WaitAsync(TimeSpan.FromSeconds(5)))
+            .Throws<OperationCanceledException>();
+    }
+
+    private static async Task ObserveResumeThreadAsync(AsyncAutoResetSignal signal, Action<int> onResumed)
+    {
+        await signal.WaitAsync(Timeout.Infinite).ConfigureAwait(false);
+        onResumed(Environment.CurrentManagedThreadId);
+    }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerPrefetchSchedulerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerPrefetchSchedulerBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 using Dekaf.Consumer;
 
@@ -63,7 +64,7 @@ public class BrokerPrefetchSchedulerBenchmarks
         for (var cycle = 0; cycle < WakeCycles; cycle++)
         {
             var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            if (!scheduler.TryStart(CompletingKey, () => completion.Task))
+            if (!scheduler.TryStart(CompletingKey, CreateTaskFactory(completion)))
                 throw new InvalidOperationException("Completing key was still in flight.");
 
             var wait = scheduler.WaitForAnyAsync(_cancellation.Token);
@@ -80,7 +81,7 @@ public class BrokerPrefetchSchedulerBenchmarks
         for (var cycle = 0; cycle < WakeCycles; cycle++)
         {
             var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            inFlight[CompletingKey] = completion.Task;
+            inFlight[CompletingKey] = CreateTaskFactory(completion)();
 
             var wait = WaitWithTaskWhenAnyAsync(inFlight, _cancellation.Token);
             completion.SetResult();
@@ -90,6 +91,10 @@ public class BrokerPrefetchSchedulerBenchmarks
                 throw new InvalidOperationException("Completing key was not tracked.");
         }
     }
+
+    // Keep both paths' factory allocation observable across the same call boundary.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Func<Task> CreateTaskFactory(TaskCompletionSource completion) => () => completion.Task;
 
     private static async ValueTask WaitWithTaskWhenAnyAsync(
         Dictionary<(int BrokerId, int ConnectionIndex), Task> inFlight,

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerPrefetchSchedulerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerPrefetchSchedulerBenchmarks.cs
@@ -3,47 +3,99 @@ using Dekaf.Consumer;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
+/// <summary>
+/// Measures one prefetch-loop wake cycle, amortized over <see cref="WakeCycles"/> cycles per
+/// invocation so per-wake time and allocation are resolvable: start a task for the completing
+/// key, wait for any in-flight task, complete it, resume, drain it. <c>TaskWhenAny_*</c> is the
+/// hand-rolled reference (dictionary snapshot + <c>Task.WhenAny</c> + <c>WaitAsync</c>) the
+/// scheduler used to inline and serves as the within-run control; <c>Scheduler_*</c> exercise
+/// <see cref="BrokerPrefetchScheduler"/> itself. Both variants pay the same per-cycle
+/// <see cref="TaskCompletionSource"/> and closure, so the difference is the wake-up mechanism.
+/// </summary>
 [MemoryDiagnoser]
 [ShortRunJob]
 public class BrokerPrefetchSchedulerBenchmarks
 {
-    private BrokerPrefetchScheduler _scheduler = null!;
-    private TaskCompletionSource _completion = null!;
+    private const int WakeCycles = 1_000;
+    private const int PendingPeers = 3;
+    private static readonly Task PendingTask = new TaskCompletionSource().Task;
+    private static readonly (int BrokerId, int ConnectionIndex) CompletingKey = (BrokerId: 0, ConnectionIndex: 0);
+
+    private BrokerPrefetchScheduler _singleScheduler = null!;
+    private BrokerPrefetchScheduler _multiScheduler = null!;
+    private Dictionary<(int BrokerId, int ConnectionIndex), Task> _whenAnySingle = null!;
+    private Dictionary<(int BrokerId, int ConnectionIndex), Task> _whenAnyMulti = null!;
     private CancellationTokenSource _cancellation = null!;
 
-    [IterationSetup]
-    public void Setup()
+    [GlobalSetup]
+    public void GlobalSetup()
     {
-        _scheduler = new BrokerPrefetchScheduler();
-        _completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         _cancellation = new CancellationTokenSource();
-
-        if (!_scheduler.TryStart((BrokerId: 1, ConnectionIndex: 0), () => _completion.Task))
-            throw new InvalidOperationException("Could not register benchmark task.");
+        _singleScheduler = new BrokerPrefetchScheduler();
+        _multiScheduler = new BrokerPrefetchScheduler();
+        _whenAnySingle = [];
+        _whenAnyMulti = [];
+        for (var peer = 1; peer <= PendingPeers; peer++)
+        {
+            var key = (BrokerId: peer, ConnectionIndex: 0);
+            _multiScheduler.TryStart(key, static () => PendingTask);
+            _whenAnyMulti[key] = PendingTask;
+        }
     }
 
-    [IterationCleanup]
-    public void Cleanup() => _cancellation.Dispose();
+    [GlobalCleanup]
+    public void GlobalCleanup() => _cancellation.Dispose();
 
-    [Benchmark(Baseline = true)]
-    public ValueTask TaskWhenAny_PendingCancellable()
+    [Benchmark(Baseline = true, OperationsPerInvoke = WakeCycles)]
+    public Task TaskWhenAny_SinglePending() => RunTaskWhenAnyCyclesAsync(_whenAnySingle);
+
+    [Benchmark(OperationsPerInvoke = WakeCycles)]
+    public Task Scheduler_SinglePending() => RunSchedulerCyclesAsync(_singleScheduler);
+
+    [Benchmark(OperationsPerInvoke = WakeCycles)]
+    public Task TaskWhenAny_MultiPending() => RunTaskWhenAnyCyclesAsync(_whenAnyMulti);
+
+    [Benchmark(OperationsPerInvoke = WakeCycles)]
+    public Task Scheduler_MultiPending() => RunSchedulerCyclesAsync(_multiScheduler);
+
+    private async Task RunSchedulerCyclesAsync(BrokerPrefetchScheduler scheduler)
     {
-        var wait = WaitWithTaskWhenAnyAsync(_completion.Task, _cancellation.Token);
-        _completion.SetResult();
-        return wait;
+        for (var cycle = 0; cycle < WakeCycles; cycle++)
+        {
+            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (!scheduler.TryStart(CompletingKey, () => completion.Task))
+                throw new InvalidOperationException("Completing key was still in flight.");
+
+            var wait = scheduler.WaitForAnyAsync(_cancellation.Token);
+            completion.SetResult();
+            await wait.ConfigureAwait(false);
+
+            if (await scheduler.DrainCompletedAsync().ConfigureAwait(false) != 1)
+                throw new InvalidOperationException("Expected exactly one completed task per cycle.");
+        }
     }
 
-    [Benchmark]
-    public ValueTask SingleTask_PendingCancellable()
+    private async Task RunTaskWhenAnyCyclesAsync(Dictionary<(int BrokerId, int ConnectionIndex), Task> inFlight)
     {
-        var wait = _scheduler.WaitForAnyAsync(_cancellation.Token);
-        _completion.SetResult();
-        return wait;
+        for (var cycle = 0; cycle < WakeCycles; cycle++)
+        {
+            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            inFlight[CompletingKey] = completion.Task;
+
+            var wait = WaitWithTaskWhenAnyAsync(inFlight, _cancellation.Token);
+            completion.SetResult();
+            await wait.ConfigureAwait(false);
+
+            if (!inFlight.Remove(CompletingKey))
+                throw new InvalidOperationException("Completing key was not tracked.");
+        }
     }
 
-    private static async ValueTask WaitWithTaskWhenAnyAsync(Task task, CancellationToken cancellationToken)
+    private static async ValueTask WaitWithTaskWhenAnyAsync(
+        Dictionary<(int BrokerId, int ConnectionIndex), Task> inFlight,
+        CancellationToken cancellationToken)
     {
-        Task[] tasks = [task];
+        var tasks = inFlight.Values.ToArray();
         await Task.WhenAny(tasks).WaitAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerPrefetchSchedulerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerPrefetchSchedulerBenchmarks.cs
@@ -4,6 +4,56 @@ using Dekaf.Consumer;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
+[MemoryDiagnoser]
+public class BrokerPrefetchDispatchBenchmarks
+{
+    private BrokerPrefetchScheduler _pending = null!;
+    private BrokerPrefetchScheduler _completed = null!;
+    private Task _task = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _pending = new BrokerPrefetchScheduler();
+        _completed = new BrokerPrefetchScheduler();
+        _task = Task.CompletedTask;
+        _pending.TryStart((1, 0), static () => new TaskCompletionSource().Task);
+        // Populate the completed list before measuring steady dispatch.
+        _completed.TryStart((1, 0), static () => Task.CompletedTask);
+        _completed.DrainCompletedAsync().GetAwaiter().GetResult();
+    }
+
+    [Benchmark(Baseline = true)]
+    public bool CapturingFactory_Pending() => _pending.TryStart((1, 0), Capture(_task));
+
+    [Benchmark]
+    public bool StateFactory_Pending() => _pending.TryStart((1, 0), _task, static task => task);
+
+    [Benchmark]
+    public ValueTask<int> CapturingFactory_StartAndDrain()
+    {
+        _completed.TryStart((1, 0), Capture(_task));
+        return _completed.DrainCompletedAsync();
+    }
+
+    [Benchmark]
+    public ValueTask<int> StateFactory_StartAndDrain()
+    {
+        _completed.TryStart((1, 0), _task, static task => task);
+        return _completed.DrainCompletedAsync();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Func<Task> Capture(Task task) => () => task;
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _pending.Dispose();
+        _completed.Dispose();
+    }
+}
+
 /// <summary>
 /// Measures one prefetch-loop wake cycle, amortized over <see cref="WakeCycles"/> cycles per
 /// invocation so per-wake time and allocation are resolvable: start a task for the completing


### PR DESCRIPTION
Fetches previously waited for the central prefetch loop to wake and rebuild dispatch state before issuing another request. This PR lets the completing broker task reissue immediately while its assignment, routing, metadata and memory-admission plan remains valid. It also reduces scheduler wake-up allocation and removes captured dispatch closures.

The central loop still owns assignment changes, pause/resume, seeks, routing transitions, backoff and memory waits. A broker task retains its connection lease and reissues only after a plain successful response and a valid plan check. Errors, stale epochs, revocations, metadata changes, expired preferred replicas, scaling and shutdown return control to the central loop. Each fetch session retains one request in flight.

Scheduler completion uses a reusable signal and cached continuation instead of allocating a task snapshot and `Task.WhenAny` wrapper. Dispatch now passes explicit state to a cached static factory, eliminating captured closures even when a key is already pending. Duplicate keys never invoke the factory; a throwing factory leaves the key unreserved. Adaptive fetch timing is recorded by the broker task. No public API changes.

Current head: `e6aabd518dbde30505fe354b6149ad1c3eddbf19`.

**Final recommendation: close this proposal.** The [warmed raw-consumer A/B/A comparison](https://github.com/thomhurst/Dekaf/pull/2993#issuecomment-5548476339) reports REGRESSION: throughput -3.636% and CPU/message +3.081% versus the bracketing main control mean. Allocation improves 30.363% (0.095004 -> 0.066158 B/message), but this is not an approved throughput-for-allocation trade. Full controls, uncertainty, latency resolution, max latency, stability, exact SHAs and run configuration are in the linked verdict.

All current PR CI checks passed. The new five-segment comparison completed with zero errors, matching message/latency counts and validated partition offsets; only its performance gate failed. [Isolated dispatch benchmarks](https://github.com/thomhurst/Dekaf/pull/2993#issuecomment-5547270119) still show 88 -> 0 B/op and faster timings, but do not establish whole-consumer acceptance. The separate pooled-wait experiment was rejected and remains absent.

The fetch-plan/lifecycle complexity is not justified by the accepted evidence. No further paid run or merge is planned. Earlier experiments and all raw results remain linked in the PR history.
