### PR TITLE
perf(producer): partition deque lock that never sleeps a millisecond when contended

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -182,7 +182,7 @@ internal struct PartitionSpinLock
 internal ref struct PartitionLockGuard
 {
     private ref PartitionSpinLock _lock;
-    private bool _taken;
+    private readonly bool _taken;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public PartitionLockGuard(ref PartitionSpinLock spinLock)
@@ -1557,6 +1557,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 #if NETSTANDARD2_0
         public PartitionSpinLock Lock = new(enableThreadOwnerTracking: false);
 #else
+        // Deliberately not readonly: the guard takes it by ref and the struct mutates its
+        // state; a readonly field would hand the guard a defensive copy and void the lock.
         public PartitionSpinLock Lock;
 #endif
 
@@ -2304,7 +2306,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Interlocked.Add(ref _bufferedBytes, splitBytes);
 
         var pd = GetOrCreateDeque(splitBatches[0].TopicPartition);
-        using (var guard = new PartitionLockGuard(ref pd.Lock))
+        using (new PartitionLockGuard(ref pd.Lock))
         {
             for (var i = splitBatches.Count - 1; i >= 0; i--)
             {
@@ -6406,7 +6408,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         BrokerUnackedByteBudget? blockedBudget = null;
         try
         {
-            using (var guard = new PartitionLockGuard(ref partitionDeque.Lock))
+            using (new PartitionLockGuard(ref partitionDeque.Lock))
             {
                 var currentBatch = partitionDeque.CurrentBatch;
                 var budget = GetCachedAdmissionBudget(partitionDeque, topic, partition);
@@ -6545,7 +6547,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int partition,
         BrokerUnackedByteBudget budget)
     {
-        using (var guard = new PartitionLockGuard(ref partitionDeque.Lock))
+        using (new PartitionLockGuard(ref partitionDeque.Lock))
         {
             if (partitionDeque.CurrentBatch is null
                 || Volatile.Read(ref partitionDeque.AdmissionFlushRequested) != 0

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -16,6 +16,8 @@ using Dekaf.Serialization;
 using Microsoft.Extensions.Logging;
 #if NETSTANDARD2_0
 using SpinLock = Dekaf.Producer.CompatibilitySpinLock;
+using PartitionSpinLock = Dekaf.Producer.CompatibilitySpinLock;
+using PartitionLockGuard = Dekaf.Producer.SpinLockGuard;
 #endif
 
 namespace Dekaf.Producer;
@@ -100,6 +102,99 @@ internal ref struct SpinLockGuard
         // the cleared owned bit — saved nothing measurable single-threaded and made four threads
         // appending to four distinct partitions ~1.7x slower per record
         // (AccumulatorAdmissionAppendBenchmarks, 4T-split: 92 ns → 154-195 ns).
+        if (_taken) _lock.Exit();
+    }
+}
+#endif
+
+#if !NETSTANDARD2_0
+/// <summary>
+/// Spin lock for the per-partition deque. Same uncontended cost as
+/// <see cref="System.Threading.SpinLock"/> (one CAS to enter, one full-fence exchange to exit)
+/// but the contended path never calls <c>Thread.Sleep(1)</c>: the BCL lock's
+/// <c>ContinueTryEnter</c> spins with <c>SpinOnce(SLEEP_ONE_FREQUENCY = 40)</c>, so once a
+/// holder is preempted (two client cores hosting the append thread, the seal drainer and one
+/// send loop per broker) every waiter beyond 40 iterations sleeps a full millisecond. The
+/// three-broker CPU profile (run 33963361644) attributed 1.7% of samples to
+/// <c>Thread.Sleep</c> under <c>AppendFromSpansAfterReservationCore</c> and
+/// <c>SealBatchesAsync</c>; a 1 ms stall of the append thread at ~1.2M msg/s delays ~1,200
+/// records. The exit keeps the full fence: a plain release store made the 4T-split append
+/// benchmark ~1.7x slower (see <see cref="SpinLockGuard.Dispose"/>).
+/// </summary>
+internal struct PartitionSpinLock
+{
+    private const int SpinIterations = 10;
+    private const int Sleep0EveryHowManyYields = 5;
+    private static readonly bool s_singleProcessor = Environment.ProcessorCount == 1;
+
+    private int _held;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Enter(ref bool lockTaken)
+    {
+        if (Interlocked.CompareExchange(ref _held, 1, 0) == 0)
+        {
+            lockTaken = true;
+            return;
+        }
+
+        EnterContended(ref lockTaken);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void EnterContended(ref bool lockTaken)
+    {
+        var spins = 0;
+        var yields = 0;
+        while (true)
+        {
+            if (!s_singleProcessor && spins < SpinIterations)
+            {
+                Thread.SpinWait(4 << spins);
+                spins++;
+            }
+            else if (++yields % Sleep0EveryHowManyYields == 0)
+            {
+                Thread.Sleep(0);
+            }
+            else
+            {
+                Thread.Yield();
+            }
+
+            if (Volatile.Read(ref _held) == 0 && Interlocked.CompareExchange(ref _held, 1, 0) == 0)
+            {
+                lockTaken = true;
+                return;
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Exit() => Interlocked.Exchange(ref _held, 0);
+
+    /// <summary>Diagnostics/tests only: whether any thread currently holds the lock.</summary>
+    internal bool IsHeld => Volatile.Read(ref _held) != 0;
+}
+
+/// <summary>RAII guard for <see cref="PartitionSpinLock"/>; use with
+/// <c>using var guard = new PartitionLockGuard(ref pd.Lock);</c>.</summary>
+internal ref struct PartitionLockGuard
+{
+    private ref PartitionSpinLock _lock;
+    private bool _taken;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public PartitionLockGuard(ref PartitionSpinLock spinLock)
+    {
+        _lock = ref spinLock;
+        _taken = false;
+        _lock.Enter(ref _taken);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Dispose()
+    {
         if (_taken) _lock.Exit();
     }
 }
@@ -1459,7 +1554,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         /// <summary>Per-partition lock for deque access (matches Java's synchronized(deque)).
         /// SpinLock avoids kernel transitions for the brief critical sections in append/drain paths.</summary>
-        public SpinLock Lock = new(enableThreadOwnerTracking: false);
+#if NETSTANDARD2_0
+        public PartitionSpinLock Lock = new(enableThreadOwnerTracking: false);
+#else
+        public PartitionSpinLock Lock;
+#endif
 
         /// <summary>Current unsealed batch accepting new records. Null if no active batch.</summary>
         public PartitionBatch? CurrentBatch;
@@ -1706,7 +1805,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
             ReadyBatch? head;
             {
-                using var guard = new SpinLockGuard(ref pd.Lock);
+                using var guard = new PartitionLockGuard(ref pd.Lock);
                 head = pd.PeekFirst();
             }
 
@@ -1826,7 +1925,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             ReadyBatch? head;
             int dequeDepth;
             {
-                using var guard = new SpinLockGuard(ref pd.Lock);
+                using var guard = new PartitionLockGuard(ref pd.Lock);
                 head = pd.PeekFirst();
                 dequeDepth = pd.Count;
             }
@@ -1956,7 +2055,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             var batchRequestSize = 0;
             var oversizedBatch = false;
             {
-                using var guard = new SpinLockGuard(ref pd.Lock);
+                using var guard = new PartitionLockGuard(ref pd.Lock);
                 batch = pd.PeekFirst();
                 if (batch is null)
                     continue;
@@ -2070,7 +2169,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         batch.Reenqueued(nowMs);
         var pd = GetOrCreateDeque(batch.TopicPartition);
         {
-            using var guard = new SpinLockGuard(ref pd.Lock);
+            using var guard = new PartitionLockGuard(ref pd.Lock);
             if (ProducerId >= 0)
                 pd.InsertInSequenceOrder(batch);
             else
@@ -2205,7 +2304,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Interlocked.Add(ref _bufferedBytes, splitBytes);
 
         var pd = GetOrCreateDeque(splitBatches[0].TopicPartition);
-        using (var guard = new SpinLockGuard(ref pd.Lock))
+        using (var guard = new PartitionLockGuard(ref pd.Lock))
         {
             for (var i = splitBatches.Count - 1; i >= 0; i--)
             {
@@ -2340,7 +2439,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     private static bool HasQueuedBatches(PartitionDeque pd)
     {
-        using var guard = new SpinLockGuard(ref pd.Lock);
+        using var guard = new PartitionLockGuard(ref pd.Lock);
         return pd.PeekFirst() is not null;
     }
 
@@ -2828,7 +2927,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         if (_partitionDeques.TryGetValue(topicPartition, out var pd))
         {
-            using var guard = new SpinLockGuard(ref pd.Lock);
+            using var guard = new PartitionLockGuard(ref pd.Lock);
             batch = pd.PollFirst();
             return batch is not null;
         }
@@ -2853,7 +2952,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             if (!_partitionDeques.TryGetValue(topicPartition, out var pd))
                 continue;
 
-            using var guard = new SpinLockGuard(ref pd.Lock);
+            using var guard = new PartitionLockGuard(ref pd.Lock);
             if (pd.Count > 0)
             {
                 batch = pd.PollFirst()!;
@@ -3547,7 +3646,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 var actualBytesAdded = 0;
 
                 {
-                    using var guard = new SpinLockGuard(ref pd.Lock);
+                    using var guard = new PartitionLockGuard(ref pd.Lock);
 
                     if (Volatile.Read(ref _disposed) != 0)
                     {
@@ -4043,7 +4142,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 var reservedFirstAwaitedProduceInBatch = false;
 
                 {
-                    using var guard = new SpinLockGuard(ref pd.Lock);
+                    using var guard = new PartitionLockGuard(ref pd.Lock);
 
                     if (Volatile.Read(ref _disposed) != 0)
                     {
@@ -4161,7 +4260,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
                         var disposedAfterReserve = false;
                         {
-                            using var guard = new SpinLockGuard(ref pd.Lock);
+                            using var guard = new PartitionLockGuard(ref pd.Lock);
 
                             if (Volatile.Read(ref _disposed) != 0)
                             {
@@ -4231,7 +4330,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     {
                         if (!committedReservedAppend)
                         {
-                            using var guard = new SpinLockGuard(ref pd.Lock);
+                            using var guard = new PartitionLockGuard(ref pd.Lock);
                             PartitionBatch.CancelReservedAppend(reservedAppend);
                             ClearAppendAndRotationInProgressUnderLock();
                         }
@@ -4529,7 +4628,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         try
         {
-            using var guard = new SpinLockGuard(ref pd.Lock);
+            using var guard = new PartitionLockGuard(ref pd.Lock);
 
             // A two-phase appender holding the admission slot has made a lease decision it has
             // not committed yet; appending ahead of it would invalidate that decision.
@@ -4644,7 +4743,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var drainPendingAfterAppend = false;
 
         {
-            using var guard = new SpinLockGuard(ref pd.Lock);
+            using var guard = new PartitionLockGuard(ref pd.Lock);
 
             if (Volatile.Read(ref _disposed) != 0
                 || pd.RotationInProgress
@@ -5055,7 +5154,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
 
         {
-            using var guard = new SpinLockGuard(ref pd.Lock);
+            using var guard = new PartitionLockGuard(ref pd.Lock);
             if (readyBatch is not null)
             {
                 // Disposal's final deque drain takes this same lock. Either publication wins
@@ -5127,7 +5226,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     private static void ClearRotationInProgress(PartitionDeque pd)
     {
-        using var guard = new SpinLockGuard(ref pd.Lock);
+        using var guard = new PartitionLockGuard(ref pd.Lock);
         ClearRotationInProgressUnderLock(pd);
     }
 
@@ -5664,7 +5763,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         if (_partitionDeques.TryGetValue(new TopicPartition(topic, partition), out var pd))
         {
-            using var guard = new SpinLockGuard(ref pd.Lock);
+            using var guard = new PartitionLockGuard(ref pd.Lock);
             if (pd.CurrentBatch is not null)
             {
                 Interlocked.Decrement(ref _unsealedBatchCount);
@@ -5882,7 +5981,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             var waitForRotation = false;
 
             {
-                using var guard = new SpinLockGuard(ref pd.Lock);
+                using var guard = new PartitionLockGuard(ref pd.Lock);
 
                 if (pd.RotationInProgress
                     || pd.AppendInProgress
@@ -6307,7 +6406,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         BrokerUnackedByteBudget? blockedBudget = null;
         try
         {
-            using (var guard = new SpinLockGuard(ref partitionDeque.Lock))
+            using (var guard = new PartitionLockGuard(ref partitionDeque.Lock))
             {
                 var currentBatch = partitionDeque.CurrentBatch;
                 var budget = GetCachedAdmissionBudget(partitionDeque, topic, partition);
@@ -6446,7 +6545,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int partition,
         BrokerUnackedByteBudget budget)
     {
-        using (var guard = new SpinLockGuard(ref partitionDeque.Lock))
+        using (var guard = new PartitionLockGuard(ref partitionDeque.Lock))
         {
             if (partitionDeque.CurrentBatch is null
                 || Volatile.Read(ref partitionDeque.AdmissionFlushRequested) != 0
@@ -6940,7 +7039,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             var dequeCount = 0;
             if (_partitionDeques.TryGetValue(batch.TopicPartition, out var pd))
             {
-                using var guard = new SpinLockGuard(ref pd.Lock);
+                using var guard = new PartitionLockGuard(ref pd.Lock);
                 dequeCount = pd.Count;
                 inDeque = pd.Contains(batch);
             }
@@ -7051,7 +7150,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             {
                 var waitForAppend = false;
                 {
-                    using var guard = new SpinLockGuard(ref pd.Lock);
+                    using var guard = new PartitionLockGuard(ref pd.Lock);
 
                     if (pd.AppendInProgress
                         || Volatile.Read(ref pd.AdmissionInProgress) != 0)
@@ -7191,7 +7290,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (!_partitionDeques.TryGetValue(batch.TopicPartition, out var pd))
             return false;
 
-        using var guard = new SpinLockGuard(ref pd.Lock);
+        using var guard = new PartitionLockGuard(ref pd.Lock);
         return pd.Contains(batch);
     }
 
@@ -7482,7 +7581,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 var appendWaitTimedOut = false;
 
                 {
-                    using var guard = new SpinLockGuard(ref pd.Lock);
+                    using var guard = new PartitionLockGuard(ref pd.Lock);
 
                     if (pd.AppendInProgress
                         || Volatile.Read(ref pd.AdmissionInProgress) != 0)
@@ -7566,7 +7665,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             var pd = kvp.Value;
             {
-                using var guard = new SpinLockGuard(ref pd.Lock);
+                using var guard = new PartitionLockGuard(ref pd.Lock);
                 DrainReadyBatchesForDisposeUnderLock(pd, disposedException);
             }
         }

--- a/tests/Dekaf.Tests.Unit/Producer/PartitionSpinLockTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PartitionSpinLockTests.cs
@@ -1,0 +1,79 @@
+#if NET10_0_OR_GREATER
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public sealed class PartitionSpinLockTests
+{
+    [Test]
+    public async Task Enter_IsMutuallyExclusiveAcrossThreads()
+    {
+        var holder = new LockHolder();
+        var counter = 0;
+        var maxInside = 0;
+        var inside = 0;
+        const int iterationsPerThread = 200_000;
+
+        var threads = new Thread[4];
+        for (var t = 0; t < threads.Length; t++)
+        {
+            threads[t] = new Thread(() =>
+            {
+                for (var i = 0; i < iterationsPerThread; i++)
+                {
+                    var taken = false;
+                    holder.Lock.Enter(ref taken);
+                    try
+                    {
+                        var now = Interlocked.Increment(ref inside);
+                        if (now > Volatile.Read(ref maxInside))
+                            Volatile.Write(ref maxInside, now);
+                        counter++;
+                        Interlocked.Decrement(ref inside);
+                    }
+                    finally
+                    {
+                        if (taken) holder.Lock.Exit();
+                    }
+                }
+            });
+            threads[t].Start();
+        }
+
+        foreach (var thread in threads)
+            thread.Join();
+
+        await Assert.That(maxInside).IsEqualTo(1);
+        await Assert.That(counter).IsEqualTo(iterationsPerThread * threads.Length);
+    }
+
+    [Test]
+    public async Task Exit_ReleasesForTheNextWaiter()
+    {
+        var holder = new LockHolder();
+        var taken = false;
+        holder.Lock.Enter(ref taken);
+        await Assert.That(taken).IsTrue();
+
+        var waiterEntered = new ManualResetEventSlim();
+        var waiter = new Thread(() =>
+        {
+            var waiterTaken = false;
+            holder.Lock.Enter(ref waiterTaken);
+            waiterEntered.Set();
+            holder.Lock.Exit();
+        });
+        waiter.Start();
+
+        await Assert.That(waiterEntered.Wait(200)).IsFalse();
+        holder.Lock.Exit();
+        await Assert.That(waiterEntered.Wait(5_000)).IsTrue();
+        waiter.Join();
+    }
+
+    private sealed class LockHolder
+    {
+        public PartitionSpinLock Lock;
+    }
+}
+#endif

--- a/tests/Dekaf.Tests.Unit/Producer/PartitionSpinLockTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PartitionSpinLockTests.cs
@@ -55,7 +55,7 @@ public sealed class PartitionSpinLockTests
         holder.Lock.Enter(ref taken);
         await Assert.That(taken).IsTrue();
 
-        var waiterEntered = new ManualResetEventSlim();
+        using var waiterEntered = new ManualResetEventSlim();
         var waiter = new Thread(() =>
         {
             var waiterTaken = false;

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -4465,7 +4465,10 @@ public class RecordAccumulatorTests
     {
         var partitionDeque = GetPartitionDeque(accumulator, topicPartition);
         var lockField = partitionDeque.GetType().GetField("Lock");
-        lockField!.SetValue(partitionDeque, Activator.CreateInstance(lockField.FieldType, [true]));
+        // PartitionSpinLock (net10.0) exposes IsHeld without owner tracking; only the
+        // netstandard2.0 compatibility lock needs a tracking-enabled instance swapped in.
+        if (lockField!.FieldType.GetConstructor([typeof(bool)]) is not null)
+            lockField.SetValue(partitionDeque, Activator.CreateInstance(lockField.FieldType, [true]));
     }
 
     private static PendingAppend CreatePendingAppend(
@@ -4655,7 +4658,12 @@ public class RecordAccumulatorTests
             if (partitionLock is SpinLock spinLock)
                 return spinLock.IsHeldByCurrentThread;
 
-            var property = partitionLock.GetType().GetProperty("IsHeldByCurrentThread");
+            var property = partitionLock.GetType().GetProperty("IsHeldByCurrentThread")
+                ?? partitionLock.GetType().GetProperty(
+                    "IsHeld",
+                    System.Reflection.BindingFlags.Instance
+                    | System.Reflection.BindingFlags.Public
+                    | System.Reflection.BindingFlags.NonPublic);
             return property != null && (bool)property.GetValue(partitionLock)!;
         }
 


### PR DESCRIPTION
## Summary

`System.Threading.SpinLock.ContinueTryEnter` spins with `SpinOnce(SLEEP_ONE_FREQUENCY = 40)` ([runtime source](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Threading/SpinLock.cs)), so once a lock holder is preempted every waiter past 40 iterations calls `Thread.Sleep(1)`. On the stress client that is exactly the situation: two cores host the append thread, the seal drainer and one send loop per broker. The three-broker CPU profile ([run 33963361644](https://github.com/thomhurst/Dekaf/actions/runs/33963361644), main product code) attributed 1.7% of samples to `Thread.Sleep`, 86% of them under `AppendFromSpansAfterReservationCore` and 12% under `SealBatchesAsync`, i.e. the per-partition deque lock; per thread, lock spin/yield was 3.5% of busy samples at 3 brokers versus 1.3% at 1 broker. A 1 ms stall of the append thread at ~1.2M msg/s delays ~1,200 records.

This PR replaces the deque lock (`PartitionDeque.Lock`, 25 guard sites) with `PartitionSpinLock`:
- uncontended path identical to the BCL lock: one CAS to enter, one full-fence `Interlocked.Exchange` to exit (the fence the 4T-split benchmark depends on, see the note on `SpinLockGuard.Dispose`);
- contended path spins ten times (`Thread.SpinWait`, doubling) then yields (`Thread.Yield`, `Sleep(0)` every fifth) and never sleeps 1 ms;
- `netstandard2.0` keeps the Monitor-based compatibility lock through aliases; other `SpinLock` users (in-flight tracker, done-task observers) are unchanged.

## Local evidence (`AccumulatorAdmissionAppendBenchmarks`, Short job, `--inProcess`, two interleaved pairs baseline/candidate/baseline/candidate, i7-12700K)

| Shape | Admission | Baseline 1 | Candidate 1 | Baseline 2 | Candidate 2 | cand/base (medians) |
|---|---|---:|---:|---:|---:|---:|
| 1T | off | 143.1 | 143.3 | 141.6 | 140.1 | 0.995 |
| 1T | on | 143.9 | 138.8 | 144.0 | 143.4 | 0.980 |
| 4T-same | off | 2774.3 | 2294.8 | 1845.0 | 2220.1 | 0.977 (noisy) |
| 4T-same | on | 2500.0 | 2307.8 | 2334.2 | 2013.7 | 0.894 (noisy) |
| 4T-split | off | 75.4 | 68.7 | 73.6 | 68.1 | **0.919** |
| 4T-split | on | 78.7 | 68.2 | 70.2 | 68.9 | **0.921** |

ns/op; Allocated `-` on every row except one candidate run reporting 1 B/op on 4T-split (the known stochastic drainer-behind cold path, absent in the second candidate run). Single-threaded cost unchanged; the 4T-split contended shape improves ~8% in both pairs.

## Tests

- New `PartitionSpinLockTests` (4-thread mutual exclusion over 800k acquisitions; exit releases a blocked waiter).
- `RecordAccumulatorTests` lock-introspection helpers adapted: `IsHeld` on the new lock, owner-tracking swap only where the lock type has a `(bool)` constructor.
- Full unit suite: 8749/8749 locally.

## Stress validation

- `producer-3b` A-B-A against exact parent `df27f1232c632e542ff585ea080eb8a07c790c4b`: [run 33981141065](https://github.com/thomhurst/Dekaf/actions/runs/33981141065) (a first dispatch, run 33981114334, was cancelled immediately because its baseline SHA was mistyped). Requires PASS.

https://claude.ai/code/session_012AEx3PnpfHTncWCKXsCH9U


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved responsiveness and throughput when multiple operations contend for the same partition.
  - Reduced delays while waiting for partition-level access, especially on supported modern runtimes.
  - Preserved compatible locking behavior across supported runtime versions.

- **Reliability**
  - Strengthened concurrent access handling to maintain mutual exclusion and ensure waiting operations can proceed after access is released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->