### PR TITLE
fix(ci): restore Claude reviews with pinned GitHub Actions

### DIFF
--- a/.github/scripts/test_action_pins.py
+++ b/.github/scripts/test_action_pins.py
@@ -16,6 +16,29 @@ PIN_PATTERN = re.compile(
 
 
 class ActionPinTests(unittest.TestCase):
+    def test_remote_actions_are_pinned_to_full_commit_shas(self) -> None:
+        for workflow_path in WORKFLOW_DIRECTORY.iterdir():
+            if workflow_path.suffix not in {".yml", ".yaml"}:
+                continue
+
+            for line_number, line in enumerate(
+                workflow_path.read_text(encoding="utf-8").splitlines(), start=1
+            ):
+                match = re.match(r"^\s*(?:-\s+)?uses:\s*([^\s#]+)", line)
+                if match is None:
+                    continue
+
+                action = match.group(1).strip("\"'")
+                if action.startswith(("./", "docker://")):
+                    continue
+
+                with self.subTest(workflow=workflow_path.name, line=line_number):
+                    self.assertRegex(
+                        action,
+                        r"^[^@]+@[0-9a-fA-F]{40}$",
+                        "Remote actions must be pinned to a full-length commit SHA",
+                    )
+
     def test_actions_without_moving_major_tags_use_exact_release_comments(self) -> None:
         found_actions: set[str] = set()
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,13 +49,13 @@ jobs:
     steps:
       # Trusted base ref at the workspace root - this is what Claude runs in.
       - name: Checkout base repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       # Untrusted PR head, kept in a subdirectory and exposed read-only via --add-dir.
       - name: Checkout pull request head
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', inputs.pr_number) }}
           path: pr-head
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@ef8bb1e43bf303cff727a1dd0b8837029fe982a2 # v1
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -15,11 +15,11 @@ jobs:
       # Cap the write-capable helper so an injected instruction cannot spam the issue.
       CLAUDE_CODE_SCRIPT_CAPS: '{"triage-issue.sh":3}'
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@ef8bb1e43bf303cff727a1dd0b8837029fe982a2 # v1
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
Claude reviews on #2990, #2992, and #2993 fail during runner setup because the repository requires actions to be pinned to full commit SHAs. The review workflow still references `actions/checkout@v7.0.1` and `anthropics/claude-code-action@v1` ([failure log](https://github.com/thomhurst/Dekaf/actions/runs/33914622389)).

Replace those references in the review and issue-triage workflows with the SHA pins already used by `claude.yml`, retaining version comments for Renovate. Extend the existing action-pin tests to check all remote action references across `.yml` and `.yaml` workflows, including inline `- uses:` steps. Existing CI already runs these tests.

Validation: the new regression check failed on all five unpinned references before the fix; all 172 Python script tests pass afterward (`python -m unittest discover -s .github/scripts -p 'test_*.py'`). `git diff --check` passes.

The automatic review uses `pull_request_target`, so it will continue using the base branch workflow until this fix is merged. A successful live Claude review still needs verification after merge.
