### PR TITLE
ci(stress): trend delivery latency on history bands and lane-scope environment shifts

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -27,7 +27,9 @@ SCENARIO_TITLES = {
     'consumer-raw-batch': 'Consumer (Raw Batch)',
 }
 
+# Delivery-latency product bars: reported, never gating (see paired_latency_thresholds).
 LATENCY_RATIO_THRESHOLD = 2.0
+LATENCY_TARGET_P95_MULTIPLIER = 3.0
 MAX_TIMELINE_ROWS = 100
 
 # Plain-language scenario labels for the user-facing docs page. Internal keys
@@ -254,86 +256,80 @@ def intra_run_throughput(result):
 
 
 def paired_latency_thresholds(results):
-    """Compare each Dekaf p50/p99 with its matching Confluent result."""
-    baselines = {}
-    for result in results:
-        if str(result.get('client', '')).casefold() != 'confluent':
-            continue
-        latency = result.get('latency')
-        if not isinstance(latency, dict):
-            continue
-        baselines[_latency_identity(result)] = latency
+    """Report each Dekaf lane against the delivery-latency product bars.
+
+    Every row is a non-gating warning (``failureEligible`` is False): p95 against
+    the configured delivery-latency target, and p50/p99 against the same-run
+    Confluent control. The regression gate for latency lives in stress_trend.py,
+    which trends each percentile against the lane's own history band; hard bars
+    placed inside a lane's run-to-run noise made that gate flip on noise
+    (producer-3b went red 8 of 10 weeks on a rotating metric with no change).
+    """
+    controls = {
+        _latency_identity(result): result
+        for result in results
+        if str(result.get('client', '')).casefold() == 'confluent'
+    }
 
     evaluations = []
     for result in results:
         client = str(result.get('client', ''))
         if not client.casefold().startswith('dekaf'):
             continue
-        latency = result.get('latency')
-        if not isinstance(latency, dict):
-            continue
 
         target_ms = result.get('deliveryLatencyTargetMs')
-        p95_us = latency.get('p95Us')
-        if _positive_finite_number(target_ms) and _positive_finite_number(p95_us):
-            ratio = p95_us / (target_ms * 1_000)
-            breached = ratio > 3.0
-            evaluations.append({
-                'scenario': _latency_scenario_label(result),
-                'metric': 'latencyP95TargetRatio',
-                'metricLabel': 'Delivery latency p95 / target',
-                'current': ratio,
-                'baselineCount': 0,
-                'median': None,
-                'mad': None,
-                'lower': None,
-                'upper': 3.0,
-                'status': 'regression' if breached else 'stable',
-                'repeatedRegression': False,
-                'thresholdBreach': breached,
-                'thresholdDirection': 'maximum',
-                'latencyThreshold': True,
-            })
+        p95_ms = delivery_latency_ms(result, 'p95Us')
+        if _positive_finite_number(target_ms) and p95_ms is not None:
+            evaluations.append(_product_bar(
+                result,
+                'latencyP95TargetRatio',
+                'Delivery latency p95 / target',
+                p95_ms / target_ms,
+                LATENCY_TARGET_P95_MULTIPLIER,
+            ))
 
         # Multi-connection Dekaf variants use their own throughput profile and have no
         # like-for-like Confluent pair, but the absolute configured target still applies.
         if client.casefold() != 'dekaf':
             continue
 
-        baseline = baselines.get(_latency_identity(result))
-        if baseline is None:
+        control = controls.get(_latency_identity(result))
+        if control is None:
             continue
 
         for field, metric, label in (
             ('p50Us', 'latencyP50Ratio', 'Delivery latency p50 / Confluent'),
             ('p99Us', 'latencyP99Ratio', 'Delivery latency p99 / Confluent'),
         ):
-            current = latency.get(field)
-            reference = baseline.get(field)
-            if (
-                not _positive_finite_number(current)
-                or not _positive_finite_number(reference)
-            ):
+            current = delivery_latency_ms(result, field)
+            reference = delivery_latency_ms(control, field)
+            if current is None or reference is None:
                 continue
-            ratio = current / reference
-            breached = ratio > LATENCY_RATIO_THRESHOLD
-            evaluations.append({
-                'scenario': _latency_scenario_label(result),
-                'metric': metric,
-                'metricLabel': label,
-                'current': ratio,
-                'baselineCount': 0,
-                'median': None,
-                'mad': None,
-                'lower': None,
-                'upper': LATENCY_RATIO_THRESHOLD,
-                'status': 'regression' if breached else 'stable',
-                'repeatedRegression': False,
-                'thresholdBreach': breached,
-                'thresholdDirection': 'maximum',
-                'latencyThreshold': True,
-            })
+            evaluations.append(_product_bar(
+                result, metric, label, current / reference, LATENCY_RATIO_THRESHOLD
+            ))
     return evaluations
+
+
+def _product_bar(result, metric, label, ratio, limit):
+    breached = ratio > limit
+    return {
+        'scenario': _latency_scenario_label(result),
+        'metric': metric,
+        'metricLabel': f'{label} (product bar)',
+        'current': ratio,
+        'baselineCount': 0,
+        'median': None,
+        'mad': None,
+        'lower': None,
+        'upper': limit,
+        'status': 'regression' if breached else 'stable',
+        'repeatedRegression': False,
+        'thresholdBreach': breached,
+        'thresholdDirection': 'maximum',
+        'latencyThreshold': True,
+        'failureEligible': False,
+    }
 
 
 def _positive_finite_number(value):
@@ -406,6 +402,17 @@ def comparison_rate(result):
     """Rate used for ranking and ratios: median interval rate when present, else headline rate."""
     rate = median_interval_rate(result)
     return rate if rate is not None else effective_rate(result)
+
+
+def delivery_latency_ms(result, field):
+    """Sampled delivery-latency percentile in milliseconds, or None when absent."""
+    latency = result.get('latency')
+    if not isinstance(latency, dict):
+        return None
+    value = latency.get(field)
+    if not _positive_finite_number(value):
+        return None
+    return value / 1_000
 
 
 def geometric_mean(values):
@@ -1458,7 +1465,8 @@ _METHODOLOGY_BULLETS = [
     "- **Round-Trip CPU Scope**: CPU time covers both bulk production and consumer validation; it is not a producer-only metric",
     "- **Round-Trip Alloc Scope**: the GC/alloc window likewise spans production plus consume-side validation; values are deliberately consumed as byte[] on both clients for parity, so each consumed payload is materialized as a fresh array (~152 B at 128 B messages) — the expected allocation floor for this lane, not a leak",
     "- **CPU Efficiency**: CPU time per message differentiates client efficiency even at equal throughput",
-    "- **Noise-Aware Trends**: each scenario is compared with its last 10 matching runs using a median ± 2×MAD band; one adverse excursion warns and two consecutive regressions fail the workflow",
+    "- **Noise-Aware Trends**: each scenario's throughput, CPU per message and Dekaf delivery-latency p50/p95/p99 are compared with its last 10 matching runs using a median ± 2×MAD band; one adverse excursion warns and two consecutive regressions fail the workflow, and paired lanes fail only when the same-run Dekaf/Confluent ratio regressed too",
+    f"- **Latency Product Bars**: p95 within {LATENCY_TARGET_P95_MULTIPLIER:g}× the configured delivery-latency target and p50/p99 within {LATENCY_RATIO_THRESHOLD:g}× the same-run Confluent control are reported as product goals, not gates; a lane that misses a bar shows a warning until the trend band moves it",
     "- **Parallel Execution**: Each scenario runs in its own isolated environment",
     "- **Both Clients**: Direct comparison between Dekaf and Confluent.Kafka",
     "- **Memory Monitoring**: Tracks GC behavior and memory usage over time",

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -2,14 +2,18 @@
 
 import argparse
 import json
+from functools import partial
 from math import isfinite
 from pathlib import Path
 from statistics import median
 
 from stress_report import (
+    LATENCY_RATIO_THRESHOLD,
+    LATENCY_TARGET_P95_MULTIPLIER,
     PAIRED_ORDER_LABELS,
     comparison_rate,
     cpu_micros_per_message,
+    delivery_latency_ms,
     effective_rate,
     geometric_mean,
     intra_run_throughput,
@@ -58,6 +62,26 @@ _METRICS = {
         "lower_is_regression": False,
     },
 }
+
+# Dekaf trends its delivery-latency percentiles like any other metric. Confluent's
+# are recorded (they seed the ratio baseline) but neither trended nor used as an
+# environment indicator: a noisy control tail must not evict a lane from the
+# baselines, and the ratio row already normalises runner-wide latency noise.
+for _percentile in ("p50", "p95", "p99"):
+    _METRICS[f"deliveryLatency{_percentile.upper()}Ms"] = {
+        "label": f"Delivery latency {_percentile} ms",
+        "extract": partial(delivery_latency_ms, field=f"{_percentile}Us"),
+        "lower_is_regression": False,
+        "environment_indicator": False,
+    }
+
+# A Confluent trend regression on these metrics marks the lane's VM as shifted.
+_ENVIRONMENT_INDICATORS = frozenset(
+    metric for metric, definition in _METRICS.items()
+    if definition.get("environment_indicator", True)
+)
+# Confluent's values for the rest are recorded for ratio baselines, never trended.
+_CONTROL_RECORD_ONLY = frozenset(_METRICS) - _ENVIRONMENT_INDICATORS
 
 
 def _finite_number(value):
@@ -187,11 +211,11 @@ def _is_confluent(result):
     return str(result.get("client", "")).casefold().startswith("confluent")
 
 
-def _pair_identity(result):
-    """Match a Dekaf scenario to its same-run Confluent control.
+def _lane_identity(result):
+    """The lane a result ran on: scenario, broker count and workload shape, i.e. one VM.
 
-    Client and consumer connection count are intentionally excluded: each client uses its
-    own connection preset, while broker count and workload shape define the paired run.
+    Client, client order and connection count are intentionally excluded: every
+    client, order and connection variant of a lane shares that VM.
     """
     return (
         str(result.get("scenario", "unknown")).casefold(),
@@ -201,8 +225,40 @@ def _pair_identity(result):
         _consumer_seed_batch_size(result),
         _roundtrip_messages(result),
         result.get("roundTripSteadySeconds"),
-        paired_order_identity(result),
     )
+
+
+def _pair_identity(result):
+    """Match a Dekaf scenario to its same-run Confluent control: the lane plus client order."""
+    return _lane_identity(result) + (paired_order_identity(result),)
+
+
+def _apply_environment_shift(run):
+    """Flag every observation from a lane whose Confluent control regressed.
+
+    Derived from the stored trend fields on every load and write rather than
+    trusted from the file, so the rule can change without migrating the committed
+    history. A lane is one paid VM: a regressed control there says nothing about
+    the other lanes. Flagging the whole run instead kept every observation since
+    2026-07-13 out of the baselines, because some Confluent row regresses in
+    nearly every run.
+    """
+    results = run.get("results", [])
+    shifted = {
+        _lane_identity(item)
+        for item in results
+        if _is_confluent(item)
+        and any(
+            item.get(f"{metric}Trend") == "regression"
+            for metric in _ENVIRONMENT_INDICATORS
+        )
+    }
+    for item in results:
+        if _lane_identity(item) in shifted:
+            item["environmentShiftSuspected"] = True
+        else:
+            item.pop("environmentShiftSuspected", None)
+    run.pop("environmentShiftSuspected", None)
 
 
 # Synthetic order-balanced aggregates carry their trend metrics precomputed under
@@ -385,6 +441,7 @@ def _reconstructed_aggregate_observation(run, family_key):
 
 def _matching_control_ratios(runs, result, metric):
     pair_key = _pair_identity(result)
+    lane = _lane_identity(result)
     candidate_key = _identity(result)
     is_aggregate = _AGGREGATE_METRICS_FIELD in result
     family_key = _order_family_key(result) if is_aggregate else None
@@ -392,8 +449,6 @@ def _matching_control_ratios(runs, result, metric):
     ratios = []
 
     for run in runs:
-        if run.get("environmentShiftSuspected", False):
-            continue
         matching_results = [
             item
             for item in run.get("results", [])
@@ -407,7 +462,7 @@ def _matching_control_ratios(runs, result, metric):
         control = next((item for item in matching_results if _is_confluent(item)), None)
         if candidate is None:
             if is_aggregate:
-                ratio = _reconstructed_control_ratio(run, family_key, pair_key, metric)
+                ratio = _reconstructed_control_ratio(run, family_key, lane, metric)
                 if ratio is not None:
                     ratios.append(ratio)
             continue
@@ -428,7 +483,7 @@ def _matching_control_ratios(runs, result, metric):
             # its geomean so order-less candidates (e.g. the "Dekaf (3conn)"
             # control) keep a continuous ratio baseline across the rename
             # window too.
-            control_value = _reconstructed_ordered_control_value(run, pair_key, metric)
+            control_value = _reconstructed_ordered_control_value(run, lane, metric)
         if control_value is None:
             continue
 
@@ -437,7 +492,7 @@ def _matching_control_ratios(runs, result, metric):
     return ratios[-HISTORY_LIMIT:]
 
 
-def _reconstructed_control_ratio(run, family_key, pair_key, metric):
+def _reconstructed_control_ratio(run, family_key, lane, metric):
     """Candidate/control ratio rebuilt from a historical run's ordered pairs.
 
     Mirrors _reconstructed_aggregate_observation for the ratio series: interim
@@ -467,27 +522,26 @@ def _reconstructed_control_ratio(run, family_key, pair_key, metric):
     candidate_value = geometric_mean(
         [sample.get(metric) for sample in candidate_samples]
     )
-    control_value = _reconstructed_ordered_control_value(run, pair_key, metric)
+    control_value = _reconstructed_ordered_control_value(run, lane, metric)
     if candidate_value is None or control_value is None:
         return None
     return candidate_value / control_value
 
 
-def _reconstructed_ordered_control_value(run, pair_key, metric):
+def _reconstructed_ordered_control_value(run, lane, metric):
     """Geomean control value rebuilt from a run's complete ordered Confluent pair.
 
     Requires a single unambiguous ordered control family matching the pair's
     shape; anything else (partial pair, duplicates, competing control
     variants) yields None so no ratio is fabricated.
     """
-    shape_key = pair_key[:-1]
     control_samples = [
         item
         for item in run.get("results", [])
         if paired_order_identity(item) is not None
         and not item.get("environmentShiftSuspected", False)
         and _is_confluent(item)
-        and _pair_identity(item)[:-1] == shape_key
+        and _lane_identity(item) == lane
     ]
     if len({_order_family_key(item) for item in control_samples}) != 1:
         return None
@@ -619,14 +673,14 @@ def evaluate_and_update(history, current_results, run_started_at):
     runs = history.get("runs", []) if history is not None else []
     if not isinstance(runs, list):
         raise ValueError("Stress history 'runs' must be a list")
+    for run in runs:
+        _apply_environment_shift(run)
 
     # A re-run of the same result set replaces its prior entry and never uses itself
     # as baseline data.
     baseline_runs = [run for run in runs if run.get("runStartedAtUtc") != run_started_at]
     evaluations = []
     observations = []
-    should_fail = False
-    environment_shift_suspected = False
     # Order-balanced pairs trend as one synthetic geomean aggregate per client
     # family (attached to the pre-rename plain series); the aggregates are
     # evaluated first so ordered diagnostics can borrow their family's verdict.
@@ -643,6 +697,7 @@ def evaluate_and_update(history, current_results, run_started_at):
         is_confluent = _is_confluent(result)
         is_aggregate = _AGGREGATE_METRICS_FIELD in result
         family_key = _order_family_key(result)
+        control = None if is_confluent else controls.get(_pair_identity(result))
         # Ordered samples stay as diagnostics for the metrics their family's
         # aggregate trends: raw values are recorded, but they carry no band,
         # cannot gate, and never grow parallel per-order history series.
@@ -651,6 +706,8 @@ def evaluate_and_update(history, current_results, run_started_at):
             if not is_aggregate and paired_order_identity(result) is not None
             else frozenset()
         )
