### PR TITLE
fix(retry): keep exponential delays capped after attempt 64

### DIFF
--- a/docs/docs/hosted-services.md
+++ b/docs/docs/hosted-services.md
@@ -236,6 +236,21 @@ public sealed class OrderProcessorService : KafkaConsumerService<string, Order>
 
 When you supply a DLQ callback to `AddConsumerService`, it passes the registered `DeadLetterOptions` into your constructor directly (see [Dead Letter Queues](consumer/dead-letter-queues.md#enabling-the-dlq)). The options are registered keyed per consumer registration — never as a plain singleton — so one consumer's DLQ settings cannot leak into another service. If you wire the hosted service manually with `AddHostedService`, resolve them with `[FromKeyedServices(typeof(IKafkaConsumer<TKey, TValue>))]` (or your service key).
 
+### Exponential retry delays
+
+`ExponentialBackoffRetryPolicy` calculates `min(BaseDelay * 2^(attempt - 1), MaxDelay)`
+using one-based retry attempts. With `Jitter = false`, the delay stays capped even
+at very large attempt numbers. The default `Jitter = true` multiplies the capped
+delay by a random factor from 0.5 up to 1.5, then caps it again at `MaxDelay`.
+Delays are truncated to whole ticks.
+
+`BaseDelay`, `MaxDelay`, and `MaxAttempts` must be nonnegative; assigning a negative
+value throws `ArgumentOutOfRangeException`. A zero base or maximum delay means
+immediate retries, and `MaxAttempts = 0` disables retries. `BaseDelay` may exceed
+`MaxDelay`; the maximum still applies to the first retry. Calling `GetNextDelay`
+with an attempt less than one throws `ArgumentOutOfRangeException`; attempts
+greater than `MaxAttempts` return `null` to stop retrying.
+
 ## Shutdown Behavior
 
 `KafkaConsumerServiceOptions` (fifth constructor parameter) controls shutdown:

--- a/src/ApiCompatExcludedAttributes.txt
+++ b/src/ApiCompatExcludedAttributes.txt
@@ -1,5 +1,6 @@
 T:System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute
 T:System.Runtime.CompilerServices.AsyncStateMachineAttribute
+T:System.Runtime.CompilerServices.CompilerGeneratedAttribute
 T:System.Runtime.CompilerServices.EmbeddedAttribute
 T:System.Runtime.CompilerServices.IteratorStateMachineAttribute
 T:System.Runtime.CompilerServices.NullableAttribute

--- a/src/Dekaf/Retry/ExponentialBackoffRetryPolicy.cs
+++ b/src/Dekaf/Retry/ExponentialBackoffRetryPolicy.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+
 namespace Dekaf.Retry;
 
 /// <summary>
@@ -6,20 +8,51 @@ namespace Dekaf.Retry;
 /// </summary>
 public sealed class ExponentialBackoffRetryPolicy : IRetryPolicy
 {
-    /// <summary>
-    /// The base delay before the first retry.
-    /// </summary>
-    public required TimeSpan BaseDelay { get; init; }
+    private readonly TimeSpan _baseDelay;
+    private readonly TimeSpan _maxDelay;
+    private readonly int _maxAttempts;
+    private int _saturationExponent;
 
     /// <summary>
-    /// The maximum delay between retries.
+    /// The nonnegative base delay before the first retry. Zero disables the delay.
     /// </summary>
-    public required TimeSpan MaxDelay { get; init; }
+    public required TimeSpan BaseDelay
+    {
+        get => _baseDelay;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value.Ticks, nameof(BaseDelay));
+            _baseDelay = value;
+            UpdateSaturation();
+        }
+    }
 
     /// <summary>
-    /// The maximum number of retry attempts. After this many failures, retrying stops.
+    /// The nonnegative maximum delay between retries. Zero disables the delay.
     /// </summary>
-    public required int MaxAttempts { get; init; }
+    public required TimeSpan MaxDelay
+    {
+        get => _maxDelay;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value.Ticks, nameof(MaxDelay));
+            _maxDelay = value;
+            UpdateSaturation();
+        }
+    }
+
+    /// <summary>
+    /// The nonnegative maximum number of retry attempts. Zero disables retries.
+    /// </summary>
+    public required int MaxAttempts
+    {
+        get => _maxAttempts;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value, nameof(MaxAttempts));
+            _maxAttempts = value;
+        }
+    }
 
     /// <summary>
     /// Whether to add random jitter (0.5x to 1.5x) to the computed delay. Default is <c>true</c>.
