### PR TITLE
chore(deps): update Reservoir to 1.6.7

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,7 +52,7 @@
     <PackageVersion Include="OpenTelemetry.Api" Version="1.18.0" />
     <PackageVersion Include="Polyfill" Version="11.2.0" />
     <PackageVersion Include="protobuf-net.Reflection" Version="3.4.21" />
-    <PackageVersion Include="Reservoir" Version="1.6.0" />
+    <PackageVersion Include="Reservoir" Version="1.6.7" />
     <PackageVersion Include="SharpFuzz" Version="2.3.0" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="SSH.NET" Version="2026.0.0" />


### PR DESCRIPTION
Update the central Reservoir dependency from 1.6.0 to 1.6.7. No Dekaf implementation changes.

Local measurements show a repeatable ~26.7% reduction in same-thread bulk completion time and a ~3–4% increase in cross-thread completion time. All measured cases report 0 B/op. This is a mixed result: an overall Kafka performance improvement and Pareto-safe acceptance are not established.

Validation: 556 focused unit tests and four real-Kafka integration tests passed. Unit, integration and benchmark Release builds completed with zero warnings/errors. Final `/simplify` review and `git diff --check` passed.

Baseline: `c080594b4790b593d67eecc6ea0e95a9efe29015`.
Candidate: `368447b0cb0134b462c97b46b9c591cb27f969a6` (the measured one-line working-tree update, now committed).

<details>
<summary>Full before/after measurements, repeats, controls and reproduction</summary>
Windows 11, Intel Core i7-12700K (12 physical / 20 logical cores), .NET SDK 10.0.400, runtime 10.0.11, BenchmarkDotNet 0.15.8, Release, Default job, MemoryDiagnoser, default outlier handling. Runs executed sequentially on the same machine; no concurrent agent builds or tests during measurement. No CPU profiler. These are local microbenchmarks: lane, dispatch shape, stress duration and CI run URL are not applicable.

Order: seven-case baseline → seven-case candidate → three-case candidate repeat → three-case baseline control. Both versions passed seven-case Dry validation first. Dependency manifests, DLL hashes, raw logs and JSON are retained in local task artifacts.

## Initial comparison

Time deltas: negative is faster. Ops/s are benchmark operations, not Kafka messages/sec.

| Method | 1.6.0 ns | 1.6.7 ns | Time delta | 1.6.0 ops/s | 1.6.7 ops/s | Throughput delta | Bytes/op before → after |
|---|---:|---:|---:|---:|---:|---:|---:|
| ValueTaskSourceRentCompleteReturn | 25.44 | 25.77 | +1.3% | 39,306,005 | 38,807,608 | -1.3% | 0 → 0 |
| PendingFetchDataRentReturn | 29.70 | 29.87 | +0.6% | 33,673,883 | 33,473,922 | -0.6% | 0 → 0 |
| BatchArenaRentReturn | 20.21 | 20.06 | -0.8% | 49,470,149 | 49,849,980 | +0.8% | 0 → 0 |
| PendingRequestRentReturn | 28.27 | 35.24 | +24.7% | 35,374,920 | 28,375,151 | -19.8% | 0 → 0 |
| PipeMemoryOwnerRentReturn | 39.61 | 39.27 | -0.9% | 25,245,481 | 25,465,512 | +0.9% | 0 → 0 |
| RentReturnSameThread | 50.49 | 37.09 | -26.5% | 19,807,353 | 26,961,120 | +36.1% | 0 → 0 |
| RentReturnCrossThread | 82.91 | 85.54 | +3.2% | 12,060,970 | 11,690,173 | -3.1% | 0 → 0 |

## Every measured result

Error is the 99.9% confidence interval half-width. Median and maximum describe iteration-average ns/op, not individual-message latency. Full statistics are retained in the local JSON reports and comparison.csv.

