### PR TITLE
perf(producer): lower the normal window-probe floor from eight to four quanta

### DIFF
--- a/src/Dekaf/Producer/BrokerWindowController.cs
+++ b/src/Dekaf/Producer/BrokerWindowController.cs
@@ -61,14 +61,19 @@ internal sealed class BrokerWindowController
 
     private const int SizeBucketCount = 16;
     private const int SizeBucketShift = 8;
-    // The control run sustained its knee at roughly seven full requests. One extra quantum
-    // absorbs response/scheduler granularity without allowing fragmented requests to redefine
-    // the floor. Descent below this floor is allowed only while the controlled-delay EWMA
-    // exceeds the delivery-latency target (see LatencyDescentPipelineQuanta).
-    private const int MinimumPipelineQuanta = 8;
-    // floor(11 * 0.75) is the first accelerated candidate that remains at or above the
-    // normal eight-quantum floor. Smaller windows use the normal step for deep descent.
-    private const int MinimumAcceleratedDescentQuanta = 11;
+    // Normal down-probes (goodput-guarded only) may reach this floor; descent below it is
+    // allowed only while the governed delay exceeds the target AND each step demonstrably
+    // buys latency (see LatencyDescentPipelineQuanta). The floor used to be eight quanta,
+    // encoding a one-broker knee of ~seven full requests. Against brokers that drain ~450 MB/s
+    // (three-broker topologies on shared cores) eight 1 MB quanta are ~18 ms of standing
+    // queue, and PR #3013's paired runs showed windows parking exactly there with the
+    // governed delay a few hundred microseconds over the budget: too little excess for the
+    // sub-floor delay-gain test, too much for the caller. Four quanta keep two requests on the
+    // wire while two seal, and the paired goodput guard still stops descent at any knee.
+    private const int MinimumPipelineQuanta = 4;
+    // floor(6 * 0.75) is the first accelerated candidate that remains at or above the
+    // normal four-quantum floor. Smaller windows use the normal step for deep descent.
+    private const int MinimumAcceleratedDescentQuanta = 6;
     // Deep-descent floor while over the latency target: two quanta keep the acknowledgement
     // clock pipelined (one request on the wire while the next seals). The eight-quantum
     // floor encoded a one-broker knee and forced ~3x the delivery-latency target of standing
@@ -454,7 +459,7 @@ internal sealed class BrokerWindowController
             requestedWindow);
     }
 
-    /// <summary>Lowest window a down-probe may propose. The legacy eight-quantum floor holds
+    /// <summary>Lowest window a down-probe may propose. The normal four-quantum floor holds
     /// while latency is on target; descent below it is justified only by a missed target,
     /// and even then each step must pass the paired goodput guard.</summary>
     private long ProbeFloorBytes(bool descentBias) => QuantaFloorBytes(

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -255,7 +255,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = new BrokerWindowController(
             targetSeconds: 0.010,
             floorBytes: 1,
-            capBytes: 1_000,
+            capBytes: 500,
             initialRequestBytes: 100,
             latencyGovernorEnabled: true);
         var now = T0;
@@ -275,9 +275,9 @@ public sealed class BrokerUnackedByteBudgetTests
             ref admissionBlocks,
             sealToSendSeconds: 0.050);
 
-        // The 10-quantum cap is below the 11-quantum accelerated threshold. Cap clamping
-        // must not turn that threshold into 10 and permit the coarse 10 -> 7 treatment.
-        await Assert.That(controller.WindowBytes).IsEqualTo(800);
+        // The 5-quantum cap is below the 6-quantum accelerated threshold. Cap clamping
+        // must not turn that threshold into 5 and permit the coarse 5 -> 3 treatment.
+        await Assert.That(controller.WindowBytes).IsEqualTo(400);
     }
 
     [Test]
@@ -331,9 +331,40 @@ public sealed class BrokerUnackedByteBudgetTests
             ref admissionBlocks,
             sealToSendSeconds: 0.050);
 
-        // The 25% treatment would jump 9 -> 6 quanta. Once that candidate would cross the
-        // normal eight-quantum floor, use the 12.5% step (9 -> 7) for deep descent instead.
-        await Assert.That(controller.WindowBytes).IsEqualTo(700);
+        // The 25% treatment jumps 9 -> 6 quanta, still above the normal four-quantum floor.
+        await Assert.That(controller.WindowBytes).IsEqualTo(600);
+        _ = CompleteActiveProbe(
+            controller,
+            baselineWindow: 900,
+            ref now,
+            ref admissionBlocks,
+            candidateSealToSendSeconds: 0.050,
+            baselineSealToSendSeconds: 0.050);
+
+        // From six quanta the 25% treatment lands exactly on the floor (6 -> 4).
+        StartNextProbe(
+            controller,
+            BrokerWindowPhase.ProbeDown,
+            ref now,
+            ref admissionBlocks,
+            sealToSendSeconds: 0.050);
+        await Assert.That(controller.WindowBytes).IsEqualTo(400);
+        _ = CompleteActiveProbe(
+            controller,
+            baselineWindow: 600,
+            ref now,
+            ref admissionBlocks,
+            candidateSealToSendSeconds: 0.050,
+            baselineSealToSendSeconds: 0.050);
+
+        // Below the floor only the 12.5% deep-descent step is used (4 -> 3).
+        StartNextProbe(
+            controller,
+            BrokerWindowPhase.ProbeDown,
+            ref now,
+            ref admissionBlocks,
+            sealToSendSeconds: 0.050);
+        await Assert.That(controller.WindowBytes).IsEqualTo(300);
     }
 
     [Test]
