### PR TITLE
fix: report producer flush checkpoints accurately

### DIFF
--- a/docs/docs/health-checks.md
+++ b/docs/docs/health-checks.md
@@ -1,5 +1,5 @@
 ---
-description: "Separate producer queue drainage, delivery outcomes, and Kafka broker connectivity in ASP.NET Core health checks."
+description: "Separate producer flush checkpoints, delivery outcomes, and Kafka broker connectivity in ASP.NET Core health checks."
 ---
 
 # Health Checks
@@ -10,20 +10,20 @@ Install `Dekaf.Extensions.HealthChecks` to register Kafka checks with ASP.NET Co
 dotnet add package Dekaf.Extensions.HealthChecks
 ```
 
-## Producer drainage and broker connectivity
+## Producer flush checkpoints and broker connectivity
 
 These checks answer different questions:
 
 | Signal | How to observe it | What success establishes |
 | --- | --- | --- |
-| Producer queue drainage | `AddDekafProducerHealthCheck<TKey, TValue>()` | The current `FlushAsync` completed within the configured timeout. |
+| Producer flush checkpoint | `AddDekafProducerHealthCheck<TKey, TValue>()` | The current `FlushAsync` completed within the configured timeout. |
 | Individual delivery outcome | Await `ProduceAsync`, or inspect the delivery callback's error | That delivery succeeded or failed under the configured acknowledgement policy. |
 | Recent delivery failures | Aggregate delivery outcomes or [producer error metrics](./observability) over an application-defined time window | Whether the workload meets the application's delivery policy during that window. |
 | Broker connectivity | `AddDekafBrokerHealthCheck()` | An active admin request reached the cluster and returned at least one broker. |
 
-The producer check reports **Healthy for queue drainage** even when a queued batch failed delivery. Failed batches leave the producer pipeline too. An idle producer can also report Healthy while every broker is unavailable, because an empty queue needs no broker request. The result explicitly states that delivery outcomes and broker connectivity are not checked.
+The producer check reports **Healthy when its flush checkpoint completes**, even when a queued batch failed delivery. Failed batches leave the producer pipeline too. Concurrent production can leave newer messages queued after that checkpoint; Healthy does not assert that the current queue is empty. An idle producer can also report Healthy while every broker is unavailable, because an empty queue needs no broker request. The result explicitly states that delivery outcomes and broker connectivity are not checked.
 
-Register the producer and broker checks separately when both drainage and connectivity matter. Their producer and admin clients must already be registered in DI; see [Dependency Injection](./dependency-injection).
+Register the producer and broker checks separately when both flush completion and connectivity matter. Their producer and admin clients must already be registered in DI; see [Dependency Injection](./dependency-injection).
 
 ```csharp
 using Dekaf.Extensions.HealthChecks;
@@ -42,13 +42,13 @@ Broker reachability does not prove that a particular topic accepts writes, that 
 
 ## Failure and recovery
 
-The drainage check returns **Unhealthy** if its flush throws or exceeds the timeout. Each invocation evaluates a new flush: the next completed flush returns Healthy. The check retains no delivery-history latch and does not turn past produce failures into a permanent unhealthy state.
+The producer check returns **Unhealthy** if its flush throws or exceeds the timeout. Each invocation evaluates a new flush: the next completed flush returns Healthy. The check retains no delivery-history latch and does not turn past produce failures into a permanent unhealthy state.
 
-If recent delivery failures are part of an application's readiness policy, choose a bounded observation window and an explicit recovery condition, such as failures aging out of that window. The built-in drainage check neither installs that policy nor resets delivery counters. Keep its status separate from the application's delivery-failure status.
+If recent delivery failures are part of an application's readiness policy, choose a bounded observation window and an explicit recovery condition, such as failures aging out of that window. The built-in producer check neither installs that policy nor resets delivery counters. Keep its status separate from the application's delivery-failure status.
 
 ## Migration note
 