+        if is_confluent:
+            diagnostic_metrics |= _CONTROL_RECORD_ONLY
         prior = _matching_observations(baseline_runs, result)
         observation = _identity_record(result)
         if is_aggregate:
@@ -672,9 +729,7 @@ def evaluate_and_update(history, current_results, run_started_at):
                     # Directly trended raw results check their same-run control;
                     # ordered diagnostics stay raw — their family's aggregate
                     # already accounted for any backlog per sample.
-                    delivered = _delivered_rate_if_backlogged(
-                        result, controls.get(_pair_identity(result))
-                    )
+                    delivered = _delivered_rate_if_backlogged(result, control)
                     if delivered is not None:
                         value = delivered
                         backlog_substituted = True
@@ -752,7 +807,6 @@ def evaluate_and_update(history, current_results, run_started_at):
             observation[f"{metric}Trend"] = evaluation["status"]
 
             ratio_evaluation = None
-            control = controls.get(_pair_identity(result)) if not is_confluent else None
             control_value = (
                 _metric_value(control, metric, definition) if control is not None else None
             )
@@ -779,13 +833,11 @@ def evaluate_and_update(history, current_results, run_started_at):
                 evaluation["failureEligible"] = evaluation["repeatedRegression"]
 
             if is_confluent and evaluation["status"] == "regression":
-                environment_shift_suspected = True
                 evaluation["environmentShiftSuspected"] = True
 
             evaluations.append(evaluation)
             if ratio_evaluation is not None:
                 evaluations.append(ratio_evaluation)
-            should_fail = should_fail or evaluation["failureEligible"]
             if metric == "messagesPerSecond":
                 throughput_regression = evaluation["status"] == "regression"
 
@@ -856,28 +908,18 @@ def evaluate_and_update(history, current_results, run_started_at):
                 })
                 observation[metric] = value
                 observation[trend_field] = status
-                should_fail = should_fail or failure_eligible
 
         observations.append(observation)
 
-    # Environment shifts model runner-wide noise: one regressed Confluent control makes
-    # every observation from the same run unsafe for future absolute baselines.
-    if environment_shift_suspected:
-        for observation in observations:
-            observation["environmentShiftSuspected"] = True
-
-    latency_evaluations = paired_latency_thresholds(current_results)
-    evaluations.extend(latency_evaluations)
-    should_fail = should_fail or any(
-        item['thresholdBreach'] for item in latency_evaluations
-    )
+    # Product bars are reported only; latency gating happened above on the bands.
+    evaluations.extend(paired_latency_thresholds(current_results))
+    should_fail = any(item.get("failureEligible", False) for item in evaluations)
 
     current_run = {
         "runStartedAtUtc": run_started_at,
         "results": observations,
     }
-    if environment_shift_suspected:
-        current_run["environmentShiftSuspected"] = True
+    _apply_environment_shift(current_run)
     updated_runs = baseline_runs + [current_run]
     updated = {
         "version": HISTORY_VERSION,
@@ -903,6 +945,13 @@ def format_markdown(evaluations):
             "Confluent regressions remain environment warnings."
         ),
         (
+            "Dekaf delivery-latency p50/p95/p99 trend under the same band and "
+            "corroboration rules. The latency product bars (p95 <= "
+            f"{LATENCY_TARGET_P95_MULTIPLIER:g}x the configured target, p50/p99 <= "
+            f"{LATENCY_RATIO_THRESHOLD:g}x the same-run Confluent control) are "
+            "reported as warnings and never fail the run."
+        ),
+        (
             "Messages/sec trends on the median sampled interval rate when the run "
             "recorded interval samples (the rate the docs tables rank on); results "
             "and history entries without samples fall back to the whole-run mean. "
@@ -921,8 +970,8 @@ def format_markdown(evaluations):
     if any(item.get("environmentShiftSuspected") for item in evaluations):
         lines.extend([
             "",
-            "> Environment shift suspected: Confluent control regressed beyond its trailing band; "
-            "this run is excluded from absolute baselines.",
+            "> Environment shift suspected: a Confluent control regressed beyond its trailing "
+            "band; that lane's observations are excluded from absolute baselines.",
         ])
 
     lines.extend([
@@ -955,7 +1004,7 @@ def format_markdown(evaluations):
         status = labels[item["status"]]
         if item.get("thresholdBreach"):
             if item.get("latencyThreshold"):
-                status = "Threshold breach (fail)"
+                status = "Product bar missed (warning)"
             elif item.get("failureEligible"):
                 status = "Repeated threshold breach (fail)"
             elif item.get("corroborated") is False:
@@ -995,9 +1044,9 @@ def emit_annotations(evaluations):
             continue
 
         if item.get("thresholdBreach"):
-            level = "error" if item.get("failureEligible", True) else "warning"
+            level = "error" if item.get("failureEligible", False) else "warning"
             prefix = (
-                "Latency threshold breach"
+                "Latency product bar missed"
                 if item.get("latencyThreshold")
                 else "Intra-run threshold breach"
             )

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -316,9 +316,14 @@ class StressReportTests(unittest.TestCase):
         self.assertEqual(1, len(evaluations))
         evaluation = evaluations[0]
         self.assertEqual("latencyP95TargetRatio", evaluation["metric"])
+        self.assertEqual(
+            "Delivery latency p95 / target (product bar)", evaluation["metricLabel"]
+        )
         self.assertAlmostEqual(3.1, evaluation["current"])
         self.assertEqual(3.0, evaluation["upper"])
         self.assertTrue(evaluation["thresholdBreach"])
+        # Product bars report; the trend band in stress_trend.py gates.
+        self.assertFalse(evaluation["failureEligible"])
 
     def test_paired_latency_thresholds_enforce_target_without_pairing_multi_connection_results(self):
         confluent = stress_result("Confluent", effective_rate=1000)

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -142,7 +142,7 @@ class StressTrendTests(unittest.TestCase):
         self.assertIn(60, _pair_identity(dekaf))
         self.assertNotIn(8_000_000, _pair_identity(dekaf))
 
-    def test_paired_latency_threshold_breach_fails_without_history(self):
+    def test_paired_latency_product_bars_warn_without_failing(self):
         confluent = result(
             client="Confluent",
             latency={"p50Us": 10_000, "p99Us": 50_000},
@@ -158,15 +158,202 @@ class StressTrendTests(unittest.TestCase):
             "2026-07-01T02:00:00Z",
         )
 
-        latency = [item for item in evaluations if item.get("latencyThreshold")]
-        self.assertTrue(should_fail)
-        self.assertEqual(2, len(latency))
-        by_metric = {item["metric"]: item for item in latency}
+        bars = [item for item in evaluations if item.get("latencyThreshold")]
+        self.assertFalse(should_fail)
+        self.assertEqual(2, len(bars))
+        by_metric = {item["metric"]: item for item in bars}
         self.assertFalse(by_metric["latencyP50Ratio"]["thresholdBreach"])
         self.assertTrue(by_metric["latencyP99Ratio"]["thresholdBreach"])
-        markdown = format_markdown(latency)
-        self.assertIn("Threshold breach (fail)", markdown)
-        self.assertNotIn("Repeated threshold breach", markdown)
+        self.assertTrue(all(item["failureEligible"] is False for item in bars))
+        markdown = format_markdown(bars)
+        self.assertIn("Product bar missed (warning)", markdown)
+        self.assertNotIn("(fail)", markdown)
+        with redirect_stdout(StringIO()) as annotations:
+            emit_annotations(bars)
+        self.assertIn("::warning", annotations.getvalue())
+        self.assertNotIn("::error", annotations.getvalue())
+        self.assertIn("Latency product bar missed", annotations.getvalue())
+
+    def test_latency_percentiles_trend_for_dekaf_and_are_recorded_for_confluent(self):
+        confluent = result(
+            client="Confluent",
+            latency={"p50Us": 6_000, "p95Us": 20_000, "p99Us": 40_000},
+        )
+        dekaf = result(
+            client="Dekaf",
+            latency={"p50Us": 9_000, "p95Us": 12_000, "p99Us": 15_000},
+        )
+
+        evaluations, updated, should_fail = evaluate_and_update(
+            {"version": 1, "runs": []},
+            [confluent, dekaf],
+            "2026-07-01T02:00:00Z",
+        )
+
+        self.assertFalse(should_fail)
+        p50 = client_metric(evaluations, "deliveryLatencyP50Ms", "Dekaf")
+        self.assertEqual("insufficient-history", p50["status"])
+        self.assertAlmostEqual(9.0, p50["current"])
+        self.assertAlmostEqual(
+            12.0, client_metric(evaluations, "deliveryLatencyP95Ms", "Dekaf")["current"]
+        )
+        self.assertAlmostEqual(
+            15.0, client_metric(evaluations, "deliveryLatencyP99Ms", "Dekaf")["current"]
+        )
+        ratio = client_metric(evaluations, "deliveryLatencyP50MsControlRatio", "Dekaf")
+        self.assertAlmostEqual(1.5, ratio["current"])
+        self.assertEqual("Delivery latency p50 ms / Confluent", ratio["metricLabel"])
+        self.assertFalse(any(
+            item["metric"].startswith("deliveryLatency")
+            and item["scenario"].split(" / ")[1] == "Confluent"
+            for item in evaluations
+        ))
+
+        observations = {
+            item["client"]: item for item in updated["runs"][-1]["results"]
+        }
+        self.assertAlmostEqual(9.0, observations["Dekaf"]["deliveryLatencyP50Ms"])
+        self.assertEqual(
+            "insufficient-history", observations["Dekaf"]["deliveryLatencyP50MsTrend"]
+        )
+        self.assertAlmostEqual(6.0, observations["Confluent"]["deliveryLatencyP50Ms"])
+        self.assertNotIn("deliveryLatencyP50MsTrend", observations["Confluent"])
+        self.assertNotIn("environmentShiftSuspected", updated["runs"][-1])
+
+    def latency_history_runs(self, dekaf_p50=8.0, confluent_p50=6.0):
+        runs = []
+        for index in range(1, 4):
+            run = paired_history_run(index)
+            run["results"][0]["deliveryLatencyP50Ms"] = dekaf_p50
+            run["results"][0]["deliveryLatencyP50MsTrend"] = "stable"
+            run["results"][1]["deliveryLatencyP50Ms"] = confluent_p50
+            runs.append(run)
+        warned = paired_history_run(4)
+        warned["results"][0]["deliveryLatencyP50Ms"] = dekaf_p50 * 1.4
+        warned["results"][0]["deliveryLatencyP50MsTrend"] = "regression"
+        warned["results"][0]["deliveryLatencyP50MsControlRatioTrend"] = "regression"
+        warned["results"][1]["deliveryLatencyP50Ms"] = confluent_p50
+        runs.append(warned)
+        return runs
+
+    def test_repeated_latency_regression_fails_when_control_ratio_also_regresses(self):
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": self.latency_history_runs()},
+            [
+                result(latency={"p50Us": 11_000}),
+                result(client="Confluent", latency={"p50Us": 6_000}),
+            ],
+            "2026-07-01T02:00:00Z",
+        )
+
+        p50 = client_metric(evaluations, "deliveryLatencyP50Ms", "Dekaf")
+        ratio = client_metric(evaluations, "deliveryLatencyP50MsControlRatio", "Dekaf")
+        self.assertEqual("regression", p50["status"])
+        self.assertTrue(p50["repeatedRegression"])
+        self.assertTrue(p50["corroborated"])
+        self.assertTrue(p50["failureEligible"])
+        self.assertEqual("regression", ratio["status"])
+        self.assertAlmostEqual(8.0, p50["median"])
+        self.assertTrue(should_fail)
+        self.assertIn("Repeated regression (fail)", format_markdown(evaluations))
+
+    def test_repeated_latency_regression_is_control_normalized_when_confluent_moves_too(self):
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": self.latency_history_runs()},
+            [
+                result(latency={"p50Us": 11_000}),
+                result(client="Confluent", latency={"p50Us": 8_250}),
+            ],
+            "2026-07-01T02:00:00Z",
+        )
+
+        p50 = client_metric(evaluations, "deliveryLatencyP50Ms", "Dekaf")
+        ratio = client_metric(evaluations, "deliveryLatencyP50MsControlRatio", "Dekaf")
+        self.assertTrue(p50["repeatedRegression"])
+        self.assertFalse(p50["corroborated"])
+        self.assertFalse(p50["failureEligible"])
+        self.assertEqual("stable", ratio["status"])
+        self.assertFalse(should_fail)
+        self.assertIn(
+            "Repeated regression (control-normalized warning)",
+            format_markdown(evaluations),
+        )
+
+    def test_first_latency_regression_warns_without_failing(self):
+        runs = self.latency_history_runs()[:3]
+
+        evaluations, updated, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [
+                result(latency={"p50Us": 11_000}),
+                result(client="Confluent", latency={"p50Us": 6_000}),
+            ],
+            "2026-07-01T02:00:00Z",
+        )
+
+        p50 = client_metric(evaluations, "deliveryLatencyP50Ms", "Dekaf")
+        self.assertEqual("regression", p50["status"])
+        self.assertFalse(p50["repeatedRegression"])
+        self.assertFalse(p50["failureEligible"])
+        self.assertFalse(should_fail)
+        self.assertEqual(
+            "regression", updated["runs"][-1]["results"][0]["deliveryLatencyP50MsTrend"]
+        )
+
+    def test_confluent_latency_regression_never_marks_environment_shift(self):
+        runs = self.latency_history_runs()[:3]
+
+        evaluations, updated, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [
+                result(latency={"p50Us": 8_000}),
+                result(client="Confluent", latency={"p50Us": 30_000}),
+            ],
+            "2026-07-01T02:00:00Z",
+        )
+
+        self.assertFalse(should_fail)
+        self.assertFalse(any(item.get("environmentShiftSuspected") for item in evaluations))
+        self.assertNotIn("environmentShiftSuspected", updated["runs"][-1])
+        confluent = next(
+            item for item in updated["runs"][-1]["results"] if item["client"] == "Confluent"
+        )
+        self.assertAlmostEqual(30.0, confluent["deliveryLatencyP50Ms"])
+        self.assertNotIn("deliveryLatencyP50MsTrend", confluent)
+        ratio = client_metric(evaluations, "deliveryLatencyP50MsControlRatio", "Dekaf")
+        self.assertEqual("improvement", ratio["status"])
+
+    def test_order_balanced_aggregate_trends_latency_geomean(self):
+        samples = self.order_balanced_samples()
+        samples[0]["latency"] = {"p50Us": 8_000}
+        samples[3]["latency"] = {"p50Us": 12_500}
+        samples[1]["latency"] = {"p50Us": 5_000}
+        samples[2]["latency"] = {"p50Us": 5_000}
+
+        evaluations, updated, _ = evaluate_and_update(
+            {"version": 1, "runs": []},
+            samples,
+            "2026-07-01T02:00:00Z",
+        )
+
+        p50_rows = [
+            item for item in evaluations
+            if item["metric"] == "deliveryLatencyP50Ms"
+        ]
+        self.assertEqual(1, len(p50_rows))
+        self.assertNotIn("first", p50_rows[0]["scenario"])
+        self.assertAlmostEqual(10.0, p50_rows[0]["current"])
+        ratio = next(
+            item for item in evaluations
+            if item["metric"] == "deliveryLatencyP50MsControlRatio"
+        )
+        self.assertAlmostEqual(2.0, ratio["current"])
+        ordered = [
+            item for item in updated["runs"][-1]["results"]
+            if item.get("pairedClientOrder") and item["client"] == "Dekaf"
+        ]
+        self.assertEqual({8.0, 12.5}, {item["deliveryLatencyP50Ms"] for item in ordered})
+        self.assertTrue(all("deliveryLatencyP50MsTrend" not in item for item in ordered))
 
     def test_first_intra_run_threshold_breach_warns_without_failing(self):
         evaluations, updated, should_fail = evaluate_and_update(
@@ -336,7 +523,6 @@ class StressTrendTests(unittest.TestCase):
         self.assertTrue(throughput["repeatedRegression"])
         self.assertFalse(throughput["failureEligible"])
         self.assertTrue(throughput["environmentShiftSuspected"])
-        self.assertTrue(updated["runs"][-1]["environmentShiftSuspected"])
         self.assertTrue(
             updated["runs"][-1]["results"][0]["environmentShiftSuspected"]
         )
@@ -347,7 +533,7 @@ class StressTrendTests(unittest.TestCase):
         self.assertIn("Environment shift suspected", annotations.getvalue())
         self.assertFalse(should_fail)
 
-    def test_environment_shift_excludes_every_observation_in_same_run(self):
+    def test_environment_shift_excludes_only_the_regressed_lane(self):
         runs = []
         for index in range(1, 4):
             run = history_run(index, client="Confluent")
@@ -374,18 +560,79 @@ class StressTrendTests(unittest.TestCase):
             {"version": 1, "runs": runs},
             [
                 result(client="Confluent", messages_per_second=650.0),
+                result(client="Dekaf", messages_per_second=1_000.0),
+                result(client="Dekaf (3conn)", messages_per_second=1_500.0),
                 result(scenario="consumer", messages_per_second=1_000.0),
             ],
             "2026-07-01T02:00:00Z",
         )
 
         current = updated["runs"][-1]