@@ -28,28 +61,47 @@ public sealed class ExponentialBackoffRetryPolicy : IRetryPolicy
     public bool Jitter { get; init; } = true;
 
     /// <inheritdoc />
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="attemptNumber"/> is less than one.</exception>
     public TimeSpan? GetNextDelay(int attemptNumber, Exception exception)
     {
-        if (attemptNumber > MaxAttempts)
+        // One unsigned range check handles both exhausted and nonpositive attempts.
+        var exponent = unchecked(attemptNumber - 1);
+        if ((uint)exponent >= (uint)MaxAttempts)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(attemptNumber, 1);
             return null;
+        }
 
-        var delayTicks = BaseDelay.Ticks * (1L << (attemptNumber - 1));
-
-        // Clamp to MaxDelay (also handles overflow: if shift overflows to negative, clamp)
-        if (delayTicks <= 0 || delayTicks > MaxDelay.Ticks)
-            delayTicks = MaxDelay.Ticks;
+        // Below the threshold, positive ticks cannot overflow; shifting zero is always safe.
+        var maxTicks = MaxDelay.Ticks;
+        var delayTicks = exponent >= _saturationExponent ? maxTicks : BaseDelay.Ticks << exponent;
 
         if (Jitter)
         {
             // Jitter range: 0.5x to 1.5x of computed delay
             var jitterMultiplier = 0.5 + Random.Shared.NextDouble();
-            delayTicks = (long)(delayTicks * jitterMultiplier);
+            // The product is below 1.5 * long.MaxValue, which fits in ulong even
+            // when it cannot fit in long. Clamp before converting back to signed ticks.
+            var jitteredTicks = (ulong)(delayTicks * jitterMultiplier);
 
-            // Clamp again so jitter cannot exceed MaxDelay
-            if (delayTicks > MaxDelay.Ticks)
-                delayTicks = MaxDelay.Ticks;
+            delayTicks = jitteredTicks > (ulong)maxTicks ? maxTicks : (long)jitteredTicks;
         }
 
         return TimeSpan.FromTicks(delayTicks);
+    }
+
+    private void UpdateSaturation()
+    {
+        var baseTicks = BaseDelay.Ticks;
+        var maxTicks = MaxDelay.Ticks;
+        // Recompute from either init setter so property assignment order is irrelevant.
+        // For positive delays below the cap, this is the first exponent whose product
+        // reaches MaxDelay. The division and logarithm happen only during initialization.
+        if (baseTicks == 0)
+            _saturationExponent = int.MaxValue;
+        else if (baseTicks >= maxTicks)
+            _saturationExponent = 0;
+        else
+            _saturationExponent = BitOperations.Log2((ulong)((maxTicks - 1) / baseTicks)) + 1;
     }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,7 +29,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers"
                       PrivateAssets="all"
                       IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
-    <!-- Compiler/polyfill implementation details differ by TFM; nullability remains enforced by PublicApiAnalyzers. -->
+    <!-- Compiler/polyfill implementation metadata is not an API contract (including auto vs explicit accessors).
+         Nullability remains enforced by PublicApiAnalyzers. -->
     <ApiCompatExcludeAttributesFile Include="$(MSBuildThisFileDirectory)ApiCompatExcludedAttributes.txt" />
   </ItemGroup>
 

