### PR TITLE
fix: release implicit share deliveries on close

### DIFF
--- a/docs/docs/consumer/share-consumers.md
+++ b/docs/docs/consumer/share-consumers.md
@@ -205,7 +205,20 @@ Common builder options beyond the connection/TLS/SASL settings shared with other
 
 ## Shutdown
 
-`Unsubscribe`, `CloseAsync`, and `DisposeAsync` flush pending acknowledgements, leave the share group, and release any still-locked records back to the group (best effort) so other members can claim them without waiting for lock expiry:
+`CloseAsync` and `DisposeAsync` release delivered records that have not yet been
+implicitly acknowledged by the next poll or `CommitAsync`. This includes disposal
+when application processing throws and records left after partial enumeration.
+Records fetched or parsed but never yielded are not implicitly accepted; session
+closure releases their acquisition locks.
+
+Explicitly selected `Accept`, `Release` and `Reject` outcomes are preserved. Outcomes
+already submitted by a previous poll/commit remain selected even if their failed
+request is retried during close. A pending `Renew` is attempted as a renewal, never
+as acceptance; session closure then releases remaining locks and stops local replay.
+Shutdown is best-effort: if cancellation or broker failure prevents release, records
+remain available for redelivery after the broker's acquisition lock expires.
+
+`Unsubscribe` releases pending records and clears the subscription. To close:
 
 ```csharp
 await consumer.CloseAsync();
@@ -229,6 +242,16 @@ foreach (var (groupId, result) in results)
 The operation uses the group coordinator and Kafka's `DeleteGroups` API, matching Kafka 4.3's `deleteShareGroups` implementation. Active groups normally return `NonEmptyGroup`; close their consumers before deletion.
 
 Per-group results cover terminal error codes only. If a request keeps failing with a retriable error, the call throws after retries are exhausted and returns no results. Duplicate group IDs raise `ArgumentException` before any request is sent. Dekaf's built-in and in-memory admin clients expose deletion through `IShareGroupDeletionAdminClient`; the `IAdminClient` extension preserves the same call syntax for binary compatibility.
+
+## Migration note: implicit acknowledgement on shutdown
+
+Earlier versions treated outstanding implicit deliveries as `Accept` during close,
+which could acknowledge records whose application processing failed. Close and
+await-using disposal now release these deliveries. After successfully processing
+the final records, call `CommitAsync` before closing when they should be accepted,
+or explicitly call `Acknowledge(record, AcknowledgeType.Accept)` for each completed
+record. Do not commit from an unconditional `finally` block after failed processing.
+The in-memory share consumer follows the same provisional-delivery shutdown rule.
 
 ## Testing
 

--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -360,7 +360,10 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
                 EnsureCommitRecordCapacity(_pending.Count);
                 var recordCount = 0;
                 foreach (var record in _pending.Values)
+                {
+                    record.ResolveImplicitAcknowledgement(allowDisposed);
                     _commitRecords[recordCount++] = record;
+                }
 
                 try
                 {
@@ -403,7 +406,10 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
 
                 EnsureSnapshotCapacity(_pending.Count);
                 foreach (var pair in _pending)
+                {
+                    pair.Value.ResolveImplicitAcknowledgement(allowDisposed);
                     _commitSnapshot[snapshotCount++] = pair;
+                }
             }
 
             for (var index = 0; index < snapshotCount; index++)
@@ -1112,7 +1118,15 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
         public TopicPartition TopicPartition { get; }
         public long Offset { get; }
         public long NextOffset { get; }
-        public AcknowledgeType AcknowledgeType { get; set; } = AcknowledgeType.Accept;
+        // A provisional delivery is accepted by poll/commit, but released by close.
+        private const AcknowledgeType ImplicitDelivery = (AcknowledgeType)byte.MaxValue;
+        public AcknowledgeType AcknowledgeType { get; set; } = ImplicitDelivery;
+
+        public void ResolveImplicitAcknowledgement(bool closing)
+        {
+            if (AcknowledgeType == ImplicitDelivery)
+                AcknowledgeType = closing ? AcknowledgeType.Release : AcknowledgeType.Accept;
+        }
     }
 
     private sealed class PendingShareRecordComparer : IComparer<PendingShareRecord>

--- a/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
@@ -11,14 +11,18 @@ namespace Dekaf.ShareConsumer;
 /// </summary>
 internal sealed class AcknowledgementTracker
 {
+    // Provisional delivery state, never sent on the wire. Requeued wire outcomes
+    // retain their actual type, so close cannot undo an already submitted Accept.
+    private const AcknowledgeType ImplicitDelivery = (AcknowledgeType)byte.MaxValue;
+
     private Dictionary<TopicPartition, PartitionAcknowledgements> _pendingAcks = new();
 
     /// <summary>
-    /// Tracks records delivered by a poll. All records default to Accept.
+    /// Tracks delivered records awaiting implicit acceptance by the next poll or commit.
     /// </summary>
     internal void TrackDeliveredRecords(TopicPartition tp, long firstOffset, long lastOffset)
     {
-        GetOrAddPartition(tp).TrackRange(firstOffset, lastOffset, AcknowledgeType.Accept);
+        GetOrAddPartition(tp).TrackRange(firstOffset, lastOffset, ImplicitDelivery);
     }
 
     /// <summary>
@@ -57,7 +61,7 @@ internal sealed class AcknowledgementTracker
     /// Atomically swaps the pending dictionary so no acks can be lost.
     /// </summary>
     /// <returns>Per-TopicPartition acknowledgement batches for the wire format.</returns>
-    internal Dictionary<TopicPartition, List<AcknowledgementBatchData>> Flush()
+    internal Dictionary<TopicPartition, List<AcknowledgementBatchData>> Flush(bool releaseImplicit = false)
     {
         // Swap to a fresh dictionary so any new acks after this point go into a fresh
         // bucket — avoids the per-partition TryRemove race of the snapshot-and-remove pattern.
@@ -68,7 +72,7 @@ internal sealed class AcknowledgementTracker
 
         foreach (var (tp, partitionAcks) in old)
         {
-            var batches = partitionAcks.BuildBatches();
+            var batches = partitionAcks.BuildBatches(releaseImplicit ? AcknowledgeType.Release : AcknowledgeType.Accept);
             if (batches.Count > 0)
             {
                 result[tp] = batches;
@@ -262,12 +266,12 @@ internal sealed class AcknowledgementTracker
             _explicitAcks[offset] = type;
         }
 
-        internal List<AcknowledgementBatchData> BuildBatches()
+        internal List<AcknowledgementBatchData> BuildBatches(AcknowledgeType implicitDisposition)
         {
             List<AcknowledgementBatchData> batches = [];
 
             foreach (var range in _ranges)
-                batches.Add(BuildRangeBatch(range));
+                batches.Add(BuildRangeBatch(range, implicitDisposition));
 
             if (_explicitAcks is not null)
                 AddStandaloneExplicitBatches(batches);
@@ -279,11 +283,13 @@ internal sealed class AcknowledgementTracker
             return MergeConsecutiveBatches(batches);
         }
 
-        private AcknowledgementBatchData BuildRangeBatch(AckRange range)
+        private AcknowledgementBatchData BuildRangeBatch(AckRange range, AcknowledgeType implicitDisposition)
         {
             var length = checked((int)(range.LastOffset - range.FirstOffset + 1));
             var acknowledgeTypes = new byte[length];
-            Array.Fill(acknowledgeTypes, (byte)range.AcknowledgeType);
+            Array.Fill(acknowledgeTypes, (byte)(range.AcknowledgeType == ImplicitDelivery
+                ? implicitDisposition
+                : range.AcknowledgeType));
 
             if (_explicitAcks is not null)
             {

--- a/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
@@ -69,7 +69,7 @@ public interface IKafkaShareConsumer<TKey, TValue> : IInitializableKafkaClient, 
     /// <summary>
     /// Sets the acknowledgement type for a specific record. Renewal is supported only in
     /// explicit acknowledgement mode and requires ShareFetch/ShareAcknowledge v2.
-    /// In implicit acknowledgement mode, records default to <see cref="AcknowledgeType.Accept"/>.
+    /// In implicit mode, delivered records are accepted only when the next poll or commit submits them.
     /// <para>
     /// <b>Warning:</b> In implicit mode, call this before the next <see cref="PollAsync"/> or
     /// <see cref="CommitAsync"/> if you need to release or reject a record.
@@ -86,8 +86,14 @@ public interface IKafkaShareConsumer<TKey, TValue> : IInitializableKafkaClient, 
     ValueTask CommitAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Closes the share consumer: flushes pending acknowledgements, closes share sessions,
-    /// leaves the share group, and releases all resources.
+    /// Closes share sessions and leaves the group. Delivered records still awaiting implicit
+    /// acceptance are released, including when DisposeAsync runs after a processing exception.
+    /// Explicit Accept/Release/Reject dispositions and outcomes already submitted by poll/commit
+    /// are preserved. Pending Renew is attempted without accepting the record; closing the session
+    /// then releases remaining acquisition locks and stops renewal replay.
+    /// Shutdown is best-effort. If cancellation or a broker failure prevents release, remaining
+    /// locks expire on the broker. Call CommitAsync after successful processing if implicit records
+    /// must be accepted before closing; DisposeAsync additionally releases local resources.
     /// </summary>
     ValueTask CloseAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -535,19 +535,19 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                             if ((fetchedRecords?.Count ?? recordCount) >= _options.MaxPollRecords)
                                 break;
 
-                            // Track only records actually yielded to the consumer so implicit
-                            // acknowledgements do not include offsets truncated by MaxPollRecords.
-                            if (_options.AcknowledgementMode == ShareAcknowledgementMode.Implicit)
-                            {
-                                _ackTracker.TrackDeliveredRecords(tp, result.Offset, result.Offset);
-                            }
-
                             RemoveRenewedRecord(result.Topic, result.Partition, result.Offset);
 
                             if (fetchedRecords is not null)
                             {
                                 fetchedRecords.Add(result);
                                 continue;
+                            }
+
+                            // Track only records actually yielded to the consumer so implicit
+                            // acknowledgements do not include offsets truncated by MaxPollRecords.
+                            if (_options.AcknowledgementMode == ShareAcknowledgementMode.Implicit)
+                            {
+                                _ackTracker.TrackDeliveredRecords(tp, result.Offset, result.Offset);
                             }
 
                             recordCount++;
@@ -578,6 +578,12 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 {
                     if (recordCount >= _options.MaxPollRecords)
                         break;
+
+                    if (_options.AcknowledgementMode == ShareAcknowledgementMode.Implicit)
+                    {
+                        var tp = new TopicPartition(fetchedRecord.Topic, fetchedRecord.Partition);
+                        _ackTracker.TrackDeliveredRecords(tp, fetchedRecord.Offset, fetchedRecord.Offset);
+                    }
 
                     recordCount++;
                     yield return fetchedRecord;
@@ -619,12 +625,12 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         await CommitCoreAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    private async ValueTask CommitCoreAsync(CancellationToken cancellationToken)
+    private async ValueTask CommitCoreAsync(CancellationToken cancellationToken, bool releaseImplicit = false)
     {
         if (!_ackTracker.HasPending)
             return;
 
-        var pendingAcks = _ackTracker.Flush();
+        var pendingAcks = _ackTracker.Flush(releaseImplicit);
         if (pendingAcks.Count == 0)
             return;
 
@@ -713,12 +719,14 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         LogClosingShareConsumer();
         ClearRenewedRecords();
 
-        // Step 1: Flush all pending acks as Accept via ShareAcknowledge
+        // Step 1: Release delivered records that have not reached a poll/commit boundary.
+        // Preserve explicit and previously submitted outcomes, including Renew. Closing
+        // the share sessions below releases any remaining acquisition locks.
         if (_ackTracker.HasPending)
         {
             try
             {
-                await CommitCoreAsync(cancellationToken).ConfigureAwait(false);
+                await CommitCoreAsync(cancellationToken, releaseImplicit: true).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/tests/Dekaf.Tests.Integration/ShareConsumerCloseTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerCloseTests.cs
@@ -1,0 +1,73 @@
+using Dekaf.Admin;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("ShareConsumer")]
+[SupportsKafka(420)]
+[NotInParallel("ShareConsumerKafka42")]
+public class ShareConsumerCloseTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    [Arguments(false, false)]
+    [Arguments(false, true)]
+    [Arguments(true, false)]
+    public async Task Close_PartialPoll_RedeliversOnlyUnacknowledgedRecords(bool explicitAccept, bool processingThrows)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var group = $"share-close-{Guid.NewGuid():N}";
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).Build();
+        await admin.IncrementalAlterConfigsAsync(new Dictionary<ConfigResource, IReadOnlyList<ConfigAlter>>
+        {
+            [new ConfigResource { Type = ConfigResourceType.Group, Name = group }] =
+                [ConfigAlter.Set("share.auto.offset.reset", "earliest")]
+        });
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).BuildAsync();
+        await ShareConsumerTestHelper.ProduceAsync(producer, topic, count: 3);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        string? firstValue = null;
+        try
+        {
+            await using var first = await Kafka.CreateShareConsumer<string, string>()
+                .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId(group).BuildAsync();
+            first.Subscribe(topic);
+
+            await foreach (var record in first.PollAsync(timeout.Token))
+            {
+                firstValue = record.Value;
+                if (explicitAccept)
+                    first.Acknowledge(record);
+                if (processingThrows)
+                    throw new ProcessingException();
+                break;
+            }
+        }
+        catch (ProcessingException) when (processingThrows)
+        {
+            // Await-using cleanup must not convert this failed delivery into Accept.
+        }
+
+        await Assert.That(firstValue).IsNotNull();
+        await using var second = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId(group).BuildAsync();
+        second.Subscribe(topic);
+        var values = new List<string?>();
+        await foreach (var record in second.PollAsync(timeout.Token))
+        {
+            values.Add(record.Value);
+            second.Acknowledge(record);
+            if (values.Count == (explicitAccept ? 2 : 3))
+                break;
+        }
+
+        string?[] producedValues = ["value-0", "value-1", "value-2"];
+        var expected = explicitAccept ? producedValues.Where(value => value != firstValue) : producedValues;
+        await Assert.That(values).IsEquivalentTo(expected);
+        await second.CommitAsync(timeout.Token);
+    }
+
+    private sealed class ProcessingException : Exception;
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
@@ -5,6 +5,54 @@ namespace Dekaf.Tests.Unit.ShareConsumer;
 public class AcknowledgementTrackerTests
 {
     [Test]
+    public async Task CloseFlush_ReleasesImplicitAndPreservesExplicitOutcomes()
+    {
+        var tracker = new AcknowledgementTracker();
+        var partition = new TopicPartition("topic", 0);
+        tracker.TrackDeliveredRecords(partition, 0, 4);
+        tracker.Acknowledge(partition, 1, AcknowledgeType.Accept);
+        tracker.Acknowledge(partition, 2, AcknowledgeType.Release);
+        tracker.Acknowledge(partition, 3, AcknowledgeType.Reject);
+        tracker.Acknowledge(partition, 4, AcknowledgeType.Renew);
+
+        var types = tracker.Flush(releaseImplicit: true)[partition][0].AcknowledgeTypes;
+
+        byte[] expected = [2, 1, 2, 3, 4];
+        await Assert.That(types).IsEquivalentTo(expected);
+        await Assert.That(types[0]).IsEqualTo((byte)AcknowledgeType.Release);
+        await Assert.That(types[1]).IsEqualTo((byte)AcknowledgeType.Accept);
+    }
+
+    [Test]
+    public async Task CloseFlush_RetriedImplicitCommit_PreservesSubmittedAccept()
+    {
+        var tracker = new AcknowledgementTracker();
+        var partition = new TopicPartition("topic", 0);
+        tracker.TrackDeliveredRecords(partition, 0, 0);
+        var submitted = tracker.Flush();
+        tracker.RequeueAcks(submitted);
+        tracker.TrackDeliveredRecords(partition, 1, 1);
+
+        var types = tracker.Flush(releaseImplicit: true)[partition][0].AcknowledgeTypes;
+
+        await Assert.That(types[0]).IsEqualTo((byte)AcknowledgeType.Accept);
+        await Assert.That(types[1]).IsEqualTo((byte)AcknowledgeType.Release);
+    }
+
+    [Test]
+    public async Task CloseFlush_RetriedRelease_RemainsReleaseOnOrdinaryCommit()
+    {
+        var tracker = new AcknowledgementTracker();
+        var partition = new TopicPartition("topic", 0);
+        tracker.TrackDeliveredRecords(partition, 0, 0);
+        tracker.RequeueAcks(tracker.Flush(releaseImplicit: true));
+
+        var types = tracker.Flush()[partition][0].AcknowledgeTypes;
+
+        await Assert.That(types[0]).IsEqualTo((byte)AcknowledgeType.Release);
+    }
+
+    [Test]
     public async Task TrackDeliveredRecords_AllDefaultToAccept()
     {
         var tracker = new AcknowledgementTracker();

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -901,13 +901,8 @@ public sealed class ShareConsumerRenewalTests
         PrepareForPoll(fixture.Consumer);
         TrackDeliveredRecord(fixture.Consumer, new TopicPartition("topic", 0), 42);
 
-        try
-        {
-            await fixture.Consumer.CloseAsync(cancellation.Token);
-        }
-        catch (OperationCanceledException)
-        {
-        }
+        // Close handles acknowledgement failures as best effort; unexpected exceptions must fail this test.
+        await fixture.Consumer.CloseAsync(cancellation.Token);
 
         var pending = FlushPendingAcknowledgements(fixture.Consumer);
         await Assert.That(pending[new TopicPartition("topic", 0)][0].AcknowledgeTypes[0])
@@ -915,18 +910,28 @@ public sealed class ShareConsumerRenewalTests
     }
 
     [Test]
-    public async Task Poll_PartialEnumeration_DoesNotTrackUnyieldedRecords()
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Poll_PartialEnumeration_DoesNotTrackUnyieldedRecords(bool requiresPreparation)
     {
         var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
         {
             ShareFetchResponse = CreateFetchResponse(0, 42, recordCount: 2)
         };
-        await using var fixture = CreateFixture(connection, ShareAcknowledgementMode.Implicit);
+        var preparer = requiresPreparation ? new PausedDeserializerPreparer() : null;
+        await using var fixture = CreateFixture(connection, ShareAcknowledgementMode.Implicit, valueDeserializer: preparer);
         PrepareForPoll(fixture.Consumer);
         fixture.Consumer.Subscribe("topic");
         await using (var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator())
         {
-            await Assert.That(await poll.MoveNextAsync()).IsTrue();
+            var moveNext = poll.MoveNextAsync();
+            if (preparer is not null)
+            {
+                await preparer.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+                await Assert.That(moveNext.IsCompleted).IsFalse();
+                preparer.Release.SetResult();
+            }
+            await Assert.That(await moveNext).IsTrue();
             await Assert.That(poll.Current.Offset).IsEqualTo(42);
         }
 
@@ -941,7 +946,8 @@ public sealed class ShareConsumerRenewalTests
         ShareAcknowledgementMode acknowledgementMode = ShareAcknowledgementMode.Explicit,
         int maxPollRecords = 500,
         CapturingConnection? secondConnection = null,
-        ShareAcknowledgementCommitCallback? acknowledgementCommitCallback = null)
+        ShareAcknowledgementCommitCallback? acknowledgementCommitCallback = null,
+        IDeserializer<string>? valueDeserializer = null)
     {
         var options = new ShareConsumerOptions
         {
@@ -997,11 +1003,34 @@ public sealed class ShareConsumerRenewalTests
         var consumer = new KafkaShareConsumer<string, string>(
             options,
             Substitute.For<IDeserializer<string>>(),
-            Substitute.For<IDeserializer<string>>(),
+            valueDeserializer ?? Substitute.For<IDeserializer<string>>(),
             pool,
             metadataManager);
         SetMemberId(consumer, "member-1");
         return new Fixture(consumer, metadataManager);
+    }
+
+    private sealed class PausedDeserializerPreparer : IDeserializer<string>, IAsyncDeserializerPreparer<string>
+    {
+        private bool _prepared;
+        public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) =>
+            Serializers.String.Deserialize(data, context);
+
+        public bool TryDeserialize(ReadOnlyMemory<byte> data, SerializationContext context, out string value)
+        {
+            value = _prepared ? Deserialize(data, context) : string.Empty;
+            return _prepared;
+        }
+
+        public async ValueTask PrepareAsync(ReadOnlyMemory<byte> data, SerializationContext context, CancellationToken cancellationToken = default)
+        {
+            Entered.TrySetResult();
+            await Release.Task.WaitAsync(cancellationToken);
+            _prepared = true;
+        }
     }
 
     private static ShareFetchResponse CreateFetchResponse(int partition, long offset, int recordCount = 1)

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -851,6 +851,91 @@ public sealed class ShareConsumerRenewalTests
         await Assert.That(connection.ShareAcknowledgeRequest).IsNotNull();
     }
 
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Close_ImplicitDelivery_ReleasesInsteadOfAccepting(bool dispose)
+    {
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2);
+        await using var fixture = CreateFixture(connection, ShareAcknowledgementMode.Implicit);
+        PrepareForPoll(fixture.Consumer);
+        TrackDeliveredRecord(fixture.Consumer, new TopicPartition("topic", 0), 42);
+
+        if (dispose)
+            await fixture.Consumer.DisposeAsync();
+        else
+            await fixture.Consumer.CloseAsync();
+
+        var acknowledgement = connection.ShareAcknowledgeRequest!.Topics[0].Partitions[0].AcknowledgementBatches[0];
+        await Assert.That(acknowledgement.AcknowledgeTypes[0]).IsEqualTo((byte)AcknowledgeType.Release);
+    }
+
+    [Test]
+    [Arguments(AcknowledgeType.Accept)]
+    [Arguments(AcknowledgeType.Release)]
+    [Arguments(AcknowledgeType.Reject)]
+    [Arguments(AcknowledgeType.Renew)]
+    public async Task Close_ExplicitDisposition_PreservesSelectedOutcome(AcknowledgeType type)
+    {
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2);
+        await using var fixture = CreateFixture(connection);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Acknowledge(CreateRecord(), type);
+
+        await fixture.Consumer.CloseAsync();
+
+        var acknowledgement = connection.ShareAcknowledgeRequest!.Topics[0].Partitions[0].AcknowledgementBatches[0];
+        await Assert.That(acknowledgement.AcknowledgeTypes[0]).IsEqualTo((byte)type);
+    }
+
+    [Test]
+    public async Task Close_CancelledAcknowledgement_NeverRequeuesImplicitAccept()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2)
+        {
+            OnSend = () => throw new OperationCanceledException(cancellation.Token)
+        };
+        await using var fixture = CreateFixture(connection, ShareAcknowledgementMode.Implicit);
+        PrepareForPoll(fixture.Consumer);
+        TrackDeliveredRecord(fixture.Consumer, new TopicPartition("topic", 0), 42);
+
+        try
+        {
+            await fixture.Consumer.CloseAsync(cancellation.Token);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        var pending = FlushPendingAcknowledgements(fixture.Consumer);
+        await Assert.That(pending[new TopicPartition("topic", 0)][0].AcknowledgeTypes[0])
+            .IsEqualTo((byte)AcknowledgeType.Release);
+    }
+
+    [Test]
+    public async Task Poll_PartialEnumeration_DoesNotTrackUnyieldedRecords()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = CreateFetchResponse(0, 42, recordCount: 2)
+        };
+        await using var fixture = CreateFixture(connection, ShareAcknowledgementMode.Implicit);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        await using (var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator())
+        {
+            await Assert.That(await poll.MoveNextAsync()).IsTrue();
+            await Assert.That(poll.Current.Offset).IsEqualTo(42);
+        }
+
+        var pending = FlushPendingAcknowledgements(fixture.Consumer);
+        var batch = pending[new TopicPartition("topic", 0)][0];
+        await Assert.That(batch.FirstOffset).IsEqualTo(42);
+        await Assert.That(batch.LastOffset).IsEqualTo(42);
+    }
+
     private static Fixture CreateFixture(
         CapturingConnection connection,
         ShareAcknowledgementMode acknowledgementMode = ShareAcknowledgementMode.Explicit,
@@ -919,13 +1004,13 @@ public sealed class ShareConsumerRenewalTests
         return new Fixture(consumer, metadataManager);
     }
 
-    private static ShareFetchResponse CreateFetchResponse(int partition, long offset)
+    private static ShareFetchResponse CreateFetchResponse(int partition, long offset, int recordCount = 1)
     {
         var buffer = new ArrayBufferWriter<byte>();
         using var batch = new RecordBatch
         {
             BaseOffset = offset,
-            Records = [new Record { IsKeyNull = true, Value = "new-value"u8.ToArray() }]
+            Records = Enumerable.Range(0, recordCount).Select(index => new Record { OffsetDelta = index, IsKeyNull = true, Value = "new-value"u8.ToArray() }).ToList()
         };
         batch.Write(buffer);
 
@@ -949,7 +1034,7 @@ public sealed class ShareConsumerRenewalTests
                                 new ShareFetchAcquiredRecords
                                 {
                                     FirstOffset = offset,
-                                    LastOffset = offset,
+                                    LastOffset = offset + recordCount - 1,
                                     DeliveryCount = 1
                                 }
                             ]

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryShareCloseTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryShareCloseTests.cs
@@ -1,0 +1,50 @@
+using Dekaf.ShareConsumer;
+using Dekaf.Testing;
+
+namespace Dekaf.Tests.Unit.Testing;
+
+public class InMemoryShareCloseTests
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Close_PreservesExplicitAccept_AndReleasesImplicit(bool explicitAccept)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        await using var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync("topic", "key", "first");
+        await producer.ProduceAsync("topic", "key", "second");
+        await using (var first = new InMemoryShareConsumer<string, string>(cluster))
+        {
+            first.Subscribe("topic");
+            var record = await first.PollAsync().FirstAsync();
+            if (explicitAccept)
+                first.Acknowledge(record);
+        }
+
+        await using var second = new InMemoryShareConsumer<string, string>(cluster);
+        second.Subscribe("topic");
+        var redelivered = await second.PollAsync().FirstAsync();
+        await Assert.That(redelivered.Value).IsEqualTo(explicitAccept ? "second" : "first");
+    }
+
+    [Test]
+    public async Task Close_AfterFailedImplicitCommit_PreservesSubmittedAccept()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        await using var producer = new InMemoryProducer<string, string>(cluster);
+        await producer.ProduceAsync("topic", "key", "first");
+        await producer.ProduceAsync("topic", "key", "second");
+        await using (var first = new InMemoryShareConsumer<string, string>(cluster))
+        {
+            first.Subscribe("topic");
+            _ = await first.PollAsync().FirstAsync();
+            cluster.FaultPlan.Fail(new KafkaFaultScope(KafkaFaultOperation.ShareAcknowledge), new InvalidOperationException("ack failure"));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await first.CommitAsync());
+        }
+
+        await using var second = new InMemoryShareConsumer<string, string>(cluster);
+        second.Subscribe("topic");
+        await Assert.That((await second.PollAsync().FirstAsync()).Value).IsEqualTo("second");
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgeCommitBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgeCommitBenchmarks.cs
@@ -12,6 +12,9 @@ public class ShareAcknowledgeCommitBenchmarks
     private const int BatchSize = 4096;
     private const int NonMatchingSelectorCount = 1024;
 
+    [Params(false, true)]
+    public bool ExplicitAcknowledgement { get; set; }
+
     private InMemoryKafkaCluster _matchingCluster = null!;
     private InMemoryKafkaCluster _nonMatchingCluster = null!;
     private InMemoryKafkaCluster _emptyCluster = null!;
@@ -106,7 +109,7 @@ public class ShareAcknowledgeCommitBenchmarks
         return consumer;
     }
 
-    private static void Prepare(
+    private void Prepare(
         InMemoryProducer<string, string> producer,
         InMemoryShareConsumer<string, string> consumer)
     {
@@ -121,7 +124,8 @@ public class ShareAcknowledgeCommitBenchmarks
                 if (!enumerator.MoveNextAsync().AsTask().GetAwaiter().GetResult())
                     throw new InvalidOperationException("Share poll ended before the benchmark batch was prepared.");
 
-                consumer.Acknowledge(enumerator.Current);
+                if (ExplicitAcknowledgement)
+                    consumer.Acknowledge(enumerator.Current);
             }
         }
         finally

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgementTrackingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgementTrackingBenchmarks.cs
@@ -1,0 +1,43 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+public class ShareAcknowledgementTrackingBenchmarks
+{
+    private readonly TopicPartition _partition = new("topic", 0);
+    private AcknowledgementTracker _tracker = null!;
+    private long _offset;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _tracker = new AcknowledgementTracker();
+        _tracker.TrackDeliveredRecords(_partition, 0, 0);
+        _tracker.Acknowledge(_partition, 0, AcknowledgeType.Accept);
+    }
+
+    [Benchmark]
+    public bool TrackDelivery()
+    {
+        var offset = ++_offset;
+        _tracker.TrackDeliveredRecords(_partition, offset, offset);
+        return _tracker.HasPending;
+    }
+
+    [Benchmark]
+    public bool UpdateExplicit()
+    {
+        _tracker.Acknowledge(_partition, 0, AcknowledgeType.Accept);
+        return _tracker.HasPending;
+    }
+
+    [Benchmark]
+    public int FlushBatch()
+    {
+        var tracker = new AcknowledgementTracker();
+        tracker.TrackDeliveredRecords(_partition, 0, 999);
+        return tracker.Flush()[_partition][0].AcknowledgeTypes.Length;
+    }
+}


### PR DESCRIPTION
Closes #3030.

Disposing a share consumer after application processing fails previously converted the outstanding delivery into `Accept`. Close now resolves provisional implicit deliveries to `Release`; the next poll or an explicit commit still resolves them to `Accept`. Explicit Accept/Release/Reject and already-submitted retry outcomes remain intact. Pending Renew is submitted unchanged, then session closure releases acquisition locks and ends local replay.

The tracker stores provisional state in its existing range type, without adding per-record objects. Delivery tracking runs immediately before yield, including the buffered path. The in-memory consumer follows the same close semantics. Interface documentation and migration guidance explain how to commit successfully processed final records.

Validation:
- Reproduced the original bug before implementation: both CloseAsync and DisposeAsync regression cases received Accept instead of Release.
- 101 share-consumer unit tests and 367 testing-double unit tests pass on each of net10.0 and net8.0 (936 total executions).
- Three Docker/Kafka 4.3.1 tests pass: normal partial enumeration, processing exception followed by await-using disposal, and explicit Accept. A second group member receives precisely the unfinished records.
- The initial broker test exposed the fixture's latest-offset initialization race. This test now sets the group's share.auto.offset.reset=earliest before producing or joining; it does not depend on priming delays.
- Cancellation, failed-commit retry, all explicit dispositions including Renew, and unyielded records have deterministic unit coverage.
- Benchmark project builds; docs production build passes and rendered migration guidance is present. /simplify and git diff --check complete. Public signatures unchanged.

Performance evidence compares baseline 0dd6f28575293da40c417977c55adf5dc3b0923e with this commit on the same Windows 11/i7-12700K host, SDK 10.0.400, runtime 10.0.11, BenchmarkDotNet 0.15.8, MemoryDiagnoser, in-process toolchain, 5 warmups and 15 iterations. Saved pre/post product DLLs were used with identical benchmark source. The measured candidate and final core build have identical IL across all 15,526 method bodies; subsequent XML documentation edits change the binary debug identity only.

| Tracker operation | Before mean ± error | After mean ± error | Delta | Allocated before → after |
| --- | ---: | ---: | ---: | ---: |
| Contiguous delivery tracking | 8.184 ± 0.120 ns | 8.235 ± 0.085 ns | +0.6% | 0 B → 0 B |
| Update existing explicit acknowledgement | 13.491 ± 0.527 ns | 12.816 ± 0.158 ns | -5.0% | 0 B → 0 B |
| Create tracker and flush 1,000-record batch | 157.995 ± 24.821 ns | 153.599 ± 9.497 ns | -2.8% | 1,944 B → 1,840 B per batch |

The warmed tracking operations remain allocation-free. The batch benchmark includes existing cold tracker/list/wire-buffer allocations; it is not a zero-allocation claim for the entire share-consumer pipeline or first-time explicit dictionary insertion (tracked separately in #3032).

Extended ShareAcknowledgeCommitBenchmarks to cover implicit and explicit acknowledgements. Results below are ns per record for a 4,096-record in-memory commit; fault-plan shape and batch size are identical before/after.

| Plan | Explicit | Before mean ± error | After mean ± error | Delta | BDN allocated before → after |
| --- | --- | ---: | ---: | ---: | ---: |
| Matching | false | 125.39 ± 15.54 | 123.00 ± 14.14 | -1.9% | 0 B → 0 B |
| Nonmatching | false | 127.11 ± 25.87 | 150.29 ± 59.82 | +18.2% | 1 B → 1 B |
| Empty | false | 55.86 ± 6.70 | 55.14 ± 6.82 | -1.3% | 1 B → 1 B |
| Matching | true | 105.98 ± 17.15 | 108.34 ± 23.26 | +2.2% | 1 B → 1 B |
| Nonmatching | true | 98.42 ± 7.05 | 98.92 ± 8.49 | +0.5% | 1 B → 1 B |
| Empty | true | 47.79 ± 2.69 | 49.88 ± 4.66 | +4.4% | 1 B → 1 B |

These short, single-invocation commit timings overlap their measurement uncertainty; the implicit nonmatching-plan result is particularly noisy and does not establish an improvement or regression. BDN's per-record allocation column includes single-invocation harness noise. A separate GC.GetAllocatedBytesForCurrentThread probe around the warmed empty-plan commit measured exactly 64 B per whole 4,096-record batch in all three samples for each acknowledgement mode, on both builds. No added per-message allocation.

No paid stress lane dispatched. These measurements cover the changed acknowledgement paths; they do not measure end-to-end throughput, p50/p99/max latency or CPU per message and are not a formal duration-lane Pareto PASS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Closing or disposing a share consumer now releases delivered but unacknowledged records for redelivery.
  - Explicitly accepted, released, or rejected records retain their selected outcomes.
  - Pending renewals are retried as renewals rather than being accepted.
  - Partial polling and processing failures no longer cause unacknowledged records to be treated as accepted.
  - Unsubscribe releases pending records and clears the subscription.

- **Documentation**
  - Added migration guidance: call `CommitAsync` or explicitly acknowledge acceptance when processed records must remain accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->