-        self.assertTrue(current["environmentShiftSuspected"])
-        self.assertTrue(all(
-            observation["environmentShiftSuspected"]
+        flagged = {
+            (observation["scenario"], observation["client"])
             for observation in current["results"]
-        ))
+            if observation.get("environmentShiftSuspected")
+        }
+        # Every client and connection variant that shared the producer VM is
+        # excluded; the consumer lane ran on its own VM and keeps its baseline.
+        self.assertEqual(
+            {("producer", "Confluent"), ("producer", "Dekaf"), ("producer", "Dekaf (3conn)")},
+            flagged,
+        )
         self.assertFalse(should_fail)
+
+    def test_stale_run_wide_shift_flags_are_rederived_on_load(self):
+        # History written by the old run-wide rule carries flags on every
+        # observation and on the run; only lanes whose Confluent control
+        # actually regressed keep them, so the frozen baselines thaw.
+        runs = []
+        for index in range(1, 5):
+            run = paired_history_run(index)
+            run["environmentShiftSuspected"] = True
+            for observation in run["results"]:
+                observation["environmentShiftSuspected"] = True
+            runs.append(run)
+
+        evaluations, updated, _ = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [result(), result(client="Confluent", messages_per_second=500.0)],
+            "2026-07-01T02:00:00Z",
+        )
+
+        throughput = client_metric(evaluations, "messagesPerSecond", "Dekaf")
+        self.assertEqual(4, throughput["baselineCount"])
+        self.assertEqual("stable", throughput["status"])
+        for run in updated["runs"]:
+            self.assertNotIn("environmentShiftSuspected", run)
+            self.assertTrue(all(
+                "environmentShiftSuspected" not in observation
+                for observation in run["results"]
+            ))
+
+    def test_clean_lane_in_shifted_run_still_feeds_absolute_and_ratio_baselines(self):
+        runs = [paired_history_run(i) for i in range(1, 4)]
+        shifted = paired_history_run(4, dekaf_messages_per_second=1000.0)
+        # The consumer lane regressed in run 4; the producer lane stayed clean
+        # and must keep contributing to both the absolute and the ratio band.
+        shifted["results"].append({
+            **shifted["results"][1],
+            "scenario": "consumer",
+            "messagesPerSecond": 200.0,
+            "messagesPerSecondTrend": "regression",
+            "environmentShiftSuspected": True,
+        })
+        runs.append(shifted)
+
+        evaluations, _, _ = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [result(), result(client="Confluent", messages_per_second=500.0)],
+            "2026-07-01T02:00:00Z",
+        )
+
+        throughput = client_metric(evaluations, "messagesPerSecond", "Dekaf")
+        ratio = client_metric(evaluations, "messagesPerSecondControlRatio", "Dekaf")
+        self.assertEqual(4, throughput["baselineCount"])
+        self.assertEqual(4, ratio["baselineCount"])
 
     def test_paired_proportional_regressions_do_not_fail_when_control_ratio_is_stable(self):
         runs = [paired_history_run(i) for i in range(1, 4)]
@@ -917,11 +1164,16 @@ class StressTrendTests(unittest.TestCase):
 
     def test_environment_shift_observations_do_not_enter_absolute_baseline(self):
         runs = [history_run(i) for i in range(1, 4)]
-        runs.append({
-            **history_run(4, messages_per_second=5000.0),
-            "environmentShiftSuspected": True,
+        # The exclusion is derived from the stored Confluent trend, not from a
+        # persisted flag, so a rule change never needs a history migration.
+        shifted = history_run(4, messages_per_second=5000.0)
+        shifted["results"].append({
+            **shifted["results"][0],
+            "client": "Confluent",
+            "messagesPerSecond": 100.0,
+            "messagesPerSecondTrend": "regression",
         })
-        runs[-1]["results"][0]["environmentShiftSuspected"] = True
+        runs.append(shifted)
 
         evaluations, _, _ = evaluate_and_update(
             {"version": 1, "runs": runs},
@@ -942,8 +1194,7 @@ class StressTrendTests(unittest.TestCase):
             dekaf_messages_per_second=5000.0,
             confluent_messages_per_second=1000.0,
         )
-        for observation in environment_shift["results"]:
-            observation["environmentShiftSuspected"] = True
+        environment_shift["results"][1]["messagesPerSecondTrend"] = "regression"
         runs.append(environment_shift)
 
         evaluations, _, _ = evaluate_and_update(

--- a/.github/stress-history.json
+++ b/.github/stress-history.json
@@ -2557,7 +2557,10 @@
           "messagesPerSecondTrend": "improvement",
           "cpuMicrosPerMessage": 1.2241880365789823,
           "cpuMicrosPerMessageTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.698320685067266,
+          "deliveryLatencyP95Ms": 23.52737766943014,
+          "deliveryLatencyP99Ms": 36.948443810260805
         },
         {
           "scenario": "producer-acks-all",
@@ -2580,7 +2583,10 @@
           "cpuMicrosPerMessageTrend": "stable",
           "cpuMicrosPerMessageControlRatio": 0.7473319946583393,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.692041341542569,
+          "deliveryLatencyP95Ms": 11.23398860601167,
+          "deliveryLatencyP99Ms": 15.793590472087084
         },
         {
           "scenario": "producer",
@@ -2603,7 +2609,10 @@
           "cpuMicrosPerMessageTrend": "regression",
           "cpuMicrosPerMessageControlRatio": 0.7419840436633542,
           "cpuMicrosPerMessageControlRatioTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.644796122523656,
+          "deliveryLatencyP95Ms": 12.277112852784242,
+          "deliveryLatencyP99Ms": 18.140079933671736
         },
         {
           "scenario": "producer",
@@ -2622,7 +2631,10 @@
           "messagesPerSecondTrend": "stable",
           "cpuMicrosPerMessage": 1.2637547392951356,
           "cpuMicrosPerMessageTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.846580197004057,
+          "deliveryLatencyP95Ms": 21.00755816367052,
+          "deliveryLatencyP99Ms": 34.340391669286475
         },
         {
           "scenario": "producer-idempotent",
@@ -2645,7 +2657,10 @@
           "cpuMicrosPerMessageTrend": "regression",
           "cpuMicrosPerMessageControlRatio": 0.7245661074508691,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.09136799214369,
+          "deliveryLatencyP95Ms": 13.411841782544258,
+          "deliveryLatencyP99Ms": 21.313903912704493
         },
         {
           "scenario": "producer-idempotent",
@@ -2664,7 +2679,10 @@
           "messagesPerSecondTrend": "improvement",
           "cpuMicrosPerMessage": 1.2822003284633765,
           "cpuMicrosPerMessageTrend": "improvement",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.346849612209195,
+          "deliveryLatencyP95Ms": 22.79950657360812,
+          "deliveryLatencyP99Ms": 35.80967048158917
         },
         {
           "scenario": "consumer-raw-batch",
@@ -2714,7 +2732,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.005083526012703276,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 12.65,
+          "deliveryLatencyP95Ms": 32.75,
+          "deliveryLatencyP99Ms": 52.85
         },
         {
           "scenario": "producer-acks-all",
@@ -2737,7 +2758,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.0004968639832635923,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.95,
+          "deliveryLatencyP95Ms": 23.95,
+          "deliveryLatencyP99Ms": 41.95
         },
         {
           "scenario": "consumer",
@@ -2807,7 +2831,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.0022870324415835666,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.55,
+          "deliveryLatencyP95Ms": 25.45,
+          "deliveryLatencyP99Ms": 40.45
         },
         {
           "scenario": "producer-acks-all",
@@ -2827,7 +2854,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.3061694080382387,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.05,
+          "deliveryLatencyP95Ms": 11.85,
+          "deliveryLatencyP99Ms": 16.25
         },
         {
           "scenario": "producer-acks-all",
@@ -2847,7 +2877,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.332904581571798,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.35,
+          "deliveryLatencyP95Ms": 10.65,
+          "deliveryLatencyP99Ms": 15.35
         },
         {
           "scenario": "producer-acks-all",
@@ -2867,7 +2900,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.16196095141324565,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.85,
+          "deliveryLatencyP95Ms": 21.75,
+          "deliveryLatencyP99Ms": 33.75
         },
         {
           "scenario": "producer-idempotent",
@@ -2894,7 +2930,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.09689022688908545,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 13.05,
+          "deliveryLatencyP95Ms": 38.25,
+          "deliveryLatencyP99Ms": 60.95
         },
         {
           "scenario": "producer-idempotent",
@@ -2921,7 +2960,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.2675969592621347,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 14.45,
+          "deliveryLatencyP95Ms": 39.55,
+          "deliveryLatencyP99Ms": 63.65
         },
         {
           "scenario": "producer-idempotent",
@@ -2944,7 +2986,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.4264123100848928,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.45,
+          "deliveryLatencyP95Ms": 13.95,
+          "deliveryLatencyP99Ms": 19.75
         },
         {
           "scenario": "consumer-raw",
@@ -2994,7 +3039,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 2.0817411825069607,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 2.85,
+          "deliveryLatencyP95Ms": 6.05,
+          "deliveryLatencyP99Ms": 9.75
         },
         {
           "scenario": "producer",
@@ -3014,7 +3062,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.016079736703673825,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.95,
+          "deliveryLatencyP95Ms": 13.05,
+          "deliveryLatencyP99Ms": 20.25
         },
         {
           "scenario": "producer",
@@ -3034,7 +3085,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.31534900061015264,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.05,
+          "deliveryLatencyP95Ms": 24.05,
+          "deliveryLatencyP99Ms": 38.35
         },
         {
           "scenario": "producer",
@@ -3054,7 +3108,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.03038997032434745,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.65,
+          "deliveryLatencyP95Ms": 18.35,
+          "deliveryLatencyP99Ms": 30.75
         },
         {
           "scenario": "producer",
@@ -3074,7 +3131,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.27390344766094876,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.35,
+          "deliveryLatencyP95Ms": 11.55,
+          "deliveryLatencyP99Ms": 16.25
         },
         {
           "scenario": "producer-transactional",
@@ -3174,7 +3234,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.08418561064862794,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.75,
+          "deliveryLatencyP95Ms": 29.95,
+          "deliveryLatencyP99Ms": 48.95
         },
         {
           "scenario": "producer",
@@ -3201,7 +3264,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.49836195297972574,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.65,
+          "deliveryLatencyP95Ms": 25.25,
+          "deliveryLatencyP99Ms": 38.95
         },
         {
           "scenario": "producer",
@@ -3224,7 +3290,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.09414834469824591,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 4.95,
+          "deliveryLatencyP95Ms": 10.55,
+          "deliveryLatencyP99Ms": 16.85
         },
         {
           "scenario": "producer-roundtrip-steady",
@@ -3294,7 +3363,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.060972967989208725,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.75,
+          "deliveryLatencyP95Ms": 10.55,
+          "deliveryLatencyP99Ms": 17.85
         },
         {
           "scenario": "producer-idempotent",
@@ -3314,7 +3386,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.05680750888513949,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.15,
+          "deliveryLatencyP95Ms": 22.95,
+          "deliveryLatencyP99Ms": 37.55
         },
         {
           "scenario": "producer-idempotent",
@@ -3334,7 +3409,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.2480908709921235,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.55,
+          "deliveryLatencyP95Ms": 22.65,
+          "deliveryLatencyP99Ms": 34.15
         },
         {
           "scenario": "producer-idempotent",
@@ -3354,7 +3432,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.1634947673909254,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.45,
+          "deliveryLatencyP95Ms": 17.05,
+          "deliveryLatencyP99Ms": 25.45
         },
         {
           "scenario": "producer-idempotent",
@@ -3381,7 +3462,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.3336220779200598,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 2.85,
+          "deliveryLatencyP95Ms": 6.25,
+          "deliveryLatencyP99Ms": 10.35
         }
       ],
       "environmentShiftSuspected": true
@@ -3410,7 +3494,10 @@
           "cpuMicrosPerMessageTrend": "regression",
           "cpuMicrosPerMessageControlRatio": 0.6631434879122253,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.74538352246847,
+          "deliveryLatencyP95Ms": 14.87455881698681,
+          "deliveryLatencyP99Ms": 23.528758998298226
         },
         {
           "scenario": "producer-acks-all",
@@ -3429,7 +3516,10 @@
           "messagesPerSecondTrend": "regression",
           "cpuMicrosPerMessage": 1.6617205191679714,
           "cpuMicrosPerMessageTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.08337899526242,
+          "deliveryLatencyP95Ms": 22.553658239851025,
+          "deliveryLatencyP99Ms": 41.3425628136428
         },
         {
           "scenario": "producer",
@@ -3452,7 +3542,10 @@
           "cpuMicrosPerMessageTrend": "regression",
           "cpuMicrosPerMessageControlRatio": 0.7688776956783381,
           "cpuMicrosPerMessageControlRatioTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.811345473481198,
+          "deliveryLatencyP95Ms": 17.321590573616504,
+          "deliveryLatencyP99Ms": 22.85820421642961
         },
         {
           "scenario": "producer",
@@ -3471,7 +3564,10 @@
           "messagesPerSecondTrend": "regression",
           "cpuMicrosPerMessage": 1.9110108257447145,
           "cpuMicrosPerMessageTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.48090185583629,
+          "deliveryLatencyP95Ms": 61.093227938945915,
+          "deliveryLatencyP99Ms": 107.00998785160195
         },
         {
           "scenario": "producer-idempotent",
@@ -3494,7 +3590,10 @@
           "cpuMicrosPerMessageTrend": "regression",
           "cpuMicrosPerMessageControlRatio": 0.6245248841275836,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.533425515660192,
+          "deliveryLatencyP95Ms": 12.806541297321457,
+          "deliveryLatencyP99Ms": 24.288423168250343
         },
         {
           "scenario": "producer-idempotent",
@@ -3513,7 +3612,10 @@
           "messagesPerSecondTrend": "regression",
           "cpuMicrosPerMessage": 1.5870538503496023,
           "cpuMicrosPerMessageTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.598295234376832,
+          "deliveryLatencyP95Ms": 37.63924149076333,
+          "deliveryLatencyP99Ms": 75.98297506678716
         },
         {
           "scenario": "consumer-raw-batch",
@@ -3559,7 +3661,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.3040390461512246,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.95,
+          "deliveryLatencyP95Ms": 28.15,
+          "deliveryLatencyP99Ms": 69.35
         },
         {
           "scenario": "producer-acks-all",
@@ -3586,7 +3691,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.3846401656786413,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 15.05,
+          "deliveryLatencyP95Ms": 39.45,
+          "deliveryLatencyP99Ms": 55.65
         },
         {
           "scenario": "consumer",
@@ -3656,7 +3764,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.3620479558908474,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 10.05,
+          "deliveryLatencyP95Ms": 16.45,
+          "deliveryLatencyP99Ms": 24.55
         },
         {
           "scenario": "producer-acks-all",
@@ -3676,7 +3787,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.05030230596814575,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.55,
+          "deliveryLatencyP95Ms": 29.15,
+          "deliveryLatencyP99Ms": 50.05
         },
         {
           "scenario": "producer-acks-all",
@@ -3696,7 +3810,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.6317557326749719,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.65,
+          "deliveryLatencyP95Ms": 17.45,
+          "deliveryLatencyP99Ms": 34.15
         },
         {
           "scenario": "producer-acks-all",
@@ -3716,7 +3833,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.10083482262763233,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.45,
+          "deliveryLatencyP95Ms": 13.45,
+          "deliveryLatencyP99Ms": 22.55
         },
         {
           "scenario": "producer-idempotent",
@@ -3743,7 +3863,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.5499381763891539,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 11.35,
+          "deliveryLatencyP95Ms": 35.35,
+          "deliveryLatencyP99Ms": 55.85
         },
         {
           "scenario": "producer-idempotent",
@@ -3766,7 +3889,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -0.9736434123061216,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.05,
+          "deliveryLatencyP95Ms": 16.45,
+          "deliveryLatencyP99Ms": 29.45
         },
         {
           "scenario": "producer-idempotent",
@@ -3793,7 +3919,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 1.4511410368252347,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 15.75,
+          "deliveryLatencyP95Ms": 39.55,
+          "deliveryLatencyP99Ms": 62.95
         },
         {
           "scenario": "consumer-raw",
@@ -3836,7 +3965,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -1.3041459923551064,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 12.75,
+          "deliveryLatencyP95Ms": 19.05,
+          "deliveryLatencyP99Ms": 25.55
         },
         {
           "scenario": "producer",
@@ -3856,7 +3988,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.2780069882463216,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.65,
+          "deliveryLatencyP95Ms": 37.95,
+          "deliveryLatencyP99Ms": 62.15
         },
         {
           "scenario": "producer",
@@ -3876,7 +4011,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.9116972275962266,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 11.75,
+          "deliveryLatencyP95Ms": 98.35,
+          "deliveryLatencyP99Ms": 184.25
         },
         {
           "scenario": "producer",
@@ -3896,7 +4034,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 1.745833083529567,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.55,
+          "deliveryLatencyP95Ms": 15.75,
+          "deliveryLatencyP99Ms": 20.45
         },
         {
           "scenario": "producer",
@@ -3923,7 +4064,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.46961277675004326,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 3.15,
+          "deliveryLatencyP95Ms": 7.95,
+          "deliveryLatencyP99Ms": 13.45
         },
         {
           "scenario": "producer-transactional",
@@ -4019,7 +4163,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -0.04747706948909008,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.55,
+          "deliveryLatencyP95Ms": 13.85,
+          "deliveryLatencyP99Ms": 24.85
         },
         {
           "scenario": "producer",
@@ -4046,7 +4193,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.5676574963254901,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.35,
+          "deliveryLatencyP95Ms": 33.85,
+          "deliveryLatencyP99Ms": 53.45
         },
         {
           "scenario": "producer",
@@ -4073,7 +4223,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.8511344514616321,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.35,
+          "deliveryLatencyP95Ms": 28.55,
+          "deliveryLatencyP99Ms": 45.75
         },
         {
           "scenario": "producer-roundtrip-steady",
@@ -4143,7 +4296,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.4336171201127048,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.05,
+          "deliveryLatencyP95Ms": 11.35,
+          "deliveryLatencyP99Ms": 23.55
         },
         {
           "scenario": "producer-idempotent",
@@ -4163,7 +4319,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.24384478967917003,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.75,
+          "deliveryLatencyP95Ms": 38.55,
+          "deliveryLatencyP99Ms": 67.25
         },
         {
           "scenario": "producer-idempotent",
@@ -4190,7 +4349,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -0.6062000633036364,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 3.35,
+          "deliveryLatencyP95Ms": 7.55,
+          "deliveryLatencyP99Ms": 11.65
         },
         {
           "scenario": "producer-idempotent",
@@ -4210,7 +4372,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -2.5485998978030855,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.45,
+          "deliveryLatencyP95Ms": 36.75,
+          "deliveryLatencyP99Ms": 85.85
         },
         {
           "scenario": "producer-idempotent",
@@ -4230,7 +4395,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.5256236989961911,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.05,
+          "deliveryLatencyP95Ms": 14.45,
+          "deliveryLatencyP99Ms": 25.05
         }
       ],
       "environmentShiftSuspected": true
