### PR TITLE
Expose live fenced-broker discovery through the admin API

### DIFF
--- a/docs/docs/admin/cluster-discovery.md
+++ b/docs/docs/admin/cluster-discovery.md
@@ -1,0 +1,36 @@
+---
+description: "Discover registered Kafka brokers, including fenced nodes, without changing routing."
+---
+
+# Cluster discovery
+
+Use the options overload to query live cluster information through Kafka's DescribeCluster RPC:
+
+```csharp
+using Dekaf;
+using Dekaf.Admin;
+
+await using var admin = Kafka.CreateAdminClient()
+    .WithBootstrapServers("localhost:9092")
+    .Build();
+
+var snapshot = await admin.DescribeClusterAsync(new DescribeClusterOptions
+{
+    IncludeFencedBrokers = true
+});
+
+foreach (var node in snapshot.Nodes)
+{
+    Console.WriteLine($"{node.NodeId}: {node.Host}:{node.Port}, fenced={node.IsFenced}");
+}
+```
+
+Fenced brokers remain registered with the cluster but are unavailable for normal client traffic. This read-only discovery does not unregister nodes, change cluster state, or add fenced nodes to producer/consumer routing metadata.
+
+`IncludeFencedBrokers` defaults to `false`. Requesting it requires DescribeCluster v2 on the actual destination broker. Dekaf throws `BrokerVersionException` when that capability is absent; it never silently drops the option.
+
+`ClusterDescriptionSnapshot.EndpointType` distinguishes broker nodes from controller nodes. With `WithBootstrapControllers(...)`, the options overload describes controllers and rejects `IncludeFencedBrokers = true` with `NotSupportedException`. Use broker bootstrap endpoints to discover fenced brokers. `ClusterNodeDescription.IsFenced` is nullable: controller nodes and responses older than v2 have no broker fencing status.
+
+The existing `DescribeClusterAsync(cancellationToken)` overload retains its metadata-cache semantics and result type. The new overload always makes a live request and returns a separate administrative snapshot. Pass a cancellation token to bound initialization, retries, and the request.
+
+Custom `IAdminClient` implementations remain compatible. They can opt into `IClusterDiscoveryAdminClient`; otherwise the extension method throws `NotSupportedException`.

--- a/docs/docs/admin/cluster-discovery.md
+++ b/docs/docs/admin/cluster-discovery.md
@@ -34,3 +34,5 @@ Fenced brokers remain registered with the cluster but are unavailable for normal
 The existing `DescribeClusterAsync(cancellationToken)` overload retains its metadata-cache semantics and result type. The new overload always makes a live request and returns a separate administrative snapshot. Pass a cancellation token to bound initialization, retries, and the request.
 
 Custom `IAdminClient` implementations remain compatible. They can opt into `IClusterDiscoveryAdminClient`; otherwise the extension method throws `NotSupportedException`.
