### PR TITLE
Add node-specific admin feature discovery

### DIFF
--- a/docs/docs/admin/node-features.md
+++ b/docs/docs/admin/node-features.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 5
+description: "Inspect supported Kafka features on a selected broker or controller."
+---
+
+# Node-specific feature discovery
+
+Use `DescribeFeaturesOptions.NodeId` to inspect an individual node during a rolling upgrade:
+
+```csharp
+using Dekaf.Admin;
+
+await using var admin = Kafka.CreateAdminClient()
+    .WithBootstrapServers("localhost:9092")
+    .Build();
+
+var features = await admin.DescribeFeaturesAsync(new DescribeFeaturesOptions
+{
+    NodeId = 2,
+    TimeoutMs = 10_000
+});
+
+foreach (var feature in features.SupportedFeatures)
+{
+    Console.WriteLine($"{feature.Key}: {feature.Value.MinVersion}..{feature.Value.MaxVersion}");
+}
+```
+
+`SupportedFeatures` contains the ranges advertised by the selected connection. `FinalizedFeatures` and `FinalizedFeaturesEpoch` describe cluster-wide finalized levels; querying an older node does not replace a newer finalized epoch already observed by this client.
+
+With broker bootstrap endpoints, `NodeId` must identify a broker in discovered metadata. With `WithBootstrapControllers`, it must identify a controller in discovered controller metadata. An explicit selection never falls back to another node. Unknown IDs, endpoint or identity mismatches, and connection failures produce errors. Version negotiation uses the selected connection, so different nodes can return different supported ranges.
+
+Omit `NodeId` to select an arbitrary broker or the active controller. The original `DescribeFeaturesAsync(CancellationToken)` overload remains available. On the options overload, `TimeoutMs` bounds initialization, connection establishment, retries, and the query; it defaults to the client's request timeout. Negative values are invalid and zero times out immediately. Expiration throws `TimeoutException`; caller cancellation throws `OperationCanceledException`.
+
+The built-in admin client exposes this additive operation through `INodeFeatureAdminClient` and an `IAdminClient` extension method. Existing custom implementations remain compatible; they must implement the optional capability to support the options overload. Unsupported implementations throw `NotSupportedException`.

--- a/src/Dekaf/Admin/AdminClient.NodeFeatures.cs
+++ b/src/Dekaf/Admin/AdminClient.NodeFeatures.cs
@@ -41,7 +41,10 @@ public sealed partial class AdminClient
         }
         catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested && timeout.IsCancellationRequested)
         {
-            throw new TimeoutException($"DescribeFeatures timed out for node {options.NodeId} after {timeoutMs} ms.", ex);
+            var message = options.NodeId is { } nodeId
+                ? $"DescribeFeatures timed out for node {nodeId} after {timeoutMs} ms."
+                : $"DescribeFeatures timed out (default) after {timeoutMs} ms.";
+            throw new TimeoutException(message, ex);
         }
     }
 

--- a/src/Dekaf/Admin/AdminClient.NodeFeatures.cs
+++ b/src/Dekaf/Admin/AdminClient.NodeFeatures.cs
@@ -1,0 +1,59 @@
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Admin;
+
+public sealed partial class AdminClient
+{
+    /// <inheritdoc cref="INodeFeatureAdminClient.DescribeFeaturesAsync"/>
+    async ValueTask<FeatureMetadata> INodeFeatureAdminClient.DescribeFeaturesAsync(
+        DescribeFeaturesOptions options,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.NodeId is { } requestedNodeId)
+            ArgumentOutOfRangeException.ThrowIfNegative(requestedNodeId, nameof(options));
+        var timeoutMs = options.TimeoutMs ?? _options.RequestTimeoutMs;
+        ArgumentOutOfRangeException.ThrowIfNegative(timeoutMs, nameof(options));
+        cancellationToken.ThrowIfCancellationRequested();
+        if (timeoutMs == 0)
+            throw new TimeoutException("DescribeFeatures timed out before node discovery.");
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(timeoutMs);
+        var operationToken = timeout.Token;
+        try
+        {
+            if (options.NodeId is not { } nodeId)
+                return await DescribeFeaturesAsync(operationToken).ConfigureAwait(false);
+
+            await EnsureInitializedAsync(operationToken, nameof(DescribeFeaturesAsync)).ConfigureAwait(false);
+            return await WithRetryAsync(async () =>
+            {
+                operationToken.ThrowIfCancellationRequested();
+                using var lease = await LeaseFeatureNodeAsync(nodeId, operationToken).ConfigureAwait(false);
+                var request = CreateFeatureRequest(lease.Connection, nodeId, out var apiVersion);
+                var response = await lease.Connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                    request, apiVersion, operationToken).ConfigureAwait(false);
+                return MapFeatureResponse(response);
+            }, operationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested && timeout.IsCancellationRequested)
+        {
+            throw new TimeoutException($"DescribeFeatures timed out for node {options.NodeId} after {timeoutMs} ms.", ex);
+        }
+    }
+
+    private ValueTask<KafkaConnectionLease> LeaseFeatureNodeAsync(int nodeId, CancellationToken cancellationToken)
+    {
+        if (_controllerMetadataManager is { } controllers)
+            return controllers.LeaseControllerAsync(nodeId, ApiKey.ApiVersions, cancellationToken);
+
+        if (_metadataManager.Metadata.GetBroker(nodeId) is null)
+            throw new KafkaException(ErrorCode.BrokerNotAvailable,
+                $"Node {nodeId} is not a known broker in the configured broker bootstrap endpoints.");
+
+        return _connectionPool.LeaseConnectionAsync(nodeId, cancellationToken);
+    }
+}

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -23,6 +23,7 @@ namespace Dekaf.Admin;
 public sealed partial class AdminClient :
     IAdminClient,
     IReplicaLogDirAdminClient,