@@ -4259,7 +4427,10 @@
           "cpuMicrosPerMessageTrend": "regression",
           "cpuMicrosPerMessageControlRatio": 0.7368244752179677,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.46684711093805,
+          "deliveryLatencyP95Ms": 11.722734322674041,
+          "deliveryLatencyP99Ms": 17.37951380217525
         },
         {
           "scenario": "producer-acks-all",
@@ -4278,7 +4449,10 @@
           "messagesPerSecondTrend": "stable",
           "cpuMicrosPerMessage": 1.2719464077683416,
           "cpuMicrosPerMessageTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.237186865887537,
+          "deliveryLatencyP95Ms": 22.53214370626994,
+          "deliveryLatencyP99Ms": 35.952433853635
         },
         {
           "scenario": "producer",
@@ -4297,7 +4471,10 @@
           "messagesPerSecondTrend": "stable",
           "cpuMicrosPerMessage": 1.3380550545632008,
           "cpuMicrosPerMessageTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.497833020279928,
+          "deliveryLatencyP95Ms": 48.79807885562708,
+          "deliveryLatencyP99Ms": 88.24606223509353
         },
         {
           "scenario": "producer",
@@ -4320,7 +4497,10 @@
           "cpuMicrosPerMessageTrend": "regression",
           "cpuMicrosPerMessageControlRatio": 0.6993507766877582,
           "cpuMicrosPerMessageControlRatioTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.76826664740529,
+          "deliveryLatencyP95Ms": 12.447590128213577,
+          "deliveryLatencyP99Ms": 18.503715843040823
         },
         {
           "scenario": "producer-idempotent",
@@ -4339,7 +4519,10 @@
           "messagesPerSecondTrend": "improvement",
           "cpuMicrosPerMessage": 1.2542725526450722,
           "cpuMicrosPerMessageTrend": "improvement",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.4492247596125845,
+          "deliveryLatencyP95Ms": 24.6732142210941,
+          "deliveryLatencyP99Ms": 38.564718331656465
         },
         {
           "scenario": "producer-idempotent",
@@ -4362,7 +4545,10 @@
           "cpuMicrosPerMessageTrend": "regression",
           "cpuMicrosPerMessageControlRatio": 0.7274145684521196,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.998392672607047,
+          "deliveryLatencyP95Ms": 11.499891303834138,
+          "deliveryLatencyP99Ms": 27.22356515961861
         },
         {
           "scenario": "consumer-raw-batch",
@@ -4412,7 +4598,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.5366451855929696,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 16.55,
+          "deliveryLatencyP95Ms": 44.95,
+          "deliveryLatencyP99Ms": 68.05
         },
         {
           "scenario": "producer-acks-all",
@@ -4435,7 +4624,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.07126859429258213,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.75,
+          "deliveryLatencyP95Ms": 22.65,
+          "deliveryLatencyP99Ms": 36.35
         },
         {
           "scenario": "consumer",
@@ -4505,7 +4697,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.10900247413082051,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.25,
+          "deliveryLatencyP95Ms": 12.55,
+          "deliveryLatencyP99Ms": 19.55
         },
         {
           "scenario": "producer-acks-all",
@@ -4525,7 +4720,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.2510279283024171,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.65,
+          "deliveryLatencyP95Ms": 24.35,
+          "deliveryLatencyP99Ms": 37.85
         },
         {
           "scenario": "producer-acks-all",
@@ -4545,7 +4743,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.08701280967820556,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.85,
+          "deliveryLatencyP95Ms": 20.85,
+          "deliveryLatencyP99Ms": 34.15
         },
         {
           "scenario": "producer-acks-all",
@@ -4565,7 +4766,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.03342404042950678,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.75,
+          "deliveryLatencyP95Ms": 10.95,
+          "deliveryLatencyP99Ms": 15.45
         },
         {
           "scenario": "producer-idempotent",
@@ -4592,7 +4796,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.4345976377692894,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 12.65,
+          "deliveryLatencyP95Ms": 32.85,
+          "deliveryLatencyP99Ms": 56.65
         },
         {
           "scenario": "producer-idempotent",
@@ -4615,7 +4822,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.0003867530159282306,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.35,
+          "deliveryLatencyP95Ms": 14.55,
+          "deliveryLatencyP99Ms": 27.85
         },
         {
           "scenario": "producer-idempotent",
@@ -4642,7 +4852,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.09427590797505356,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 12.35,
+          "deliveryLatencyP95Ms": 32.65,
+          "deliveryLatencyP99Ms": 53.85
         },
         {
           "scenario": "consumer-raw",
@@ -4685,7 +4898,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.12383987107552884,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.95,
+          "deliveryLatencyP95Ms": 72.05,
+          "deliveryLatencyP99Ms": 109.45
         },
         {
           "scenario": "producer",
@@ -4705,7 +4921,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.5043820943337922,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.65,
+          "deliveryLatencyP95Ms": 10.95,
+          "deliveryLatencyP99Ms": 15.05
         },
         {
           "scenario": "producer",
@@ -4725,7 +4944,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.07306291303044751,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 10.05,
+          "deliveryLatencyP95Ms": 14.15,
+          "deliveryLatencyP99Ms": 22.75
         },
         {
           "scenario": "producer",
@@ -4745,7 +4967,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.07257486147810871,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.65,
+          "deliveryLatencyP95Ms": 33.05,
+          "deliveryLatencyP99Ms": 71.15
         },
         {
           "scenario": "producer",
@@ -4772,7 +4997,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 1.5451931424394345,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 2.95,
+          "deliveryLatencyP95Ms": 6.65,
+          "deliveryLatencyP99Ms": 10.85
         },
         {
           "scenario": "producer-transactional",
@@ -4872,7 +5100,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.2574742620548281,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.05,
+          "deliveryLatencyP95Ms": 27.45,
+          "deliveryLatencyP99Ms": 46.85
         },
         {
           "scenario": "producer",
@@ -4899,7 +5130,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.4299886883796119,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.65,
+          "deliveryLatencyP95Ms": 29.25,
+          "deliveryLatencyP99Ms": 50.15
         },
         {
           "scenario": "producer",
@@ -4922,7 +5156,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.02182263383364181,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.05,
+          "deliveryLatencyP95Ms": 11.95,
+          "deliveryLatencyP99Ms": 21.85
         },
         {
           "scenario": "producer-roundtrip-steady",
@@ -4992,7 +5229,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.12573758589014983,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.35,
+          "deliveryLatencyP95Ms": 23.55,
+          "deliveryLatencyP99Ms": 36.95
         },
         {
           "scenario": "producer-idempotent",
@@ -5012,7 +5252,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.5111574407285947,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.15,
+          "deliveryLatencyP95Ms": 11.55,
+          "deliveryLatencyP99Ms": 28.45
         },
         {
           "scenario": "producer-idempotent",
@@ -5039,7 +5282,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.9008244729480329,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 2.85,
+          "deliveryLatencyP95Ms": 6.65,
+          "deliveryLatencyP99Ms": 10.55
         },
         {
           "scenario": "producer-idempotent",
@@ -5059,7 +5305,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.11008718571353139,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.85,
+          "deliveryLatencyP95Ms": 11.45,
+          "deliveryLatencyP99Ms": 26.05
         },
         {
           "scenario": "producer-idempotent",
@@ -5079,7 +5328,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.05681074410999696,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.55,
+          "deliveryLatencyP95Ms": 25.85,
+          "deliveryLatencyP99Ms": 40.25
         }
       ],
       "environmentShiftSuspected": true
