### PR TITLE
Update TUnit and wait for schema-store readiness

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,8 +66,8 @@
     <PackageVersion Include="Testcontainers.Kafka" Version="4.14.0" />
     <PackageVersion Include="Testcontainers.Toxiproxy" Version="4.14.0" />
     <PackageVersion Include="ToxiproxyNetCore" Version="1.0.50" />
-    <PackageVersion Include="TUnit" Version="1.66.10" />
-    <PackageVersion Include="TUnit.Logging.Microsoft" Version="1.66.10" />
+    <PackageVersion Include="TUnit" Version="1.66.16" />
+    <PackageVersion Include="TUnit.Logging.Microsoft" Version="1.66.16" />
     <PackageVersion Include="Verify.TUnit" Version="32.0.0" />
     <PackageVersion Include="ZstdSharp.Port" Version="0.8.8" />
   </ItemGroup>

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
 using System.Net.Sockets;
+using Dekaf.Admin;
+using Dekaf.Errors;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Networks;
@@ -93,9 +95,10 @@ public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposa
         _bootstrapServers = _kafkaContainer.GetBootstrapAddress();
         Console.WriteLine($"[KafkaWithSchemaRegistry] Kafka started at {_bootstrapServers}");
 
-        // Verify Kafka is accepting connections before starting Schema Registry.
-        // Without this, Schema Registry may fail to connect to Kafka on startup.
-        await WaitForKafkaAsync().ConfigureAwait(false);
+        // Schema Registry can fail its initial Noop write if topic creation has completed
+        // but the _schemas partition is not serving leader requests yet.
+        using var readinessTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await PrepareSchemaStoreAsync(_bootstrapServers, readinessTimeout.Token).ConfigureAwait(false);
 
         Console.WriteLine("[KafkaWithSchemaRegistry] Starting Schema Registry container...");
 
@@ -120,6 +123,43 @@ public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposa
         Console.WriteLine($"[KafkaWithSchemaRegistry] Schema Registry started at {_registryUrl}");
 
         await WaitForServicesAsync().ConfigureAwait(false);
+    }
+
+    internal static async Task PrepareSchemaStoreAsync(string bootstrapServers, CancellationToken cancellationToken)
+    {
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers(bootstrapServers)
+            .Build();
+        await admin.CreateTopicsAsync(
+            [new NewTopic
+            {
+                Name = "_schemas",
+                NumPartitions = 1,
+                ReplicationFactor = 1,
+                Configs = new Dictionary<string, string> { ["cleanup.policy"] = "compact" }
+            }], cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var partition = new TopicPartition("_schemas", 0);
+        TopicPartitionOffsetSpec[] offsets = [new() { TopicPartition = partition, Spec = OffsetSpec.Latest }];
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                // Refresh routing before probing the partition's leader, rather than trusting
+                // TCP readiness or only the controller's CreateTopics acknowledgement.
+                await admin.DescribeTopicsAsync(["_schemas"], cancellationToken).ConfigureAwait(false);
+                var result = await admin.ListOffsetsAsync(offsets, cancellationToken: cancellationToken).ConfigureAwait(false);
+                if (result.TryGetValue(partition, out var offset) && offset.Offset >= 0)
+                    return;
+            }
+            catch (KafkaException exception) when (exception.IsRetriable)
+            {
+                Console.WriteLine($"[KafkaWithSchemaRegistry] Waiting for _schemas leader: {exception.Message}");
+            }
+
+            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     private async Task WaitForKafkaAsync()

--- a/tests/Dekaf.Tests.Integration/SchemaStoreReadinessTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaStoreReadinessTests.cs
@@ -1,0 +1,42 @@
+using Dekaf.Admin;
+using Testcontainers.Kafka;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Serialization")]
+[NotInParallel("SchemaStoreReadiness")]
+public sealed class SchemaStoreReadinessTests
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task PrepareSchemaStore_ProvidesCompactedPartitionBeforeRegistryStartup(bool currentBroker)
+    {
+        var tag = currentBroker ? KafkaContainerDefault.DefaultTag : "4.0.2";
+        await using var kafka = KafkaContainerDefault.ConfigureBuilderForVersion(
+                new KafkaBuilder($"apache/kafka:{tag}")
+                    .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx512m -Xms512m"), tag)
+            .WithCommand(KafkaTestContainer.StartupCommandOverride)
+            .Build();
+        await kafka.StartAsync();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await KafkaWithSchemaRegistryContainer.PrepareSchemaStoreAsync(kafka.GetBootstrapAddress(), timeout.Token);
+
+        // No Schema Registry process has started: the fixture itself must establish this state.
+        await using var admin = Kafka.CreateAdminClient().WithBootstrapServers(kafka.GetBootstrapAddress()).Build();
+        var descriptions = await admin.DescribeTopicsAsync(["_schemas"], timeout.Token);
+        var partitions = descriptions["_schemas"].Partitions;
+        await Assert.That(partitions.Count).IsEqualTo(1);
+        await Assert.That(partitions[0].LeaderId).IsGreaterThanOrEqualTo(0);
+        await Assert.That(partitions[0].IsrNodes.Count).IsEqualTo(1);
+        var resource = ConfigResource.Topic("_schemas");
+        var configs = await admin.DescribeConfigsAsync([resource], cancellationToken: timeout.Token);
+        await Assert.That(configs[resource].Single(config => config.Name == "cleanup.policy").Value).IsEqualTo("compact");
+        var partition = new TopicPartition("_schemas", 0);
+        var offsets = await admin.ListOffsetsAsync(
+            [new TopicPartitionOffsetSpec { TopicPartition = partition, Spec = OffsetSpec.Latest }],
+            cancellationToken: timeout.Token);
+        await Assert.That(offsets[partition].Offset).IsEqualTo(0);
+    }
+}


### PR DESCRIPTION
Update TUnit and TUnit.Logging.Microsoft from 1.66.10 to 1.66.16, and fix the Schema Registry fixture readiness race exposed by the integration run.

The [failed messaging job](https://github.com/thomhurst/Dekaf/actions/runs/34036660222/job/101497122576) had 42 setup failures from one Schema Registry container: its initial Noop write to newly created `_schemas-0` failed with `NotLeaderOrFollowerException` roughly 200 ms after topic creation. TCP readiness plus a fixed two-second sleep did not establish that partition's readiness.

The local fixture now creates `_schemas` with one partition, replication factor 1 and [the required compact cleanup policy](https://docs.confluent.io/platform/current/schema-registry/security/index.html). It refreshes metadata and waits for a successful leader ListOffsets response under a 30-second cancellation deadline before starting Schema Registry. Only retriable Kafka errors continue the readiness probe; other errors remain visible. This does not retry the failed CI job or restart a failed Schema Registry process.

Validation:
- CI's captured setup failure supplies the pre-fix evidence; its timing-dependent process exit is not suitable for a deterministic red rerun.
- Two new broker tests establish the compacted, ready, empty `_schemas` partition before any Schema Registry process starts, covering the fixture's Kafka 4.0.2 and 4.3.1 configurations.
- Full Serialization category: 106/106 passed, including both readiness cases (75.6 seconds).
- Release integration build: zero warnings/errors; `/simplify`; `git diff --check`.

Changes are confined to test dependencies and fixtures; library sources are unchanged, so no product performance benchmark is needed.

