### PR TITLE
ci(stress): optional fourth A-B-A segment so candidate drift is measured like control drift

### DIFF
--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -169,11 +169,24 @@ def _metric_status(
     tolerance_percent,
     max_control_drift_percent,
     floor_status=None,
+    candidate_b2=None,
 ):
     baseline_mean = (baseline_a + baseline_a2) / 2
     if baseline_mean == 0:
         raise ValueError(f"Baseline mean is zero for {metric.label}")
 
+    # With a second candidate segment the candidate value is the mean of both, the
+    # decisiveness overrides must hold for the weaker candidate sample, and candidate drift
+    # is gated exactly like control drift: two candidate samples that disagree by more than
+    # the cap cannot certify a bracketed delta any better than two disagreeing controls.
+    candidate_samples = [candidate] if candidate_b2 is None else [candidate, candidate_b2]
+    candidate_mean = sum(candidate_samples) / len(candidate_samples)
+    candidate_drift_percent = (
+        0.0
+        if candidate_b2 is None or candidate_mean == 0
+        else 100 * abs(candidate_b2 - candidate) / abs(candidate_mean)
+    )
+    candidate = candidate_mean
     delta_percent = 100 * (candidate - baseline_mean) / baseline_mean
     control_drift_percent = 100 * abs(baseline_a2 - baseline_a) / abs(baseline_mean)
     control_spread = abs(baseline_a2 - baseline_a)