+    INodeFeatureAdminClient,
     ITopicIdAdminClient,
     IStreamsGroupManagementAdminClient,
     ITransactionRemediationAdminClient,
@@ -936,57 +937,70 @@ public sealed partial class AdminClient :
                 ? await LeaseAnyBrokerConnectionAsync(cancellationToken).ConfigureAwait(false)
                 : await LeaseControllerAsync(Protocol.ApiKey.ApiVersions, cancellationToken).ConfigureAwait(false);
             var connection = connectionLease.Connection;
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+            var request = CreateFeatureRequest(
                 connection,
-                Protocol.ApiKey.ApiVersions,
-                ApiVersionsRequest.LowestSupportedVersion,
-                ApiVersionsRequest.HighestSupportedVersion);
+                _controllerMetadataManager?.Snapshot.ActiveControllerId ?? connection.BrokerId,
+                out var apiVersion);
             var response = await connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
-                new ApiVersionsRequest
-                {
-                    ClientSoftwareName = "dekaf",
-                    ClientSoftwareVersion = typeof(AdminClient).Assembly.GetName().Version?.ToString() ?? "0.0.0",
-                    ClusterId = apiVersion >= 5
-                        ? _controllerMetadataManager?.Snapshot.ClusterId ?? _metadataManager.Metadata.ClusterId
-                        : null,
-                    NodeId = apiVersion >= 5
-                        ? _controllerMetadataManager?.Snapshot.ActiveControllerId ?? connection.BrokerId
-                        : -1
-                },
-                apiVersion,
-                cancellationToken).ConfigureAwait(false);
-            if (response.ErrorCode != Protocol.ErrorCode.None)
-            {
-                throw KafkaException.FromErrorCode(
-                    response.ErrorCode,
-                    $"DescribeFeatures failed: {response.ErrorCode}");
-            }
-
-            var capabilities = KafkaConnectionCapabilities.Create(response);
-            _metadataManager.ObserveClusterCapabilities(
-                _metadataManager.Metadata.ClusterId,
-                capabilities);
-            _metadataManager.GetClusterFinalizedFeatureMetadata(
-                out var finalizedFeaturesEpoch,
-                out var finalizedFeatureData);
-
-            return new FeatureMetadata
-            {
-                FinalizedFeaturesEpoch = finalizedFeaturesEpoch,
-                SupportedFeatures = capabilities.SupportedFeatures.ToDictionary(
-                    static feature => feature.Key,
-                    static feature => new FeatureVersionRange(
-                        feature.Value.MinVersion,
-                        feature.Value.MaxVersion),
-                    StringComparer.Ordinal),
-                FinalizedFeatures = finalizedFeatureData.ToDictionary(
-                    static feature => feature.Key,
-                    static feature => new FeatureVersionRange(
-                        feature.Value.MinVersion,
-                        feature.Value.MaxVersion),
-                    StringComparer.Ordinal)
-            };
+                request, apiVersion, cancellationToken).ConfigureAwait(false);
+            return MapFeatureResponse(response);
         }, cancellationToken).ConfigureAwait(false);