-Earlier descriptions claimed that a successful producer health check proved connectivity or successful delivery. Those claims were incorrect; the underlying check waited for queue drainage. The corrected description states that scope explicitly. Existing Healthy/Unhealthy status behavior and registration signatures remain compatible. Applications that used this check as a connectivity probe should also register the broker check; applications that need delivery assurance must observe delivery results.
+Earlier descriptions claimed that a successful producer health check proved connectivity or successful delivery. Those claims were incorrect; the underlying check waited for a flush checkpoint. The corrected description states that scope explicitly. Existing Healthy/Unhealthy status behavior and registration signatures remain compatible. Applications that used this check as a connectivity probe should also register the broker check; applications that need delivery assurance must observe delivery results.
 
 ## Consumer checks
 

--- a/docs/docs/health-checks.md
+++ b/docs/docs/health-checks.md
@@ -1,0 +1,55 @@
+---
+description: "Separate producer queue drainage, delivery outcomes, and Kafka broker connectivity in ASP.NET Core health checks."
+---
+
+# Health Checks
+
+Install `Dekaf.Extensions.HealthChecks` to register Kafka checks with ASP.NET Core's health-check services.
+
+```bash
+dotnet add package Dekaf.Extensions.HealthChecks
+```
+
+## Producer drainage and broker connectivity
+
+These checks answer different questions:
+
+| Signal | How to observe it | What success establishes |
+| --- | --- | --- |
+| Producer queue drainage | `AddDekafProducerHealthCheck<TKey, TValue>()` | The current `FlushAsync` completed within the configured timeout. |
+| Individual delivery outcome | Await `ProduceAsync`, or inspect the delivery callback's error | That delivery succeeded or failed under the configured acknowledgement policy. |
+| Recent delivery failures | Aggregate delivery outcomes or [producer error metrics](./observability) over an application-defined time window | Whether the workload meets the application's delivery policy during that window. |
+| Broker connectivity | `AddDekafBrokerHealthCheck()` | An active admin request reached the cluster and returned at least one broker. |
+
+The producer check reports **Healthy for queue drainage** even when a queued batch failed delivery. Failed batches leave the producer pipeline too. An idle producer can also report Healthy while every broker is unavailable, because an empty queue needs no broker request. The result explicitly states that delivery outcomes and broker connectivity are not checked.
+
+Register the producer and broker checks separately when both drainage and connectivity matter. Their producer and admin clients must already be registered in DI; see [Dependency Injection](./dependency-injection).
+
+```csharp
+using Dekaf.Extensions.HealthChecks;
+
+builder.Services.AddHealthChecks()
+    .AddDekafProducerHealthCheck<string, string>(
+        name: "kafka-producer-queue",
+        options: new DekafProducerHealthCheckOptions
+        {
+            Timeout = TimeSpan.FromSeconds(5)
+        })
+    .AddDekafBrokerHealthCheck(name: "kafka-broker-connectivity");
+```
+
+Broker reachability does not prove that a particular topic accepts writes, that the producer's credentials permit them, or that earlier messages succeeded. Delivery outcomes remain a separate signal. `FireAsync` has no delivery result; use a result-returning or callback-based produce API when application health depends on individual delivery outcomes.
+
+## Failure and recovery
+
+The drainage check returns **Unhealthy** if its flush throws or exceeds the timeout. Each invocation evaluates a new flush: the next completed flush returns Healthy. The check retains no delivery-history latch and does not turn past produce failures into a permanent unhealthy state.
+
+If recent delivery failures are part of an application's readiness policy, choose a bounded observation window and an explicit recovery condition, such as failures aging out of that window. The built-in drainage check neither installs that policy nor resets delivery counters. Keep its status separate from the application's delivery-failure status.
+
+## Migration note
+
+Earlier descriptions claimed that a successful producer health check proved connectivity or successful delivery. Those claims were incorrect; the underlying check waited for queue drainage. The corrected description states that scope explicitly. Existing Healthy/Unhealthy status behavior and registration signatures remain compatible. Applications that used this check as a connectivity probe should also register the broker check; applications that need delivery assurance must observe delivery results.
+
+## Consumer checks
+
+`AddDekafConsumerHealthCheck<TKey, TValue>()` evaluates consumer liveness and lag using its configured thresholds. A live group member with no assignment can be a healthy standby. See [Consumer Groups](./consumer/consumer-groups) and [Observability](./observability) for the related signals.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -80,6 +80,7 @@ const sidebars = {
       label: 'Operations & Administration',
       items: [
         'observability',
+        'health-checks',
         'admin/topic-identifiers',
         'admin/transaction-remediation',
         'admin/replica-log-directories',

--- a/src/Dekaf.Extensions.HealthChecks/DekafProducerHealthCheck.cs
+++ b/src/Dekaf.Extensions.HealthChecks/DekafProducerHealthCheck.cs
@@ -4,13 +4,17 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 namespace Dekaf.Extensions.HealthChecks;
 
 /// <summary>
-/// Health check that flushes any pending producer messages and reports delivery success or failure.
-/// Reports <see cref="HealthStatus.Healthy"/> when the producer can successfully flush,
-/// and <see cref="HealthStatus.Unhealthy"/> when the flush fails or times out.
+/// Health check that waits for the producer queue to drain.
+/// Reports <see cref="HealthStatus.Healthy"/> when the flush completes,
+/// and <see cref="HealthStatus.Unhealthy"/> when the flush throws or times out.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Limitation:</b> This health check only validates that already-queued messages can be delivered.
+/// <b>Scope:</b> Queue drainage does not establish successful delivery. Failed delivery
+/// attempts also leave the queue. Observe produce results or delivery callbacks for those failures;
+/// this check does not retain or evaluate delivery history.
+/// </para>
+/// <para>
 /// <see cref="IKafkaProducer{TKey, TValue}.FlushAsync"/> returns immediately when no messages are pending,
 /// even if all brokers are offline. This means the check will report <see cref="HealthStatus.Healthy"/>
 /// when the producer has an empty queue, regardless of actual broker connectivity.
@@ -19,6 +23,8 @@ namespace Dekaf.Extensions.HealthChecks;
 /// For a true broker connectivity check, use <see cref="DekafBrokerHealthCheck"/> with
 /// <see cref="Dekaf.Admin.IAdminClient.DescribeClusterAsync"/>, which actively queries the cluster metadata.
 /// </para>
+/// <para>Each invocation evaluates its own flush. A successful flush after a failed or timed-out
+/// check returns Healthy; earlier failures do not latch this check into an unhealthy state.</para>
 /// </remarks>
 /// <typeparam name="TKey">The producer key type.</typeparam>
 /// <typeparam name="TValue">The producer value type.</typeparam>
@@ -52,7 +58,8 @@ public sealed class DekafProducerHealthCheck<TKey, TValue> : IHealthCheck
 
             await _producer.FlushAsync(timeoutCts.Token).ConfigureAwait(false);
 
-            return HealthCheckResult.Healthy("Producer is connected and can flush successfully.");
+            return HealthCheckResult.Healthy(
+                "Producer queue drained. Delivery outcomes and broker connectivity are not checked.");
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
@@ -62,7 +69,7 @@ public sealed class DekafProducerHealthCheck<TKey, TValue> : IHealthCheck
         catch (Exception ex)
         {
             return HealthCheckResult.Unhealthy(
-                "Producer health check failed.",
+                "Producer queue drainage check failed.",
                 exception: ex);
         }
     }

--- a/src/Dekaf.Extensions.HealthChecks/DekafProducerHealthCheck.cs
+++ b/src/Dekaf.Extensions.HealthChecks/DekafProducerHealthCheck.cs
@@ -4,16 +4,18 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 namespace Dekaf.Extensions.HealthChecks;
 
 /// <summary>
-/// Health check that waits for the producer queue to drain.
+/// Health check that waits for a producer flush checkpoint to complete.
 /// Reports <see cref="HealthStatus.Healthy"/> when the flush completes,
 /// and <see cref="HealthStatus.Unhealthy"/> when the flush throws or times out.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Scope:</b> Queue drainage does not establish successful delivery. Failed delivery
+/// <b>Scope:</b> Flush completion does not establish successful delivery. Failed delivery
 /// attempts also leave the queue. Observe produce results or delivery callbacks for those failures;
 /// this check does not retain or evaluate delivery history.
 /// </para>
+/// <para>Concurrent production can leave newer messages queued after the flush checkpoint
+/// completes. Healthy does not assert that the current queue is empty.</para>
 /// <para>
 /// <see cref="IKafkaProducer{TKey, TValue}.FlushAsync"/> returns immediately when no messages are pending,
 /// even if all brokers are offline. This means the check will report <see cref="HealthStatus.Healthy"/>
@@ -59,7 +61,7 @@ public sealed class DekafProducerHealthCheck<TKey, TValue> : IHealthCheck
             await _producer.FlushAsync(timeoutCts.Token).ConfigureAwait(false);
 
             return HealthCheckResult.Healthy(
-                "Producer queue drained. Delivery outcomes and broker connectivity are not checked.");
+                "Producer flush checkpoint completed. Delivery outcomes and broker connectivity are not checked.");
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
@@ -69,7 +71,7 @@ public sealed class DekafProducerHealthCheck<TKey, TValue> : IHealthCheck
         catch (Exception ex)
         {
             return HealthCheckResult.Unhealthy(
-                "Producer queue drainage check failed.",
+                "Producer flush checkpoint check failed.",
                 exception: ex);
         }
     }

