### PR TITLE
ci(stress): refuse baseline_sha together with adaptive_connections

### DIFF
--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -1956,6 +1956,10 @@ class StressTrendTests(unittest.TestCase):
             selector,
         )
         self.assertIn(
+            '[ -n "$BASELINE_SHA" ] && [ "$ADAPTIVE_CONNECTIONS" = "true" ]',
+            selector,
+        )
+        self.assertIn(
             'ADAPTIVE_CONNECTIONS: ${{ github.event.inputs.adaptive_connections }}',
             workflow,
         )

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -206,6 +206,10 @@ jobs:
             echo "::error::full_run cannot enable adaptive_connections because relabelling every producer result 'Dekaf (adaptive)' removes the Dekaf group from the published comparison and silently blanks the headline rows."
             exit 1
           fi
+          if [ -n "$BASELINE_SHA" ] && [ "$ADAPTIVE_CONNECTIONS" = "true" ]; then
+            echo "::error::baseline_sha cannot be combined with adaptive_connections: the flag is forwarded to the baseline checkouts too, a pre-#3014 baseline rejects --adaptive-connections as an unknown argument, and a pinned-versus-adaptive pairing would not be a like-for-like A-B-A anyway."
+            exit 1
+          fi
 
           profile_mode="${PROFILE_MODE:-off}"
           case "$profile_mode" in


### PR DESCRIPTION
Follow-up to #3014 addressing the CodeRabbit thread left open at merge: `EXTRA_ARGS` (which now carries `--adaptive-connections`) is passed to the `baseline-a`/`baseline-a2` segments too, so an A-B-A whose `baseline_sha` predates #3014 would fail on an unknown argument, and a pinned-versus-adaptive pairing is not a like-for-like comparison regardless. `select-lanes` now fails fast on that combination, mirroring the existing `full_run` and `consumer_fetch_diagnostics` guards, and the workflow test asserts it (`test_stress_trend`: 65/65).

https://claude.ai/code/session_012AEx3PnpfHTncWCKXsCH9U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent incompatible `baseline_sha` A-B-A runs from being combined with `adaptive_connections`.
  * The workflow now displays a clear error and stops before selecting the test matrix when these options are used together.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->