@@ -5108,7 +5360,10 @@
           "cpuMicrosPerMessageTrend": "stable",
           "cpuMicrosPerMessageControlRatio": 0.6448438022368973,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.744191371602334,
+          "deliveryLatencyP95Ms": 11.08636550001848,
+          "deliveryLatencyP99Ms": 15.993670623093374
         },
         {
           "scenario": "producer-acks-all",
@@ -5127,7 +5382,10 @@
           "messagesPerSecondTrend": "regression",
           "cpuMicrosPerMessage": 1.414799993641419,
           "cpuMicrosPerMessageTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.567914433060162,
+          "deliveryLatencyP95Ms": 23.59602720798567,
+          "deliveryLatencyP99Ms": 39.983840485876286
         },
         {
           "scenario": "producer",
@@ -5146,7 +5404,10 @@
           "messagesPerSecondTrend": "regression",
           "cpuMicrosPerMessage": 1.6693954993747349,
           "cpuMicrosPerMessageTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.785093956608118,
+          "deliveryLatencyP95Ms": 21.401343415776495,
+          "deliveryLatencyP99Ms": 36.95108252812089
         },
         {
           "scenario": "producer",
@@ -5169,7 +5430,10 @@
           "cpuMicrosPerMessageTrend": "regression",
           "cpuMicrosPerMessageControlRatio": 0.6311374239637985,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.315712533134546,
+          "deliveryLatencyP95Ms": 12.811030403523368,
+          "deliveryLatencyP99Ms": 18.922539470166264
         },
         {
           "scenario": "producer-idempotent",
@@ -5192,7 +5456,10 @@
           "cpuMicrosPerMessageTrend": "regression",
           "cpuMicrosPerMessageControlRatio": 0.7058762792428503,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.649421946003098,
+          "deliveryLatencyP95Ms": 25.608055373260974,
+          "deliveryLatencyP99Ms": 35.2687184343293
         },
         {
           "scenario": "producer-idempotent",
@@ -5211,7 +5478,10 @@
           "messagesPerSecondTrend": "regression",
           "cpuMicrosPerMessage": 1.5868622661626053,
           "cpuMicrosPerMessageTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.279251335130557,
+          "deliveryLatencyP95Ms": 69.9565758167165,
+          "deliveryLatencyP99Ms": 161.0678971738316
         },
         {
           "scenario": "consumer-raw-batch",
@@ -5261,7 +5531,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.14031668909233797,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 14.05,
+          "deliveryLatencyP95Ms": 36.95,
+          "deliveryLatencyP99Ms": 57.65
         },
         {
           "scenario": "producer-acks-all",
@@ -5284,7 +5557,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -1.0152556344935322,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.65,
+          "deliveryLatencyP95Ms": 25.75,
+          "deliveryLatencyP99Ms": 42.15
         },
         {
           "scenario": "consumer",
@@ -5354,7 +5630,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.1404956503067346,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.45,
+          "deliveryLatencyP95Ms": 10.55,
+          "deliveryLatencyP99Ms": 15.55
         },
         {
           "scenario": "producer-acks-all",
@@ -5374,7 +5653,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.459629826034277,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.95,
+          "deliveryLatencyP95Ms": 21.05,
+          "deliveryLatencyP99Ms": 37.05
         },
         {
           "scenario": "producer-acks-all",
@@ -5394,7 +5676,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.42444616309577493,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.25,
+          "deliveryLatencyP95Ms": 26.45,
+          "deliveryLatencyP99Ms": 43.15
         },
         {
           "scenario": "producer-acks-all",
@@ -5414,7 +5699,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.21010283252300446,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.05,
+          "deliveryLatencyP95Ms": 11.65,
+          "deliveryLatencyP99Ms": 16.45
         },
         {
           "scenario": "producer-idempotent",
@@ -5441,7 +5729,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 2.27817955321993,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 11.85,
+          "deliveryLatencyP95Ms": 31.05,
+          "deliveryLatencyP99Ms": 51.55
         },
         {
           "scenario": "producer-idempotent",
@@ -5468,7 +5759,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.45632027774295336,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 14.95,
+          "deliveryLatencyP95Ms": 39.25,
+          "deliveryLatencyP99Ms": 61.85
         },
         {
           "scenario": "producer-idempotent",
@@ -5491,7 +5785,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 1.293412604756731,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.75,
+          "deliveryLatencyP95Ms": 27.45,
+          "deliveryLatencyP99Ms": 45.55
         },
         {
           "scenario": "consumer-raw",
@@ -5541,7 +5838,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.4086226251503349,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 3.55,
+          "deliveryLatencyP95Ms": 8.85,
+          "deliveryLatencyP99Ms": 14.15
         },
         {
           "scenario": "producer",
@@ -5561,7 +5861,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.48570431007670467,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.25,
+          "deliveryLatencyP95Ms": 25.95,
+          "deliveryLatencyP99Ms": 46.05
         },
         {
           "scenario": "producer",
@@ -5581,7 +5884,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.06783271137022154,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.55,
+          "deliveryLatencyP95Ms": 11.85,
+          "deliveryLatencyP99Ms": 16.85
         },
         {
           "scenario": "producer",
@@ -5601,7 +5907,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.03600804582764137,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 10.15,
+          "deliveryLatencyP95Ms": 13.85,
+          "deliveryLatencyP99Ms": 21.25
         },
         {
           "scenario": "producer",
@@ -5621,7 +5930,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.3717338954305682,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.35,
+          "deliveryLatencyP95Ms": 17.65,
+          "deliveryLatencyP99Ms": 29.65
         },
         {
           "scenario": "producer-transactional",
@@ -5721,7 +6033,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 3.310077651793561,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.45,
+          "deliveryLatencyP95Ms": 25.55,
+          "deliveryLatencyP99Ms": 46.15
         },
         {
           "scenario": "producer",
@@ -5744,7 +6059,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.14860828779915886,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.05,
+          "deliveryLatencyP95Ms": 12.05,
+          "deliveryLatencyP99Ms": 22.95
         },
         {
           "scenario": "producer",
@@ -5771,7 +6089,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.24890121892770697,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.15,
+          "deliveryLatencyP95Ms": 22.75,
+          "deliveryLatencyP99Ms": 40.95
         },
         {
           "scenario": "producer-roundtrip-steady",
@@ -5841,7 +6162,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.1449410492546993,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.75,
+          "deliveryLatencyP95Ms": 28.45,
+          "deliveryLatencyP99Ms": 40.85
         },
         {
           "scenario": "producer-idempotent",
@@ -5861,7 +6185,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -2.180406882899528,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.85,
+          "deliveryLatencyP95Ms": 126.95,
+          "deliveryLatencyP99Ms": 365.65
         },
         {
           "scenario": "producer-idempotent",
@@ -5888,7 +6215,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 1.4025950964933365,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 3.45,
+          "deliveryLatencyP95Ms": 8.65,
+          "deliveryLatencyP99Ms": 13.65
         },
         {
           "scenario": "producer-idempotent",
@@ -5908,7 +6238,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.1641575204659609,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.75,
+          "deliveryLatencyP95Ms": 38.55,
+          "deliveryLatencyP99Ms": 70.95
         },
         {
           "scenario": "producer-idempotent",
@@ -5928,7 +6261,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 1.4445434004590967,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.55,
+          "deliveryLatencyP95Ms": 23.05,
+          "deliveryLatencyP99Ms": 30.45
         }
       ],
       "environmentShiftSuspected": true
@@ -5953,7 +6289,10 @@
           "messagesPerSecondTrend": "regression",
           "cpuMicrosPerMessage": 1.48169833909624,
           "cpuMicrosPerMessageTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.290270264464,
