### PR TITLE
fix(oauth): honor registry token refresh buffer

### DIFF
--- a/src/Dekaf.SchemaRegistry/SchemaRegistryAuthenticationHandler.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryAuthenticationHandler.cs
@@ -8,6 +8,7 @@ internal sealed class SchemaRegistryAuthenticationHandler : DelegatingHandler
 {
     private readonly AuthenticationHeaderValue? _staticAuthorization;
     private readonly OAuthBearerAuthenticator? _oauthAuthenticator;
+    private readonly Func<CancellationToken, ValueTask<OAuthBearerToken>>? _configuredTokenProvider;
     private readonly OAuthBearerTokenProvider? _ownedTokenProvider;
 
     internal SchemaRegistryAuthenticationHandler(
@@ -26,18 +27,17 @@ internal sealed class SchemaRegistryAuthenticationHandler : DelegatingHandler
         }
         else if (config.OAuthBearerConfig is not null)
         {
-            Func<CancellationToken, ValueTask<OAuthBearerToken>> tokenProvider;
+            // The configured provider owns caching and its refresh window. An authenticator's
+            // separate fixed window would hide an earlier configured refresh deadline.
             if (oauthBearerTokenProviderFactory is not null)
             {
-                tokenProvider = oauthBearerTokenProviderFactory(config.OAuthBearerConfig);
+                _configuredTokenProvider = oauthBearerTokenProviderFactory(config.OAuthBearerConfig);
             }
             else
             {
                 _ownedTokenProvider = new OAuthBearerTokenProvider(config.OAuthBearerConfig);
-                tokenProvider = _ownedTokenProvider.GetTokenAsync;
+                _configuredTokenProvider = _ownedTokenProvider.GetTokenAsync;
             }
-
-            _oauthAuthenticator = new OAuthBearerAuthenticator(tokenProvider);
         }
         else if (!string.IsNullOrEmpty(config.BasicAuthUserInfo))
         {
@@ -46,20 +46,35 @@ internal sealed class SchemaRegistryAuthenticationHandler : DelegatingHandler
         }
     }
 
-    protected override async Task<HttpResponseMessage> SendAsync(
+    protected override Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
         CancellationToken cancellationToken)
     {
-        if (_oauthAuthenticator is not null)
+        if (_oauthAuthenticator is not null || _configuredTokenProvider is not null)
         {
-            var token = await _oauthAuthenticator.GetTokenAsync(cancellationToken).ConfigureAwait(false);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.TokenValue);
+            var token = _oauthAuthenticator is not null
+                ? _oauthAuthenticator.GetTokenAsync(cancellationToken)
+                : _configuredTokenProvider!(cancellationToken);
+            if (!token.IsCompletedSuccessfully)
+                return SendWithTokenAsync(request, token, cancellationToken);
+
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Result.TokenValue);
         }
         else if (_staticAuthorization is not null)
         {
             request.Headers.Authorization = _staticAuthorization;
         }
 
+        return base.SendAsync(request, cancellationToken);
+    }
+
+    private async Task<HttpResponseMessage> SendWithTokenAsync(
+        HttpRequestMessage request,
+        ValueTask<OAuthBearerToken> pendingToken,
+        CancellationToken cancellationToken)
+    {
+        var token = await pendingToken.ConfigureAwait(false);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.TokenValue);
         return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryHttpPipelineIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryHttpPipelineIntegrationTests.cs
@@ -6,12 +6,41 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Dekaf.SchemaRegistry;
+using Dekaf.Security.Sasl;
 
 namespace Dekaf.Tests.Integration;
 
 [ClassDataSource<KafkaWithSchemaRegistryContainer>(Shared = SharedType.PerTestSession)]
 public sealed class SchemaRegistryHttpPipelineIntegrationTests(KafkaWithSchemaRegistryContainer testInfra)
 {
+    [Test]
+    [Arguments(300, 2)]
+    [Arguments(60, 1)]
+    [Arguments(10, 1)]
+    public async Task OAuthConfig_UsesConfiguredRefreshWindow(int bufferSeconds, int expectedTokenRequests)
+    {
+        await using var endpoint = new LocalTokenEndpoint();
+        using var handler = new CapturingDelegatingHandler(new SocketsHttpHandler());
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = testInfra.RegistryUrl,
+            OAuthBearerConfig = new OAuthBearerConfig
+            {
+                TokenEndpointUrl = endpoint.Url,
+                ClientId = "schema-registry-client",
+                ClientSecret = "secret",
+                TokenRefreshBufferSeconds = bufferSeconds
+            }
+        }, handler);
+
+        _ = await client.GetAllSubjectsAsync();
+        await Assert.That(handler.Authorization).IsEqualTo("Bearer token-1");
+        _ = await client.GetAllSubjectsAsync();
+
+        await Assert.That(endpoint.RequestCount).IsEqualTo(expectedTokenRequests);
+        await Assert.That(handler.Authorization).IsEqualTo($"Bearer token-{expectedTokenRequests}");
+    }
+
     [Test]
     public async Task CustomDelegatingHandler_SeesVersionedDefaultUserAgent()
     {
@@ -29,13 +58,74 @@ public sealed class SchemaRegistryHttpPipelineIntegrationTests(KafkaWithSchemaRe
         : DelegatingHandler(innerHandler)
     {
         internal string? UserAgent { get; private set; }
+        internal string? Authorization { get; private set; }
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
             UserAgent = request.Headers.UserAgent.ToString();
+            Authorization = request.Headers.Authorization?.ToString();
             return base.SendAsync(request, cancellationToken);
+        }
+    }
+
+    private sealed class LocalTokenEndpoint : IAsyncDisposable
+    {
+        private readonly TcpListener _listener = new(IPAddress.Loopback, 0);
+        private readonly CancellationTokenSource _stopping = new();
+        private readonly Task _serving;
+        private int _requestCount;
+
+        public LocalTokenEndpoint()
+        {
+            _listener.Start();
+            Url = $"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/token";
+            _serving = ServeAsync();
+        }
+
+        public string Url { get; }
+        public int RequestCount => Volatile.Read(ref _requestCount);
+
+        private async Task ServeAsync()
+        {
+            while (!_stopping.IsCancellationRequested)
+            {
+                using var connection = await _listener.AcceptTcpClientAsync(_stopping.Token);
+                await using var stream = connection.GetStream();
+                using var reader = new StreamReader(stream, Encoding.ASCII, leaveOpen: true);
+                var contentLength = 0;
+                while (await reader.ReadLineAsync(_stopping.Token) is { Length: > 0 } line)
+                {
+                    if (line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase))
+                        contentLength = int.Parse(line.AsSpan("Content-Length:".Length), System.Globalization.CultureInfo.InvariantCulture);
+                }
+                var body = new char[contentLength];
+                if (await reader.ReadBlockAsync(body.AsMemory(), _stopping.Token) != contentLength)
+                    throw new EndOfStreamException("Incomplete token request body.");
+                var count = Interlocked.Increment(ref _requestCount);
+                var json = $"{{\"access_token\":\"token-{count}\",\"expires_in\":120}}";
+                var response = Encoding.ASCII.GetBytes(
+                    $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {json.Length}\r\nConnection: close\r\n\r\n{json}");
+                await stream.WriteAsync(response, _stopping.Token);
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _stopping.CancelAsync();
+            _listener.Stop();
+            try
+            {
+                await _serving;
+            }
+            catch (OperationCanceledException) when (_stopping.IsCancellationRequested)
+            {
+            }
+            finally
+            {
+                _stopping.Dispose();
+            }
         }
     }
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryAuthenticationTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryAuthenticationTests.cs
@@ -182,6 +182,103 @@ public sealed class SchemaRegistryAuthenticationTests
         await Assert.That(authorization?.Parameter).IsEqualTo("oidc-token");
     }
 
+    [Test]
+    [Arguments(300, 120, 2)]
+    [Arguments(300, 600, 1)]
+    [Arguments(null, 120, 1)]
+    [Arguments(null, 30, 2)]
+    [Arguments(10, 30, 1)]
+    [Arguments(10, 0, 2)]
+    public async Task Client_OAuthConfig_HonorsProviderRefreshBuffer(
+        int? refreshBufferSeconds, int expiresInSeconds, int expectedTokenRequests)
+    {
+        var config = new OAuthBearerConfig
+        {
+            TokenEndpointUrl = "https://auth.local/token",
+            ClientId = "schema-registry-client",
+            ClientSecret = "secret",
+            TokenRefreshBufferSeconds = refreshBufferSeconds ?? NewOAuthConfig().TokenRefreshBufferSeconds
+        };
+        using var tokenEndpoint = new TokenEndpointHandler(expiresInSeconds);
+        using var tokenHttpClient = new HttpClient(tokenEndpoint);
+        using var tokenProvider = new OAuthBearerTokenProvider(config, tokenHttpClient);
+        var registry = new CapturingSchemaRegistryHandler();
+        using var client = new SchemaRegistryClient(
+            new SchemaRegistryConfig { Url = "http://schema-registry.local", OAuthBearerConfig = config },
+            registry,
+            oauthBearerTokenProviderFactory: _ => tokenProvider.GetTokenAsync);
+
+        _ = await client.GetAllSubjectsAsync();
+        _ = await client.GetAllSubjectsAsync();
+
+        await Assert.That(tokenEndpoint.RequestCount).IsEqualTo(expectedTokenRequests);
+        await Assert.That(registry.AuthorizationHeaders.Count).IsEqualTo(2);
+        await Assert.That(registry.AuthorizationHeaders[0]?.Parameter).IsEqualTo("token-1");
+        await Assert.That(registry.AuthorizationHeaders[1]?.Parameter).IsEqualTo($"token-{expectedTokenRequests}");
+    }
+
+    [Test]
+    [Arguments(false, false)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(true, true)]
+    public async Task Client_WaitsForOAuthToken_AndObservesCancellation(bool configuredProvider, bool cancel)
+    {
+        var pendingToken = new TaskCompletionSource<OAuthBearerToken>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellation = new CancellationTokenSource();
+        ValueTask<OAuthBearerToken> GetToken(CancellationToken token)
+        {
+            requested.SetResult();
+            return new(pendingToken.Task.WaitAsync(token));
+        }
+
+        var registry = new CapturingSchemaRegistryHandler();
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://schema-registry.local",
+            OAuthBearerConfig = configuredProvider ? NewOAuthConfig() : null,
+            OAuthBearerTokenProvider = configuredProvider ? null : GetToken
+        }, registry, oauthBearerTokenProviderFactory: _ => GetToken);
+
+        var request = client.GetAllSubjectsAsync(cancellation.Token);
+        await requested.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await Assert.That(request.IsCompleted).IsFalse();
+        await Assert.That(registry.AuthorizationHeaders).IsEmpty();
+
+        if (cancel)
+        {
+            await cancellation.CancelAsync();
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await request);
+            await Assert.That(registry.AuthorizationHeaders).IsEmpty();
+        }
+        else
+        {
+            pendingToken.SetResult(NewToken("ready-token"));
+            _ = await request;
+            await Assert.That(registry.AuthorizationHeaders[0]?.Parameter).IsEqualTo("ready-token");
+        }
+    }
+
+    private sealed class TokenEndpointHandler(int expiresInSeconds) : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(System.Text.Json.JsonSerializer.Serialize(new
+                {
+                    access_token = $"token-{RequestCount}",
+                    token_type = "Bearer",
+                    expires_in = expiresInSeconds
+                }))
+            });
+        }
+    }
+
     private static OAuthBearerToken NewToken(string tokenValue) => new()
     {
         TokenValue = tokenValue,


### PR DESCRIPTION
With TokenRefreshBufferSeconds = 300 and a token lasting 120 seconds, Schema Registry reused the first token because an outer authenticator cache imposed its own 60-second window. Configured providers now own refresh timing and cached-token reuse directly. Custom token providers retain their existing authenticator cache. Cached-token requests now return the inner handler task directly; an async helper handles pending tokens.

Validation:
- Regression failed before the fix: the 300-second buffer made one token request instead of two.
- Six unit cases cover large, default, and small buffers, with refresh and reuse for each; four further cases verify pending-token success and cancellation for configured/custom providers; existing authentication precedence tests remain green.
- 2,529 Schema Registry unit tests and 86 OAuth provider/authenticator tests pass across net8.0/net10.0. Release unit/integration builds have zero warnings/errors.
- Four HTTP-pipeline integration tests pass against Kafka 4.0.2 and Schema Registry 7.9.0, including three real local token-endpoint cases exercising the owned provider through the public client constructor. Registry fixture accepts the header; these tests verify client refresh/header behavior, not identity-server authorization.
- `/simplify` and `git diff --check` complete.

Closes #3059


Performance validation: local BenchmarkDotNet 0.15.8 `[MemoryDiagnoser]`, .NET 10.0.11 / SDK 10.0.400, Windows 11, i7-12700K; in-process, 5 warmups and 15 measured iterations per case. Same cached-token HTTP-handler fixture and configuration for each run; request, response, and completed inner-handler Task are preallocated. Token HTTP fetching runs only during setup. Baseline is immediately preceding product SHA 71020dd9a885588ff2e89ecf450fe168cf40f230; final candidate is ae07ef85d154bceff648c531181bd958c00255f1.

| Cached authenticated request | Baseline mean ± error (SD), ns | Candidate mean ± error (SD), ns | Time delta | Allocated before → after |
|---|---:|---:|---:|---:|
| Configured provider | 77.09 ± 1.134 (1.005) | 50.89 ± 0.267 (0.237) | -34.0% | 104 B → 32 B |
| Custom provider control | 77.72 ± 0.647 (0.573) | 69.50 ± 1.226 (1.024) | -10.6% | 104 B → 32 B |

The remaining 32 B is the existing per-HTTP-request Authorization header, outside cached serialization/message paths. The 72 B reduction removes the completed handler Task wrapper. This measures local cached authentication overhead, not Kafka throughput or network latency. CPU/message, p50/p99/max network latency, and long-running stability were not measured by this microbenchmark; no paid stress lane was dispatched.

Two uncommitted prototypes were rejected before the final shape: a common delegate path measured configured/custom 60.34/80.09 ns (104 B each); a larger async method with direct custom-provider calls measured 60.48/82.49 ns (104 B each). Both improved configured access while worsening the custom control. The final synchronous-completion path improves both versus baseline and both prototypes, with lower allocations.

Loaded Schema Registry assembly SHA256 verified in each run: baseline EC64C72918D3AB52C146B842184620ADD4B8F3317D00CD03851CE28B7946C7DD; final candidate 0E3A9AA3925698BBB3A38605EFA5FE78D853684C34C2257A81CA90BDFA618EA8. Local reports/fixture remain under `.artifacts/oauth-buffer-bench` and `.artifacts/bench-{before,after,final,fast}` in the isolated issue worktree. Command: `dotnet run --project .artifacts/oauth-buffer-bench --configuration Release -- --filter '*OAuthBufferBenchmarks*' --inProcess --warmupCount 5 --iterationCount 15 --artifacts <result-directory>`.
