### PR TITLE
Fix idempotent producer initialization when a broker is offline

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -5754,7 +5754,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
                         }
                         catch (Exception ex) when (!initializationToken.IsCancellationRequested
                             && ex is System.Net.Sockets.SocketException or IOException or TimeoutException
-                                or KafkaTimeoutException or KafkaException { IsRetriable: true })
+                                or KafkaTimeoutException or DnsResolutionException or KafkaException { IsRetriable: true })
                         {
                             lastFailure = ex;
                             LogIdempotentInitializationBrokerFailed(ex, brokerId);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -5753,8 +5753,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
                             return;
                         }
                         catch (Exception ex) when (!initializationToken.IsCancellationRequested
-                            && ex is System.Net.Sockets.SocketException or IOException or TimeoutException
-                                or KafkaTimeoutException or DnsResolutionException or KafkaException { IsRetriable: true })
+                            && RetryHelper.IsRetriableBrokerFailure(ex))
                         {
                             lastFailure = ex;
                             LogIdempotentInitializationBrokerFailed(ex, brokerId);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -5693,62 +5693,89 @@ public sealed partial class KafkaProducer<TKey, TValue> :
                 return;
             }
 
-            // Retry with backoff for retriable errors (e.g. CoordinatorLoadInProgress during broker startup)
+            var startedAt = Stopwatch.GetTimestamp();
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(_options.MaxBlockMs);
+            var initializationToken = timeoutCts.Token;
+            Exception? lastFailure = null;
             var consecutiveFailures = 0;
 
-            while (true)
+            try
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                // For non-transactional idempotent producers, send to any broker (no coordinator needed)
-                var brokers = _metadataManager.Metadata.GetBrokers();
-                if (brokers.Count == 0)
+                while (true)
                 {
-                    throw new InvalidOperationException("No brokers available for idempotent producer initialization");
+                    initializationToken.ThrowIfCancellationRequested();
+
+                    // Non-transactional IDs can come from any broker. Try every known broker
+                    // before backing off, and pick up metadata changes on the next round.
+                    var brokers = _metadataManager.Metadata.GetBrokers();
+                    if (brokers.Count == 0)
+                    {
+                        throw new InvalidOperationException("No brokers available for idempotent producer initialization");
+                    }
+
+                    for (var brokerIndex = 0; brokerIndex < brokers.Count; brokerIndex++)
+                    {
+                        initializationToken.ThrowIfCancellationRequested();
+                        var brokerId = brokers[brokerIndex].NodeId;
+                        try
+                        {
+                            var request = new InitProducerIdRequest
+                            {
+                                TransactionalId = null,
+                                TransactionTimeoutMs = -1,
+                                ProducerId = _producerId,
+                                ProducerEpoch = _producerEpoch
+                            };
+
+                            var response = await SendWithConnectionLeaseAsync<InitProducerIdRequest, InitProducerIdResponse>(
+                                    brokerId,
+                                    request,
+                                    initializationToken)
+                                .ConfigureAwait(false);
+                            initializationToken.ThrowIfCancellationRequested();
+
+                            if (response.ErrorCode != ErrorCode.None)
+                            {
+                                throw KafkaException.FromErrorCode(response.ErrorCode,
+                                    $"Failed to initialize idempotent producer: {response.ErrorCode}");
+                            }
+
+                            _producerId = response.ProducerId;
+                            _producerEpoch = response.ProducerEpoch;
+
+                            // Wire the producer ID/epoch into the accumulator for RecordBatch headers.
+                            _accumulator.ProducerId = _producerId;
+                            _accumulator.ProducerEpoch = _producerEpoch;
+                            _idempotentInitialized = true;
+
+                            LogIdempotentProducerInitialized(_producerId, _producerEpoch);
+                            return;
+                        }
+                        catch (Exception ex) when (!initializationToken.IsCancellationRequested
+                            && ex is System.Net.Sockets.SocketException or IOException or TimeoutException
+                                or KafkaTimeoutException or KafkaException { IsRetriable: true })
+                        {
+                            lastFailure = ex;
+                            LogIdempotentInitializationBrokerFailed(ex, brokerId);
+                        }
+                    }
+
+                    var retryDelayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                        _options.RetryBackoffMs,
+                        _options.RetryBackoffMaxMs,
+                        ++consecutiveFailures);
+                    await Task.Delay(retryDelayMs, initializationToken).ConfigureAwait(false);
                 }
-
-                var request = new InitProducerIdRequest
-                {
-                    TransactionalId = null,
-                    TransactionTimeoutMs = -1,
-                    ProducerId = _producerId,
-                    ProducerEpoch = _producerEpoch
-                };
-
-                var response = await SendWithConnectionLeaseAsync<InitProducerIdRequest, InitProducerIdResponse>(
-                        brokers[0].NodeId,
-                        request,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-
-                if (response.ErrorCode == ErrorCode.None)
-                {
-                    _producerId = response.ProducerId;
-                    _producerEpoch = response.ProducerEpoch;
-
-                    // Wire the producer ID/epoch into the accumulator for RecordBatch headers
-                    _accumulator.ProducerId = _producerId;
-                    _accumulator.ProducerEpoch = _producerEpoch;
-
-                    _idempotentInitialized = true;
-
-                    LogIdempotentProducerInitialized(_producerId, _producerEpoch);
-                    return;
-                }
-
-                if (!response.ErrorCode.IsRetriable())
-                {
-                    throw KafkaException.FromErrorCode(response.ErrorCode,
-                        $"Failed to initialize idempotent producer: {response.ErrorCode}");
-                }
-
-                var retryDelayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
-                    _options.RetryBackoffMs,
-                    _options.RetryBackoffMaxMs,
-                    ++consecutiveFailures);
-                LogInitProducerIdRetriable(response.ErrorCode, retryDelayMs);
-
-                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested && timeoutCts.IsCancellationRequested)
+            {
+                throw new KafkaTimeoutException(
+                    TimeoutKind.Api,
+                    Stopwatch.GetElapsedTime(startedAt),
+                    TimeSpan.FromMilliseconds(_options.MaxBlockMs),
+                    $"InitProducerId failed to initialize the idempotent producer within MaxBlockMs ({_options.MaxBlockMs}ms).",
+                    lastFailure ?? ex);
             }
         }
         finally
@@ -6713,8 +6740,8 @@ public sealed partial class KafkaProducer<TKey, TValue> :
     [LoggerMessage(Level = LogLevel.Debug, Message = "Initialized idempotent producer: ProducerId={ProducerId}, Epoch={Epoch}")]
     private partial void LogIdempotentProducerInitialized(long producerId, short epoch);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "InitProducerId returned retriable error {ErrorCode}, retrying in {DelayMs}ms")]
