### PR TITLE
ci(stress): add an adaptive-connections measurement pass for the producer lanes

### DIFF
--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -1951,6 +1951,14 @@ class StressTrendTests(unittest.TestCase):
             '[ "$full_run" = "true" ] && [ "$CONSUMER_FETCH_DIAGNOSTICS" = "true" ]',
             selector,
         )
+        self.assertIn(
+            '[ "$full_run" = "true" ] && [ "$ADAPTIVE_CONNECTIONS" = "true" ]',
+            selector,
+        )
+        self.assertIn(
+            'ADAPTIVE_CONNECTIONS: ${{ github.event.inputs.adaptive_connections }}',
+            workflow,
+        )
         self.assertIn('echo "full_run=$full_run"', selector)
         self.assertIn(
             "(github.event_name == 'schedule' || github.event.inputs.full_run == 'true') && 'all-schedule'",

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -48,6 +48,11 @@ on:
         description: 'Enable Dekaf consumer fetch diagnostics (debug runs only; adds Dekaf-only overhead to the measured window)'
         required: false
         default: 'false'
+      adaptive_connections:
+        description: 'Leave Dekaf producer adaptive connection scaling at the library default instead of pinning one connection (results labelled "Dekaf (adaptive)"; measurement only, never published)'
+        required: false
+        type: boolean
+        default: false
       # Keep this choice input below duration_minutes: the options-sync test in
       # .github/scripts/test_stress_trend.py slices the workflow text from the
       # first 'options:' to 'duration_minutes:' to read the lane list.
@@ -479,6 +484,9 @@ jobs:
           EXTRA_ARGS=()
           if [ "${{ github.event.inputs.consumer_fetch_diagnostics }}" = "true" ]; then
             EXTRA_ARGS+=(--consumer-fetch-diagnostics)
+          fi
+          if [ "${{ github.event.inputs.adaptive_connections }}" = "true" ]; then
+            EXTRA_ARGS+=(--adaptive-connections)
           fi
 
           if [ -n "$BASELINE_SHA" ]; then

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -139,6 +139,7 @@ jobs:
           DISPATCH_SHAPE: ${{ github.event.inputs.dispatch_shape }}
           FULL_RUN: ${{ github.event.inputs.full_run }}
           CONSUMER_FETCH_DIAGNOSTICS: ${{ github.event.inputs.consumer_fetch_diagnostics }}
+          ADAPTIVE_CONNECTIONS: ${{ github.event.inputs.adaptive_connections }}
           BASELINE_SHA: ${{ github.event.inputs.baseline_sha }}
           PROFILE_MODE: ${{ github.event.inputs.profile_mode }}
           EVENT_NAME: ${{ github.event_name }}
@@ -199,6 +200,10 @@ jobs:
           fi
           if [ "$full_run" = "true" ] && [ "$CONSUMER_FETCH_DIAGNOSTICS" = "true" ]; then
             echo "::error::full_run cannot enable consumer_fetch_diagnostics because its Dekaf-only overhead would invalidate the published comparison."
+            exit 1
+          fi
+          if [ "$full_run" = "true" ] && [ "$ADAPTIVE_CONNECTIONS" = "true" ]; then
+            echo "::error::full_run cannot enable adaptive_connections because relabelling every producer result 'Dekaf (adaptive)' removes the Dekaf group from the published comparison and silently blanks the headline rows."
             exit 1
           fi
 

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -137,8 +137,13 @@ public static class Program
             $"fail at {ProgressWatchdog.DefaultExitAfter.TotalMinutes:F0} minutes");
         if (options.ConnectionsPerBroker > 1)
             Console.WriteLine($"Multi-connection: {options.ConnectionsPerBroker} connections per broker (Dekaf only)");
-        if (options.AdaptiveConnections)
+        // Adaptive scaling is only effective on the single-connection pass; the 3-connection
+        // control pass pins its count even when the flag is forwarded to it (see
+        // StressTestOptions.AdaptiveConnections below), so the banner mirrors that condition.
+        if (options.AdaptiveConnections && options.ConnectionsPerBroker == 1)
             Console.WriteLine("Adaptive connections: Dekaf producer scaling left at the library default (Dekaf only)");
+        else if (options.AdaptiveConnections)
+            Console.WriteLine("Adaptive connections: requested but pinned for this multi-connection pass");
         Console.WriteLine(new string('-', 50));
 
         Directory.CreateDirectory(options.OutputPath);

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -137,6 +137,8 @@ public static class Program
             $"fail at {ProgressWatchdog.DefaultExitAfter.TotalMinutes:F0} minutes");
         if (options.ConnectionsPerBroker > 1)
             Console.WriteLine($"Multi-connection: {options.ConnectionsPerBroker} connections per broker (Dekaf only)");
