### PR TITLE
fix(testing): invoke delivery callbacks once when handlers throw

### DIFF
--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -251,14 +251,33 @@ public sealed class InMemoryProducer<TKey, TValue> :
     {
         ArgumentNullException.ThrowIfNull(deliveryHandler);
 
+        RecordMetadata metadata;
         try
         {
-            var metadata = await ProduceAsync(message).ConfigureAwait(false);
-            deliveryHandler(metadata, null);
+            metadata = await ProduceAsync(message).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            deliveryHandler(default, ex);
+            InvokeDeliveryHandler(deliveryHandler, default, ex);
+            return;
+        }
+
+        InvokeDeliveryHandler(deliveryHandler, metadata, null);
+    }
+
+    private static void InvokeDeliveryHandler(
+        Action<RecordMetadata, Exception?> deliveryHandler,
+        RecordMetadata metadata,
+        Exception? deliveryError)
+    {
+        try
+        {
+            deliveryHandler(metadata, deliveryError);
+        }
+        catch
+        {
+            // Match the production producer: callback exceptions do not change delivery
+            // outcomes or escape to the sender. Handlers own their exception handling.
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryDeliveryCallbackTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryDeliveryCallbackTests.cs
@@ -1,0 +1,158 @@
+using System.Buffers;
+using System.Text;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+using Dekaf.Testing;
+
+namespace Dekaf.Tests.Unit.Testing;
+
+public sealed class InMemoryDeliveryCallbackTests
+{
+    [Test]
+    [Arguments(false, false, false)]
+    [Arguments(false, false, true)]
+    [Arguments(false, true, false)]
+    [Arguments(false, true, true)]
+    [Arguments(true, false, false)]
+    [Arguments(true, false, true)]
+    [Arguments(true, true, false)]
+    [Arguments(true, true, true)]
+    public async Task ThrowingCallback_IsInvokedOnceAndDoesNotChangeDelivery(
+        bool topicWrapper, bool deliveryFails, bool suspended)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events");
+        var deliveryFailure = new InvalidOperationException("delivery failure");
+        var callbackFailure = new InvalidOperationException("callback failure");
+        var serializer = new PausedSerializer(deliveryFails ? deliveryFailure : null);
+        await using var producer = suspended
+            ? new InMemoryProducer<string, string>(cluster, Serializers.String, serializer)
+            : new InMemoryProducer<string, string>(cluster);
+        if (deliveryFails && !suspended)
+            cluster.FailProduces("events", deliveryFailure);
+
+        var invocations = 0;
+        RecordMetadata observedMetadata = default;
+        Exception? observedError = null;
+        void Handler(RecordMetadata metadata, Exception? error)
+        {
+            invocations++;
+            observedMetadata = metadata;
+            observedError = error;
+            if (invocations == 1)
+                throw callbackFailure;
+        }
+
+        var pending = Send(producer, topicWrapper, Handler);
+        if (suspended)
+        {
+            try
+            {
+                await serializer.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+                await Assert.That(pending.IsCompleted).IsFalse();
+                await Assert.That(invocations).IsEqualTo(0);
+                await Assert.That(cluster.ReadRecords("events")).Count().IsEqualTo(0);
+            }
+            finally
+            {
+                serializer.Release.TrySetResult();
+            }
+        }
+
+        Exception? escaped = null;
+        try
+        {
+            await pending;
+        }
+        catch (Exception exception)
+        {
+            escaped = exception;
+        }
+
+        await Assert.That(invocations).IsEqualTo(1);
+        await Assert.That(cluster.ReadRecords("events")).Count().IsEqualTo(deliveryFails ? 0 : 1);
+        await Assert.That(escaped).IsNull();
+        if (deliveryFails)
+        {
+            await Assert.That(observedError).IsSameReferenceAs(deliveryFailure);
+            await Assert.That(observedMetadata).IsEqualTo(default(RecordMetadata));
+        }
+        else
+        {
+            await Assert.That(observedError).IsNull();
+            await Assert.That(observedMetadata.Topic).IsEqualTo("events");
+            await Assert.That(observedMetadata.Offset).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    [Arguments(false, false)]
+    [Arguments(false, true)]
+    [Arguments(true, false)]
+    [Arguments(true, true)]
+    public async Task NonthrowingCallback_ReceivesOriginalDeliveryOutcome(bool topicWrapper, bool deliveryFails)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events");
+        await using var producer = new InMemoryProducer<string, string>(cluster);
+        var failure = new InvalidOperationException("delivery failure");
+        if (deliveryFails)
+            cluster.FailProduces("events", failure);
+
+        var invocations = 0;
+        Exception? observedError = null;
+        await Send(producer, topicWrapper, (_, error) =>
+        {
+            invocations++;
+            observedError = error;
+        });
+
+        await Assert.That(invocations).IsEqualTo(1);
+        await Assert.That(observedError).IsSameReferenceAs(deliveryFails ? failure : null);
+        await Assert.That(cluster.ReadRecords("events")).Count().IsEqualTo(deliveryFails ? 0 : 1);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task NullHandler_IsRejectedBeforeDelivery(bool topicWrapper)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events");
+        await using var producer = new InMemoryProducer<string, string>(cluster);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => Send(producer, topicWrapper, null!).AsTask());
+
+        await Assert.That(exception!.ParamName).IsEqualTo("deliveryHandler");
+        await Assert.That(cluster.ReadRecords("events")).Count().IsEqualTo(0);
+    }
+
+    private static ValueTask Send(
+        InMemoryProducer<string, string> producer,
+        bool topicWrapper,
+        Action<RecordMetadata, Exception?> handler) => topicWrapper
+        ? producer.ForTopic("events").FireAsync("key", "value", handler)
+        : producer.FireAsync(new ProducerMessage<string, string>
+        {
+            Topic = "events", Key = "key", Value = "value"
+        }, handler);
+
+    private sealed class PausedSerializer(Exception? failure) : IAsyncSerializer<string>
+    {
+        public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async ValueTask SerializeAsync(
+            string value,
+            IBufferWriter<byte> destination,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            Entered.TrySetResult();
+            await Release.Task.WaitAsync(cancellationToken);
+            if (failure is not null)
+                throw failure;
+            destination.Write(Encoding.UTF8.GetBytes(value));
+        }
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryDeliveryCallbackBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/InMemoryDeliveryCallbackBenchmarks.cs
@@ -1,0 +1,49 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Producer;
+using Dekaf.Testing;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+public class InMemoryDeliveryCallbackBenchmarks
+{
+    private const int BatchSize = 1024;
+    private readonly InMemoryKafkaCluster _cluster = new();
+    private readonly ProducerMessage<string, string> _message = new()
+    {
+        Topic = "callbacks", Key = "key", Value = "value"
+    };
+    private InMemoryProducer<string, string> _producer = null!;
+    private Action<RecordMetadata, Exception?> _handler = null!;
+    private long _lastOffset;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _cluster.CreateTopic(_message.Topic);
+        _producer = new InMemoryProducer<string, string>(_cluster);
+        _handler = ObserveDelivery;
+    }
+
+    [Benchmark(OperationsPerInvoke = BatchSize)]
+    public long DeliverBatch()
+    {
+        for (var i = 0; i < BatchSize; i++)
+            _producer.FireAsync(_message, _handler).GetAwaiter().GetResult();
+
+        // Bound retained simulator records. Reset cost is amortized over the batch.
+        _cluster.DeleteTopic(_message.Topic);
+        _cluster.CreateTopic(_message.Topic);
+        return _lastOffset;
+    }
+
+    private void ObserveDelivery(RecordMetadata metadata, Exception? error)
+    {
+        if (error is not null)
+            throw error;
+        _lastOffset = metadata.Offset;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _producer.DisposeAsync().GetAwaiter().GetResult();
+}


### PR DESCRIPTION
A throwing success callback made `InMemoryProducer.FireAsync` invoke the handler again with a false delivery failure. A throwing failure callback escaped to the caller. Delivery errors now route to one guarded handler invocation, and handler exceptions are suppressed for both outcomes, matching the production producer. Topic-producer wrappers inherit the fix; null-handler validation is unchanged.

Fourteen deterministic cases cover throwing and nonthrowing handlers, direct/topic wrappers, successful/failed delivery, and genuinely suspended serialization. They assert invocation count and stored-record count; success callback exceptions cannot become synthetic delivery failures.

Validation:
- Eight throwing-callback cases reproduced the bug before the fix; six normal-callback/null-handler controls already passed.
- Final full in-memory namespace: 385 tests passed on each of .NET 10 and .NET 8.
- Two real Kafka 4.3.1 callback tests passed for direct and topic producers.
- Release builds of unit/integration and benchmark projects passed with zero warnings/errors; `/simplify` and diff checks complete.

Performance: baseline `0a25915dca5ed05e7528ad28aeedccd179482c20` → candidate `0cf627b9229896abe5f8ba1894190b352227b8e8`. BenchmarkDotNet 0.15.8, Windows 11/i7-12700K, .NET 10.0.11 / SDK 10.0.400, in-process, five warmups/15 iterations, MemoryDiagnoser. Saved baseline/candidate DLLs were measured sequentially after builds/tests stopped. Each invocation sends 1,024 records and recreates the topic to bound retained simulator storage; reset cost is included and amortized.

| Per simulated message | Before | After | Delta |
|---|---:|---:|---:|
| Mean | 202.0 ns | 197.4 ns | -4.6 ns (-2.3%) |
| Error | 14.26 ns | 12.02 ns | — |
| StdDev | 12.64 ns | 10.04 ns | — |
| Allocated | 785 B | 785 B | 0 B |

Timing confidence intervals overlap: no speedup claim, no measured regression. The 785 B is existing simulator serialization/owned-record storage plus amortized reset cost; callback isolation adds no allocation. This does not claim zero allocation for the in-memory storage implementation or change the core Kafka producer hot path.

An initial implementation retained metadata/error locals across `await`, increasing the compiler-generated async state from 104 B to 160 B. It was rejected. The final shared guarded helper keeps the state at 104 B with the same fields as baseline, avoiding that additional allocation on suspended deliveries. No paid stress run; broker throughput, latency percentiles, and CPU/message were not remeasured because runtime changes are confined to the test double.

Maintained benchmark: `dotnet run --project tools/Dekaf.Benchmarks -c Release -- --filter '*InMemoryDeliveryCallbackBenchmarks*' --inProcess --warmupCount 5 --iterationCount 15`.

Closes #3052