+          "deliveryLatencyP95Ms": 32.63835933376554,
+          "deliveryLatencyP99Ms": 53.39660569736617
         },
         {
           "scenario": "producer-idempotent",
@@ -5976,7 +6315,10 @@
           "cpuMicrosPerMessageTrend": "improvement",
           "cpuMicrosPerMessageControlRatio": 0.47897756499586325,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.7470363864440515,
+          "deliveryLatencyP95Ms": 12.64782590013003,
+          "deliveryLatencyP99Ms": 26.064391418178168
         },
         {
           "scenario": "producer-acks-all",
@@ -5995,7 +6337,10 @@
           "messagesPerSecondTrend": "stable",
           "cpuMicrosPerMessage": 1.3061363067625564,
           "cpuMicrosPerMessageTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.69981343023819,
+          "deliveryLatencyP95Ms": 26.656003076230316,
+          "deliveryLatencyP99Ms": 41.733469781459576
         },
         {
           "scenario": "producer-acks-all",
@@ -6018,7 +6363,10 @@
           "cpuMicrosPerMessageTrend": "improvement",
           "cpuMicrosPerMessageControlRatio": 0.5399060411205128,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.092434738692674,
+          "deliveryLatencyP95Ms": 11.434268669224107,
+          "deliveryLatencyP99Ms": 16.259381907071372
         },
         {
           "scenario": "producer",
@@ -6037,7 +6385,10 @@
           "messagesPerSecondTrend": "stable",
           "cpuMicrosPerMessage": 1.4893734506097644,
           "cpuMicrosPerMessageTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.488852339059595,
+          "deliveryLatencyP95Ms": 19.174136225655644,
+          "deliveryLatencyP99Ms": 38.32541584901591
         },
         {
           "scenario": "producer",
@@ -6060,7 +6411,10 @@
           "cpuMicrosPerMessageTrend": "improvement",
           "cpuMicrosPerMessageControlRatio": 0.5016223469303657,
           "cpuMicrosPerMessageControlRatioTrend": "improvement",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.387937768009488,
+          "deliveryLatencyP95Ms": 12.549601587301488,
+          "deliveryLatencyP99Ms": 18.16968629338437
         },
         {
           "scenario": "producer-roundtrip-steady",
@@ -6137,7 +6491,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.190856311049972,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 3.55,
+          "deliveryLatencyP95Ms": 7.25,
+          "deliveryLatencyP99Ms": 11.95
         },
         {
           "scenario": "producer-idempotent",
@@ -6157,7 +6514,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.17679352645487917,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.65,
+          "deliveryLatencyP95Ms": 38.25,
+          "deliveryLatencyP99Ms": 62.05
         },
         {
           "scenario": "producer-idempotent",
@@ -6177,7 +6537,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.6990205367432683,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.55,
+          "deliveryLatencyP95Ms": 11.55,
+          "deliveryLatencyP99Ms": 21.95
         },
         {
           "scenario": "producer-idempotent",
@@ -6197,7 +6560,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.535537575665581,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.95,
+          "deliveryLatencyP95Ms": 13.85,
+          "deliveryLatencyP99Ms": 30.95
         },
         {
           "scenario": "producer-idempotent",
@@ -6217,7 +6583,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -0.34504093428367466,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.95,
+          "deliveryLatencyP95Ms": 27.85,
+          "deliveryLatencyP99Ms": 45.95
         },
         {
           "scenario": "producer",
@@ -6244,7 +6613,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.4634732402892114,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.45,
+          "deliveryLatencyP95Ms": 28.05,
+          "deliveryLatencyP99Ms": 46.35
         },
         {
           "scenario": "producer",
@@ -6271,7 +6643,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.18804046384740597,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 10.55,
+          "deliveryLatencyP95Ms": 29.65,
+          "deliveryLatencyP99Ms": 51.35
         },
         {
           "scenario": "producer",
@@ -6294,7 +6669,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.07759995713880749,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 4.95,
+          "deliveryLatencyP95Ms": 12.85,
+          "deliveryLatencyP99Ms": 27.65
         },
         {
           "scenario": "producer-acks-all",
@@ -6314,7 +6692,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.14093456811376928,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.65,
+          "deliveryLatencyP95Ms": 31.65,
+          "deliveryLatencyP99Ms": 49.55
         },
         {
           "scenario": "producer-acks-all",
@@ -6334,7 +6715,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.020672382895528772,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.75,
+          "deliveryLatencyP95Ms": 10.85,
+          "deliveryLatencyP99Ms": 15.15
         },
         {
           "scenario": "producer-acks-all",
@@ -6354,7 +6738,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.0927982462366426,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.45,
+          "deliveryLatencyP95Ms": 12.05,
+          "deliveryLatencyP99Ms": 17.45
         },
         {
           "scenario": "producer-acks-all",
@@ -6374,7 +6761,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.015730660075363036,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.75,
+          "deliveryLatencyP95Ms": 22.45,
+          "deliveryLatencyP99Ms": 35.15
         },
         {
           "scenario": "producer-acks-all",
@@ -6401,7 +6791,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.17147194887311806,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 13.75,
+          "deliveryLatencyP95Ms": 33.95,
+          "deliveryLatencyP99Ms": 55.35
         },
         {
           "scenario": "producer-acks-all",
@@ -6424,7 +6817,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.10241949798846521,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.75,
+          "deliveryLatencyP95Ms": 28.05,
+          "deliveryLatencyP99Ms": 51.25
         },
         {
           "scenario": "consumer-batch",
@@ -6497,7 +6893,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.2735045191291342,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 13.45,
+          "deliveryLatencyP95Ms": 31.35,
+          "deliveryLatencyP99Ms": 58.65
         },
         {
           "scenario": "producer-idempotent",
@@ -6520,7 +6919,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.039945884538268965,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.55,
+          "deliveryLatencyP95Ms": 14.45,
+          "deliveryLatencyP99Ms": 22.05
         },
         {
           "scenario": "producer-idempotent",
@@ -6547,7 +6949,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.18065501220034036,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 13.05,
+          "deliveryLatencyP95Ms": 34.05,
+          "deliveryLatencyP99Ms": 58.15
         },
         {
           "scenario": "producer",
@@ -6574,7 +6979,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -1.040183058896148,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 4.05,
+          "deliveryLatencyP95Ms": 11.35,
+          "deliveryLatencyP99Ms": 19.95
         },
         {
           "scenario": "producer",
@@ -6594,7 +7002,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.10256051424699557,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.85,
+          "deliveryLatencyP95Ms": 23.05,
+          "deliveryLatencyP99Ms": 44.85
         },
         {
           "scenario": "producer",
@@ -6614,7 +7025,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.16783860772871428,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.95,
+          "deliveryLatencyP95Ms": 12.45,
+          "deliveryLatencyP99Ms": 17.15
         },
         {
           "scenario": "producer",
@@ -6634,7 +7048,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.46664653189886446,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.85,
+          "deliveryLatencyP95Ms": 12.65,
+          "deliveryLatencyP99Ms": 19.25
         },
         {
           "scenario": "producer",
@@ -6654,7 +7071,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.31632834355459516,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.15,
+          "deliveryLatencyP95Ms": 15.95,
+          "deliveryLatencyP99Ms": 32.75
         },
         {
           "scenario": "producer-transactional",
@@ -6806,7 +7226,10 @@
           "cpuMicrosPerMessageTrend": "stable",
           "cpuMicrosPerMessageControlRatio": 0.4966975702723304,
           "cpuMicrosPerMessageControlRatioTrend": "improvement",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.686839402511282,
+          "deliveryLatencyP95Ms": 19.2618145562665,
+          "deliveryLatencyP99Ms": 32.25511587329985
         },
         {
           "scenario": "producer-idempotent",
@@ -6825,7 +7248,10 @@
           "messagesPerSecondTrend": "regression",
           "cpuMicrosPerMessage": 1.6030766718115483,
           "cpuMicrosPerMessageTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.8853104505171,
+          "deliveryLatencyP95Ms": 75.52630336511908,
+          "deliveryLatencyP99Ms": 192.92140238967798
         },
         {
           "scenario": "producer-acks-all",
@@ -6848,7 +7274,10 @@
           "cpuMicrosPerMessageTrend": "improvement",
           "cpuMicrosPerMessageControlRatio": 0.5429157254381748,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.834060249959788,
+          "deliveryLatencyP95Ms": 12.446385017345396,
+          "deliveryLatencyP99Ms": 17.19120414630691
         },
         {
           "scenario": "producer-acks-all",
@@ -6867,7 +7296,10 @@
           "messagesPerSecondTrend": "stable",
           "cpuMicrosPerMessage": 1.3278099116496818,
           "cpuMicrosPerMessageTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.330284353802757,
+          "deliveryLatencyP95Ms": 31.723611080707695,
+          "deliveryLatencyP99Ms": 52.81285354911245
         },
         {
           "scenario": "producer",
@@ -6890,7 +7322,10 @@
           "cpuMicrosPerMessageTrend": "improvement",
           "cpuMicrosPerMessageControlRatio": 0.503309538879728,
           "cpuMicrosPerMessageControlRatioTrend": "improvement",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.831727453580097,
+          "deliveryLatencyP95Ms": 10.849539160720141,
+          "deliveryLatencyP99Ms": 15.793590472087084
         },
         {
           "scenario": "producer",
@@ -6909,7 +7344,10 @@
           "messagesPerSecondTrend": "stable",
           "cpuMicrosPerMessage": 1.428030274159108,
           "cpuMicrosPerMessageTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.199759609828131,
+          "deliveryLatencyP95Ms": 14.493015559227144,
+          "deliveryLatencyP99Ms": 32.79355881876806
         },
         {
           "scenario": "producer-roundtrip-steady",
@@ -6986,7 +7424,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.47814061257799023,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 4.45,
+          "deliveryLatencyP95Ms": 12.75,
+          "deliveryLatencyP99Ms": 24.95
         },
         {
           "scenario": "producer-idempotent",
@@ -7006,7 +7447,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 1.2681606656141704,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.25,
+          "deliveryLatencyP95Ms": 12.95,
+          "deliveryLatencyP99Ms": 22.35
         },
         {
           "scenario": "producer-idempotent",
@@ -7026,7 +7470,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.199518293325395,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.45,
+          "deliveryLatencyP95Ms": 68.85,
+          "deliveryLatencyP99Ms": 176.35
         },
         {
           "scenario": "producer-idempotent",
@@ -7046,7 +7493,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 2.5421734056995233,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.35,
+          "deliveryLatencyP95Ms": 82.85,
+          "deliveryLatencyP99Ms": 211.05
         },
         {
           "scenario": "producer-idempotent",
@@ -7066,7 +7516,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.1559097618706626,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.15,
+          "deliveryLatencyP95Ms": 28.65,
+          "deliveryLatencyP99Ms": 46.55
         },
         {
           "scenario": "producer",
@@ -7093,7 +7546,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 2.163361087488552,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.05,
+          "deliveryLatencyP95Ms": 32.25,
+          "deliveryLatencyP99Ms": 52.75
         },
         {
           "scenario": "producer",
@@ -7120,7 +7576,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.5189261302145685,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.95,
+          "deliveryLatencyP95Ms": 35.85,
+          "deliveryLatencyP99Ms": 58.95
         },
         {
           "scenario": "producer",
@@ -7143,7 +7602,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -3.983177217634591,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.25,
+          "deliveryLatencyP95Ms": 12.95,
+          "deliveryLatencyP99Ms": 26.15
         },
         {
           "scenario": "producer-acks-all",
@@ -7163,7 +7625,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.6831990215614507,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.35,
+          "deliveryLatencyP95Ms": 12.15,
+          "deliveryLatencyP99Ms": 17.75
         },
         {
           "scenario": "producer-acks-all",
@@ -7183,7 +7648,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.34473221419276856,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.85,
+          "deliveryLatencyP95Ms": 35.25,
+          "deliveryLatencyP99Ms": 57.45
         },
         {
           "scenario": "producer-acks-all",
@@ -7203,7 +7671,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.017022984721358277,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.85,
+          "deliveryLatencyP95Ms": 28.55,
+          "deliveryLatencyP99Ms": 48.55
         },
         {
           "scenario": "producer-acks-all",
@@ -7223,7 +7694,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.04631453823226147,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.35,
+          "deliveryLatencyP95Ms": 12.75,
+          "deliveryLatencyP99Ms": 16.65
         },
         {
           "scenario": "producer-acks-all",
@@ -7250,7 +7724,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.08001509477069484,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 15.15,
+          "deliveryLatencyP95Ms": 38.45,
+          "deliveryLatencyP99Ms": 56.55
         },
         {
           "scenario": "producer-acks-all",
@@ -7273,7 +7750,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.4111358537518554,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.25,
+          "deliveryLatencyP95Ms": 26.55,
+          "deliveryLatencyP99Ms": 43.65
         },
         {
           "scenario": "consumer-batch",
@@ -7346,7 +7826,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.2201843290349208,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 13.35,
+          "deliveryLatencyP95Ms": 40.95,
+          "deliveryLatencyP99Ms": 63.85
         },
         {
           "scenario": "producer-idempotent",
@@ -7369,7 +7852,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.27675654998160204,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.35,
+          "deliveryLatencyP95Ms": 14.65,
+          "deliveryLatencyP99Ms": 26.85
         },
         {
           "scenario": "producer-idempotent",
@@ -7396,7 +7882,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.30067470475624325,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 12.75,
+          "deliveryLatencyP95Ms": 30.45,
+          "deliveryLatencyP99Ms": 50.15
         },
         {
           "scenario": "producer",
@@ -7416,7 +7905,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.10317571118820412,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.35,
+          "deliveryLatencyP95Ms": 10.75,
+          "deliveryLatencyP99Ms": 16.25
         },
         {
           "scenario": "producer",
@@ -7436,7 +7928,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.1011843049707835,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.25,
+          "deliveryLatencyP95Ms": 14.95,
+          "deliveryLatencyP99Ms": 33.45
         },
         {
           "scenario": "producer",
@@ -7463,7 +7958,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.4405966443601097,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 4.05,
+          "deliveryLatencyP95Ms": 8.15,
+          "deliveryLatencyP99Ms": 14.15
         },
         {
           "scenario": "producer",
@@ -7483,7 +7981,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.32121107285010275,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.15,
+          "deliveryLatencyP95Ms": 14.05,
+          "deliveryLatencyP99Ms": 32.15
         },
         {
           "scenario": "producer",
@@ -7503,7 +8004,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.009478971311333283,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.35,
+          "deliveryLatencyP95Ms": 10.95,
+          "deliveryLatencyP99Ms": 15.35
         },
         {
           "scenario": "producer-transactional",
@@ -7651,7 +8155,10 @@
           "messagesPerSecondTrend": "regression",
           "cpuMicrosPerMessage": 1.7633037467386827,
           "cpuMicrosPerMessageTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.862397540218725,
+          "deliveryLatencyP95Ms": 64.57412407458581,
+          "deliveryLatencyP99Ms": 157.7886798854721
         },
         {
           "scenario": "producer-idempotent",
@@ -7674,7 +8181,10 @@
           "cpuMicrosPerMessageTrend": "regression",
           "cpuMicrosPerMessageControlRatio": 0.5649664172661764,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.849152501793606,
+          "deliveryLatencyP95Ms": 18.460295230575273,
+          "deliveryLatencyP99Ms": 32.41492711699349
         },
         {
           "scenario": "producer-acks-all",
@@ -7693,7 +8203,10 @@
           "messagesPerSecondTrend": "regression",
           "cpuMicrosPerMessage": 1.9040090209043579,
           "cpuMicrosPerMessageTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.335016496684332,
+          "deliveryLatencyP95Ms": 33.04039194682775,
+          "deliveryLatencyP99Ms": 57.672285371745076
         },
         {
           "scenario": "producer-acks-all",
@@ -7716,7 +8229,10 @@
           "cpuMicrosPerMessageTrend": "stable",
           "cpuMicrosPerMessageControlRatio": 0.46443962168861186,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.562855832022398,
+          "deliveryLatencyP95Ms": 14.103811541565637,
+          "deliveryLatencyP99Ms": 19.290606522346568
         },
         {
           "scenario": "producer",
@@ -7735,7 +8251,10 @@
           "messagesPerSecondTrend": "regression",
           "cpuMicrosPerMessage": 1.7528535147729845,
           "cpuMicrosPerMessageTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.83831119502469,
+          "deliveryLatencyP95Ms": 42.52249404726868,
+          "deliveryLatencyP99Ms": 84.97315752636239
         },
         {
           "scenario": "producer",
@@ -7758,7 +8277,10 @@
           "cpuMicrosPerMessageTrend": "regression",
           "cpuMicrosPerMessageControlRatio": 0.46464186231532356,
           "cpuMicrosPerMessageControlRatioTrend": "improvement",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 10.337915650652212,
+          "deliveryLatencyP95Ms": 16.013666038730797,
+          "deliveryLatencyP99Ms": 23.82031695842858
         },
         {
           "scenario": "producer-roundtrip-steady",
@@ -7828,7 +8350,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 1.367884255095501,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.85,
+          "deliveryLatencyP95Ms": 24.55,
+          "deliveryLatencyP99Ms": 46.55
         },
         {
           "scenario": "producer-idempotent",
@@ -7848,7 +8373,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.04295320041697914,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.95,
+          "deliveryLatencyP95Ms": 13.55,
+          "deliveryLatencyP99Ms": 30.15
         },
         {
           "scenario": "producer-idempotent",
@@ -7868,7 +8396,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.7759897715680986,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.85,
+          "deliveryLatencyP95Ms": 25.15,
+          "deliveryLatencyP99Ms": 34.85
         },
         {
           "scenario": "producer-idempotent",
@@ -7888,7 +8419,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": 0.6298899411294713,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.05,
+          "deliveryLatencyP95Ms": 169.85,
+          "deliveryLatencyP99Ms": 534.85
         },
         {
           "scenario": "producer-idempotent",
@@ -7915,7 +8449,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -0.01252102490492542,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 4.35,
+          "deliveryLatencyP95Ms": 11.55,
+          "deliveryLatencyP99Ms": 20.15
         },
         {
           "scenario": "producer",
@@ -7942,7 +8479,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.7223780649588998,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.55,
+          "deliveryLatencyP95Ms": 25.25,
+          "deliveryLatencyP99Ms": 45.15
         },
         {
           "scenario": "producer",
@@ -7965,7 +8505,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.8320227890672725,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.95,
+          "deliveryLatencyP95Ms": 16.25,
+          "deliveryLatencyP99Ms": 32.65
         },
         {
           "scenario": "producer",
@@ -7992,7 +8535,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 1.1390054060444634,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.45,
+          "deliveryLatencyP95Ms": 37.35,
+          "deliveryLatencyP99Ms": 59.75
         },
         {
           "scenario": "producer-acks-all",
@@ -8012,7 +8558,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.1586917496959638,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.85,
+          "deliveryLatencyP95Ms": 37.45,
+          "deliveryLatencyP99Ms": 68.65
         },
         {
           "scenario": "producer-acks-all",
@@ -8032,7 +8581,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.3600230449452447,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 10.55,
+          "deliveryLatencyP95Ms": 15.85,
+          "deliveryLatencyP99Ms": 22.35
         },
         {
           "scenario": "producer-acks-all",
@@ -8052,7 +8604,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.6023356186394826,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.95,
+          "deliveryLatencyP95Ms": 12.55,
+          "deliveryLatencyP99Ms": 16.65
         },
         {
           "scenario": "producer-acks-all",
@@ -8072,7 +8627,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.5556146173291767,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.85,
+          "deliveryLatencyP95Ms": 29.15,
+          "deliveryLatencyP99Ms": 48.45
         },
         {
           "scenario": "producer-acks-all",
@@ -8095,7 +8653,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.07735311447059807,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.55,
+          "deliveryLatencyP95Ms": 23.35,
+          "deliveryLatencyP99Ms": 42.95
         },
         {
           "scenario": "producer-acks-all",
@@ -8122,7 +8683,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.09248612362381455,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 10.95,
+          "deliveryLatencyP95Ms": 31.95,
+          "deliveryLatencyP99Ms": 47.95
         },
         {
           "scenario": "consumer-batch",
@@ -8191,7 +8755,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.8554083834044836,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.15,
+          "deliveryLatencyP95Ms": 18.45,
+          "deliveryLatencyP99Ms": 34.15
         },
         {
           "scenario": "producer-idempotent",
@@ -8218,7 +8785,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.6458872135442112,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 16.15,
+          "deliveryLatencyP95Ms": 53.65,
+          "deliveryLatencyP99Ms": 84.15
         },
         {
           "scenario": "producer-idempotent",
@@ -8245,7 +8815,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.5212611205428235,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 13.05,
+          "deliveryLatencyP95Ms": 37.75,
+          "deliveryLatencyP99Ms": 63.25
         },
         {
           "scenario": "producer",
@@ -8265,7 +8838,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -2.87792896073804,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.45,
+          "deliveryLatencyP95Ms": 31.75,
+          "deliveryLatencyP99Ms": 72.75
         },
         {
           "scenario": "producer",
@@ -8285,7 +8861,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.738420207241877,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 10.85,
+          "deliveryLatencyP95Ms": 18.65,
+          "deliveryLatencyP99Ms": 25.85
         },
         {
           "scenario": "producer",
@@ -8312,7 +8891,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.3103741720839979,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 3.85,
+          "deliveryLatencyP95Ms": 8.35,
+          "deliveryLatencyP99Ms": 13.75
         },
         {
           "scenario": "producer",
@@ -8332,7 +8914,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.5027912239507132,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.85,
+          "deliveryLatencyP95Ms": 13.75,
+          "deliveryLatencyP99Ms": 21.95
         },
         {
           "scenario": "producer",
@@ -8352,7 +8937,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": 0.5791321229839904,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.25,
+          "deliveryLatencyP95Ms": 56.95,
+          "deliveryLatencyP99Ms": 99.25
         },
         {
           "scenario": "producer-transactional",
@@ -8504,7 +9092,10 @@
           "cpuMicrosPerMessageTrend": "stable",
           "cpuMicrosPerMessageControlRatio": 0.5855890071786233,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.099845677542259,
+          "deliveryLatencyP95Ms": 19.74835436181962,
+          "deliveryLatencyP99Ms": 30.773649442339465
         },
         {
           "scenario": "producer-idempotent",
@@ -8523,7 +9114,10 @@
           "messagesPerSecondTrend": "stable",
           "cpuMicrosPerMessage": 1.4134246197799596,
           "cpuMicrosPerMessageTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.089950738717023,
+          "deliveryLatencyP95Ms": 25.399950787353895,
+          "deliveryLatencyP99Ms": 41.81127240350383
         },
         {
           "scenario": "producer-acks-all",
@@ -8546,7 +9140,10 @@
           "cpuMicrosPerMessageTrend": "improvement",
           "cpuMicrosPerMessageControlRatio": 0.4796394684174767,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.492791060658446,
+          "deliveryLatencyP95Ms": 13.603767860412793,
+          "deliveryLatencyP99Ms": 22.094965489902897
         },
         {
           "scenario": "producer-acks-all",
@@ -8565,7 +9162,10 @@
           "messagesPerSecondTrend": "regression",
           "cpuMicrosPerMessage": 1.557254653499717,
           "cpuMicrosPerMessageTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.435301279598031,
+          "deliveryLatencyP95Ms": 15.219149122076434,
+          "deliveryLatencyP99Ms": 28.232738088963327
         },
         {
           "scenario": "producer",
@@ -8588,7 +9188,10 @@
           "cpuMicrosPerMessageTrend": "improvement",
           "cpuMicrosPerMessageControlRatio": 0.5165998017123898,
           "cpuMicrosPerMessageControlRatioTrend": "improvement",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.373499879980798,
+          "deliveryLatencyP95Ms": 13.019504598870114,
+          "deliveryLatencyP99Ms": 20.24073862288627
         },
         {
           "scenario": "producer",
@@ -8607,7 +9210,10 @@
           "messagesPerSecondTrend": "stable",
           "cpuMicrosPerMessage": 1.472711072759994,
           "cpuMicrosPerMessageTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.499772722576815,
+          "deliveryLatencyP95Ms": 20.479562983618575,
+          "deliveryLatencyP99Ms": 40.08968071711223
         },
         {
           "scenario": "producer-roundtrip-steady",
@@ -8684,7 +9290,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.49534931785594144,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 3.75,
+          "deliveryLatencyP95Ms": 8.05,
+          "deliveryLatencyP99Ms": 12.55
         },
         {
           "scenario": "producer-idempotent",
@@ -8704,7 +9313,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.4208705956804811,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.05,
+          "deliveryLatencyP95Ms": 12.85,
+          "deliveryLatencyP99Ms": 21.45
         },
         {
           "scenario": "producer-idempotent",
@@ -8724,7 +9336,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.2730357915189828,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.45,
+          "deliveryLatencyP95Ms": 25.45,
+          "deliveryLatencyP99Ms": 40.05
         },
         {
           "scenario": "producer-idempotent",
@@ -8744,7 +9359,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.4994760178108836,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.75,
+          "deliveryLatencyP95Ms": 25.35,
+          "deliveryLatencyP99Ms": 43.65
         },
         {
           "scenario": "producer-idempotent",
@@ -8764,7 +9382,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.44332564390571605,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.15,
+          "deliveryLatencyP95Ms": 30.35,
+          "deliveryLatencyP99Ms": 44.15
         },
         {
           "scenario": "producer",
@@ -8791,7 +9412,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.2543098367192739,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.85,
+          "deliveryLatencyP95Ms": 23.25,
+          "deliveryLatencyP99Ms": 41.35
         },
         {
           "scenario": "producer",
@@ -8814,7 +9438,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.03938393649963255,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 4.85,
+          "deliveryLatencyP95Ms": 11.25,
+          "deliveryLatencyP99Ms": 26.85
         },
         {
           "scenario": "producer",
@@ -8841,7 +9468,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.06284275847198931,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.25,
+          "deliveryLatencyP95Ms": 27.25,
+          "deliveryLatencyP99Ms": 48.45
         },
         {
           "scenario": "producer-acks-all",
@@ -8861,7 +9491,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.44167193894776147,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.85,
+          "deliveryLatencyP95Ms": 15.75,
+          "deliveryLatencyP99Ms": 26.75
         },
         {
           "scenario": "producer-acks-all",
@@ -8881,7 +9514,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.5687352746531169,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.05,
+          "deliveryLatencyP95Ms": 13.35,
+          "deliveryLatencyP99Ms": 26.35
         },
         {
           "scenario": "producer-acks-all",
@@ -8901,7 +9537,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 2.0040890484426304,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.85,
+          "deliveryLatencyP95Ms": 17.35,
+          "deliveryLatencyP99Ms": 30.25
         },
         {
           "scenario": "producer-acks-all",
@@ -8921,7 +9560,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 1.064643713909829,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.15,
+          "deliveryLatencyP95Ms": 11.75,
+          "deliveryLatencyP99Ms": 18.25
         },
         {
           "scenario": "producer-acks-all",
@@ -8944,7 +9586,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 1.0160316806299683,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.25,
+          "deliveryLatencyP95Ms": 30.65,
+          "deliveryLatencyP99Ms": 59.25
         },
         {
           "scenario": "producer-acks-all",
@@ -8971,7 +9616,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.6624861528700362,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 12.35,
+          "deliveryLatencyP95Ms": 28.15,
+          "deliveryLatencyP99Ms": 45.45
         },
         {
           "scenario": "consumer-batch",
@@ -9044,7 +9692,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.10603813345619822,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 13.65,
+          "deliveryLatencyP95Ms": 37.95,
+          "deliveryLatencyP99Ms": 58.95
         },
         {
           "scenario": "producer-idempotent",
@@ -9067,7 +9718,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.056999985187648525,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.55,
+          "deliveryLatencyP95Ms": 14.75,
+          "deliveryLatencyP99Ms": 24.45
         },
         {
           "scenario": "producer-idempotent",
@@ -9094,7 +9748,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.47258559965446384,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 11.15,
+          "deliveryLatencyP95Ms": 29.05,
+          "deliveryLatencyP99Ms": 54.05
         },
         {
           "scenario": "producer",
@@ -9114,7 +9771,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.22681474058468074,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.25,
+          "deliveryLatencyP95Ms": 11.65,
+          "deliveryLatencyP99Ms": 17.25
         },
         {
           "scenario": "producer",
@@ -9134,7 +9794,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.4520095252398559,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.45,
+          "deliveryLatencyP95Ms": 22.25,
+          "deliveryLatencyP99Ms": 42.35
         },
         {
           "scenario": "producer",
@@ -9154,7 +9817,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.2595266830676389,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.55,
+          "deliveryLatencyP95Ms": 18.85,
+          "deliveryLatencyP99Ms": 37.95
         },
         {
           "scenario": "producer",
@@ -9174,7 +9840,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.3663201121748107,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 10.65,
+          "deliveryLatencyP95Ms": 14.55,
+          "deliveryLatencyP99Ms": 23.75
         },
         {
           "scenario": "producer",
@@ -9201,7 +9870,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.761713304942358,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 4.15,
+          "deliveryLatencyP95Ms": 10.95,
+          "deliveryLatencyP99Ms": 17.15
         },
         {
           "scenario": "producer-transactional",
@@ -9349,7 +10021,10 @@
           "messagesPerSecondTrend": "improvement",
           "cpuMicrosPerMessage": 1.352424810344043,
           "cpuMicrosPerMessageTrend": "improvement",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.98268334445339,
+          "deliveryLatencyP95Ms": 18.0895688174152,
+          "deliveryLatencyP99Ms": 30.485857376823105
         },
         {
           "scenario": "producer-idempotent",
@@ -9372,7 +10047,10 @@
           "cpuMicrosPerMessageTrend": "stable",
           "cpuMicrosPerMessageControlRatio": 0.5581346871822164,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.298458741405613,
+          "deliveryLatencyP95Ms": 24.732114749855096,
+          "deliveryLatencyP99Ms": 30.52658677284442
         },
         {
           "scenario": "producer-acks-all",
@@ -9391,7 +10069,10 @@
           "messagesPerSecondTrend": "regression",
           "cpuMicrosPerMessage": 1.438810540919022,
           "cpuMicrosPerMessageTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.646991800807339,
+          "deliveryLatencyP95Ms": 27.36672249283791,
+          "deliveryLatencyP99Ms": 49.29449766454668
         },
         {
           "scenario": "producer-acks-all",
@@ -9414,7 +10095,10 @@
           "cpuMicrosPerMessageTrend": "improvement",
           "cpuMicrosPerMessageControlRatio": 0.518359609104064,
           "cpuMicrosPerMessageControlRatioTrend": "improvement",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.927326157034285,
+          "deliveryLatencyP95Ms": 11.228201102580947,
+          "deliveryLatencyP99Ms": 16.753432484120975
         },
         {
           "scenario": "producer",
@@ -9433,7 +10117,10 @@
           "messagesPerSecondTrend": "stable",
           "cpuMicrosPerMessage": 1.2714475786608153,
           "cpuMicrosPerMessageTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.994789404140899,
+          "deliveryLatencyP95Ms": 19.375564507905302,
+          "deliveryLatencyP99Ms": 32.847260159715
         },
         {
           "scenario": "producer",
@@ -9456,7 +10143,10 @@
           "cpuMicrosPerMessageTrend": "improvement",
           "cpuMicrosPerMessageControlRatio": 0.583860646704943,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.399831079153091,
+          "deliveryLatencyP95Ms": 10.39987980699777,
+          "deliveryLatencyP99Ms": 14.746948836962853
         },
         {
           "scenario": "producer-roundtrip-steady",
@@ -9533,7 +10223,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.4341049273961063,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 3.65,
+          "deliveryLatencyP95Ms": 8.25,
+          "deliveryLatencyP99Ms": 14.65
         },
         {
           "scenario": "producer-idempotent",
@@ -9553,7 +10246,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.6619919238968297,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.95,
+          "deliveryLatencyP95Ms": 24.15,
+          "deliveryLatencyP99Ms": 37.25
         },
         {
           "scenario": "producer-idempotent",
@@ -9573,7 +10269,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.07699300970193794,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.15,
+          "deliveryLatencyP95Ms": 21.35,
+          "deliveryLatencyP99Ms": 27.05
         },
         {
           "scenario": "producer-idempotent",
@@ -9593,7 +10292,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.05849386150632568,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.45,
+          "deliveryLatencyP95Ms": 28.65,
+          "deliveryLatencyP99Ms": 34.45
         },
         {
           "scenario": "producer-idempotent",
@@ -9613,7 +10315,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.04980148277718926,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.15,
+          "deliveryLatencyP95Ms": 13.55,
+          "deliveryLatencyP99Ms": 24.95
         },
         {
           "scenario": "producer",
@@ -9640,7 +10345,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.18864540258054008,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.75,
+          "deliveryLatencyP95Ms": 29.35,
+          "deliveryLatencyP99Ms": 51.15
         },
         {
           "scenario": "producer",
@@ -9663,7 +10371,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.25987622291046697,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.15,
+          "deliveryLatencyP95Ms": 12.05,
+          "deliveryLatencyP99Ms": 24.25
         },
         {
           "scenario": "producer",
@@ -9690,7 +10401,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.5569633536090085,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.55,
+          "deliveryLatencyP95Ms": 36.85,
+          "deliveryLatencyP99Ms": 57.65
         },
         {
           "scenario": "producer-acks-all",
@@ -9710,7 +10424,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.48266169717855256,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.85,
+          "deliveryLatencyP95Ms": 26.05,
+          "deliveryLatencyP99Ms": 42.15
         },
         {
           "scenario": "producer-acks-all",
@@ -9730,7 +10447,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.1606640038093365,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 8.55,
+          "deliveryLatencyP95Ms": 11.95,
+          "deliveryLatencyP99Ms": 18.05
         },
         {
           "scenario": "producer-acks-all",
@@ -9750,7 +10470,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.1061085396346996,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.35,
+          "deliveryLatencyP95Ms": 10.55,
+          "deliveryLatencyP99Ms": 15.55
         },
         {
           "scenario": "producer-acks-all",
@@ -9770,7 +10493,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.822469598772978,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.45,
+          "deliveryLatencyP95Ms": 28.75,
+          "deliveryLatencyP99Ms": 57.65
         },
         {
           "scenario": "producer-acks-all",
@@ -9797,7 +10523,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 2.146452177626689,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 11.95,
+          "deliveryLatencyP95Ms": 33.55,
+          "deliveryLatencyP99Ms": 58.25
         },
         {
           "scenario": "producer-acks-all",
@@ -9820,7 +10549,10 @@
           "steadyStatePeakRatioTrend": "regression",
           "slopePercentPerMinute": -1.1673319467017451,
           "slopePercentPerMinuteTrend": "regression",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.65,
+          "deliveryLatencyP95Ms": 35.15,
+          "deliveryLatencyP99Ms": 58.15
         },
         {
           "scenario": "consumer-batch",
@@ -9893,7 +10625,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.43543523633841946,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 14.75,
+          "deliveryLatencyP95Ms": 47.45,
+          "deliveryLatencyP99Ms": 72.45
         },
         {
           "scenario": "producer-idempotent",
@@ -9916,7 +10651,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.10359352838870062,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.45,
+          "deliveryLatencyP95Ms": 18.55,
+          "deliveryLatencyP99Ms": 31.45
         },
         {
           "scenario": "producer-idempotent",
@@ -9943,7 +10681,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.017710600214804136,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 14.55,
+          "deliveryLatencyP95Ms": 41.15,
+          "deliveryLatencyP99Ms": 63.05
         },
         {
           "scenario": "producer",
@@ -9970,7 +10711,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.02531661598555648,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 3.15,
+          "deliveryLatencyP95Ms": 6.95,
+          "deliveryLatencyP99Ms": 12.65
         },
         {
           "scenario": "producer",
@@ -9990,7 +10734,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.45482196017673554,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.25,
+          "deliveryLatencyP95Ms": 21.15,
+          "deliveryLatencyP99Ms": 35.55
         },
         {
           "scenario": "producer",
@@ -10010,7 +10757,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.03186701438489427,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.45,
+          "deliveryLatencyP95Ms": 10.45,
+          "deliveryLatencyP99Ms": 14.45
         },
         {
           "scenario": "producer",
@@ -10030,7 +10780,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.10454459699184544,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.35,
+          "deliveryLatencyP95Ms": 10.35,
+          "deliveryLatencyP99Ms": 15.05
         },
         {
           "scenario": "producer",
@@ -10050,7 +10803,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.6686548733280883,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.75,
+          "deliveryLatencyP95Ms": 17.75,
+          "deliveryLatencyP99Ms": 30.35
         },
         {
           "scenario": "producer-transactional",
@@ -10202,7 +10958,10 @@
           "cpuMicrosPerMessageTrend": "improvement",
           "cpuMicrosPerMessageControlRatio": 0.5545650382760037,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.799816173985882,
+          "deliveryLatencyP95Ms": 11.680004280821136,
+          "deliveryLatencyP99Ms": 21.490172172414074
         },
         {
           "scenario": "producer-idempotent",
@@ -10221,7 +10980,10 @@
           "messagesPerSecondTrend": "improvement",
           "cpuMicrosPerMessage": 1.2875983616338225,
           "cpuMicrosPerMessageTrend": "improvement",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.45,
+          "deliveryLatencyP95Ms": 17.89657788517123,
+          "deliveryLatencyP99Ms": 30.59799830054247
         },
         {
           "scenario": "producer-acks-all",
@@ -10240,7 +11002,10 @@
           "messagesPerSecondTrend": "stable",
           "cpuMicrosPerMessage": 1.2828393186968927,
           "cpuMicrosPerMessageTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.5818903608007195,
+          "deliveryLatencyP95Ms": 16.701272406616212,
+          "deliveryLatencyP99Ms": 30.105190582356393
         },
         {
           "scenario": "producer-acks-all",
@@ -10263,7 +11028,10 @@
           "cpuMicrosPerMessageTrend": "improvement",
           "cpuMicrosPerMessageControlRatio": 0.5569984860708426,
           "cpuMicrosPerMessageControlRatioTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.747418925035616,
+          "deliveryLatencyP95Ms": 11.499021697518447,
+          "deliveryLatencyP99Ms": 16.23491607616128
         },
         {
           "scenario": "producer",
@@ -10282,7 +11050,10 @@
           "messagesPerSecondTrend": "stable",
           "cpuMicrosPerMessage": 1.2834278376130697,
           "cpuMicrosPerMessageTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.337389052283282,
+          "deliveryLatencyP95Ms": 22.795558777972524,
+          "deliveryLatencyP99Ms": 36.548768789112444
         },
         {
           "scenario": "producer",
@@ -10305,7 +11076,10 @@
           "cpuMicrosPerMessageTrend": "improvement",
           "cpuMicrosPerMessageControlRatio": 0.5633610111437208,
           "cpuMicrosPerMessageControlRatioTrend": "improvement",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.649346377305712,
+          "deliveryLatencyP95Ms": 10.699883176932355,
+          "deliveryLatencyP99Ms": 14.749661013053824
         },
         {
           "scenario": "consumer-batch",
@@ -10494,7 +11268,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.11264026305927717,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.85,
+          "deliveryLatencyP95Ms": 13.85,
+          "deliveryLatencyP99Ms": 22.15
         },
         {
           "scenario": "producer-idempotent",
@@ -10514,7 +11291,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.23520403751130878,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.45,
+          "deliveryLatencyP95Ms": 18.25,
+          "deliveryLatencyP99Ms": 30.25
         },
         {
           "scenario": "producer-idempotent",
@@ -10541,7 +11321,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.06417880642409912,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 3.65,
+          "deliveryLatencyP95Ms": 8.75,
+          "deliveryLatencyP99Ms": 16.15
         },
         {
           "scenario": "producer-idempotent",
@@ -10561,7 +11344,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.19808054933124453,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.45,
+          "deliveryLatencyP95Ms": 17.55,
+          "deliveryLatencyP99Ms": 30.95
         },
         {
           "scenario": "producer-idempotent",
@@ -10581,7 +11367,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.001834537166769588,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.75,
+          "deliveryLatencyP95Ms": 9.85,
+          "deliveryLatencyP99Ms": 20.85
         },
         {
           "scenario": "producer-transactional",
@@ -10654,7 +11443,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.3196243731363057,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.55,
+          "deliveryLatencyP95Ms": 25.15,
+          "deliveryLatencyP99Ms": 47.35
         },
         {
           "scenario": "producer-acks-all",
@@ -10681,7 +11473,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.044783699695643955,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 13.55,
+          "deliveryLatencyP95Ms": 31.35,
+          "deliveryLatencyP99Ms": 47.75
         },
         {
           "scenario": "producer-acks-all",
@@ -10701,7 +11496,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.20953040152144325,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.05,
+          "deliveryLatencyP95Ms": 24.15,
+          "deliveryLatencyP99Ms": 39.15
         },
         {
           "scenario": "producer-acks-all",
@@ -10721,7 +11519,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.10179851153447574,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.55,
+          "deliveryLatencyP95Ms": 11.35,
+          "deliveryLatencyP99Ms": 15.55
         },
         {
           "scenario": "producer-acks-all",
@@ -10741,7 +11542,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.016022314456469164,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.95,
+          "deliveryLatencyP95Ms": 11.65,
+          "deliveryLatencyP99Ms": 16.95
         },
         {
           "scenario": "producer-acks-all",
@@ -10761,7 +11565,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.035702272222866434,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.15,
+          "deliveryLatencyP95Ms": 11.55,
+          "deliveryLatencyP99Ms": 23.15
         },
         {
           "scenario": "producer-idempotent",
@@ -10784,7 +11591,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.13453445026980557,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.95,
+          "deliveryLatencyP95Ms": 13.65,
+          "deliveryLatencyP99Ms": 27.65
         },
         {
           "scenario": "producer-idempotent",
@@ -10811,7 +11621,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.3714395116124863,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 12.55,
+          "deliveryLatencyP95Ms": 30.35,
+          "deliveryLatencyP99Ms": 52.95
         },
         {
           "scenario": "producer-idempotent",
@@ -10838,7 +11651,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.1282794031267207,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 12.45,
+          "deliveryLatencyP95Ms": 29.25,
+          "deliveryLatencyP99Ms": 51.75
         },
         {
           "scenario": "producer",
@@ -10865,7 +11681,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.31126167332235033,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 4.95,
+          "deliveryLatencyP95Ms": 16.65,
+          "deliveryLatencyP99Ms": 30.25
         },
         {
           "scenario": "producer",
@@ -10885,7 +11704,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.1335779283824431,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 6.75,
+          "deliveryLatencyP95Ms": 23.25,
+          "deliveryLatencyP99Ms": 36.85
         },
         {
           "scenario": "producer",
@@ -10905,7 +11727,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.056532299530838076,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.75,
+          "deliveryLatencyP95Ms": 10.75,
+          "deliveryLatencyP99Ms": 14.85
         },
         {
           "scenario": "producer",
@@ -10925,7 +11750,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.016181248479354433,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 7.55,
+          "deliveryLatencyP95Ms": 10.65,
+          "deliveryLatencyP99Ms": 14.65
         },
         {
           "scenario": "producer",
@@ -10945,7 +11773,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.2906220355570796,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 5.95,
+          "deliveryLatencyP95Ms": 22.35,
+          "deliveryLatencyP99Ms": 36.25
         },
         {
           "scenario": "producer",
@@ -10968,7 +11799,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.25938679780223045,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 4.95,
+          "deliveryLatencyP95Ms": 11.95,
+          "deliveryLatencyP99Ms": 24.85
         },
         {
           "scenario": "producer",
@@ -10995,7 +11829,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": -0.08889272650577588,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 10.05,
+          "deliveryLatencyP95Ms": 27.75,
+          "deliveryLatencyP99Ms": 46.95
         },
         {
           "scenario": "producer",
@@ -11022,7 +11859,10 @@
           "steadyStatePeakRatioTrend": "stable",
           "slopePercentPerMinute": 0.16567548004437818,
           "slopePercentPerMinuteTrend": "stable",
-          "environmentShiftSuspected": true
+          "environmentShiftSuspected": true,
+          "deliveryLatencyP50Ms": 9.45,
+          "deliveryLatencyP95Ms": 28.45,
+          "deliveryLatencyP99Ms": 46.35
         }
       ],
       "environmentShiftSuspected": true