+        if (options.AdaptiveConnections)
+            Console.WriteLine("Adaptive connections: Dekaf producer scaling left at the library default (Dekaf only)");
         Console.WriteLine(new string('-', 50));
 
         Directory.CreateDirectory(options.OutputPath);
@@ -225,6 +227,7 @@ public static class Program
             Compression = options.Compression,
             BrokerCount = options.Brokers,
             ConnectionsPerBroker = connectionsPerBroker,
+            AdaptiveConnections = options.AdaptiveConnections && connectionsPerBroker == 1,
             RoundTripSteadySeconds = options.RoundTripSteadySeconds,
             RoundTripSteadyMaxLogBytes = roundTripSteadyMaxLogBytes,
             EnableProducerDeliveryDiagnostics = options.EnableProducerDeliveryDiagnostics,
@@ -295,6 +298,8 @@ public static class Program
                 Console.WriteLine($"=== Running: {scenario.Client} {scenario.Name} ===");
 
                 var result = await RunScenarioAsync(scenario, connectionsPerBroker: 1).ConfigureAwait(false);
+                if (options.AdaptiveConnections && scenario.Client == "Dekaf" && UsesProducerTopic(scenario.Name))
+                    result.Client = "Dekaf (adaptive)";
                 results.Add(result);
 
                 GC.Collect();
@@ -964,6 +969,9 @@ public static class Program
                 case "--roundtrip-steady-seconds":
                     options.RoundTripSteadySeconds = ParsePositiveInt(args[++i], "--roundtrip-steady-seconds");
                     break;
+                case "--adaptive-connections":
+                    options.AdaptiveConnections = true;
+                    break;
                 case "--producer-delivery-diagnostics":
                     options.EnableProducerDeliveryDiagnostics = true;
                     break;
@@ -1089,6 +1097,7 @@ public static class Program
               --compression <type>   Compression type: none, lz4, snappy, zstd (default: none)
               --brokers <count>      Number of Kafka brokers (default: 1, use 3 for multi-broker)
               --connections-per-broker <n>  TCP connections per broker (default: 1, pass 3 for multi-connection comparison)
+              --adaptive-connections  Keep Dekaf's default adaptive connection scaling (results labelled "Dekaf (adaptive)")
               --seed-messages <count> Messages pre-seeded into the consumer topic (default: 2000000)
               --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message loss and watchdog stalls
               --consumer-fetch-diagnostics  Capture Dekaf consumer fetch diagnostics (debug runs only; adds Dekaf-only overhead)
@@ -1145,6 +1154,7 @@ public static class Program
         public string Compression { get; set; } = "none";
         public int Brokers { get; set; } = 1;
         public int ConnectionsPerBroker { get; set; } = 1;
+        public bool AdaptiveConnections { get; set; }
         public int SeedMessages { get; set; } = 2_000_000;
         public int RoundTripSteadySeconds { get; set; } = 60;
         public bool EnableProducerDeliveryDiagnostics { get; set; }

--- a/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
+++ b/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
@@ -27,6 +27,13 @@ internal sealed class StressTestOptions
     public string Compression { get; init; } = "none";
     public int BrokerCount { get; init; } = 1;
     public int ConnectionsPerBroker { get; init; } = 1;
+
+    /// <summary>
+    /// Leaves the Dekaf producer's default adaptive connection scaling enabled instead of
+    /// pinning the configured connection count. Measures the library default configuration;
+    /// results are labelled "Dekaf (adaptive)" so they never enter the pinned baseline band.
+    /// </summary>
+    public bool AdaptiveConnections { get; init; }
     public int RoundTripSteadySeconds { get; init; } = 60;
 
     /// <summary>

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
@@ -36,7 +36,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             // Confluent uses exactly the configured connection count. Pin Dekaf too so adaptive
             // scale-up under backpressure (1 -> 3 connections/broker) cannot leak into the
             // like-for-like baseline; the multi-connection pass measures that separately.
-            .WithoutAdaptiveConnections()
+            .WithStressConnectionPolicy(options)
             .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
 
         _ = options.Compression switch

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
@@ -32,7 +32,7 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
             // Confluent uses exactly the configured connection count. Pin Dekaf too so adaptive
             // scale-up under backpressure (1 -> 3 connections/broker) cannot leak into the
             // like-for-like baseline; the multi-connection pass measures that separately.
-            .WithoutAdaptiveConnections()
+            .WithStressConnectionPolicy(options)
             .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
 
         _ = options.Compression switch

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
@@ -32,7 +32,7 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
             // Confluent uses exactly the configured connection count. Pin Dekaf too so adaptive
             // scale-up under backpressure (1 -> 3 connections/broker) cannot leak into the
             // like-for-like baseline; the multi-connection pass measures that separately.