+
+`Dekaf.Testing.InMemoryAdminClient` implements this capability with its single in-memory broker. Both option values return that broker with `IsFenced = false`; the in-memory cluster does not simulate fencing. Discovery observes the configured admin fault plan and cancellation, and leaves routing metadata unchanged.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -79,6 +79,7 @@ const sidebars = {
       type: 'category',
       label: 'Operations & Administration',
       items: [
+        'admin/cluster-discovery',
         'observability',
         'admin/topic-identifiers',
         'admin/transaction-remediation',

--- a/src/Dekaf.Testing/InMemoryAdminClient.ClusterDiscovery.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.ClusterDiscovery.cs
@@ -1,0 +1,36 @@
+using Dekaf.Admin;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Testing;
+
+public sealed partial class InMemoryAdminClient : IClusterDiscoveryAdminClient
+{
+    /// <inheritdoc />
+    async ValueTask<ClusterDescriptionSnapshot> IClusterDiscoveryAdminClient.DescribeClusterAsync(
+        DescribeClusterOptions options,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        await ApplyAdminFaultAsync(cancellationToken).ConfigureAwait(false);
+
+        // The in-memory cluster has one broker and does not simulate broker fencing.
+        return new ClusterDescriptionSnapshot
+        {
+            ClusterId = _cluster.Options.ClusterId,
+            ControllerId = 0,
+            EndpointType = DescribeClusterEndpointType.Broker,
+            Nodes =
+            [
+                new ClusterNodeDescription
+                {
+                    NodeId = 0,
+                    Host = "in-memory",
+                    Port = 0,
+                    IsFenced = false
+                }
+            ]
+        };
+    }
+}

--- a/src/Dekaf/Admin/AdminClient.ClusterDiscovery.cs
+++ b/src/Dekaf/Admin/AdminClient.ClusterDiscovery.cs
@@ -1,0 +1,71 @@
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Admin;
+
+public sealed partial class AdminClient : IClusterDiscoveryAdminClient
+{
+    async ValueTask<ClusterDescriptionSnapshot> IClusterDiscoveryAdminClient.DescribeClusterAsync(
+        DescribeClusterOptions options,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        cancellationToken.ThrowIfCancellationRequested();
+        var endpointType = _controllerMetadataManager is null
+            ? DescribeClusterEndpointType.Broker
+            : DescribeClusterEndpointType.Controller;
+        if (options.IncludeFencedBrokers && endpointType == DescribeClusterEndpointType.Controller)
+        {
+            throw new NotSupportedException(
+                "Fenced broker discovery requires broker bootstrap endpoints; controller endpoints describe controllers.");
+        }
+
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        return await WithRetryAsync(async () =>
+        {
+            using var lease = endpointType == DescribeClusterEndpointType.Broker
+                ? await LeaseAnyBrokerConnectionAsync(cancellationToken).ConfigureAwait(false)
+                : await LeaseControllerAsync(ApiKey.DescribeCluster, cancellationToken).ConfigureAwait(false);
+            var connection = lease.Connection;
+            var minimumVersion = endpointType == DescribeClusterEndpointType.Controller ? (short)1 : (short)0;
+            if (options.IncludeFencedBrokers)
+                minimumVersion = 2;
+            var version = _metadataManager.GetNegotiatedApiVersion(
+                connection, ApiKey.DescribeCluster, minimumVersion, DescribeClusterRequest.HighestSupportedVersion);
+            var response = await connection.SendAsync<DescribeClusterRequest, DescribeClusterResponse>(
+                new DescribeClusterRequest
+                {
+                    EndpointType = endpointType,
+                    IncludeFencedBrokers = options.IncludeFencedBrokers
+                }, version, cancellationToken).ConfigureAwait(false);
+            if (response.ErrorCode != ErrorCode.None)
+                throw KafkaException.FromErrorCode(response.ErrorCode, response.ErrorMessage ?? "DescribeCluster failed.");
+            if (response.EndpointType != endpointType)
+                throw KafkaException.FromErrorCode(ErrorCode.MismatchedEndpointType,
+                    $"DescribeCluster returned {response.EndpointType} nodes for a {endpointType} endpoint.");
+
+            var nodes = new ClusterNodeDescription[response.Nodes.Count];
+            for (var i = 0; i < nodes.Length; i++)
+            {
+                var node = response.Nodes[i];
+                nodes[i] = new ClusterNodeDescription
+                {
+                    NodeId = node.NodeId,
+                    Host = node.Host,
+                    Port = node.Port,
+                    Rack = node.Rack,
+                    IsFenced = endpointType == DescribeClusterEndpointType.Broker && version >= 2
+                        ? node.IsFenced : null
+                };
+            }
+
+            return new ClusterDescriptionSnapshot
+            {
+                ClusterId = response.ClusterId,
+                ControllerId = response.ControllerId,
+                EndpointType = endpointType,
+                Nodes = nodes
+            };
+        }, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Dekaf/Admin/IClusterDiscoveryAdminClient.cs
+++ b/src/Dekaf/Admin/IClusterDiscoveryAdminClient.cs
@@ -1,0 +1,71 @@
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Admin;
+
+/// <summary>
+/// Optional admin-client capability for live cluster discovery, including fenced brokers.
+/// </summary>
+public interface IClusterDiscoveryAdminClient
+{
+    /// <summary>
+    /// Queries the configured endpoint using DescribeCluster instead of cached metadata.
+    /// Results are an administrative snapshot and are never added to client routing metadata.
+    /// </summary>
+    ValueTask<ClusterDescriptionSnapshot> DescribeClusterAsync(
+        DescribeClusterOptions options,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Live cluster discovery operations for <see cref="IAdminClient"/>.</summary>
+public static class AdminClientClusterDiscoveryExtensions
+{
+    /// <summary>
+    /// Queries live cluster information. The existing no-options overload retains its cached semantics.
+    /// </summary>
+    /// <exception cref="NotSupportedException">The client does not implement this optional capability.</exception>
+    public static ValueTask<ClusterDescriptionSnapshot> DescribeClusterAsync(
+        this IAdminClient adminClient,
+        DescribeClusterOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(adminClient);
+        ArgumentNullException.ThrowIfNull(options);
+        return adminClient is IClusterDiscoveryAdminClient discovery
+            ? discovery.DescribeClusterAsync(options, cancellationToken)
+            : throw new NotSupportedException(
+                $"Admin client type '{adminClient.GetType().FullName}' does not support live cluster discovery.");
+    }
+}
+
+/// <summary>Options for live DescribeCluster discovery.</summary>
+public sealed class DescribeClusterOptions
+{
+    /// <summary>
+    /// Includes fenced but registered brokers. Requires DescribeCluster v2 on the destination.
+    /// Not supported with controller bootstrap endpoints, which describe controller nodes instead.
+    /// </summary>
+    public bool IncludeFencedBrokers { get; init; }
+}
+
+/// <summary>A live administrative cluster snapshot, independent of producer/consumer routing.</summary>
+public sealed class ClusterDescriptionSnapshot
+{
+    public required string ClusterId { get; init; }
+    public int ControllerId { get; init; }
+    /// <summary>Identifies whether Nodes describes brokers or controllers.</summary>
+    public DescribeClusterEndpointType EndpointType { get; init; }
+    public required IReadOnlyList<ClusterNodeDescription> Nodes { get; init; }
+}
+
+/// <summary>A node returned by live cluster discovery.</summary>
+public sealed class ClusterNodeDescription
+{
+    public int NodeId { get; init; }
+    public required string Host { get; init; }
+    public int Port { get; init; }
+    public string? Rack { get; init; }
+    /// <summary>
+    /// Broker fencing status, or null for controller nodes and responses older than DescribeCluster v2.
+    /// </summary>
+    public bool? IsFenced { get; init; }
+}

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -568,3 +568,33 @@ Dekaf.ShareConsumer.ShareAcknowledgementCommitResult.TopicPartition.get -> Dekaf
 Dekaf.ShareConsumer.ShareConsumerOptions.AcknowledgementCommitCallback.get -> Dekaf.ShareConsumer.ShareAcknowledgementCommitCallback?
 Dekaf.ShareConsumer.ShareConsumerOptions.AcknowledgementCommitCallback.init -> void
 Dekaf.ShareConsumerBuilder<TKey, TValue>.WithAcknowledgementCommitCallback(Dekaf.ShareConsumer.ShareAcknowledgementCommitCallback! callback) -> Dekaf.ShareConsumerBuilder<TKey, TValue>!
+Dekaf.Admin.AdminClientClusterDiscoveryExtensions
+Dekaf.Admin.ClusterDescriptionSnapshot
+Dekaf.Admin.ClusterDescriptionSnapshot.ClusterDescriptionSnapshot() -> void
+Dekaf.Admin.ClusterDescriptionSnapshot.ClusterId.get -> string!
+Dekaf.Admin.ClusterDescriptionSnapshot.ClusterId.init -> void
+Dekaf.Admin.ClusterDescriptionSnapshot.ControllerId.get -> int
+Dekaf.Admin.ClusterDescriptionSnapshot.ControllerId.init -> void
+Dekaf.Admin.ClusterDescriptionSnapshot.EndpointType.get -> Dekaf.Protocol.Messages.DescribeClusterEndpointType
+Dekaf.Admin.ClusterDescriptionSnapshot.EndpointType.init -> void
+Dekaf.Admin.ClusterDescriptionSnapshot.Nodes.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Admin.ClusterNodeDescription!>!
+Dekaf.Admin.ClusterDescriptionSnapshot.Nodes.init -> void
+Dekaf.Admin.ClusterNodeDescription
+Dekaf.Admin.ClusterNodeDescription.ClusterNodeDescription() -> void
+Dekaf.Admin.ClusterNodeDescription.Host.get -> string!
+Dekaf.Admin.ClusterNodeDescription.Host.init -> void
+Dekaf.Admin.ClusterNodeDescription.IsFenced.get -> bool?
+Dekaf.Admin.ClusterNodeDescription.IsFenced.init -> void
+Dekaf.Admin.ClusterNodeDescription.NodeId.get -> int
+Dekaf.Admin.ClusterNodeDescription.NodeId.init -> void
+Dekaf.Admin.ClusterNodeDescription.Port.get -> int
+Dekaf.Admin.ClusterNodeDescription.Port.init -> void
+Dekaf.Admin.ClusterNodeDescription.Rack.get -> string?
+Dekaf.Admin.ClusterNodeDescription.Rack.init -> void
+Dekaf.Admin.DescribeClusterOptions
+Dekaf.Admin.DescribeClusterOptions.DescribeClusterOptions() -> void
+Dekaf.Admin.DescribeClusterOptions.IncludeFencedBrokers.get -> bool
+Dekaf.Admin.DescribeClusterOptions.IncludeFencedBrokers.init -> void
+Dekaf.Admin.IClusterDiscoveryAdminClient
+Dekaf.Admin.IClusterDiscoveryAdminClient.DescribeClusterAsync(Dekaf.Admin.DescribeClusterOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.ClusterDescriptionSnapshot!>
+static Dekaf.Admin.AdminClientClusterDiscoveryExtensions.DescribeClusterAsync(this Dekaf.Admin.IAdminClient! adminClient, Dekaf.Admin.DescribeClusterOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.ClusterDescriptionSnapshot!>

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -568,3 +568,33 @@ Dekaf.ShareConsumer.ShareAcknowledgementCommitResult.TopicPartition.get -> Dekaf
 Dekaf.ShareConsumer.ShareConsumerOptions.AcknowledgementCommitCallback.get -> Dekaf.ShareConsumer.ShareAcknowledgementCommitCallback?
 Dekaf.ShareConsumer.ShareConsumerOptions.AcknowledgementCommitCallback.init -> void
 Dekaf.ShareConsumerBuilder<TKey, TValue>.WithAcknowledgementCommitCallback(Dekaf.ShareConsumer.ShareAcknowledgementCommitCallback! callback) -> Dekaf.ShareConsumerBuilder<TKey, TValue>!
+Dekaf.Admin.AdminClientClusterDiscoveryExtensions
+Dekaf.Admin.ClusterDescriptionSnapshot
+Dekaf.Admin.ClusterDescriptionSnapshot.ClusterDescriptionSnapshot() -> void
+Dekaf.Admin.ClusterDescriptionSnapshot.ClusterId.get -> string!
+Dekaf.Admin.ClusterDescriptionSnapshot.ClusterId.init -> void
+Dekaf.Admin.ClusterDescriptionSnapshot.ControllerId.get -> int
+Dekaf.Admin.ClusterDescriptionSnapshot.ControllerId.init -> void
+Dekaf.Admin.ClusterDescriptionSnapshot.EndpointType.get -> Dekaf.Protocol.Messages.DescribeClusterEndpointType
+Dekaf.Admin.ClusterDescriptionSnapshot.EndpointType.init -> void
+Dekaf.Admin.ClusterDescriptionSnapshot.Nodes.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Admin.ClusterNodeDescription!>!
+Dekaf.Admin.ClusterDescriptionSnapshot.Nodes.init -> void
+Dekaf.Admin.ClusterNodeDescription
+Dekaf.Admin.ClusterNodeDescription.ClusterNodeDescription() -> void
+Dekaf.Admin.ClusterNodeDescription.Host.get -> string!
+Dekaf.Admin.ClusterNodeDescription.Host.init -> void
+Dekaf.Admin.ClusterNodeDescription.IsFenced.get -> bool?
+Dekaf.Admin.ClusterNodeDescription.IsFenced.init -> void
+Dekaf.Admin.ClusterNodeDescription.NodeId.get -> int
+Dekaf.Admin.ClusterNodeDescription.NodeId.init -> void
+Dekaf.Admin.ClusterNodeDescription.Port.get -> int
+Dekaf.Admin.ClusterNodeDescription.Port.init -> void
+Dekaf.Admin.ClusterNodeDescription.Rack.get -> string?
+Dekaf.Admin.ClusterNodeDescription.Rack.init -> void
+Dekaf.Admin.DescribeClusterOptions
+Dekaf.Admin.DescribeClusterOptions.DescribeClusterOptions() -> void
+Dekaf.Admin.DescribeClusterOptions.IncludeFencedBrokers.get -> bool
+Dekaf.Admin.DescribeClusterOptions.IncludeFencedBrokers.init -> void
+Dekaf.Admin.IClusterDiscoveryAdminClient
+Dekaf.Admin.IClusterDiscoveryAdminClient.DescribeClusterAsync(Dekaf.Admin.DescribeClusterOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.ClusterDescriptionSnapshot!>
+static Dekaf.Admin.AdminClientClusterDiscoveryExtensions.DescribeClusterAsync(this Dekaf.Admin.IAdminClient! adminClient, Dekaf.Admin.DescribeClusterOptions! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Dekaf.Admin.ClusterDescriptionSnapshot!>

--- a/tests/Dekaf.Tests.Integration/ControllerBootstrapIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ControllerBootstrapIntegrationTests.cs
@@ -17,6 +17,11 @@ public sealed class ControllerBootstrapIntegrationTests(ControllerOnlyKafkaConta
 
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var cluster = await admin.DescribeClusterAsync(timeout.Token).ConfigureAwait(false);
+        var live = await admin.DescribeClusterAsync(new DescribeClusterOptions(), timeout.Token).ConfigureAwait(false);
+        await Assert.That(live.EndpointType).IsEqualTo(Dekaf.Protocol.Messages.DescribeClusterEndpointType.Controller);
+        await Assert.That(live.Nodes.Single().IsFenced).IsNull();
+        await Assert.ThrowsAsync<NotSupportedException>(async () =>
+            await admin.DescribeClusterAsync(new DescribeClusterOptions { IncludeFencedBrokers = true }, timeout.Token));
         var quorum = await admin.DescribeMetadataQuorumAsync(timeout.Token).ConfigureAwait(false);
         var features = await admin.DescribeFeaturesAsync(timeout.Token).ConfigureAwait(false);
 

--- a/tests/Dekaf.Tests.Integration/FencedBrokerDiscoveryIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/FencedBrokerDiscoveryIntegrationTests.cs
@@ -1,0 +1,51 @@
+using Dekaf.Admin;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Admin")]
+public sealed class FencedBrokerDiscoveryIntegrationTests
+{
+    [Test]
+    [Timeout(240_000)]
+    public async Task DescribeClusterAsync_ObservesRegisteredBrokerBeforeAndAfterFencing(CancellationToken cancellationToken)
+    {
+        await using var kafka = new RackAwareKafkaContainer();
+        await kafka.InitializeAsync();
+        // Keep discovery on a surviving broker when broker 3 stops.
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers(kafka.BootstrapServers.Split(',')[0])
+            .WithMetadataMaxAge(TimeSpan.FromMilliseconds(100))
+            .Build();
+        var options = new DescribeClusterOptions { IncludeFencedBrokers = true };
+        var initial = await admin.DescribeClusterAsync(options, cancellationToken);
+        await Assert.That(initial.EndpointType).IsEqualTo(DescribeClusterEndpointType.Broker);
+        await Assert.That(initial.Nodes.Select(node => node.NodeId)).IsEquivalentTo([1, 2, 3]);
+        await Assert.That(initial.Nodes.All(node => node.IsFenced == false)).IsTrue();
+
+        await kafka.StopBrokerAsync(3, cancellationToken);
+        using var observation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        observation.CancelAfter(TimeSpan.FromSeconds(60));
+        while (true)
+        {
+            var snapshot = await admin.DescribeClusterAsync(options, observation.Token);
+            if (snapshot.Nodes.Any(node => node.NodeId == 3 && node.IsFenced == true))
+                break;
+            await Task.Delay(TimeSpan.FromMilliseconds(100), observation.Token);
+        }
+
+        var ordinary = await admin.DescribeClusterAsync(new DescribeClusterOptions(), cancellationToken);
+        await Assert.That(ordinary.Nodes.Select(node => node.NodeId)).IsEquivalentTo([1, 2]);
+        var included = await admin.DescribeClusterAsync(options, cancellationToken);
+        await Assert.That(included.Nodes.Single(node => node.NodeId == 3).IsFenced).IsTrue();
+
+        // Discovery must not reintroduce fenced registrations into ordinary metadata routing.
+        while (true)
+        {
+            var cached = await admin.DescribeClusterAsync(observation.Token);
+            if (!cached.Nodes.Any(node => node.NodeId == 3))
+                break;
+            await Task.Delay(TimeSpan.FromMilliseconds(100), observation.Token);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientClusterDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientClusterDiscoveryTests.cs
@@ -18,7 +18,7 @@ public sealed class AdminClientClusterDiscoveryTests
     {
         var (admin, connection, pool, metadata) = CreateAdmin();
         await using var client = admin;
-        var result = await ((IAdminClient)client).DescribeClusterAsync(
+        var result = await client.DescribeClusterAsync(
             new DescribeClusterOptions { IncludeFencedBrokers = includeFenced });
 
         await Assert.That(result.ClusterId).IsEqualTo("cluster");

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientClusterDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientClusterDiscoveryTests.cs
@@ -1,0 +1,219 @@
+using System.Buffers;
+using Dekaf.Admin;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+public sealed class AdminClientClusterDiscoveryTests
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task DescribeClusterAsync_MapsLiveResultsWithoutChangingRouting(bool includeFenced)
+    {
+        var (admin, connection, pool, metadata) = CreateAdmin();
+        await using var client = admin;
+        var result = await ((IAdminClient)client).DescribeClusterAsync(
+            new DescribeClusterOptions { IncludeFencedBrokers = includeFenced });
+
+        await Assert.That(result.ClusterId).IsEqualTo("cluster");
+        await Assert.That(result.ControllerId).IsEqualTo(1);
+        await Assert.That(result.EndpointType).IsEqualTo(DescribeClusterEndpointType.Broker);
+        await Assert.That(result.Nodes.Count).IsEqualTo(includeFenced ? 2 : 1);
+        await Assert.That(result.Nodes[0].IsFenced).IsFalse();
+        if (includeFenced)
+        {
+            var fenced = result.Nodes[1];
+            await Assert.That(fenced.NodeId).IsEqualTo(2);
+            await Assert.That(fenced.Host).IsEqualTo("fenced");
+            await Assert.That(fenced.Port).IsEqualTo(9093);
+            await Assert.That(fenced.Rack).IsEqualTo("rack-b");
+            await Assert.That(fenced.IsFenced).IsTrue();
+        }
+
+        await connection.Received(1).SendAsync<DescribeClusterRequest, DescribeClusterResponse>(
+            Arg.Is<DescribeClusterRequest>(r => r.IncludeFencedBrokers == includeFenced &&
+                r.EndpointType == DescribeClusterEndpointType.Broker), 2, Arg.Any<CancellationToken>());
+        pool.DidNotReceive().RegisterBroker(2, Arg.Any<string>(), Arg.Any<int>());
+        await Assert.That(metadata.Metadata.GetBrokers().Select(n => n.NodeId)).IsEquivalentTo([1]);
+        // The existing default-literal call must remain unambiguous on concrete clients.
+        var cached = await client.DescribeClusterAsync(default);
+        await Assert.That(cached.Nodes.Select(n => n.NodeId)).IsEquivalentTo([1]);
+    }
+
+    [Test]
+    public async Task DescribeClusterAsync_EncodesRequestedOption()
+    {
+        var (admin, connection, _, _) = CreateAdmin();
+        await using var client = admin;
+        DescribeClusterRequest? request = null;
+        _ = connection.SendAsync<DescribeClusterRequest, DescribeClusterResponse>(
+            Arg.Do<DescribeClusterRequest>(r => request = r), Arg.Any<short>(), Arg.Any<CancellationToken>());
+        await client.DescribeClusterAsync(new DescribeClusterOptions { IncludeFencedBrokers = true });
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        request!.Write(ref writer, 2);
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var authorized = reader.ReadBoolean();
+        var endpoint = reader.ReadInt8();
+        var includeFenced = reader.ReadBoolean();
+        await Assert.That(authorized).IsFalse();
+        await Assert.That(endpoint).IsEqualTo((sbyte)DescribeClusterEndpointType.Broker);
+        await Assert.That(includeFenced).IsTrue();
+    }
+
+    [Test]
+    public async Task DescribeClusterAsync_RequiresV2OnActualDestination()
+    {
+        var (admin, connection, _, metadata) = CreateAdmin(version: 1);
+        await using var client = admin;
+        metadata.SetApiVersion(ApiKey.DescribeCluster, 0, 2);
+        await Assert.ThrowsAsync<BrokerVersionException>(async () =>
+            await client.DescribeClusterAsync(new DescribeClusterOptions { IncludeFencedBrokers = true }));
+        await connection.DidNotReceiveWithAnyArgs().SendAsync<DescribeClusterRequest, DescribeClusterResponse>(
+            default!, default, default);
+    }
+
+    [Test]
+    public async Task DescribeClusterAsync_V1ReportsUnknownFencing()
+    {
+        var (admin, _, _, _) = CreateAdmin(version: 1);
+        await using var client = admin;
+        var result = await client.DescribeClusterAsync(new DescribeClusterOptions());
+        await Assert.That(result.Nodes[0].IsFenced).IsNull();
+    }
+
+    [Test]
+    [Arguments(ErrorCode.ClusterAuthorizationFailed)]
+    [Arguments(ErrorCode.UnsupportedVersion)]
+    public async Task DescribeClusterAsync_PreservesRpcError(ErrorCode error)
+    {
+        var (admin, connection, _, _) = CreateAdmin();
+        await using var client = admin;
+        connection.SendAsync<DescribeClusterRequest, DescribeClusterResponse>(
+            Arg.Any<DescribeClusterRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new DescribeClusterResponse
+            { ClusterId = "cluster", Nodes = [], ErrorCode = error, ErrorMessage = "denied" }));
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await client.DescribeClusterAsync(new DescribeClusterOptions()));
+        await Assert.That(exception!.ErrorCode).IsEqualTo(error);
+    }
+
+    [Test]
+    public async Task DescribeClusterAsync_RejectsMismatchedEndpoint()
+    {
+        var (admin, connection, _, _) = CreateAdmin();
+        await using var client = admin;
+        connection.SendAsync<DescribeClusterRequest, DescribeClusterResponse>(
+            Arg.Any<DescribeClusterRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new DescribeClusterResponse
+            { ClusterId = "cluster", Nodes = [], EndpointType = DescribeClusterEndpointType.Controller }));
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await client.DescribeClusterAsync(new DescribeClusterOptions()));
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.MismatchedEndpointType);
+    }
+
+    [Test]
+    public async Task DescribeClusterAsync_CustomAdminWithoutCapabilityFailsExplicitly()
+    {
+        var admin = Substitute.For<IAdminClient>();
+        await Assert.ThrowsAsync<NotSupportedException>(async () =>
+            await admin.DescribeClusterAsync(new DescribeClusterOptions()));
+    }
+
+    [Test]
+    public async Task DescribeClusterAsync_CancelsInFlightRpc()
+    {
+        var (admin, connection, _, _) = CreateAdmin();
+        await using var client = admin;
+        using var cancellation = new CancellationTokenSource();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.SendAsync<DescribeClusterRequest, DescribeClusterResponse>(
+            Arg.Any<DescribeClusterRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(call => WaitForCancellationAsync(call.Arg<CancellationToken>()));
+        var operation = client.DescribeClusterAsync(new DescribeClusterOptions(), cancellation.Token).AsTask();
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        cancellation.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await operation);
+
+        async ValueTask<DescribeClusterResponse> WaitForCancellationAsync(CancellationToken token)
+        {
+            entered.SetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            throw new InvalidOperationException("RPC should have been cancelled.");
+        }
+    }
+
+    private static (AdminClient, IKafkaConnection, IConnectionPool, MetadataManager) CreateAdmin(short version = 2)
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.BrokerId.Returns(1);
+        connection.Host.Returns("localhost");
+        connection.Port.Returns(9092);
+        connection.IsConnected.Returns(true);
+        var versions = new ApiVersionsResponse
+        {
+            ErrorCode = ErrorCode.None,
+            ApiKeys = [new(ApiKey.ApiVersions, 0, 4), new(ApiKey.Metadata, 9, 13), new(ApiKey.DescribeCluster, 0, version)]
+        };
+        IKafkaConnection destination = new CapabilityConnection(connection, KafkaConnectionCapabilities.Create(versions));
+        connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            Arg.Any<ApiVersionsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>()).Returns(ValueTask.FromResult(versions));
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+            Arg.Any<MetadataRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new MetadataResponse
+            { ClusterId = "cluster", ControllerId = 1, Brokers = [new() { NodeId = 1, Host = "localhost", Port = 9092 }], Topics = [] }));
+        connection.SendAsync<DescribeClusterRequest, DescribeClusterResponse>(
+            Arg.Any<DescribeClusterRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(call => ValueTask.FromResult(new DescribeClusterResponse
+            {
+                ClusterId = "cluster", ControllerId = 1,
+                Nodes = call.Arg<DescribeClusterRequest>().IncludeFencedBrokers
+                    ? [new() { NodeId = 1, Host = "localhost", Port = 9092 }, new() { NodeId = 2, Host = "fenced", Port = 9093, Rack = "rack-b", IsFenced = true }]
+                    : [new() { NodeId = 1, Host = "localhost", Port = 9092 }]
+            }));
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(ValueTask.FromResult(destination));
+        pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(ValueTask.FromResult(destination));
+        var metadata = new MetadataManager(pool, ["localhost:9092"]);
+        return (new AdminClient(new AdminClientOptions { BootstrapServers = ["localhost:9092"], RetryBackoffMs = 1 }, pool, metadata, ownsResources: true), connection, pool, metadata);
+    }
+
+    private sealed class CapabilityConnection(IKafkaConnection inner, KafkaConnectionCapabilities capabilities)
+        : IKafkaConnection, IKafkaCapabilityProvider
+    {
+        public int BrokerId => inner.BrokerId;
+        public string Host => inner.Host;
+        public int Port => inner.Port;
+        public bool IsConnected => inner.IsConnected;
+        public KafkaConnectionCapabilities Capabilities => capabilities;
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => inner.ConnectAsync(cancellationToken);
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(TRequest request, short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse =>
+            inner.SendAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(TRequest request, short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(TRequest request, short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request, short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request, short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientControllerBootstrapTests.cs
@@ -12,6 +12,28 @@ namespace Dekaf.Tests.Unit.Admin;
 public sealed class AdminClientControllerBootstrapTests
 {
     [Test]
+    public async Task DescribeClusterAsync_WithOptions_QueriesControllerAndLeavesFencingUnknown()
+    {
+        await using var context = new ControllerAdminContext();
+        var result = await context.Client.DescribeClusterAsync(new DescribeClusterOptions());
+        await Assert.That(result.EndpointType).IsEqualTo(DescribeClusterEndpointType.Controller);
+        await Assert.That(result.Nodes.Count).IsEqualTo(2);
+        await Assert.That(result.Nodes.All(node => node.IsFenced is null)).IsTrue();
+        await Assert.That(context.DiscoveryRequests).IsEqualTo(2);
+        await Assert.That(context.LastDiscoveryRequest!.EndpointType).IsEqualTo(DescribeClusterEndpointType.Controller);
+        await Assert.That(context.LastDiscoveryRequest.IncludeFencedBrokers).IsFalse();
+    }
+
+    [Test]
+    public async Task DescribeClusterAsync_FencedBrokersOnControllerBootstrap_RejectsBeforeDiscovery()
+    {
+        await using var context = new ControllerAdminContext();
+        await Assert.ThrowsAsync<NotSupportedException>(async () =>
+            await context.Client.DescribeClusterAsync(new DescribeClusterOptions { IncludeFencedBrokers = true }));
+        await Assert.That(context.DiscoveryRequests).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task DescribeClusterAsync_DiscoversControllersWithoutRegisteringBrokers()
     {
         await using var context = new ControllerAdminContext();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryClusterDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryClusterDiscoveryTests.cs
@@ -1,0 +1,62 @@
+using Dekaf.Admin;
+using Dekaf.Protocol.Messages;
+using Dekaf.Testing;
+
+namespace Dekaf.Tests.Unit.Testing;
+
+public sealed class InMemoryClusterDiscoveryTests
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task DescribeCluster_ReportsUnfencedInMemoryBroker(bool includeFenced)
+    {
+        var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions { ClusterId = "discovery-test" });
+        await using var admin = new InMemoryAdminClient(cluster);
+        IAdminClient client = admin;
+        var snapshot = await client.DescribeClusterAsync(new DescribeClusterOptions { IncludeFencedBrokers = includeFenced });
+        var cached = await admin.DescribeClusterAsync(default);
+
+        await Assert.That(snapshot.ClusterId).IsEqualTo("discovery-test");
+        await Assert.That(snapshot.ControllerId).IsEqualTo(cached.ControllerId);
+        await Assert.That(snapshot.EndpointType).IsEqualTo(DescribeClusterEndpointType.Broker);
+        await Assert.That(snapshot.Nodes.Count).IsEqualTo(1);
+        await Assert.That(snapshot.Nodes[0].NodeId).IsEqualTo(cached.Nodes[0].NodeId);
+        await Assert.That(snapshot.Nodes[0].Host).IsEqualTo("in-memory");
+        await Assert.That(snapshot.Nodes[0].Port).IsEqualTo(0);
+        await Assert.That(snapshot.Nodes[0].Rack).IsNull();
+        await Assert.That(snapshot.Nodes[0].IsFenced).IsFalse();
+        await Assert.That(admin.Metadata.GetBrokers()).IsEmpty();
+    }
+
+    [Test]
+    public async Task DescribeCluster_ObservesAdminFaultsAndCancellation()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        await using var admin = new InMemoryAdminClient(cluster);
+        IAdminClient client = admin;
+        var failure = new InvalidOperationException("discovery failed");
+        cluster.FaultPlan.Fail(new KafkaFaultScope(KafkaFaultOperation.Admin), failure);
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => client.DescribeClusterAsync(new DescribeClusterOptions()).AsTask());
+        await Assert.That(actual).IsSameReferenceAs(failure);
+
+        var barrier = cluster.FaultPlan.PauseNext(new KafkaFaultScope(KafkaFaultOperation.Admin));
+        using var cancellation = new CancellationTokenSource();
+        var pending = client.DescribeClusterAsync(new DescribeClusterOptions(), cancellation.Token).AsTask();
+        await barrier.WaitUntilEnteredAsync();
+        cancellation.Cancel();
+        _ = await Assert.ThrowsAsync<OperationCanceledException>(() => pending);
+        barrier.Release();
+        var recovered = await client.DescribeClusterAsync(new DescribeClusterOptions());
+        await Assert.That(recovered.Nodes.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task DescribeCluster_DisposedClientThrows()
+    {
+        var admin = new InMemoryAdminClient(new InMemoryKafkaCluster());
+        await admin.DisposeAsync();
+        IAdminClient client = admin;
+        _ = await Assert.ThrowsAsync<ObjectDisposedException>(() => client.DescribeClusterAsync(new DescribeClusterOptions()).AsTask());
+    }
+}


### PR DESCRIPTION
## Summary

Adds live DescribeCluster discovery with `IncludeFencedBrokers`, allowing operators to inspect registered but fenced brokers without changing routing metadata or cluster state.

The additive `IClusterDiscoveryAdminClient` capability returns a separate snapshot with endpoint type and nullable fencing status. The existing cached operation and `DescribeClusterAsync(default)` remain compatible. Controller bootstrap describes controller nodes and explicitly rejects fenced-broker discovery. Requested fencing requires v2 on the actual destination; unsupported versions never silently drop the option.

## Validation

- 360 admin unit tests passed, including option encoding, destination negotiation, result mapping, endpoint errors, cancellation, and routing isolation.
- Kafka 4.3.1 integration passed: register three brokers, stop broker 3, observe its fenced registration, verify default exclusion and unchanged routing metadata.
- Controller-only Kafka integration passed, including live controller discovery and fenced-option rejection.
- Release builds passed for integration targets net10.0/net8.0; final netstandard2.0 library build passed with API analyzers.
- `npm run build --prefix docs` and `/simplify` completed.

## Performance evidence

Baseline: `0dd6f2857` (immediately preceding main). Candidate: `34b66e3afd6a7cb74f7fe8074288a00b0e1faf01`. Local Windows 11, Intel i7-12700K, .NET SDK 10.0.400 / runtime 10.0.11, BenchmarkDotNet 0.15.8, MemoryDiagnoser. No paid stress lane dispatched.

Existing `ControllerMetadataRefreshBenchmarks.Refresh`, identical configuration (1 launch, 3 warmups, 10 iterations):

| Build | Mean | 99.9% CI half-width | Allocated/op |
|---|---:|---:|---:|
| Before | 422.7 ns | 130.5 ns | 1.18 KB |
| After | 337.9 ns | 29.70 ns | 1.18 KB |

Allocation delta: 0. Mean delta: -20.1%; the noisy baseline prevents a speedup claim. This is a cold administrative control, not producer/consumer performance evidence. Production/consumption/protocol serialization hot paths and routing types are unchanged; new allocations belong to explicit administrative snapshot requests.

Task-local initialized-controller query harness (one returned node, synchronous fake transport, InProcessEmitToolchain, 3 warmups/10 iterations, MemoryDiagnoser): cached query 68.35 ns ±1.214 ns / 168 B; new live query 126.49 ns ±0.803 ns / 256 B. This exercises the new request/mapping path while excluding network latency and wire response parsing. The operations have intentionally different semantics; these numbers characterize the new cold API, not a performance trade in an existing message path.
Closes #3028




Addressed the in-memory parity finding in e5c5ca8e2. `InMemoryAdminClient` now explicitly implements `IClusterDiscoveryAdminClient`: both option values describe its single broker with `IsFenced=false`, preserve routing metadata, and honor cancellation, disposal, and the admin fault plan. Explicit implementation preserves `DescribeClusterAsync(default)` source compatibility. The guide explains that the in-memory cluster does not simulate fencing.

Four tests reproduced the missing capability before implementation. Final validation: 360 admin + 368 testing tests on each of net10.0/net8.0 (1,456 total), zero build warnings/errors, docs build pass, `/simplify` and diff checks complete. Real-broker implementation is unchanged by this review fix.

Before/after BDN MemoryDiagnoser evidence for the testing package (cold admin calls):

| Operation | Product | Mean | Error | StdDev | Allocated |
| --- | --- | ---: | ---: | ---: | ---: |
| Existing cached discovery | 34b66e3af | 25.18 ns | 1.083 ns | 1.013 ns | 104 B |
| Existing cached discovery | e5c5ca8e2 | 23.09 ns | 0.828 ns | 0.734 ns | 104 B |
| New live snapshot | e5c5ca8e2 | 24.51 ns | 0.544 ns | 0.454 ns | 112 B |

Cached mean -8.3%, allocations unchanged; no speedup claim from separate local runs. The new API was unsupported before this change, so its 112 B is a new per-admin snapshot, not a per-message regression. Same fixture with saved baseline DLL versus current product, matching loaded candidate DLL hash; BDN 0.15.8, .NET 10.0.11/SDK 10.0.400, Windows 11/i7-12700K, in-process, 5 warmups/15 iterations. No paid stress run or message-path change.