--- a/docs/docs/stress-tests.md
+++ b/docs/docs/stress-tests.md
@@ -379,7 +379,8 @@ Stress tests measure sustained performance over extended periods against real Ka
 - **Round-Trip CPU Scope**: CPU time covers both bulk production and consumer validation; it is not a producer-only metric
 - **Round-Trip Alloc Scope**: the GC/alloc window likewise spans production plus consume-side validation; values are deliberately consumed as byte[] on both clients for parity, so each consumed payload is materialized as a fresh array (~152 B at 128 B messages) — the expected allocation floor for this lane, not a leak
 - **CPU Efficiency**: CPU time per message differentiates client efficiency even at equal throughput
-- **Noise-Aware Trends**: each scenario is compared with its last 10 matching runs using a median ± 2×MAD band; one adverse excursion warns and two consecutive regressions fail the workflow
+- **Noise-Aware Trends**: each scenario's throughput, CPU per message and Dekaf delivery-latency p50/p95/p99 are compared with its last 10 matching runs using a median ± 2×MAD band; one adverse excursion warns and two consecutive regressions fail the workflow, and paired lanes fail only when the same-run Dekaf/Confluent ratio regressed too
+- **Latency Product Bars**: p95 within 3× the configured delivery-latency target and p50/p99 within 2× the same-run Confluent control are reported as product goals, not gates; a lane that misses a bar shows a warning until the trend band moves it
 - **Parallel Execution**: Each scenario runs in its own isolated environment
 - **Both Clients**: Direct comparison between Dekaf and Confluent.Kafka
 - **Memory Monitoring**: Tracks GC behavior and memory usage over time


