### PR TITLE
refactor(oauth): clarify custom token cache ownership

### DIFF
--- a/src/Dekaf.SchemaRegistry/SchemaRegistryAuthenticationHandler.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryAuthenticationHandler.cs
@@ -7,7 +7,7 @@ namespace Dekaf.SchemaRegistry;
 internal sealed class SchemaRegistryAuthenticationHandler : DelegatingHandler
 {
     private readonly AuthenticationHeaderValue? _staticAuthorization;
-    private readonly OAuthBearerAuthenticator? _oauthAuthenticator;
+    private readonly OAuthBearerAuthenticator? _customTokenAuthenticator;
     private readonly Func<CancellationToken, ValueTask<OAuthBearerToken>>? _configuredTokenProvider;
     private readonly OAuthBearerTokenProvider? _ownedTokenProvider;
 
@@ -19,7 +19,7 @@ internal sealed class SchemaRegistryAuthenticationHandler : DelegatingHandler
     {
         if (config.OAuthBearerTokenProvider is not null)
         {
-            _oauthAuthenticator = new OAuthBearerAuthenticator(config.OAuthBearerTokenProvider);
+            _customTokenAuthenticator = new OAuthBearerAuthenticator(config.OAuthBearerTokenProvider);
         }
         else if (!string.IsNullOrEmpty(config.BearerAuthToken))
         {
@@ -50,10 +50,10 @@ internal sealed class SchemaRegistryAuthenticationHandler : DelegatingHandler
         HttpRequestMessage request,
         CancellationToken cancellationToken)
     {
-        if (_oauthAuthenticator is not null || _configuredTokenProvider is not null)
+        if (_customTokenAuthenticator is not null || _configuredTokenProvider is not null)
         {
-            var token = _oauthAuthenticator is not null
-                ? _oauthAuthenticator.GetTokenAsync(cancellationToken)
+            var token = _customTokenAuthenticator is not null
+                ? _customTokenAuthenticator.GetTokenAsync(cancellationToken)
                 : _configuredTokenProvider!(cancellationToken);
             if (!token.IsCompletedSuccessfully)
                 return SendWithTokenAsync(request, token, cancellationToken);


### PR DESCRIPTION
The schema registry handler now names its custom-delegate cache `_customTokenAuthenticator`, making its ownership distinct from `_configuredTokenProvider`. This addresses the naming suggestion on #3067; that PR merged while the cleanup was being validated.

Only a private field and its five references change. No public API or control flow changes. The cherry-pick onto main is unchanged, and the relevant source/test trees match the tested parent.

Validation completed on the identical change (ae07ef85d154bceff648c531181bd958c00255f1 → 7098d75daf295b9a643430a007df5b84295f8bfb):
- Release build: zero warnings/errors; 18 authentication tests passed on each of net8.0 and net10.0.
- All 3,135 net8.0 and 3,128 net10.0 method bodies retain identical IL bytes, maximum stack, and local initialization flags.
- `/simplify` and `git diff --check` passed.

BenchmarkDotNet 0.15.8, MemoryDiagnoser, .NET 10.0.11 / SDK 10.0.400, Windows 11, i7-12700K, in-process, five warmups and 15 iterations; cached HTTP authentication fixture with preallocated request/response:

| Cached token source | Before mean ± error (SD), ns | After mean ± error (SD), ns | Delta | Allocated before → after |
| --- | --- | --- | --- | --- |
| Configured | 50.89 ± 0.267 (0.237) | 51.80 ± 0.562 (0.498) | +0.91 ns / +1.8% | 32 B → 32 B |
| Custom delegate | 69.50 ± 1.226 (1.024) | 69.89 ± 1.653 (1.546) | +0.39 ns / +0.6% | 32 B → 32 B |

This metadata-only rename makes no speed claim; method IL is identical. The 32 B is the existing per-HTTP authorization header, not per-message allocation. Both measurements remain below the original pre-feature baseline (77.09 / 77.72 ns and 104 B). Candidate measured assembly SHA-256: DA362BA032DC6B08B03A5D11D0CABCEDC14271D6DE072462BC4ECF27982619B9. Reports are under the original worktree `.artifacts/bench-rename`. No paid stress run or network throughput/CPU/stability measurement was performed for this field rename.