--- a/src/Dekaf.Extensions.HealthChecks/DekafProducerHealthCheckOptions.cs
+++ b/src/Dekaf.Extensions.HealthChecks/DekafProducerHealthCheckOptions.cs
@@ -6,7 +6,7 @@ namespace Dekaf.Extensions.HealthChecks;
 public sealed class DekafProducerHealthCheckOptions
 {
     /// <summary>
-    /// The timeout for waiting for the producer queue to drain.
+    /// The timeout for waiting for a producer flush checkpoint to complete.
     /// Default is 5 seconds.
     /// </summary>
     public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(5);

--- a/src/Dekaf.Extensions.HealthChecks/DekafProducerHealthCheckOptions.cs
+++ b/src/Dekaf.Extensions.HealthChecks/DekafProducerHealthCheckOptions.cs
@@ -6,7 +6,7 @@ namespace Dekaf.Extensions.HealthChecks;
 public sealed class DekafProducerHealthCheckOptions
 {
     /// <summary>
-    /// The timeout for the producer connectivity check.
+    /// The timeout for waiting for the producer queue to drain.
     /// Default is 5 seconds.
     /// </summary>
     public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(5);

--- a/src/Dekaf.Extensions.HealthChecks/HealthCheckExtensions.cs
+++ b/src/Dekaf.Extensions.HealthChecks/HealthCheckExtensions.cs
@@ -45,8 +45,8 @@ public static class HealthCheckExtensions
     }
 
     /// <summary>
-    /// Adds a health check that waits for the producer queue to drain within its timeout.
-    /// Delivery failures can also drain the queue; successful delivery and broker connectivity
+    /// Adds a health check that waits for a producer flush checkpoint to complete within its timeout.
+    /// Concurrent production can leave newer messages queued. Successful delivery and broker connectivity
     /// are not evaluated. Use <see cref="DekafBrokerHealthCheck"/> for broker connectivity.
     /// The producer must be registered in the service collection as <see cref="IKafkaProducer{TKey, TValue}"/>.
     /// </summary>

--- a/src/Dekaf.Extensions.HealthChecks/HealthCheckExtensions.cs
+++ b/src/Dekaf.Extensions.HealthChecks/HealthCheckExtensions.cs
@@ -45,7 +45,9 @@ public static class HealthCheckExtensions
     }
 
     /// <summary>