+    }
+
+    private ApiVersionsRequest CreateFeatureRequest(
+        IKafkaConnection connection,
+        int nodeId,
+        out short apiVersion)
+    {
+        apiVersion = _metadataManager.GetNegotiatedApiVersion(
+            connection,
+            Protocol.ApiKey.ApiVersions,
+            ApiVersionsRequest.LowestSupportedVersion,
+            ApiVersionsRequest.HighestSupportedVersion);
+        return new ApiVersionsRequest
+        {
+            ClientSoftwareName = "dekaf",
+            ClientSoftwareVersion = typeof(AdminClient).Assembly.GetName().Version?.ToString() ?? "0.0.0",
+            ClusterId = apiVersion >= 5
+                ? _controllerMetadataManager?.Snapshot.ClusterId ?? _metadataManager.Metadata.ClusterId
+                : null,
+            NodeId = apiVersion >= 5 ? nodeId : -1
+        };
+    }
+
+    private FeatureMetadata MapFeatureResponse(ApiVersionsResponse response)
+    {
+        if (response.ErrorCode != Protocol.ErrorCode.None)
+        {
+            throw KafkaException.FromErrorCode(
+                response.ErrorCode,
+                $"DescribeFeatures failed: {response.ErrorCode}");
+        }
+
+        var capabilities = KafkaConnectionCapabilities.Create(response);
+        _metadataManager.ObserveClusterCapabilities(
+            _controllerMetadataManager?.Snapshot.ClusterId ?? _metadataManager.Metadata.ClusterId,
+            capabilities);
+        _metadataManager.GetClusterFinalizedFeatureMetadata(
+            out var finalizedFeaturesEpoch,
+            out var finalizedFeatureData);
+
+        return new FeatureMetadata
+        {
+            FinalizedFeaturesEpoch = finalizedFeaturesEpoch,
+            SupportedFeatures = capabilities.SupportedFeatures.ToDictionary(
+                static feature => feature.Key,
+                static feature => new FeatureVersionRange(
+                    feature.Value.MinVersion,
+                    feature.Value.MaxVersion),
+                StringComparer.Ordinal),
+            FinalizedFeatures = finalizedFeatureData.ToDictionary(
+                static feature => feature.Key,
+                static feature => new FeatureVersionRange(
+                    feature.Value.MinVersion,
+                    feature.Value.MaxVersion),
+                StringComparer.Ordinal)
+        };
     }
 
     public async ValueTask<IReadOnlyDictionary<string, FeatureUpdateResultInfo>> UpdateFeaturesAsync(

--- a/src/Dekaf/Admin/INodeFeatureAdminClient.cs
+++ b/src/Dekaf/Admin/INodeFeatureAdminClient.cs
@@ -1,0 +1,42 @@
+namespace Dekaf.Admin;
+
+/// <summary>Optional capability for querying the features supported by a selected node.</summary>
+public interface INodeFeatureAdminClient
+{
+    /// <summary>Queries node-supported ranges and cluster-finalized feature metadata.</summary>
+    ValueTask<FeatureMetadata> DescribeFeaturesAsync(
+        DescribeFeaturesOptions options,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Controls feature discovery within the configured broker or controller endpoint mode.</summary>
+public sealed class DescribeFeaturesOptions
+{
+    /// <summary>The broker or controller ID to query. Null selects an arbitrary broker or the active controller.</summary>
+    public int? NodeId { get; init; }
+
+    /// <summary>Total operation timeout in milliseconds, including discovery and retries. Null uses the client's request timeout.</summary>
+    public int? TimeoutMs { get; init; }
+}
+
+/// <summary>Node-specific feature discovery for admin clients.</summary>
+public static class AdminClientNodeFeatureExtensions
+{
+    /// <summary>
+    /// Queries supported features on the selected node. Finalized levels and epoch describe the cluster.
+    /// Explicit node IDs never fall back to another node. IDs must belong to the configured endpoint mode.
+    /// </summary>
+    /// <exception cref="NotSupportedException">The client does not implement <see cref="INodeFeatureAdminClient"/>.</exception>
+    public static ValueTask<FeatureMetadata> DescribeFeaturesAsync(
+        this IAdminClient adminClient,
+        DescribeFeaturesOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(adminClient);
+        ArgumentNullException.ThrowIfNull(options);
+        return adminClient is INodeFeatureAdminClient nodeFeatureAdminClient
+            ? nodeFeatureAdminClient.DescribeFeaturesAsync(options, cancellationToken)
+            : throw new NotSupportedException(
+                $"Admin client type '{adminClient.GetType().FullName}' does not support node-specific feature queries.");
+    }
+}

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -598,3 +598,13 @@ Dekaf.Admin.DescribeClusterOptions.IncludeFencedBrokers.init -> void
 Dekaf.Admin.IClusterDiscoveryAdminClient
 Dekaf.Admin.IClusterDiscoveryAdminClient.DescribeClusterAsync(Dekaf.Admin.DescribeClusterOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.ClusterDescriptionSnapshot!>
 static Dekaf.Admin.AdminClientClusterDiscoveryExtensions.DescribeClusterAsync(this Dekaf.Admin.IAdminClient! adminClient, Dekaf.Admin.DescribeClusterOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.ClusterDescriptionSnapshot!>
+Dekaf.Admin.AdminClientNodeFeatureExtensions
+Dekaf.Admin.DescribeFeaturesOptions
+Dekaf.Admin.DescribeFeaturesOptions.DescribeFeaturesOptions() -> void
+Dekaf.Admin.DescribeFeaturesOptions.NodeId.get -> int?
+Dekaf.Admin.DescribeFeaturesOptions.NodeId.init -> void
+Dekaf.Admin.DescribeFeaturesOptions.TimeoutMs.get -> int?
+Dekaf.Admin.DescribeFeaturesOptions.TimeoutMs.init -> void
+Dekaf.Admin.INodeFeatureAdminClient
+Dekaf.Admin.INodeFeatureAdminClient.DescribeFeaturesAsync(Dekaf.Admin.DescribeFeaturesOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.FeatureMetadata!>
+static Dekaf.Admin.AdminClientNodeFeatureExtensions.DescribeFeaturesAsync(this Dekaf.Admin.IAdminClient! adminClient, Dekaf.Admin.DescribeFeaturesOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.FeatureMetadata!>

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -598,3 +598,13 @@ Dekaf.Admin.DescribeClusterOptions.IncludeFencedBrokers.init -> void
 Dekaf.Admin.IClusterDiscoveryAdminClient
 Dekaf.Admin.IClusterDiscoveryAdminClient.DescribeClusterAsync(Dekaf.Admin.DescribeClusterOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.ClusterDescriptionSnapshot!>
 static Dekaf.Admin.AdminClientClusterDiscoveryExtensions.DescribeClusterAsync(this Dekaf.Admin.IAdminClient! adminClient, Dekaf.Admin.DescribeClusterOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.ClusterDescriptionSnapshot!>
+Dekaf.Admin.AdminClientNodeFeatureExtensions
+Dekaf.Admin.DescribeFeaturesOptions
+Dekaf.Admin.DescribeFeaturesOptions.DescribeFeaturesOptions() -> void
+Dekaf.Admin.DescribeFeaturesOptions.NodeId.get -> int?
+Dekaf.Admin.DescribeFeaturesOptions.NodeId.init -> void
+Dekaf.Admin.DescribeFeaturesOptions.TimeoutMs.get -> int?
+Dekaf.Admin.DescribeFeaturesOptions.TimeoutMs.init -> void
+Dekaf.Admin.INodeFeatureAdminClient
+Dekaf.Admin.INodeFeatureAdminClient.DescribeFeaturesAsync(Dekaf.Admin.DescribeFeaturesOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.FeatureMetadata!>
+static Dekaf.Admin.AdminClientNodeFeatureExtensions.DescribeFeaturesAsync(this Dekaf.Admin.IAdminClient! adminClient, Dekaf.Admin.DescribeFeaturesOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.FeatureMetadata!>

--- a/tests/Dekaf.Tests.Integration/AdminClientTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdminClientTests.cs
@@ -1127,6 +1127,21 @@ public class AdminClientTests(KafkaTestContainer kafka) : KafkaIntegrationTest(k
     }
 
     [Test]
+    public async Task DescribeFeaturesAsync_QueriesEachBrokerAndRejectsUnknownNode()
+    {
+        await using var admin = CreateAdminClient();
+        var cluster = await admin.DescribeClusterAsync();
+        foreach (var node in cluster.Nodes)
+        {
+            var features = await admin.DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = node.NodeId });
+            await Assert.That(features.SupportedFeatures).ContainsKey("metadata.version");
+            await Assert.That(features.FinalizedFeaturesEpoch).IsGreaterThanOrEqualTo(0);
+        }
+        await Assert.ThrowsAsync<KafkaException>(async () =>
+            await admin.DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = int.MaxValue }));
+    }
+
+    [Test]
     [SupportsKafka(270)]
     public async Task UpdateFeaturesAsync_ValidateOnlyEmptyUpdateSucceeds()
     {

--- a/tests/Dekaf.Tests.Integration/ControllerBootstrapIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ControllerBootstrapIntegrationTests.cs
@@ -24,6 +24,10 @@ public sealed class ControllerBootstrapIntegrationTests(ControllerOnlyKafkaConta
             await admin.DescribeClusterAsync(new DescribeClusterOptions { IncludeFencedBrokers = true }, timeout.Token));
         var quorum = await admin.DescribeMetadataQuorumAsync(timeout.Token).ConfigureAwait(false);
         var features = await admin.DescribeFeaturesAsync(timeout.Token).ConfigureAwait(false);
+        var selectedFeatures = await admin.DescribeFeaturesAsync(
+            new DescribeFeaturesOptions { NodeId = cluster.ControllerId }, timeout.Token);
+        await Assert.That(selectedFeatures.SupportedFeatures).IsEquivalentTo(features.SupportedFeatures);
+        await Assert.That(selectedFeatures.FinalizedFeaturesEpoch).IsGreaterThanOrEqualTo(0);
 
         await Assert.That(cluster.ControllerId).IsEqualTo(1);
         await Assert.That(cluster.Nodes.Select(static node => node.NodeId)).IsEquivalentTo([1]);

--- a/tests/Dekaf.Tests.Integration/NodeFeatureIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/NodeFeatureIntegrationTests.cs
@@ -1,0 +1,25 @@
+using Dekaf.Admin;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Admin")]
+[NotInParallel("RackAwareKafkaContainer")]
+[ClassDataSource<RackAwareKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class NodeFeatureIntegrationTests(RackAwareKafkaContainer kafka)
+{
+    [Test]
+    [Timeout(120_000)]
+    public async Task DescribeFeaturesAsync_QueriesAllThreeBrokerDestinations(CancellationToken cancellationToken)
+    {
+        await using var admin = new AdminClientBuilder().WithBootstrapServers(kafka.BootstrapServers).Build();
+        var cluster = await admin.DescribeClusterAsync(cancellationToken);
+        await Assert.That(cluster.Nodes.Count).IsEqualTo(3);
+        foreach (var node in cluster.Nodes)
+        {
+            var features = await admin.DescribeFeaturesAsync(
+                new DescribeFeaturesOptions { NodeId = node.NodeId, TimeoutMs = 10_000 }, cancellationToken);
+            await Assert.That(features.SupportedFeatures).ContainsKey("metadata.version");
+            await Assert.That(features.FinalizedFeaturesEpoch).IsGreaterThanOrEqualTo(0);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
@@ -34,6 +34,47 @@ public sealed class AdminClientControllerBootstrapTests
     }
 
     [Test]
+    [Arguments(1)]
+    [Arguments(2)]
+    public async Task DescribeFeaturesAsync_SelectedController_UsesItsIdentity(int nodeId)
+    {
+        await using var context = new ControllerAdminContext();
+        var target = nodeId == 1 ? context.OtherController : context.ActiveController;
+        var other = nodeId == 1 ? context.ActiveController : context.OtherController;
+        var response = new ApiVersionsResponse
+        {
+            ErrorCode = ErrorCode.None,
+            ApiKeys = [new ApiVersion(ApiKey.ApiVersions, 0, 5)],
+            SupportedFeatures = [new SupportedFeature("metadata.version", 7, (short)(19 + nodeId))],
+            FinalizedFeaturesEpoch = 42,
+            FinalizedFeatures = [new FinalizedFeature("metadata.version", 17, 17)]
+        };
+        target.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            Arg.Any<ApiVersionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(response));
+
+        var result = await context.Client.DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = nodeId });
+
+        await Assert.That(result.FinalizedFeaturesEpoch).IsEqualTo(42L);
+        await Assert.That(result.SupportedFeatures["metadata.version"].MaxVersion).IsEqualTo((short)(19 + nodeId));
+        await target.Received(1).SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            Arg.Is<ApiVersionsRequest>(request => request.NodeId == nodeId && request.ClusterId == "cluster-a"),
+            5, Arg.Any<CancellationToken>());
+        await other.DidNotReceiveWithAnyArgs().SendAsync<ApiVersionsRequest, ApiVersionsResponse>(default!, default, default);
+    }
+
+    [Test]
+    public async Task DescribeFeaturesAsync_UnknownController_DoesNotQueryActiveController()
+    {
+        await using var context = new ControllerAdminContext();
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await context.Client.DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = 99 }));
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.UnknownControllerId);
+        await context.ActiveController.DidNotReceiveWithAnyArgs()
+            .SendAsync<ApiVersionsRequest, ApiVersionsResponse>(default!, default, default);
+    }
+
+    [Test]
     public async Task DescribeClusterAsync_DiscoversControllersWithoutRegisteringBrokers()
     {
         await using var context = new ControllerAdminContext();
@@ -541,6 +582,7 @@ public sealed class AdminClientControllerBootstrapTests
 
             _metadataManager = new MetadataManager(Pool, []);
             _metadataManager.SetApiVersion(ApiKey.DescribeCluster, 1, 2);
+            _metadataManager.SetApiVersion(ApiKey.ApiVersions, 0, 5);
             _metadataManager.SetApiVersion(ApiKey.DescribeQuorum, 0, 2);
             _metadataManager.SetApiVersion(ApiKey.CreateTopics, 0, 7);
             _metadataManager.SetApiVersion(ApiKey.DescribeConfigs, 4, 4);

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientFeatureTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientFeatureTests.cs
@@ -11,6 +11,145 @@ namespace Dekaf.Tests.Unit.Admin;
 public sealed class AdminClientFeatureTests
 {
     [Test]
+    public async Task DescribeFeaturesAsync_DefaultLiteralAndEmptyOptions_PreserveDefaultSelection()
+    {
+        var (admin, _, second) = CreateAdmin(updateFeaturesVersion: 1);
+        var original = await admin.DescribeFeaturesAsync(default);
+        var optionsResult = await admin.DescribeFeaturesAsync(new DescribeFeaturesOptions());
+        await Assert.That(optionsResult.SupportedFeatures).IsEquivalentTo(original.SupportedFeatures);
+        await Assert.That(optionsResult.FinalizedFeatures).IsEquivalentTo(original.FinalizedFeatures);
+        await second.DidNotReceiveWithAnyArgs().SendAsync<ApiVersionsRequest, ApiVersionsResponse>(default!, default, default);
+    }
+
+    [Test]
+    [Arguments(-1)]
+    [Arguments(0)]
+    public async Task DescribeFeaturesAsync_InvalidOrExpiredTimeout_DoesNotInitialize(int timeoutMs)
+    {
+        var (admin, first, _) = CreateAdmin(updateFeaturesVersion: 1);
+        if (timeoutMs < 0)
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+                await admin.DescribeFeaturesAsync(new DescribeFeaturesOptions { TimeoutMs = timeoutMs }));
+        else
+            await Assert.ThrowsAsync<TimeoutException>(async () =>
+                await admin.DescribeFeaturesAsync(new DescribeFeaturesOptions { TimeoutMs = timeoutMs }));
+        await first.DidNotReceiveWithAnyArgs().SendAsync<MetadataRequest, MetadataResponse>(default!, default, default);
+    }
+
+    [Test]
+    public async Task DescribeFeaturesAsync_PreCancelled_DoesNotInitialize()
+    {
+        var (admin, first, _) = CreateAdmin(updateFeaturesVersion: 1);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await admin.DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = 2 }, cancellation.Token));
+        await first.DidNotReceiveWithAnyArgs().SendAsync<MetadataRequest, MetadataResponse>(default!, default, default);
+    }
+
+    [Test]
+    public async Task DescribeFeaturesAsync_FailedExplicitNode_NeverQueriesAnotherNode()
+    {
+        var (admin, first, second) = CreateAdmin(updateFeaturesVersion: 1);
+        await admin.DescribeClusterAsync();
+        first.ClearReceivedCalls();
+        second.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            Arg.Any<ApiVersionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<ApiVersionsResponse>(new KafkaException(ErrorCode.MismatchedEndpointType, "wrong endpoint")));
+
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await admin.DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = 2 }));
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.MismatchedEndpointType);
+        await first.DidNotReceiveWithAnyArgs().SendAsync<ApiVersionsRequest, ApiVersionsResponse>(default!, default, default);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task DescribeFeaturesAsync_BlockedNode_ObservesCancellationAndTimeout(bool callerCancels)
+    {
+        var (admin, first, second) = CreateAdmin(updateFeaturesVersion: 1);
+        await admin.DescribeClusterAsync();
+        first.ClearReceivedCalls();
+        using var cancellation = new CancellationTokenSource();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        second.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            Arg.Any<ApiVersionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(call => WaitForCancellationAsync(started, call.Arg<CancellationToken>()));
+        var operation = admin.DescribeFeaturesAsync(
+            new DescribeFeaturesOptions { NodeId = 2, TimeoutMs = callerCancels ? 30_000 : 200 }, cancellation.Token).AsTask();
+        await started.Task;
+        if (callerCancels)
+        {
+            cancellation.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await operation);
+        }
+        else
+        {
+            await Assert.ThrowsAsync<TimeoutException>(async () => await operation);
+        }
+        await first.DidNotReceiveWithAnyArgs().SendAsync<ApiVersionsRequest, ApiVersionsResponse>(default!, default, default);
+    }
+
+    private static async ValueTask<ApiVersionsResponse> WaitForCancellationAsync(
+        TaskCompletionSource started, CancellationToken cancellationToken)
+    {
+        started.SetResult();
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        throw new InvalidOperationException("Expected cancellation");
+    }
+
+    [Test]
+    public async Task DescribeFeaturesAsync_ExplicitNode_UsesDestinationCapabilities()
+    {
+        var (admin, first, second) = CreateAdmin(updateFeaturesVersion: 1);
+        var result = await ((IAdminClient)admin).DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = 2 });
+
+        await Assert.That(result.SupportedFeatures["metadata.version"])
+            .IsEqualTo(new FeatureVersionRange(7, 20));
+        await Assert.That(result.FinalizedFeaturesEpoch).IsEqualTo(42L);
+        await second.Received(1).SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            Arg.Is<ApiVersionsRequest>(request => request.NodeId == 2 && request.ClusterId == "test-cluster"),
+            5, Arg.Any<CancellationToken>());
+        // The first connection is used only for metadata initialization, not the feature query.
+        await first.DidNotReceive().SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            Arg.Any<ApiVersionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task DescribeFeaturesAsync_UnknownNode_DoesNotFallBack()
+    {
+        var (admin, first, second) = CreateAdmin(updateFeaturesVersion: 1);
+        await admin.DescribeClusterAsync();
+        first.ClearReceivedCalls();
+        second.ClearReceivedCalls();
+
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await ((IAdminClient)admin).DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = 99 }));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.BrokerNotAvailable);
+        await first.DidNotReceiveWithAnyArgs().SendAsync<ApiVersionsRequest, ApiVersionsResponse>(default!, default, default);
+        await second.DidNotReceiveWithAnyArgs().SendAsync<ApiVersionsRequest, ApiVersionsResponse>(default!, default, default);
+    }
+
+    [Test]
+    public async Task DescribeFeaturesAsync_InvalidNode_RejectsBeforeInitialization()
+    {
+        var (admin, first, _) = CreateAdmin(updateFeaturesVersion: 1);
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            await ((IAdminClient)admin).DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = -1 }));
+        await first.DidNotReceiveWithAnyArgs().SendAsync<MetadataRequest, MetadataResponse>(default!, default, default);
+    }
+
+    [Test]
+    public async Task DescribeFeaturesAsync_LegacyImplementation_RejectsUnsupportedCapability()
+    {
+        var admin = Substitute.For<IAdminClient>();
+        await Assert.ThrowsAsync<NotSupportedException>(async () =>
+            await admin.DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = 2 }));
+    }
+
+    [Test]
     public async Task DescribeFeaturesAsync_MapsConnectionCapabilitySnapshot()
     {
         var (admin, connection, _) = CreateAdmin(updateFeaturesVersion: 1);
@@ -205,7 +344,16 @@ public sealed class AdminClientFeatureTests
             FinalizedFeatures = [new FinalizedFeature("metadata.version", 17, 7)]
         };
         var first = CreateConnection(1, apiVersions);
