### PR TITLE
feat(admin): support partition validation and replica assignments

### DIFF
--- a/docs/docs/admin/partition-expansion.md
+++ b/docs/docs/admin/partition-expansion.md
@@ -55,7 +55,9 @@ await admin.CreatePartitionsAsync(new Dictionary<string, int> { ["orders"] = 5 }
 ```
 
 Typed expansion is an optional `IPartitionExpansionAdminClient` capability implemented
-by the built-in `AdminClient`. Extensions expose it through `IAdminClient` without
+by the built-in `AdminClient` and `InMemoryAdminClient`. The in-memory client supports
+validation-only requests and explicit assignments to its single broker, ID `0`;
+other broker IDs are rejected. Extensions expose it through `IAdminClient` without
 adding required members to existing custom implementations. Clients without this
 capability throw `NotSupportedException` for the typed overload.
 

--- a/docs/docs/admin/partition-expansion.md
+++ b/docs/docs/admin/partition-expansion.md
@@ -1,0 +1,63 @@
+---
+sidebar_position: 5
+---
+
+# Partition expansion
+
+Use `CreatePartitionsAsync` to increase a topic's partition count. `TotalCount`
+is the **final total**, including existing partitions. Existing partition replica
+assignments remain unchanged.
+
+```csharp
+using Dekaf.Admin;
+
+await using var admin = new AdminClientBuilder()
+    .WithBootstrapServers("localhost:9092")
+    .Build();
+
+// A topic with 3 partitions and replication factor 2 grows to 5 partitions.
+var expansion = new Dictionary<string, NewPartitions>
+{
+    ["orders"] = new()
+    {
+        TotalCount = 5,
+        ReplicaAssignments = [[2, 1], [1, 3]]
+    }
+};
+
+await admin.CreatePartitionsAsync(expansion, new CreatePartitionsOptions
+{
+    ValidateOnly = true,
+    TimeoutMs = 10_000
+});
+
+// Apply the same specification after successful validation.
+await admin.CreatePartitionsAsync(expansion);
+```
+
+Assignments describe only additional partitions, in ascending partition order.
+In this example, partition 3 prefers broker 2 and partition 4 prefers broker 1.
+Replica ordering is preserved. Leave `ReplicaAssignments` null to let the
+controller choose replicas. Each assignment must contain unique, nonnegative
+broker IDs and have the same replication factor. The controller checks assignment
+count, replication factor, broker availability and current topic state.
+
+`ValidateOnly` performs broker validation without creating partitions. A successful
+validation does not reserve the expansion: cluster state can change before it is
+applied. Validation retries never infer success from an earlier ambiguous mutation.
+`TimeoutMs` controls the broker operation timeout; pass a cancellation token to
+bound the caller's entire operation, including initialization and retries.
+
+The original count-only overload remains available:
+
+```csharp
+await admin.CreatePartitionsAsync(new Dictionary<string, int> { ["orders"] = 5 });
+```
+
+Typed expansion is an optional `IPartitionExpansionAdminClient` capability implemented
+by the built-in `AdminClient`. Extensions expose it through `IAdminClient` without
+adding required members to existing custom implementations. Clients without this
+capability throw `NotSupportedException` for the typed overload.
+
+See Kafka's [NewPartitions contract](https://kafka.apache.org/43/javadoc/org/apache/kafka/clients/admin/NewPartitions.html)
+and [CreatePartitionsOptions](https://kafka.apache.org/43/javadoc/org/apache/kafka/clients/admin/CreatePartitionsOptions.html).

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -83,6 +83,7 @@ const sidebars = {
         'observability',
         'health-checks',
         'admin/topic-identifiers',
+        'admin/partition-expansion',
         'admin/transaction-remediation',
         'admin/replica-log-directories',
         'admin/streams-group-management',

--- a/src/Dekaf.Testing/InMemoryAdminClient.PartitionExpansion.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.PartitionExpansion.cs
@@ -1,0 +1,44 @@
+using Dekaf.Admin;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Testing;
+
+public sealed partial class InMemoryAdminClient : IPartitionExpansionAdminClient
+{
+    /// <inheritdoc />
+    async ValueTask IPartitionExpansionAdminClient.CreatePartitionsAsync(
+        IReadOnlyDictionary<string, NewPartitions> newPartitions,
+        CreatePartitionsOptions? options,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(newPartitions);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        var timeoutMs = options?.TimeoutMs ?? 30000;
+        ArgumentOutOfRangeException.ThrowIfNegative(timeoutMs);
+
+        // Validate and snapshot the whole batch before faults can suspend or mutations begin.
+        var topics = new List<CreatePartitionsTopic>(newPartitions.Count);
+        foreach (var pair in newPartitions)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(pair.Key);
+            ArgumentNullException.ThrowIfNull(pair.Value);
+            ArgumentOutOfRangeException.ThrowIfLessThan(pair.Value.TotalCount, 1);
+            topics.Add(new CreatePartitionsTopic
+            {
+                Name = pair.Key,
+                Count = pair.Value.TotalCount,
+                Assignments = AdminClient.CopyPartitionAssignments(pair.Value, nameof(newPartitions))
+            });
+        }
+
+        if (topics.Count == 0)
+            await ApplyAdminFaultAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (var topic in topics)
+        {
+            await ApplyAdminFaultAsync(cancellationToken, topic: topic.Name).ConfigureAwait(false);
+            _cluster.CreatePartitions(topic, options?.ValidateOnly ?? false);
+        }
+    }
+}

--- a/src/Dekaf.Testing/InMemoryAdminClient.PartitionExpansion.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.PartitionExpansion.cs
@@ -1,5 +1,4 @@
 using Dekaf.Admin;
-using Dekaf.Protocol.Messages;
 
 namespace Dekaf.Testing;
 
@@ -18,19 +17,7 @@ public sealed partial class InMemoryAdminClient : IPartitionExpansionAdminClient
         ArgumentOutOfRangeException.ThrowIfNegative(timeoutMs);
 
         // Validate and snapshot the whole batch before faults can suspend or mutations begin.
-        var topics = new List<CreatePartitionsTopic>(newPartitions.Count);
-        foreach (var pair in newPartitions)
-        {
-            ArgumentException.ThrowIfNullOrWhiteSpace(pair.Key);
-            ArgumentNullException.ThrowIfNull(pair.Value);
-            ArgumentOutOfRangeException.ThrowIfLessThan(pair.Value.TotalCount, 1);
-            topics.Add(new CreatePartitionsTopic
-            {
-                Name = pair.Key,
-                Count = pair.Value.TotalCount,
-                Assignments = AdminClient.CopyPartitionAssignments(pair.Value, nameof(newPartitions))
-            });
-        }
+        var topics = AdminClient.BuildPartitionExpansionTopics(newPartitions);
 
         if (topics.Count == 0)
             await ApplyAdminFaultAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -1463,6 +1463,36 @@ public sealed class InMemoryKafkaCluster
         }
     }
 
+    internal void CreatePartitions(CreatePartitionsTopic expansion, bool validateOnly)
+    {
+        lock (_gate)
+        {
+            // Validation must never auto-create a missing topic, including with AutoCreateTopics enabled.
+            if (!_topics.TryGetValue(expansion.Name, out var topic))
+                throw new KafkaException(ErrorCode.UnknownTopicOrPartition, $"Topic '{expansion.Name}' does not exist.");
+            if (expansion.Count <= topic.Partitions.Count)
+                throw new KafkaException(ErrorCode.InvalidPartitions, "The total partition count must increase.");
+
+            if (expansion.Assignments is { } assignments)
+            {
+                if (assignments.Count != expansion.Count - topic.Partitions.Count)
+                    throw new KafkaException(ErrorCode.InvalidReplicaAssignment, "Assignments must describe every additional partition.");
+                foreach (var assignment in assignments)
+                {
+                    // In-memory metadata models one broker, with replication factor one.
+                    if (assignment.BrokerIds.Count != 1 || assignment.BrokerIds[0] != 0)
+                        throw new KafkaException(ErrorCode.InvalidReplicaAssignment, "The in-memory cluster supports only replica broker 0.");
+                }
+            }
+
+            if (!validateOnly)
+            {
+                while (topic.Partitions.Count < expansion.Count)
+                    topic.Partitions.Add(new PartitionState());
+            }
+        }
+    }
+
     internal IReadOnlyDictionary<string, TopicDescription> DescribeTopics(IEnumerable<string> topicNames)
     {
         lock (_gate)

--- a/src/Dekaf/Admin/AdminClient.PartitionExpansion.cs
+++ b/src/Dekaf/Admin/AdminClient.PartitionExpansion.cs
@@ -34,7 +34,7 @@ public sealed partial class AdminClient
         await CreatePartitionsCoreAsync(topics, timeoutMs, options?.ValidateOnly ?? false, cancellationToken).ConfigureAwait(false);
     }
 
-    private static CreatePartitionsAssignment[]? CopyPartitionAssignments(NewPartitions partitions, string parameterName)
+    internal static CreatePartitionsAssignment[]? CopyPartitionAssignments(NewPartitions partitions, string parameterName)
     {
         var assignments = partitions.ReplicaAssignments;
         if (assignments is null)
@@ -79,10 +79,13 @@ public sealed partial class AdminClient
 
     private static IReadOnlyList<CreatePartitionsTopic> ExcludeConfirmedPartitionExpansions(
         IReadOnlyList<CreatePartitionsTopic> topics,
-        IReadOnlyList<CreatePartitionsResponseResult> results)
+        IReadOnlyList<CreatePartitionsResponseResult> results,
+        string? metadataConfirmedTopic = null)
     {
         // Only allocate on a partial failure, outside the successful admin request path.
         HashSet<string>? confirmed = null;
+        if (metadataConfirmedTopic is not null)
+            (confirmed = new(StringComparer.Ordinal)).Add(metadataConfirmedTopic);
         foreach (var result in results)
         {
             if (result.ErrorCode == Protocol.ErrorCode.None)

--- a/src/Dekaf/Admin/AdminClient.PartitionExpansion.cs
+++ b/src/Dekaf/Admin/AdminClient.PartitionExpansion.cs
@@ -26,7 +26,7 @@ public sealed partial class AdminClient
             {
                 Name = pair.Key,
                 Count = pair.Value.TotalCount,
-                Assignments = CopyPartitionAssignments(pair.Value)
+                Assignments = CopyPartitionAssignments(pair.Value, nameof(newPartitions))
             });
         }
 
@@ -34,14 +34,14 @@ public sealed partial class AdminClient
         await CreatePartitionsCoreAsync(topics, timeoutMs, options?.ValidateOnly ?? false, cancellationToken).ConfigureAwait(false);
     }
 
-    private static CreatePartitionsAssignment[]? CopyPartitionAssignments(NewPartitions partitions)
+    private static CreatePartitionsAssignment[]? CopyPartitionAssignments(NewPartitions partitions, string parameterName)
     {
         var assignments = partitions.ReplicaAssignments;
         if (assignments is null)
             return null;
 
         if (assignments.Count == 0 || assignments.Count >= partitions.TotalCount)
-            throw new ArgumentException("Assignments must describe only the additional partitions of an existing topic.", nameof(partitions));
+            throw new ArgumentException("Assignments must describe only the additional partitions of an existing topic.", parameterName);
 
         var result = new CreatePartitionsAssignment[assignments.Count];
         var replicationFactor = 0;
@@ -49,7 +49,7 @@ public sealed partial class AdminClient
         {
             var replicas = assignments[index];
             if (replicas is null || replicas.Count == 0 || (index > 0 && replicas.Count != replicationFactor))
-                throw new ArgumentException("Each assignment must contain the same nonzero number of replicas.", nameof(partitions));
+                throw new ArgumentException("Each assignment must contain the same nonzero number of replicas.", parameterName);
 
             replicationFactor = replicas.Count;
             var brokerIds = new int[replicas.Count];
@@ -58,7 +58,7 @@ public sealed partial class AdminClient
             {
                 var brokerId = replicas[replica];
                 if (brokerId < 0 || !seen.Add(brokerId))
-                    throw new ArgumentException("Replica broker IDs must be nonnegative and unique within a partition.", nameof(partitions));
+                    throw new ArgumentException("Replica broker IDs must be nonnegative and unique within a partition.", parameterName);
                 brokerIds[replica] = brokerId;
             }
             result[index] = new CreatePartitionsAssignment { BrokerIds = brokerIds };
@@ -75,5 +75,28 @@ public sealed partial class AdminClient
                 return topics[index];
         }
         throw new InvalidOperationException($"Unexpected CreatePartitions response topic '{name}'.");
+    }
+
+    private static IReadOnlyList<CreatePartitionsTopic> ExcludeConfirmedPartitionExpansions(
+        IReadOnlyList<CreatePartitionsTopic> topics,
+        IReadOnlyList<CreatePartitionsResponseResult> results)
+    {
+        // Only allocate on a partial failure, outside the successful admin request path.
+        HashSet<string>? confirmed = null;
+        foreach (var result in results)
+        {
+            if (result.ErrorCode == Protocol.ErrorCode.None)
+                (confirmed ??= new(StringComparer.Ordinal)).Add(result.Name);
+        }
+        if (confirmed is null)
+            return topics;
+
+        var remaining = new List<CreatePartitionsTopic>(topics.Count);
+        foreach (var topic in topics)
+        {
+            if (!confirmed.Contains(topic.Name))
+                remaining.Add(topic);
+        }
+        return remaining;
     }
 }

--- a/src/Dekaf/Admin/AdminClient.PartitionExpansion.cs
+++ b/src/Dekaf/Admin/AdminClient.PartitionExpansion.cs
@@ -1,0 +1,79 @@
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Admin;
+
+public sealed partial class AdminClient
+{
+    /// <inheritdoc />
+    public async ValueTask CreatePartitionsAsync(
+        IReadOnlyDictionary<string, NewPartitions> newPartitions,
+        CreatePartitionsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(newPartitions);
+        cancellationToken.ThrowIfCancellationRequested();
+        var timeoutMs = options?.TimeoutMs ?? 30000;
+        ArgumentOutOfRangeException.ThrowIfNegative(timeoutMs);
+
+        // Snapshot caller-owned collections before any await so retries preserve replica order.
+        var topics = new List<CreatePartitionsTopic>(newPartitions.Count);
+        foreach (var pair in newPartitions)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(pair.Key);
+            ArgumentNullException.ThrowIfNull(pair.Value);
+            ArgumentOutOfRangeException.ThrowIfLessThan(pair.Value.TotalCount, 1);
+            topics.Add(new CreatePartitionsTopic
+            {
+                Name = pair.Key,
+                Count = pair.Value.TotalCount,
+                Assignments = CopyPartitionAssignments(pair.Value)
+            });
+        }
+
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        await CreatePartitionsCoreAsync(topics, timeoutMs, options?.ValidateOnly ?? false, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static CreatePartitionsAssignment[]? CopyPartitionAssignments(NewPartitions partitions)
+    {
+        var assignments = partitions.ReplicaAssignments;
+        if (assignments is null)
+            return null;
+
+        if (assignments.Count == 0 || assignments.Count >= partitions.TotalCount)
+            throw new ArgumentException("Assignments must describe only the additional partitions of an existing topic.", nameof(partitions));
+
+        var result = new CreatePartitionsAssignment[assignments.Count];
+        var replicationFactor = 0;
+        for (var index = 0; index < assignments.Count; index++)
+        {
+            var replicas = assignments[index];
+            if (replicas is null || replicas.Count == 0 || (index > 0 && replicas.Count != replicationFactor))
+                throw new ArgumentException("Each assignment must contain the same nonzero number of replicas.", nameof(partitions));
+
+            replicationFactor = replicas.Count;
+            var brokerIds = new int[replicas.Count];
+            var seen = new HashSet<int>();
+            for (var replica = 0; replica < replicas.Count; replica++)
+            {
+                var brokerId = replicas[replica];
+                if (brokerId < 0 || !seen.Add(brokerId))
+                    throw new ArgumentException("Replica broker IDs must be nonnegative and unique within a partition.", nameof(partitions));
+                brokerIds[replica] = brokerId;
+            }
+            result[index] = new CreatePartitionsAssignment { BrokerIds = brokerIds };
+        }
+        return result;
+    }
+
+    private static CreatePartitionsTopic GetRequestedPartitionExpansion(IReadOnlyList<CreatePartitionsTopic> topics, string name)
+    {
+        // Only used while resolving an ambiguous admin mutation, never on a message path.
+        for (var index = 0; index < topics.Count; index++)
+        {
+            if (topics[index].Name == name)
+                return topics[index];
+        }
+        throw new InvalidOperationException($"Unexpected CreatePartitions response topic '{name}'.");
+    }
+}

--- a/src/Dekaf/Admin/AdminClient.PartitionExpansion.cs
+++ b/src/Dekaf/Admin/AdminClient.PartitionExpansion.cs
@@ -16,6 +16,14 @@ public sealed partial class AdminClient
         ArgumentOutOfRangeException.ThrowIfNegative(timeoutMs);
 
         // Snapshot caller-owned collections before any await so retries preserve replica order.
+        var topics = BuildPartitionExpansionTopics(newPartitions);
+
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        await CreatePartitionsCoreAsync(topics, timeoutMs, options?.ValidateOnly ?? false, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static List<CreatePartitionsTopic> BuildPartitionExpansionTopics(IReadOnlyDictionary<string, NewPartitions> newPartitions)
+    {
         var topics = new List<CreatePartitionsTopic>(newPartitions.Count);
         foreach (var pair in newPartitions)
         {
@@ -30,11 +38,10 @@ public sealed partial class AdminClient
             });
         }
 
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        await CreatePartitionsCoreAsync(topics, timeoutMs, options?.ValidateOnly ?? false, cancellationToken).ConfigureAwait(false);
+        return topics;
     }
 
-    internal static CreatePartitionsAssignment[]? CopyPartitionAssignments(NewPartitions partitions, string parameterName)
+    private static CreatePartitionsAssignment[]? CopyPartitionAssignments(NewPartitions partitions, string parameterName)
     {
         var assignments = partitions.ReplicaAssignments;
         if (assignments is null)

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -2392,6 +2392,8 @@ public sealed partial class AdminClient :
                             GetRequestedPartitionExpansion(topics, topicResult.Name),
                             cancellationToken).ConfigureAwait(false))
                     {
+                        // Retain metadata-confirmed success if a later sibling forces another retry.
+                        topics = ExcludeConfirmedPartitionExpansions(topics, response.Results, topicResult.Name);
                         continue;
                     }
 

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -28,6 +28,7 @@ public sealed partial class AdminClient :
     IStreamsGroupManagementAdminClient,
     ITransactionRemediationAdminClient,
     IShareGroupDeletionAdminClient,
+    IPartitionExpansionAdminClient,
     IKafkaClientInstanceIdentity,
     IKafkaClientStatusProvider
 {
@@ -490,18 +491,39 @@ public sealed partial class AdminClient :
             $"Topic(s) {string.Join(", ", topicNames)} did not have all partition leaders elected after {leaderWaitRetries} attempts");
     }
 
-    private async ValueTask<bool> TopicHasAtLeastPartitionCountAsync(
-        string topicName,
-        int partitionCount,
+    private async ValueTask<bool> TopicMatchesPartitionExpansionAsync(
+        CreatePartitionsTopic requested,
         CancellationToken cancellationToken)
     {
         await _metadataManager.RefreshMetadataAsync(
-            [topicName],
+            [requested.Name],
             forceRefresh: true,
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        var topic = _metadataManager.Metadata.GetTopic(topicName);
-        return topic is { ErrorCode: Protocol.ErrorCode.None } && topic.PartitionCount >= partitionCount;
+        var topic = _metadataManager.Metadata.GetTopic(requested.Name);
+        if (topic is not { ErrorCode: Protocol.ErrorCode.None } || topic.PartitionCount < requested.Count)
+            return false;
+        if (requested.Assignments is not { } assignments)
+            return true;
+
+        var firstNewPartition = requested.Count - assignments.Count;
+        var matched = 0;
+        foreach (var partition in topic.Partitions)
+        {
+            var assignmentIndex = partition.PartitionIndex - firstNewPartition;
+            if (assignmentIndex < 0 || assignmentIndex >= assignments.Count)
+                continue;
+            var expected = assignments[assignmentIndex].BrokerIds;
+            if (partition.ErrorCode != Protocol.ErrorCode.None || partition.ReplicaNodes.Count != expected.Count)
+                return false;
+            for (var index = 0; index < expected.Count; index++)
+            {
+                if (partition.ReplicaNodes[index] != expected[index])
+                    return false;
+            }
+            matched++;
+        }
+        return matched == assignments.Count;
     }
 
     public async ValueTask DeleteTopicsAsync(
@@ -2316,9 +2338,18 @@ public sealed partial class AdminClient :
             Name = kvp.Key,
             Count = kvp.Value
         }).ToList();
+        await CreatePartitionsCoreAsync(topics, 30000, false, cancellationToken).ConfigureAwait(false);
+    }
+
+    private ValueTask CreatePartitionsCoreAsync(
+        IReadOnlyList<CreatePartitionsTopic> topics,
+        int timeoutMs,
+        bool validateOnly,
+        CancellationToken cancellationToken)
+    {
         var createPartitionsMayHaveApplied = false;
 
-        await WithRetryAsync(async () =>
+        return WithRetryAsync(async () =>
         {
             var isRetryAttempt = createPartitionsMayHaveApplied;
             using var controllerLease = await LeaseControllerAsync(Protocol.ApiKey.CreatePartitions, cancellationToken).ConfigureAwait(false);
@@ -2326,7 +2357,9 @@ public sealed partial class AdminClient :
 
             var request = new CreatePartitionsRequest
             {
-                Topics = topics
+                Topics = topics,
+                TimeoutMs = timeoutMs,
+                ValidateOnly = validateOnly
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
@@ -2345,7 +2378,7 @@ public sealed partial class AdminClient :
             }
             catch
             {
-                createPartitionsMayHaveApplied = true;
+                createPartitionsMayHaveApplied = !validateOnly;
                 throw;
             }
 
@@ -2355,9 +2388,8 @@ public sealed partial class AdminClient :
                 {
                     if (isRetryAttempt &&
                         topicResult.ErrorCode == Protocol.ErrorCode.InvalidPartitions &&
-                        await TopicHasAtLeastPartitionCountAsync(
-                            topicResult.Name,
-                            newPartitionCounts[topicResult.Name],
+                        await TopicMatchesPartitionExpansionAsync(
+                            GetRequestedPartitionExpansion(topics, topicResult.Name),
                             cancellationToken).ConfigureAwait(false))
                     {
                         continue;
@@ -2367,7 +2399,7 @@ public sealed partial class AdminClient :
                         $"CreatePartitions failed for topic '{topicResult.Name}': {topicResult.ErrorMessage ?? topicResult.ErrorCode.ToString()}");
                 }
             }
-        }, cancellationToken).ConfigureAwait(false);
+        }, cancellationToken);
     }
 
     public async ValueTask AlterPartitionReassignmentsAsync(

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -2395,6 +2395,9 @@ public sealed partial class AdminClient :
                         continue;
                     }
 
+                    // A sibling topic can already have succeeded, even when this result appears first.
+                    // Preserve every confirmed success before retrying the remaining request.
+                    topics = ExcludeConfirmedPartitionExpansions(topics, response.Results);
                     throw new KafkaException(topicResult.ErrorCode,
                         $"CreatePartitions failed for topic '{topicResult.Name}': {topicResult.ErrorMessage ?? topicResult.ErrorCode.ToString()}");
                 }

--- a/src/Dekaf/Admin/IPartitionExpansionAdminClient.cs
+++ b/src/Dekaf/Admin/IPartitionExpansionAdminClient.cs
@@ -1,0 +1,65 @@
+namespace Dekaf.Admin;
+
+/// <summary>
+/// Optional admin capability for validating partition expansion and assigning new replicas.
+/// </summary>
+public interface IPartitionExpansionAdminClient
+{
+    /// <summary>
+    /// Increases topics to their final partition counts, or validates the requested expansion.
+    /// </summary>
+    ValueTask CreatePartitionsAsync(
+        IReadOnlyDictionary<string, NewPartitions> newPartitions,
+        CreatePartitionsOptions? options = null,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Partition expansion operations for <see cref="IAdminClient"/>.
+/// </summary>
+public static class AdminClientPartitionExpansionExtensions
+{
+    /// <summary>
+    /// Increases topics to their final partition counts. Replica assignments describe only
+    /// additional partitions, in partition order; existing assignments remain unchanged.
+    /// </summary>
+    /// <exception cref="NotSupportedException">The client does not implement the optional capability.</exception>
+    public static ValueTask CreatePartitionsAsync(
+        this IAdminClient adminClient,
+        IReadOnlyDictionary<string, NewPartitions> newPartitions,
+        CreatePartitionsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(adminClient);
+        return adminClient is IPartitionExpansionAdminClient expansionClient
+            ? expansionClient.CreatePartitionsAsync(newPartitions, options, cancellationToken)
+            : throw new NotSupportedException($"Admin client type '{adminClient.GetType().FullName}' does not support typed partition expansion.");
+    }
+}
+
+/// <summary>
+/// Describes the final partition count and assignments of newly added partitions.
+/// </summary>
+public sealed class NewPartitions
+{
+    /// <summary>The total partition count after expansion, not the number to add.</summary>
+    public required int TotalCount { get; init; }
+
+    /// <summary>
+    /// Replica broker IDs for each additional partition, or null for controller assignment.
+    /// The outer count must equal TotalCount minus the current partition count; each inner
+    /// list must match the topic replication factor. The first broker is the preferred replica.
+    /// The controller validates these constraints against current cluster state.
+    /// </summary>
+    public IReadOnlyList<IReadOnlyList<int>>? ReplicaAssignments { get; init; }
+}
+
+/// <summary>Options for partition expansion.</summary>
+public sealed class CreatePartitionsOptions
+{
+    /// <summary>Broker operation timeout in milliseconds.</summary>
+    public int TimeoutMs { get; init; } = 30000;
+
+    /// <summary>Validate the expansion without changing partitions or replica assignments.</summary>
+    public bool ValidateOnly { get; init; }
+}

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -608,3 +608,20 @@ Dekaf.Admin.DescribeFeaturesOptions.TimeoutMs.init -> void
 Dekaf.Admin.INodeFeatureAdminClient
 Dekaf.Admin.INodeFeatureAdminClient.DescribeFeaturesAsync(Dekaf.Admin.DescribeFeaturesOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.FeatureMetadata!>
 static Dekaf.Admin.AdminClientNodeFeatureExtensions.DescribeFeaturesAsync(this Dekaf.Admin.IAdminClient! adminClient, Dekaf.Admin.DescribeFeaturesOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.FeatureMetadata!>
+Dekaf.Admin.AdminClient.CreatePartitionsAsync(System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.NewPartitions!>! newPartitions, Dekaf.Admin.CreatePartitionsOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Dekaf.Admin.AdminClientPartitionExpansionExtensions
+Dekaf.Admin.CreatePartitionsOptions
+Dekaf.Admin.CreatePartitionsOptions.CreatePartitionsOptions() -> void
+Dekaf.Admin.CreatePartitionsOptions.TimeoutMs.get -> int
+Dekaf.Admin.CreatePartitionsOptions.TimeoutMs.init -> void
+Dekaf.Admin.CreatePartitionsOptions.ValidateOnly.get -> bool
+Dekaf.Admin.CreatePartitionsOptions.ValidateOnly.init -> void
+Dekaf.Admin.IPartitionExpansionAdminClient
+Dekaf.Admin.IPartitionExpansionAdminClient.CreatePartitionsAsync(System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.NewPartitions!>! newPartitions, Dekaf.Admin.CreatePartitionsOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Dekaf.Admin.NewPartitions
+Dekaf.Admin.NewPartitions.NewPartitions() -> void
+Dekaf.Admin.NewPartitions.ReplicaAssignments.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.IReadOnlyList<int>!>?
+Dekaf.Admin.NewPartitions.ReplicaAssignments.init -> void
+Dekaf.Admin.NewPartitions.TotalCount.get -> int
+Dekaf.Admin.NewPartitions.TotalCount.init -> void
+static Dekaf.Admin.AdminClientPartitionExpansionExtensions.CreatePartitionsAsync(this Dekaf.Admin.IAdminClient! adminClient, System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.NewPartitions!>! newPartitions, Dekaf.Admin.CreatePartitionsOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -608,3 +608,20 @@ Dekaf.Admin.DescribeFeaturesOptions.TimeoutMs.init -> void
 Dekaf.Admin.INodeFeatureAdminClient
 Dekaf.Admin.INodeFeatureAdminClient.DescribeFeaturesAsync(Dekaf.Admin.DescribeFeaturesOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.FeatureMetadata!>
 static Dekaf.Admin.AdminClientNodeFeatureExtensions.DescribeFeaturesAsync(this Dekaf.Admin.IAdminClient! adminClient, Dekaf.Admin.DescribeFeaturesOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.FeatureMetadata!>
+Dekaf.Admin.AdminClient.CreatePartitionsAsync(System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.NewPartitions!>! newPartitions, Dekaf.Admin.CreatePartitionsOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Dekaf.Admin.AdminClientPartitionExpansionExtensions
+Dekaf.Admin.CreatePartitionsOptions
+Dekaf.Admin.CreatePartitionsOptions.CreatePartitionsOptions() -> void
+Dekaf.Admin.CreatePartitionsOptions.TimeoutMs.get -> int
+Dekaf.Admin.CreatePartitionsOptions.TimeoutMs.init -> void
+Dekaf.Admin.CreatePartitionsOptions.ValidateOnly.get -> bool
+Dekaf.Admin.CreatePartitionsOptions.ValidateOnly.init -> void
+Dekaf.Admin.IPartitionExpansionAdminClient
+Dekaf.Admin.IPartitionExpansionAdminClient.CreatePartitionsAsync(System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.NewPartitions!>! newPartitions, Dekaf.Admin.CreatePartitionsOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Dekaf.Admin.NewPartitions
+Dekaf.Admin.NewPartitions.NewPartitions() -> void
+Dekaf.Admin.NewPartitions.ReplicaAssignments.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.IReadOnlyList<int>!>?
+Dekaf.Admin.NewPartitions.ReplicaAssignments.init -> void
+Dekaf.Admin.NewPartitions.TotalCount.get -> int
+Dekaf.Admin.NewPartitions.TotalCount.init -> void
+static Dekaf.Admin.AdminClientPartitionExpansionExtensions.CreatePartitionsAsync(this Dekaf.Admin.IAdminClient! adminClient, System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.NewPartitions!>! newPartitions, Dekaf.Admin.CreatePartitionsOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask

--- a/tests/Dekaf.Tests.Integration/AdminPartitionExpansionTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdminPartitionExpansionTests.cs
@@ -26,7 +26,11 @@ public class AdminPartitionExpansionTests(KafkaTestContainer kafka) : KafkaInteg
         await Assert.That(validated.Partitions[0].ReplicaNodes[0]).IsEqualTo(broker);
 
         await admin.CreatePartitionsAsync(expansion);
-        var applied = (await admin.DescribeTopicsAsync([topic]))[topic];
+        // Controller acknowledgement can precede propagation to broker metadata.
+        var applied = await WaitForConditionAsync(
+            async () => (await admin.DescribeTopicsAsync([topic]))[topic],
+            description => description.Partitions.Count == 3,
+            description: "expanded partition metadata");
         await Assert.That(applied.Partitions.Count).IsEqualTo(3);
         foreach (var partition in applied.Partitions)
         {

--- a/tests/Dekaf.Tests.Integration/AdminPartitionExpansionTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdminPartitionExpansionTests.cs
@@ -1,5 +1,6 @@
 using Dekaf.Admin;
 using Dekaf.Errors;
+using Dekaf.Protocol;
 
 namespace Dekaf.Tests.Integration;
 
@@ -41,9 +42,11 @@ public class AdminPartitionExpansionTests(KafkaTestContainer kafka) : KafkaInteg
         await using var admin = new AdminClientBuilder().WithBootstrapServers(KafkaContainer.BootstrapServers).Build();
         var before = (await admin.DescribeTopicsAsync([topic]))[topic];
         var broker = before.Partitions[0].ReplicaNodes[0];
-        await Assert.ThrowsAsync<KafkaException>(async () => await admin.CreatePartitionsAsync(
+        // The assignment shape is valid locally; only the controller knows how many partitions already exist.
+        var error = await Assert.ThrowsAsync<KafkaException>(async () => await admin.CreatePartitionsAsync(
             new Dictionary<string, NewPartitions> { [topic] = new() { TotalCount = 3, ReplicaAssignments = [[broker]] } },
             new CreatePartitionsOptions { ValidateOnly = true }));
+        await Assert.That(error!.ErrorCode).IsEqualTo(ErrorCode.InvalidReplicaAssignment);
         await Assert.That((await admin.DescribeTopicsAsync([topic]))[topic].Partitions.Count).IsEqualTo(1);
     }
 }

--- a/tests/Dekaf.Tests.Integration/AdminPartitionExpansionTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdminPartitionExpansionTests.cs
@@ -1,0 +1,49 @@
+using Dekaf.Admin;
+using Dekaf.Errors;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Admin")]
+public class AdminPartitionExpansionTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task ValidateThenApply_PreservesExistingPartitions(bool explicitAssignments)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        await using var admin = new AdminClientBuilder().WithBootstrapServers(KafkaContainer.BootstrapServers).Build();
+        var before = (await admin.DescribeTopicsAsync([topic]))[topic];
+        var broker = before.Partitions[0].ReplicaNodes[0];
+        var expansion = new Dictionary<string, NewPartitions>
+        {
+            [topic] = new() { TotalCount = 3, ReplicaAssignments = explicitAssignments ? [[broker], [broker]] : null }
+        };
+        await admin.CreatePartitionsAsync(expansion, new CreatePartitionsOptions { ValidateOnly = true });
+        var validated = (await admin.DescribeTopicsAsync([topic]))[topic];
+        await Assert.That(validated.Partitions.Count).IsEqualTo(1);
+        await Assert.That(validated.Partitions[0].ReplicaNodes[0]).IsEqualTo(broker);
+
+        await admin.CreatePartitionsAsync(expansion);
+        var applied = (await admin.DescribeTopicsAsync([topic]))[topic];
+        await Assert.That(applied.Partitions.Count).IsEqualTo(3);
+        foreach (var partition in applied.Partitions)
+        {
+            await Assert.That(partition.ReplicaNodes.Count).IsEqualTo(1);
+            await Assert.That(partition.ReplicaNodes[0]).IsEqualTo(broker);
+        }
+    }
+
+    [Test]
+    public async Task IncorrectAdditionalAssignmentCount_IsRejectedByController()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        await using var admin = new AdminClientBuilder().WithBootstrapServers(KafkaContainer.BootstrapServers).Build();
+        var before = (await admin.DescribeTopicsAsync([topic]))[topic];
+        var broker = before.Partitions[0].ReplicaNodes[0];
+        await Assert.ThrowsAsync<KafkaException>(async () => await admin.CreatePartitionsAsync(
+            new Dictionary<string, NewPartitions> { [topic] = new() { TotalCount = 3, ReplicaAssignments = [[broker]] } },
+            new CreatePartitionsOptions { ValidateOnly = true }));
+        await Assert.That((await admin.DescribeTopicsAsync([topic]))[topic].Partitions.Count).IsEqualTo(1);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientIdempotentRetryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientIdempotentRetryTests.cs
@@ -421,7 +421,7 @@ public sealed class AdminClientIdempotentRetryTests
         ]
     };
 
-    private static (AdminClient Admin, IKafkaConnection Connection) CreateAdminWithMockConnection(
+    internal static (AdminClient Admin, IKafkaConnection Connection) CreateAdminWithMockConnection(
         params ApiKey[] extraApiKeys)
     {
         var connection = Substitute.For<IKafkaConnection>();

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientPartitionExpansionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientPartitionExpansionTests.cs
@@ -10,6 +10,45 @@ namespace Dekaf.Tests.Unit.Admin;
 public sealed class AdminClientPartitionExpansionTests
 {
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task AmbiguousPartialSuccess_RetriesOnlyUnconfirmedTopics(bool typed)
+    {
+        var (admin, connection) = AdminClientIdempotentRetryTests.CreateAdminWithMockConnection(ApiKey.CreatePartitions);
+        await using var client = admin;
+        var calls = 0;
+        connection.SendAsync<CreatePartitionsRequest, CreatePartitionsResponse>(Arg.Any<CreatePartitionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var request = call.Arg<CreatePartitionsRequest>();
+                if (++calls == 1)
+                    throw new KafkaException(ErrorCode.RequestTimedOut, "ambiguous timeout");
+                if (calls == 2)
+                    return ValueTask.FromResult(new CreatePartitionsResponse
+                    {
+                        Results =
+                        [
+                            new() { Name = "retry-topic", ErrorCode = ErrorCode.InvalidPartitions },
+                            new() { Name = "still-pending", ErrorCode = ErrorCode.NotController }
+                        ]
+                    });
+                if (request.Topics.Count != 1 || request.Topics[0].Name != "still-pending")
+                    throw new InvalidOperationException("A metadata-confirmed topic was sent again.");
+                return ValueTask.FromResult(new CreatePartitionsResponse { Results = [new() { Name = "still-pending" }] });
+            });
+
+        if (typed)
+            await admin.CreatePartitionsAsync(new Dictionary<string, NewPartitions>
+            {
+                ["retry-topic"] = new() { TotalCount = 3 }, ["still-pending"] = new() { TotalCount = 3 }
+            });
+        else
+            await admin.CreatePartitionsAsync(new Dictionary<string, int> { ["retry-topic"] = 3, ["still-pending"] = 3 });
+
+        await Assert.That(calls).IsEqualTo(3);
+    }
+
+    [Test]
     [Arguments(false, false)]
     [Arguments(false, true)]
     [Arguments(true, false)]

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientPartitionExpansionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientPartitionExpansionTests.cs
@@ -1,0 +1,207 @@
+using System.Buffers;
+using Dekaf.Admin;
+using Dekaf.Errors;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+public sealed class AdminClientPartitionExpansionTests
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task CreatePartitions_PropagatesOptionsAndOrderedAssignments(bool explicitAssignments)
+    {
+        var (admin, connection) = AdminClientIdempotentRetryTests.CreateAdminWithMockConnection(ApiKey.CreatePartitions);
+        await using var client = admin;
+        CreatePartitionsRequest? captured = null;
+        connection.SendAsync<CreatePartitionsRequest, CreatePartitionsResponse>(Arg.Any<CreatePartitionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                captured = call.Arg<CreatePartitionsRequest>();
+                return ValueTask.FromResult(new CreatePartitionsResponse { Results = [] });
+            });
+
+        IAdminClient capability = admin;
+        await capability.CreatePartitionsAsync(new Dictionary<string, NewPartitions>
+        {
+            ["retry-topic"] = new() { TotalCount = 5, ReplicaAssignments = explicitAssignments ? [[3, 1], [1, 3]] : null }
+        }, new CreatePartitionsOptions { ValidateOnly = true, TimeoutMs = 1234 });
+
+        await Assert.That(captured!.ValidateOnly).IsTrue();
+        await Assert.That(captured.TimeoutMs).IsEqualTo(1234);
+        await Assert.That(captured.Topics[0].Count).IsEqualTo(5);
+        if (explicitAssignments)
+        {
+            await Assert.That(captured.Topics[0].Assignments![0].BrokerIds[1]).IsEqualTo(1);
+            await Assert.That(captured.Topics[0].Assignments![0].BrokerIds[0]).IsEqualTo(3);
+        }
+        else
+            await Assert.That(captured.Topics[0].Assignments).IsNull();
+
+        VerifyWire(captured, explicitAssignments);
+    }
+
+    private static void VerifyWire(CreatePartitionsRequest request, bool explicitAssignments)
+    {
+        foreach (short version in new short[] { 2, 3 })
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            var writer = new KafkaProtocolWriter(buffer);
+            request.Write(ref writer, version);
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            if (reader.ReadUnsignedVarInt() != 2 || reader.ReadCompactString() != "retry-topic" || reader.ReadInt32() != 5)
+                throw new InvalidOperationException("Incorrect topic encoding");
+            if (reader.ReadUnsignedVarInt() != (explicitAssignments ? 3u : 0u))
+                throw new InvalidOperationException("Incorrect assignment count");
+            if (explicitAssignments)
+            {
+                foreach (var expected in new[] { new[] { 3, 1 }, new[] { 1, 3 } })
+                {
+                    if (reader.ReadUnsignedVarInt() != 3 || reader.ReadInt32() != expected[0] || reader.ReadInt32() != expected[1] || reader.ReadUnsignedVarInt() != 0)
+                        throw new InvalidOperationException("Incorrect replica order");
+                }
+            }
+            if (reader.ReadUnsignedVarInt() != 0 || reader.ReadInt32() != 1234 || !reader.ReadBoolean() || reader.ReadUnsignedVarInt() != 0 || reader.Remaining != 0)
+                throw new InvalidOperationException("Incorrect options encoding");
+        }
+    }
+
+    [Test]
+    public async Task ValidateOnly_AmbiguousRetry_DoesNotSuppressInvalidPartitions()
+    {
+        var (admin, connection) = AdminClientIdempotentRetryTests.CreateAdminWithMockConnection(ApiKey.CreatePartitions);
+        await using var client = admin;
+        var calls = 0;
+        connection.SendAsync<CreatePartitionsRequest, CreatePartitionsResponse>(Arg.Any<CreatePartitionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (++calls == 1)
+                    throw new KafkaException(ErrorCode.RequestTimedOut, "ambiguous timeout");
+                return ValueTask.FromResult(new CreatePartitionsResponse
+                {
+                    Results = [new() { Name = "retry-topic", ErrorCode = ErrorCode.InvalidPartitions }]
+                });
+            });
+        var error = await Assert.ThrowsAsync<KafkaException>(async () => await admin.CreatePartitionsAsync(
+            new Dictionary<string, NewPartitions> { ["retry-topic"] = new() { TotalCount = 3 } },
+            new CreatePartitionsOptions { ValidateOnly = true }));
+        await Assert.That(error!.ErrorCode).IsEqualTo(ErrorCode.InvalidPartitions);
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(2)]
+    [Arguments(3)]
+    [Arguments(4)]
+    [Arguments(5)]
+    [Arguments(6)]
+    public async Task InvalidShape_IsRejectedBeforeSending(int shape)
+    {
+        var (admin, connection) = AdminClientIdempotentRetryTests.CreateAdminWithMockConnection(ApiKey.CreatePartitions);
+        await using var client = admin;
+        IReadOnlyList<IReadOnlyList<int>> assignments = shape switch
+        {
+            0 => [], 1 => [[]], 2 => [[1, 1]], 3 => [[-1]],
+            4 => [[1], [1, 2]], 5 => [null!], _ => [[1], [1], [1], [1], [1]]
+        };
+        await Assert.ThrowsAsync<ArgumentException>(async () => await admin.CreatePartitionsAsync(
+            new Dictionary<string, NewPartitions> { ["retry-topic"] = new() { TotalCount = 5, ReplicaAssignments = assignments } }));
+        await connection.DidNotReceive().SendAsync<CreatePartitionsRequest, CreatePartitionsResponse>(Arg.Any<CreatePartitionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task ExplicitAssignments_AmbiguousRetry_RequiresMatchingReplicas(bool matches)
+    {
+        var (admin, connection) = AdminClientIdempotentRetryTests.CreateAdminWithMockConnection(ApiKey.CreatePartitions);
+        await using var client = admin;
+        var calls = 0;
+        var replicas = new[] { matches ? 1 : 2 };
+        connection.SendAsync<CreatePartitionsRequest, CreatePartitionsResponse>(Arg.Any<CreatePartitionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var request = call.Arg<CreatePartitionsRequest>();
+                if (request.Topics[0].Assignments![0].BrokerIds[0] != (matches ? 1 : 2))
+                    throw new InvalidOperationException("Retry lost original replica assignment");
+                replicas[0] = 99;
+                if (++calls == 1)
+                    throw new KafkaException(ErrorCode.RequestTimedOut, "ambiguous timeout");
+                return ValueTask.FromResult(new CreatePartitionsResponse
+                {
+                    Results = [new() { Name = "retry-topic", ErrorCode = ErrorCode.InvalidPartitions }]
+                });
+            });
+        var expansion = new Dictionary<string, NewPartitions>
+        {
+            ["retry-topic"] = new() { TotalCount = 3, ReplicaAssignments = [replicas] }
+        };
+        if (matches)
+            await admin.CreatePartitionsAsync(expansion);
+        else
+        {
+            var error = await Assert.ThrowsAsync<KafkaException>(async () => await admin.CreatePartitionsAsync(expansion));
+            await Assert.That(error!.ErrorCode).IsEqualTo(ErrorCode.InvalidPartitions);
+        }
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ValidateOnly_RetriableResponse_PreservesOptions()
+    {
+        var (admin, connection) = AdminClientIdempotentRetryTests.CreateAdminWithMockConnection(ApiKey.CreatePartitions);
+        await using var client = admin;
+        var calls = 0;
+        connection.SendAsync<CreatePartitionsRequest, CreatePartitionsResponse>(Arg.Any<CreatePartitionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var request = call.Arg<CreatePartitionsRequest>();
+                if (!request.ValidateOnly || request.TimeoutMs != 2000)
+                    throw new InvalidOperationException("Retry changed validation options");
+                return ValueTask.FromResult(new CreatePartitionsResponse
+                {
+                    Results = [new() { Name = "retry-topic", ErrorCode = ++calls == 1 ? ErrorCode.NotController : ErrorCode.None }]
+                });
+            });
+        await admin.CreatePartitionsAsync(new Dictionary<string, NewPartitions> { ["retry-topic"] = new() { TotalCount = 5 } },
+            new CreatePartitionsOptions { ValidateOnly = true, TimeoutMs = 2000 });
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task CancelledOperation_DoesNotSend()
+    {
+        var (admin, connection) = AdminClientIdempotentRetryTests.CreateAdminWithMockConnection(ApiKey.CreatePartitions);
+        await using var client = admin;
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await admin.CreatePartitionsAsync(
+            new Dictionary<string, NewPartitions> { ["retry-topic"] = new() { TotalCount = 5 } },
+            cancellationToken: new CancellationToken(true)));
+        await connection.DidNotReceive().SendAsync<CreatePartitionsRequest, CreatePartitionsResponse>(Arg.Any<CreatePartitionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    [Arguments(0, 30000)]
+    [Arguments(-1, 30000)]
+    [Arguments(5, -1)]
+    public async Task InvalidCountOrTimeout_IsRejectedBeforeSending(int count, int timeoutMs)
+    {
+        var (admin, connection) = AdminClientIdempotentRetryTests.CreateAdminWithMockConnection(ApiKey.CreatePartitions);
+        await using var client = admin;
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await admin.CreatePartitionsAsync(
+            new Dictionary<string, NewPartitions> { ["retry-topic"] = new() { TotalCount = count } },
+            new CreatePartitionsOptions { TimeoutMs = timeoutMs }));
+        await connection.DidNotReceive().SendAsync<CreatePartitionsRequest, CreatePartitionsResponse>(Arg.Any<CreatePartitionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task UnsupportedCustomClient_ThrowsClearly()
+    {
+        var custom = Substitute.For<IAdminClient>();
+        await Assert.ThrowsAsync<NotSupportedException>(async () => await custom.CreatePartitionsAsync(new Dictionary<string, NewPartitions>()));
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientPartitionExpansionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientPartitionExpansionTests.cs
@@ -10,6 +10,42 @@ namespace Dekaf.Tests.Unit.Admin;
 public sealed class AdminClientPartitionExpansionTests
 {
     [Test]
+    [Arguments(false, false)]
+    [Arguments(false, true)]
+    [Arguments(true, false)]
+    [Arguments(true, true)]
+    public async Task PartialSuccess_RetriesOnlyUnconfirmedTopics(bool successFirst, bool typed)
+    {
+        var (admin, connection) = AdminClientIdempotentRetryTests.CreateAdminWithMockConnection(ApiKey.CreatePartitions);
+        await using var client = admin;
+        var calls = 0;
+        connection.SendAsync<CreatePartitionsRequest, CreatePartitionsResponse>(Arg.Any<CreatePartitionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var request = call.Arg<CreatePartitionsRequest>();
+                if (++calls == 1)
+                {
+                    var success = new CreatePartitionsResponseResult { Name = "applied", ErrorCode = ErrorCode.None };
+                    var retry = new CreatePartitionsResponseResult { Name = "retry-topic", ErrorCode = ErrorCode.NotController };
+                    return ValueTask.FromResult(new CreatePartitionsResponse { Results = successFirst ? [success, retry] : [retry, success] });
+                }
+                if (request.Topics.Count != 1 || request.Topics[0].Name != "retry-topic")
+                    throw new InvalidOperationException("A confirmed topic was sent again.");
+                return ValueTask.FromResult(new CreatePartitionsResponse { Results = [new() { Name = "retry-topic" }] });
+            });
+
+        if (typed)
+            await admin.CreatePartitionsAsync(new Dictionary<string, NewPartitions>
+            {
+                ["applied"] = new() { TotalCount = 3 }, ["retry-topic"] = new() { TotalCount = 3 }
+            });
+        else
+            await admin.CreatePartitionsAsync(new Dictionary<string, int> { ["applied"] = 3, ["retry-topic"] = 3 });
+
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
     [Arguments(false)]
     [Arguments(true)]
     public async Task CreatePartitions_PropagatesOptionsAndOrderedAssignments(bool explicitAssignments)
@@ -109,8 +145,9 @@ public sealed class AdminClientPartitionExpansionTests
             0 => [], 1 => [[]], 2 => [[1, 1]], 3 => [[-1]],
             4 => [[1], [1, 2]], 5 => [null!], _ => [[1], [1], [1], [1], [1]]
         };
-        await Assert.ThrowsAsync<ArgumentException>(async () => await admin.CreatePartitionsAsync(
+        var error = await Assert.ThrowsAsync<ArgumentException>(async () => await admin.CreatePartitionsAsync(
             new Dictionary<string, NewPartitions> { ["retry-topic"] = new() { TotalCount = 5, ReplicaAssignments = assignments } }));
+        await Assert.That(error!.ParamName).IsEqualTo("newPartitions");
         await connection.DidNotReceive().SendAsync<CreatePartitionsRequest, CreatePartitionsResponse>(Arg.Any<CreatePartitionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>());
     }
 

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientPartitionExpansionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientPartitionExpansionTests.cs
@@ -94,15 +94,18 @@ public sealed class AdminClientPartitionExpansionTests
                 throw new InvalidOperationException("Incorrect assignment count");
             if (explicitAssignments)
             {
-                foreach (var expected in new[] { new[] { 3, 1 }, new[] { 1, 3 } })
-                {
-                    if (reader.ReadUnsignedVarInt() != 3 || reader.ReadInt32() != expected[0] || reader.ReadInt32() != expected[1] || reader.ReadUnsignedVarInt() != 0)
-                        throw new InvalidOperationException("Incorrect replica order");
-                }
+                VerifyReplicaAssignment(ref reader, 3, 1);
+                VerifyReplicaAssignment(ref reader, 1, 3);
             }
             if (reader.ReadUnsignedVarInt() != 0 || reader.ReadInt32() != 1234 || !reader.ReadBoolean() || reader.ReadUnsignedVarInt() != 0 || reader.Remaining != 0)
                 throw new InvalidOperationException("Incorrect options encoding");
         }
+    }
+
+    private static void VerifyReplicaAssignment(ref KafkaProtocolReader reader, int firstBroker, int secondBroker)
+    {
+        if (reader.ReadUnsignedVarInt() != 3 || reader.ReadInt32() != firstBroker || reader.ReadInt32() != secondBroker || reader.ReadUnsignedVarInt() != 0)
+            throw new InvalidOperationException("Incorrect replica order");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryPartitionExpansionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryPartitionExpansionTests.cs
@@ -1,0 +1,153 @@
+using Dekaf.Admin;
+using Dekaf.Errors;
+using Dekaf.Protocol;
+using Dekaf.Testing;
+
+namespace Dekaf.Tests.Unit.Testing;
+
+public sealed class InMemoryPartitionExpansionTests
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task TypedExpansion_ValidatesThenExpands(bool explicitAssignments)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        await using var admin = new InMemoryAdminClient(cluster);
+        IAdminClient client = admin;
+        var expansion = new Dictionary<string, NewPartitions>
+        {
+            ["orders"] = new() { TotalCount = 3, ReplicaAssignments = explicitAssignments ? [[0], [0]] : null }
+        };
+        await client.CreatePartitionsAsync(expansion, new CreatePartitionsOptions { ValidateOnly = true });
+        await Assert.That(cluster.DescribeTopics(["orders"])["orders"].Partitions.Count).IsEqualTo(1);
+        await client.CreatePartitionsAsync(expansion);
+        var partitions = cluster.DescribeTopics(["orders"])["orders"].Partitions;
+        await Assert.That(partitions.Count).IsEqualTo(3);
+        await Assert.That(partitions[2].ReplicaNodes).Count().IsEqualTo(1);
+        await Assert.That(partitions[2].ReplicaNodes[0]).IsEqualTo(0);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task InvalidClusterAssignment_DoesNotMutate(bool validateOnly)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        await using var admin = new InMemoryAdminClient(cluster);
+        IAdminClient client = admin;
+        foreach (var assignments in new IReadOnlyList<IReadOnlyList<int>>[] { [[0]], [[0], [1]], [[0, 1], [0, 1]] })
+        {
+            var error = await Assert.ThrowsAsync<KafkaException>(() => client.CreatePartitionsAsync(
+                new Dictionary<string, NewPartitions> { ["orders"] = new() { TotalCount = 3, ReplicaAssignments = assignments } },
+                new CreatePartitionsOptions { ValidateOnly = validateOnly }).AsTask());
+            await Assert.That(error!.ErrorCode).IsEqualTo(ErrorCode.InvalidReplicaAssignment);
+            await Assert.That(cluster.DescribeTopics(["orders"])["orders"].Partitions.Count).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task FaultPause_SnapshotsAssignmentsAndHonorsCancellation()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        await using var admin = new InMemoryAdminClient(cluster);
+        IAdminClient client = admin;
+        var replicas = new[] { 0 };
+        var expansion = new Dictionary<string, NewPartitions> { ["orders"] = new() { TotalCount = 2, ReplicaAssignments = [replicas] } };
+        var barrier = cluster.FaultPlan.PauseNext(new KafkaFaultScope(KafkaFaultOperation.Admin, topic: "orders"));
+        var pending = client.CreatePartitionsAsync(expansion).AsTask();
+        await barrier.WaitUntilEnteredAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        replicas[0] = 99;
+        barrier.Release();
+        await pending;
+        await Assert.That(cluster.DescribeTopics(["orders"])["orders"].Partitions.Count).IsEqualTo(2);
+
+        expansion["orders"] = new() { TotalCount = 3 };
+        barrier = cluster.FaultPlan.PauseNext(new KafkaFaultScope(KafkaFaultOperation.Admin, topic: "orders"));
+        using var cancellation = new CancellationTokenSource();
+        pending = client.CreatePartitionsAsync(expansion, cancellationToken: cancellation.Token).AsTask();
+        await barrier.WaitUntilEnteredAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        cancellation.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => pending);
+        barrier.Release();
+        await Assert.That(cluster.DescribeTopics(["orders"])["orders"].Partitions.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task InvalidLaterShape_PreservesFaultAndEarlierTopic()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders");
+        await using var admin = new InMemoryAdminClient(cluster);
+        IAdminClient client = admin;
+        var failure = new InvalidOperationException("blocked");
+        cluster.FaultPlan.Fail(new KafkaFaultScope(KafkaFaultOperation.Admin), failure);
+        await Assert.ThrowsAsync<ArgumentException>(() => client.CreatePartitionsAsync(new Dictionary<string, NewPartitions>
+        {
+            ["orders"] = new() { TotalCount = 2 },
+            ["later"] = new() { TotalCount = 3, ReplicaAssignments = [[0, 0]] }
+        }).AsTask());
+        await Assert.That(cluster.DescribeTopics(["orders"])["orders"].Partitions.Count).IsEqualTo(1);
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => client.CreatePartitionsAsync(
+            new Dictionary<string, NewPartitions> { ["orders"] = new() { TotalCount = 2 } }).AsTask());
+        await Assert.That(actual).IsSameReferenceAs(failure);
+    }
+
+    [Test]
+    public async Task MissingTopic_ValidationDoesNotAutoCreate()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        await using var admin = new InMemoryAdminClient(cluster);
+        IAdminClient client = admin;
+        var error = await Assert.ThrowsAsync<KafkaException>(() => client.CreatePartitionsAsync(
+            new Dictionary<string, NewPartitions> { ["missing"] = new() { TotalCount = 2 } },
+            new CreatePartitionsOptions { ValidateOnly = true }).AsTask());
+        await Assert.That(error!.ErrorCode).IsEqualTo(ErrorCode.UnknownTopicOrPartition);
+        await Assert.That(await admin.ListTopicsAsync()).IsEmpty();
+    }
+
+    [Test]
+    [Arguments(1)]
+    [Arguments(2)]
+    public async Task NonIncreasingTotal_IsRejected(int total)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders", partitionCount: 2);
+        await using var admin = new InMemoryAdminClient(cluster);
+        IAdminClient client = admin;
+        var error = await Assert.ThrowsAsync<KafkaException>(() => client.CreatePartitionsAsync(
+            new Dictionary<string, NewPartitions> { ["orders"] = new() { TotalCount = total } }).AsTask());
+        await Assert.That(error!.ErrorCode).IsEqualTo(ErrorCode.InvalidPartitions);
+        await Assert.That(cluster.DescribeTopics(["orders"])["orders"].Partitions.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    [Arguments(0, 30000)]
+    [Arguments(2, -1)]
+    public async Task InvalidCountOrTimeout_PreservesFault(int total, int timeoutMs)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        await using var admin = new InMemoryAdminClient(cluster);
+        IAdminClient client = admin;
+        cluster.FaultPlan.Fail(new KafkaFaultScope(KafkaFaultOperation.Admin), new InvalidOperationException("blocked"));
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => client.CreatePartitionsAsync(
+            new Dictionary<string, NewPartitions> { ["orders"] = new() { TotalCount = total } },
+            new CreatePartitionsOptions { TimeoutMs = timeoutMs }).AsTask());
+        await Assert.That(cluster.FaultPlan.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task DisposedAndPreCancelledCalls_AreRejected()
+    {
+        var admin = new InMemoryAdminClient(new InMemoryKafkaCluster());
+        IAdminClient client = admin;
+        var expansion = new Dictionary<string, NewPartitions> { ["orders"] = new() { TotalCount = 2 } };
+        await Assert.ThrowsAsync<OperationCanceledException>(() => client.CreatePartitionsAsync(expansion,
+            cancellationToken: new CancellationToken(true)).AsTask());
+        await admin.DisposeAsync();
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => client.CreatePartitionsAsync(expansion).AsTask());
+    }
+}


### PR DESCRIPTION
Typed partition expansion lets applications validate an expansion without changing the topic and choose ordered replica assignments for newly added partitions. The original count-only overload remains available; an optional `IPartitionExpansionAdminClient` capability exposes the new overload through `IAdminClient` without adding required members to custom implementations.

The implementation snapshots replica assignments before awaiting, validates their shape, propagates the broker timeout, and keeps validation-only retries outside ambiguous-mutation success inference. Multi-topic retries exclude both successful response results and metadata-confirmed ambiguous successes before later retries. InMemoryAdminClient implements the optional capability with validation-only support, shared assignment validation, snapshots before fault pauses, and its single broker (ID 0). Applied explicit assignments require matching ordered replicas in refreshed metadata before an ambiguous retry can be accepted. Documentation explains final total count versus additional partition assignments and controller-side validation against current state.

Validation:
- Release unit builds for net10.0 and net8.0: zero warnings/errors, including both core public API baselines.
- 384 admin and 380 in-memory testing unit tests passed on each runtime, including automatic/explicit wire encoding for v2/v3, preferred replica order, invalid counts/assignments/timeouts, caller mutation during retries, cancellation and validation-only retry behavior.
- 3 Docker-backed Kafka 4.3.1 integration tests passed: validate-only leaves counts unchanged, automatic/explicit apply produces the requested partitions and replica assignments, and inconsistent assignment counts are rejected by the controller.
- `npm run build --prefix docs` passed.
- `/simplify` completed; shared retry logic retains a direct ValueTask return without an extra async wrapper. `git diff --check` passed.

Performance evidence (cold admin operation; no per-message paths changed):

| Product | Mean/call | Error (99.9% CI half-width) | StdDev | Allocated/call |
| --- | ---: | ---: | ---: | ---: |
| Baseline `0dd6f2857` | 109.6 ns | 7.66 ns | 6.40 ns | 344 B |
| Candidate `978309374` | 112.4 ns | 13.60 ns | 10.62 ns | 336 B |

Mean delta +2.6% lies within measurement uncertainty; allocation delta -8 B (-2.3%). No material regression detected. These allocations are per administrative request, not per message. No throughput/latency/CPU trade is claimed, and this microbenchmark does not measure broker latency or message throughput.

BenchmarkDotNet 0.15.8 `[MemoryDiagnoser]`, .NET SDK 10.0.400/runtime 10.0.11, Windows 11, i7-12700K. Identical warmed count-only `CreatePartitionsAsync` harness with a prebuilt dictionary, initialized metadata and a non-recording fake connection returning a cached successful response; baseline saved DLL versus candidate build, matching loaded candidate DLL SHA256 verified. Both runs used `--inProcess --warmupCount 5 --iterationCount 15`. A recording-mock prototype was discarded because mock overhead and concurrent local work produced noise; the table uses only the lightweight fake harness. No paid stress workflow dispatched.

Closes #3035


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added administration APIs for increasing topic partition counts.
  - Supports optional replica assignments, validation-only requests, configurable timeouts, and cancellation.
  - Added capability detection for clients that support partition expansion.
  - Added support in the built-in and in-memory admin clients.

- **Documentation**
  - Added guidance covering partition totals, replica assignments, validation, timeouts, cancellation, and client support.

- **Bug Fixes**
  - Improved retry handling to preserve assignments and retry only unconfirmed expansions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Review-fix validation and before/after performance:

Addressed the blocking review in c78eff1b6 (subsequent head 9045a90e8): multi-topic retries now remove every confirmed success before resending, regardless of response order. Four regression cases failed before the fix and now pass, covering both public overloads and both response orders. Assignment validation now reports the public parameter name `newPartitions`.

Validation: 370 admin unit tests on each of net8.0/net10.0; three Kafka 4.3.1 integration cases; zero build warnings/errors; `/simplify` and `git diff --check` complete. A final integration run exposed broker metadata propagation lag after controller acknowledgement; 9045a90e8 fixes that test race with bounded condition polling, and all three cases pass afterward.

Performance: immediately preceding head 978309374 versus c78eff1b6, identical successful count-only admin request fixture, BDN 0.15.8 MemoryDiagnoser, .NET 10.0.11 / SDK 10.0.400, Windows 11 i7-12700K, in-process, 5 warmups/15 iterations. Before: 115.3 ns, error 2.30 ns, SD 2.04 ns, 336 B. After: 106.2 ns, error 1.66 ns, SD 1.38 ns, 336 B. Mean -7.9%, allocation unchanged; no speedup claim from separate local runs. Candidate loaded DLL hash verified against product output. No per-message code changed; additional tracking exists only after partial admin failure. No paid stress run.



Final retry and in-memory parity validation:

The multi-topic ambiguity regression first failed on `3ae8b93ac7915227f346354225e4a52f339f65ea` for both overloads: an earlier transport timeout, then a metadata-confirmed InvalidPartitions result followed by a sibling NotController result, resent the confirmed topic. Confirmed topics are now removed immediately, retaining evidence across any later retry. Eight initial in-memory capability cases also failed before implementation; all now pass, plus four count/timeout boundary cases. Existing count-only in-memory behavior remains unchanged. Missing-topic validation cannot auto-create a topic.

Immediately preceding exact head `3ae8b93ac7915227f346354225e4a52f339f65ea` versus final candidate `68b6a6681823080cb5af2f34ff05a20a36f599dc`, same successful count-only admin fixture and BDN MemoryDiagnoser environment described above, 3 warmups/8 iterations: **120.7 ± 11.70 ns, SD 5.20 ns, 336 B → 107.8 ± 5.03 ns, SD 2.63 ns, 336 B**. Mean -10.7%, allocations unchanged. The timing runs shared a local machine with other work; this is no speedup claim. Successful request handling gained no new tracking or allocation; pruning runs only during ambiguous/partial admin failures. Candidate loaded DLL SHA256 matches product output. No message-path change, paid stress run, or claim about broker throughput/p99/CPU.

Addressed the shared-validation suggestion in fc7c9c2e3914af133b6a2412d37f10b82571f9bc. Both clients now call BuildPartitionExpansionTopics for the same per-topic validation and snapshots. CopyPartitionAssignments is private again. Existing validation order, parameter names, options, and pre-await snapshot timing are preserved.

Validation: 783 admin/in-memory tests on each of net10.0/net8.0; all 3 real Kafka partition-expansion integration cases; Release builds zero warnings/errors; /simplify and diff checks. Existing regression coverage exercises the extraction; no implementation-mirroring test added.

MemoryDiagnoser, immediately preceding exact head 38617deb71d8f20db9bd154d5212052bb89f86e0 → fc7c9c2e3914af133b6a2412d37f10b82571f9bc, typed successful request fixture:
- Automatic assignments: 98.37 ± 5.728 ns (SD 4.472) → 105.2 ± 18.37 ns (SD 14.35), +6.9%; 280 B → 280 B.
- Explicit assignments: 197.65 ± 27.369 ns (SD 21.368) → 177.8 ± 9.24 ns (SD 7.21), -10.0%; 768 B → 768 B.

Timing intervals overlap on this shared local host; no material regression detected or speedup claimed. Same fixture and BDN 0.15.8 in-process / 5 warmups / 12 iterations / .NET 10.0.11 / SDK 10.0.400 / Windows 11 / i7-12700K. Candidate DLL SHA256 matches benchmark-loaded assembly. Administrative request allocations only; no message-path change or paid stress run. Earlier full-feature evidence remains in the PR body.

Resolved the two older CodeQL Where suggestions after verifying the explicit-loop disposition remains valid and a subsequent completed review raised no rebuttal. The extracted builder does not alter those loops.