-    private partial void LogInitProducerIdRetriable(ErrorCode errorCode, int delayMs);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Idempotent InitProducerId failed on broker {BrokerId}; trying remaining brokers before retrying")]
+    private partial void LogIdempotentInitializationBrokerFailed(Exception exception, int brokerId);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Bumped producer epoch: ProducerId={ProducerId}, Epoch={Epoch}")]
     private partial void LogProducerEpochBumped(long producerId, short epoch);

--- a/src/Dekaf/Retry/RetryHelper.cs
+++ b/src/Dekaf/Retry/RetryHelper.cs
@@ -1,3 +1,4 @@
+using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 
@@ -103,15 +104,27 @@ internal static class RetryHelper
         }
     }
 
+    /// <summary>
+    /// Classifies a direct broker-operation failure for failover. Fatal exceptions and
+    /// cancellation are not retried, even when they wrap a transient transport failure.
+    /// Callers must separately check their cancellation token and remaining retry budget.
+    /// </summary>
+    internal static bool IsRetriableBrokerFailure(Exception exception) =>
+        exception is KafkaTimeoutException
+            or KafkaException { IsRetriable: true }
+            or IOException
+            or System.Net.Sockets.SocketException
+            or TimeoutException
+            or DnsResolutionException;
+
     internal static bool IsRetriableRequestFailure(Exception exception)
     {
+        // Request retries respect the outer Kafka error, including terminal operation
+        // deadlines. Broker failover can retry a KafkaTimeoutException within its own budget.
         if (exception is KafkaException kafkaException)
             return kafkaException.IsRetriable;
 
-        if (exception is IOException
-            or System.Net.Sockets.SocketException
-            or TimeoutException
-            or DnsResolutionException)
+        if (IsRetriableBrokerFailure(exception))
             return true;
 
         if (exception is AggregateException aggregateException)

--- a/tests/Dekaf.Tests.Integration/IdempotentInitializationIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/IdempotentInitializationIntegrationTests.cs
@@ -1,0 +1,77 @@
+using Dekaf.Internal;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Producer")]
+[Category("Resilience")]
+[NotInParallel("RackAwareKafkaContainer")]
+[ClassDataSource<RackAwareKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class IdempotentInitializationIntegrationTests(RackAwareKafkaContainer kafka)
+{
+    [Test]
+    [Timeout(180_000)]
+    public async Task InitializeAsync_FirstKnownBrokerOffline_ObtainsIdAndProduces(CancellationToken cancellationToken)
+    {
+        var topic = await kafka.CreateReplicatedTopicAsync();
+        var bootstrapServers = kafka.BootstrapServers.Split(',');
+        await using var pool = new ConnectionPool(
+            "idempotent-init-failover",
+            new ConnectionOptions { ConnectionTimeout = TimeSpan.FromSeconds(2), RequestTimeout = TimeSpan.FromSeconds(5) },
+            GlobalTestSetup.GetLoggerFactory());
+        await using var metadata = new MetadataManager(pool, bootstrapServers,
+            options: new MetadataOptions { EnableBackgroundRefresh = false });
+        await metadata.InitializeAsync(cancellationToken);
+
+        // Cache the real cluster view, then stop exactly the broker initialization will
+        // select first. Disabling background refresh keeps the stale view deterministic.
+        var firstBroker = metadata.Metadata.GetBrokers()[0];
+        var previousLeader = await kafka.GetPartitionLeaderIdAsync(topic, cancellationToken);
+        try
+        {
+            await kafka.StopBrokerAsync(firstBroker.NodeId, cancellationToken);
+            await pool.CloseAllAsync();
+            if (previousLeader == firstBroker.NodeId)
+                await kafka.WaitForPartitionLeaderChangeAsync(topic, previousLeader, cancellationToken);
+
+            await using (var producer = new KafkaProducer<string, string>(
+                new ProducerOptions
+                {
+                    BootstrapServers = bootstrapServers,
+                    EnableIdempotence = true,
+                    Acks = Acks.All,
+                    MaxBlockMs = 30_000,
+                    RequestTimeoutMs = 5000,
+                    DeliveryTimeoutMs = 45_000
+                }, Serializers.String, Serializers.String, pool, metadata, DekafMemoryBudget.Global,
+                GlobalTestSetup.GetLoggerFactory()))
+            {
+                await Assert.That(metadata.Metadata.GetBrokers()[0].NodeId).IsEqualTo(firstBroker.NodeId);
+                await producer.InitializeAsync(cancellationToken);
+                await Assert.That(producer.RecordAccumulator.ProducerId).IsGreaterThanOrEqualTo(0L);
+                var result = await producer.ProduceAsync(topic, "cached-metadata", "first", cancellationToken);
+                await Assert.That(result.Offset).IsEqualTo(0L);
+            }
+
+            // Also exercise the public builder's complete bootstrap + initialization path
+            // against all original addresses while that broker is still offline.
+            await using var builtProducer = await Kafka.CreateProducer<string, string>()
+                .WithBootstrapServers(kafka.BootstrapServers)
+                .WithIdempotence(true)
+                .WithAcks(Acks.All)
+                .WithRequestTimeout(TimeSpan.FromSeconds(5))
+                .WithDeliveryTimeout(TimeSpan.FromSeconds(45))
+                .BuildAsync(cancellationToken);
+            var builtResult = await builtProducer.ProduceAsync(topic, "build-async", "second", cancellationToken);
+            await Assert.That(builtResult.Offset).IsEqualTo(1L);
+        }
+        finally
+        {
+            await kafka.StartBrokerAsync(firstBroker.NodeId, CancellationToken.None);
+            await kafka.WaitForInSyncReplicasAsync(topic, 3, CancellationToken.None);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/IdempotentInitializationIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/IdempotentInitializationIntegrationTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Sockets;
 using Dekaf.Internal;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -13,14 +15,23 @@ namespace Dekaf.Tests.Integration;
 public sealed class IdempotentInitializationIntegrationTests(RackAwareKafkaContainer kafka)
 {
     [Test]
+    [Arguments(0)] // TCP connection failure.
+    [Arguments(1)] // DNS resolver throws.
+    [Arguments(2)] // DNS resolver returns no addresses.
     [Timeout(180_000)]
-    public async Task InitializeAsync_FirstKnownBrokerOffline_ObtainsIdAndProduces(CancellationToken cancellationToken)
+    public async Task InitializeAsync_FirstKnownBrokerOffline_ObtainsIdAndProduces(
+        int dnsFailureMode, CancellationToken cancellationToken)
     {
         var topic = await kafka.CreateReplicatedTopicAsync();
         var bootstrapServers = kafka.BootstrapServers.Split(',');
         await using var pool = new ConnectionPool(
             "idempotent-init-failover",
-            new ConnectionOptions { ConnectionTimeout = TimeSpan.FromSeconds(2), RequestTimeout = TimeSpan.FromSeconds(5) },
+            new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromSeconds(2),
+                RequestTimeout = TimeSpan.FromSeconds(5),
+                DnsResolver = new ClientDnsEndpointResolver(new FailingDnsLookup(returnEmptyAddresses: dnsFailureMode == 2))
+            },
             GlobalTestSetup.GetLoggerFactory());
         await using var metadata = new MetadataManager(pool, bootstrapServers,
             options: new MetadataOptions { EnableBackgroundRefresh = false });
@@ -34,6 +45,10 @@ public sealed class IdempotentInitializationIntegrationTests(RackAwareKafkaConta
         {
             await kafka.StopBrokerAsync(firstBroker.NodeId, cancellationToken);
             await pool.CloseAllAsync();
+            // Numeric addresses bypass DNS. Override only the stopped broker's endpoint
+            // to exercise real connection-layer wrapping of resolver errors/empty results.
+            if (dnsFailureMode != 0)
+                pool.RegisterBroker(firstBroker.NodeId, "offline-broker.invalid", firstBroker.Port);
             if (previousLeader == firstBroker.NodeId)
                 await kafka.WaitForPartitionLeaderChangeAsync(topic, previousLeader, cancellationToken);
 
@@ -73,5 +88,16 @@ public sealed class IdempotentInitializationIntegrationTests(RackAwareKafkaConta
             await kafka.StartBrokerAsync(firstBroker.NodeId, CancellationToken.None);
             await kafka.WaitForInSyncReplicasAsync(topic, 3, CancellationToken.None);
         }
+    }
+
+    private sealed class FailingDnsLookup(bool returnEmptyAddresses) : IDnsLookup
+    {
+        public ValueTask<IPAddress[]> GetHostAddressesAsync(string host, CancellationToken cancellationToken)
+            => returnEmptyAddresses
+                ? ValueTask.FromResult<IPAddress[]>([])
+                : ValueTask.FromException<IPAddress[]>(new SocketException((int)SocketError.HostNotFound));
+
+        public ValueTask<IPHostEntry> GetHostEntryAsync(string host, CancellationToken cancellationToken)
+            => ValueTask.FromException<IPHostEntry>(new SocketException((int)SocketError.HostNotFound));
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/IdempotentInitializationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/IdempotentInitializationTests.cs
@@ -191,9 +191,17 @@ public sealed class IdempotentInitializationTests
     {
         await using var harness = new Harness(retryBackoffMs: 10_000);
         using var caller = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        harness.Send = (_, _) => ValueTask.FromResult(new InitProducerIdResponse { ErrorCode = ErrorCode.CoordinatorLoadInProgress });
+        var requestsObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        harness.Send = (_, _) =>
+        {
+            if (harness.Requests.Count == 2)
+                requestsObserved.TrySetResult();
+
+            return ValueTask.FromResult(new InitProducerIdResponse { ErrorCode = ErrorCode.CoordinatorLoadInProgress });
+        };
 
         var initialization = harness.Producer.InitializeAsync(caller.Token).AsTask();
+        await requestsObserved.Task.WaitAsync(cancellationToken);
         await Assert.That(harness.Requests.Count).IsEqualTo(2);
         await Assert.That(initialization.IsCompleted).IsFalse();
         caller.Cancel();

--- a/tests/Dekaf.Tests.Unit/Producer/IdempotentInitializationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/IdempotentInitializationTests.cs
@@ -120,9 +120,10 @@ public sealed class IdempotentInitializationTests
         await using var harness = new Harness();
         harness.Send = (_, _) => ValueTask.FromResult(new InitProducerIdResponse { ErrorCode = errorCode });
 
-        var exception = await CaptureAsync(() => harness.Producer.InitializeAsync(cancellationToken));
+        var exception = await Assert.That(async () => await harness.Producer.InitializeAsync(cancellationToken))
+            .Throws<KafkaException>();
 
-        await Assert.That(((KafkaException)exception).ErrorCode).IsEqualTo(errorCode);
+        await Assert.That(exception!.ErrorCode).IsEqualTo(errorCode);
         await Assert.That(harness.Requests.Count).IsEqualTo(1);
         await Assert.That(harness.Producer.RecordAccumulator.ProducerId).IsEqualTo(-1L);
     }
@@ -138,7 +139,8 @@ public sealed class IdempotentInitializationTests
         await using var harness = new Harness();
         harness.Connect = (_, _) => ValueTask.FromException<IKafkaConnection>(failure);
 
-        var exception = await CaptureAsync(() => harness.Producer.InitializeAsync(cancellationToken));
+        var exception = await Assert.That(async () => await harness.Producer.InitializeAsync(cancellationToken))
+            .Throws<Exception>();
 
         await Assert.That(ReferenceEquals(exception, failure)).IsTrue();
         await Assert.That(harness.ConnectionAttempts.Count).IsEqualTo(1);
@@ -158,14 +160,15 @@ public sealed class IdempotentInitializationTests
         harness.Connect = (id, _) => ValueTask.FromException<IKafkaConnection>(
             id == harness.BrokerIds[0] ? firstFailure : lastFailure);
 
-        var exception = (KafkaTimeoutException)await CaptureAsync(() => harness.Producer.InitializeAsync(cancellationToken));
+        var exception = await Assert.That(async () => await harness.Producer.InitializeAsync(cancellationToken))
+            .Throws<KafkaTimeoutException>();
 
-        await Assert.That(exception.Configured).IsEqualTo(TimeSpan.FromMilliseconds(1000));
-        await Assert.That(exception.TimeoutKind).IsEqualTo(TimeoutKind.Api);
-        await Assert.That(exception.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
-        await Assert.That(exception.Message).Contains("InitProducerId");
-        await Assert.That(ReferenceEquals(exception.InnerException, lastFailure)).IsTrue();
-        await Assert.That(ReferenceEquals(exception.InnerException!.InnerException, firstFailure)).IsTrue();
+        await Assert.That(exception!.Configured).IsEqualTo(TimeSpan.FromMilliseconds(1000));
+        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Api);
+        await Assert.That(exception!.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
+        await Assert.That(exception!.Message).Contains("InitProducerId");
+        await Assert.That(ReferenceEquals(exception!.InnerException, lastFailure)).IsTrue();
+        await Assert.That(ReferenceEquals(exception!.InnerException!.InnerException, firstFailure)).IsTrue();
         await Assert.That(harness.ConnectionAttempts.ToArray()).IsEquivalentTo(harness.BrokerIds);
     }
 
@@ -175,10 +178,11 @@ public sealed class IdempotentInitializationTests
         await using var harness = new Harness(maxBlockMs: 1000, retryBackoffMs: 10_000);
         harness.Send = (_, _) => ValueTask.FromResult(new InitProducerIdResponse { ErrorCode = ErrorCode.CoordinatorLoadInProgress });
 
-        var exception = (KafkaTimeoutException)await CaptureAsync(() => harness.Producer.InitializeAsync(cancellationToken));
+        var exception = await Assert.That(async () => await harness.Producer.InitializeAsync(cancellationToken))
+            .Throws<KafkaTimeoutException>();
 
-        await Assert.That(((KafkaException)exception.InnerException!).ErrorCode).IsEqualTo(ErrorCode.CoordinatorLoadInProgress);
-        await Assert.That(exception.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
+        await Assert.That(((KafkaException)exception!.InnerException!).ErrorCode).IsEqualTo(ErrorCode.CoordinatorLoadInProgress);
+        await Assert.That(exception!.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
         await Assert.That(harness.Requests.Count).IsEqualTo(2);
     }
 
@@ -263,9 +267,10 @@ public sealed class IdempotentInitializationTests
                 return Success();
             };
 
-        var exception = (KafkaTimeoutException)await CaptureAsync(() => harness.Producer.InitializeAsync(cancellationToken));
+        var exception = await Assert.That(async () => await harness.Producer.InitializeAsync(cancellationToken))
+            .Throws<KafkaTimeoutException>();
 
-        await Assert.That(exception.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
+        await Assert.That(exception!.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
         await Assert.That(harness.ConnectionAttempts.Count).IsEqualTo(1);
     }
 
@@ -369,19 +374,6 @@ public sealed class IdempotentInitializationTests
         ProducerId = 1234,
         ProducerEpoch = 7
     };
-
-    private static async Task<Exception> CaptureAsync(Func<ValueTask> action)
-    {
-        try
-        {
-            await action();
-        }
-        catch (Exception exception)
-        {
-            return exception;
-        }
-        throw new InvalidOperationException("Expected initialization to fail.");
-    }
 
     private sealed class Harness : IAsyncDisposable
     {

--- a/tests/Dekaf.Tests.Unit/Producer/IdempotentInitializationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/IdempotentInitializationTests.cs
@@ -1,0 +1,439 @@
+using System.Net.Sockets;
+using System.Reflection;
+using Dekaf.Errors;
+using Dekaf.Internal;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+[Timeout(15_000)]
+public sealed class IdempotentInitializationTests
+{
+    [Test]
+    public async Task InitializeAsync_ConnectionRefused_TriesNextBroker(CancellationToken cancellationToken)
+    {
+        await using var harness = new Harness();
+        harness.Connect = (id, _) => id == harness.BrokerIds[0]
+            ? ValueTask.FromException<IKafkaConnection>(new SocketException((int)SocketError.ConnectionRefused))
+            : ValueTask.FromResult(harness.Connections[id]);
+
+        await harness.Producer.InitializeAsync(cancellationToken);
+
+        await Assert.That(harness.ConnectionAttempts.Take(2).ToArray()).IsEquivalentTo(harness.BrokerIds);
+        await Assert.That(harness.Requests.Single().BrokerId).IsEqualTo(harness.BrokerIds[1]);
+        await AssertInitializedAsync(harness);
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(2)]
+    [Arguments(3)]
+    [Arguments(4)]
+    public async Task InitializeAsync_RetryableSendFailure_TriesNextBroker(int failureKind, CancellationToken cancellationToken)
+    {
+        Exception failure = failureKind switch
+        {
+            0 => new SocketException((int)SocketError.ConnectionReset),
+            1 => new IOException("Connection closed unexpectedly"),
+            2 => new KafkaException(ErrorCode.NetworkException, "Connection lost"),
+            3 => new KafkaTimeoutException("Request timed out"),
+            _ => new TimeoutException("Connection setup timed out")
+        };
+        await using var harness = new Harness();
+        harness.Send = (id, _) => id == harness.BrokerIds[0]
+            ? ValueTask.FromException<InitProducerIdResponse>(failure)
+            : ValueTask.FromResult(Success());
+
+        await harness.Producer.InitializeAsync(cancellationToken);
+
+        await Assert.That(harness.Requests.Select(r => r.BrokerId).ToArray()).IsEquivalentTo(harness.BrokerIds);
+        await AssertInitializedAsync(harness);
+    }
+
+    [Test]
+    public async Task InitializeAsync_RetriableResponses_RotatesAndRetriesWholeRound(CancellationToken cancellationToken)
+    {
+        await using var harness = new Harness();
+        harness.Send = (_, _) => ValueTask.FromResult(harness.Requests.Count <= 4
+            ? new InitProducerIdResponse { ErrorCode = ErrorCode.CoordinatorLoadInProgress }
+            : Success());
+
+        await harness.Producer.InitializeAsync(cancellationToken);
+
+        var expectedOrder = new[]
+        {
+            harness.BrokerIds[0], harness.BrokerIds[1],
+            harness.BrokerIds[0], harness.BrokerIds[1], harness.BrokerIds[0]
+        };
+        await Assert.That(harness.Requests.Select(r => r.BrokerId).SequenceEqual(expectedOrder)).IsTrue();
+        await AssertInitializedAsync(harness);
+    }
+
+    [Test]
+    public async Task InitializeAsync_MetadataChangesBetweenRounds_UsesCurrentBrokers(CancellationToken cancellationToken)
+    {
+        await using var harness = new Harness();
+        var remainingBroker = harness.Metadata.Metadata.GetBrokers()[1];
+        harness.Send = (_, _) =>
+        {
+            if (harness.Requests.Count == 2)
+            {
+                harness.Metadata.Metadata.Update(new MetadataResponse
+                {
+                    Brokers = [new BrokerMetadata
+                    {
+                        NodeId = remainingBroker.NodeId, Host = remainingBroker.Host, Port = remainingBroker.Port
+                    }],
+                    Topics = []
+                });
+            }
+            return ValueTask.FromResult(harness.Requests.Count <= 2
+                ? new InitProducerIdResponse { ErrorCode = ErrorCode.CoordinatorLoadInProgress }
+                : Success());
+        };
+
+        await harness.Producer.InitializeAsync(cancellationToken);
+
+        var expectedOrder = new[] { harness.BrokerIds[0], remainingBroker.NodeId, remainingBroker.NodeId };
+        await Assert.That(harness.Requests.Select(r => r.BrokerId).SequenceEqual(expectedOrder)).IsTrue();
+        await AssertInitializedAsync(harness);
+    }
+
+    [Test]
+    [Arguments(ErrorCode.ClusterAuthorizationFailed)]
+    [Arguments(ErrorCode.TransactionalIdAuthorizationFailed)]
+    [Arguments(ErrorCode.UnsupportedVersion)]
+    public async Task InitializeAsync_FatalResponse_DoesNotRetry(ErrorCode errorCode, CancellationToken cancellationToken)
+    {
+        await using var harness = new Harness();
+        harness.Send = (_, _) => ValueTask.FromResult(new InitProducerIdResponse { ErrorCode = errorCode });
+
+        var exception = await CaptureAsync(() => harness.Producer.InitializeAsync(cancellationToken));
+
+        await Assert.That(((KafkaException)exception).ErrorCode).IsEqualTo(errorCode);
+        await Assert.That(harness.Requests.Count).IsEqualTo(1);
+        await Assert.That(harness.Producer.RecordAccumulator.ProducerId).IsEqualTo(-1L);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task InitializeAsync_FatalException_PreservesExceptionWithoutRetry(bool authenticationFailure, CancellationToken cancellationToken)
+    {
+        Exception failure = authenticationFailure
+            ? new AuthenticationException("Invalid credentials")
+            : new InvalidOperationException("Invalid client state");
+        await using var harness = new Harness();
+        harness.Connect = (_, _) => ValueTask.FromException<IKafkaConnection>(failure);
+
+        var exception = await CaptureAsync(() => harness.Producer.InitializeAsync(cancellationToken));
+
+        await Assert.That(ReferenceEquals(exception, failure)).IsTrue();
+        await Assert.That(harness.ConnectionAttempts.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task InitializeAsync_AllBrokersUnavailable_TimeoutPreservesLastTransportFailure(CancellationToken cancellationToken)
+    {
+        await using var harness = new Harness(maxBlockMs: 1000, retryBackoffMs: 10_000);
+        var firstFailure = new SocketException((int)SocketError.ConnectionRefused);
+        var lastFailure = new IOException("Last broker disconnected", firstFailure);
+        harness.Connect = (id, _) => ValueTask.FromException<IKafkaConnection>(
+            id == harness.BrokerIds[0] ? firstFailure : lastFailure);
+
+        var exception = (KafkaTimeoutException)await CaptureAsync(() => harness.Producer.InitializeAsync(cancellationToken));
+
+        await Assert.That(exception.Configured).IsEqualTo(TimeSpan.FromMilliseconds(1000));
+        await Assert.That(exception.TimeoutKind).IsEqualTo(TimeoutKind.Api);
+        await Assert.That(exception.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
+        await Assert.That(exception.Message).Contains("InitProducerId");
+        await Assert.That(ReferenceEquals(exception.InnerException, lastFailure)).IsTrue();
+        await Assert.That(harness.ConnectionAttempts.ToArray()).IsEquivalentTo(harness.BrokerIds);
+    }
+
+    [Test]
+    public async Task InitializeAsync_RetriableResponsesUntilDeadline_PreservesErrorCode(CancellationToken cancellationToken)
+    {
+        await using var harness = new Harness(maxBlockMs: 1000, retryBackoffMs: 10_000);
+        harness.Send = (_, _) => ValueTask.FromResult(new InitProducerIdResponse { ErrorCode = ErrorCode.CoordinatorLoadInProgress });
+
+        var exception = (KafkaTimeoutException)await CaptureAsync(() => harness.Producer.InitializeAsync(cancellationToken));
+
+        await Assert.That(((KafkaException)exception.InnerException!).ErrorCode).IsEqualTo(ErrorCode.CoordinatorLoadInProgress);
+        await Assert.That(exception.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
+        await Assert.That(harness.Requests.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task InitializeAsync_TransportFailuresRecoverOnNextRound_Succeeds(CancellationToken cancellationToken)
+    {
+        await using var harness = new Harness();
+        harness.Connect = (id, _) => harness.ConnectionAttempts.Count <= 2
+            ? ValueTask.FromException<IKafkaConnection>(new SocketException((int)SocketError.ConnectionRefused))
+            : ValueTask.FromResult(harness.Connections[id]);
+
+        await harness.Producer.InitializeAsync(cancellationToken);
+
+        var expectedOrder = new[] { harness.BrokerIds[0], harness.BrokerIds[1], harness.BrokerIds[0] };
+        await Assert.That(harness.ConnectionAttempts.Take(3).SequenceEqual(expectedOrder)).IsTrue();
+        await AssertInitializedAsync(harness);
+    }
+
+    [Test]
+    public async Task InitializeAsync_CancelDuringBackoff_DoesNotAttemptAnotherRound(CancellationToken cancellationToken)
+    {
+        await using var harness = new Harness(retryBackoffMs: 10_000);
+        using var caller = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        harness.Send = (_, _) => ValueTask.FromResult(new InitProducerIdResponse { ErrorCode = ErrorCode.CoordinatorLoadInProgress });
+
+        var initialization = harness.Producer.InitializeAsync(caller.Token).AsTask();
+        await Assert.That(harness.Requests.Count).IsEqualTo(2);
+        await Assert.That(initialization.IsCompleted).IsFalse();
+        caller.Cancel();
+
+        await Assert.That(() => initialization).Throws<OperationCanceledException>();
+        await Assert.That(harness.Requests.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task InitializeAsync_TimeoutThenRecovery_CanInitializeAgain(CancellationToken cancellationToken)
+    {
+        await using var harness = new Harness(maxBlockMs: 1000, retryBackoffMs: 10_000);
+        harness.Send = (_, _) => ValueTask.FromResult(new InitProducerIdResponse { ErrorCode = ErrorCode.CoordinatorLoadInProgress });
+        await Assert.That(async () => await harness.Producer.InitializeAsync(cancellationToken)).Throws<KafkaTimeoutException>();
+
+        harness.Send = (_, _) => ValueTask.FromResult(Success());
+        await harness.Producer.InitializeAsync(cancellationToken);
+
+        await AssertInitializedAsync(harness);
+    }
+
+    [Test]
+    public async Task InitializeAsync_NoKnownBrokers_FailsWithoutConnecting(CancellationToken cancellationToken)
+    {
+        await using var harness = new Harness();
+        harness.Metadata.Metadata.Update(new MetadataResponse { Brokers = [], Topics = [] });
+
+        await Assert.That(async () => await harness.Producer.InitializeAsync(cancellationToken)).Throws<InvalidOperationException>();
+        await Assert.That(harness.ConnectionAttempts.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task InitializeAsync_StalledOperation_RespectsMaxBlock(bool duringConnect, CancellationToken cancellationToken)
+    {
+        await using var harness = new Harness(maxBlockMs: 1000);
+        if (duringConnect)
+            harness.Connect = async (_, token) =>
+            {
+                await Task.Delay(Timeout.Infinite, token);
+                return harness.Connections[1];
+            };
+        else
+            harness.Send = async (_, token) =>
+            {
+                await Task.Delay(Timeout.Infinite, token);
+                return Success();
+            };
+
+        var exception = (KafkaTimeoutException)await CaptureAsync(() => harness.Producer.InitializeAsync(cancellationToken));
+
+        await Assert.That(exception.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
+        await Assert.That(harness.ConnectionAttempts.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task InitializeAsync_CallerCancellation_StopsInFlightOperation(bool duringConnect, CancellationToken cancellationToken)
+    {
+        await using var harness = new Harness();
+        using var caller = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (duringConnect)
+            harness.Connect = async (_, token) =>
+            {
+                started.SetResult();
+                await Task.Delay(Timeout.Infinite, token);
+                return harness.Connections[1];
+            };
+        else
+            harness.Send = async (_, token) =>
+            {
+                started.SetResult();
+                await Task.Delay(Timeout.Infinite, token);
+                return Success();
+            };
+
+        var initialization = harness.Producer.InitializeAsync(caller.Token).AsTask();
+        await started.Task.WaitAsync(cancellationToken);
+        caller.Cancel();
+
+        await Assert.That(() => initialization).Throws<OperationCanceledException>();
+        await Assert.That(harness.ConnectionAttempts.Count).IsEqualTo(1);
+        // Cancellation must release both initialization locks and leave initialization retryable.
+        harness.Connect = (id, _) => ValueTask.FromResult(harness.Connections[id]);
+        harness.Send = (_, _) => ValueTask.FromResult(Success());
+        await harness.Producer.InitializeAsync(cancellationToken);
+        await AssertInitializedAsync(harness);
+    }
+
+    [Test]
+    public async Task InitializeAsync_PreCancelled_DoesNotConnect(CancellationToken cancellationToken)
+    {
+        await using var harness = new Harness();
+        using var caller = new CancellationTokenSource();
+        caller.Cancel();
+
+        await Assert.That(async () => await harness.Producer.InitializeAsync(caller.Token)).Throws<OperationCanceledException>();
+        await Assert.That(harness.ConnectionAttempts.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task InitializeAsync_ConcurrentCalls_ObtainOnlyOneProducerId(CancellationToken cancellationToken)
+    {
+        await using var harness = new Harness();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        harness.Send = async (_, token) =>
+        {
+            started.SetResult();
+            await release.Task.WaitAsync(token);
+            return Success();
+        };
+
+        var first = harness.Producer.InitializeAsync(cancellationToken).AsTask();
+        await started.Task.WaitAsync(cancellationToken);
+        var second = harness.Producer.InitializeAsync(cancellationToken).AsTask();
+        release.SetResult();
+        await Task.WhenAll(first, second);
+        await harness.Producer.InitializeAsync(cancellationToken);
+
+        await Assert.That(harness.Requests.Count).IsEqualTo(1);
+        await AssertInitializedAsync(harness);
+    }
+
+    [Test]
+    [Arguments(false, null)]
+    [Arguments(true, "transactional-producer")]
+    public async Task InitializeAsync_NonIdempotentOrTransactional_DoesNotRequestProducerId(bool idempotent, string? transactionalId, CancellationToken cancellationToken)
+    {
+        await using var harness = new Harness(idempotent: idempotent, transactionalId: transactionalId);
+        await harness.Producer.InitializeAsync(cancellationToken);
+        await Assert.That(harness.Requests.Count).IsEqualTo(0);
+    }
+
+    private static async Task AssertInitializedAsync(Harness harness)
+    {
+        await Assert.That(harness.Producer.RecordAccumulator.ProducerId).IsEqualTo(1234L);
+        await Assert.That(harness.Producer.RecordAccumulator.ProducerEpoch).IsEqualTo((short)7);
+        foreach (var (_, request) in harness.Requests)
+        {
+            await Assert.That(request.TransactionalId).IsNull();
+            await Assert.That(request.TransactionTimeoutMs).IsEqualTo(-1);
+            await Assert.That(request.ProducerId).IsEqualTo(-1L);
+            await Assert.That(request.ProducerEpoch).IsEqualTo((short)-1);
+        }
+    }
+
+    private static InitProducerIdResponse Success() => new()
+    {
+        ErrorCode = ErrorCode.None,
+        ProducerId = 1234,
+        ProducerEpoch = 7
+    };
+
+    private static async Task<Exception> CaptureAsync(Func<ValueTask> action)
+    {
+        try
+        {
+            await action();
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+        throw new InvalidOperationException("Expected initialization to fail.");
+    }
+
+    private sealed class Harness : IAsyncDisposable
+    {
+        private readonly ConnectionPool _pool;
+        private readonly MetadataManager _metadata;
+        public MetadataManager Metadata => _metadata;
+        public KafkaProducer<string, string> Producer { get; }
+        public Dictionary<int, IKafkaConnection> Connections { get; } = [];
+        public int[] BrokerIds { get; }
+        public List<int> ConnectionAttempts { get; } = [];
+        public List<(int BrokerId, InitProducerIdRequest Request)> Requests { get; } = [];
+        public Func<int, CancellationToken, ValueTask<IKafkaConnection>> Connect { get; set; }
+        public Func<int, CancellationToken, ValueTask<InitProducerIdResponse>> Send { get; set; } = (_, _) => ValueTask.FromResult(Success());
+
+        public Harness(int maxBlockMs = 5000, int retryBackoffMs = 1, bool idempotent = true, string? transactionalId = null)
+        {
+            Connect = (id, _) => ValueTask.FromResult(Connections[id]);
+            _pool = new ConnectionPool("idempotent-init-test", new ConnectionOptions { ReconnectBackoff = TimeSpan.Zero }, 1,
+                (id, _, _, _, token) =>
+                {
+                    ConnectionAttempts.Add(id);
+                    return Connect(id, token);
+                });
+            _metadata = new MetadataManager(_pool, ["localhost:9092"]);
+            _metadata.Metadata.Update(new MetadataResponse
+            {
+                Brokers =
+                [
+                    new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 },
+                    new BrokerMetadata { NodeId = 2, Host = "localhost", Port = 9093 }
+                ],
+                Topics = []
+            });
+            // Skip only metadata bootstrap; exercise the public producer initialization path.
+            typeof(MetadataManager).GetField("_initialized", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(_metadata, true);
+            _metadata.SetApiVersion(ApiKey.InitProducerId, 2, 5);
+            BrokerIds = _metadata.Metadata.GetBrokers().Select(broker => broker.NodeId).ToArray();
+            foreach (var broker in _metadata.Metadata.GetBrokers())
+            {
+                _pool.RegisterBroker(broker.NodeId, broker.Host, broker.Port);
+                var connection = Substitute.For<IKafkaConnection>();
+                connection.BrokerId.Returns(broker.NodeId);
+                connection.Host.Returns(broker.Host);
+                connection.Port.Returns(broker.Port);
+                connection.IsConnected.Returns(true);
+                connection.SendAsync<InitProducerIdRequest, InitProducerIdResponse>(
+                        Arg.Any<InitProducerIdRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+                    .Returns(call =>
+                    {
+                        Requests.Add((broker.NodeId, call.ArgAt<InitProducerIdRequest>(0)));
+                        return Send(broker.NodeId, call.ArgAt<CancellationToken>(2));
+                    });
+                Connections.Add(broker.NodeId, connection);
+            }
+            Producer = new KafkaProducer<string, string>(new ProducerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                EnableIdempotence = idempotent,
+                TransactionalId = transactionalId,
+                MaxBlockMs = maxBlockMs,
+                RetryBackoffMs = retryBackoffMs,
+                RetryBackoffMaxMs = retryBackoffMs,
+                CloseTimeoutMs = 100
+            }, Serializers.String, Serializers.String, _pool, _metadata, DekafMemoryBudget.Global);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Producer.DisposeAsync();
+            await _metadata.DisposeAsync();
+            await _pool.DisposeAsync();
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/IdempotentInitializationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/IdempotentInitializationTests.cs
@@ -16,11 +16,16 @@ namespace Dekaf.Tests.Unit.Producer;
 public sealed class IdempotentInitializationTests
 {
     [Test]
-    public async Task InitializeAsync_ConnectionRefused_TriesNextBroker(CancellationToken cancellationToken)
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task InitializeAsync_ConnectionFailure_TriesNextBroker(bool dnsFailure, CancellationToken cancellationToken)
     {
         await using var harness = new Harness();
+        Exception failure = dnsFailure
+            ? new DnsResolutionException("offline-broker", 9092, new SocketException((int)SocketError.HostNotFound))
+            : new SocketException((int)SocketError.ConnectionRefused);
         harness.Connect = (id, _) => id == harness.BrokerIds[0]
-            ? ValueTask.FromException<IKafkaConnection>(new SocketException((int)SocketError.ConnectionRefused))
+            ? ValueTask.FromException<IKafkaConnection>(failure)
             : ValueTask.FromResult(harness.Connections[id]);
 
         await harness.Producer.InitializeAsync(cancellationToken);
@@ -140,11 +145,16 @@ public sealed class IdempotentInitializationTests
     }
 
     [Test]
-    public async Task InitializeAsync_AllBrokersUnavailable_TimeoutPreservesLastTransportFailure(CancellationToken cancellationToken)
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task InitializeAsync_AllBrokersUnavailable_TimeoutPreservesLastTransportFailure(
+        bool dnsFailure, CancellationToken cancellationToken)
     {
         await using var harness = new Harness(maxBlockMs: 1000, retryBackoffMs: 10_000);
         var firstFailure = new SocketException((int)SocketError.ConnectionRefused);
-        var lastFailure = new IOException("Last broker disconnected", firstFailure);
+        Exception lastFailure = dnsFailure
+            ? new DnsResolutionException("last-broker", 9093, firstFailure)
+            : new IOException("Last broker disconnected", firstFailure);
         harness.Connect = (id, _) => ValueTask.FromException<IKafkaConnection>(
             id == harness.BrokerIds[0] ? firstFailure : lastFailure);
 
@@ -155,6 +165,7 @@ public sealed class IdempotentInitializationTests
         await Assert.That(exception.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
         await Assert.That(exception.Message).Contains("InitProducerId");
         await Assert.That(ReferenceEquals(exception.InnerException, lastFailure)).IsTrue();
+        await Assert.That(ReferenceEquals(exception.InnerException!.InnerException, firstFailure)).IsTrue();
         await Assert.That(harness.ConnectionAttempts.ToArray()).IsEquivalentTo(harness.BrokerIds);
     }
 

--- a/tests/Dekaf.Tests.Unit/Retry/RetryHelperTests.cs
+++ b/tests/Dekaf.Tests.Unit/Retry/RetryHelperTests.cs
@@ -11,6 +11,40 @@ namespace Dekaf.Tests.Unit.Retry;
 public sealed class RetryHelperTests
 {
     [Test]
+    [MethodDataSource(nameof(FailureClassifications))]
+    public async Task FailureClassification_PreservesBrokerAndRequestPolicies(
+        string scenario, Func<Exception> createFailure, bool retryBroker, bool retryRequest)
+    {
+        var failure = createFailure();
+        await Assert.That(RetryHelper.IsRetriableBrokerFailure(failure)).IsEqualTo(retryBroker);
+        await Assert.That(RetryHelper.IsRetriableRequestFailure(failure)).IsEqualTo(retryRequest);
+    }
+
+    public static IEnumerable<(string Scenario, Func<Exception> CreateFailure, bool RetryBroker, bool RetryRequest)> FailureClassifications()
+    {
+        yield return ("socket", static () => new SocketException((int)SocketError.ConnectionRefused), true, true);
+        yield return ("io", static () => new IOException("connection reset"), true, true);
+        yield return ("request timeout", static () => new TimeoutException("request timed out"), true, true);
+        yield return ("dns", static () => new DnsResolutionException("broker", 9092), true, true);
+        yield return ("Kafka timeout", static () => new KafkaTimeoutException("operation timed out"), true, false);
+        yield return ("retriable Kafka error", static () => CreateRequestTimeout(), true, true);
+        yield return ("fatal Kafka error", static () => new KafkaException(ErrorCode.UnsupportedVersion, "unsupported"), false, false);
+        yield return ("unclassified Kafka error", static () => new KafkaException("unknown error"), false, false);
+        yield return ("retry override", static () => new KafkaException(ErrorCode.UnknownServerError, "retry", isRetriable: true), true, true);
+        yield return ("fatal override", static () => new KafkaException(ErrorCode.RequestTimedOut, "terminal", isRetriable: false), false, false);
+        yield return ("authentication", static () => new AuthenticationException("invalid credentials", new IOException("transport")), false, false);
+        yield return ("bootstrap deadline", static () => new BootstrapResolutionException(
+            ["broker:9092"], TimeSpan.FromSeconds(1), new DnsResolutionException("broker", 9092)), false, false);
+        yield return ("cancellation", static () => new OperationCanceledException(), false, false);
+        yield return ("task cancellation", static () => new TaskCanceledException(), false, false);
+        yield return ("disposed", static () => new ObjectDisposedException("connection"), false, false);
+        yield return ("invalid state", static () => new InvalidOperationException("invalid state"), false, false);
+        yield return ("wrapped transport", static () => new InvalidOperationException("wrapper", new IOException("transport")), false, true);
+        yield return ("aggregate transport", static () => new AggregateException(new IOException("transport")), false, true);
+        yield return ("aggregate fatal", static () => new AggregateException(new AuthenticationException("invalid credentials")), false, false);
+    }
+
+    [Test]
     public async Task MetadataRefreshUnavailable_RetriesOriginalOperation()
     {
         await using var metadataManager = CreateUnavailableMetadataManager();


### PR DESCRIPTION
A fresh idempotent producer could fail initialization when the first metadata broker was offline, even with other brokers available. Non-transactional `InitProducerId` now tries every known broker before exponential backoff, reads the current metadata snapshot between rounds, and bounds producer-ID initialization with `MaxBlockMs`.

Transport failures (including broker DNS resolution failures), request/setup timeouts, and retriable Kafka errors trigger failover. Fatal errors propagate immediately. Caller cancellation remains cancellation; deadline expiration throws `KafkaTimeoutException` with the last failure attached. Metadata initialization retains its existing separate timeout budget. The change is confined to startup and its diagnostic logger.

Closes #2994.

## Coverage and validation

- Added **29 unit cases** covering connection/send failures, broker rotation, metadata changes, fatal errors, deadline duration and exception context, stalled operations, cancellation during requests/backoff, recovery after cancellation/timeout, empty metadata, concurrency, and transactional/non-idempotent exclusions.
- Added **19 classifier cases** covering direct transport errors, cancellation, fatal Kafka errors and overrides, exception wrappers/aggregates, and the distinct broker-failover versus request-retry timeout policies.
- Added a deterministic three-broker integration test with TCP-failure, DNS-exception, and empty-DNS-result variants: cache real metadata, stop exactly the first selected broker, initialize a fresh idempotent producer, and acknowledge a record. Also exercise public `BuildAsync` with the broker still offline and verify consecutive acknowledged offsets.
- Regression proof: the new integration test fails against the original producer source at `InitIdempotentProducerAsync` with a connection setup timeout on the stopped broker; passes with this fix.
- **132 focused unit tests passed on .NET 10**, including existing producer initialization, transaction, and retry-helper tests.
- **54 initialization and retry-helper tests passed on .NET 8**.
- **3 initialization integration variants passed** (TCP failure, DNS exception, empty DNS result). Both existing consumer leader-handoff/rolling-restart scenarios also passed during the initial implementation validation.
- Release unit builds for net10.0/net8.0 and integration build for net10.0 completed with zero warnings/errors. `/simplify` review and `git diff --check` completed.

DNS review follow-up (`6724e99f786d6a1ba6f55ae9ce55b0428227b71f`): both new DNS unit cases failed before the filter fix and passed afterward. Coverage verifies failover plus preservation of the complete DNS exception chain on timeout. The connection-layer integration variants exercise both resolver exceptions and empty address results with deterministic injected DNS.

Shared classification follow-up (`7d10d1cbf`): `RetryHelper.IsRetriableBrokerFailure` centralizes direct broker failures; both producer initialization and existing request-retry classification use it. Cancellation/budget handling remains with callers, and existing request-wrapper/terminal-timeout behavior is preserved. CodeQL follow-up (`06abf5b79`) removes the broad-catching test helper in favor of TUnit exception assertions.

## Performance evidence and limits

Baseline: `aa85154ea55c60464530d316e6ba3c2ef6b94703`.
Candidate: `93beb3279954036a9e3464885c3aac7dd362eff8`.

Local `ProducerFireHotPathBenchmarks.FireBatch`, `[MemoryDiagnoser]`, `ShortRun` (3 warmups, 3 measured iterations), 1000-byte messages, all 16 parameter combinations. Windows 11, Intel Core i7-12700K, .NET SDK 10.0.400 / runtime 10.0.11. No paid stress workflow was dispatched.

**Timing is inconclusive:** the baseline overlapped a unit-project build and short-run variance is large. No throughput/latency/CPU/stability Pareto verdict is claimed. One candidate allocation sample reported **5 B/message**; an isolated exact-configuration repeat reported **0 B/message**. Both results are retained below; the initial sample's exact allocation source is unproven. The benchmark disables idempotence and marks the producer initialized before measurement, so it does not execute the modified startup method.

<details>
<summary>Full before/after measurements and allocation investigation</summary>

All results are nanoseconds and allocated bytes per message. Tracing-enabled cases intentionally include Activity allocations in both builds.

| Target ms | Partitions | Tracing | Prepared | Baseline mean | Candidate mean | Mean delta | Baseline allocated | Candidate allocated |
|---:|---:|---|---|---:|---:|---:|---:|---:|
| 0 | 1 | False | False | 261.0 ns | 235.0 ns | -10.0% | 0 B | 0 B |
| 0 | 1 | False | True | 302.3 ns | 269.7 ns | -10.8% | 0 B | 0 B |
| 0 | 1 | True | False | 971.4 ns | 811.3 ns | -16.5% | 1248 B | 1248 B |
| 0 | 1 | True | True | 889.5 ns | 1,007.9 ns | +13.3% | 1248 B | 1248 B |
| 0 | 12 | False | False | 258.5 ns | 282.1 ns | +9.1% | 0 B | 0 B |
| 0 | 12 | False | True | 301.9 ns | 325.3 ns | +7.8% | 0 B | 0 B |
| 0 | 12 | True | False | 840.8 ns | 1,029.9 ns | +22.5% | 1248 B | 1248 B |
| 0 | 12 | True | True | 852.5 ns | 1,111.0 ns | +30.3% | 1248 B | 1248 B |
| 10 | 1 | False | False | 273.2 ns | 282.5 ns | +3.4% | 0 B | 0 B |
| 10 | 1 | False | True | 305.2 ns | 324.4 ns | +6.3% | 0 B | 0 B |
| 10 | 1 | True | False | 889.7 ns | 1,059.2 ns | +19.1% | 1248 B | 1248 B |
| 10 | 1 | True | True | 1,250.2 ns | 882.9 ns | -29.4% | 1248 B | 1248 B |
| 10 | 12 | False | False | 285.0 ns | 225.9 ns | -20.7% | 0 B | 0 B |
| 10 | 12 | False | True | 308.5 ns | 264.3 ns | -14.3% | 0 B | 5 B |
| 10 | 12 | True | False | 1,187.0 ns | 814.2 ns | -31.4% | 1248 B | 1248 B |
| 10 | 12 | True | True | 1,330.7 ns | 885.6 ns | -33.4% | 1248 B | 1248 B |

### Allocation sample investigation

The candidate full run reported 5 B/message for target=10 ms, partitions=12, tracing=false, prepared=true (15,717,768 allocated bytes across 3,276,800 messages in the diagnostic iteration). The other seven tracing-disabled configurations reported 0 B/message; tracing-enabled allocations matched baseline at 1248 B/message.

An isolated exact-configuration candidate repeat reported 267.6 ns, allocated 0 B. Both samples are retained; the original allocation sample is not discarded or relabeled as a zero-allocation run.

The benchmark sets EnableIdempotence=false and marks the producer initialized before measurement, so the modified InitIdempotentProducerAsync method is never executed by its measured workload. Existing accumulator pools and the concurrent drainer can introduce cold-path allocation variability, but this run did not collect allocation stacks, so the exact source of the 5 B sample is unproven. No persistent new per-message allocation was demonstrated. Timing is inconclusive because short-run variance is large and baseline overlapped build activity; no throughput/latency Pareto verdict or performance improvement is claimed.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved idempotent producer initialization to try all available brokers when the first broker is unavailable.
  * Initialization now respects the configured timeout and reports timeout details more clearly.
  * Improved recovery from temporary broker connection and response failures.
  * Preserved fatal errors and caller cancellation behavior without unnecessary retries.

* **Tests**
  * Added comprehensive coverage for broker failover, retries, timeouts, cancellation, recovery, and concurrent initialization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->