-        var second = CreateConnection(2, apiVersions);
+        var secondApiVersions = new ApiVersionsResponse
+        {
+            ErrorCode = ErrorCode.None,
+            ApiKeys = [new ApiVersion(ApiKey.ApiVersions, 0, 5), new ApiVersion(ApiKey.Metadata, 9, 13),
+                new ApiVersion(ApiKey.UpdateFeatures, 0, updateFeaturesVersion)],
+            SupportedFeatures = [new SupportedFeature("metadata.version", 7, 20)],
+            FinalizedFeaturesEpoch = 41,
+            FinalizedFeatures = [new FinalizedFeature("metadata.version", 16, 7)]
+        };
+        var second = CreateConnection(2, secondApiVersions);
         var metadataCalls = 0;
         first.SendAsync<MetadataRequest, MetadataResponse>(
                 Arg.Any<MetadataRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
@@ -215,12 +363,14 @@ public sealed class AdminClientFeatureTests
                 Arg.Any<MetadataRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult(CreateMetadataResponse(2)));
 
+        IKafkaConnection firstEndpoint = new CapabilityConnection(first, apiVersions);
+        IKafkaConnection secondEndpoint = new CapabilityConnection(second, secondApiVersions);
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(callInfo => ValueTask.FromResult(
-                callInfo.Arg<int>() == 2 ? second : first));
+                callInfo.Arg<int>() == 2 ? secondEndpoint : firstEndpoint));
         pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(ValueTask.FromResult(first));