--- a/tests/Dekaf.Tests.Unit/Retry/ExponentialBackoffBoundaryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Retry/ExponentialBackoffBoundaryTests.cs
@@ -1,0 +1,145 @@
+using System.Numerics;
+using Dekaf.Retry;
+
+namespace Dekaf.Tests.Unit.Retry;
+
+public class ExponentialBackoffBoundaryTests
+{
+    private static readonly Exception Failure = new InvalidOperationException("retry");
+
+    [Test]
+    [Arguments(63)]
+    [Arguments(64)]
+    [Arguments(65)]
+    [Arguments(66)]
+    [Arguments(67)]
+    [Arguments(129)]
+    [Arguments(1000000)]
+    [Arguments(int.MaxValue)]
+    public async Task CappedDelay_DoesNotRestartAtLargeAttempts(int attempt)
+    {
+        var policy = Create(TimeSpan.TicksPerSecond, 30 * TimeSpan.TicksPerSecond);
+
+        await Assert.That(policy.GetNextDelay(attempt, Failure)).IsEqualTo(TimeSpan.FromSeconds(30));
+    }
+
+    [Test]
+    [Arguments(1L, long.MaxValue)]
+    [Arguments(4611686018427387905L, long.MaxValue)]
+    [Arguments(long.MaxValue, long.MaxValue)]
+    [Arguments(0L, long.MaxValue)]
+    [Arguments(1L, 0L)]
+    [Arguments(10L, 5L)]
+    [Arguments(3L, 17L)]
+    [Arguments(10000000L, 300000000L)]
+    public async Task UnjitteredDelay_MatchesUnboundedIntegerFormula(long baseTicks, long maximumTicks)
+    {
+        var policy = Create(baseTicks, maximumTicks);
+        for (var attempt = 1; attempt <= 130; attempt++)
+        {
+            var expected = (long)BigInteger.Min(maximumTicks, new BigInteger(baseTicks) << (attempt - 1));
+            await Assert.That(policy.GetNextDelay(attempt, Failure)).IsEqualTo(TimeSpan.FromTicks(expected));
+        }
+    }
+
+    [Test]
+    [Arguments(0L, 17L)]
+    [Arguments(3L, 17L)]
+    [Arguments(17L, 3L)]
+    [Arguments(long.MaxValue, long.MaxValue)]
+    public async Task DelayConfiguration_IsIndependentOfInitializationOrder(long baseTicks, long maximumTicks)
+    {
+        var policy = new ExponentialBackoffRetryPolicy
+        {
+            MaxDelay = TimeSpan.FromTicks(maximumTicks),
+            BaseDelay = TimeSpan.FromTicks(baseTicks),
+            MaxAttempts = int.MaxValue,
+            Jitter = false
+        };
+
+        for (var attempt = 1; attempt <= 130; attempt++)
+        {
+            var expected = (long)BigInteger.Min(maximumTicks, new BigInteger(baseTicks) << (attempt - 1));
+            await Assert.That(policy.GetNextDelay(attempt, Failure)).IsEqualTo(TimeSpan.FromTicks(expected));
+        }
+    }
+
+    [Test]
+    public async Task ZeroBaseDelay_RemainsZeroAtMaximumAttempt()
+    {
+        await Assert.That(Create(0, long.MaxValue).GetNextDelay(int.MaxValue, Failure))
+            .IsEqualTo(TimeSpan.Zero);
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(-1)]
+    [Arguments(int.MinValue)]
+    public async Task NonpositiveAttempt_IsRejectedEvenWhenRetriesDisabled(int attempt)
+    {
+        var policy = new ExponentialBackoffRetryPolicy
+        {
+            BaseDelay = TimeSpan.Zero, MaxDelay = TimeSpan.Zero, MaxAttempts = 0
+        };
+
+        await Assert.That(() => policy.GetNextDelay(attempt, Failure)).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    [Arguments(-1L, 10L, 1, "BaseDelay")]
+    [Arguments(1L, -1L, 1, "MaxDelay")]
+    [Arguments(1L, 10L, -1, "MaxAttempts")]
+    public async Task NegativeConfiguration_IsRejected(long baseTicks, long maximumTicks, int maximumAttempts, string parameter)
+    {
+        var exception = await Assert.That(() => new ExponentialBackoffRetryPolicy
+        {
+            BaseDelay = TimeSpan.FromTicks(baseTicks),
+            MaxDelay = TimeSpan.FromTicks(maximumTicks),
+            MaxAttempts = maximumAttempts
+        }).Throws<ArgumentOutOfRangeException>();
+
+        await Assert.That(exception!.ParamName).IsEqualTo(parameter);
+    }
+
+    [Test]
+    public async Task ZeroMaximumAttempts_DisablesRetries()
+    {
+        var policy = new ExponentialBackoffRetryPolicy
+        {
+            BaseDelay = TimeSpan.Zero, MaxDelay = TimeSpan.Zero, MaxAttempts = 0
+        };
+
+        await Assert.That(policy.GetNextDelay(1, Failure)).IsNull();
+        await Assert.That(policy.GetNextDelay(int.MaxValue, Failure)).IsNull();
+    }
+
+    [Test]
+    [Arguments(1L)]
+    [Arguments(300000000L)]
+    [Arguments(long.MaxValue)]
+    public async Task JitteredCap_StaysNonnegativeAndWithinDocumentedRange(long maximumTicks)
+    {
+        var policy = new ExponentialBackoffRetryPolicy
+        {
+            BaseDelay = TimeSpan.FromTicks(maximumTicks),
+            MaxDelay = TimeSpan.FromTicks(maximumTicks),
+            MaxAttempts = int.MaxValue,
+            Jitter = true
+        };
+
+        for (var sample = 0; sample < 200; sample++)
+        {
+            var delay = policy.GetNextDelay(int.MaxValue, Failure)!.Value.Ticks;
+            await Assert.That(delay).IsGreaterThanOrEqualTo(maximumTicks / 2);
+            await Assert.That(delay).IsLessThanOrEqualTo(maximumTicks);
+        }
+    }
+
+    private static ExponentialBackoffRetryPolicy Create(long baseTicks, long maximumTicks) => new()
+    {
+        BaseDelay = TimeSpan.FromTicks(baseTicks),
+        MaxDelay = TimeSpan.FromTicks(maximumTicks),
+        MaxAttempts = int.MaxValue,
+        Jitter = false
+    };
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ExponentialBackoffRetryPolicyBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ExponentialBackoffRetryPolicyBenchmarks.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Retry;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+public class ExponentialBackoffRetryPolicyBenchmarks
+{
+    private readonly Exception _failure = new InvalidOperationException();
+    private ExponentialBackoffRetryPolicy _policy = null!;
+
+    [Params(2, 6, 65)]
+    public int Attempt { get; set; }
+
+    [Params(false, true)]
+    public bool Jitter { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => _policy = Create(Jitter);
+
+    [Benchmark]
+    public TimeSpan? NextDelay() => _policy.GetNextDelay(Attempt, _failure);
+
+    private static ExponentialBackoffRetryPolicy Create(bool jitter) => new()
+    {
+        BaseDelay = TimeSpan.FromSeconds(1),
+        MaxDelay = TimeSpan.FromSeconds(30),
+        MaxAttempts = int.MaxValue,
+        Jitter = jitter
+    };
+}


### PR DESCRIPTION
Exponential retries restarted at attempt 65 because the shift count wrapped. Positive multiplication overflow and jitter near `TimeSpan.MaxValue` could also produce invalid delays. Cache the exact saturation exponent during initialization, then use a bounded shift and an unsigned jitter intermediate to retain the hard cap.

Negative configuration values and nonpositive attempts now throw `ArgumentOutOfRangeException`. Zero delays remain zero; zero attempts disable retries. Tests cover both initialization orders, attempts 63–67 through `int.MaxValue`, and an independent `BigInteger` formula over 130 attempts. Documentation states the boundary contract.

The internal `ExponentialRetryBackoff` helper uses milliseconds and a different jitter range, so reuse would change this public policy's tick precision and 0.5–1.5 jitter contract.

## Validation

- Red reproduction: 16 of 27 new boundary cases failed before the fix.
- Final retry namespace: 81 tests passed on .NET 10 and .NET 8.
- Hosted consumer tests: 37 passed on each framework.
- Five real Kafka 4.3.1 retry-policy integration tests passed.
- Library, unit/integration projects, and repository benchmark project built in Release.
- Documentation production build passed; generated hosted-services page contains the new contract.
- `/simplify` completed; cached state reduced to one integer, with no changes to successful produce/consume paths.

## Performance evidence

Baseline `71020dd9a885588ff2e89ecf450fe168cf40f230` → candidate `6b01d16900088076994b3c78e4572fb239ac1b53`. Saved before/after DLLs, identical runtime-parameter benchmark, serial runs after local builds/tests completed. BenchmarkDotNet 0.15.8, .NET 10.0.11 / SDK 10.0.400, Windows 11, i7-12700K; in-process toolchain, 5 warmups, 15 measured iterations, MemoryDiagnoser. No paid stress dispatch.

| Attempt | Jitter | Before mean ± error (ns) | After mean ± error (ns) | Mean delta (ns) | Allocated before → after |
|---|---|---:|---:|---:|---:|
| 2 | false | 0.6198 ± 0.4300 | 0.1970 ± 0.0929 | -0.4228 | 0 B → 0 B |
| 2 | true | 4.0191 ± 0.2100 | 4.3243 ± 0.2677 | +0.3052 | 0 B → 0 B |
| 6 | false | 0.9281 ± 0.3161 | 0.6029 ± 0.0381 | -0.3252 | 0 B → 0 B |
| 6 | true | 13.5372 ± 0.5953 | 4.3751 ± 0.0654 | -9.1621 | 0 B → 0 B |
| 65 | false | 0.3040 ± 0.1583 | 0.6268 ± 0.0555 | +0.3228 | 0 B → 0 B |
| 65 | true | 3.6920 ± 0.1249 | 4.7245 ± 0.2875 | +1.0325 | 0 B → 0 B |

Attempt 65 changes behavior: the old policy incorrectly jittered a 1-second delay; the fixed policy jitters the 30-second cap. Attempt 6 supplies the equivalent capped-work comparator. Capped jitter improves by about 68%; early jitter confidence intervals overlap. Unjittered sub-nanosecond estimates approach harness-overhead resolution and should not be interpreted as precise percentage gains. Every retry case remains allocation-free.

Earlier runtime-parameter baseline means for attempts 2/65 with jitter false/true were 0.3217/4.3496/0.3602/4.3392 ns, also 0 B. The final early-jitter result agrees with that control. The first arithmetic-only candidate measured 0.5258/4.9838/0.6498/11.7909 ns and was replaced after detecting calculation overhead. Unsigned jitter plus a combined input check measured 0.512/4.440/0.973/4.750/0.803/4.618 ns for attempts 2/6/65, false/true, all 0 B; the final cached threshold removes its extra unjittered work. An initial constant-argument harness was superseded because constant folding limited its usefulness.

Construction allocation was measured separately over 1,024 retained policies: 40 B → 48 B per policy instance for the cached threshold and object padding. This is one-time configuration memory, not allocation per retry or message. These measurements cover retry-policy CPU time and allocations; they do not claim broker throughput or p99 latency improvements. No successful-message path changed.

Reproduce the maintained benchmark with `dotnet run --project tools/Dekaf.Benchmarks -c Release -- --filter '*ExponentialBackoffRetryPolicyBenchmarks*' --inProcess --warmupCount 5 --iterationCount 15` against saved baseline/candidate libraries.

Closes #3051