### PR TITLE
docs: clarify package and runtime compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Taking the Java out of Kafka** 
 
-Dekaf is a high-performance, pure C# Apache Kafka client for .NET 10+. No JVM, no interop, no native dependencies - just clean, modern C# all the way down.
+Dekaf is a high-performance, pure C# Apache Kafka client optimized for .NET 10, with compatible package assets for earlier runtimes. No JVM, no interop, no native dependencies - just clean, modern C# all the way down.
 
 If you like, or use this library, a sponsor is appreciated!
 
@@ -16,8 +16,8 @@ Unlike libraries that wrap librdkafka, Dekaf is a native .NET implementation wit
 
 - **Pure C#** - No native dependencies, no interop overhead
 - **Zero-allocation hot paths** - Uses `Span<T>`, `ref struct`, and object pooling for minimal GC pressure
-- **Modern .NET** - Built for .NET 10+ with nullable reference types, `IAsyncEnumerable`, and all the good stuff
-- **Native AOT compatible** - Trim-safe and Native AOT ready, verified by CI smoke tests on every build
+- **Modern .NET** - Optimized for .NET 10 with nullable reference types and `IAsyncEnumerable`; see package compatibility below
+- **Native AOT coverage** - .NET 10 `linux-x64` smoke and Kafka integration tests in code-change CI; see coverage below
 - **Simple API** - Intuitive fluent builders that do what you'd expect
 - **Batteries included for services** - Hosted consumer base class with graceful shutdown, retries, retry topics, and dead letter queues built in
 
@@ -26,6 +26,32 @@ Unlike libraries that wrap librdkafka, Dekaf is a native .NET implementation wit
 ```bash
 dotnet add package Dekaf
 ```