| Run | Method | Mean ± error ns | StdDev ns | Median ns | Max ns | Iterations | Bytes/op |
|---|---|---:|---:|---:|---:|---:|---:|
| before | ValueTaskSourceRentCompleteReturn | 25.44 ± 0.09 | 0.07 | 25.43 | 25.60 | 13 | 0 |
| before | PendingFetchDataRentReturn | 29.70 ± 0.27 | 0.22 | 29.59 | 30.24 | 13 | 0 |
| before | BatchArenaRentReturn | 20.21 ± 0.12 | 0.10 | 20.19 | 20.43 | 13 | 0 |
| before | PendingRequestRentReturn | 28.27 ± 0.16 | 0.14 | 28.19 | 28.55 | 14 | 0 |
| before | PipeMemoryOwnerRentReturn | 39.61 ± 0.25 | 0.21 | 39.54 | 40.03 | 13 | 0 |
| before | RentReturnSameThread | 50.49 ± 0.52 | 0.46 | 50.24 | 51.39 | 14 | 0 |
| before | RentReturnCrossThread | 82.91 ± 1.62 | 1.86 | 82.88 | 86.63 | 20 | 0 |
| after | ValueTaskSourceRentCompleteReturn | 25.77 ± 0.36 | 0.32 | 25.65 | 26.51 | 14 | 0 |
| after | PendingFetchDataRentReturn | 29.87 ± 0.16 | 0.14 | 29.88 | 30.11 | 14 | 0 |
| after | BatchArenaRentReturn | 20.06 ± 0.11 | 0.09 | 20.03 | 20.27 | 13 | 0 |
| after | PendingRequestRentReturn | 35.24 ± 0.15 | 0.13 | 35.20 | 35.48 | 13 | 0 |
| after | PipeMemoryOwnerRentReturn | 39.27 ± 0.19 | 0.16 | 39.21 | 39.54 | 13 | 0 |
| after | RentReturnSameThread | 37.09 ± 0.14 | 0.12 | 37.07 | 37.30 | 13 | 0 |
| after | RentReturnCrossThread | 85.54 ± 1.40 | 1.81 | 85.08 | 89.61 | 24 | 0 |
| after-repeat | PendingRequestRentReturn | 28.34 ± 0.15 | 0.12 | 28.27 | 28.55 | 13 | 0 |
| after-repeat | RentReturnSameThread | 36.96 ± 0.16 | 0.13 | 36.89 | 37.20 | 13 | 0 |
| after-repeat | RentReturnCrossThread | 86.45 ± 1.63 | 3.06 | 85.75 | 94.83 | 44 | 0 |
| before-control | PendingRequestRentReturn | 28.99 ± 0.31 | 0.27 | 28.92 | 29.61 | 14 | 0 |
| before-control | RentReturnSameThread | 50.49 ± 0.41 | 0.34 | 50.49 | 51.31 | 13 | 0 |
| before-control | RentReturnCrossThread | 83.42 ± 1.30 | 1.15 | 83.19 | 86.66 | 14 | 0 |

## Interpretation and limits

- Same-thread bulk completion lifecycle improved consistently: baseline 50.49 / 50.49 ns; candidate 37.09 / 36.96 ns, about 26.7% less time.
- Cross-thread completion lifecycle was consistently slower in these local runs: baseline 82.91 / 83.42 ns; candidate 85.54 / 86.45 ns, about 3–4% more time. Run variance and scheduling remain possible contributors; this is a potential regression, not proof of a production regression.
- Pending-request first candidate run was 35.24 ns versus 28.27 ns baseline (+24.7%). This did not reproduce: candidate repeat 28.34 ns; baseline control 28.99 ns. Retain the first result as run variability, not a discarded result or a confirmed improvement.
- Other four cases changed between -0.9% and +1.3% in the initial comparison. All 20 measured cases reported 0 B/op and completed without benchmark failures.
- Decision: mixed microbenchmark result; do not claim Pareto-safe acceptance or a general Kafka throughput improvement. The cross-thread tradeoff remains explicit for maintainer review; this report does not classify the update as Pareto-safe.
- End-to-end throughput, individual-message p50/p99/max latency, CPU/message, process-wide allocations on other threads, and long-duration stability were not measured. MemoryDiagnoser alone does not establish allocation behavior on background worker threads. No paid stress run dispatched. No historical accepted stress baseline or within-run Kafka control comparison was performed.

## Reproduction

Set the central Reservoir version to the selected version, then run from the repository root (use distinct artifact paths per run):

```powershell
dotnet run --project tools/Dekaf.Benchmarks -c Release -- --filter '*PoolHotPathBenchmarks*' '*ValueTaskSourcePoolBenchmarks*' --job Default --artifacts <unique-path> --exporters fulljson
```

For repeat/control runs, replace the first filter with '*PoolHotPathBenchmarks.PendingRequestRentReturn'. Candidate repeat used --no-build; baseline control rebuilt. Dry runs used the full filters with --job Dry. Existing benchmark implementations were unchanged.

## Correctness validation

- Reservoir 1.6.7: unit and integration Release builds succeeded with 0 warnings and 0 errors.
- 556 focused unit tests passed: pool classes, PendingFetchData, BatchArena, PartitionInflightTracker, RentedBufferWriter and RecordBatch.
- Four real-Kafka integration tests passed: acknowledged-response pooled ownership, concurrent production, consumer subscribe/consume, and header consumption.
- Initial unit invocation failed before test execution because whole-path OR filters are unsupported by the installed test runner. Corrected to segment alternatives; retained the original error log. No failing test was blindly rerun.
- Final simplification review: the one-line central package update needs no additional code changes. git diff --check passed.

Exact successful test commands (after Release builds):

```powershell
./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe --treenode-filter '/*/*/(*Pool*|PendingFetchDataTests|BatchArenaTests|PartitionInflightTrackerTests|RentedBufferWriterTests|RecordBatchTests)/*'
./tests/Dekaf.Tests.Integration/bin/Release/net10.0/Dekaf.Tests.Integration.exe --treenode-filter '/*/*/*/(Producer_AcknowledgedResponses_ReleasePooledOwnership|Producer_ConcurrentProducesToSameTopic_AllMessagesDelivered|Consumer_SubscribeAndConsume_ReceivesMessages|Consumer_ConsumeWithHeaders_ReceivesHeaders)'
```

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the centrally managed Reservoir package to version 1.6.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->