### PR DESCRIPTION
## Why

The weekly stress gate has been red for 10 consecutive full runs (last green weekly run: 2026-07-05) and the red carried no information. Two defects, both in `.github/scripts/stress_trend.py` / `stress_report.py`:

**1. Latency thresholds were hard fails placed inside the noise.** `paired_latency_thresholds` failed the run on p95/target > 3.0 and p50/p99 vs Confluent > 2.0 with no band, no two-consecutive rule and no control corroboration, unlike every other metric. Recomputed over the last 10 full runs (07-26 → 09-05):

| Lane / rule | Bar | Median | MAD | Fails |
|---|---:|---:|---:|---:|
| producer 3b p50/Conf | 2.0 | 1.80 | 0.24 | 3/10 |
| producer 3b p95/target | 3.0 | 2.84 | 0.20 | 2/10 |
| producer 3b p99/Conf | 2.0 | 1.91 | 0.10 | 4/10 |
| acks-all 3b p50/Conf | 2.0 | 1.90 | 0.18 | 4/10 |
| acks-all 3b p95/target | 3.0 | 3.31 | 0.23 | 9/10 |
| idem 3b p50/Conf | 2.0 | 2.08 | 0.13 | 6/10 |
| idem 3b p95/target | 3.0 | 4.03 | 0.81 | 9/10 |
| idem 3b p99/Conf | 2.0 | 2.42 | 0.22 | 8/10 |
| all 1b lanes (60 samples) | | | | 1/60 |

producer-3b went red 8/10 weeks on a *rotating* metric (three coin flips OR'd). acks-all/idem-3b p95 are genuine persistent misses (a product problem, not a regression), so the gate was red on a known state every week and any new regression would have landed in the same red.

**2. The environment-shift exclusion flagged every observation in a run whenever any Confluent row regressed.** With ~15 Confluent rows per 37-row run that happened every week since 2026-07-13, so no observation since then entered an absolute baseline and every band was frozen at 11-13 July values (e.g. the txn-3b baseline of 333 msg/s predates the fairness overhaul). The lanes run on separate VMs, so a slow consumer VM says nothing about the producer-3b VM.

## What changed

- `_METRICS` gains `deliveryLatencyP50Ms` / `P95Ms` / `P99Ms` (ms, from `results[].latency`). Dekaf trends them on its own median ± max(2×MAD, 1%) band with the two-consecutive rule and same-run Confluent-ratio corroboration, exactly like throughput and CPU. Confluent's values are recorded (they seed the ratio baseline) but neither trended nor used as an environment indicator (`environment_indicator: False`), so a noisy control tail cannot evict a lane from the baselines.
- The absolute bars stay as rows labelled "(product bar)" with status "Product bar missed (warning)"; they never enter `should_fail`, which is now computed once from every row's `failureEligible`.
- Environment-shift exclusion is lane-scoped and **derived on every load and write** from the stored Confluent `*Trend` fields (`_apply_environment_shift`), instead of being trusted from the file. A lane is `_lane_identity` (scenario × brokers × workload shape = one VM); `_pair_identity` is now composed from it. The rule change therefore needs no flag migration, survives the weekly history rewrite, and the write-only run-level flag is dropped.
- `.github/stress-history.json`: additive latency backfill only (28 producer observations × 3 percentiles for each of the 10 full runs 08-02 → 09-05, from their `stress-test-results-merged` artifacts: 30730003731, 30928193941, 30964729481, 31290933607, 31921975314, 32613019856, 33061350644, 33216354227, 33287537914, 33948814595). No existing value or flag changed; the `environmentShiftSuspected` line count is identical (389) and the flags are ignored at load anyway.
- Docs methodology bullets and the step-summary preamble describe the new rules; bar constants are interpolated rather than restated.

## Evidence

- `python3 -m unittest discover -s .github/scripts -p 'test_*.py'`: 180 tests pass (was 178; one latency-threshold test rewritten to the new semantics, six latency-trend tests and three lane-scope / re-derivation tests added, two env-shift tests changed from persisted flags to stored Confluent trends).
- Dry run of the 09-05 merged results (run 33948814595) against the backfilled history: `should_fail=false`; only 6/37 observations of that run are excluded (consumer, acks-all-3b and txn-3b lanes, where Confluent regressed) instead of 37/37; producer-1b throughput band is now 1.37M–1.73M around a 1.55M median instead of July's 1.61M; 3-broker latency bands are live (producer-3b p50 10.05 ms within 6.35–10.55); the 3conn-1b tail growth (p99 13.4 → 30.3 ms) and acks-all-1b p95/p99 ratios surface as first-excursion warnings, i.e. the gate produces information again. The five product-bar misses appear as warnings.

Follow-up (not in this PR): the product-bar rows duplicate values the trend rows already carry; folding the bar into the metric row would delete `paired_latency_thresholds` and its identity clones.

No `src/` change; no performance impact.

https://claude.ai/code/session_012AEx3PnpfHTncWCKXsCH9U


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added delivery-latency reporting for p50, p95, and p99 percentiles.
  * Added comparisons against configured latency targets and same-run Confluent controls.
  * Added lane-specific environment-shift detection for more accurate trend analysis.

* **Bug Fixes**
  * Latency product-bar misses are now reported as warnings rather than workflow failures.
  * Latency trends remain available even when some control data is missing.

* **Documentation**
  * Updated stress-test methodology to document latency metrics, targets, and comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->