+            .Returns(ValueTask.FromResult(firstEndpoint));
 
         var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
         var admin = new AdminClient(
@@ -261,4 +411,50 @@ public sealed class AdminClientFeatureTests
         ControllerId = controllerId,
         Topics = []
     };
+
+    private sealed class CapabilityConnection(IKafkaConnection inner, ApiVersionsResponse response)
+        : IKafkaConnection, IKafkaCapabilityProvider
+    {
+        public int BrokerId => inner.BrokerId;
+        public string Host => inner.Host;
+        public int Port => inner.Port;
+        public bool IsConnected => inner.IsConnected;
+        public KafkaConnectionCapabilities Capabilities { get; } = KafkaConnectionCapabilities.Create(response);
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => inner.SendAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientFeatureTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientFeatureTests.cs
@@ -64,9 +64,11 @@ public sealed class AdminClientFeatureTests
     }
 
     [Test]
-    [Arguments(true)]
-    [Arguments(false)]
-    public async Task DescribeFeaturesAsync_BlockedNode_ObservesCancellationAndTimeout(bool callerCancels)
+    [Arguments(true, 2)]
+    [Arguments(false, 2)]
+    [Arguments(true, null)]
+    [Arguments(false, null)]
+    public async Task DescribeFeaturesAsync_BlockedNode_ObservesCancellationAndTimeout(bool callerCancels, int? nodeId)
     {
         var (admin, first, second) = CreateAdmin(updateFeaturesVersion: 1);
         await admin.DescribeClusterAsync();
@@ -76,9 +78,13 @@ public sealed class AdminClientFeatureTests
         second.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
             Arg.Any<ApiVersionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
             .Returns(call => WaitForCancellationAsync(started, call.Arg<CancellationToken>()));
+        if (nodeId is null)
+            first.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                Arg.Any<ApiVersionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+                .Returns(call => WaitForCancellationAsync(started, call.Arg<CancellationToken>()));
         var operation = admin.DescribeFeaturesAsync(
-            new DescribeFeaturesOptions { NodeId = 2, TimeoutMs = callerCancels ? 30_000 : 200 }, cancellation.Token).AsTask();
-        await started.Task;
+            new DescribeFeaturesOptions { NodeId = nodeId, TimeoutMs = callerCancels ? 30_000 : 200 }, cancellation.Token).AsTask();
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(10));
         if (callerCancels)
         {
             cancellation.Cancel();
@@ -86,9 +92,11 @@ public sealed class AdminClientFeatureTests
         }
         else
         {
-            await Assert.ThrowsAsync<TimeoutException>(async () => await operation);
+            var exception = await Assert.ThrowsAsync<TimeoutException>(async () => await operation);
+            await Assert.That(exception!.Message).Contains(nodeId is null ? "(default)" : "node 2");
         }