-    /// Adds a health check that verifies producer connectivity by flushing pending messages.
+    /// Adds a health check that waits for the producer queue to drain within its timeout.
+    /// Delivery failures can also drain the queue; successful delivery and broker connectivity
+    /// are not evaluated. Use <see cref="DekafBrokerHealthCheck"/> for broker connectivity.
     /// The producer must be registered in the service collection as <see cref="IKafkaProducer{TKey, TValue}"/>.
     /// </summary>
     /// <typeparam name="TKey">The producer key type.</typeparam>

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -175,12 +175,13 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Waits for pending delivery attempts to leave the producer queue.
+    /// Waits for delivery attempts captured by a flush checkpoint to complete.
     /// </summary>
     /// <remarks>
     /// Failed delivery attempts also complete a flush. Observe produce results or delivery
     /// callbacks to determine delivery success. An empty queue completes immediately without
-    /// checking broker connectivity.
+    /// checking broker connectivity. Concurrent production can leave newer messages queued
+    /// after this checkpoint completes; completion does not assert that the current queue is empty.
     /// </remarks>
     ValueTask FlushAsync(CancellationToken cancellationToken = default);
 

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -81,7 +81,7 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// On the hot path (buffer has space), the returned <see cref="ValueTask"/> completes synchronously
     /// with zero allocation.</para>
     ///
