### PR TITLE
fix(sasl): reject malformed OAuth challenges

### DIFF
--- a/src/Dekaf/Security/Sasl/OAuthBearerAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerAuthenticator.cs
@@ -135,18 +135,12 @@ public sealed class OAuthBearerAuthenticator : ISaslAuthenticator
     /// <inheritdoc />
     public byte[]? EvaluateChallenge(byte[] challenge)
     {
-        // OAUTHBEARER is a single-round mechanism
-        // If we receive a challenge, it's an error response from the server
-        // The error will be in JSON format as per RFC 7628
+        // Successful OAUTHBEARER authentication has no further challenge data.
+        // RFC 7628 errors use JSON, but malformed or unexpected nonempty replies must also fail.
         if (challenge.Length > 0)
         {
             var errorResponse = Encoding.UTF8.GetString(challenge);
-
-            // If the response starts with '{', it's a JSON error
-            if (errorResponse.StartsWith('{'))
-            {
-                throw new AuthenticationException($"OAUTHBEARER authentication failed: {errorResponse}");
-            }
+            throw new AuthenticationException($"OAUTHBEARER authentication failed: {errorResponse}");
         }
 
         _complete = true;

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerAuthenticatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerAuthenticatorTests.cs
@@ -115,17 +115,50 @@ public class OAuthBearerAuthenticatorTests
     }
 
     [Test]
-    public async Task EvaluateChallenge_WithJsonError_ThrowsAuthenticationException()
+    [Arguments("")]
+    [Arguments(" ")]
+    [Arguments("\r\n")]
+    [Arguments("\t \r\n")]
+    public async Task EvaluateChallenge_WithJsonError_ThrowsAuthenticationException(string prefix)
     {
         var token = CreateValidToken();
         var authenticator = new OAuthBearerAuthenticator(token);
         _ = authenticator.GetInitialResponse();
 
-        var errorChallenge = Encoding.UTF8.GetBytes("{\"status\":\"invalid_token\",\"scope\":\"required_scope\"}");
+        var errorChallenge = Encoding.UTF8.GetBytes(prefix + "{\"status\":\"invalid_token\",\"scope\":\"required_scope\"}");
 
         await Assert.That(() => authenticator.EvaluateChallenge(errorChallenge))
             .Throws<AuthenticationException>()
             .WithMessageContaining("invalid_token");
+        await Assert.That(authenticator.IsComplete).IsFalse();
+    }
+
+    [Test]
+    [Arguments("invalid response")]
+    [Arguments(" \r\n\t")]
+    [Arguments("{malformed")]
+    [Arguments("[]")]
+    [Arguments("null")]
+    [Arguments("\u0001")]
+    public async Task EvaluateChallenge_WithUnexpectedNonemptyResponse_DoesNotComplete(string response)
+    {
+        var authenticator = new OAuthBearerAuthenticator(CreateValidToken());
+        _ = authenticator.GetInitialResponse();
+
+        await Assert.That(() => authenticator.EvaluateChallenge(Encoding.UTF8.GetBytes(response)))
+            .Throws<AuthenticationException>();
+        await Assert.That(authenticator.IsComplete).IsFalse();
+    }
+
+    [Test]
+    public async Task EvaluateChallenge_WithInvalidUtf8_DoesNotComplete()
+    {
+        var authenticator = new OAuthBearerAuthenticator(CreateValidToken());
+        _ = authenticator.GetInitialResponse();
+
+        await Assert.That(() => authenticator.EvaluateChallenge([0xff, 0xfe]))
+            .Throws<AuthenticationException>();
+        await Assert.That(authenticator.IsComplete).IsFalse();
     }
 
     [Test]


### PR DESCRIPTION
OAuth error JSON with leading whitespace and arbitrary nonempty challenge data previously set `IsComplete=true`. `OAuthBearerAuthenticator` now rejects every nonempty challenge with `AuthenticationException`, preserving error diagnostics and the existing empty successful-response handling. This follows the failure-challenge semantics in [RFC 7628 §3.2.2](https://www.rfc-editor.org/rfc/rfc7628.html#section-3.2.2).

This fixes authenticator validation; KafkaConnection already independently rejects nonzero broker SASL error codes, so this is not evidence of a broker authentication bypass.

Validation:
- Nine regression cases failed before the fix. Coverage includes JSON whitespace, malformed JSON/text, whitespace-only data, control bytes, invalid UTF-8, ordinary JSON errors, empty success, and incomplete state after failure.
- 183 security unit tests passed on net10.0; 180 passed on net8.0.
- Six real Kafka OAuth integration tests passed (dedicated Kafka 4.0.2 fixture): producer, consumer, admin, JWT token endpoint, round trip, and invalid-token rejection.
- Release builds: zero warnings/errors. `/simplify` and `git diff --check` complete.

Performance evidence, baseline `fd414eb407f010282a9f2a947958ae0d388df394` versus candidate `6effe811113ac2aa7b969bd4c5e98b3b91f4abe9`:

| Successful authentication operation | Before | After | Allocation |
| --- | ---: | ---: | ---: |
| New authenticator + initial response + empty server response | 117.0 ns (error 2.12, SD 1.88) | 119.86 ns (error 4.28, SD 4.00) | 656 B → 656 B |
| Empty challenge evaluation alone | below timing resolution | below timing resolution | 0 B → 0 B |

Handshake mean delta +2.4% lies within measurement uncertainty (overlapping confidence intervals); no speed change claimed. The 656 B are existing per-connection token/initial-response allocations, not per-message allocations. The empty-success branch is unchanged; only invalid server data now throws. No paid stress run or produce/consume hot-path change.

Task-scoped BDN 0.15.8 MemoryDiagnoser fixture, .NET 10.0.11 / SDK 10.0.400, Windows 11 i7-12700K, in-process, five warmups/15 iterations. Same saved baseline DLL versus current product; loaded candidate DLL hash verified. Tiny challenge-only latency is too small to compare reliably (0.0034 versus 0.0189 ns after harness-overhead subtraction), which is why the table uses the complete client-side handshake for timing.

Closes #3061