-        await first.DidNotReceiveWithAnyArgs().SendAsync<ApiVersionsRequest, ApiVersionsResponse>(default!, default, default);
+        if (nodeId is not null)
+            await first.DidNotReceiveWithAnyArgs().SendAsync<ApiVersionsRequest, ApiVersionsResponse>(default!, default, default);
     }
 
     private static async ValueTask<ApiVersionsResponse> WaitForCancellationAsync(

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientFeatureTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientFeatureTests.cs
@@ -103,7 +103,8 @@ public sealed class AdminClientFeatureTests
     public async Task DescribeFeaturesAsync_ExplicitNode_UsesDestinationCapabilities()
     {
         var (admin, first, second) = CreateAdmin(updateFeaturesVersion: 1);
-        var result = await ((IAdminClient)admin).DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = 2 });
+        IAdminClient client = admin;
+        var result = await client.DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = 2 });
 
         await Assert.That(result.SupportedFeatures["metadata.version"])
             .IsEqualTo(new FeatureVersionRange(7, 20));
@@ -120,12 +121,13 @@ public sealed class AdminClientFeatureTests
     public async Task DescribeFeaturesAsync_UnknownNode_DoesNotFallBack()
     {
         var (admin, first, second) = CreateAdmin(updateFeaturesVersion: 1);
+        IAdminClient client = admin;
         await admin.DescribeClusterAsync();
         first.ClearReceivedCalls();
         second.ClearReceivedCalls();
 
         var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
-            await ((IAdminClient)admin).DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = 99 }));
+            await client.DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = 99 }));
 
         await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.BrokerNotAvailable);
         await first.DidNotReceiveWithAnyArgs().SendAsync<ApiVersionsRequest, ApiVersionsResponse>(default!, default, default);