-    /// <para>To ensure all messages are delivered, call <see cref="FlushAsync"/> before disposing the producer.</para>
+    /// <para>To wait for pending delivery attempts to finish, call <see cref="FlushAsync"/> before disposing the producer.</para>
     ///
     /// <para>Key and value are serialized into producer-owned buffers before the returned
     /// <see cref="ValueTask"/> completes, so callers may reuse or mutate input buffers
@@ -104,7 +104,7 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// On the hot path (buffer has space), the returned <see cref="ValueTask"/> completes synchronously
     /// with zero allocation.</para>
     ///
-    /// <para>To ensure all messages are delivered, call <see cref="FlushAsync"/> before disposing the producer.</para>
+    /// <para>To wait for pending delivery attempts to finish, call <see cref="FlushAsync"/> before disposing the producer.</para>
     ///
     /// <para>Key and value are serialized into producer-owned buffers before the returned
     /// <see cref="ValueTask"/> completes, so callers may reuse or mutate input buffers
@@ -175,8 +175,13 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Flushes any pending messages.
+    /// Waits for pending delivery attempts to leave the producer queue.
     /// </summary>
+    /// <remarks>
+    /// Failed delivery attempts also complete a flush. Observe produce results or delivery
+    /// callbacks to determine delivery success. An empty queue completes immediately without
+    /// checking broker connectivity.
+    /// </remarks>
     ValueTask FlushAsync(CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Dekaf/Producer/ITopicProducer.cs
+++ b/src/Dekaf/Producer/ITopicProducer.cs
@@ -99,7 +99,7 @@ public interface ITopicProducer<TKey, TValue> : IAsyncDisposable
     /// On the hot path (buffer has space), the returned <see cref="ValueTask"/> completes synchronously
     /// with zero allocation.</para>
     ///
-    /// <para>To ensure all messages are delivered, call <see cref="FlushAsync"/> before disposing.</para>
+    /// <para>To wait for pending delivery attempts to finish, call <see cref="FlushAsync"/> before disposing.</para>
     /// </remarks>
     /// <param name="key">The message key (can be null).</param>
     /// <param name="value">The message value.</param>
@@ -150,8 +150,15 @@ public interface ITopicProducer<TKey, TValue> : IAsyncDisposable
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Flushes any pending messages.
+    /// Waits for delivery attempts captured by a flush checkpoint to complete.
     /// </summary>
+    /// <remarks>
+    /// Failed delivery attempts also complete a flush. Observe produce results or delivery
+    /// callbacks to determine delivery success. An empty queue completes immediately without
+    /// checking broker connectivity. Concurrent production can leave newer messages queued
+    /// after this checkpoint completes; completion does not assert that the current queue is empty.
+    /// This flushes the shared underlying producer, including messages for other bound topics.
+    /// </remarks>
     /// <param name="cancellationToken">Cancellation token.</param>
     ValueTask FlushAsync(CancellationToken cancellationToken = default);
 }

