### PR TITLE
perf(producer): govern queueing delay against the target minus configured linger

### DIFF
--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -396,7 +396,7 @@ Soft target for per-broker queueing latency (append to broker acknowledgement):
 .WithDeliveryLatencyTarget(TimeSpan.Zero)                 // disable the bound
 ```
 
-Default: 10ms. Before a broker's first successful acknowledgement, the producer admits one configured batch per current connection. This prevents an unsampled startup burst from filling the full pipeline. The adaptive controller then starts from a wider request window and probes up and down for the smallest whole-request window that preserves acknowledged goodput without increasing controllable queueing delay. `Acks.None` keeps the normal controller window because no acknowledgement can end the startup phase. When a broker reaches its budget, produce calls block exactly like `BufferMemory` exhaustion (subject to `WithMaxBlock` and cancellation). Raise the target if you prefer deeper buffering over latency; set `TimeSpan.Zero` to disable the bound.
+Default: 10ms. The target is end to end, so the configured `WithLinger` delay counts against it: the controller governs the remainder (target minus linger, never below half the target) as controllable queueing latency. With the default 10ms target and a 5ms linger, standing per-broker queueing is steered toward 5ms. Before a broker's first successful acknowledgement, the producer admits one configured batch per current connection. This prevents an unsampled startup burst from filling the full pipeline. The adaptive controller then starts from a wider request window and probes up and down for the smallest whole-request window that preserves acknowledged goodput without increasing controllable queueing delay. `Acks.None` keeps the normal controller window because no acknowledgement can end the startup phase. When a broker reaches its budget, produce calls block exactly like `BufferMemory` exhaustion (subject to `WithMaxBlock` and cancellation). Raise the target if you prefer deeper buffering over latency; set `TimeSpan.Zero` to disable the bound.
 
 ### WithSocketSendBufferBytes / WithSocketReceiveBufferBytes
 
@@ -448,7 +448,7 @@ Enable logging:
 | `WithoutAdaptiveConnections` | - | Disable adaptive scaling |
 | `WithBufferMemory` | auto-tuned | Max buffer for unsent messages |
 | `WithBufferMemoryAllocationStrategy` | Full | Full arena or pooled incremental chunks |
-| `WithDeliveryLatencyTarget` | 10ms | Per-broker queueing latency target; `TimeSpan.Zero` disables |
+| `WithDeliveryLatencyTarget` | 10ms | Per-broker delivery latency target (append to ack, linger counts against it); `TimeSpan.Zero` disables |
 | `WithMaxBlock` | 60000ms | Max time produce calls wait for metadata or buffer space |
 | `WithDeliveryTimeout` | 120000ms | Max time for delivery success or failure |
 | `WithRequestTimeout` | 30000ms | Per-request timeout |

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -216,11 +216,13 @@ public sealed class ProducerBuilder<TKey, TValue>
     }
 
     /// <summary>
-    /// Sets the soft target for per-broker producer queueing latency (append to ack).
-    /// The producer bounds each broker's unacknowledged bytes to a preferred measured
-    /// bandwidth-delay product safety horizon, capped by the target but never below one
-    /// bandwidth-delay product. This avoids standing queueing under sustained overload
-    /// without making throughput window-limited.
+    /// Sets the soft target for per-broker producer delivery latency (append to ack).
+    /// The configured linger is the caller's chosen batching delay, so the controller
+    /// governs the remainder (target minus linger, never below half the target) as
+    /// controllable queueing latency. The producer bounds each broker's unacknowledged
+    /// bytes to a preferred measured bandwidth-delay product safety horizon, capped by that
+    /// budget but never below one bandwidth-delay product. This avoids standing queueing
+    /// under sustained overload without making throughput window-limited.
     /// </summary>
     /// <param name="target">The latency target. <see cref="TimeSpan.Zero"/> disables the bound.</param>
     /// <remarks>

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -99,7 +99,6 @@ internal sealed class BrokerUnackedByteBudget
         long initialRequestBytes = 0,
         long? coldStartBudgetBytes = null)
     {
-        _ = lingerSeconds;
         var floor = Math.Max(1, floorBytes);
         _floorBytes = floor;
         var cap = Math.Max(floor, initialCapBytes);
@@ -110,7 +109,7 @@ internal sealed class BrokerUnackedByteBudget
         // override, acknowledgements exist to pace the slow start) plus a positive latency
         // target: with no target there is no delay budget for the descent bias to enforce.
         _controller = new BrokerWindowController(
-            targetSeconds,
+            ComputeGovernedTargetSeconds(targetSeconds, lingerSeconds),
             floor,
             cap,
             initialRequestBytes,
@@ -129,6 +128,28 @@ internal sealed class BrokerUnackedByteBudget
             _probeEvents = new Queue<BrokerBudgetProbeEvent>();
         }
     }
+
+    /// <summary>
+    /// Converts the caller's end-to-end delivery-latency target into the queueing budget the
+    /// window controller governs. Configured linger is the caller's chosen batching delay and
+    /// is excluded from the governed delay sample, so it must also leave the target: a 10 ms
+    /// target with 5 ms linger leaves 5 ms for controllable queueing. Otherwise the controller
+    /// reports "on target" while callers observe target-plus-linger and no descent bias runs
+    /// (weekly run 33948814595: three-broker windows parked at the eight-quantum floor with
+    /// governed delay 7-11 ms against a 10 ms target while delivered p50 was 10-13.6 ms).
+    /// The budget never drops below half the target, so a linger at or beyond the target
+    /// still leaves the governor a positive delay budget instead of a zero or negative one.
+    /// </summary>
+    internal static double ComputeGovernedTargetSeconds(double targetSeconds, double lingerSeconds)
+    {
+        if (targetSeconds <= 0)
+            return targetSeconds;
+
+        var linger = Math.Max(0, lingerSeconds);
+        return Math.Max(targetSeconds - linger, targetSeconds / 2);
+    }
+
+    internal long GovernedTargetDelayTicks => _controller.TargetDelayTicks;
 
     internal static long ComputeCap(int batchSize, int connectionCount) =>
         ComputeBudget(batchSize, connectionCount, CapBatchMultiplier);

--- a/src/Dekaf/Producer/BrokerWindowController.cs
+++ b/src/Dekaf/Producer/BrokerWindowController.cs
@@ -212,6 +212,8 @@ internal sealed class BrokerWindowController
     internal long MaximumGoodputBytesPerSecond => (long)_maximumGoodputBytesPerSecond;
     internal long GovernedDelayEwmaTicks => (long)GovernedDelayEwma;
     internal long RequestQuantumBytes => _requestQuantumBytes;
+    internal long TargetDelayTicks => _targetDelayTicks;
+    internal bool DelayOverTargetForTest => DelayOverTarget;
     internal double WindowScale => _capBytes == 0 ? 1 : (double)_windowBytes / _capBytes;
     internal long CapacityProbeSuccessCount { get; private set; }
     internal long CapacityProbeFailureCount { get; private set; }

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -206,9 +206,11 @@ public sealed class ProducerOptions
     internal bool IsAutoTuned { get; init; }
 
     /// <summary>
-    /// Soft target, in milliseconds, for controllable per-broker producer queueing latency
-    /// (batch seal to socket send). Configured linger and broker round-trip time are excluded.
-    /// Controls a per-broker logical-byte congestion window. The controller probes upward
+    /// Soft target, in milliseconds, for per-broker producer delivery latency (append to
+    /// broker acknowledgement). Configured <see cref="LingerMs"/> is the caller's chosen
+    /// batching delay, so the controller governs the remainder (target minus linger, never
+    /// below half the target) as controllable queueing latency; broker round-trip time is
+    /// excluded from the governed sample. Controls a per-broker logical-byte congestion window. The controller probes upward
     /// and downward to find the smallest window that preserves acknowledged goodput; upward
     /// growth is retained only when goodput improves without controllable queue-delay growth.
     /// Persistent delay causes a fast decrease. Every record reserves the window before

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -23,6 +23,75 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    [Arguments(0.010, 0.000, 0.010)]
+    [Arguments(0.010, 0.005, 0.005)]
+    [Arguments(0.010, 0.002, 0.008)]
+    [Arguments(0.010, 0.010, 0.005)]
+    [Arguments(0.010, 0.100, 0.005)]
+    [Arguments(0.010, -0.001, 0.010)]
+    [Arguments(0.000, 0.005, 0.000)]
+    public async Task GovernedTarget_DeductsConfiguredLingerButKeepsHalfTheTarget(
+        double targetSeconds,
+        double lingerSeconds,
+        double expectedSeconds)
+    {
+        var governed = BrokerUnackedByteBudget.ComputeGovernedTargetSeconds(
+            targetSeconds,
+            lingerSeconds);
+
+        await Assert.That(governed).IsEqualTo(expectedSeconds).Within(1e-12);
+    }
+
+    [Test]
+    public async Task GovernedTarget_BudgetPassesLingerDeductedTargetToController()
+    {
+        var withoutLinger = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 1,
+            initialCapBytes: 10_000,
+            initialRequestBytes: 100);
+        var withLinger = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 1,
+            initialCapBytes: 10_000,
+            lingerSeconds: 0.005,
+            initialRequestBytes: 100);
+
+        await Assert.That(withoutLinger.GovernedTargetDelayTicks).IsEqualTo(Seconds(0.010));
+        await Assert.That(withLinger.GovernedTargetDelayTicks).IsEqualTo(Seconds(0.005));
+    }
+
+    [Test]
+    public async Task GovernedTarget_LingerDeductionEnablesDescentBiasAtSameGovernedDelay()
+    {
+        // 7ms of controllable delay: on target against the full 10ms budget, over target once
+        // a 5ms linger leaves only 5ms for queueing. Same delay samples, different verdicts.
+        var full = new BrokerWindowController(
+            targetSeconds: BrokerUnackedByteBudget.ComputeGovernedTargetSeconds(0.010, 0),
+            floorBytes: 1,
+            capBytes: 10_000,
+            initialRequestBytes: 100,
+            latencyGovernorEnabled: true);
+        var deducted = new BrokerWindowController(
+            targetSeconds: BrokerUnackedByteBudget.ComputeGovernedTargetSeconds(0.010, 0.005),
+            floorBytes: 1,
+            capBytes: 10_000,
+            initialRequestBytes: 100,
+            latencyGovernorEnabled: true);
+
+        var now = T0;
+        var admissionBlocks = 0L;
+        for (var i = 0; i < 64; i++)
+        {
+            _ = DriveControllerEpoch(full, ref now, ref admissionBlocks, sealToSendSeconds: 0.007);
+            _ = DriveControllerEpoch(deducted, ref now, ref admissionBlocks, sealToSendSeconds: 0.007);
+        }
+
+        await Assert.That(full.DelayOverTargetForTest).IsFalse();
+        await Assert.That(deducted.DelayOverTargetForTest).IsTrue();
+    }
+
+    [Test]
     public async Task ColdStartAdmission_UsesOneRequestWaveUntilFirstAcknowledgement()
     {
         var budget = CreateColdStartBudget();


### PR DESCRIPTION
## Summary

The delivery-latency target is documented as append-to-ack (`WithDeliveryLatencyTarget` doc, `producer-options.md`), but `BrokerWindowController` compared its governed delay (seal-to-send + RTT excess + admission wait; configured linger deliberately excluded by `GovernedOriginTicks`) against the **full** target. With the stress configuration (10 ms target, 5 ms linger) the controller read 7-11 ms as "on target" while callers observed target-plus-linger, so the delay-biased descent never engaged and three-broker windows parked at the eight-quantum floor.

This PR deducts the configured linger from the governed target (never below half the target). `BrokerUnackedByteBudget` already received `lingerSeconds` and discarded it. Default configuration (linger 0) is unchanged.

## Evidence from weekly run 33948814595 (main `0795104e6`)

Per-broker steady state from `results[].producerDeliveryDiagnostics.brokerBudgetSamples` (minutes 3-15):

| Lane | Broker | Window | Drain | Queue = window/drain | Governed EWMA | Target |
|---|---|---:|---:|---:|---:|---:|
| producer-idempotent-3b | b1 / b2 / b3 | 8 / 8 / 5 MB | 458 / 450 / 475 MB/s | 18.3 / 18.6 / 11.0 ms | 8.7 / 8.9 / 8.7 ms | 10 ms |
| producer-acks-all-3b | b1 / b2 / b3 | 8 / 8 / 6 MB | 388 / 390 / 399 MB/s | 21.6 / 21.5 / 15.8 ms | 10.7 / 9.3 / 15.8 ms | 10 ms |
| producer-1b | b1 | 12 MB | 1,721 MB/s | 7.3 ms | 5.4 ms | 10 ms |

Delivered latency (harness, append to ack): idempotent-3b p50 12.6 / p95 30.4 ms, acks-all-3b p50 13.6 / p95 31.4 ms versus Confluent 6.0 / 13.7 and 6.6 / 25.2 ms. Gate breaches: p95/target 3.04 and 3.13, p50/Confluent 2.11 and 2.07. Every 1-broker lane passes.

Mechanism: descent below `MinimumPipelineQuanta = 8` runs only while `GovernedDelayEwma > target`. At 3 brokers the EWMA sits 7-11 ms against a 10 ms target, so brokers 1-2 never descend; the one broker that did (b3, 5-6 MB) then takes 1.1-1.2 M admission blocks versus 66-183 K on the others because the single produce loop stalls on it. With the governed target at 5 ms, all three brokers become "over target" and the existing goodput-guarded, delay-earning descent (>= 10% delay gain, >= 0.99 goodput per step) decides how far each can shrink.

## Tests

- `GovernedTarget_DeductsConfiguredLingerButKeepsHalfTheTarget` (7 cases), `GovernedTarget_BudgetPassesLingerDeductedTargetToController`, `GovernedTarget_LingerDeductionEnablesDescentBiasAtSameGovernedDelay`.
- `BrokerUnackedByteBudgetTests`, `RecordAccumulatorBudgetTests`, `KafkaProducerBudgetTests`, `BrokerUnackedAdmissionTests`: 88/88 locally.

## Stress validation

| Lane | Run | Verdict | Throughput | p50 | p95 | p99 | CPU/msg | Alloc/msg |
|---|---|---|---:|---:|---:|---:|---:|---:|
| producer-idempotent-3b A-B-A #1 | [33961873612](https://github.com/thomhurst/Dekaf/actions/runs/33961873612) | INCONCLUSIVE (allocation control drift 16% at 0.5 B/msg; every metric row passed) | +1.9% | -38% | -32% | -8% | -11% | inconclusive |
| producer-idempotent-3b A-B-A #2 (exact repeat) | [33964050486](https://github.com/thomhurst/Dekaf/actions/runs/33964050486) | **PASS** | +2.6% | -27% | -40% | -21% | -9.4% | -8.9% |
| producer-1b A-B-A #1 | [33966278396](https://github.com/thomhurst/Dekaf/actions/runs/33966278396) | INCONCLUSIVE (allocation control drift 33% at 0.6-0.9 B/msg; every metric row passed) | +1.3% | -19% | -13% | -19% | +0.1% | inconclusive |
| producer-1b A-B-A #2 (exact repeat) | [33968617930](https://github.com/thomhurst/Dekaf/actions/runs/33968617930) | INCONCLUSIVE (baseline A collapsed: steady/peak 0.824 < 0.85 floor; candidate and A2 clean) | +4.4% | -29% | -31% | -35% | -1.8% | -21% |

Two consecutive INCONCLUSIVE results on `producer-1b` (sub-byte allocation drift, then a collapsed control): no further identical run without maintainer approval; the full six-segment synthesis is in the comments. Baseline `fb58c128be4d4f9e0ad8485e39d81173b43d8d19` (exact parent, product-equivalent to the weekly run's `0795104e6`), cheap shape, 15 min per segment, one VM per run. Candidate p50 is 9.15 ms in both 3-broker runs while the four parent segments spread 11.25-16.85 ms; per-broker windows and probe detail are in the comments.

No hot-path code changes: constructor-only arithmetic, no allocation impact.

https://claude.ai/code/session_012AEx3PnpfHTncWCKXsCH9U