@@ -136,8 +138,9 @@ public sealed class AdminClientFeatureTests
     public async Task DescribeFeaturesAsync_InvalidNode_RejectsBeforeInitialization()
     {
         var (admin, first, _) = CreateAdmin(updateFeaturesVersion: 1);
+        IAdminClient client = admin;
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
-            await ((IAdminClient)admin).DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = -1 }));
+            await client.DescribeFeaturesAsync(new DescribeFeaturesOptions { NodeId = -1 }));
         await first.DidNotReceiveWithAnyArgs().SendAsync<MetadataRequest, MetadataResponse>(default!, default, default);
     }
 


### PR DESCRIPTION
## Summary

Adds exact-node feature discovery through `DescribeFeaturesOptions`, `INodeFeatureAdminClient`, and an `IAdminClient` extension method. Broker bootstrap resolves broker IDs; controller bootstrap resolves controller IDs. Explicit requests keep their destination through retries and use that connection's ApiVersions negotiation and v5 identity fields. Unknown or failed destinations never fall back to a different node.

The options overload bounds initialization, connection acquisition, retries, and the request with one timeout. The original overload and `DescribeFeaturesAsync(default)` remain source-compatible. Supported ranges remain node-specific while finalized levels/epoch remain cluster-wide; controller queries now retain finalized metadata under the controller cluster ID.

