### PR TITLE
ci(stress): let multi-broker lanes start their own cluster under profile mode

### DIFF
--- a/tools/profile-stress-test.sh
+++ b/tools/profile-stress-test.sh
@@ -27,7 +27,8 @@
 #   PROFILE_START_TIMEOUT Seconds allowed for measured phase to start (default: 300).
 #   STRESS_CPUSET         Optional target process CPU affinity.
 #   PROFILER_CPUSET       Optional diagnostics process CPU affinity.
-#   KAFKA_BOOTSTRAP_SERVERS External Kafka address (default: localhost:9092).
+#   KAFKA_BOOTSTRAP_SERVERS External Kafka address (default when unset: localhost:9092;
+#                         export it empty to let the harness start its own brokers).
 
 set -euo pipefail
 
@@ -54,7 +55,11 @@ PROFILE_GCDUMP="${PROFILE_GCDUMP:-false}"
 PROFILE_SUMMARY="${PROFILE_SUMMARY:-true}"
 PROFILE_VALIDATE_ONLY="${PROFILE_VALIDATE_ONLY:-false}"
 PROFILE_START_TIMEOUT="${PROFILE_START_TIMEOUT:-300}"
-export KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS:-localhost:9092}"
+# Default only when the variable is UNSET. The workflow exports an explicitly empty value
+# for multi-broker lanes so the harness starts its own cluster; ":-" turned that empty
+# value into localhost:9092 and every 3-broker profile run failed with connection refused
+# (run 33963174587).
+export KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS-localhost:9092}"
 
 fail() {
     echo "ERROR: $*" >&2


### PR DESCRIPTION
## Summary

`tools/profile-stress-test.sh` defaulted `KAFKA_BOOTSTRAP_SERVERS` with `${VAR:-localhost:9092}`, which also replaces the **explicitly empty** value the workflow exports for 3-broker lanes (`KAFKA_BOOTSTRAP_SERVERS: ${{ matrix.brokers == 1 && 'localhost:9092' || '' }}`). Under `profile_mode` the harness therefore printed `Using external Kafka at localhost:9092` and every 3-broker profile run failed with connection refused: [run 33963174587](https://github.com/thomhurst/Dekaf/actions/runs/33963174587).

Default only when the variable is unset (`${VAR-localhost:9092}`), so local use keeps the default and the workflow's empty export lets the harness start its own cluster exactly as the unprofiled path does.

## Verification

- `bash -n` passes; empty export now yields empty, unset yields `localhost:9092`.
- Re-dispatched `producer-3b` with `profile_mode=cpu` from this branch (link in comments once queued).

https://claude.ai/code/session_012AEx3PnpfHTncWCKXsCH9U