### PR TITLE
Keep outbox leases alive throughout batch publishing

### DIFF
--- a/docs/docs/producer/outbox.md
+++ b/docs/docs/producer/outbox.md
@@ -222,8 +222,9 @@ var messageId = outboxResult.Headers.FirstOrDefault(h => h.Key == "x-outbox-mess
 | `BucketCount` | 8 | Upper bound on relay parallelism. Must match across all writers and relays. |
 | `BatchSize` | 500 | Rows fetched and published per database round trip. |
 | `PollInterval` | 100 ms | Idle delay when no bucket had work. |
-| `LeaseDuration` | 30 s | Stalled-relay takeover time; also the duplicate window on takeover. Set it comfortably above the producer's delivery timeout: the relay yields for renewal between batches, so only a *single* batch publish outlasting the remaining lease can enter the takeover window, and a lease longer than the worst-case publish makes that unreachable. |
-| `LeaseRenewInterval` | 10 s | Must be comfortably below `LeaseDuration`. |
+| `LeaseDuration` | 30 s | Time until takeover after the last successful renewal. The EF store renews during slow publishes, so the default 120 s producer delivery timeout does not expire an otherwise healthy relay's lease. Longer leases tolerate longer store/process stalls but delay takeover. |
+| `LeaseRenewInterval` | 10 s | Renewal cadence, including pending publishes. Leave enough slack for database latency, scheduling pauses, and clock skew. |
+| `MaxPublishDuration` | `null` | Required only for stores without `IOutboxLeaseRenewalStore`. Bound the **entire** publish call, not one record's delivery timeout. The budget plus a renewal interval must fit inside `LeaseDuration`. |
 | `MessageIdHeaderName` | `x-outbox-message-id` | Dedup header stamped on every record. |
 
 Pass options at registration:
@@ -240,6 +241,29 @@ builder.Services.AddDekafOutboxRelay(
 ```
 
 ## Custom Stores (Relational, NoSQL, or Anything Else)
+
+### Lease timing and migration
+
+The EF store implements `IOutboxLeaseRenewalStore`. Its renewal atomically checks ownership and unexpired leases, extends them, and refreshes the relay heartbeat. It does **not** acquire or relinquish buckets while a publish is pending. Fair-share rebalancing resumes between publish calls. Store calls remain serialized: renewal runs alongside the publisher, never alongside another store operation from that relay.
+
+Custom stores should implement the same optional capability. Without it, registration must provide `MaxPublishDuration`; an unspecified bound now fails at startup with `OutboxMisconfigurationException`. For example, if measurement establishes that a custom publisher's whole batch completes within two minutes:
+
+```csharp
+var relayOptions = new OutboxRelayOptions
+{
+    MaxPublishDuration = TimeSpan.FromMinutes(2),
+    LeaseDuration = TimeSpan.FromMinutes(3),
+    LeaseRenewInterval = TimeSpan.FromSeconds(10)
+};
+```
+
+The relay measures lease age from **before** acquisition, then rechecks after the pending-bucket probe and batch fetch. Before a legacy-store publish, it reserves the full publish budget plus one renewal interval, renewing first if necessary. If acquisition latency still leaves too little time, it keeps the rows unpublished and logs the configuration problem. `BatchSize`, sequential submission, backpressure and delivery attempts all affect the whole-call bound. Raising a lease above one record's timeout alone does not establish safety.
+
+`MaxPublishDuration` is a timing contract, not a timeout that aborts Kafka delivery. Exceeding it faults the relay instead of repeatedly publishing under an invalid assumption. Custom publishers must yield during asynchronous waits, honor shutdown cancellation, and account for all work covered by their bound.
+
+Renewal cannot protect against a process pause or database outage longer than the remaining lease. After losing a lease during a pending publish, the relay observes the publisher's completion and retains the rows for takeover; it does not start another publish concurrently. Cancellation cannot retract records already appended to Kafka. Such records can still arrive after takeover, so consumer-side message-ID deduplication remains necessary.
+
+### Store contract
 
 `IOutboxStore` is a four-method contract (`AcquireBucketLeasesAsync`, `GetBucketsWithPendingAsync`, `GetNextBatchAsync`, `MarkPublishedAsync`) with **no relational assumptions** — implement it for Dapper, raw ADO.NET, MongoDB, DynamoDB, Cosmos DB, or any storage that offers the two primitives below. The relay engine (`Dekaf.Outbox`) never touches a database API; the EF Core package is just one store.
 

--- a/src/Dekaf.Outbox.EntityFrameworkCore/EfCoreOutboxStore.cs
+++ b/src/Dekaf.Outbox.EntityFrameworkCore/EfCoreOutboxStore.cs
@@ -17,7 +17,7 @@ namespace Dekaf.Outbox.EntityFrameworkCore;
 /// a Kafka hot path, so EF/LINQ usage here is intentional and fine.</para>
 /// </remarks>
 /// <typeparam name="TContext">The application's context type containing the outbox model.</typeparam>
-public sealed class EfCoreOutboxStore<TContext> : IOutboxStore
+public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxLeaseRenewalStore
     where TContext : DbContext
 {
     /// <summary>
@@ -144,6 +144,36 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore
             .Select(m => m.Bucket)
             .Distinct()
             .ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<bool> RenewBucketLeasesAsync(
+        OutboxLeaseRequest request,
+        IReadOnlyList<int> buckets,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(buckets);
+        if (buckets.Count == 0)
+            return true;
+
+        var context = await _contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await using var contextDisposal = context.ConfigureAwait(false);
+        var now = _timeProvider.GetUtcNow();
+        var expiry = now + request.LeaseDuration;
+        var bucketArray = buckets as int[] ?? [.. buckets];
+        var renewed = await context.Set<OutboxLease>()
+            .Where(lease => lease.Owner == request.RelayId && lease.ExpiresAtUtc > now
+                && lease.Bucket >= 0 && lease.Bucket < request.BucketCount && bucketArray.Contains(lease.Bucket))
+            .ExecuteUpdateAsync(setters => setters.SetProperty(lease => lease.ExpiresAtUtc, expiry), cancellationToken)
+            .ConfigureAwait(false);
+        // Matching leases may already be extended after a partial mismatch. The relay
+        // drops its local ownership and reacquires valid buckets on the next cycle,
+        // rather than continuing publication on a partially renewed set.
+        if (renewed != buckets.Count)
+            return false;
+
+        await RecordHeartbeatAsync(context, request, now, cancellationToken).ConfigureAwait(false);
+        return true;
     }
 
     public async ValueTask<IReadOnlyList<OutboxMessage>> GetNextBatchAsync(

--- a/src/Dekaf.Outbox.EntityFrameworkCore/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.Outbox.EntityFrameworkCore/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Dekaf.Outbox.EntityFrameworkCore.EfCoreOutboxStore<TContext>.RenewBucketLeasesAsync(Dekaf.Outbox.OutboxLeaseRequest! request, System.Collections.Generic.IReadOnlyList<int>! buckets, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<bool>

--- a/src/Dekaf.Outbox/IOutboxLeaseRenewalStore.cs
+++ b/src/Dekaf.Outbox/IOutboxLeaseRenewalStore.cs
@@ -1,0 +1,24 @@
+namespace Dekaf.Outbox;
+
+/// <summary>
+/// Optional store capability for keeping leases alive throughout an asynchronous publish.
+/// </summary>
+public interface IOutboxLeaseRenewalStore
+{
+    /// <summary>
+    /// Renews the supplied, still-valid leases and this relay's heartbeat without acquiring
+    /// new buckets or releasing existing buckets for fair-share rebalancing.
+    /// </summary>
+    /// <remarks>
+    /// Never reacquire an expired lease, even if its owner has not changed. Each update must
+    /// atomically require the requesting owner and an expiry later than the renewal's start.
+    /// The relay also rejects a response received after its previous lease deadline, since
+    /// a delayed response cannot prove continuous ownership. Return false if any
+    /// supplied bucket could not be renewed. The relay serializes this method with all
+    /// other store calls; only the publisher can run concurrently with it.
+    /// </remarks>
+    ValueTask<bool> RenewBucketLeasesAsync(
+        OutboxLeaseRequest request,
+        IReadOnlyList<int> buckets,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Dekaf.Outbox/IOutboxPublisher.cs
+++ b/src/Dekaf.Outbox/IOutboxPublisher.cs
@@ -22,6 +22,15 @@ public interface IOutboxPublisher : IAsyncDisposable
     /// order across partial failures: if row 1 fails while row 2 succeeds, retrying both can
     /// deliver 2, 1, 2. Message-id deduplication still leaves 2, 1. Implementations promising
     /// stronger ordering must prevent later rows becoming visible before earlier rows succeed.
+    /// <para>
+    /// With an IOutboxLeaseRenewalStore, the relay maintains ownership throughout an
+    /// asynchronous call without rebalancing its active buckets. Implementations must
+    /// yield while waiting and observe cancellation so renewal and shutdown can run.
+    /// With a legacy store, OutboxRelayOptions.MaxPublishDuration must bound the entire
+    /// call: submission of every row, local/backpressure waits, and every delivery attempt.
+    /// It is not one record's delivery timeout and is not enforced by cancelling delivery.
+    /// An already-appended Kafka record can still be delivered after cancellation or lease loss.
+    /// </para>
     /// </remarks>
     /// <param name="messages">The rows to publish, in ascending id order.</param>
     /// <param name="messageIdHeaderName">Header name to stamp with each row's message id.</param>

--- a/src/Dekaf.Outbox/OutboxRelayOptions.cs
+++ b/src/Dekaf.Outbox/OutboxRelayOptions.cs
@@ -54,8 +54,23 @@ public sealed class OutboxRelayOptions
 
     /// <summary>
     /// How often leases are renewed. Must be comfortably below <see cref="LeaseDuration"/>.
+    /// Stores implementing IOutboxLeaseRenewalStore also renew while publication is pending.
     /// </summary>
     public TimeSpan LeaseRenewInterval { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Conservative bound for an entire PublishAsync call, including submission of every
+    /// row, backpressure and all delivery attempts. Required when the store does not implement
+    /// <see cref="IOutboxLeaseRenewalStore"/>. A single record's delivery timeout is not this bound.
+    /// </summary>
+    /// <remarks>
+    /// This is a publisher timing contract, not a cancellation timeout. The relay reserves
+    /// this much remaining lease time plus a renewal interval after fetching and stops if
+    /// the publisher exceeds it.
+    /// Cancellation cannot fence records already appended to Kafka. Null uses in-flight
+    /// renewal and requires a store supporting that capability.
+    /// </remarks>
+    public TimeSpan? MaxPublishDuration { get; init; }
 
     /// <summary>
     /// Header name stamped with <see cref="OutboxMessage.MessageId"/> on every published
@@ -95,6 +110,16 @@ public sealed class OutboxRelayOptions
         {
             throw new ArgumentException(
                 "LeaseRenewInterval must be less than LeaseDuration, otherwise leases expire between renewals.");
+        }
+
+        if (MaxPublishDuration is { } publishDuration)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(publishDuration, TimeSpan.Zero);
+            if (publishDuration >= LeaseDuration - LeaseRenewInterval)
+            {
+                throw new ArgumentException(
+                    "MaxPublishDuration plus LeaseRenewInterval must be less than LeaseDuration.");
+            }
         }
     }
 }

--- a/src/Dekaf.Outbox/OutboxRelayService.Leases.cs
+++ b/src/Dekaf.Outbox/OutboxRelayService.Leases.cs
@@ -1,0 +1,124 @@
+using Microsoft.Extensions.Logging;
+
+namespace Dekaf.Outbox;
+
+public sealed partial class OutboxRelayService
+{
+    private Task? _renewalDelay;
+    private CancellationTokenSource? _renewalDelayCancellation;
+    private long _renewalDelayStarted;
+    private TimeSpan _renewalDelayDuration;
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        CancelRenewalDelay();
+    }
+
+    private void CancelRenewalDelay()
+    {
+        var cancellation = Interlocked.Exchange(ref _renewalDelayCancellation, null);
+        cancellation?.Cancel();
+        cancellation?.Dispose();
+        _renewalDelay = null;
+    }
+
+    private Task GetRenewalDelay(TimeSpan remaining, CancellationToken cancellationToken)
+    {
+        var delay = TimeSpan.FromTicks(Math.Max(1,
+            Math.Min(_options.LeaseRenewInterval.Ticks, remaining.Ticks / 2)));
+        // Carry one pending timer across quickly completed batches. Replacing it per
+        // batch creates timer and cancellation allocations proportional to throughput.
+        if (_renewalDelay is not null && (_renewalDelay.IsCompleted ||
+            _renewalDelayDuration - _timeProvider.GetElapsedTime(_renewalDelayStarted) <= delay))
+            return _renewalDelay;
+
+        CancelRenewalDelay();
+        _renewalDelayCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _renewalDelayStarted = _timeProvider.GetTimestamp();
+        _renewalDelayDuration = delay;
+        return _renewalDelay = Task.Delay(delay, _timeProvider, _renewalDelayCancellation.Token);
+    }
+
+    private bool OwnsBucket(int bucket)
+    {
+        for (var i = 0; i < _ownedBuckets.Count; i++)
+        {
+            if (_ownedBuckets[i] == bucket)
+                return true;
+        }
+
+        return false;
+    }
+
+    private async ValueTask<bool> PreparePublishLeaseAsync(int bucket, CancellationToken cancellationToken)
+    {
+        if (_renewalStore is not null)
+            return !RenewalDue || await RenewOwnedLeasesAsync(cancellationToken).ConfigureAwait(false);
+
+        var publishBudget = _options.MaxPublishDuration!.Value;
+        var latestStart = _options.LeaseDuration - publishBudget - _options.LeaseRenewInterval;
+        if (LeaseAge() >= latestStart)
+            await RefreshLeasesIfDueAsync(cancellationToken, force: true).ConfigureAwait(false);
+
+        // An acquisition can rebalance this bucket away; a slow acquisition can also use
+        // up the reserved publish budget. Neither case permits publishing the fetched rows.
+        if (!OwnsBucket(bucket) || LeaseAge() >= latestStart)
+        {
+            LogInsufficientPublishLease(publishBudget);
+            ResetLeaseState();
+            return false;
+        }
+
+        return true;
+    }
+
+    private async ValueTask<bool> RenewOwnedLeasesAsync(CancellationToken cancellationToken)
+    {
+        if (LeaseAge() >= _options.LeaseDuration)
+        {
+            ResetLeaseState();
+            return false;
+        }
+
+        var previousTimestamp = _leaseTimestamp;
+        var timestamp = _timeProvider.GetTimestamp();
+        var renewed = await _renewalStore!.RenewBucketLeasesAsync(_leaseRequest, _ownedBuckets, cancellationToken)
+            .ConfigureAwait(false);
+        // A response arriving after the old lease expired cannot prove continuous
+        // ownership, even if the database eventually extended that lease successfully.
+        if (!renewed || _timeProvider.GetElapsedTime(previousTimestamp) >= _options.LeaseDuration)
+        {
+            ResetLeaseState();
+            return false;
+        }
+
+        _leaseTimestamp = timestamp;
+        return true;
+    }
+
+    private void ValidatePublishDuration(long started)
+    {
+        if (_options.MaxPublishDuration is { } budget && _timeProvider.GetElapsedTime(started) > budget)
+        {
+            ResetLeaseState();
+            throw new OutboxMisconfigurationException(
+                $"PublishAsync exceeded MaxPublishDuration ({budget}). Configure a bound for the entire " +
+                "batch, or use an IOutboxLeaseRenewalStore. Cancellation cannot fence already-appended records.");
+        }
+    }
+
+    private OutboxPublishResult LostPublishLease(Exception? error = null)
+    {
+        ResetLeaseState();
+        LogLeaseLostDuringPublish();
+        return new OutboxPublishResult(0, error ??
+            new InvalidOperationException("The outbox lease expired before publishing completed."));
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Not enough remaining outbox lease time for MaxPublishDuration ({PublishBudget}); fetched rows remain unpublished. Increase LeaseDuration or implement IOutboxLeaseRenewalStore")]
+    private partial void LogInsufficientPublishLease(TimeSpan publishBudget);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Outbox lease lost during publishing; rows retained for at-least-once takeover. Already-appended Kafka records may still be delivered")]
+    private partial void LogLeaseLostDuringPublish();
+}

--- a/src/Dekaf.Outbox/OutboxRelayService.Leases.cs
+++ b/src/Dekaf.Outbox/OutboxRelayService.Leases.cs
@@ -17,10 +17,9 @@ public sealed partial class OutboxRelayService
 
     private void CancelRenewalDelay()
     {
-        var cancellation = Interlocked.Exchange(ref _renewalDelayCancellation, null);
-        cancellation?.Cancel();
-        cancellation?.Dispose();
+        using var cancellation = Interlocked.Exchange(ref _renewalDelayCancellation, null);
         _renewalDelay = null;
+        cancellation?.Cancel();
     }
 
     private Task GetRenewalDelay(TimeSpan remaining, CancellationToken cancellationToken)

--- a/src/Dekaf.Outbox/OutboxRelayService.cs
+++ b/src/Dekaf.Outbox/OutboxRelayService.cs
@@ -288,6 +288,8 @@ public sealed partial class OutboxRelayService : BackgroundService
                 }
                 catch (Exception ex)
                 {
+                    // Store/timer failures must not bypass observation of the in-flight
+                    // publisher below. Preserve the error and retain rows after it finishes.
                     renewalError = ex;
                     ResetLeaseState();
                 }

--- a/src/Dekaf.Outbox/OutboxRelayService.cs
+++ b/src/Dekaf.Outbox/OutboxRelayService.cs
@@ -27,6 +27,7 @@ public sealed partial class OutboxRelayService : BackgroundService
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<OutboxRelayService> _logger;
     private readonly OutboxLeaseRequest _leaseRequest;
+    private readonly IOutboxLeaseRenewalStore? _renewalStore;
 
     private IReadOnlyList<int> _ownedBuckets = [];
     private long _leaseTimestamp;
@@ -43,6 +44,14 @@ public sealed partial class OutboxRelayService : BackgroundService
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(logger);
         options.Validate();
+        _renewalStore = store as IOutboxLeaseRenewalStore;
+        if (_renewalStore is null && options.MaxPublishDuration is null)
+        {
+            throw new OutboxMisconfigurationException(
+                "The outbox store must implement IOutboxLeaseRenewalStore or configure MaxPublishDuration " +
+                "as a bound for the entire publisher call, including all rows, backpressure and delivery attempts. " +
+                "One record's producer delivery timeout is not a whole-batch bound.");
+        }
 
         _store = store;
         _publisher = publisher;
@@ -162,12 +171,15 @@ public sealed partial class OutboxRelayService : BackgroundService
             if (cancellationToken.IsCancellationRequested)
                 break;
 
-            if (LeaseAge() >= _options.LeaseDuration)
+            if (_ownedBuckets.Count == 0 || LeaseAge() >= _options.LeaseDuration)
             {
                 // Lease may have expired mid-cycle; stop publishing until re-acquired.
                 ResetLeaseState();
                 break;
             }
+
+            if (_renewalStore is null && !OwnsBucket(pendingBuckets[i]))
+                continue;
 
             var bucketResult = await DrainBucketAsync(pendingBuckets[i], cancellationToken).ConfigureAwait(false);
             publishedAny |= bucketResult.PublishedAny;
@@ -189,9 +201,9 @@ public sealed partial class OutboxRelayService : BackgroundService
     /// </summary>
     private bool RenewalDue => _leaseTimestamp == 0 || LeaseAge() >= _options.LeaseRenewInterval;
 
-    private async Task RefreshLeasesIfDueAsync(CancellationToken cancellationToken)
+    private async Task RefreshLeasesIfDueAsync(CancellationToken cancellationToken, bool force = false)
     {
-        if (!RenewalDue)
+        if (!force && !RenewalDue)
             return;
 
         // Captured before the store call: the database computes lease expiry when the call
@@ -223,11 +235,8 @@ public sealed partial class OutboxRelayService : BackgroundService
             // A long backlog must not outlive the lease from inside this loop: stop as soon
             // as renewal is due so the next cycle renews before the lease can expire and a
             // peer relay could claim the bucket (which would break single-writer ordering).
-            // The first batch is always allowed: a slow-but-successful acquisition can
-            // return a lease that is already renewal-due (its age is measured from before
-            // the call, deliberately), and yielding before any work would leave the relay
-            // renewing forever without publishing. The cycle-level expiry check still gates
-            // truly dead leases.
+            // Fetch the first batch even after a slow acquisition. PreparePublishLeaseAsync
+            // then renews or reserves its whole-call budget before publishing begins.
             if (!firstBatch && RenewalDue)
                 break;
 
@@ -248,8 +257,58 @@ public sealed partial class OutboxRelayService : BackgroundService
 
             firstBatch = false;
 
-            var result = await _publisher.PublishAsync(batch, _options.MessageIdHeaderName, cancellationToken)
-                .ConfigureAwait(false);
+            if (!await PreparePublishLeaseAsync(bucket, cancellationToken).ConfigureAwait(false))
+                return new CycleResult(publishedAny, HadError: true);
+
+            var publishStarted = _options.MaxPublishDuration.HasValue ? _timeProvider.GetTimestamp() : 0;
+            var publish = _publisher.PublishAsync(batch, _options.MessageIdHeaderName, cancellationToken);
+            OutboxPublishResult result;
+            Exception? renewalError = null;
+            if (_renewalStore is not null && !publish.IsCompletedSuccessfully)
+            {
+                var publishTask = publish.AsTask();
+                try
+                {
+                    while (!publishTask.IsCompleted)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        var remaining = _options.LeaseDuration - LeaseAge();
+                        if (remaining <= TimeSpan.Zero)
+                            throw new InvalidOperationException("The outbox lease expired during publishing.");
+
+                        var nextRenewal = GetRenewalDelay(remaining, cancellationToken);
+                        if (await Task.WhenAny(publishTask, nextRenewal).ConfigureAwait(false) == publishTask)
+                            break;
+
+                        await nextRenewal.ConfigureAwait(false);
+                        CancelRenewalDelay();
+                        if (!await RenewOwnedLeasesAsync(cancellationToken).ConfigureAwait(false))
+                            throw new InvalidOperationException("The outbox no longer owns all publishing leases.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    renewalError = ex;
+                    ResetLeaseState();
+                }
+
+                // Always observe publishing before another cycle, including after lease
+                // loss. Cancellation cannot retract an already-appended Kafka record.
+                result = await publishTask.ConfigureAwait(false);
+            }
+            else
+            {
+                result = await publish.ConfigureAwait(false);
+            }
+
+            // Cooperative shutdown retains rows for at-least-once replay instead of
+            // misclassifying the elapsed publish budget as a fatal configuration error.
+            cancellationToken.ThrowIfCancellationRequested();
+            ValidatePublishDuration(publishStarted);
+            if (renewalError is OutboxMisconfigurationException misconfiguration)
+                throw misconfiguration;
+            if (renewalError is not null || LeaseAge() >= _options.LeaseDuration)
+                result = LostPublishLease(renewalError);
 
             if (result.AckedCount > 0)
             {

--- a/src/Dekaf.Outbox/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.Outbox/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+override Dekaf.Outbox.OutboxRelayService.Dispose() -> void
+Dekaf.Outbox.IOutboxLeaseRenewalStore
+Dekaf.Outbox.IOutboxLeaseRenewalStore.RenewBucketLeasesAsync(Dekaf.Outbox.OutboxLeaseRequest! request, System.Collections.Generic.IReadOnlyList<int>! buckets, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<bool>
+Dekaf.Outbox.OutboxRelayOptions.MaxPublishDuration.get -> System.TimeSpan?
+Dekaf.Outbox.OutboxRelayOptions.MaxPublishDuration.init -> void

--- a/tests/Dekaf.Tests.Integration/OutboxRelayIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/OutboxRelayIntegrationTests.cs
@@ -19,7 +19,9 @@ public class OutboxRelayIntegrationTests(KafkaTestContainer kafka) : KafkaIntegr
     private const int BucketCount = 4;
 
     [Test]
-    public async Task Relay_PublishesEnqueuedRowsInOrder_AndEmptiesTable()
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Relay_PublishesEnqueuedRowsInOrder_AndEmptiesTable(bool holdForRenewal)
     {
         var topic = $"outbox-relay-{Guid.NewGuid():N}";
         await KafkaContainer.CreateTopicAsync(topic, partitions: 2);
@@ -45,7 +47,7 @@ public class OutboxRelayIntegrationTests(KafkaTestContainer kafka) : KafkaIntegr
             .Options;
         try
         {
-            await RunRelayScenarioAsync(topic, contextOptions);
+            await RunRelayScenarioAsync(topic, contextOptions, holdForRenewal);
         }
         finally
         {
@@ -55,7 +57,8 @@ public class OutboxRelayIntegrationTests(KafkaTestContainer kafka) : KafkaIntegr
 
     private async Task RunRelayScenarioAsync(
         string topic,
-        DbContextOptions<OutboxContext> contextOptions)
+        DbContextOptions<OutboxContext> contextOptions,
+        bool holdForRenewal)
     {
         await using (var context = new OutboxContext(contextOptions))
         {
@@ -74,19 +77,24 @@ public class OutboxRelayIntegrationTests(KafkaTestContainer kafka) : KafkaIntegr
             await context.SaveChangesAsync();
         }
 
-        var store = new EfCoreOutboxStore<OutboxContext>(new ContextFactory(contextOptions));
+        var store = new ObservedRenewalStore(
+            new EfCoreOutboxStore<OutboxContext>(new ContextFactory(contextOptions)));
         var producer = Kafka.CreateProducer<byte[]?, byte[]?>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithClientId("outbox-relay-integration")
             .WithAcks(Acks.All)
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .Build();
-        await using var publisher = new DekafOutboxPublisher(producer);
+        await using var producerPublisher = new DekafOutboxPublisher(producer);
+        IOutboxPublisher publisher = holdForRenewal
+            ? new HoldingPublisher(producerPublisher, store.RenewalObserved.Task)
+            : producerPublisher;
 
         var relayOptions = new OutboxRelayOptions
         {
             BucketCount = BucketCount,
             PollInterval = TimeSpan.FromMilliseconds(50),
+            LeaseRenewInterval = holdForRenewal ? TimeSpan.FromSeconds(1) : TimeSpan.FromSeconds(10),
             RelayId = "integration-relay"
         };
 
@@ -120,6 +128,11 @@ public class OutboxRelayIntegrationTests(KafkaTestContainer kafka) : KafkaIntegr
             }
 
             await Assert.That(messages.Count).IsEqualTo(5);
+            if (holdForRenewal)
+            {
+                await store.RenewalObserved.Task.WaitAsync(TimeSpan.FromSeconds(30));
+                await Assert.That(store.PeerBuckets).IsEmpty();
+            }
             for (var i = 0; i < 5; i++)
             {
                 await Assert.That(messages[i].Key).IsEqualTo("order-1");
@@ -140,6 +153,51 @@ public class OutboxRelayIntegrationTests(KafkaTestContainer kafka) : KafkaIntegr
         finally
         {
             await relay.StopAsync(CancellationToken.None);
+        }
+    }
+
+    private sealed class HoldingPublisher(IOutboxPublisher inner, Task release) : IOutboxPublisher
+    {
+        public ValueTask InitializeAsync(CancellationToken cancellationToken = default) => inner.InitializeAsync(cancellationToken);
+        public async ValueTask<OutboxPublishResult> PublishAsync(IReadOnlyList<OutboxMessage> messages,
+            string messageIdHeaderName, CancellationToken cancellationToken = default)
+        {
+            var result = await inner.PublishAsync(messages, messageIdHeaderName, cancellationToken);
+            // Hold the complete publish call open until a real database renewal and peer probe finish.
+            await release.WaitAsync(cancellationToken);
+            return result;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class ObservedRenewalStore(EfCoreOutboxStore<OutboxContext> inner)
+        : IOutboxStore, IOutboxLeaseRenewalStore
+    {
+        internal TaskCompletionSource RenewalObserved { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal IReadOnlyList<int> PeerBuckets { get; private set; } = [];
+        public ValueTask<IReadOnlyList<int>> AcquireBucketLeasesAsync(OutboxLeaseRequest request,
+            CancellationToken cancellationToken = default) => inner.AcquireBucketLeasesAsync(request, cancellationToken);
+        public ValueTask<IReadOnlyList<int>> GetBucketsWithPendingAsync(IReadOnlyList<int> buckets,
+            CancellationToken cancellationToken = default) => inner.GetBucketsWithPendingAsync(buckets, cancellationToken);
+        public ValueTask<IReadOnlyList<OutboxMessage>> GetNextBatchAsync(int bucket, int maxCount,
+            CancellationToken cancellationToken = default) => inner.GetNextBatchAsync(bucket, maxCount, cancellationToken);
+        public ValueTask MarkPublishedAsync(int bucket, IReadOnlyList<OutboxMessage> publishedMessages,
+            CancellationToken cancellationToken = default) => inner.MarkPublishedAsync(bucket, publishedMessages, cancellationToken);
+
+        public async ValueTask<bool> RenewBucketLeasesAsync(OutboxLeaseRequest request, IReadOnlyList<int> buckets,
+            CancellationToken cancellationToken = default)
+        {
+            var renewed = await inner.RenewBucketLeasesAsync(request, buckets, cancellationToken);
+            if (renewed && !RenewalObserved.Task.IsCompleted)
+            {
+                PeerBuckets = await inner.AcquireBucketLeasesAsync(new OutboxLeaseRequest
+                {
+                    RelayId = "peer-relay", BucketCount = request.BucketCount, LeaseDuration = request.LeaseDuration
+                }, cancellationToken);
+                RenewalObserved.SetResult();
+            }
+            return renewed;
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Outbox/EfCoreOutboxStoreTests.cs
+++ b/tests/Dekaf.Tests.Unit/Outbox/EfCoreOutboxStoreTests.cs
@@ -12,6 +12,38 @@ public class EfCoreOutboxStoreTests
     private static readonly int[] AllBuckets = [0, 1, 2, 3];
     private static readonly int[] BucketsZeroAndTwo = [0, 2];
 
+    [Test]
+    public async Task ActivePublishRenewal_DoesNotReleaseBucketsToNewPeer()
+    {
+        using var db = new SqliteOutboxDatabase();
+        var store = db.CreateStore();
+        var request = Request("relay-a");
+        var owned = await store.AcquireBucketLeasesAsync(request);
+        await store.AcquireBucketLeasesAsync(Request("relay-b"));
+        db.Time.Advance(TimeSpan.FromSeconds(20));
+        var renewed = await ((IOutboxLeaseRenewalStore)store).RenewBucketLeasesAsync(request, owned);
+        await Assert.That(renewed).IsTrue();
+        db.Time.Advance(TimeSpan.FromSeconds(20));
+        await Assert.That(await store.AcquireBucketLeasesAsync(Request("relay-b"))).IsEmpty();
+        // Fair-share changes resume only between publish calls.
+        await Assert.That((await store.AcquireBucketLeasesAsync(request)).Count).IsEqualTo(2);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task ActivePublishRenewal_DoesNotResurrectExpiredOrStolenLease(bool takeover)
+    {
+        using var db = new SqliteOutboxDatabase();
+        var store = db.CreateStore();
+        var request = Request("relay-a");
+        var owned = await store.AcquireBucketLeasesAsync(request);
+        db.Time.Advance(TimeSpan.FromSeconds(61));
+        if (takeover)
+            await store.AcquireBucketLeasesAsync(Request("relay-b"));
+        await Assert.That(await ((IOutboxLeaseRenewalStore)store).RenewBucketLeasesAsync(request, owned)).IsFalse();
+    }
+
     private static OutboxLeaseRequest Request(string relayId, int bucketCount = 4) => new()
     {
         RelayId = relayId,

--- a/tests/Dekaf.Tests.Unit/Outbox/ManualLeaseTimeProvider.cs
+++ b/tests/Dekaf.Tests.Unit/Outbox/ManualLeaseTimeProvider.cs
@@ -34,8 +34,9 @@ internal sealed class ManualLeaseTimeProvider : TimeProvider
         lock (_gate)
         {
             Interlocked.Add(ref _ticks, elapsed.Ticks);
-            foreach (var timer in _timers)
+            for (var index = 0; index < _timers.Count; index++)
             {
+                var timer = _timers[index];
                 if (timer.Due > _ticks)
                     continue;
                 timer.Due = timer.Period > TimeSpan.Zero ? _ticks + timer.Period.Ticks : long.MaxValue;

--- a/tests/Dekaf.Tests.Unit/Outbox/ManualLeaseTimeProvider.cs
+++ b/tests/Dekaf.Tests.Unit/Outbox/ManualLeaseTimeProvider.cs
@@ -1,0 +1,81 @@
+using System.Threading.Channels;
+
+namespace Dekaf.Tests.Unit.Outbox;
+
+internal sealed class ManualLeaseTimeProvider : TimeProvider
+{
+    private readonly object _gate = new();
+    private readonly List<LeaseTimer> _timers = [];
+    private readonly Channel<TimeSpan> _scheduled = Channel.CreateUnbounded<TimeSpan>();
+    private long _ticks = TimeSpan.TicksPerSecond;
+
+    public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+    public override long GetTimestamp() => Interlocked.Read(ref _ticks);
+    public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(GetTimestamp());
+
+    public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+    {
+        var timer = new LeaseTimer(this, callback, state);
+        lock (_gate)
+            _timers.Add(timer);
+        timer.Change(dueTime, period);
+        return timer;
+    }
+
+    public async Task WaitForTimerAsync(TimeSpan dueTime)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        while (await _scheduled.Reader.ReadAsync(timeout.Token) != dueTime) { }
+    }
+
+    public void Advance(TimeSpan elapsed)
+    {
+        List<LeaseTimer> due = [];
+        lock (_gate)
+        {
+            Interlocked.Add(ref _ticks, elapsed.Ticks);
+            foreach (var timer in _timers)
+            {
+                if (timer.Due > _ticks)
+                    continue;
+                timer.Due = timer.Period > TimeSpan.Zero ? _ticks + timer.Period.Ticks : long.MaxValue;
+                due.Add(timer);
+            }
+        }
+
+        foreach (var timer in due)
+            timer.Invoke();
+    }
+
+    private sealed class LeaseTimer(ManualLeaseTimeProvider owner, TimerCallback callback, object? state) : ITimer
+    {
+        internal long Due { get; set; } = long.MaxValue;
+        internal TimeSpan Period { get; private set; }
+
+        public bool Change(TimeSpan dueTime, TimeSpan period)
+        {
+            lock (owner._gate)
+            {
+                Due = dueTime == Timeout.InfiniteTimeSpan ? long.MaxValue : owner._ticks + dueTime.Ticks;
+                Period = period;
+            }
+
+            if (dueTime != Timeout.InfiniteTimeSpan)
+                owner._scheduled.Writer.TryWrite(dueTime);
+            return true;
+        }
+
+        internal void Invoke() => callback(state);
+        public void Dispose()
+        {
+            lock (owner._gate)
+                owner._timers.Remove(this);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Outbox/OutboxLeaseRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/Outbox/OutboxLeaseRenewalTests.cs
@@ -9,6 +9,21 @@ public sealed class OutboxLeaseRenewalTests
     private static readonly TimeSpan SignalTimeout = TimeSpan.FromSeconds(30);
 
     [Test]
+    public async Task Dispose_ThrowingRenewalCancellation_StillDisposesSource()
+    {
+        var time = new ManualLeaseTimeProvider();
+        using var relay = CreateRelay(new RenewableStore(time), new Publisher(), time);
+        using var cancellation = new CancellationTokenSource();
+        using var registration = cancellation.Token.Register(static () => throw new InvalidOperationException("callback failed"));
+        // Inject a failing callback into the privately owned source without exposing test-only API.
+        typeof(OutboxRelayService).GetField("_renewalDelayCancellation",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!.SetValue(relay, cancellation);
+
+        await Assert.That(() => relay.Dispose()).Throws<AggregateException>();
+        await Assert.That(() => cancellation.Token).Throws<ObjectDisposedException>();
+    }
+
+    [Test]
     public async Task SlowPublish_RenewsBeyondOriginalExpiry_PeerCannotTakeOver()
     {
         var time = new ManualLeaseTimeProvider();

--- a/tests/Dekaf.Tests.Unit/Outbox/OutboxLeaseRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/Outbox/OutboxLeaseRenewalTests.cs
@@ -1,0 +1,377 @@
+using Dekaf.Outbox;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Threading.Channels;
+
+namespace Dekaf.Tests.Unit.Outbox;
+
+public sealed class OutboxLeaseRenewalTests
+{
+    private static readonly TimeSpan SignalTimeout = TimeSpan.FromSeconds(30);
+
+    [Test]
+    public async Task SlowPublish_RenewsBeyondOriginalExpiry_PeerCannotTakeOver()
+    {
+        var time = new ManualLeaseTimeProvider();
+        var store = new RenewableStore(time);
+        var publisher = new PausedPublisher();
+        using var relay = CreateRelay(store, publisher, time);
+        await relay.StartAsync(CancellationToken.None);
+        try
+        {
+            await publisher.Entered.Task.WaitAsync(SignalTimeout);
+            for (var i = 0; i < 4; i++)
+            {
+                await time.WaitForTimerAsync(TimeSpan.FromSeconds(10));
+                time.Advance(TimeSpan.FromSeconds(10));
+                await store.Renewals.Reader.ReadAsync().AsTask().WaitAsync(SignalTimeout);
+                await Assert.That(await store.AcquireBucketLeasesAsync(PeerRequest())).IsEmpty();
+            }
+
+            publisher.Completion.SetResult(new OutboxPublishResult(1, null));
+            await store.Marked.Task.WaitAsync(SignalTimeout);
+            await Assert.That(store.MarkCount).IsEqualTo(1);
+        }
+        finally
+        {
+            publisher.Completion.TrySetResult(new OutboxPublishResult(0, null));
+            await relay.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Test]
+    public async Task ExpiredLease_TakenByPeer_OriginalPublishIsObservedButRowsRetained()
+    {
+        var time = new ManualLeaseTimeProvider();
+        var store = new RenewableStore(time);
+        var publisher = new PausedPublisher();
+        using var relay = CreateRelay(store, publisher, time);
+        await relay.StartAsync(CancellationToken.None);
+        try
+        {
+            await publisher.Entered.Task.WaitAsync(SignalTimeout);
+            await time.WaitForTimerAsync(TimeSpan.FromSeconds(10));
+            // Simulate a process pause: renewal cannot run before the original expiry.
+            time.Advance(TimeSpan.FromSeconds(31));
+            await Assert.That(await store.AcquireBucketLeasesAsync(PeerRequest())).IsEquivalentTo([0]);
+            publisher.Completion.SetResult(new OutboxPublishResult(1, null));
+            await time.WaitForTimerAsync(TimeSpan.FromSeconds(1)); // error backoff, after observing publish
+            await Assert.That(store.MarkCount).IsEqualTo(0);
+            await Assert.That(store.Owner).IsEqualTo("relay-b");
+            await Assert.That(publisher.Calls).IsEqualTo(1);
+        }
+        finally
+        {
+            publisher.Completion.TrySetResult(new OutboxPublishResult(0, null));
+            await relay.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Test]
+    public async Task FetchNearLeaseBoundary_RenewsBeforeStartingPublisher()
+    {
+        var time = new ManualLeaseTimeProvider();
+        var store = new RenewableStore(time) { FetchDuration = TimeSpan.FromSeconds(29) };
+        var publisher = new PausedPublisher();
+        using var relay = CreateRelay(store, publisher, time);
+        await relay.StartAsync(CancellationToken.None);
+        try
+        {
+            await publisher.Entered.Task.WaitAsync(SignalTimeout);
+            await Assert.That(store.RenewalCount).IsEqualTo(1);
+            await Assert.That(store.ExpiresAt - time.GetUtcNow()).IsEqualTo(TimeSpan.FromSeconds(30));
+            publisher.Completion.SetResult(new OutboxPublishResult(1, null));
+            await store.Marked.Task.WaitAsync(SignalTimeout);
+        }
+        finally
+        {
+            publisher.Completion.TrySetResult(new OutboxPublishResult(0, null));
+            await relay.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Test]
+    public async Task RenewalResponseAfterOldExpiry_RetainsRowsDespiteSuccessfulStoreResponse()
+    {
+        var time = new ManualLeaseTimeProvider();
+        var store = new RenewableStore(time) { RenewalDuration = TimeSpan.FromSeconds(21) };
+        var publisher = new PausedPublisher();
+        using var relay = CreateRelay(store, publisher, time);
+        await relay.StartAsync(CancellationToken.None);
+        try
+        {
+            await publisher.Entered.Task.WaitAsync(SignalTimeout);
+            await time.WaitForTimerAsync(TimeSpan.FromSeconds(10));
+            time.Advance(TimeSpan.FromSeconds(10));
+            await store.Renewals.Reader.ReadAsync().AsTask().WaitAsync(SignalTimeout);
+            publisher.Completion.SetResult(new OutboxPublishResult(1, null));
+            await time.WaitForTimerAsync(TimeSpan.FromSeconds(1));
+            await Assert.That(store.MarkCount).IsEqualTo(0);
+            await Assert.That(store.RenewalCount).IsEqualTo(1);
+        }
+        finally
+        {
+            publisher.Completion.TrySetResult(new OutboxPublishResult(0, null));
+            await relay.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Test]
+    public async Task SynchronousPublisherCrossesExpiry_RetainsRows()
+    {
+        var time = new ManualLeaseTimeProvider();
+        var store = new RenewableStore(time);
+        using var relay = CreateRelay(store,
+            new Publisher(() => time.Advance(TimeSpan.FromSeconds(31))), time);
+        await relay.StartAsync(CancellationToken.None);
+        try
+        {
+            await time.WaitForTimerAsync(TimeSpan.FromSeconds(1));
+            await Assert.That(store.MarkCount).IsEqualTo(0);
+        }
+        finally
+        {
+            await relay.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Test]
+    public async Task WholePublishBudgetExceeded_FaultsRelayWithoutMarkingRows()
+    {
+        var time = new ManualLeaseTimeProvider();
+        var store = new RenewableStore(time);
+        using var relay = new OutboxRelayService(store,
+            new Publisher(() => time.Advance(TimeSpan.FromSeconds(6))),
+            new OutboxRelayOptions { MaxPublishDuration = TimeSpan.FromSeconds(5) },
+            NullLogger<OutboxRelayService>.Instance, time);
+        await relay.StartAsync(CancellationToken.None);
+        await Assert.That(async () => await relay.ExecuteTask!.WaitAsync(SignalTimeout))
+            .Throws<OutboxMisconfigurationException>();
+        await Assert.That(store.MarkCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task FailedRenewal_DoesNotPublishAnotherBucketFromStaleProbe()
+    {
+        var time = new ManualLeaseTimeProvider();
+        var store = new RenewableStore(time)
+        {
+            Buckets = [0, 1], FetchDuration = TimeSpan.FromSeconds(10), RenewalSucceeds = false
+        };
+        var publisher = new PausedPublisher();
+        using var relay = new OutboxRelayService(store, publisher,
+            new OutboxRelayOptions { RelayId = "relay-a", BucketCount = 2 },
+            NullLogger<OutboxRelayService>.Instance, time);
+        await relay.StartAsync(CancellationToken.None);
+        try
+        {
+            await time.WaitForTimerAsync(TimeSpan.FromSeconds(1));
+            await Assert.That(store.FetchCount).IsEqualTo(1);
+            await Assert.That(publisher.Calls).IsEqualTo(0);
+        }
+        finally
+        {
+            publisher.Completion.TrySetResult(new OutboxPublishResult(0, null));
+            await relay.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Test]
+    [Arguments(0, true)]
+    [Arguments(20, false)]
+    public async Task LegacyStore_ReservesWholePublishBudgetAfterFetch(int acquisitionSeconds, bool canPublish)
+    {
+        var time = new ManualLeaseTimeProvider();
+        var inner = new RenewableStore(time)
+        {
+            FetchDuration = TimeSpan.FromSeconds(26),
+            SubsequentAcquisitionDuration = TimeSpan.FromSeconds(acquisitionSeconds)
+        };
+        var publisher = new PausedPublisher();
+        using var relay = new OutboxRelayService(new LegacyStore(inner), publisher,
+            new OutboxRelayOptions { RelayId = "relay-a", BucketCount = 1, MaxPublishDuration = TimeSpan.FromSeconds(5) },
+            NullLogger<OutboxRelayService>.Instance, time);
+        await relay.StartAsync(CancellationToken.None);
+        try
+        {
+            if (canPublish)
+            {
+                await publisher.Entered.Task.WaitAsync(SignalTimeout);
+                await Assert.That(inner.ExpiresAt - time.GetUtcNow()).IsEqualTo(TimeSpan.FromSeconds(30));
+                publisher.Completion.SetResult(new OutboxPublishResult(1, null));
+                await inner.Marked.Task.WaitAsync(SignalTimeout);
+            }
+            else
+            {
+                await time.WaitForTimerAsync(TimeSpan.FromSeconds(1));
+                await Assert.That(publisher.Calls).IsEqualTo(0);
+                await Assert.That(inner.MarkCount).IsEqualTo(0);
+            }
+
+            await Assert.That(inner.AcquisitionCount).IsEqualTo(2);
+        }
+        finally
+        {
+            publisher.Completion.TrySetResult(new OutboxPublishResult(0, null));
+            await relay.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Test]
+    public async Task StoreWithoutRenewal_RequiresWholePublishBudget()
+    {
+        await Assert.That(() => new OutboxRelayService(
+            new LegacyStore(), new Publisher(), new OutboxRelayOptions(),
+            NullLogger<OutboxRelayService>.Instance)).Throws<OutboxMisconfigurationException>();
+    }
+
+    [Test]
+    public async Task WholePublishBudget_MustFitWithRenewalSlack()
+    {
+        await Assert.That(() => new OutboxRelayOptions
+        {
+            LeaseDuration = TimeSpan.FromSeconds(30),
+            LeaseRenewInterval = TimeSpan.FromSeconds(10),
+            MaxPublishDuration = TimeSpan.FromSeconds(20)
+        }.Validate()).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task LegacyStore_WithExplicitWholePublishBudget_RemainsSupported()
+    {
+        using var relay = new OutboxRelayService(new LegacyStore(), new Publisher(),
+            new OutboxRelayOptions { MaxPublishDuration = TimeSpan.FromSeconds(5) },
+            NullLogger<OutboxRelayService>.Instance);
+        await Assert.That(relay).IsNotNull();
+    }
+
+    private sealed class LegacyStore(IOutboxStore? inner = null) : IOutboxStore
+    {
+        public ValueTask<IReadOnlyList<int>> AcquireBucketLeasesAsync(OutboxLeaseRequest request,
+            CancellationToken cancellationToken = default) => inner?.AcquireBucketLeasesAsync(request, cancellationToken)
+                ?? ValueTask.FromResult<IReadOnlyList<int>>([0]);
+        public ValueTask<IReadOnlyList<int>> GetBucketsWithPendingAsync(IReadOnlyList<int> buckets,
+            CancellationToken cancellationToken = default) => inner?.GetBucketsWithPendingAsync(buckets, cancellationToken)
+                ?? ValueTask.FromResult<IReadOnlyList<int>>([]);
+        public ValueTask<IReadOnlyList<OutboxMessage>> GetNextBatchAsync(int bucket, int maxCount,
+            CancellationToken cancellationToken = default) => inner?.GetNextBatchAsync(bucket, maxCount, cancellationToken)
+                ?? ValueTask.FromResult<IReadOnlyList<OutboxMessage>>([]);
+        public ValueTask MarkPublishedAsync(int bucket, IReadOnlyList<OutboxMessage> publishedMessages,
+            CancellationToken cancellationToken = default) => inner?.MarkPublishedAsync(bucket, publishedMessages, cancellationToken)
+                ?? ValueTask.CompletedTask;
+    }
+
+    private sealed class Publisher(Action? beforeReturn = null) : IOutboxPublisher
+    {
+        public ValueTask InitializeAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask<OutboxPublishResult> PublishAsync(IReadOnlyList<OutboxMessage> messages,
+            string messageIdHeaderName, CancellationToken cancellationToken = default)
+        {
+            beforeReturn?.Invoke();
+            return ValueTask.FromResult(new OutboxPublishResult(messages.Count, null));
+        }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private static OutboxLeaseRequest PeerRequest() => new()
+    {
+        RelayId = "relay-b", BucketCount = 1, LeaseDuration = TimeSpan.FromSeconds(30)
+    };
+
+    private static OutboxRelayService CreateRelay(IOutboxStore store, IOutboxPublisher publisher, TimeProvider time) =>
+        new(store, publisher, new OutboxRelayOptions { RelayId = "relay-a", BucketCount = 1 },
+            NullLogger<OutboxRelayService>.Instance, time);
+
+    private sealed class PausedPublisher : IOutboxPublisher
+    {
+        internal TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal TaskCompletionSource<OutboxPublishResult> Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal int Calls { get; private set; }
+        public ValueTask InitializeAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask<OutboxPublishResult> PublishAsync(IReadOnlyList<OutboxMessage> messages,
+            string messageIdHeaderName, CancellationToken cancellationToken = default)
+        {
+            Calls++;
+            Entered.TrySetResult();
+            return new ValueTask<OutboxPublishResult>(Completion.Task.WaitAsync(cancellationToken));
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class RenewableStore(ManualLeaseTimeProvider time) : IOutboxStore, IOutboxLeaseRenewalStore
+    {
+        private readonly object _gate = new();
+        private readonly OutboxMessage[] _batch = [new()
+        { Id = 1, MessageId = Guid.NewGuid(), Bucket = 0, Topic = "topic", CreatedAtUtc = DateTimeOffset.UnixEpoch }];
+        private string? _owner;
+        private DateTimeOffset _expiresAt;
+        private int _markCount;
+        private int _renewalCount;
+        private int _acquisitionCount;
+        private int _fetchCount;
+        internal string? Owner { get { lock (_gate) return _owner; } }
+        internal DateTimeOffset ExpiresAt { get { lock (_gate) return _expiresAt; } }
+        internal int MarkCount => Volatile.Read(ref _markCount);
+        internal int RenewalCount => Volatile.Read(ref _renewalCount);
+        internal int AcquisitionCount => Volatile.Read(ref _acquisitionCount);
+        internal int FetchCount => Volatile.Read(ref _fetchCount);
+        internal IReadOnlyList<int> Buckets { get; init; } = [0];
+        internal bool RenewalSucceeds { get; init; } = true;
+        internal TimeSpan FetchDuration { get; init; }
+        internal TimeSpan RenewalDuration { get; init; }
+        internal TimeSpan SubsequentAcquisitionDuration { get; init; }
+        internal Channel<int> Renewals { get; } = Channel.CreateUnbounded<int>();
+        internal TaskCompletionSource Marked { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ValueTask<IReadOnlyList<int>> AcquireBucketLeasesAsync(OutboxLeaseRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            lock (_gate)
+            {
+                if (_owner is null || _owner == request.RelayId || _expiresAt <= time.GetUtcNow())
+                {
+                    _owner = request.RelayId;
+                    _expiresAt = time.GetUtcNow() + request.LeaseDuration;
+                    if (Interlocked.Increment(ref _acquisitionCount) > 1)
+                        time.Advance(SubsequentAcquisitionDuration);
+                    return ValueTask.FromResult(Buckets);
+                }
+
+                return ValueTask.FromResult<IReadOnlyList<int>>([]);
+            }
+        }
+
+        public ValueTask<bool> RenewBucketLeasesAsync(OutboxLeaseRequest request, IReadOnlyList<int> buckets,
+            CancellationToken cancellationToken = default)
+        {
+            lock (_gate)
+            {
+                if (!RenewalSucceeds || _owner != request.RelayId || _expiresAt <= time.GetUtcNow())
+                    return ValueTask.FromResult(false);
+                _expiresAt = time.GetUtcNow() + request.LeaseDuration;
+                time.Advance(RenewalDuration);
+                Renewals.Writer.TryWrite(Interlocked.Increment(ref _renewalCount));
+                return ValueTask.FromResult(true);
+            }
+        }
+
+        public ValueTask<IReadOnlyList<int>> GetBucketsWithPendingAsync(IReadOnlyList<int> buckets,
+            CancellationToken cancellationToken = default) => ValueTask.FromResult<IReadOnlyList<int>>(MarkCount == 0 ? Buckets : []);
+
+        public ValueTask<IReadOnlyList<OutboxMessage>> GetNextBatchAsync(int bucket, int maxCount,
+            CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _fetchCount);
+            time.Advance(FetchDuration);
+            return ValueTask.FromResult<IReadOnlyList<OutboxMessage>>(_batch);
+        }
+
+        public ValueTask MarkPublishedAsync(int bucket, IReadOnlyList<OutboxMessage> publishedMessages,
+            CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _markCount);
+            Marked.TrySetResult();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Outbox/OutboxRelayServiceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Outbox/OutboxRelayServiceTests.cs
@@ -16,6 +16,7 @@ public class OutboxRelayServiceTests
         ErrorBackoff = TimeSpan.FromMilliseconds(1),
         LeaseDuration = TimeSpan.FromSeconds(60),
         LeaseRenewInterval = TimeSpan.FromSeconds(20),
+        MaxPublishDuration = TimeSpan.FromSeconds(5),
         RelayId = "test-relay"
     };
 


### PR DESCRIPTION
A normal producer delivery attempt can outlast the outbox's 30-second lease. The relay now renews owned leases throughout the entire asynchronous batch publish, including submission, backpressure and delivery waits. EF renewal checks ownership and expiry without acquiring or relinquishing buckets; fair-share rebalancing remains between publish calls.

Custom stores can implement `IOutboxLeaseRenewalStore`. Otherwise they must explicitly configure `MaxPublishDuration` for the entire publisher call, with both that budget and one renewal interval reserved after fetching. Missing or inconsistent configuration fails clearly; exceeding the bound faults the relay. This is a migration requirement for existing custom stores.

Acquisition/fetch latency and late renewal responses count against the existing lease. After ownership loss, the relay observes the original publish, retains rows, and stops using its stale bucket probe. Cancellation still cannot fence records already appended to Kafka; delivery remains at-least-once.

Rebased onto current main at 45a94c6b71134c149ee892d7c60e88d087ebbab1. The merged partial-failure ordering contract and lease-renewal contract are both retained. Every changed production source file has identical executable statements to measured commit 5523f40170ec68b18656c00216e494bdc2135505; rebase resolutions and review clarifications change comments only.

## Validation

- 71 outbox unit tests pass on both .NET 10 and .NET 8; builds have zero warnings/errors.
- Deterministic coverage includes slow publication across multiple lease periods, peer takeover after expiry, renewal near expiry, late successful renewal responses, synchronous publication crossing expiry, legacy-store residual budgets, and stale multi-bucket probes.
- Two Kafka integration cases pass, including a complete publish held open until actual EF renewal and a competing relay acquisition attempt finish.
- `npm ci --prefix docs` and `npm run build --prefix docs` pass.
- `/simplify` completed. Renewal shares a pending timer across batches and uses the existing drain state machine.

## Performance evidence

Baseline `0dd6f28575293da40c417977c55adf5dc3b0923e`; candidate `5523f40170ec68b18656c00216e494bdc2135505`. Task-local BenchmarkDotNet 0.15.8 harnesses, `[MemoryDiagnoser]`, Windows 11 / i7-12700K / .NET 10.0.11 / SDK 10.0.400. Same local machine; other agents can create load. Figures are per **500-row batch/cycle**, not per Kafka message.

| Measurement | Before mean ± error | After mean ± error | Allocated before → after |
|---|---:|---:|---:|
| Coordination only, synchronous fake publisher | 134.4 ± 1.10 ns | 226.3 ± 10.19 ns | 144 → 144 B |
| Coordination only, publisher yields once | 938.8 ± 17.25 ns | 1,356.0 ± 128.21 ns | 503 → 673 B |
| EF SQLite fetch / asynchronous fake publish / delete, 500 × 1 KiB rows | 5.747 ± 0.5877 ms | 5.337 ± 0.6241 ms | 1,609,096 → 1,608,368 B |

Coordination cases use three warmups and ten measured iterations. SQLite uses an in-memory database, five warmups and fifteen measured iterations, with rows reseeded outside measurement and one invocation per iteration. Both harnesses invoke the real relay cycle through a delegate bound once during setup; the SQL case uses the actual EF store.

The added coordination cost is explicit: +91.9 ns for synchronous completion, +417.2 ns and +170 B for asynchronous completion. This is per-batch relay overhead, outside the Kafka client's hot paths; the existing outbox publisher explicitly permits relay-side allocations. SQLite batch timing intervals overlap and allocations are stable (−0.045%); no material whole-relay regression is demonstrated. The discarded implementation allocated 1,209 B in the asynchronous coordination case; timer reuse and removing the extra async wrapper reduced that overhead.

No per-message producer, serializer, consumer, or networking code changed. These measurements do not establish Kafka throughput, CPU, or p99/max latency improvements; no producer stress lane was dispatched. The isolated coordination overhead should remain visible in review rather than be described as a speedup.

Closes #3037




Review follow-up 8a85b77ed73f80d4a25069988a08d7021cd9556c fixes disposal when a renewal-cancellation callback throws. The source is detached with Interlocked.Exchange and disposed by a using declaration even on failure; saved delay state clears before invoking callbacks. A deterministic injected-callback regression failed before and passes after. Timer filtering now uses indexed iteration, and the generic catch documents why every renewal error must still allow observation of an in-flight publish.

Validation: 72 outbox tests on each of net8.0/net10.0 (144 total), both real Kafka relay tests, Release unit/integration builds with zero warnings/errors, `/simplify`, and diff checks pass.

Focused before/after MemoryDiagnoser control, prior exact head 45a94c6b71134c149ee892d7c60e88d087ebbab1 → 8a85b77ed73f80d4a25069988a08d7021cd9556c: create and cancel a real renewal timer, 195.4 ± 4.47 ns (SD 4.18) → 199.2 ± 2.48 ns (SD 2.07), +3.8 ns / 1.9%; 456 B → 456 B. Confidence intervals overlap; no timing improvement claimed. These are existing per-renewal timer/CTS/Task allocations, not per-message allocations. Same local fixture, BDN 0.15.8 in-process, 5 warmups/15 iterations, .NET 10.0.11 / SDK 10.0.400 / Windows 11 / i7-12700K. The helper delegates are bound once in setup; the measured call creates and cancels the timer and consumes its cancelled state. No paid stress lane or network p50/p99/max/CPU-per-message/stability measurement; original PR relay/SQLite benchmark evidence remains applicable to unchanged publication/lease algorithms.

Loaded Outbox assembly SHA256: before A2A12893B9D44DDE82E6226BA50247506984CCADC24BD89F6015D5259B6FF788; after 87657A30DD86E5286CF193FB0AAB27C7617597E993CB05214C362109904A4901. Local fixture/reports remain in `.artifacts/cleanup-bench`, `.artifacts/before`, and `.artifacts/after` within the isolated review worktree.

