### PR TITLE
ci(stress): give the A-B-A allocation gate a 1 B/msg noise floor

### DIFF
--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -21,6 +21,10 @@ class Metric:
     higher_is_better: bool
     gated: bool = True
     floor: bool = False
+    # Absolute spread below which differences in this metric's unit are treated as noise in
+    # both directions: neither control drift nor a candidate delta smaller than this can
+    # decide the metric. Percentage gates still apply above it.
+    noise_floor: float = 0.0
 
 
 # Steady/peak is a shape statistic: it normalizes a run's settled throughput by that same
@@ -38,7 +42,13 @@ METRICS = (
     Metric("p95", "Latency p95", "ms", False),
     Metric("p99", "Latency p99", "ms", False),
     Metric("cpu", "CPU", "us/msg", False),
-    Metric("alloc", "Allocation", "B/msg", False),
+    # Producer hot paths allocate 0 B/msg by design; the residual 0.5-0.9 B/msg is cold-path
+    # activity (metadata refreshes, probes, samplers) whose run-to-run spread is 0.1-0.25
+    # B/msg, i.e. 16-33% relative. Runs 33961873612 and 33966278396 were ruled INCONCLUSIVE
+    # on that spread alone while every other row passed. Sub-byte allocation differences are
+    # not evidence in either direction, so the allocation gate carries a 1 B/msg noise floor;
+    # consumer lanes at ~2 KB/msg are unaffected because their 3% tolerance is ~60 B/msg.
+    Metric("alloc", "Allocation", "B/msg", False, noise_floor=1.0),
     Metric("stability", "Steady/peak ratio", "ratio", True, floor=True),
     Metric("max", "Latency max", "ms", False, gated=False),
     Metric("averageRequest", "Average request", "KiB", True, gated=False),
@@ -166,6 +176,8 @@ def _metric_status(
 
     delta_percent = 100 * (candidate - baseline_mean) / baseline_mean
     control_drift_percent = 100 * abs(baseline_a2 - baseline_a) / abs(baseline_mean)
+    control_spread = abs(baseline_a2 - baseline_a)
+    noise_floor = metric.noise_floor
     if not metric.gated:
         status = "recorded"
     elif metric.floor:
@@ -174,15 +186,25 @@ def _metric_status(
         if metric.higher_is_better:
             worse_than_both = candidate < min(baseline_a, baseline_a2) * (
                 1 - tolerance_percent / 100
-            )
+            ) and min(baseline_a, baseline_a2) - candidate > noise_floor
             better_than_both = candidate >= max(baseline_a, baseline_a2)
-            adverse = delta_percent < -tolerance_percent
+            adverse = delta_percent < -tolerance_percent and (
+                baseline_mean - candidate > noise_floor
+            )
         else:
             worse_than_both = candidate > max(baseline_a, baseline_a2) * (
                 1 + tolerance_percent / 100
-            )
+            ) and candidate - max(baseline_a, baseline_a2) > noise_floor
             better_than_both = candidate <= min(baseline_a, baseline_a2)
-            adverse = delta_percent > tolerance_percent
+            adverse = delta_percent > tolerance_percent and (
+                candidate - baseline_mean > noise_floor
+            )
+        # A control spread inside the noise floor cannot make the comparison inconclusive:
+        # the controls agree to within what the metric can resolve.
+        controls_disagree = (
+            control_drift_percent > max_control_drift_percent
+            and control_spread > noise_floor
+        )
 
         # Symmetric decisiveness overrides for noisy controls: a candidate worse than both
         # bracketing controls by more than the tolerance is a regression no matter how far
@@ -195,7 +217,7 @@ def _metric_status(
             status = "regression"
         elif better_than_both:
             status = "pass"
-        elif control_drift_percent > max_control_drift_percent:
+        elif controls_disagree:
             status = "inconclusive"
         elif adverse:
             status = "regression"
@@ -212,6 +234,7 @@ def _metric_status(
         "baselineMean": baseline_mean,
         "deltaPercent": delta_percent,
         "controlDriftPercent": control_drift_percent,
+        "noiseFloor": noise_floor,
         "status": status,
         "gated": metric.gated,
     }
@@ -296,7 +319,8 @@ def markdown(comparison, baseline_sha, candidate_sha):
         "",
         f"Baseline: `{baseline_sha}` · Candidate: `{candidate_sha}` · "
         f"adverse tolerance: {comparison['tolerancePercent']:.1f}% · "
-        f"maximum control drift: {comparison['maxControlDriftPercent']:.1f}%",
+        f"maximum control drift: {comparison['maxControlDriftPercent']:.1f}% · "
+        "allocation noise floor: 1.0 B/msg",
         "",
         "| Metric | Baseline A | Candidate B | Baseline A2 | B vs mean | Control drift | Gate |",
         "|---|---:|---:|---:|---:|---:|---|",

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -105,6 +105,67 @@ class StressAbaComparisonTests(unittest.TestCase):
         self.assertEqual("inconclusive", throughput["status"])
         self.assertAlmostEqual(20.0, throughput["controlDriftPercent"])
 
+    def test_sub_byte_allocation_control_drift_is_not_inconclusive(self):
+        # Runs 33961873612 (0.527 / 0.542 / 0.620 B/msg) and 33966278396
+        # (0.866 / 0.649 / 0.619 B/msg): 16-33% relative control drift at sub-byte scale on
+        # a 0 B/msg hot path ruled otherwise-passing comparisons inconclusive.
+        for baseline_a, candidate, baseline_a2 in (
+            (0.527, 0.542, 0.620),
+            (0.866, 0.649, 0.619),
+        ):
+            with self.subTest(baseline_a=baseline_a, candidate=candidate):
+                comparison = compare(
+                    result(allocation=baseline_a),
+                    result(allocation=candidate),
+                    result(allocation=baseline_a2),
+                )
+
+                self.assertEqual("pass", comparison["verdict"])
+                alloc = next(
+                    metric for metric in comparison["metrics"] if metric["key"] == "alloc"
+                )
+                self.assertEqual("pass", alloc["status"])
+                self.assertGreater(alloc["controlDriftPercent"], 10.0)
+                self.assertEqual(1.0, alloc["noiseFloor"])
+
+    def test_sub_byte_allocation_candidate_delta_is_not_a_regression(self):
+        # +50% relative but +0.3 B/msg absolute: below what the metric can resolve.
+        comparison = compare(
+            result(allocation=0.6), result(allocation=0.9), result(allocation=0.6)
+        )
+
+        self.assertEqual("pass", comparison["verdict"])
+
+    def test_allocation_regression_above_noise_floor_still_rejected(self):
+        # +2 B/msg above both controls is a real per-message allocation, floor or not.
+        comparison = compare(
+            result(allocation=0.6), result(allocation=2.7), result(allocation=0.6)
+        )
+
+        self.assertEqual("regression", comparison["verdict"])
+        alloc = next(
+            metric for metric in comparison["metrics"] if metric["key"] == "alloc"
+        )
+        self.assertEqual("regression", alloc["status"])
+
+    def test_allocation_percentage_gates_unchanged_at_consumer_scale(self):
+        # ~2 KB/msg string consumers: 4% over the control mean is 80 B/msg, far above the
+        # floor, so the percentage gates decide exactly as before.
+        comparison = compare(
+            result(allocation=2024.0),
+            result(allocation=2105.0),
+            result(allocation=2024.0),
+        )
+
+        self.assertEqual("regression", comparison["verdict"])
+        noisy = compare(
+            result(allocation=1900.0),
+            result(allocation=2000.0),
+            result(allocation=2150.0),
+        )
+        alloc = next(metric for metric in noisy["metrics"] if metric["key"] == "alloc")
+        self.assertEqual("inconclusive", alloc["status"])
+
     def test_candidate_beating_both_noisy_controls_passes(self):
         # Run 29525842754: candidate p99 (14.85ms) was better than both controls
         # (17.25 / 15.25ms), yet 12.3% control drift ruled the metric inconclusive.


### PR DESCRIPTION
## Summary

The exact-SHA A-B-A comparison (`stress_aba.py`) gates allocation purely on percentages: a 3% adverse tolerance and a 10% control-drift cap. On producer lanes the hot path allocates 0 B/msg by design, so the measured 0.5-0.9 B/msg is cold-path activity (metadata refreshes, probes, samplers) whose run-to-run spread is 0.1-0.25 B/msg, i.e. 16-33% relative. Two comparisons this session were ruled INCONCLUSIVE on that spread alone while every other row passed, each costing a ~55-minute exact repeat:

| Run | Lane | Allocation A / B / A2 (B/msg) | Control drift | Every other gated row |
|---|---|---|---:|---|
| [33961873612](https://github.com/thomhurst/Dekaf/actions/runs/33961873612) | producer-idempotent-3b | 0.527 / 0.542 / 0.620 | 16.17% | pass |
| [33966278396](https://github.com/thomhurst/Dekaf/actions/runs/33966278396) | producer-1b | 0.866 / 0.649 / 0.619 | 33.21% | pass |

CLAUDE.md rule 7 asks for the experimental design to be fixed after repeated control noise rather than more paid runs. This is that fix.

## Change

`Metric` gains a `noise_floor` (unit-absolute); allocation gets 1.0 B/msg. Below the floor, differences are treated as noise in **both** directions:

- control drift cannot mark the metric inconclusive unless the controls disagree by more than the floor;
- a candidate delta counts as adverse (or worse-than-both) only when it exceeds the percentage gate **and** the floor.

Above the floor nothing changes: a +2 B/msg candidate is still a regression, and consumer lanes at ~2 KB/msg keep their existing percentage semantics (3% there is ~60 B/msg). The floor is recorded per metric in `comparison.json` (`noiseFloor`) and in the summary header.

## Evidence

- Replaying the two artifacts above through the patched script: both verdicts become **PASS**; the allocation rows still report their 16.17% / 33.21% control drift, now gated `pass`.
- `test_stress_aba`: 24/24 including four new cases (the two real runs, a +0.3 B/msg candidate delta, a +2 B/msg regression above the floor, and consumer-scale percentage behaviour unchanged). `test_stress_trend`: 65/65.

https://claude.ai/code/session_012AEx3PnpfHTncWCKXsCH9U


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metric comparison results by treating changes below the configured noise threshold as inconclusive rather than regressions.
  * Allocation comparisons now correctly distinguish insignificant sub-byte differences from meaningful regressions.
  * Percentage-based checks remain decisive for larger allocation changes.

* **Reporting**
  * Comparison results now include the applicable noise threshold.
  * Allocation reports display the configured resolution threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->