+
+### Package and runtime compatibility
+
+.NET 10 is the preferred runtime for Dekaf's performance-oriented APIs. Package
+assets and tested runtimes are separate:
+
+| Packages | Target frameworks shipped in NuGet |
+| --- | --- |
+| `Dekaf`, `Dekaf.Abstractions` | `net10.0`, `netstandard2.0` |
+| `Dekaf.Compression.*`, `Dekaf.Serialization.*`, `Dekaf.SchemaRegistry` and its extensions, `Dekaf.Extensions.*`, `Dekaf.OpenTelemetry`, `Dekaf.Outbox` and its EF Core extension, `Dekaf.Testing` | `net8.0`, `net10.0` |
+
+- **Tested runtimes:** CI runs unit tests on .NET 8 and .NET 10. PR Kafka integration
+  tests run on .NET 10; the NuGet release gate tests both runtimes against Kafka
+  4.0.2, 4.1.2, 4.2.1 and 4.3.1.
+- **Development:** use the .NET 10 SDK to build this repository. Running its
+  `net8.0` tests also requires the .NET 8 runtime (or SDK).
+- **Native AOT:** code-change CI publishes and runs core and dependency-injection
+  smoke apps plus a Kafka integration smoke subset on .NET 10 `linux-x64`.
+  Release validation expands AOT integration coverage against Kafka 4.0.2 and
+  4.3.1. This is coverage of those scenarios, not every package/API/platform.
+
+A `netstandard2.0` asset does not mean every compatible runtime is tested or has
+identical APIs and performance. .NET 8 uses the core's `netstandard2.0` asset;
+optional packages require their own compatible assets. See
+[API and runtime compatibility](https://thomhurst.github.io/Dekaf/docs/api-compatibility)
+for asset differences, package validation and AOT limits.
 
 ### Producing Messages
 

--- a/docs/docs/api-compatibility.md
+++ b/docs/docs/api-compatibility.md
@@ -1,18 +1,59 @@
 ---
 sidebar_position: 5
-description: "How Dekaf locks its public API surface with analyzer baselines, how to validate a change locally, and how to update a baseline."
+description: "Package targets, tested runtimes, Native AOT coverage, and how Dekaf validates its public API surface."
 ---
 
-# Public API Compatibility
+# API and Runtime Compatibility
+
+## Package assets and tested runtimes
+
+The `Dekaf` and `Dekaf.Abstractions` packages ship `net10.0` and
+`netstandard2.0` assets. .NET 10 applications select the optimized `net10.0`
+asset; .NET 8 applications use the core's `netstandard2.0` asset. Compatibility
+with .NET Standard alone is not a promise of testing on every implementing
+runtime, identical API shapes or equivalent performance on all runtimes.
+
+The other shipping packages target `net8.0` and `net10.0`: compression,
+serialization, Schema Registry and its extensions (including KMS), dependency
+injection, hosting, health checks, OpenTelemetry, outbox/EF Core and testing.
+Those package requirements apply even when the core package could run on an
+older runtime. The Avro POCO source generator targets `netstandard2.0` as a
+compiler analyzer bundled in `Dekaf.SchemaRegistry.Avro`; it is not a separate
+runtime package and does not lower the Avro package's runtime requirements.
+
+Build the repository with the .NET 10 SDK; install the .NET 8 runtime (or SDK)
+to execute the `net8.0` test binaries. The configured CI/release coverage is:
+
+| Validation | Runtime / target | Broker versions |
+| --- | --- | --- |
+| Unit tests for code changes | .NET 8 and .NET 10 | No broker required |
+| PR integration tests | .NET 10 | Kafka 4.3.1 |
+| NuGet release integration gate | .NET 8 and .NET 10 | Kafka 4.0.2, 4.1.2, 4.2.1, 4.3.1 |
+| Native AOT core and DI smoke apps | .NET 10, `linux-x64` | No broker required |
+| PR Native AOT integration smoke subset | .NET 10, `linux-x64` | Kafka 4.3.1 |
+| NuGet release Native AOT integration sweep | .NET 10, `linux-x64` | Kafka 4.0.2 and 4.3.1 |
+
+Manual non-publishing CI runs also execute ordinary integration tests on both
+.NET 8 and .NET 10. Native AOT coverage validates the scenarios exercised by
+the smoke apps and integration suites; it does not establish support for
+every package API, third-party serializer or target platform. Modern .NET
+library assets enable AOT/trim analyzers. The `netstandard2.0` assets do not,
+and third-party dependency warnings still need attention in an application's
+own publish output.
+
+The source of truth is the package project files, `src/Directory.Build.props`
+and `.github/workflows/ci.yml`.
+
+## Public API baselines
 
 Every shipping project under `src/` uses
 `Microsoft.CodeAnalysis.PublicApiAnalyzers`. Its `PublicAPI.Shipped*.txt` and
 `PublicAPI.Unshipped*.txt` files make additions, removals, nullable annotations,
 generic constraints, parameter names, and other signature changes visible in
-code review. The core `Dekaf` package has separate `net10.0` and
+code review. The `Dekaf` and `Dekaf.Abstractions` packages have separate `net10.0` and
 `netstandard2.0` files because those assets intentionally expose a few
-TFM-specific collection and ref-struct shapes. Other packages share one API
-baseline across `net8.0` and `net10.0`.
+TFM-specific collection and ref-struct shapes. Other runtime packages share one
+API baseline across `net8.0` and `net10.0`.
 
 ## Validate locally
 


### PR DESCRIPTION
The README previously described Dekaf as .NET 10+ without explaining the netstandard2.0 core assets or the different requirements of optional packages. It now includes a grouped package compatibility table near Getting Started and separates package targets, tested runtimes, development SDK requirements and Native AOT coverage.

Detailed compatibility guidance records the CI/release broker matrix and explains that the bundled Avro source generator does not lower the Avro runtime package requirement. Broad AOT wording is scoped to the actual .NET 10 linux-x64 smoke and integration coverage.

Validation:
- Evaluated `PackageId`, `TargetFramework`, `TargetFrameworks` and `IsPackable` with MSBuild for every source project; checked inherited target/AOT settings and CI/release jobs.
- All fenced code snippets in both edited documents match the original blocks exactly; no snippet changes require new snippet checks.
- `/simplify` reviewed the final documentation for consistency and scope.
- `npm run build --prefix docs` and `git diff --check` passed.

Closes #3040
