### PR TITLE
Pin the .NET SDK and enable the native MTP runner

### DIFF
--- a/.github/scripts/test_mutation_report.py
+++ b/.github/scripts/test_mutation_report.py
@@ -110,7 +110,12 @@ class MutationReportTests(unittest.TestCase):
         workflow_path = Path(__file__).parents[1] / "workflows" / "mutation-tests.yml"
         workflow = workflow_path.read_text(encoding="utf-8")
 
-        self.assertIn("dotnet-version: |\n            8.0.x\n            10.0.x", workflow)
+        self.assertIn("global-json-file: global.json", workflow)
+        self.assertIn("dotnet-version: '8.0.x'", workflow)
+        sdk_config = json.loads((Path(__file__).parents[2] / "global.json").read_text(encoding="utf-8"))
+        self.assertTrue(sdk_config["sdk"]["version"].startswith("10."))
+        self.assertFalse(sdk_config["sdk"]["allowPrerelease"])
+        self.assertEqual("Microsoft.Testing.Platform", sdk_config["test"]["runner"])
 
     def test_producer_mutation_host_presizes_thread_pool(self):
         project_path = (

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,7 +14,6 @@ permissions:
   contents: read
 
 env:
-  DOTNET_VERSION: '10.0.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   ContinuousIntegrationBuild: true
@@ -58,8 +57,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          dotnet-quality: 'preview'
+          global-json-file: global.json
 
       - name: Build
         run: dotnet build --configuration Release
@@ -94,8 +92,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          dotnet-quality: 'preview'
+          global-json-file: global.json
 
       # Broker and benchmark process are pinned to disjoint cores (0-1 vs 2-3 on the
       # 4-vCPU runner) so scheduler interference between them stops randomizing the
@@ -171,8 +168,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          dotnet-quality: 'preview'
+          global-json-file: global.json
 
       - name: Build
         run: dotnet build --configuration Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ permissions:
   pull-requests: read
 
 env:
-  DOTNET_VERSION: '10.0.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   ContinuousIntegrationBuild: true
@@ -102,14 +101,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          dotnet-quality: 'preview'
+          global-json-file: global.json
 
       - name: Cache NuGet packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('global.json', '**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Compile documentation snippets
@@ -133,14 +131,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          dotnet-quality: 'preview'
+          global-json-file: global.json
 
       - name: Cache NuGet packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets', '**/.config/dotnet-tools.json') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('global.json', '**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets', '**/.config/dotnet-tools.json') }}
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Test vulnerability gate
@@ -184,8 +181,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          dotnet-quality: 'preview'
+          global-json-file: global.json
 
       - name: Setup .NET 8 runtime
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
@@ -196,7 +192,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('global.json', '**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Test Agent Lock Worktree Isolation
@@ -237,6 +233,13 @@ jobs:
           # matrix is green — never here.
           NuGet__ShouldPublish: 'false'
         run: dotnet run --project tools/Dekaf.Pipeline
+
+      - name: Verify native MTP test runner
+        run: >-
+          dotnet test --project tests/Dekaf.Tests.Unit
+          --configuration Release --framework net10.0 --no-build
+          --treenode-filter "/*/*/AdminClientFeatureTests/DescribeFeaturesAsync_MapsConnectionCapabilitySnapshot"
+          --minimum-expected-tests 1
 
       - name: Test Public API Gate
         shell: pwsh
@@ -377,14 +380,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          dotnet-quality: 'preview'
+          global-json-file: global.json
 
       - name: Cache NuGet packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('global.json', '**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Build unit tests (Debug)
@@ -453,8 +455,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '10.0.x'
-          dotnet-quality: 'preview'
+          global-json-file: global.json
 
       - name: Download test binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -549,14 +550,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          dotnet-quality: 'preview'
+          global-json-file: global.json
 
       - name: Cache NuGet packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('global.json', '**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Verify NativeAOT prerequisites
@@ -606,14 +606,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          dotnet-quality: 'preview'
+          global-json-file: global.json
 
       - name: Cache NuGet packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('global.json', '**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Verify NativeAOT prerequisites
@@ -723,8 +722,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          dotnet-quality: 'preview'
+          global-json-file: global.json
 
       - name: Check Formatting
         run: dotnet format --verify-no-changes --verbosity diagnostic
@@ -770,8 +768,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          dotnet-quality: 'preview'
+          global-json-file: global.json
 
       - name: Setup .NET 8 runtime
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
@@ -782,7 +779,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('global.json', '**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Install GitVersion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,10 +234,10 @@ jobs:
           NuGet__ShouldPublish: 'false'
         run: dotnet run --project tools/Dekaf.Pipeline
 
-      - name: Verify native MTP test runner
+      - name: Verify native MTP test discovery
         run: >-
           dotnet test --project tests/Dekaf.Tests.Unit
-          --configuration Release --framework net10.0 --no-build
+          --configuration Release --framework net10.0 --no-build --list-tests
           --treenode-filter "/*/*/AdminClientFeatureTests/DescribeFeaturesAsync_MapsConnectionCapabilitySnapshot"
           --minimum-expected-tests 1
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,9 +34,8 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: |
-            8.0.x
-            10.0.x
+          global-json-file: global.json
+          dotnet-version: '8.0.x'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/fault-injection.yml
+++ b/.github/workflows/fault-injection.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Build Fault Injection Suite
         run: dotnet build tools/Dekaf.StressTests --configuration Release

--- a/.github/workflows/integration-groups.yml
+++ b/.github/workflows/integration-groups.yml
@@ -66,8 +66,7 @@ jobs:
         if: inputs.framework != 'aot'
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '10.0.x'
-          dotnet-quality: 'preview'
+          global-json-file: global.json
 
       - name: Setup .NET 8 runtime
         if: inputs.framework == 'net8.0'

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -55,9 +55,8 @@ jobs:
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           # Stryker 4.16 targets net8.0; the test projects build with the net10 SDK.
-          dotnet-version: |
-            8.0.x
-            10.0.x
+          global-json-file: global.json
+          dotnet-version: '8.0.x'
 
       - name: Restore local tools
         run: dotnet tool restore

--- a/.github/workflows/protocol-fuzzing.yml
+++ b/.github/workflows/protocol-fuzzing.yml
@@ -22,7 +22,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DOTNET_VERSION: '10.0.x'
   LIBFUZZER_DOTNET_VERSION: 'v2025.05.02.0904'
   LIBFUZZER_DOTNET_SHA256: 'c2c2a90d94c409a4af339a0d4f244e0442c5a5d249be0f1252ba07871f285958'
   MAX_INPUT_LENGTH: '1048576'
@@ -55,8 +54,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          dotnet-quality: 'preview'
+          global-json-file: global.json
 
       - name: Install pinned fuzzing tools
         shell: bash

--- a/.github/workflows/soak-tests.yml
+++ b/.github/workflows/soak-tests.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Build Soak Runner
         run: dotnet build tools/Dekaf.StressTests --configuration Release
@@ -141,7 +141,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Build Soak Runner
         run: dotnet build tools/Dekaf.StressTests --configuration Release

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -383,7 +383,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Install stack diagnostics
         run: |
@@ -724,7 +724,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Download All Results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,10 +171,18 @@ tools/
 
 ## Build Commands
 
+The root `global.json` selects stable .NET SDK 10.0.400 or a later 10.0.4xx patch (`latestPatch`, previews disabled), and selects Microsoft.Testing.Platform (MTP). CI installs from that same file. SDK selection does not change the net8.0/net10.0 target frameworks; install the .NET 8 runtime as well to run net8.0 tests. Run `dotnet --version` from the repository root or a project directory to check selection.
+
 ```bash
 # Restore and build
 dotnet build
 
+# Run a focused TUnit test through the native MTP dotnet test runner
+# Use --project (not a positional project path), and pass test options directly (no extra --).
+dotnet test --project tests/Dekaf.Tests.Unit --configuration Release --framework net10.0 \
+  --treenode-filter "/*/*/AdminClientFeatureTests/DescribeFeaturesAsync_MapsConnectionCapabilitySnapshot"
+
+# Direct executables remain supported (also for net8.0 after building that target).
 # Run unit tests
 dotnet build tests/Dekaf.Tests.Unit --configuration Release
 ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit
@@ -196,7 +204,7 @@ dotnet run --project tools/Dekaf.StressTests --configuration Release -- \
 
 ### Test Filtering (TUnit)
 
-TUnit uses `--treenode-filter` with the syntax `/<Assembly>/<Namespace>/<Class>/<Test>`. Use `*` as wildcard.
+Both direct test executables and `dotnet test --project <project>` use `--treenode-filter` with the syntax `/<Assembly>/<Namespace>/<Class>/<Test>`. Use `*` as wildcard.
 
 ```bash
 # Run all tests in a specific class

--- a/global.json
+++ b/global.json
@@ -1,0 +1,10 @@
+{
+  "sdk": {
+    "version": "10.0.400",
+    "rollForward": "latestPatch",
+    "allowPrerelease": false
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
Pins stable .NET SDK 10.0.400 with `latestPatch` and `allowPrerelease: false`, and opts `dotnet test` into Microsoft.Testing.Platform. All .NET 10 workflow setup steps now read `global.json`; existing .NET 8 runtime installs and direct-executable workflows remain intact. NuGet cache keys include the SDK configuration, and CI runs a focused native-MTP smoke test after the existing build pipeline.

Contributor guidance documents `--project`, direct `--treenode-filter` forwarding without an extra `--`, and the unchanged net8.0/net10.0 executable paths. `/simplify` reviewed the final configuration changes.

Validation:
- SDK 10.0.400 selected from root and test-project directory while 11.0.100-preview.7.26381.103 was also installed.
- Release unit project built for both target frameworks without warnings/errors.
- Native `dotnet test --list-tests` discovered exactly the requested test; focused runs passed on net8.0 and net10.0.
- Direct executable admin suites passed: 348 tests on each target framework.
- All 14 workflow YAML files parsed; actionlint passed with shellcheck disabled and only the existing custom `ubicloud-standard-8` runner-label diagnostic excluded. `git diff --check` passed.

Version source: [official .NET 10 release metadata](https://github.com/dotnet/core/blob/main/release-notes/10.0/releases.json). [SDK selection policy](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json) permits servicing updates within the 10.0.4xx feature band while excluding newer features and previews. Configuration-only change; actual SDK selection and runner execution provide behavioral validation.

Closes #3039