--- a/tests/Dekaf.Tests.Integration/ProducerHealthCheckIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerHealthCheckIntegrationTests.cs
@@ -1,0 +1,118 @@
+using Dekaf.Admin;
+using Dekaf.Errors;
+using Dekaf.Extensions.HealthChecks;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Docker.DotNet;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Producer")]
+[Category("HealthChecks")]
+[NotInParallel("ProducerHealthKafkaContainer")]
+[ClassDataSource<ProducerHealthKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class ProducerHealthCheckIntegrationTests(ProducerHealthKafkaContainer kafka)
+{
+    [Test]
+    public async Task RejectedDelivery_DrainsQueue_AndLaterDeliverySucceeds()
+    {
+        var topic = $"health-rejected-{Guid.NewGuid():N}";
+        await using var admin = kafka.CreateAdminClient();
+        await admin.CreateTopicsAsync([
+            new NewTopic
+            {
+                Name = topic,
+                NumPartitions = 1,
+                ReplicationFactor = 1,
+                Configs = new Dictionary<string, string> { ["max.message.bytes"] = "1024" }
+            }
+        ]);
+        await using var producer = await CreateProducerAsync();
+        var health = CreateHealthCheck(producer);
+
+        var failure = await Assert.ThrowsAsync<ProduceException>(async () =>
+            await producer.ProduceAsync(topic, "key", new string('x', 8192)));
+        await Assert.That(failure!.ErrorCode).IsEqualTo(ErrorCode.MessageTooLarge);
+
+        // A broker-rejected batch has left the real accumulator despite failed delivery.
+        var drainedAfterFailure = await health.CheckHealthAsync(new HealthCheckContext());
+        await AssertDrainageOnlyAsync(drainedAfterFailure);
+
+        var delivered = await producer.ProduceAsync(topic, "key", "accepted");
+        await Assert.That(delivered.Offset).IsEqualTo(0L);
+        await AssertDrainageOnlyAsync(await health.CheckHealthAsync(new HealthCheckContext()));
+    }
+
+    [Test]
+    public async Task SuccessfulDelivery_DrainsQueue()
+    {
+        var topic = await kafka.CreateTestTopicAsync();
+        await using var producer = await CreateProducerAsync();
+        var delivery = producer.ProduceAsync(topic, "key", "accepted");
+
+        var drained = await CreateHealthCheck(producer).CheckHealthAsync(new HealthCheckContext());
+        var delivered = await delivery;
+
+        await Assert.That(delivered.Offset).IsEqualTo(0L);
+        await AssertDrainageOnlyAsync(drained);
+    }
+
+    [Test]
+    public async Task IdleQueue_WhenBrokerUnavailable_DrainsWithoutClaimingConnectivity()
+    {
+        await using var producer = await CreateProducerAsync();
+        // A fresh admin must contact the broker, rather than reuse initialized metadata.
+        await using var admin = kafka.CreateAdminClient();
+        var connectivity = new DekafBrokerHealthCheck(admin,
+            new DekafBrokerHealthCheckOptions { Timeout = TimeSpan.FromSeconds(1) });
+
+        await kafka.SetPausedAsync(true);
+        try
+        {
+            await AssertDrainageOnlyAsync(await CreateHealthCheck(producer)
+                .CheckHealthAsync(new HealthCheckContext()));
+            var brokerResult = await connectivity.CheckHealthAsync(new HealthCheckContext());
+            await Assert.That(brokerResult.Status).IsEqualTo(HealthStatus.Unhealthy);
+        }
+        finally
+        {
+            await kafka.SetPausedAsync(false);
+        }
+    }
+
+    private async Task<IKafkaProducer<string, string>> CreateProducerAsync() =>
+        await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithAcks(Acks.All)
+            .WithBatchSize(16384)
+            .WithMaxRequestSize(32768)
+            .WithLinger(TimeSpan.Zero)
+            .WithDeliveryTimeout(TimeSpan.FromSeconds(15))
+            .WithRequestTimeout(TimeSpan.FromSeconds(5))
+            .BuildAsync();
+
+    private static DekafProducerHealthCheck<string, string> CreateHealthCheck(IKafkaProducer<string, string> producer) =>
+        new(producer, new DekafProducerHealthCheckOptions());
+
+    private static async Task AssertDrainageOnlyAsync(HealthCheckResult result)
+    {
+        await Assert.That(result.Status).IsEqualTo(HealthStatus.Healthy);
+        await Assert.That(result.Description).IsEqualTo(
+            "Producer queue drained. Delivery outcomes and broker connectivity are not checked.");
+    }
+}
+
+// Isolated from the general Kafka fixture so pausing cannot affect unrelated tests.
+public sealed class ProducerHealthKafkaContainer : KafkaContainerDefault
+{
+    public async Task SetPausedAsync(bool paused)
+    {
+        using var client = new DockerClientBuilder().Build();
+        var containerId = ContainerInstance!.Id;
+        if (paused)
+            await client.Containers.PauseContainerAsync(containerId);
+        else
+            await client.Containers.UnpauseContainerAsync(containerId);
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ProducerHealthCheckIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerHealthCheckIntegrationTests.cs
@@ -37,11 +37,11 @@ public sealed class ProducerHealthCheckIntegrationTests(ProducerHealthKafkaConta
 
         // A broker-rejected batch has left the real accumulator despite failed delivery.
         var drainedAfterFailure = await health.CheckHealthAsync(new HealthCheckContext());
-        await AssertDrainageOnlyAsync(drainedAfterFailure);
+        await AssertFlushCheckpointAsync(drainedAfterFailure);
 
         var delivered = await producer.ProduceAsync(topic, "key", "accepted");
         await Assert.That(delivered.Offset).IsEqualTo(0L);
-        await AssertDrainageOnlyAsync(await health.CheckHealthAsync(new HealthCheckContext()));
+        await AssertFlushCheckpointAsync(await health.CheckHealthAsync(new HealthCheckContext()));
     }
 
     [Test]
@@ -55,7 +55,7 @@ public sealed class ProducerHealthCheckIntegrationTests(ProducerHealthKafkaConta
         var delivered = await delivery;
 
         await Assert.That(delivered.Offset).IsEqualTo(0L);
-        await AssertDrainageOnlyAsync(drained);
+        await AssertFlushCheckpointAsync(drained);
     }
 
     [Test]
@@ -70,7 +70,7 @@ public sealed class ProducerHealthCheckIntegrationTests(ProducerHealthKafkaConta
         await kafka.SetPausedAsync(true);
         try
         {
-            await AssertDrainageOnlyAsync(await CreateHealthCheck(producer)
+            await AssertFlushCheckpointAsync(await CreateHealthCheck(producer)
                 .CheckHealthAsync(new HealthCheckContext()));
             var brokerResult = await connectivity.CheckHealthAsync(new HealthCheckContext());
             await Assert.That(brokerResult.Status).IsEqualTo(HealthStatus.Unhealthy);
@@ -95,11 +95,11 @@ public sealed class ProducerHealthCheckIntegrationTests(ProducerHealthKafkaConta
     private static DekafProducerHealthCheck<string, string> CreateHealthCheck(IKafkaProducer<string, string> producer) =>
         new(producer, new DekafProducerHealthCheckOptions());
 
-    private static async Task AssertDrainageOnlyAsync(HealthCheckResult result)
+    private static async Task AssertFlushCheckpointAsync(HealthCheckResult result)
     {
         await Assert.That(result.Status).IsEqualTo(HealthStatus.Healthy);
         await Assert.That(result.Description).IsEqualTo(
-            "Producer queue drained. Delivery outcomes and broker connectivity are not checked.");
+            "Producer flush checkpoint completed. Delivery outcomes and broker connectivity are not checked.");
     }
 }
 

--- a/tests/Dekaf.Tests.Unit/Extensions/HealthCheckTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/HealthCheckTests.cs
@@ -479,7 +479,7 @@ public class HealthCheckTests
 
         await Assert.That(result.Status).IsEqualTo(HealthStatus.Healthy);
         await Assert.That(result.Description).IsEqualTo(
-            "Producer queue drained. Delivery outcomes and broker connectivity are not checked.");
+            "Producer flush checkpoint completed. Delivery outcomes and broker connectivity are not checked.");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Extensions/HealthCheckTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/HealthCheckTests.cs
@@ -478,6 +478,26 @@ public class HealthCheckTests
         var result = await healthCheck.CheckHealthAsync(CreateContext());
 
         await Assert.That(result.Status).IsEqualTo(HealthStatus.Healthy);
+        await Assert.That(result.Description).IsEqualTo(
+            "Producer queue drained. Delivery outcomes and broker connectivity are not checked.");
+    }
+
+    [Test]
+    public async Task ProducerHealthCheck_FlushRecovers_DoesNotLatchFailure()
+    {
+        var producer = Substitute.For<IKafkaProducer<string, string>>();
+        producer.FlushAsync(Arg.Any<CancellationToken>()).Returns(
+            _ => ValueTask.FromException(new InvalidOperationException("flush failed")),
+            _ => ValueTask.CompletedTask);
+        var healthCheck = new DekafProducerHealthCheck<string, string>(
+            producer, new DekafProducerHealthCheckOptions());
+
+        var failed = await healthCheck.CheckHealthAsync(CreateContext());
+        var recovered = await healthCheck.CheckHealthAsync(CreateContext());
+
+        await Assert.That(failed.Status).IsEqualTo(HealthStatus.Unhealthy);
+        await Assert.That(recovered.Status).IsEqualTo(HealthStatus.Healthy);
+        await Assert.That(recovered.Exception).IsNull();
     }
 
     [Test]


### PR DESCRIPTION
The old producer health check could report connectivity after a broker rejected a batch or while an idle producer had no reachable broker. It now reports completion of its flush checkpoint and explicitly excludes delivery outcomes and broker connectivity. Concurrent production can leave newer records queued; Healthy does not claim the current queue is empty.

Flush exceptions/timeouts remain Unhealthy, and each completed later flush recovers without retaining a historical failure latch. Observe produce results/callbacks or an application-defined recent-error window for delivery outcomes. The guide shows the independent broker connectivity check and explains both contracts. Registration signatures and status behavior remain compatible.

Production runtime changes are health-result string literals. Producer executable source is unchanged; its FlushAsync/fire-and-forget XML now describes delivery-attempt completion without claiming successful delivery or current queue emptiness.

Validation:
- Initial implementation reproduced the incorrect connected message in a unit assertion and real Kafka rejection scenario.
- Final head: 149 extension unit tests pass on each of net10.0/net8.0 (298 total), including failure/recovery without a latch.
- Three Kafka 4.3.1 integration scenarios pass: rejected delivery followed by success, ordinary success, and an idle initialized producer with its isolated broker paused. In the paused case, the producer checkpoint is Healthy while the broker check is Unhealthy.
- Topic message-size limits are configured at creation to avoid propagation races. The pause fixture is isolated and uses KAFKA_TEST_IMAGE_TAG.
- Final Release builds have zero warnings/errors; docs production build and diff checks pass; /simplify complete. All 459 documentation snippets were verified for the original implementation; code samples are unchanged by the review correction.

Performance evidence: identical initialized health-check fixture with a non-recording DispatchProxy returning a completed flush; proxy overhead included. Windows 11/i7-12700K, SDK 10.0.400/runtime 10.0.11, BDN 0.15.8 MemoryDiagnoser, in-process, five warmups/15 iterations. Each pair measured sequentially after builds finished.

| Measurement pair | Product | Mean/probe | Error | StdDev | Allocated |
| --- | --- | ---: | ---: | ---: | ---: |
| Original implementation | e5d02b583 | 83.10 ns | 2.380 ns | 2.110 ns | 264 B |
| Original implementation | 423729d1f | 89.02 ns | 6.152 ns | 5.754 ns | 264 B |
| Review correction | 423729d1f | 93.21 ns | 3.012 ns | 2.818 ns | 264 B |
| Review correction | 2081380ba | 99.65 ns | 6.631 ns | 6.203 ns | 264 B |

Review-pair mean delta +6.9% has overlapping reported confidence intervals; allocation cost unchanged. Separate local runs show timing variance, so these results establish neither a speedup nor a timing regression. Loaded candidate DLL SHA256 verified: E49539926456222C98142A123B0F384C251F6ED779DA2158458A148D733428E5. These are cold health-probe/proxy costs, not per-message costs. Network latency percentiles, CPU/message and long-run stability were not measured; no paid stress run.

Closes #3036
