### PR TITLE
docs: correct native MTP alternative filters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,7 @@ Both direct test executables and `dotnet test --project <project>` use `--treeno
 - `=` exact match: `/*/*/*[Category=Unit]`
 - `!=` exclude: `/*/*/*[Category!=Slow]`
 - `&` AND: `/*/*/*[Category=Unit]&[Priority=High]`
-- `|` OR (requires parentheses): `(/*/*/ClassA/*)|(/*/*/ClassB/*)`
+- `|` OR within one path segment: `/*/*/(ClassA|ClassB)/*`. Do not wrap complete paths in parentheses; run separate commands when combining different path shapes.
 
 **Common mistakes to avoid:**
 - Do NOT use `--filter` (that's for VSTest, not Microsoft.Testing.Platform)


### PR DESCRIPTION
The documented parenthesized full-path OR filter throws an MTP parser error. Use alternatives within a single path segment instead, and run separate commands when path shapes differ.

Validation: reproduced the old parser failure; the corrected two-class native-MTP discovery command returned 12 tests. All 189 Python script tests pass. `/simplify` and diff checks complete. Documentation only.

Follow-up to #3046, which merged while this correction was being pushed. Refs #3039.