## Validation

- 362 admin unit tests passed, including mixed destination capabilities, stale finalized epochs, exact controller identity, no fallback, cancellation, timeout, and legacy implementation/default-literal compatibility.
- Kafka 4.3.1 integration: feature queries and unknown broker ID (2 tests), controller-only bootstrap (1 test), and individually querying all three brokers (1 test) passed.
- Release builds passed for net10.0 tests and netstandard2.0 library/API baseline; final serialized builds had no warnings or errors.
- `npm run build --prefix docs` passed.
- `/simplify` completed; shared helpers are synchronous to avoid introducing another async state machine.

## Performance evidence

Baseline: `0dd6f2857` (immediately preceding product commit). Candidate: `f287760ecc97eca1f4f41879ba361c892fe41fea`.

BenchmarkDotNet MemoryDiagnoser, .NET 10, same Windows host, deterministic in-memory broker responses, initialized `AdminClient.DescribeFeaturesAsync`, 5 warmups / 15 measured iterations, InProcessEmitToolchain. Baseline and candidate DLLs were run sequentially after local builds completed.

| Version | Mean/query | StdDev | Allocated/query |
| --- | ---: | ---: | ---: |
| Baseline | 1.144 us | 0.1623 us | 2.36 KB |
| Candidate | 1.073 us | 0.1797 us | 2.36 KB |

Mean delta -6.2%; allocations unchanged. Timing variance does not support a speedup claim, but this measurement shows no observed regression. Allocations are existing cold administrative query/result costs, not per-message costs. Produce, consume, and wire serialization hot paths are unchanged. Network latency percentiles, CPU/message, and long-run stability were not measured by this microbenchmark; no paid stress lane was dispatched. An exploratory run overlapped local builds and preceded the final synchronous-helper refinement, so it is not used for acceptance.

Closes #3029