@@ -390,8 +421,8 @@ public sealed class BrokerUnackedByteBudgetTests
         _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
 
         // Delay is over target but window-independent (a fixed 50ms): shrinking below the
-        // legacy floor cannot help, so every sub-floor experiment fails its delay-gain
-        // requirement and the window holds at the legacy floor.
+        // normal floor cannot help, so every sub-floor experiment fails its delay-gain
+        // requirement and the window holds at the normal four-quantum floor.
         for (var i = 0; i < 2_000; i++)
         {
             _ = DriveControllerEpoch(
@@ -401,7 +432,7 @@ public sealed class BrokerUnackedByteBudgetTests
                 sealToSendSeconds: 0.050);
         }
 
-        await Assert.That(controller.WindowBytes).IsGreaterThanOrEqualTo(800);
+        await Assert.That(controller.WindowBytes).IsGreaterThanOrEqualTo(400);
     }
 
     [Test]
@@ -412,12 +443,12 @@ public sealed class BrokerUnackedByteBudgetTests
         var admissionBlocks = 0L;
         _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
 
-        // On-target delay keeps the legacy eight-quantum floor: the governor's deep descent
+        // On-target delay keeps the normal four-quantum floor: the governor's deep descent
         // is justified only by a missed latency target.
         for (var i = 0; i < 1_000; i++)
             _ = DriveControllerEpoch(controller, ref now, ref admissionBlocks);
 
-        await Assert.That(controller.WindowBytes).IsGreaterThanOrEqualTo(800);
+        await Assert.That(controller.WindowBytes).IsGreaterThanOrEqualTo(400);
     }
 
     [Test]
@@ -428,13 +459,25 @@ public sealed class BrokerUnackedByteBudgetTests
         var admissionBlocks = 0L;
         _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
 
-        // Flat goodput walks the window down to the legacy floor; sustained admission
+        // Flat goodput walks the window down to the normal floor; sustained admission
         // blocking then lets up-probes pass at "not worse" goodput, so the window recovers
         // instead of staying trapped under the +3% growth bar it can never clear on noise.
+        // Flat goodput also passes every later down-probe, so the trajectory is a sawtooth:
+        // assert the recovery itself (a window above the optimistic start after touching the
+        // floor) rather than the phase the sawtooth happens to be in at a fixed epoch.
+        var touchedFloor = false;
+        var recoveredAfterFloor = 0L;
         for (var i = 0; i < 5_000; i++)
+        {
             _ = DriveControllerEpoch(controller, ref now, ref admissionBlocks);
+            if (controller.WindowBytes <= 400)
+                touchedFloor = true;
+            else if (touchedFloor)
+                recoveredAfterFloor = Math.Max(recoveredAfterFloor, controller.WindowBytes);
+        }
 
-        await Assert.That(controller.WindowBytes).IsGreaterThan(1_600);
+        await Assert.That(touchedFloor).IsTrue();
+        await Assert.That(recoveredAfterFloor).IsGreaterThan(1_600);
     }
 
     [Test]
@@ -1146,7 +1189,7 @@ public sealed class BrokerUnackedByteBudgetTests
             _ = DriveControllerEpoch(controller, ref now, ref admissionBlocks, rttSeconds: 0.050);
 
         await Assert.That(controller.RequestQuantumBytes).IsEqualTo(100);
-        await Assert.That(controller.WindowBytes).IsGreaterThanOrEqualTo(800);
+        await Assert.That(controller.WindowBytes).IsGreaterThanOrEqualTo(400);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Stacked on #3013 (base branch is `perf/governed-target-excludes-linger`; the diff here is only the floor change).

With #3013 the three-broker windows descend symmetrically, but they still park at the eight-quantum normal probe floor: in run 33964050486 the candidate settled at 4 / 8 / 8 MB with governed EWMA 6.1 / 5.6 / 5.7 ms against a 5 ms budget. Eight 1 MB quanta against a ~450 MB/s broker are ~18 ms of standing queue, and the few hundred microseconds of over-target excess are too small for the sub-floor delay-gain test (>= 10%) to pass, so the descent stops there. Delivered p50 was 9.15 ms versus Confluent's 6.0 ms on the same lane in the weekly run.

The eight-quantum floor encoded a one-broker knee of about seven full requests. This PR lowers the normal floor to four quanta (two requests on the wire while two seal) and moves the accelerated 25% treatment threshold with it (six quanta) so a coarse step never lands below the floor. Deep descent below four quanta keeps the existing delay-earning rule; every step above it keeps the paired goodput guard, which is what stops descent at whatever knee a topology actually has.

## Expected effect

- 3 brokers: windows may reach 4 MB (~9 ms queue) where goodput holds; p50 should move toward 7 ms, p95/p99 amplification of broker stalls shrinks with the queue.
- 1 broker: #3013's candidate settled at 10-12 MB with the floor not binding; if the knee really is ~7 requests, down-probes to 6-7 quanta will fail their goodput guard and the window stays. The A-B-A decides.

## Tests

`BrokerUnackedByteBudgetTests` updated for the new floor (cap-clamp case now uses a 5-quantum cap below the 6-quantum threshold; the accelerated-descent case asserts 9 -> 6 -> 4 -> 3; the flat-goodput recovery test now asserts recovery after touching the floor instead of the sawtooth's phase at a fixed epoch). Full unit suite green locally.

## Stress validation

- `producer-idempotent-3b` A-B-A against #3013's head `60cd643a3` (exact parent): [run 33980288545](https://github.com/thomhurst/Dekaf/actions/runs/33980288545). Requires PASS.
- `producer-1b` A-B-A follows a PASS.

No hot-path code changes: two constants and comments.

https://claude.ai/code/session_012AEx3PnpfHTncWCKXsCH9U
