### PR TITLE
fix(oauth): coordinate concurrent custom token refreshes

### DIFF
--- a/docs/docs/security/oauth.md
+++ b/docs/docs/security/oauth.md
@@ -212,6 +212,18 @@ var producer = await Kafka.CreateProducer<string, string>()
 
 Dekaf automatically refreshes tokens before they expire. The token provider is called whenever a new token is needed.
 
+Each `OAuthBearerAuthenticator` serializes its token refreshes. Concurrent callers
+wait for the active refresh, then reuse its cached token if it remains outside the
+60-second refresh buffer. This also applies to a shared Schema Registry client
+configured with a custom token provider. Separate authenticators do not share this
+gate, so a provider shared across clients must support concurrent calls.
+
+Cancelling a waiting caller stops only that caller's wait. The caller performing
+the refresh passes its token to the provider. If that refresh fails or is cancelled,
+the gate is released and another caller can retry; the failure is not cached.
+Providers must honor cancellation to bound their active work. Tokens returned
+inside the refresh buffer can trigger another refresh on the next call.
+
 ```csharp
 .WithOAuthBearer(async ct =>
 {

--- a/src/Dekaf/Security/Sasl/OAuthBearerAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerAuthenticator.cs
@@ -12,6 +12,8 @@ public sealed class OAuthBearerAuthenticator : ISaslAuthenticator
     private readonly Func<CancellationToken, ValueTask<OAuthBearerToken>> _tokenProvider;
     private readonly object _tokenLock = new();
     private OAuthBearerToken? _currentToken;
+    private bool _refreshInProgress;
+    private TaskCompletionSource<bool>? _refreshWaiters;
     private bool _complete;
 
     /// <summary>
@@ -43,24 +45,93 @@ public sealed class OAuthBearerAuthenticator : ISaslAuthenticator
     /// <summary>
     /// Gets the current token, fetching a new one if needed.
     /// </summary>
-    public async ValueTask<OAuthBearerToken> GetTokenAsync(CancellationToken cancellationToken = default)
+    /// <remarks>
+    /// Refreshes are serialized per authenticator. Waiting callers recheck the cache after
+    /// the active refresh completes. Cancelling a waiter does not cancel the active provider;
+    /// the caller performing the refresh supplies its cancellation token to the provider.
+    /// A failed or cancelled refresh releases waiting callers to retry with their own tokens.
+    /// </remarks>
+    public ValueTask<OAuthBearerToken> GetTokenAsync(CancellationToken cancellationToken = default)
     {
-        OAuthBearerToken? cachedToken;
+        var cachedToken = Volatile.Read(ref _currentToken);
+        return cachedToken is not null && !cachedToken.IsExpired(bufferSeconds: 60)
+            ? new ValueTask<OAuthBearerToken>(cachedToken)
+            : RefreshTokenAsync(cachedToken, cancellationToken);
+    }
+
+    private ValueTask<OAuthBearerToken> RefreshTokenAsync(OAuthBearerToken? observedToken, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            return new ValueTask<OAuthBearerToken>(Task.FromCanceled<OAuthBearerToken>(cancellationToken));
+
+        Task? refreshCompleted = null;
         lock (_tokenLock)
         {
-            cachedToken = _currentToken;
+            var cachedToken = _currentToken;
+            // Only a replacement token can invalidate the caller's expired-cache observation.
+            if (!ReferenceEquals(cachedToken, observedToken) && cachedToken is not null && !cachedToken.IsExpired(bufferSeconds: 60))
+                return new ValueTask<OAuthBearerToken>(cachedToken);
+
+            if (_refreshInProgress)
+                refreshCompleted = (_refreshWaiters ??= new(TaskCreationOptions.RunContinuationsAsynchronously)).Task;
+            else
+                _refreshInProgress = true;
         }
 
-        if (cachedToken is null || cachedToken.IsExpired(bufferSeconds: 60))
+        if (refreshCompleted is not null)
+            return WaitForRefreshAsync(refreshCompleted, cancellationToken);
+
+        // Invoke user code outside the lock; only genuinely overlapping callers need a signal.
+        try
         {
-            var newToken = await _tokenProvider(cancellationToken).ConfigureAwait(false);
-            lock (_tokenLock)
+            var pendingToken = _tokenProvider(cancellationToken);
+            if (pendingToken.IsCompletedSuccessfully)
             {
-                _currentToken = newToken;
-                cachedToken = newToken;
+                var token = pendingToken.GetAwaiter().GetResult();
+                CompleteRefresh(token);
+                return new ValueTask<OAuthBearerToken>(token);
             }
+            return AwaitTokenAsync(pendingToken);
         }
-        return cachedToken;
+        catch (Exception exception)
+        {
+            // Await preserves cancellation semantics for a provider that throws synchronously.
+            return AwaitTokenAsync(new ValueTask<OAuthBearerToken>(Task.FromException<OAuthBearerToken>(exception)));
+        }
+    }
+
+    private async ValueTask<OAuthBearerToken> AwaitTokenAsync(ValueTask<OAuthBearerToken> pendingToken)
+    {
+        OAuthBearerToken? token = null;
+        try
+        {
+            token = await pendingToken.ConfigureAwait(false);
+            return token;
+        }
+        finally
+        {
+            CompleteRefresh(token);
+        }
+    }
+
+    private async ValueTask<OAuthBearerToken> WaitForRefreshAsync(Task refreshCompleted, CancellationToken cancellationToken)
+    {
+        await refreshCompleted.WaitAsync(cancellationToken).ConfigureAwait(false);
+        return await GetTokenAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private void CompleteRefresh(OAuthBearerToken? token)
+    {
+        TaskCompletionSource<bool>? waiters;
+        lock (_tokenLock)
+        {
+            if (token is not null)
+                Volatile.Write(ref _currentToken, token);
+            _refreshInProgress = false;
+            waiters = _refreshWaiters;
+            _refreshWaiters = null;
+        }
+        waiters?.TrySetResult(true);
     }
 
     /// <inheritdoc />

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryOAuthConcurrencyIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryOAuthConcurrencyIntegrationTests.cs
@@ -1,0 +1,56 @@
+using System.Collections.Concurrent;
+using Dekaf.SchemaRegistry;
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Tests.Integration;
+
+[ClassDataSource<KafkaWithSchemaRegistryContainer>(Shared = SharedType.PerTestSession)]
+public sealed class SchemaRegistryOAuthConcurrencyIntegrationTests(KafkaWithSchemaRegistryContainer testInfra)
+{
+    [Test]
+    public async Task ConcurrentRegistryRequests_ShareOneCustomTokenRefresh()
+    {
+        var response = new TaskCompletionSource<OAuthBearerToken>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var providerCalls = 0;
+        using var handler = new AuthorizationCaptureHandler(new SocketsHttpHandler());
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = testInfra.RegistryUrl,
+            OAuthBearerTokenProvider = cancellationToken =>
+            {
+                Interlocked.Increment(ref providerCalls);
+                return new ValueTask<OAuthBearerToken>(response.Task.WaitAsync(cancellationToken));
+            }
+        }, handler);
+        var requests = new Task[16];
+        for (var index = 0; index < requests.Length; index++)
+            requests[index] = client.GetAllSubjectsAsync();
+        var callsBeforeCompletion = Volatile.Read(ref providerCalls);
+        var sentBeforeCompletion = handler.Tokens.Count;
+        response.SetResult(new OAuthBearerToken
+        {
+            TokenValue = "shared-custom-token",
+            PrincipalName = "integration-test",
+            Expiration = DateTimeOffset.UtcNow.AddHours(1)
+        });
+        await Task.WhenAll(requests).WaitAsync(TimeSpan.FromSeconds(30));
+
+        await Assert.That(callsBeforeCompletion).IsEqualTo(1);
+        await Assert.That(providerCalls).IsEqualTo(1);
+        await Assert.That(sentBeforeCompletion).IsEqualTo(0);
+        await Assert.That(handler.Tokens.Count).IsEqualTo(requests.Length);
+        foreach (var token in handler.Tokens)
+            await Assert.That(token).IsEqualTo("Bearer shared-custom-token");
+    }
+
+    private sealed class AuthorizationCaptureHandler(HttpMessageHandler innerHandler) : DelegatingHandler(innerHandler)
+    {
+        internal ConcurrentBag<string?> Tokens { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Tokens.Add(request.Headers.Authorization?.ToString());
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerRefreshConcurrencyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerRefreshConcurrencyTests.cs
@@ -1,0 +1,181 @@
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Tests.Unit.Security.Sasl;
+
+public sealed class OAuthBearerRefreshConcurrencyTests
+{
+    [Test]
+    public async Task ConcurrentMisses_DoNotStartOutOfOrderRefreshes()
+    {
+        var firstResponse = new TaskCompletionSource<OAuthBearerToken>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondResponse = new TaskCompletionSource<OAuthBearerToken>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var authenticator = new OAuthBearerAuthenticator(_ => new ValueTask<OAuthBearerToken>(
+            Interlocked.Increment(ref calls) == 1 ? firstResponse.Task : secondResponse.Task));
+        var first = authenticator.GetTokenAsync().AsTask();
+        var second = authenticator.GetTokenAsync().AsTask();
+        var callsBeforeCompletion = Volatile.Read(ref calls);
+        var older = Token("older", 120);
+        var newer = Token("newer", 3600);
+
+        // Reproduce reverse completion without allowing an uncompleted task to escape on failure.
+        secondResponse.SetResult(newer);
+        firstResponse.SetResult(older);
+        var results = await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(10));
+
+        await Assert.That(callsBeforeCompletion).IsEqualTo(1);
+        await Assert.That(calls).IsEqualTo(1);
+        await Assert.That(results[0]).IsSameReferenceAs(older);
+        await Assert.That(results[1]).IsSameReferenceAs(older);
+        await Assert.That(await authenticator.GetTokenAsync()).IsSameReferenceAs(older);
+    }
+
+    [Test]
+    public async Task FailedRefresh_ReleasesWaitingCallerToRetry()
+    {
+        var response = new TaskCompletionSource<OAuthBearerToken>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var recovered = Token("recovered");
+        var authenticator = new OAuthBearerAuthenticator(_ => Interlocked.Increment(ref calls) == 1
+            ? new ValueTask<OAuthBearerToken>(response.Task) : ValueTask.FromResult(recovered));
+        var first = authenticator.GetTokenAsync().AsTask();
+        var waiter = authenticator.GetTokenAsync().AsTask();
+        var waiterWasPending = !waiter.IsCompleted;
+        var failure = new InvalidOperationException("refresh failed");
+        response.SetException(failure);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => first.WaitAsync(TimeSpan.FromSeconds(10)));
+        var result = await waiter.WaitAsync(TimeSpan.FromSeconds(10));
+        await Assert.That(waiterWasPending).IsTrue();
+        await Assert.That(actual).IsSameReferenceAs(failure);
+        await Assert.That(result).IsSameReferenceAs(recovered);
+        await Assert.That(calls).IsEqualTo(2);
+        await Assert.That(await authenticator.GetTokenAsync()).IsSameReferenceAs(recovered);
+    }
+
+    [Test]
+    public async Task CancelledWaiter_DoesNotCancelActiveProvider()
+    {
+        var response = new TaskCompletionSource<OAuthBearerToken>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        CancellationToken activeToken = default;
+        var authenticator = new OAuthBearerAuthenticator(token =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+                activeToken = token;
+            return new ValueTask<OAuthBearerToken>(response.Task.WaitAsync(token));
+        });
+        var first = authenticator.GetTokenAsync().AsTask();
+        using var cancellation = new CancellationTokenSource();
+        var waiter = authenticator.GetTokenAsync(cancellation.Token).AsTask();
+        cancellation.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => waiter.WaitAsync(TimeSpan.FromSeconds(10)));
+        var token = Token("success");
+        response.SetResult(token);
+        var result = await first.WaitAsync(TimeSpan.FromSeconds(10));
+
+        await Assert.That(activeToken.IsCancellationRequested).IsFalse();
+        await Assert.That(calls).IsEqualTo(1);
+        await Assert.That(result).IsSameReferenceAs(token);
+        await Assert.That(await authenticator.GetTokenAsync()).IsSameReferenceAs(token);
+    }
+
+    [Test]
+    public async Task CancelledActiveRefresh_ReleasesWaitingCallerToRetry()
+    {
+        var response = new TaskCompletionSource<OAuthBearerToken>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var recovered = Token("recovered");
+        var authenticator = new OAuthBearerAuthenticator(token => Interlocked.Increment(ref calls) == 1
+            ? new ValueTask<OAuthBearerToken>(response.Task.WaitAsync(token)) : ValueTask.FromResult(recovered));
+        using var cancellation = new CancellationTokenSource();
+        var first = authenticator.GetTokenAsync(cancellation.Token).AsTask();
+        var waiter = authenticator.GetTokenAsync().AsTask();
+        var waiterWasPending = !waiter.IsCompleted;
+        cancellation.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => first.WaitAsync(TimeSpan.FromSeconds(10)));
+        var result = await waiter.WaitAsync(TimeSpan.FromSeconds(10));
+
+        await Assert.That(waiterWasPending).IsTrue();
+        await Assert.That(result).IsSameReferenceAs(recovered);
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task SynchronousProviderFailure_AllowsNextRefresh()
+    {
+        var calls = 0;
+        var token = Token("recovered");
+        var authenticator = new OAuthBearerAuthenticator(_ => ++calls == 1
+            ? throw new InvalidOperationException("refresh failed") : ValueTask.FromResult(token));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => authenticator.GetTokenAsync().AsTask());
+        await Assert.That(await authenticator.GetTokenAsync()).IsSameReferenceAs(token);
+    }
+
+    [Test]
+    public async Task TokensInsideRefreshBuffer_SerializeEveryWaitingRefresh()
+    {
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var active = 0;
+        var overlapping = 0;
+        var token = Token("short-lived", 30);
+        var authenticator = new OAuthBearerAuthenticator(async _ =>
+        {
+            Interlocked.Increment(ref calls);
+            if (Interlocked.Increment(ref active) != 1)
+                Interlocked.Increment(ref overlapping);
+            try
+            {
+                await release.Task;
+                return token;
+            }
+            finally
+            {
+                Interlocked.Decrement(ref active);
+            }
+        });
+        var requests = new Task<OAuthBearerToken>[32];
+        for (var index = 0; index < requests.Length; index++)
+            requests[index] = authenticator.GetTokenAsync().AsTask();
+        release.SetResult();
+        await Task.WhenAll(requests).WaitAsync(TimeSpan.FromSeconds(10));
+
+        await Assert.That(calls).IsEqualTo(requests.Length);
+        await Assert.That(overlapping).IsEqualTo(0);
+        await Assert.That(active).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SynchronousProviderCancellation_ReleasesGateAndReturnsCancelledTask()
+    {
+        var calls = 0;
+        var token = Token("recovered");
+        var authenticator = new OAuthBearerAuthenticator(_ => ++calls == 1
+            ? throw new OperationCanceledException() : ValueTask.FromResult(token));
+        var cancelled = authenticator.GetTokenAsync().AsTask();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => cancelled);
+        await Assert.That(cancelled.IsCanceled).IsTrue();
+        await Assert.That(await authenticator.GetTokenAsync()).IsSameReferenceAs(token);
+    }
+
+    [Test]
+    public async Task CachedToken_CompletesSynchronouslyWithoutCallingProvider()
+    {
+        var calls = 0;
+        var token = Token("cached");
+        var authenticator = new OAuthBearerAuthenticator(_ => { calls++; return ValueTask.FromResult(token); });
+        await authenticator.GetTokenAsync();
+        var cached = authenticator.GetTokenAsync();
+        await Assert.That(cached.IsCompletedSuccessfully).IsTrue();
+        await Assert.That(await cached).IsSameReferenceAs(token);
+        await Assert.That(calls).IsEqualTo(1);
+    }
+
+    private static OAuthBearerToken Token(string value, int lifetimeSeconds = 3600) => new()
+    {
+        TokenValue = value,
+        PrincipalName = "test-user",
+        Expiration = DateTimeOffset.UtcNow.AddSeconds(lifetimeSeconds)
+    };
+}

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerRefreshConcurrencyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerRefreshConcurrencyTests.cs
@@ -18,7 +18,9 @@ public sealed class OAuthBearerRefreshConcurrencyTests
         var older = Token("older", 120);
         var newer = Token("newer", 3600);
 
-        // Reproduce reverse completion without allowing an uncompleted task to escape on failure.
+        // Before the fix both provider calls start, so these responses reproduce reverse completion.
+        // With serialized refreshes the second response is intentionally unused: preventing that
+        // second invocation is the regression assertion. Complete both sources for either outcome.
         secondResponse.SetResult(newer);
         firstResponse.SetResult(older);
         var results = await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(10));

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/OAuthBearerRefreshBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/OAuthBearerRefreshBenchmarks.cs
@@ -1,0 +1,40 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Token-cache reads and synchronous refresh coordination, without identity-service I/O.</summary>
+[MemoryDiagnoser]
+public class OAuthBearerRefreshBenchmarks
+{
+    private static readonly OAuthBearerToken ValidToken = new()
+    {
+        TokenValue = "cached-token",
+        PrincipalName = "benchmark",
+        Expiration = DateTimeOffset.MaxValue
+    };
+
+    private static readonly OAuthBearerToken RefreshRequiredToken = new()
+    {
+        TokenValue = "refresh-token",
+        PrincipalName = "benchmark",
+        Expiration = DateTimeOffset.MinValue
+    };
+
+    private OAuthBearerAuthenticator _cached = null!;
+    private OAuthBearerAuthenticator _refresh = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _cached = new OAuthBearerAuthenticator(ValidToken);
+        _refresh = new OAuthBearerAuthenticator(static _ => ValueTask.FromResult(RefreshRequiredToken));
+        _refresh.GetTokenAsync().GetAwaiter().GetResult();
+    }
+
+    [Benchmark]
+    public ValueTask<OAuthBearerToken> CachedToken() => _cached.GetTokenAsync();
+
+    [Benchmark]
+    public ValueTask<OAuthBearerToken> SynchronousRefresh() => _refresh.GetTokenAsync();
+}


### PR DESCRIPTION
Concurrent cache misses could invoke a custom OAuth token provider independently, allowing an older response to overwrite a newer cached token. Refreshes now serialize per OAuthBearerAuthenticator. Waiting callers recheck the cache; cancelling a waiter leaves the active provider alone, while a failed or cancelled active refresh releases waiting callers to retry.

Cached reads use volatile publication and a synchronous ValueTask return. Provider code runs outside the coordination lock. Uncontended synchronous refreshes allocate no task or gate; a shared completion signal is allocated only for overlapping refresh callers. The existing 60-second cache refresh buffer remains unchanged. Documentation distinguishes per-authenticator coordination from providers shared across independent clients.

Validation:
- Four deterministic concurrency regressions failed before the fix. Eight final concurrency cases cover reverse provider completion, failed refresh recovery, active/waiter cancellation, synchronous throw/cancellation, cached synchronous completion, and 32 overlapping calls requiring successive refreshes.
- Security suites passed on net10.0 (190 cases) and net8.0 (187 cases), followed by the final 16 concurrency/Schema Registry authentication cases on each runtime after adding the 32-caller case.
- Seven Docker-backed integration cases passed on the final implementation: six Kafka OAUTHBEARER authentication cases plus a shared Schema Registry client making 16 concurrent requests with exactly one custom-provider invocation and consistent Authorization headers.
- Release unit/integration/benchmark builds passed with zero warnings/errors; core netstandard2.0 compiled through net8.0 tests. Docs production build, /simplify, and git diff --check passed.

Before/after performance, exact baseline `0a25915dca5ed05e7528ad28aeedccd179482c20` → candidate `06db8fc09d76b05cc233f34b78e9d2472f067d7e`:

| Benchmark | Before mean ± error | After mean ± error | Mean delta | Allocated before → after |
| --- | ---: | ---: | ---: | ---: |
| CachedToken | 42.67 ± 0.640 ns | 22.92 ± 0.983 ns | -46.3% | 0 B → 0 B |
| SynchronousRefresh | 59.24 ± 0.463 ns | 53.85 ± 1.131 ns | -9.1% | 0 B → 0 B |

BenchmarkDotNet 0.15.8 MemoryDiagnoser, .NET SDK 10.0.400/runtime 10.0.11, Windows 11/i7-12700K; identical committed harness using saved baseline versus candidate DLLs, in-process, 5 warmups/12 iterations. Standard deviations: 0.500/0.361 ns before, 0.711/0.883 ns after. Loaded candidate DLL SHA256 matches product output. The synchronous-refresh case uses a prebuilt expired token to force the refresh path without identity-service I/O; setup excludes one-time initialization. The first semaphore implementation was rejected (136.82 ns synchronous refresh). Final coordination uses no semaphore and retains 0 B for both measured paths. Contended refreshes allocate an occasional completion signal/async wait state; no allocation is added per message or cached request. This is authentication coordination, not a producer/consumer message path; these microbenchmarks do not establish broker throughput, p99/max latency, or CPU per message. No paid stress workflow dispatched.

Closes #3060