@@ -184,18 +197,18 @@ def _metric_status(
         status = floor_status
     else:
         if metric.higher_is_better:
-            worse_than_both = candidate < min(baseline_a, baseline_a2) * (
+            worse_than_both = max(candidate_samples) < min(baseline_a, baseline_a2) * (
                 1 - tolerance_percent / 100
-            ) and min(baseline_a, baseline_a2) - candidate > noise_floor
-            better_than_both = candidate >= max(baseline_a, baseline_a2)
+            ) and min(baseline_a, baseline_a2) - max(candidate_samples) > noise_floor
+            better_than_both = min(candidate_samples) >= max(baseline_a, baseline_a2)
             adverse = delta_percent < -tolerance_percent and (
                 baseline_mean - candidate > noise_floor
             )
         else:
-            worse_than_both = candidate > max(baseline_a, baseline_a2) * (
+            worse_than_both = min(candidate_samples) > max(baseline_a, baseline_a2) * (
                 1 + tolerance_percent / 100
-            ) and candidate - max(baseline_a, baseline_a2) > noise_floor
-            better_than_both = candidate <= min(baseline_a, baseline_a2)
+            ) and min(candidate_samples) - max(baseline_a, baseline_a2) > noise_floor
+            better_than_both = max(candidate_samples) <= min(baseline_a, baseline_a2)
             adverse = delta_percent > tolerance_percent and (
                 candidate - baseline_mean > noise_floor
             )
@@ -219,6 +232,11 @@ def _metric_status(
             status = "pass"
         elif controls_disagree:
             status = "inconclusive"
+        elif (
+            candidate_drift_percent > max_control_drift_percent
+            and abs(candidate_samples[-1] - candidate_samples[0]) > noise_floor
+        ):
+            status = "inconclusive"
         elif adverse:
             status = "regression"
         else:
@@ -230,6 +248,9 @@ def _metric_status(
         "unit": metric.unit,
         "baselineA": baseline_a,
         "candidate": candidate,
+        "candidateB": candidate_samples[0],
+        "candidateB2": candidate_b2,
+        "candidateDriftPercent": candidate_drift_percent,
         "baselineA2": baseline_a2,
         "baselineMean": baseline_mean,
         "deltaPercent": delta_percent,
@@ -246,6 +267,7 @@ def compare(
     baseline_a2_result,
     tolerance_percent=DEFAULT_TOLERANCE_PERCENT,
     max_control_drift_percent=DEFAULT_MAX_CONTROL_DRIFT_PERCENT,
+    candidate_b2_result=None,
 ):
     if tolerance_percent < 0 or max_control_drift_percent < 0:
         raise ValueError("Comparison thresholds cannot be negative")
@@ -255,6 +277,8 @@ def compare(
         _identity(candidate_result),
         _identity(baseline_a2_result),
     }
+    if candidate_b2_result is not None:
+        identities.add(_identity(candidate_b2_result))
     if len(identities) != 1:
         raise ValueError("A-B-A results do not have the same workload identity")
     if _errors(baseline_a_result) or _errors(baseline_a2_result):
@@ -265,7 +289,12 @@ def compare(
     baseline_a = _measurements(baseline_a_result)
     candidate = _measurements(candidate_result)
     baseline_a2 = _measurements(baseline_a2_result)
-    if _stability_breached(candidate_result):
+    candidate_b2 = (
+        None if candidate_b2_result is None else _measurements(candidate_b2_result)
+    )
+    if _stability_breached(candidate_result) or (
+        candidate_b2_result is not None and _stability_breached(candidate_b2_result)
+    ):
         stability_status = "regression"
     elif _stability_breached(baseline_a_result) or _stability_breached(baseline_a2_result):
         stability_status = "inconclusive"
@@ -280,11 +309,16 @@ def compare(
             tolerance_percent,
             max_control_drift_percent,
             floor_status=stability_status if metric.floor else None,
+            candidate_b2=None if candidate_b2 is None else candidate_b2[metric.key],
         )
         for metric in METRICS
     ]
 
     candidate_failed = _errors(candidate_result) > 0 or _delivery_mismatch(candidate_result)
+    if candidate_b2_result is not None:
+        candidate_failed = candidate_failed or (
+            _errors(candidate_b2_result) > 0 or _delivery_mismatch(candidate_b2_result)
+        )
     statuses = {item["status"] for item in metrics if item["gated"]}
     if candidate_failed or "regression" in statuses:
         verdict = "regression"
@@ -297,8 +331,11 @@ def compare(
         "verdict": verdict,
         "tolerancePercent": tolerance_percent,
         "maxControlDriftPercent": max_control_drift_percent,
-        "candidateErrors": _errors(candidate_result),
-        "candidateDeliveryMismatch": _delivery_mismatch(candidate_result),
+        "candidateErrors": _errors(candidate_result)
+        + (0 if candidate_b2_result is None else _errors(candidate_b2_result)),
+        "candidateDeliveryMismatch": _delivery_mismatch(candidate_result)
+        or (candidate_b2_result is not None and _delivery_mismatch(candidate_b2_result)),
+        "candidateSegments": 1 if candidate_b2_result is None else 2,
         "identity": list(_identity(candidate_result)),
         "metrics": metrics,
     }
@@ -321,19 +358,46 @@ def markdown(comparison, baseline_sha, candidate_sha):
         f"adverse tolerance: {comparison['tolerancePercent']:.1f}% · "
         f"maximum control drift: {comparison['maxControlDriftPercent']:.1f}% · "
         "allocation noise floor: 1.0 B/msg",
-        "",
-        "| Metric | Baseline A | Candidate B | Baseline A2 | B vs mean | Control drift | Gate |",
-        "|---|---:|---:|---:|---:|---:|---|",
     ]
-    for item in comparison["metrics"]:
-        lines.append(
-            f"| {item['label']} ({item['unit']}) | "
-            f"{_format_number(item['baselineA'])} | "
-            f"{_format_number(item['candidate'])} | "
-            f"{_format_number(item['baselineA2'])} | "
-            f"{item['deltaPercent']:+.2f}% | "
-            f"{item['controlDriftPercent']:.2f}% | {item['status']} |"
+    two_candidates = comparison.get("candidateSegments", 1) == 2
+    if two_candidates:
+        lines[-1] += " · four segments (A-B-A-B): candidate = mean of B and B2"
+        lines.extend(
+            [
+                "",
+                "| Metric | Baseline A | Candidate B | Baseline A2 | Candidate B2 | B mean vs control mean | Control drift | Candidate drift | Gate |",
+                "|---|---:|---:|---:|---:|---:|---:|---:|---|",
+            ]
         )
+    else:
+        lines.extend(
+            [
+                "",
+                "| Metric | Baseline A | Candidate B | Baseline A2 | B vs mean | Control drift | Gate |",
+                "|---|---:|---:|---:|---:|---:|---|",
+            ]
+        )
+    for item in comparison["metrics"]:
+        if two_candidates:
+            lines.append(
+                f"| {item['label']} ({item['unit']}) | "
+                f"{_format_number(item['baselineA'])} | "
+                f"{_format_number(item['candidateB'])} | "
+                f"{_format_number(item['baselineA2'])} | "
+                f"{_format_number(item['candidateB2'])} | "
+                f"{item['deltaPercent']:+.2f}% | "
+                f"{item['controlDriftPercent']:.2f}% | "
+                f"{item['candidateDriftPercent']:.2f}% | {item['status']} |"
+            )
+        else:
+            lines.append(
+                f"| {item['label']} ({item['unit']}) | "
+                f"{_format_number(item['baselineA'])} | "
+                f"{_format_number(item['candidate'])} | "
+                f"{_format_number(item['baselineA2'])} | "
+                f"{item['deltaPercent']:+.2f}% | "
+                f"{item['controlDriftPercent']:.2f}% | {item['status']} |"
+            )
     if comparison["candidateErrors"] or comparison["candidateDeliveryMismatch"]:
         lines.extend(
             [
@@ -357,6 +421,7 @@ def main(argv=None):
     parser.add_argument("--baseline-a", required=True)
     parser.add_argument("--candidate", required=True)
     parser.add_argument("--baseline-a2", required=True)
+    parser.add_argument("--candidate-b2", help="Optional fourth segment (A-B-A-B).")
     parser.add_argument("--baseline-sha", required=True)
     parser.add_argument("--candidate-sha", required=True)
     parser.add_argument("--output", required=True)
@@ -377,6 +442,7 @@ def main(argv=None):
         _single_result(args.baseline_a2),
         args.tolerance_percent,
         args.max_control_drift_percent,
+        candidate_b2_result=None if not args.candidate_b2 else _single_result(args.candidate_b2),
     )
     report = markdown(comparison, args.baseline_sha, args.candidate_sha)
     print(report, end="")

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from stress_aba import compare, main
+from stress_aba import compare, main, markdown
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -165,6 +165,64 @@ class StressAbaComparisonTests(unittest.TestCase):
         )
         alloc = next(metric for metric in noisy["metrics"] if metric["key"] == "alloc")
         self.assertEqual("inconclusive", alloc["status"])
+
+    def test_four_segments_average_candidates_and_pass(self):
+        comparison = compare(
+            result(100), result(104), result(100), candidate_b2_result=result(102)
+        )
+
+        self.assertEqual("pass", comparison["verdict"])
+        self.assertEqual(2, comparison["candidateSegments"])
+        throughput = next(
+            metric for metric in comparison["metrics"] if metric["key"] == "throughput"
+        )
+        self.assertAlmostEqual(103.0, throughput["candidate"])
+        self.assertAlmostEqual(104.0, throughput["candidateB"])
+        self.assertAlmostEqual(102.0, throughput["candidateB2"])
+        self.assertGreater(throughput["candidateDriftPercent"], 1.0)
+
+    def test_four_segments_candidate_drift_is_inconclusive_like_control_drift(self):
+        # Candidates disagree by 20% while both controls agree: the mean sits above the
+        # controls but neither decisiveness override holds, so the metric is inconclusive.
+        comparison = compare(
+            result(100), result(95), result(100), candidate_b2_result=result(116)
+        )
+
+        throughput = next(
+            metric for metric in comparison["metrics"] if metric["key"] == "throughput"
+        )
+        self.assertEqual("inconclusive", throughput["status"])
+        self.assertEqual("inconclusive", comparison["verdict"])
+
+    def test_four_segments_decisive_overrides_need_both_candidates(self):
+        both_better = compare(
+            result(p99=15.0), result(p99=12.0), result(p99=16.0), candidate_b2_result=result(p99=13.0)
+        )
+        p99 = next(metric for metric in both_better["metrics"] if metric["key"] == "p99")
+        self.assertEqual("pass", p99["status"])
+
+        one_worse = compare(
+            result(p99=15.0), result(p99=12.0), result(p99=16.0), candidate_b2_result=result(p99=17.0)
+        )
+        p99 = next(metric for metric in one_worse["metrics"] if metric["key"] == "p99")
+        self.assertNotEqual("pass", p99["status"])
+
+    def test_four_segments_second_candidate_stability_breach_is_regression(self):
+        comparison = compare(
+            result(100), result(100), result(100), candidate_b2_result=result(100, stability=0.7)
+        )
+
+        self.assertEqual("regression", comparison["verdict"])
+
+    def test_four_segments_markdown_shows_both_candidates(self):
+        comparison = compare(
+            result(100), result(104), result(100), candidate_b2_result=result(102)
+        )
+        report = markdown(comparison, "a" * 40, "b" * 40)
+
+        self.assertIn("four segments (A-B-A-B)", report)
+        self.assertIn("| Candidate B2 |", report)
+        self.assertIn("Candidate drift", report)
 
     def test_candidate_beating_both_noisy_controls_passes(self):
         # Run 29525842754: candidate p99 (14.85ms) was better than both controls
@@ -348,18 +406,24 @@ class StressAbaWorkflowTests(unittest.TestCase):
         self.assertIn('.client = "dekaf"', self.workflow)
         self.assertIn('.paired_samples = 1', self.workflow)
         self.assertIn('| drop_3conn', self.workflow)
-        self.assertIn('.timeout_minutes = $segment_budget * 3', self.workflow)
+        self.assertIn('.timeout_minutes = $segment_budget * $aba_segments', self.workflow)
+        self.assertIn('.aba_second_candidate = ($aba_segments == 4)', self.workflow)
+        self.assertIn('aba_second_candidate:', self.workflow)
 
     def test_runs_baseline_candidate_baseline_in_that_order(self):
         first = self.workflow.index("run_aba \\\n              baseline-a \\")
         candidate = self.workflow.index("run_aba \\\n              candidate-b \\")
         second = self.workflow.index("run_aba \\\n              baseline-a2 \\")
+        fourth = self.workflow.index("run_aba \\\n                candidate-b2 \\")
         self.assertLess(first, candidate)
         self.assertLess(candidate, second)
+        self.assertLess(second, fourth)
+        self.assertIn('if [ "${{ matrix.aba_second_candidate }}" = "true" ]; then', self.workflow)
 
     def test_compares_and_uploads_controls_separately(self):
         self.assertIn("python3 .github/scripts/stress_aba.py", self.workflow)
         self.assertIn("--candidate tools/Dekaf.StressTests/results", self.workflow)
+        self.assertIn("extra+=(--candidate-b2 aba-results/candidate-b2)", self.workflow)
         self.assertIn("name: aba-controls-", self.workflow)
         self.assertIn("path: aba-results/", self.workflow)
 

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -79,6 +79,11 @@ on:
         description: 'Duration-based producer lanes only: exact SHA for baseline → candidate → baseline; triples duration and blocks on regression/noisy controls'
         required: false
         default: ''
+      aba_second_candidate:
+        description: 'Exact-SHA A-B-A only: add a fourth segment (candidate again after the second baseline) so candidate drift is measured and gated like control drift; quadruples the measured duration'
+        required: false
+        type: boolean
+        default: false
       profile_mode:
         description: 'Attach phased diagnostics to one Dekaf lane (off for normal acceptance runs)'
         required: false
@@ -141,6 +146,7 @@ jobs:
           CONSUMER_FETCH_DIAGNOSTICS: ${{ github.event.inputs.consumer_fetch_diagnostics }}
           ADAPTIVE_CONNECTIONS: ${{ github.event.inputs.adaptive_connections }}
           BASELINE_SHA: ${{ github.event.inputs.baseline_sha }}
+          ABA_SECOND_CANDIDATE: ${{ github.event.inputs.aba_second_candidate }}
           PROFILE_MODE: ${{ github.event.inputs.profile_mode }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
@@ -281,7 +287,11 @@ jobs:
           # cannot hold a paid runner for the full-shape budget. A-B-A reserves
           # three segment budgets; profile runs keep the lane budget because
           # attach tooling adds overhead outside that per-duration model.
-          matrix=$(jq -c --arg lane "$lane" --arg client "$client" --arg shape "$shape" --arg profile_mode "$profile_mode" --arg baseline_sha "$baseline_sha" '
+          aba_segments=3
+          if [ -n "$baseline_sha" ] && [ "$ABA_SECOND_CANDIDATE" = "true" ]; then
+            aba_segments=4
+          fi
+          matrix=$(jq -c --arg lane "$lane" --arg client "$client" --arg shape "$shape" --arg profile_mode "$profile_mode" --arg baseline_sha "$baseline_sha" --argjson aba_segments "$aba_segments" '
             def segments: ((.paired_samples // 1) * (if .client == "all" then 2 else 1 end)) + (if .run_3conn == true then 1 else 0 end) + (if .run_adaptive == true then 1 else 0 end);
             def drop_3conn: .run_3conn = false | .artifact_suffix = "";
             def drop_adaptive: .run_adaptive = false;
@@ -303,7 +313,8 @@ jobs:
                   | drop_3conn
                   | drop_adaptive
                   | .artifact_suffix = "-aba"
-                  | .timeout_minutes = $segment_budget * 3
+                  | .aba_second_candidate = ($aba_segments == 4)
+                  | .timeout_minutes = $segment_budget * $aba_segments
                 elif $profile_mode != "off" then
                   .client = "dekaf"
                   | .paired_samples = 1
@@ -535,6 +546,12 @@ jobs:
               baseline-a2 \
               "$GITHUB_WORKSPACE/baseline-source/tools/Dekaf.StressTests" \
               "$GITHUB_WORKSPACE/aba-results/baseline-a2"
+            if [ "${{ matrix.aba_second_candidate }}" = "true" ]; then
+              run_aba \
+                candidate-b2 \
+                "$GITHUB_WORKSPACE/tools/Dekaf.StressTests" \
+                "$GITHUB_WORKSPACE/aba-results/candidate-b2"
+            fi
             exit 0
           fi
 
@@ -655,15 +672,20 @@ jobs:
 
       - name: Compare exact baseline A-B-A
         if: always() && matrix.baseline_sha != ''
-        run: >-
-          python3 .github/scripts/stress_aba.py
-          --baseline-a aba-results/baseline-a
-          --candidate tools/Dekaf.StressTests/results
-          --baseline-a2 aba-results/baseline-a2
-          --baseline-sha "${{ matrix.baseline_sha }}"
-          --candidate-sha "${{ github.sha }}"
-          --output aba-results/comparison.json
-          --summary "$GITHUB_STEP_SUMMARY"
+        run: |
+          extra=()
+          if [ "${{ matrix.aba_second_candidate }}" = "true" ]; then
+            extra+=(--candidate-b2 aba-results/candidate-b2)
+          fi
+          python3 .github/scripts/stress_aba.py \
+            --baseline-a aba-results/baseline-a \
+            --candidate tools/Dekaf.StressTests/results \
+            --baseline-a2 aba-results/baseline-a2 \
+            "${extra[@]}" \
+            --baseline-sha "${{ matrix.baseline_sha }}" \
+            --candidate-sha "${{ github.sha }}" \
+            --output aba-results/comparison.json \
+            --summary "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Results
         if: always()


### PR DESCRIPTION
## Summary

Every exact-SHA A-B-A on the three-broker lanes this week (#3013, #3018, #3019) ran into control drift of 13-28% between the two baseline segments, which voided any candidate whose effect was smaller than that spread. The single candidate segment sits between them with no drift measure of its own, so a candidate that happened to land on a good or bad minute of the VM is indistinguishable from a real effect.

This adds an opt-in `aba_second_candidate` dispatch input (default off, nothing changes without it): after the second baseline the candidate runs once more (A-B-A-B). The comparison then:

- uses the mean of the two candidate samples as the candidate value;
- requires the decisiveness overrides ("better than both controls", "worse than both controls") to hold for the weaker candidate sample;
- treats candidate drift above the control-drift cap as inconclusive, exactly like control drift;
- treats a stability breach or errors in either candidate segment as a regression;
- reports both candidate columns and candidate drift in the summary and `comparison.json` (`candidateSegments`, `candidateB`, `candidateB2`, `candidateDriftPercent`).

Workflow: the input flows through `select-lanes` into the matrix (`aba_second_candidate`, timeout budget `$segment_budget * $aba_segments`), the run block adds the `candidate-b2` segment after `baseline-a2`, the results land in the existing `aba-controls-*` artifact, and the compare step passes `--candidate-b2` only when the segment ran.

## Evidence

- Three-segment behaviour is unchanged: replaying the four real artifacts from this week (runs 33961873612, 33964050486, 33966278396, 33981141065) reproduces their original verdicts (INCONCLUSIVE, PASS, INCONCLUSIVE, REGRESSION) byte-for-byte on the gate columns.
- Four-segment mode exercised on real data by pairing run 33964050486's segments with run 33961873612's candidate as B2 (a cross-VM mix, so an INCONCLUSIVE on throughput/p95/p99 is the expected and correct outcome): p50 shows 0.00% candidate drift and passes at -27%, while the rows where the two candidate samples disagree by 12-25% are flagged inconclusive instead of being decided by whichever sample was measured.
- `test_stress_aba`: 25/25 including five new cases (averaging, candidate-drift inconclusive, overrides needing both samples, second-candidate stability breach, markdown). `test_stress_trend`: 70/70.

## Cost

Only when `aba_second_candidate=true` on a `baseline_sha` dispatch: one extra measured duration (four segments instead of three, ~75 min instead of ~55 at 15 min). Intended for candidates whose expected effect is below the lane's control drift, where a three-segment run is known to be inconclusive in advance.

https://claude.ai/code/session_012AEx3PnpfHTncWCKXsCH9U


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional four-segment A-B-A-B stress testing with a second candidate run.
  - Candidate results are combined for performance metrics, error counts, and delivery consistency.
  - Added candidate drift and stability checks across both candidate runs.
  - Added support for configuring and running the second candidate segment.

- **Reporting**
  - Reports now display separate four-segment comparison tables when the extended test mode is enabled.
  - Results identify the number of candidate segments included in the comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->