-            .WithoutAdaptiveConnections()
+            .WithStressConnectionPolicy(options)
             .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
 
         _ = options.Compression switch

--- a/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
@@ -35,7 +35,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             // Confluent uses exactly the configured connection count. Pin Dekaf too so adaptive
             // scale-up under backpressure (1 -> 3 connections/broker) cannot leak into the
             // like-for-like baseline; the multi-connection pass measures that separately.
-            .WithoutAdaptiveConnections()
+            .WithStressConnectionPolicy(options)
             .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
 
         _ = options.Compression switch

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -50,7 +50,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             .WithConnectionsPerBroker(options.ConnectionsPerBroker)
             // Confluent uses exactly the configured connection count. Keep this comparison
             // fixed too so adaptive scale events cannot change ordering or the test profile.
-            .WithoutAdaptiveConnections();
+            .WithStressConnectionPolicy(options);
 
         _ = options.Compression switch
         {

--- a/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
@@ -36,7 +36,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
             // Confluent uses exactly the configured connection count. Pin Dekaf too so adaptive
             // scale-up under backpressure (1 -> 3 connections/broker) cannot leak into the
             // like-for-like baseline; the multi-connection pass measures that separately.
-            .WithoutAdaptiveConnections()
+            .WithStressConnectionPolicy(options)
             .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
 
         _ = options.Compression switch

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -11,6 +11,15 @@ namespace Dekaf.StressTests.Scenarios;
 internal static class StressTestHelpers
 {
     /// <summary>
+    /// Pins the configured connection count for like-for-like comparison with Confluent
+    /// unless the run asked to measure Dekaf's default adaptive scaling.
+    /// </summary>
+    internal static ProducerBuilder<TKey, TValue> WithStressConnectionPolicy<TKey, TValue>(
+        this ProducerBuilder<TKey, TValue> builder,
+        StressTestOptions options) =>
+        options.AdaptiveConnections ? builder : builder.WithoutAdaptiveConnections();
+
+    /// <summary>
     /// Producer scenarios sample true end-to-end delivery latency on 1 in N messages.
     /// Fire-and-forget latency only measures buffer-append time, which says nothing
     /// about broker round-trips; sampling keeps the measurement honest without


### PR DESCRIPTION
## Summary

Every published producer lane pins `WithoutAdaptiveConnections()` (e.g. `ProducerStressTest.cs:39`) so Confluent's fixed connection count is matched like for like. The library default, adaptive scaling on, has therefore never been measured in any lane, while the fixed 3-connection control shows what is available:

| Weekly run 33948814595, producer-1b | Median msg/s | p50 | p95 | p99 | CPU us/msg |
|---|---:|---:|---:|---:|---:|
| Dekaf, 1 pinned connection | 1,567,107 | 7.6 ms | 10.7 ms | 14.7 ms | 0.72 |
| Dekaf, 3 pinned connections | 2,964,629 | 4.95 ms | 16.7 ms | 30.3 ms | 0.59 |
| Confluent, 1 connection | 1,404,612 | 6.4 ms | 22.8 ms | 36.5 ms | 1.28 |

If adaptive scaling reaches 3 connections on its own under this load, the default configuration is nearly 2x the published headline; if it does not, that is a product defect worth fixing. Either answer needs a measurement.

## Changes

- Harness: `--adaptive-connections` leaves the builder default (no `WithoutAdaptiveConnections()`), applied through a `WithStressConnectionPolicy(options)` helper in all six producer scenarios; results are labelled `Dekaf (adaptive)` so `client_sample_groups` keeps them out of the pinned Dekaf band and the headline comparison.
- Workflow: `adaptive_connections` boolean `workflow_dispatch` input forwarded through `EXTRA_ARGS` (covers the plain, paired-sample and `baseline_sha` A-B-A paths). Manual dispatches never publish, so this is measurement only. Placed below `duration_minutes`, so the options-sync test is unaffected (`test_stress_trend`: 65/65).

## Measurement

`producer-1b`, cheap shape, 15 min, `adaptive_connections=true`: run 33962337460 (in progress). Results will be posted here.

https://claude.ai/code/session_012AEx3PnpfHTncWCKXsCH9U


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to run producer stress tests with adaptive connection scaling enabled.
  - Added the `--adaptive-connections` command-line option and workflow input.
  - Adaptive runs are clearly labeled separately from fixed-connection baseline results.

- **Bug Fixes**
  - Stress-test scenarios now consistently apply the selected connection policy, preserving fixed connection counts for comparison runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->