### PR TITLE
fix(schema-registry): invalidate deleted subject caches

### DIFF
--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -461,6 +461,31 @@ var config = new SchemaRegistryConfig
 using var schemaRegistry = new SchemaRegistryClient(config);
 ```
 
+### Deleting and restoring subjects
+
+After `SchemaRegistryClient.DeleteSubjectAsync` receives a successful HTTP response,
+it removes that subject's cached registrations, including both normalization settings,
+and subject-qualified schema lookups, including formatted results. A later
+`RegisterSchemaAsync` reaches the registry again. Re-registering through POST is how
+[Confluent restores a soft-deleted subject](https://docs.confluent.io/platform/current/schema-registry/schema-deletion-guidelines.html#recovering-a-soft-deleted-schema).
+Hard deletion requires soft deletion first.
+
+Earlier in-flight requests may still return their original results to their callers,
+but cannot repopulate the deleted subject's cache entries. Requests and cache entries
+for unrelated subjects remain valid. Tracking lasts only for active requests, including
+cleanup when requests fail or are cancelled. A lookup that explicitly includes deleted
+versions does not populate the active subject lookup cache.
+
+Global integer-ID and GUID caches retain resolved schema definitions, which may be
+shared by other subjects or needed to decode existing records. This also applies after
+hard deletion: a cached definition is not proof that the registry still stores it or
+that a subject is registered. Other client instances and serializer caches are independent.
+
+An unsuccessful HTTP deletion leaves local caches unchanged. Once HTTP success confirms
+deletion, invalidation remains in effect even if reading the response body later fails
+or is cancelled. Concurrent registry operations are not a transaction; coordinate
+deletion and registration in the application when their ordering matters.
+
 ### HTTP pipeline customization
 
 `SchemaRegistryClient` accepts a caller-owned `HttpMessageHandler`, or a handler factory whose

--- a/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
@@ -241,6 +241,14 @@ public interface ISchemaRegistryClient : IDisposable
     /// <param name="permanent">If true, permanently delete (hard delete).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>List of deleted version numbers.</returns>
+    /// <remarks>
+    /// <see cref="SchemaRegistryClient"/> invalidates local registration and subject-qualified
+    /// lookup entries after a successful HTTP deletion response. Earlier in-flight responses
+    /// cannot restore those entries. Unrelated subjects and cached schema definitions identified
+    /// by global ID or GUID are retained; cached definitions do not prove registry membership.
+    /// A failed HTTP deletion leaves caches unchanged. A successful response invalidates caches
+    /// even if its body cannot subsequently be read. Other clients and serializer caches are independent.
+    /// </remarks>
     Task<IReadOnlyList<int>> DeleteSubjectAsync(string subject, bool permanent = false, CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.SubjectCache.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.SubjectCache.cs
@@ -1,0 +1,91 @@
+namespace Dekaf.SchemaRegistry;
+
+public sealed partial class SchemaRegistryClient
+{
+    // Entries exist only while subject HTTP requests are active. Completed requests release
+    // their subject references, so repeated deletion does not accumulate generation tombstones.
+    private readonly Dictionary<string, SubjectCacheRequestState> _subjectCacheRequests = new(StringComparer.Ordinal);
+    private long _nextSubjectCacheGeneration;
+
+    internal int ActiveSubjectCacheRequestCount
+    {
+        get
+        {
+            lock (_cacheLock)
+                return _subjectCacheRequests.Count;
+        }
+    }
+
+    private SubjectCacheRequest BeginSubjectCacheRequest(string subject)
+    {
+        if (_maxCachedSchemas == 0 || subject is null)
+            return default;
+
+        lock (_cacheLock)
+        {
+            if (!_subjectCacheRequests.TryGetValue(subject, out var state))
+                state.Generation = unchecked(++_nextSubjectCacheGeneration);
+            state.Count++;
+            _subjectCacheRequests[subject] = state;
+            return new SubjectCacheRequest(this, subject, state.Generation);
+        }
+    }
+
+    private void EndSubjectCacheRequest(string subject)
+    {
+        lock (_cacheLock)
+        {
+            var state = _subjectCacheRequests[subject];
+            if (--state.Count == 0)
+                _subjectCacheRequests.Remove(subject);
+            else
+                _subjectCacheRequests[subject] = state;
+        }
+    }
+
+    // Called while holding _cacheLock, which also serializes deletion and cache population.
+    private bool IsSubjectCacheRequestCurrent(string subject, long? generation) =>
+        generation is null ||
+        (_subjectCacheRequests.TryGetValue(subject, out var state) && state.Generation == generation.Value);
+
+    private void InvalidateSubjectCaches(string subject)
+    {
+        lock (_cacheLock)
+        {
+            if (_subjectCacheRequests.TryGetValue(subject, out var state))
+            {
+                state.Generation = unchecked(++_nextSubjectCacheGeneration);
+                _subjectCacheRequests[subject] = state;
+            }
+
+            // Subject deletion is a cold operation; cache-hit paths keep their direct
+            // dictionary lookups. Both normalization settings and every format are removed.
+            foreach (var entry in _idBySchemaCache)
+            {
+                if (string.Equals(entry.Key.Subject, subject, StringComparison.Ordinal))
+                    _idBySchemaCache.TryRemove(entry.Key, out _);
+            }
+            foreach (var entry in _schemaBySubjectAndIdCache)
+            {
+                if (string.Equals(entry.Key.Subject, subject, StringComparison.Ordinal))
+                    _schemaBySubjectAndIdCache.TryRemove(entry.Key, out _);
+            }
+
+            // Integer IDs and GUIDs identify schema content shared across subjects.
+            // Retain those cached definitions; they do not prove subject membership.
+        }
+    }
+
+    private struct SubjectCacheRequestState
+    {
+        internal long Generation;
+        internal int Count;
+    }
+
+    private readonly struct SubjectCacheRequest(SchemaRegistryClient? owner, string? subject, long generation) : IDisposable
+    {
+        internal long Generation { get; } = generation;
+
+        public void Dispose() => owner?.EndSubjectCacheRequest(subject!);
+    }
+}

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -16,7 +16,7 @@ namespace Dekaf.SchemaRegistry;
 /// <summary>
 /// HTTP client for Confluent Schema Registry.
 /// </summary>
-public sealed class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISchemaRegistryCache
+public sealed partial class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISchemaRegistryCache
 {
     private const string AcceptUnknownPropertiesHeader = "Confluent-Accept-Unknown-Properties";
     private static readonly TimeSpan PooledConnectionLifetime = TimeSpan.FromMinutes(2);
@@ -493,6 +493,7 @@ public sealed class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISche
         if (_idBySchemaCache.TryGetValue(cacheKey, out var cachedId))
             return cachedId;
 
+        using var cacheRequest = BeginSubjectCacheRequest(subject);
         var request = CreateRegisterSchemaRequest(schema);
 
         using var response = await PostAsJsonWithFailoverAsync(
@@ -514,7 +515,8 @@ public sealed class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISche
             subject,
             schema,
             effectiveNormalize,
-            schemaGuid: effectiveNormalize ? null : schemaGuid);
+            schemaGuid: effectiveNormalize ? null : schemaGuid,
+            subjectCacheGeneration: cacheRequest.Generation);
 
         return id;
     }
@@ -604,6 +606,7 @@ public sealed class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISche
         if (_schemaBySubjectAndIdCache.TryGetValue(key, out var cached))
             return cached;
 
+        using var cacheRequest = BeginSubjectCacheRequest(subject);
         using var response = await GetWithFailoverAsync(
             WithQuery(
                 $"schemas/ids/{id.ToString(CultureInfo.InvariantCulture)}",
@@ -619,7 +622,7 @@ public sealed class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISche
             throw new SchemaRegistryException((int)response.StatusCode, "Schema Registry returned an empty schema response");
 
         var schema = CreateSchema(result);
-        CacheSubjectSchema(id, subject, format, schema);
+        CacheSubjectSchema(id, subject, format, schema, cacheRequest.Generation);
         return schema;
     }
 
@@ -660,6 +663,9 @@ public sealed class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISche
         CancellationToken cancellationToken = default)
     {
         format = NormalizeFormat(format);
+        using var cacheRequest = format is not null && ignoreDeletedSchemas
+            ? BeginSubjectCacheRequest(subject)
+            : default;
         using var response = await GetWithFailoverAsync(
             WithQuery(
                 $"subjects/{Uri.EscapeDataString(subject)}/versions/{Uri.EscapeDataString(version)}",
@@ -683,7 +689,9 @@ public sealed class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISche
         }
         else
         {
-            CacheSubjectSchema(result.Id, subject, format, schema);
+            // A deleted-inclusive lookup does not prove active subject membership.
+            if (ignoreDeletedSchemas)
+                CacheSubjectSchema(result.Id, subject, format, schema, cacheRequest.Generation);
             if (schemaGuid is { } guid)
                 CacheGuidSchema(guid, format, schema);
         }
@@ -706,6 +714,7 @@ public sealed class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISche
         CancellationToken cancellationToken = default)
     {
         var effectiveNormalize = normalize || _config.NormalizeSchemas;
+        using var cacheRequest = ignoreDeletedSchemas ? BeginSubjectCacheRequest(subject) : default;
         var request = CreateRegisterSchemaRequest(schema);
         var path = WithQuery(
             $"subjects/{Uri.EscapeDataString(subject)}",
@@ -734,7 +743,8 @@ public sealed class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISche
             schema,
             effectiveNormalize,
             schemaById: registeredSchema,
-            schemaGuid: schemaGuid);
+            schemaGuid: schemaGuid,
+            subjectCacheGeneration: cacheRequest.Generation);
 
         return new RegisteredSchema
         {
@@ -763,6 +773,7 @@ public sealed class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISche
         if (_idBySchemaCache.TryGetValue(cacheKey, out var cachedId))
             return cachedId;
 
+        using var cacheRequest = BeginSubjectCacheRequest(subject);
         // Try to get existing schema first
         var request = CreateRegisterSchemaRequest(schema);
 
@@ -797,7 +808,8 @@ public sealed class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISche
             schema,
             effectiveNormalize,
             schemaById: registeredSchema,
-            schemaGuid: schemaGuid);
+            schemaGuid: schemaGuid,
+            subjectCacheGeneration: cacheRequest.Generation);
 
         return result.Id;
     }
@@ -808,7 +820,8 @@ public sealed class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISche
         Schema schema,
         bool normalize = false,
         Schema? schemaById = null,
-        Guid? schemaGuid = null)
+        Guid? schemaGuid = null,
+        long? subjectCacheGeneration = null)
     {
         if (_maxCachedSchemas == 0)
             return;
@@ -821,7 +834,7 @@ public sealed class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISche
                 _schemaByIdCache[id] = schemaById;
             else
                 _schemaByIdCache.TryAdd(id, schema);
-            if (subject is not null)
+            if (subject is not null && IsSubjectCacheRequestCurrent(subject, subjectCacheGeneration))
             {
                 _idBySchemaCache.TryAdd((subject, schema, normalize), id);
             }
@@ -830,13 +843,16 @@ public sealed class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISche
         }
     }
 
-    private void CacheSubjectSchema(int id, string subject, string? format, Schema schema)
+    private void CacheSubjectSchema(int id, string subject, string? format, Schema schema, long cacheGeneration)
     {
         if (_maxCachedSchemas == 0)
             return;
 
         lock (_cacheLock)
         {
+            if (!IsSubjectCacheRequestCurrent(subject, cacheGeneration))
+                return;
+
             ClearCachesIfFull();
 
             _schemaBySubjectAndIdCache[(id, subject, NormalizeFormat(format))] = schema;
@@ -992,6 +1008,8 @@ public sealed class SchemaRegistryClient : IFormattedSchemaRegistryClient, ISche
         using var response = await DeleteWithFailoverAsync(url, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
+        // HTTP success confirms deletion even if reading its response body subsequently fails.
+        InvalidateSubjectCaches(subject);
         return await response.Content.ReadFromJsonAsync<List<int>>(
             SchemaRegistryJsonContext.Default.ListInt32, cancellationToken).ConfigureAwait(false) ?? [];
     }

--- a/tests/Dekaf.Tests.Integration/SchemaRegistrySubjectDeletionIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistrySubjectDeletionIntegrationTests.cs
@@ -1,0 +1,40 @@
+using Dekaf.SchemaRegistry;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Serialization")]
+[ClassDataSource<KafkaWithSchemaRegistryContainer>(Shared = SharedType.PerTestSession)]
+public sealed class SchemaRegistrySubjectDeletionIntegrationTests(KafkaWithSchemaRegistryContainer infrastructure)
+{
+    [Test]
+    [Arguments(false, false)]
+    [Arguments(false, true)]
+    [Arguments(true, false)]
+    [Arguments(true, true)]
+    public async Task DeleteThenReregister_RestoresSubject(bool normalize, bool permanent)
+    {
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig { Url = infrastructure.RegistryUrl });
+        using var observer = new SchemaRegistryClient(new SchemaRegistryConfig { Url = infrastructure.RegistryUrl });
+        var subject = $"subject-deletion-{Guid.NewGuid():N}";
+        var schema = new Schema
+        {
+            SchemaString = $$"""{"type":"record","name":"DeletionRecord_{{Guid.NewGuid():N}}","fields":[{"name":"value","type":"string"}]}""",
+            SchemaType = SchemaType.Avro
+        };
+        var originalId = await client.RegisterSchemaAsync(subject, schema, normalize);
+
+        await client.DeleteSubjectAsync(subject);
+        if (permanent)
+            await client.DeleteSubjectAsync(subject, permanent: true);
+        await Assert.ThrowsAsync<SchemaRegistryException>(() => observer.GetSchemaBySubjectAsync(subject));
+
+        var restoredId = await client.RegisterSchemaAsync(subject, schema, normalize);
+        var restored = await observer.GetSchemaBySubjectAsync(subject);
+
+        await Assert.That(restored.Subject).IsEqualTo(subject);
+        await Assert.That(restored.Id).IsEqualTo(restoredId);
+        await Assert.That(Avro.Schema.Parse(restored.Schema.SchemaString)).IsEqualTo(Avro.Schema.Parse(schema.SchemaString));
+        if (!permanent)
+            await Assert.That(restoredId).IsEqualTo(originalId);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistrySubjectDeletionTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistrySubjectDeletionTests.cs
@@ -1,0 +1,397 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Dekaf.SchemaRegistry;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public sealed class SchemaRegistrySubjectDeletionTests
+{
+    private static readonly Schema StringSchema = new() { SchemaString = "\"string\"", SchemaType = SchemaType.Avro };
+    private static readonly Schema IntSchema = new() { SchemaString = "\"int\"", SchemaType = SchemaType.Avro };
+
+    [Test]
+    [Arguments(false, false)]
+    [Arguments(false, true)]
+    [Arguments(true, false)]
+    [Arguments(true, true)]
+    public async Task RegisterDeleteRegister_RestoresSubject(bool normalize, bool permanent)
+    {
+        using var registry = new StatefulRegistry();
+        using var client = CreateClient(registry);
+        await client.RegisterSchemaAsync("events", StringSchema, normalize);
+
+        await client.DeleteSubjectAsync("events", permanent);
+        await Assert.That(registry.ContainsSubject("events")).IsFalse();
+        await client.RegisterSchemaAsync("events", StringSchema, normalize);
+
+        await Assert.That(registry.Registrations("events")).IsEqualTo(2);
+        await Assert.That(registry.ContainsSubject("events")).IsTrue();
+    }
+
+    [Test]
+    public async Task Delete_InvalidatesEverySubjectEntryAndPreservesUnrelatedIdentities()
+    {
+        using var registry = new StatefulRegistry();
+        using var client = CreateClient(registry);
+        foreach (var schema in new[] { StringSchema, IntSchema })
+        {
+            await client.RegisterSchemaAsync("events", schema, normalize: false);
+            await client.RegisterSchemaAsync("events", schema, normalize: true);
+        }
+        var sharedId = await client.RegisterSchemaAsync("events-other", StringSchema);
+        await client.GetSchemaAsync(sharedId, "events");
+        await client.GetSchemaAsync(sharedId, "events", "serialized");
+        await client.GetSchemaAsync(sharedId, "events-other");
+
+        await client.DeleteSubjectAsync("events", permanent: true);
+
+        await Assert.That(client.CachedSchemaIdCount).IsEqualTo(1);
+        await Assert.That(client.CachedSchemaBySubjectAndIdCount).IsEqualTo(1);
+        await Assert.That(client.TryGetCachedSchema(sharedId, "events", out _)).IsFalse();
+        await Assert.That(client.TryGetCachedSchema(sharedId, "events-other", out _)).IsTrue();
+        await Assert.That(client.TryGetCachedSchema(sharedId, out _)).IsTrue();
+        await Assert.That(client.TryGetCachedSchema(StatefulRegistry.SchemaGuid(sharedId), null, out _)).IsTrue();
+        await client.RegisterSchemaAsync("events-other", StringSchema);
+        await Assert.That(registry.Registrations("events-other")).IsEqualTo(1);
+
+        foreach (var schema in new[] { StringSchema, IntSchema })
+        {
+            await client.RegisterSchemaAsync("events", schema, normalize: false);
+            await client.RegisterSchemaAsync("events", schema, normalize: true);
+        }
+        await Assert.That(registry.Registrations("events")).IsEqualTo(8);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task FailedDelete_PreservesCachedRegistrationsAndSubjectLookups(bool permanent)
+    {
+        using var registry = new StatefulRegistry { FailDeletion = true };
+        using var client = CreateClient(registry);
+        var id = await client.RegisterSchemaAsync("events", StringSchema);
+        var schema = await client.GetSchemaAsync(id, "events");
+
+        await Assert.ThrowsAsync<SchemaRegistryException>(() => client.DeleteSubjectAsync("events", permanent));
+
+        await Assert.That(await client.RegisterSchemaAsync("events", StringSchema)).IsEqualTo(id);
+        await Assert.That(client.TryGetCachedSchema(id, "events", out var cached)).IsTrue();
+        await Assert.That(cached).IsSameReferenceAs(schema);
+        await Assert.That(registry.Registrations("events")).IsEqualTo(1);
+        await Assert.That(registry.ContainsSubject("events")).IsTrue();
+    }
+
+    [Test]
+    [Arguments("register")]
+    [Arguments("get-or-register")]
+    [Arguments("lookup")]
+    [Arguments("subject-id")]
+    [Arguments("formatted-id")]
+    [Arguments("formatted-version")]
+    public async Task CompletionFromBeforeDeletion_CannotRestoreSubjectCache(string operation)
+    {
+        using var registry = new StatefulRegistry();
+        using var client = CreateClient(registry);
+        var id = registry.Seed("events", StringSchema.SchemaString);
+        var paused = registry.PauseNext("events");
+        var pending = ReadOrRegister(client, operation, "events", id);
+        try
+        {
+            await paused.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await client.DeleteSubjectAsync("events");
+        }
+        finally
+        {
+            paused.Release.TrySetResult();
+        }
+        await pending;
+
+        await Assert.That(client.CachedSchemaBySubjectAndIdCount).IsEqualTo(0);
+        var registrations = registry.Registrations("events");
+        await client.RegisterSchemaAsync("events", StringSchema);
+        await Assert.That(registry.Registrations("events")).IsEqualTo(registrations + 1);
+        await Assert.That(registry.ContainsSubject("events")).IsTrue();
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task UnaffectedInFlightRegistration_RemainsCacheable(bool failedDelete)
+    {
+        using var registry = new StatefulRegistry { FailDeletion = failedDelete };
+        using var client = CreateClient(registry);
+        registry.Seed("events", StringSchema.SchemaString);
+        var requestSubject = failedDelete ? "events" : "unrelated";
+        var paused = registry.PauseNext(requestSubject);
+        var pending = client.RegisterSchemaAsync(requestSubject, StringSchema);
+        try
+        {
+            await paused.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            if (failedDelete)
+                await Assert.ThrowsAsync<SchemaRegistryException>(() => client.DeleteSubjectAsync("events"));
+            else
+                await client.DeleteSubjectAsync("events");
+        }
+        finally
+        {
+            paused.Release.TrySetResult();
+        }
+        await pending;
+
+        await client.RegisterSchemaAsync(requestSubject, StringSchema);
+        await Assert.That(registry.Registrations(requestSubject)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task NewRegistrationDuringOlderCompletion_RemainsCached()
+    {
+        using var registry = new StatefulRegistry();
+        using var client = CreateClient(registry);
+        var paused = registry.PauseNext("events");
+        var oldRequest = client.RegisterSchemaAsync("events", StringSchema);
+        try
+        {
+            await paused.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await client.DeleteSubjectAsync("events");
+            await client.RegisterSchemaAsync("events", IntSchema);
+        }
+        finally
+        {
+            paused.Release.TrySetResult();
+        }
+        await oldRequest;
+
+        await Assert.That(client.CachedSchemaIdCount).IsEqualTo(1);
+        await Assert.That(client.ActiveSubjectCacheRequestCount).IsEqualTo(0);
+        await client.RegisterSchemaAsync("events", IntSchema);
+        await Assert.That(registry.Registrations("events")).IsEqualTo(2);
+        await client.RegisterSchemaAsync("events", StringSchema);
+        await Assert.That(registry.Registrations("events")).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task SuccessfulDeleteWithUnreadableBody_StillInvalidatesSubject()
+    {
+        using var registry = new StatefulRegistry { MalformedDeletionResponse = true };
+        using var client = CreateClient(registry);
+        await client.RegisterSchemaAsync("events", StringSchema);
+
+        await Assert.ThrowsAsync<JsonException>(() => client.DeleteSubjectAsync("events"));
+        await client.RegisterSchemaAsync("events", StringSchema);
+
+        await Assert.That(registry.Registrations("events")).IsEqualTo(2);
+        await Assert.That(registry.ContainsSubject("events")).IsTrue();
+    }
+
+    [Test]
+    public async Task RequestTracking_IsReleasedAfterCancellationFailureAndRepeatedDeletion()
+    {
+        using var registry = new StatefulRegistry();
+        using var client = CreateClient(registry);
+        using var cancellation = new CancellationTokenSource();
+        var paused = registry.PauseNext("cancelled");
+        var pending = client.RegisterSchemaAsync("cancelled", StringSchema, cancellation.Token);
+        await paused.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await Assert.That(client.ActiveSubjectCacheRequestCount).IsEqualTo(1);
+        cancellation.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => pending);
+        await Assert.That(client.ActiveSubjectCacheRequestCount).IsEqualTo(0);
+
+        await Assert.ThrowsAsync<SchemaRegistryException>(() => client.LookupSchemaAsync("missing", StringSchema));
+        await Assert.That(client.ActiveSubjectCacheRequestCount).IsEqualTo(0);
+        for (var index = 0; index < 50; index++)
+        {
+            var subject = $"temporary-{index}";
+            await client.RegisterSchemaAsync(subject, StringSchema);
+            await client.DeleteSubjectAsync(subject);
+        }
+        await Assert.That(client.ActiveSubjectCacheRequestCount).IsEqualTo(0);
+        await Assert.That(client.CachedSchemaIdCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task FormattedDeletedVersionLookup_DoesNotCacheActiveSubjectMembership()
+    {
+        using var registry = new StatefulRegistry();
+        using var client = CreateClient(registry);
+        registry.Seed("events", StringSchema.SchemaString);
+
+        await client.GetSchemaBySubjectAsync("events", "latest", ignoreDeletedSchemas: false, format: "serialized");
+
+        await Assert.That(client.CachedSchemaBySubjectAndIdCount).IsEqualTo(0);
+        await Assert.That(client.ActiveSubjectCacheRequestCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ConfiguredNormalization_IsInvalidatedAfterDeletion()
+    {
+        using var registry = new StatefulRegistry();
+        using var client = CreateClient(registry, normalize: true);
+        await client.RegisterSchemaAsync("events", StringSchema);
+        await client.DeleteSubjectAsync("events");
+        await client.GetOrRegisterSchemaAsync("events", StringSchema);
+
+        await Assert.That(registry.Registrations("events")).IsEqualTo(2);
+        await Assert.That(registry.ContainsSubject("events")).IsTrue();
+    }
+
+    private static SchemaRegistryClient CreateClient(StatefulRegistry registry, bool normalize = false) => new(new SchemaRegistryConfig
+    {
+        Url = "https://registry.test", NormalizeSchemas = normalize
+    }, registry);
+
+    private static async Task ReadOrRegister(SchemaRegistryClient client, string operation, string subject, int id)
+    {
+        switch (operation)
+        {
+            case "register": await client.RegisterSchemaAsync(subject, StringSchema); break;
+            case "get-or-register": await client.GetOrRegisterSchemaAsync(subject, StringSchema); break;
+            case "lookup": await client.LookupSchemaAsync(subject, StringSchema); break;
+            case "subject-id": await client.GetSchemaAsync(id, subject); break;
+            case "formatted-id": await client.GetSchemaAsync(id, subject, "serialized"); break;
+            case "formatted-version": await client.GetSchemaBySubjectAsync(subject, "latest", true, "serialized"); break;
+            default: throw new ArgumentOutOfRangeException(nameof(operation));
+        }
+    }
+
+    private sealed class PausedResponse
+    {
+        public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    private sealed class StatefulRegistry : HttpMessageHandler
+    {
+        private static readonly int[] DeletedVersions = [1];
+        private readonly object _gate = new();
+        private readonly Dictionary<string, Dictionary<string, int>> _subjects = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, int> _ids = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, int> _registrations = new(StringComparer.Ordinal);
+        private (string Subject, PausedResponse Response)? _nextPause;
+        public bool FailDeletion { get; init; }
+        public bool MalformedDeletionResponse { get; init; }
+
+        public static Guid SchemaGuid(int id) => Guid.Parse(id.ToString("x32"));
+
+        public int Seed(string subject, string schema)
+        {
+            lock (_gate)
+            {
+                if (!_ids.TryGetValue(schema, out var id))
+                    _ids.Add(schema, id = _ids.Count + 1);
+                if (!_subjects.TryGetValue(subject, out var schemas))
+                    _subjects.Add(subject, schemas = new(StringComparer.Ordinal));
+                schemas[schema] = id;
+                return id;
+            }
+        }
+
+        public bool ContainsSubject(string subject)
+        {
+            lock (_gate) return _subjects.ContainsKey(subject);
+        }
+
+        public int Registrations(string subject)
+        {
+            lock (_gate) return _registrations.GetValueOrDefault(subject);
+        }
+
+        public PausedResponse PauseNext(string subject)
+        {
+            lock (_gate)
+            {
+                var response = new PausedResponse();
+                _nextPause = (subject, response);
+                return response;
+            }
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string? schema = null;
+            if (request.Content is not null)
+            {
+                using var document = JsonDocument.Parse(await request.Content.ReadAsStringAsync(cancellationToken));
+                schema = document.RootElement.GetProperty("schema").GetString();
+            }
+            var parts = request.RequestUri!.AbsolutePath.Trim('/').Split('/');
+            var subject = parts[0] == "subjects" ? Uri.UnescapeDataString(parts[1]) : QuerySubject(request.RequestUri);
+            HttpResponseMessage response;
+            PausedResponse? pause = null;
+            lock (_gate)
+            {
+                response = Respond(request.Method, parts, subject, schema);
+                if (request.Method != HttpMethod.Delete && _nextPause is { } next && next.Subject == subject)
+                {
+                    pause = next.Response;
+                    _nextPause = null;
+                }
+            }
+            if (pause is not null)
+            {
+                pause.Entered.TrySetResult();
+                try
+                {
+                    await pause.Release.Task.WaitAsync(cancellationToken);
+                }
+                catch
+                {
+                    response.Dispose();
+                    throw;
+                }
+            }
+            return response;
+        }
+
+        private HttpResponseMessage Respond(HttpMethod method, string[] parts, string subject, string? schema)
+        {
+            if (method == HttpMethod.Delete)
+            {
+                if (FailDeletion) return Json(new { error_code = 40301, message = "denied" }, HttpStatusCode.Forbidden);
+                if (!_subjects.Remove(subject)) return Missing();
+                if (MalformedDeletionResponse) return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{") };
+                return Json(DeletedVersions);
+            }
+            if (method == HttpMethod.Post && parts.Length == 3)
+            {
+                _registrations[subject] = _registrations.GetValueOrDefault(subject) + 1;
+                var id = Seed(subject, schema!);
+                return Json(new { id, guid = SchemaGuid(id).ToString("D") });
+            }
+            if (!_subjects.TryGetValue(subject, out var schemas)) return Missing();
+            if (parts[0] == "schemas")
+            {
+                var id = int.Parse(parts[2]);
+                foreach (var pair in schemas)
+                    if (pair.Value == id) return SchemaResponse(subject, pair.Key, id);
+                return Missing();
+            }
+            if (schema is null)
+            {
+                var first = schemas.First();
+                return SchemaResponse(subject, first.Key, first.Value);
+            }
+            return schemas.TryGetValue(schema, out var schemaId) ? SchemaResponse(subject, schema, schemaId) : Missing();
+        }
+
+        private static string QuerySubject(Uri uri)
+        {
+            foreach (var part in uri.Query.TrimStart('?').Split('&'))
+                if (part.StartsWith("subject=", StringComparison.Ordinal)) return Uri.UnescapeDataString(part[8..]);
+            throw new InvalidOperationException("Expected subject-qualified lookup");
+        }
+
+        private static HttpResponseMessage SchemaResponse(string subject, string schema, int id) => Json(new
+        {
+            subject, schema, id, version = 1, schemaType = "AVRO", guid = SchemaGuid(id).ToString("D")
+        });
+
+        private static HttpResponseMessage Missing() => Json(new { error_code = 40401, message = "missing subject" }, HttpStatusCode.NotFound);
+
+        private static HttpResponseMessage Json<T>(T value, HttpStatusCode status = HttpStatusCode.OK) => new(status)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(value), Encoding.UTF8, "application/vnd.schemaregistry.v1+json")
+        };
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistrySubjectCacheBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistrySubjectCacheBenchmarks.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Dekaf.SchemaRegistry;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+public class SchemaRegistrySubjectCacheBenchmarks
+{
+    private readonly Schema _schema = new() { SchemaString = "{}", SchemaType = SchemaType.Json };
+    private SchemaRegistryClient _client = null!;
+    private StaticSchemaHandler _handler = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _handler = new StaticSchemaHandler();
+        _client = new SchemaRegistryClient(new SchemaRegistryConfig { Url = "https://registry.test" }, _handler);
+        _client.CacheSchema(42, "events", _schema);
+        _client.GetSchemaAsync(42, "events").GetAwaiter().GetResult();
+    }
+
+    [Benchmark]
+    public Task<int> CachedRegistration() => _client.RegisterSchemaAsync("events", _schema);
+
+    [Benchmark]
+    public Task<int> CachedGetOrRegister() => _client.GetOrRegisterSchemaAsync("events", _schema);
+
+    [Benchmark]
+    public Schema CachedSubjectIdentity()
+    {
+        _client.TryGetCachedSchema(42, "events", out var schema);
+        return schema;
+    }
+
+    [Benchmark]
+    public Schema CachedGlobalIdentity()
+    {
+        _client.TryGetCachedSchema(42, out var schema);
+        return schema;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _client.Dispose();
+        _handler.Dispose();
+    }
+
+    private sealed class StaticSchemaHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"schema":"{}","schemaType":"JSON"}""", Encoding.UTF8, "application/json")
+            });
+    }
+}


### PR DESCRIPTION
After deleting a subject, `RegisterSchemaAsync` could return its cached ID without restoring the subject in Schema Registry. Successful deletion now removes every registration and subject-qualified lookup entry for that subject, covering normalization settings and formatted schemas.

Subject generations are tracked only while HTTP requests are active. Deletion and cache population share the existing cache lock, so a response started before deletion cannot restore stale subject membership. Failed/cancelled requests release their tracking entries; unrelated subjects remain cacheable. Deleted-inclusive formatted lookups no longer populate the active subject cache.

Global ID/GUID caches retain resolved schema definitions, including after permanent deletion, because definitions may be shared across subjects and are distinct from proof of registry membership. This policy, overlapping-request behavior, independent serializer caches, and successful-HTTP/unreadable-body invalidation are documented. Failed HTTP deletion preserves caches. Re-registration behavior follows [Confluent's deletion guidance](https://docs.confluent.io/platform/current/schema-registry/schema-deletion-guidelines.html#recovering-a-soft-deleted-schema).

## Validation

- Initial stateful reproduction: 12 of 16 tests failed; failed-deletion and unrelated-request controls passed.
- Added coverage for new registrations overlapping stale completions, cancellation/failure cleanup, repeated subject deletion, successful deletion with unreadable JSON, and deleted-inclusive formatted lookup. The latter reproduced separately before its guard was added.
- Final full schema-registry namespace: 1,273 tests passed on .NET 10; 1,276 passed on .NET 8.
- Four live Confluent Schema Registry 7.9.0 / Kafka 4.0.2 cases cover soft/permanent deletion with normalization on/off. All four reproduced the original bug; final cases pass with unique subject/schema identities to isolate concurrent hard deletions. A separate client verifies that re-registration actually restores the subject.
- Release library/unit/integration/benchmark builds passed with zero warnings/errors.
- Documentation production build passed; generated page verified; `/simplify` and diff checks complete.

## Performance evidence

Baseline `0a25915dca5ed05e7528ad28aeedccd179482c20` → candidate `10d5f822cc7881a1049d544016e03fd2ae7d5628`. Saved DLLs, identical harness, serial runs after local builds/tests completed; candidate DLL hash verified. BDN 0.15.8, Windows 11/i7-12700K, .NET 10.0.11 / SDK 10.0.400, in-process, five warmups/15 iterations, MemoryDiagnoser.

| Cache-hit operation | Before mean ± error (ns) | After mean ± error (ns) | Mean delta (ns) | Allocated before → after |
|---|---:|---:|---:|---:|
| RegisterSchemaAsync | 26.2656 ± 5.3359 | 16.2691 ± 0.3146 | -9.9965 | 72 B → 72 B |
| GetOrRegisterSchemaAsync | 23.7814 ± 3.8807 | 18.4485 ± 0.9973 | -5.3329 | 72 B → 72 B |
| Subject identity | 8.9155 ± 1.2017 | 8.1792 ± 0.9792 | -0.7363 | 0 B → 0 B |
| Global identity | 0.7497 ± 0.0117 | 0.8609 ± 0.1162 | +0.1112 | 0 B → 0 B |

No speedup claim from shared-machine timing variation. Identity-cache confidence intervals overlap; the sub-nanosecond global lookup is near harness-overhead resolution. Existing Task-returning registration APIs retain their 72 B result allocation for ID 42; deserializer identity hits remain 0 B. Cache-hit reads add no generation lookup, lock, or allocation.

Request tracking applies to HTTP misses, not record processing. Reflection/Unsafe.SizeOf against the compiled state-machine types records the suspended-state payload separately: RegisterSchemaAsync 104 → 128 B; GetOrRegisterSchemaAsync 120 → 144 B; subject-qualified GetSchemaAsync 104 → 128 B. This is 24 B of tracking state per genuinely suspended HTTP request, not per cached message. The tracking dictionary retains no completed-subject entries and its capacity is bounded by peak concurrent subject requests. Deletion scans the bounded client caches on the cold deletion path.

No producer/consumer/network hot path changed, no paid stress run, and no claim about broker throughput or latency percentiles. Maintained benchmark: `dotnet run --project tools/Dekaf.Benchmarks -c Release -- --filter '*SchemaRegistrySubjectCacheBenchmarks*' --inProcess --warmupCount 5 --iterationCount 15`.

Closes #3058