### PR TITLE
Document and test outbox ordering after partial failures

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -56,7 +56,7 @@ Most consumers live inside an ASP.NET Core or Worker Service app, so Dekaf ships
 
 - [Hosted consumer services](./hosted-services) — write one `ProcessAsync` override, get the consume loop, graceful shutdown, and final offset commit for free
 - Failure handling built in: in-place retries, [tiered retry topics, and dead letter queues](./consumer/dead-letter-queues)
-- [Transactional outbox](./producer/outbox) — at-least-once database-to-Kafka publishing with per-key ordering: write the message in the same transaction as your business data, and a background relay delivers it
+- [Transactional outbox](./producer/outbox) — at-least-once database-to-Kafka publishing with ordered submission: write the message in the same transaction as your business data, and a background relay delivers it. Partial publish failures can change consumer-observed order; see the [ordering contract](./producer/outbox#partial-failures-and-consumer-order).
 - [Dependency injection](./dependency-injection) with `appsettings.json` binding, keyed clients, and global interceptors
 - [OpenTelemetry observability](./observability) — traces with W3C context propagation and OTel semantic-convention metrics, one line to enable
 

--- a/docs/docs/producer/outbox.md
+++ b/docs/docs/producer/outbox.md
@@ -80,7 +80,7 @@ builder.Services.AddDekafOutboxRelay(
     producer => producer.WithBootstrapServers("localhost:9092"));
 ```
 
-The relay **enforces** `Acks.All`, idempotence, and a key-respecting partitioner (`Murmur2RandomPartitioner`) on its producer after your `configureProducer` delegate runs — durable acks make prefix deletion safe, while sequencing orders admitted idempotent batches, and per-key ordering only survives if equal keys map to one partition, so none of them can be downgraded there (any partitioner set in the delegate is overridden). Murmur2-random rather than the stock default because the default sticky-rotates zero-length keys, while the outbox treats an empty serialized key as a real key with an ordering requirement; placement for non-empty keys is identical. If you genuinely need different producer semantics, register your own `IOutboxPublisher` instead (the deliberate opt-out).
+The relay **enforces** `Acks.All`, idempotence, and a key-respecting partitioner (`Murmur2RandomPartitioner`) on its producer after your `configureProducer` delegate runs — durable acks make prefix deletion safe, idempotence sequences admitted batches, and the partitioner maps equal keys to one partition, so none of them can be downgraded there (any partitioner set in the delegate is overridden). Murmur2-random rather than the stock default because the default sticky-rotates zero-length keys, while the outbox treats an empty serialized key as a real key with an ordering requirement; placement for non-empty keys is identical. These settings do not prevent consumer-visible reordering after partial publish failures. If you need different producer semantics, register your own `IOutboxPublisher` instead (the deliberate opt-out).
 
 ## Database Schema
 

--- a/docs/docs/producer/outbox.md
+++ b/docs/docs/producer/outbox.md
@@ -20,13 +20,13 @@ Dekaf ships this as two packages:
 
 ## Ordering
 
-Records that share a key must arrive in enqueue order. The outbox preserves this with **buckets**:
+The outbox uses **buckets** to serialize submission and database acknowledgement accounting for records sharing a key. This is not an unconditional consumer-observed ordering guarantee across partial failures:
 
-- Each row's key is hashed to one of N buckets (default 8) at enqueue time. Rows with an explicit partition override are bucketed by that partition instead, so records pinned to one Kafka partition keep their enqueue order too.
-- Each bucket is leased to exactly **one relay instance** at a time, and that relay publishes the bucket's rows in insertion order.
+- Each row's key is hashed to one of N buckets (default 8) at enqueue time. Rows with an explicit partition override are bucketed by that partition instead, so records pinned to one Kafka partition share the same submission sequence.
+- Each bucket is leased to exactly **one relay instance** at a time, and that relay submits the bucket's rows in insertion order.
 - After a partial publish failure, only the **contiguous acknowledged prefix** of a batch is removed — rows are never marked out of order.
 
-Running multiple service instances is safe: relays register heartbeats and divide the buckets fairly among themselves, taking over expired leases when an instance dies. A relay that stalls past its lease may cause **duplicates** (another relay republishes rows it had not yet marked), never loss. During such a takeover the duplicate copies from the old and new owner can interleave on the topic, so a consumer that does **not** deduplicate on the message-id header may briefly observe an older copy after a newer row for the same key — there is no broker-side fencing of an in-flight stale publish short of Kafka transactions. Deduplicating consumers are unaffected.
+Running multiple service instances is safe: relays register heartbeats and divide the buckets fairly among themselves, taking over expired leases when an instance dies. A relay that stalls past its lease may cause **duplicates** (another relay republishes rows it had not yet marked), never loss. During such a takeover the duplicate copies from the old and new owner can interleave on the topic, so a consumer that does **not** deduplicate on the message-id header may briefly observe an older copy after a newer row for the same key — there is no broker-side fencing of an in-flight stale publish short of Kafka transactions. Message-id deduplication removes repeated copies; it does not repair a first delivery that arrives after a later row.
 
 One boundary shared by every identity-ordered outbox (not specific to Dekaf): **"enqueue order" means commit order for a key, and only writers that serialize their writes to a key have one.** If two uncoordinated transactions enqueue for the same key concurrently, the database can hand the earlier transaction a lower id while the later one commits first — the relay may then publish the higher id before the lower one exists to read. In practice this doesn't bite, because aggregates written under any concurrency control (optimistic rowversion, `UPDATE ... WHERE version = @n`, a unique constraint) serialize their commits and therefore their ids; two truly uncoordinated concurrent writes to one aggregate have no defined order at the business level either. If you have keys written concurrently without any such control, that's the thing to fix.
 
@@ -35,6 +35,16 @@ Lease expiry is compared against timestamps written by the relay hosts themselve
 :::warning
 `BucketCount` must be identical across every writer and relay sharing an outbox table. Changing it requires draining the table and deleting the lease rows first. If the store finds rows in buckets the relay can never claim (a writer configured with a larger count), it throws `OutboxMisconfigurationException` and the relay **faults instead of retrying** — under the default host behavior the application stops, turning the silent-loss misconfiguration into an unmissable failure.
 :::
+
+### Partial failures and consumer order
+
+The default `DekafOutboxPublisher` starts all produce operations in a batch before awaiting their results. An earlier row can fail locally (for example, exceeding the producer's request-size limit) or be permanently rejected by the broker (`MESSAGE_TOO_LARGE`), while later rows on the same key and partition succeed. Idempotence does not make these separate produce operations atomic.
+
+A concrete Kafka-tested example uses rows **1, 2, 3**, all sharing one key and partition. Row 1 is too large; Kafka accepts rows 2 and 3. The acknowledged prefix is empty, so all three database rows remain pending. After repairing row 1's payload while preserving its message ID, retrying the batch yields consumer order **2, 3, 1, 2, 3**. Deduplicating by `x-outbox-message-id` leaves **2, 3, 1**, not enqueue order. This occurs with the real default publisher and its enforced idempotent producer, without a custom publisher or mocked delivery results.
+
+The contract is **ordered submission, front-to-back deletion, and at-least-once delivery**. When all rows succeed, records on a partition retain submission order. Transient retries of an admitted idempotent batch retain producer sequencing, but a permanently rejected or locally unappended row has no earlier delivery for deduplication to preserve. Applications requiring strict business ordering across such failures need an application sequence with consumer-side gap handling or a publisher protocol that prevents later records becoming visible before earlier ones succeed. A custom `IOutboxPublisher` must state and test its own ordering guarantees; returning a contiguous prefix alone is insufficient.
+
+The built-in publisher retains concurrent sends so Kafka can batch records. It does not wait for one broker round trip per outbox row.
 
 ## Setup
 
@@ -70,7 +80,7 @@ builder.Services.AddDekafOutboxRelay(
     producer => producer.WithBootstrapServers("localhost:9092"));
 ```
 
-The relay **enforces** `Acks.All`, idempotence, and a key-respecting partitioner (`Murmur2RandomPartitioner`) on its producer after your `configureProducer` delegate runs — durable acks and sequencing are what make contiguous-prefix accounting sound, and per-key ordering only survives if equal keys map to one partition, so none of them can be downgraded there (any partitioner set in the delegate is overridden). Murmur2-random rather than the stock default because the default sticky-rotates zero-length keys, while the outbox treats an empty serialized key as a real key with an ordering requirement; placement for non-empty keys is identical. If you genuinely need different producer semantics, register your own `IOutboxPublisher` instead (the deliberate opt-out).
+The relay **enforces** `Acks.All`, idempotence, and a key-respecting partitioner (`Murmur2RandomPartitioner`) on its producer after your `configureProducer` delegate runs — durable acks make prefix deletion safe, while sequencing orders admitted idempotent batches, and per-key ordering only survives if equal keys map to one partition, so none of them can be downgraded there (any partitioner set in the delegate is overridden). Murmur2-random rather than the stock default because the default sticky-rotates zero-length keys, while the outbox treats an empty serialized key as a real key with an ordering requirement; placement for non-empty keys is identical. If you genuinely need different producer semantics, register your own `IOutboxPublisher` instead (the deliberate opt-out).
 
 ## Database Schema
 
@@ -80,7 +90,7 @@ The relay **enforces** `Acks.All`, idempotence, and a key-respecting partitioner
 
 | Column | Type (portable) | Constraints |
 |---|---|---|
-| `Id` | 64-bit integer | Primary key, auto-increment. Publish order within a bucket. |
+| `Id` | 64-bit integer | Primary key, auto-increment. Submission order within a bucket. |
 | `MessageId` | GUID/UUID | Required. Stable dedup id, stamped as the `x-outbox-message-id` header. |
 | `Bucket` | 32-bit integer | Required. Ordering bucket. |
 | `Topic` | string(249) | Required. |

--- a/src/Dekaf.Outbox/DekafOutboxPublisher.cs
+++ b/src/Dekaf.Outbox/DekafOutboxPublisher.cs
@@ -5,8 +5,9 @@ namespace Dekaf.Outbox;
 
 /// <summary>
 /// Default <see cref="IOutboxPublisher"/> backed by a Dekaf byte-array producer. The producer
-/// should keep idempotence enabled (the Dekaf default) so broker-side retries cannot reorder
-/// records within a partition, which keeps the relay's contiguous-prefix accounting sound.
+/// should keep idempotence enabled (the Dekaf default) for retries of admitted batches.
+/// Partial failures can still let later rows arrive before a failed row is retried; message-id
+/// deduplication does not restore enqueue order in that case.
 /// </summary>
 public sealed class DekafOutboxPublisher : IOutboxPublisher
 {
@@ -45,11 +46,10 @@ public sealed class DekafOutboxPublisher : IOutboxPublisher
         // producer contract that ValueTasks must not be stored; the Task allocations are
         // relay-side, per-batch-attempt cost.
         //
-        // Firing the whole batch is order-safe: the producer keeps per-partition FIFO from
-        // pending-append through idempotent sequencing, so a broker-side failure of record
-        // N also fails every later record on that partition (no gap can be acked) and the
-        // contiguous-prefix accounting below stays truthful. Publishing one-record-at-a-time
-        // would defeat batching entirely (one linger + round trip per row).
+        // Later rows can succeed even when an earlier row is rejected locally or by Kafka.
+        // Prefix accounting keeps those rows for retry; it cannot undo their delivery or
+        // restore consumer-observed order, even after message-id deduplication.
+        // Concurrent sends preserve batching (rather than one round trip per row).
         // The per-row Headers, id buffer, ProducerMessage, and Task allocations below are
         // accepted: the relay is not the Kafka client's hot path, and the header value
         // cannot be pooled - a produce cancelled after append keeps delivering in the

--- a/src/Dekaf.Outbox/IOutboxPublisher.cs
+++ b/src/Dekaf.Outbox/IOutboxPublisher.cs
@@ -12,14 +12,16 @@ public interface IOutboxPublisher : IAsyncDisposable
     ValueTask InitializeAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Publishes the batch in order and waits for broker acknowledgment of every record.
+    /// Submits the batch in order and waits for the outcome of every started record.
     /// </summary>
     /// <remarks>
     /// The result's <see cref="OutboxPublishResult.AckedCount"/> is the length of the
     /// contiguous acknowledged prefix: the first failed record stops the count even if later
     /// records were acknowledged. The relay marks exactly that prefix as published, so a
-    /// bucket's rows are only ever removed front-to-back and publish order is preserved
-    /// across retries.
+    /// bucket's rows are only ever removed front-to-back. This does not guarantee consumer
+    /// order across partial failures: if row 1 fails while row 2 succeeds, retrying both can
+    /// deliver 2, 1, 2. Message-id deduplication still leaves 2, 1. Implementations promising
+    /// stronger ordering must prevent later rows becoming visible before earlier rows succeed.
     /// </remarks>
     /// <param name="messages">The rows to publish, in ascending id order.</param>
     /// <param name="messageIdHeaderName">Header name to stamp with each row's message id.</param>

--- a/src/Dekaf.Outbox/IOutboxStore.cs
+++ b/src/Dekaf.Outbox/IOutboxStore.cs
@@ -7,8 +7,11 @@ namespace Dekaf.Outbox;
 /// <remarks>
 /// <para><b>Concurrency model:</b> the store never locks individual rows. Bucket leases are
 /// the only concurrency control - a relay may read and publish a bucket's rows only while it
-/// holds that bucket's lease, so each bucket has a single writer and per-key ordering is
-/// preserved. A relay that pauses past its lease expiry may double-publish rows another relay
+/// holds that bucket's lease, so each bucket has a single lease owner submitting rows in
+/// enqueue order. Ordered submission and contiguous-prefix deletion do not guarantee
+/// consumer-observed order after partial publish failures: a later row can become visible
+/// before an earlier failed row succeeds, even after message-id deduplication.
+/// A relay that pauses past its lease expiry may double-publish rows another relay
 /// picked up; that is the documented at-least-once duplicate window, never message loss.</para>
 /// <para><b>Storage-agnostic by design:</b> nothing in this contract requires a relational
 /// database. Leases need only an atomic conditional write (SQL guarded UPDATE, MongoDB

--- a/src/Dekaf.Outbox/OutboxBucket.cs
+++ b/src/Dekaf.Outbox/OutboxBucket.cs
@@ -6,7 +6,8 @@ namespace Dekaf.Outbox;
 /// <summary>
 /// Maps record keys to ordering buckets. The mapping is deterministic and stable across
 /// processes and machines, so every writer assigns a given key to the same bucket and the
-/// single relay owning that bucket preserves the key's enqueue order.
+/// single relay owning that bucket submits rows in enqueue order. This does not guarantee
+/// consumer-observed order across partial publish failures.
 /// </summary>
 public static class OutboxBucket
 {

--- a/src/Dekaf.Outbox/OutboxMessage.cs
+++ b/src/Dekaf.Outbox/OutboxMessage.cs
@@ -21,7 +21,7 @@ public class OutboxMessage
 {
     /// <summary>
     /// Ordering value used by relational stores (typically a database identity column):
-    /// unique and ascending within the outbox table, determining publish order within a
+    /// unique and ascending within the outbox table, determining submission order within a
     /// bucket. Stores that maintain enqueue order by other means (a time-ordered document
     /// id, a sequence field on a subclass) may leave this zero - the relay never reads it.
     /// </summary>
@@ -36,7 +36,8 @@ public class OutboxMessage
     /// <summary>
     /// Ordering bucket computed from the record key via <see cref="OutboxBucket.Compute(byte[], Guid, int)"/>.
     /// Each bucket has a single publishing relay at any time, so records that share a key
-    /// (and therefore a bucket) are published in enqueue order.
+    /// (and therefore a bucket) are submitted in enqueue order. Partial failures can change
+    /// consumer-observed order when retained rows are retried.
     /// </summary>
     public required int Bucket { get; init; }
 

--- a/src/Dekaf.Outbox/OutboxRelayService.cs
+++ b/src/Dekaf.Outbox/OutboxRelayService.cs
@@ -12,9 +12,10 @@ namespace Dekaf.Outbox;
 /// acknowledgment, so a crash at any point republishes rather than loses. Consumers that
 /// need effective exactly-once should deduplicate on the
 /// <see cref="OutboxRelayOptions.MessageIdHeaderName"/> header.</para>
-/// <para><b>Ordering:</b> within a bucket, rows publish in ascending id order and are only
-/// ever marked front-to-back (contiguous acknowledged prefix), so records sharing a key keep
-/// their enqueue order across retries.</para>
+/// <para><b>Ordering:</b> within a bucket, rows are submitted in ascending id order and are
+/// marked front-to-back (contiguous acknowledged prefix). Later rows may already be delivered
+/// when an earlier row fails. Retrying the retained rows can reorder consumer-observed first
+/// deliveries; message-id deduplication removes duplicates but does not restore order.</para>
 /// <para>The service does not own the publisher or store; their lifetimes belong to the
 /// dependency injection container (or whoever constructed them).</para>
 /// </remarks>

--- a/src/Dekaf.Outbox/OutboxServiceCollectionExtensions.cs
+++ b/src/Dekaf.Outbox/OutboxServiceCollectionExtensions.cs
@@ -18,8 +18,9 @@ public static class OutboxServiceCollectionExtensions
     /// <param name="services">The service collection.</param>
     /// <param name="configureProducer">Configures the relay's producer; at minimum set bootstrap
     /// servers. <see cref="Acks.All"/> and idempotence are enforced after this delegate runs -
-    /// the at-least-once and ordering guarantees depend on them, so they cannot be downgraded
-    /// here. Register a custom <see cref="IOutboxPublisher"/> to opt out deliberately.</param>
+    /// durable acknowledgement and sequencing of admitted batches depend on them, so they
+    /// cannot be downgraded here. Partial publish failures can still reorder consumer-visible
+    /// records. Register a custom <see cref="IOutboxPublisher"/> to opt out deliberately.</param>
     /// <param name="options">Relay options; defaults are production-reasonable.</param>
     public static IServiceCollection AddDekafOutboxRelay(
         this IServiceCollection services,
@@ -53,8 +54,9 @@ public static class OutboxServiceCollectionExtensions
         configureProducer(builder);
         // Applied after the caller's delegate so they cannot be downgraded: prefix
         // accounting is only truthful when every counted ack is durable (Acks.All) and
-        // per-partition sequencing holds (idempotence), and per-key ordering survives only
-        // when equal keys map to one partition. Murmur2RandomPartitioner rather than the
+        // admitted batches retain per-partition sequencing (idempotence), with equal keys
+        // mapped to one partition. Partial publish failures can still reorder visible rows.
+        // Murmur2RandomPartitioner rather than the
         // stock Default: Default sticky-rotates zero-length keys across partitions, but the
         // outbox treats an empty serialized key as a real key with an ordering requirement.
         // Placement for non-empty keys is identical (both are Kafka's Murmur2); null keys

--- a/tests/Dekaf.Tests.Integration/OutboxOrderingIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/OutboxOrderingIntegrationTests.cs
@@ -1,0 +1,108 @@
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Outbox;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("MessagingPatterns")]
+public sealed class OutboxOrderingIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    private const string MessageIdHeader = OutboxRelayOptions.DefaultMessageIdHeaderName;
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    [Timeout(90_000)]
+    public async Task PartialFailure_Retry_CanReorderEvenAfterMessageIdDeduplication(bool localFailure, CancellationToken cancellationToken)
+    {
+        var topic = $"outbox-order-{Guid.NewGuid():N}";
+        await using var admin = KafkaContainer.CreateAdminClient();
+        await admin.CreateTopicsAsync([new NewTopic
+        {
+            Name = topic,
+            NumPartitions = 1,
+            ReplicationFactor = 1,
+            Configs = new Dictionary<string, string> { ["max.message.bytes"] = localFailure ? "65536" : "512" }
+        }], cancellationToken: cancellationToken);
+
+        var producer = OutboxServiceCollectionExtensions.CreateRelayProducerBuilder(
+            builder => builder.WithBootstrapServers(KafkaContainer.BootstrapServers)
+                .WithBatchSize(256)
+                .WithMaxRequestSize(localFailure ? 1024 : 65536)
+                .WithLinger(TimeSpan.FromMilliseconds(10)),
+            GlobalTestSetup.GetLoggerFactory()).Build();
+        await using var publisher = new DekafOutboxPublisher(producer);
+        await publisher.InitializeAsync(cancellationToken);
+        _ = await producer.GetPartitionsForAsync(topic, cancellationToken);
+
+        OutboxMessage[] rows = [Row(topic, 1, 4096), Row(topic, 2, 1), Row(topic, 3, 1)];
+        var firstAttempt = await publisher.PublishAsync(rows, MessageIdHeader, cancellationToken);
+        await Assert.That(firstAttempt.AckedCount).IsEqualTo(0);
+        await Assert.That(firstAttempt.FirstError).IsAssignableTo<KafkaException>();
+        await Assert.That(((KafkaException)firstAttempt.FirstError!).ErrorCode).IsEqualTo(ErrorCode.MessageTooLarge);
+        var beforeRetry = await EndOffsetAsync(admin, topic, cancellationToken);
+
+        // Repair the invalid stored payload, preserving the stable deduplication identity.
+        // No change to broker configuration and no delay-dependent config propagation.
+        rows[0] = Row(topic, 1, 1, rows[0].MessageId);
+        var retry = await publisher.PublishAsync(rows, MessageIdHeader, cancellationToken);
+        await Assert.That(retry.FirstError).IsNull();
+        await Assert.That(retry.AckedCount).IsEqualTo(3);
+        var endOffset = await EndOffsetAsync(admin, topic, cancellationToken);
+
+        await using var consumer = await Kafka.CreateConsumer<byte[], byte[]>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId($"outbox-order-reader-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .BuildAsync(cancellationToken);
+        consumer.Assign(new TopicPartition(topic, 0));
+        var observed = new List<int>();
+        var deduplicated = new List<int>();
+        var seen = new HashSet<Guid>();
+        await foreach (var record in consumer.ConsumeAsync(cancellationToken))
+        {
+            var messageId = Guid.Parse(record.Headers.Single(header => header.Key == MessageIdHeader).GetValueAsString()!);
+            var rowId = Array.FindIndex(rows, row => row.MessageId == messageId) + 1;
+            await Assert.That(rowId).IsGreaterThan(0);
+            await Assert.That(record.Partition).IsEqualTo(0);
+            await Assert.That(record.Key.SequenceEqual(new byte[] { 1 })).IsTrue();
+            observed.Add(rowId);
+            if (seen.Add(messageId))
+                deduplicated.Add(rowId);
+            if (record.Offset + 1 == endOffset)
+                break;
+        }
+
+        // This is the documented batched publisher contract: prefix accounting preserves
+        // rows for retry, but cannot retract later records already accepted by Kafka.
+        await Assert.That(beforeRetry).IsEqualTo(2L);
+        await Assert.That(endOffset).IsEqualTo(5L);
+        await Assert.That(string.Join(',', observed)).IsEqualTo("2,3,1,2,3");
+        await Assert.That(string.Join(',', deduplicated)).IsEqualTo("2,3,1");
+    }
+
+    private static OutboxMessage Row(string topic, int id, int valueLength, Guid? messageId = null) => new()
+    {
+        Id = id,
+        MessageId = messageId ?? Guid.NewGuid(),
+        Bucket = 0,
+        Topic = topic,
+        Key = [1],
+        Value = new byte[valueLength],
+        Partition = 0,
+        CreatedAtUtc = DateTimeOffset.UtcNow
+    };
+
+    private static async Task<long> EndOffsetAsync(IAdminClient admin, string topic, CancellationToken cancellationToken)
+    {
+        var partition = new TopicPartition(topic, 0);
+        var result = await admin.ListOffsetsAsync([
+            new TopicPartitionOffsetSpec { TopicPartition = partition, Spec = OffsetSpec.Latest }
+        ], cancellationToken: cancellationToken);
+        return result[partition].Offset;
+    }
+}


### PR DESCRIPTION
## Findings

Real Kafka 4.3.1 reproduces consumer reordering with the default batched outbox publisher and its enforced idempotent producer. Rows 1, 2, 3 share one key and partition. Row 1 exceeds either the local request-size limit or the broker's topic message-size limit; rows 2 and 3 still arrive. After repairing row 1's payload without changing its message ID, retrying the retained batch yields raw order `2,3,1,2,3` and deduplicated order `2,3,1`.

This PR takes the issue's explicit contract-clarification option. The guide and XML/source comments now promise ordered submission, contiguous-prefix deletion, and at-least-once delivery, and explain why message-id deduplication cannot restore first-delivery order after these failures. Custom publishers must establish their own stronger ordering protocol. No executable production code or batching behavior changes.

## Validation

- The initial assertions of deduplicated enqueue order failed for both real local and broker rejection scenarios, each observing `2,3,1`.
- Integration tests now pin the documented limitation: actual end offsets, raw order, message IDs, deduplicated order, key, partition, error code, and acknowledged prefix. Both scenarios passed, alongside the existing normal-order end-to-end relay test (3 integration tests total).
- 56 outbox unit tests passed; Release unit/integration builds passed without warnings/errors.
- Final docs build and `git diff --check` passed; `/simplify` completed.
- Compared every changed `src/` file against its parent after excluding comment/blank lines: executable source is identical.

## Performance evidence

Baseline `0dd6f2857`; candidate `a2bb6fd0f6726718348c1f1cc78e7a616f26c8ad`. BenchmarkDotNet MemoryDiagnoser, .NET 10, same Windows host, InProcessEmitToolchain, 5 warmups and 15 measured iterations. An initialized publisher sends a one-row batch to a deterministic acknowledgement proxy; proxy costs are included on both sides. The task-scoped benchmark uses saved baseline/candidate Outbox DLLs sequentially.

| Version | Mean/attempt | StdDev | Allocated/attempt |
| --- | ---: | ---: | ---: |
| Baseline | 103.4 ns | 2.06 ns | 904 B |
| Candidate | 106.9 ns | 4.63 ns | 904 B |

Mean differs by +3.4% with overlapping reported confidence intervals; allocations are unchanged, and executable source is identical. This is timing variation, not evidence of a changed publishing cost. These are synthetic relay-attempt costs including the test proxy, not Kafka network latency or zero-allocation client-hot-path results. Network latency percentiles, CPU/message, and long-run stability were not measured; no paid stress run was dispatched.

Closes #3038
