### PR TITLE
Fix malformed trace context interrupting consumption

### DIFF
--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -56,6 +56,11 @@ The two consume flavors match the span's actual lifetime. In the streaming `Cons
 
 Producer spans inject W3C `traceparent` (and `tracestate`) headers into the outgoing message. On the consumer side, the extracted producer context is attached as a **span link** rather than a parent — consumer spans start a new trace linked to the producing trace, per the OTel messaging conventions. Messages without a valid `traceparent` header produce an unlinked consumer span.
 
+Malformed trace context is ignored without interrupting record delivery. Extraction
+requires lowercase hexadecimal, nonzero trace/span IDs and a valid version/length;
+unknown future versions may append opaque fields after the standard prefix, as
+specified by [W3C Trace Context](https://www.w3.org/TR/trace-context/#versioning-of-traceparent).
+
 ### Span Attributes
 
 Both spans set `messaging.system = kafka` plus:

--- a/src/Dekaf/Diagnostics/TraceContextPropagator.cs
+++ b/src/Dekaf/Diagnostics/TraceContextPropagator.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Dekaf.Serialization;
 
 namespace Dekaf.Diagnostics;
@@ -98,99 +99,114 @@ internal static class TraceContextPropagator
         return ExtractTraceContextSlow(headers);
     }
 
+#if NET10_0_OR_GREATER
+    [SkipLocalsInit] // Every byte/character in the consumed stack slices is written first.
+#endif
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static ActivityContext? ExtractTraceContextSlow(IReadOnlyList<Header> headers)
+    private static unsafe ActivityContext? ExtractTraceContextSlow(IReadOnlyList<Header> headers)
     {
-        string? traceparent = null;
-        string? tracestate = null;
+        Header? traceparent = null;
+        Header? tracestate = null;
 
         for (var i = 0; i < headers.Count; i++)
         {
             var header = headers[i];
             if (header.Key == TraceparentHeader)
             {
-                traceparent = header.GetValueAsString();
+                traceparent = header;
             }
             else if (header.Key == TracestateHeader)
             {
-                tracestate = header.GetValueAsString();
+                tracestate = header;
             }
         }
 
-        if (traceparent is null)
+        if (traceparent is not { IsValueNull: false } parent)
             return null;
 
-        return ParseTraceparent(traceparent, tracestate);
+        if (parent.DeferredValue is string text)
+            return ParseTraceparent(text.AsSpan(), tracestate);
+
+        // Only the fixed prefix and its extension delimiter are understood. Avoid decoding
+        // the whole UTF-8 header, including arbitrarily large unknown future-version fields.
+        Span<byte> deferred = stackalloc byte[TraceparentLength];
+        scoped ReadOnlySpan<byte> bytes = parent.RawValue.Span;
+        if (parent.DeferredValue is Activity activity)
+        {
+            WriteTraceparentUnchecked(activity, deferred);
+            bytes = deferred;
+        }
+
+        Span<char> prefix = stackalloc char[TraceparentLength + 1];
+        var length = Math.Min(bytes.Length, prefix.Length);
+        if (length < TraceparentLength)
+            return null;
+
+        // The pointer overload also supports netstandard2.0 without an intermediate array.
+        fixed (byte* source = bytes)
+        fixed (char* destination = prefix)
+            Encoding.ASCII.GetChars(source, length, destination, length);
+
+        return ParseTraceparent(prefix[..length], tracestate);
     }
 
     /// <summary>
     /// Parses a W3C traceparent header value into an <see cref="ActivityContext"/>.
     /// Format: {version}-{traceId}-{spanId}-{traceFlags}
     /// </summary>
-    private static ActivityContext? ParseTraceparent(string traceparent, string? tracestate)
+#if NET10_0_OR_GREATER
+    [SkipLocalsInit] // IDs are consumed only after both decoders fill their entire destination.
+#endif
+    private static ActivityContext? ParseTraceparent(ReadOnlySpan<char> span, Header? tracestate)
     {
         // Minimum length: "00-" + 32 (traceId) + "-" + 16 (spanId) + "-" + 2 (flags) = 55
-        if (traceparent.Length < 55)
+        if (span.Length < TraceparentLength)
             return null;
 
-        var span = traceparent.AsSpan();
-
-        // Skip version prefix "00-"
-        if (span[2] != '-')
+        if (span[2] != '-' || span[35] != '-' || span[52] != '-')
             return null;
 
-        var traceIdSpan = span.Slice(3, 32);
-        if (span[35] != '-')
+        if (!TryParseHexByte(span[..2], out var version) || version == 0xff)
             return null;
 
-        var spanIdSpan = span.Slice(36, 16);
-        if (span[52] != '-')
+        // Version 00 has exactly 55 characters. Higher versions may append opaque fields
+        // after a dash; W3C requires readers not to interpret those unknown fields.
+        if (span.Length > TraceparentLength && (version == 0 || span[TraceparentLength] != '-'))
             return null;
 
-        var flagsSpan = span.Slice(53, 2);
-
-        if (!TryParseTraceId(traceIdSpan, out var traceId))
+        if (!TryParseHexByte(span.Slice(53, 2), out var flags))
             return null;
 
-        if (!TryParseSpanId(spanIdSpan, out var spanId))
+        Span<byte> traceId = stackalloc byte[16];
+        Span<byte> spanId = stackalloc byte[8];
+        if (!TryDecodeIdentifier(span.Slice(3, 32), traceId) ||
+            !TryDecodeIdentifier(span.Slice(36, 16), spanId))
             return null;
 
-        if (!TryParseHexByte(flagsSpan, out var flags))
-            return null;
-
-        return new ActivityContext(traceId, spanId, (ActivityTraceFlags)flags, tracestate, isRemote: true);
+        // Validate and decode once before the platform APIs materialize their owned strings.
+        return new ActivityContext(
+            ActivityTraceId.CreateFromBytes(traceId),
+            ActivitySpanId.CreateFromBytes(spanId),
+            (ActivityTraceFlags)flags,
+            tracestate?.GetValueAsString(),
+            isRemote: true);
     }
 
-    private static bool TryParseTraceId(ReadOnlySpan<char> chars, out ActivityTraceId result)
+    private static bool TryDecodeIdentifier(ReadOnlySpan<char> chars, Span<byte> bytes)
     {
-        // Validate all characters are hex before calling CreateFromString
-        for (var i = 0; i < chars.Length; i++)
+        var nonzero = 0;
+        for (var i = 0; i < bytes.Length; i++)
         {
-            if (HexCharToNibble(chars[i]) < 0)
-            {
-                result = default;
+            var hi = HexCharToNibble(chars[i * 2]);
+            var lo = HexCharToNibble(chars[(i * 2) + 1]);
+            if ((hi | lo) < 0)
                 return false;
-            }
+
+            var value = (hi << 4) | lo;
+            bytes[i] = (byte)value;
+            nonzero |= value;
         }
-
-        result = ActivityTraceId.CreateFromString(chars);
-        return true;
-    }
-
-    private static bool TryParseSpanId(ReadOnlySpan<char> chars, out ActivitySpanId result)
-    {
-        // Validate all characters are hex before calling CreateFromString
-        for (var i = 0; i < chars.Length; i++)
-        {
-            if (HexCharToNibble(chars[i]) < 0)
-            {
-                result = default;
-                return false;
-            }
-        }
-
-        result = ActivitySpanId.CreateFromString(chars);
-        return true;
+        return nonzero != 0;
     }
 
     private static bool TryParseHexByte(ReadOnlySpan<char> hex, out byte result)
@@ -213,7 +229,6 @@ internal static class TraceContextPropagator
     {
         >= '0' and <= '9' => c - '0',
         >= 'a' and <= 'f' => c - 'a' + 10,
-        >= 'A' and <= 'F' => c - 'A' + 10,
         _ => -1
     };
 }

--- a/src/Dekaf/Diagnostics/TraceContextPropagator.cs
+++ b/src/Dekaf/Diagnostics/TraceContextPropagator.cs
@@ -99,9 +99,7 @@ internal static class TraceContextPropagator
         return ExtractTraceContextSlow(headers);
     }
 
-#if NET10_0_OR_GREATER
     [SkipLocalsInit] // Every byte/character in the consumed stack slices is written first.
-#endif
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static unsafe ActivityContext? ExtractTraceContextSlow(IReadOnlyList<Header> headers)
     {
@@ -123,9 +121,6 @@ internal static class TraceContextPropagator
 
         if (traceparent is not { IsValueNull: false } parent)
             return null;
-
-        if (parent.DeferredValue is string text)
-            return ParseTraceparent(text.AsSpan(), tracestate);
 
         // Only the fixed prefix and its extension delimiter are understood. Avoid decoding
         // the whole UTF-8 header, including arbitrarily large unknown future-version fields.
@@ -154,9 +149,7 @@ internal static class TraceContextPropagator
     /// Parses a W3C traceparent header value into an <see cref="ActivityContext"/>.
     /// Format: {version}-{traceId}-{spanId}-{traceFlags}
     /// </summary>
-#if NET10_0_OR_GREATER
     [SkipLocalsInit] // IDs are consumed only after both decoders fill their entire destination.
-#endif
     private static ActivityContext? ParseTraceparent(ReadOnlySpan<char> span, Header? tracestate)
     {
         // Minimum length: "00-" + 32 (traceId) + "-" + 16 (spanId) + "-" + 2 (flags) = 55

--- a/tests/Dekaf.Tests.Integration/MalformedTraceContextConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/MalformedTraceContextConsumerTests.cs
@@ -13,6 +13,7 @@ namespace Dekaf.Tests.Integration;
 public sealed class MalformedTraceContextConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]
+    [SkipWhenNativeAot("Confluent.Kafka native delegate binding requires runtime reflection.")]
     [Arguments(false)]
     [Arguments(true)]
     public async Task InvalidTracingHeaders_DoNotInterruptDelivery(bool streaming)

--- a/tests/Dekaf.Tests.Integration/MalformedTraceContextConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/MalformedTraceContextConsumerTests.cs
@@ -1,0 +1,106 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text;
+using Dekaf.Consumer;
+using Dekaf.Diagnostics;
+using Microsoft.Extensions.Logging;
+using ConfluentKafka = Confluent.Kafka;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Consumer")]
+[NotInParallel("DekafInstrumentation")]
+public sealed class MalformedTraceContextConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task InvalidTracingHeaders_DoNotInterruptDelivery(bool streaming)
+    {
+        const string valid = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        string[] traceparents =
+        [
+            "00-00000000000000000000000000000000-00f067aa0ba902b7-01",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01",
+            "00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa0ba902b7-01",
+            "ff" + valid[2..],
+            "zz" + valid[2..],
+            valid + "-extra",
+            valid
+        ];
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        var activities = new ConcurrentBag<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = static source => source.Name == DekafDiagnostics.ActivitySourceName,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activity =>
+            {
+                if (activity.GetTagItem(DekafDiagnostics.MessagingDestinationName) as string == topic &&
+                    activity.Kind is ActivityKind.Consumer or ActivityKind.Client)
+                    activities.Add(activity);
+            }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        // An independent producer preserves malformed headers instead of injecting Dekaf tracing.
+        using var producer = new ConfluentKafka.ProducerBuilder<string, string>(new ConfluentKafka.ProducerConfig
+        {
+            BootstrapServers = KafkaContainer.BootstrapServers,
+            Acks = ConfluentKafka.Acks.All
+        }).Build();
+        for (var index = 0; index < traceparents.Length; index++)
+        {
+            await producer.ProduceAsync(topic, new ConfluentKafka.Message<string, string>
+            {
+                Key = "key",
+                Value = $"record-{index}",
+                Headers = new ConfluentKafka.Headers
+                {
+                    { "traceparent", Encoding.UTF8.GetBytes(traceparents[index]) },
+                    { "tracestate", "vendor=value"u8.ToArray() }
+                }
+            });
+        }
+
+        using var logs = new CapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(logs));
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId($"trace-validation-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithLoggerFactory(loggerFactory)
+            .BuildAsync();
+        consumer.Assign(new TopicPartition(topic, 0));
+        var received = new List<string?>();
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        if (streaming)
+        {
+            await foreach (var record in consumer.ConsumeAsync(cancellation.Token))
+            {
+                received.Add(record.Value);
+                if (received.Count == traceparents.Length)
+                    break;
+            }
+        }
+        else
+        {
+            for (var index = 0; index < traceparents.Length; index++)
+            {
+                var record = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cancellation.Token);
+                await Assert.That(record).IsNotNull();
+                received.Add(record!.Value.Value);
+            }
+        }
+
+        await Assert.That(received.Count).IsEqualTo(traceparents.Length);
+        for (var index = 0; index < received.Count; index++)
+            await Assert.That(received[index]).IsEqualTo($"record-{index}");
+        await Assert.That(logs.Entries.Any(entry => entry.Message.StartsWith("Record parsing error", StringComparison.Ordinal))).IsFalse();
+        await Assert.That(activities.Count).IsEqualTo(traceparents.Length);
+        var linked = activities.SelectMany(static activity => activity.Links).ToArray();
+        await Assert.That(linked.Length).IsEqualTo(1);
+        await Assert.That(linked[0].Context.TraceId.ToHexString()).IsEqualTo("4bf92f3577b34da6a3ce929d0e0e4736");
+        await Assert.That(linked[0].Context.TraceState).IsEqualTo("vendor=value");
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Diagnostics/TraceparentValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/TraceparentValidationTests.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics;
+using System.Text;
+using Dekaf.Diagnostics;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Diagnostics;
+
+public sealed class TraceparentValidationTests
+{
+    private const string Suffix = "-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+    [Test]
+    [Arguments("00-00000000000000000000000000000000-00f067aa0ba902b7-01")]
+    [Arguments("00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01")]
+    [Arguments("00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa0ba902b7-01")]
+    [Arguments("00-4bf92f3577b34da6a3ce929d0e0e4736-00F067AA0BA902B7-01")]
+    [Arguments("ff" + Suffix)]
+    [Arguments("zz" + Suffix)]
+    [Arguments("0A" + Suffix)]
+    [Arguments("00" + Suffix + "-extra")]
+    [Arguments("00" + Suffix + "-")]
+    [Arguments("01" + Suffix + "extra")]
+    [Arguments("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-0F")]
+    [Arguments("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-0z")]
+    [Arguments("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-0")]
+    [Arguments("00-4bf92f3577b34da6a3ce929d0e0e4736_00f067aa0ba902b7-01")]
+    [Arguments("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7_01")]
+    [Arguments("00_4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")]
+    [Arguments(" 00" + Suffix)]
+    [Arguments("00" + Suffix + " ")]
+    [Arguments("00-4bf92f3577b34da6a3ce929d0e0e473é-00f067aa0ba902b7-01")]
+    [Arguments("")]
+    public async Task MalformedTraceparent_IsIgnored(string value)
+    {
+        var headers = new Headers().Add("traceparent", value).Add("tracestate", "vendor=value");
+        var result = TraceContextPropagator.ExtractTraceContext(headers);
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    [Arguments("00" + Suffix)]
+    [Arguments("01" + Suffix)]
+    [Arguments("0a" + Suffix)]
+    [Arguments("fe" + Suffix)]
+    [Arguments("01" + Suffix + "-")]
+    [Arguments("01" + Suffix + "-future-fields")]
+    public async Task ValidVersion_PreservesContextAndTracestate(string value)
+    {
+        var headers = new Headers().Add("traceparent", value).Add("tracestate", "vendor=value");
+        var result = TraceContextPropagator.ExtractTraceContext(headers);
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.TraceId.ToHexString()).IsEqualTo("4bf92f3577b34da6a3ce929d0e0e4736");
+        await Assert.That(result.Value.SpanId.ToHexString()).IsEqualTo("00f067aa0ba902b7");
+        await Assert.That(result.Value.TraceFlags).IsEqualTo(ActivityTraceFlags.Recorded);
+        await Assert.That(result.Value.TraceState).IsEqualTo("vendor=value");
+        await Assert.That(result.Value.IsRemote).IsTrue();
+    }
+
+    [Test]
+    public async Task MinimalNonzeroIds_AreValid()
+    {
+        var result = TraceContextPropagator.ExtractTraceContext(new Headers().Add("traceparent",
+            "00-00000000000000000000000000000001-0000000000000001-00"));
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.TraceFlags).IsEqualTo(ActivityTraceFlags.None);
+    }
+
+    [Test]
+    public async Task NullAndInvalidUtf8Values_AreIgnored()
+    {
+        await Assert.That(TraceContextPropagator.ExtractTraceContext(new Headers().Add("traceparent", (byte[]?)null))).IsNull();
+        var bytes = Encoding.UTF8.GetBytes("00" + Suffix);
+        bytes[3] = 0xff;
+        await Assert.That(TraceContextPropagator.ExtractTraceContext(new Headers().Add("traceparent", bytes))).IsNull();
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerActivityHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerActivityHotPathBenchmarks.cs
@@ -10,7 +10,7 @@ using Dekaf.Serialization;
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
 /// <summary>
-/// Broker-free cost benchmark for the sampled, no-producer-context consumer activity path.
+/// Broker-free cost benchmark for sampled consumer activities with and without producer context.
 /// Activity sampling intentionally creates a diagnostic span; the zero-listener consume path
 /// remains the zero-allocation hot-path gate.
 /// </summary>
@@ -22,10 +22,17 @@ public class ConsumerActivityHotPathBenchmarks
     private PendingFetchData _pending = null!;
     private ActivityListener _listener = null!;
     private StartConsumeActivity _startActivity = null!;
+    private Header[]? _headers;
+
+    [Params(false, true)]
+    public bool WithProducerContext { get; set; }
 
     [GlobalSetup]
     public void Setup()
     {
+        _headers = WithProducerContext
+            ? [new Header("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"u8.ToArray())]
+            : null;
         _listener = new ActivityListener
         {
             ShouldListenTo = static source =>
@@ -76,7 +83,7 @@ public class ConsumerActivityHotPathBenchmarks
         using var activity = _startActivity(
             _consumer,
             _pending,
-            headers: null,
+            headers: _headers,
             offset: 42,
             isTombstone: false,
             isProcessSpan: false);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TraceContextExtractionBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TraceContextExtractionBenchmarks.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Diagnostics;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Separates trace-context materialization from the zero-allocation no-listener guard.
+/// ActivityTraceId/ActivitySpanId own strings when a valid context is materialized.
+/// </summary>
+[MemoryDiagnoser]
+public class TraceContextExtractionBenchmarks
+{
+    private readonly Header[] _valid = [new("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"u8.ToArray())];
+    private readonly Header[] _withState =
+    [
+        new("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"u8.ToArray()),
+        new("tracestate", "vendor=value"u8.ToArray())
+    ];
+    private readonly Header[] _invalid = [new("traceparent", "zz-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"u8.ToArray())];
+
+    [Benchmark]
+    public ActivityContext? Valid() => TraceContextPropagator.ExtractTraceContext(_valid);
+
+    [Benchmark]
+    public ActivityContext? WithTracestate() => TraceContextPropagator.ExtractTraceContext(_withState);
+
+    [Benchmark]
+    public ActivityContext? InvalidVersion() => TraceContextPropagator.ExtractTraceContext(_invalid);
+
+    [Benchmark]
+    public ActivityContext? NoHeaders() => TraceContextPropagator.ExtractTraceContext(null);
+
+    [Benchmark]
+    public ActivityContext? NoListenerGuard() => DekafDiagnostics.Source.HasListeners()
+        ? TraceContextPropagator.ExtractTraceContext(_valid)
+        : null;
+}


### PR DESCRIPTION
Malformed `traceparent` headers can currently throw while consuming a record or be accepted despite invalid versions and lengths. Validate the bounded W3C prefix before creating `ActivityContext`; ignore invalid context while delivering every record normally. Preserve valid future-version extensions and tracestate.

The parser decodes at most 56 ASCII bytes into stack storage, avoids a full-header string, and rejects invalid input before ID materialization. The pointer decoder overload provides the same bounded implementation on netstandard2.0. Consumer listener guards remain unchanged. [W3C versioning rules](https://www.w3.org/TR/trace-context/#versioning-of-traceparent) require unknown extension fields to remain opaque.

Validation:
- Regression tests first: 12 of 28 cases failed against the original parser.
- 81 diagnostics unit tests on each of net10.0 and net8.0 (the latter exercises netstandard2.0).
- Two real Kafka integration cases: streaming and single-record consumption with tracing enabled; six malformed headers followed by a valid one all arrive in order, with no record-parsing error and only the valid producer context linked.
- Documentation production build; benchmark project build; `/simplify`; `git diff --check`.

Performance:
Base: `0992c5264bbe38612a3464cdeb0396ee14214871`; candidate: `de94a75f7d77b0ff78bcc3d75afa64f9a5f44b43`.
BenchmarkDotNet 0.15.8, MemoryDiagnoser, .NET 10.0.11 / SDK 10.0.400, Windows 11, i7-12700K; in-process, 5 warmups and 12 measured iterations. Identical benchmark bodies run against saved baseline and candidate assemblies. The harness fixes the in-process job rather than adding the benchmark class's second default job. Candidate DLL SHA256 matched the DLL loaded by the harness. Broker-free local run; stress lane, dispatch shape, duration and profiling mode: not applicable.

| Operation | Baseline mean ± error (ns) | Candidate mean ± error (ns) | Mean delta | Baseline → candidate bytes |
| --- | ---: | ---: | ---: | ---: |
| Valid traceparent | 89.564 ± 1.468 | 64.132 ± 1.309 | -28.4% | 280 → 144 |
| With tracestate | 111.142 ± 5.189 | 81.261 ± 0.910 | -26.9% | 328 → 192 |
| Invalid version | 99.404 ± 7.315 | 19.456 ± 0.401 | -80.4% | 280 → 0 |
| Consumer Activity, no context control | 312.161 ± 7.950 | 314.387 ± 8.474 | +0.7%, intervals overlap | 864 → 864 |
| Consumer Activity with producer context | 456.604 ± 13.785 | 429.721 ± 15.627 | -5.9%, intervals overlap | 1360 → 1224 |
| No headers | 0.006 ± 0.014 | 0.025 ± 0.025 | Below useful timing resolution | 0 → 0 |
| No listener guard | 0.277 ± 0.018 | 0.149 ± 0.025 | Below useful timing resolution | 0 → 0 |

Error is the 99.9% confidence half-width, not message p99 latency. Baseline → candidate standard deviations (ns): valid 0.971 → 1.022; tracestate 3.752 → 0.658; invalid 5.711 → 0.313; no-context control 5.746 → 6.123; linked Activity 10.764 → 12.201. Sampled-Activity timing intervals overlap; the extraction improvements and allocation reduction are the clear results. The unchanged no-context control shows no material regression.

Local candidate comparison: the initial scalar byte-to-char copy was rejected (valid extraction 108.735 ns versus the initial 94.322 ns baseline, 3 warmups/8 iterations). Bounded ASCII decoding reduced that to 93.506 ns, but the matched 5/12 baseline measured 89.564 ns. Decoding IDs directly removed duplicate platform validation (64.450 ns valid, 80.431 ns with state, 21.360 ns invalid); eliminating redundant stack initialization then gave the final numbers above. The preceding decoded candidate's consumer control/link means were 304.634/418.415 ns; their final movement to 314.387/429.721 ns tracks the unchanged control and overlaps confidence intervals. Final valid/state timing remains within the preceding candidate's intervals, and invalid-version cost improves. No performance trade is being accepted.

No-listener extraction remains 0 B. Valid extraction necessarily owns the platform ActivityTraceId/ActivitySpanId strings (144 B), plus decoded tracestate when present; the existing sampled Activity benchmark intentionally includes diagnostic-span allocations. Those existing costs decrease here. Invalid extraction is 0 B. No end-to-end throughput, p99/max delivery latency, or CPU/message claim is inferred from these local microbenchmarks; no paid stress dispatch was used.

Review candidate: `2ae0c82b5e964695e237c02e7bceb8d95f45df3c`.

Review cleanup: remove the unused deferred-string traceparent branch and apply SkipLocalsInit on both targets, matching existing protocol/header code. The project supplies the compatibility attribute through Polyfill; stack slices are fully written before consumption. Existing deferred-Activity round-trip coverage remains intact.

Validation: 81 diagnostics unit tests and both malformed-header integration cases pass on each of net8.0/net10.0 (166 total). Release unit/integration builds have zero warnings/errors. /simplify and diff checks pass.

Review comparison against immediately preceding head 9cc985b586b1fe7bbda40d552eafa1c921683966: same temporary fixture copied from TraceContextExtractionBenchmarks, BDN 0.15.8 + MemoryDiagnoser, in-process, 5 warmups / 15 iterations, Windows 11 / i7-12700K / SDK 10.0.400, runtimes .NET 8.0.30 and 10.0.11. Own builds/tests completed before measurement. Error is 99.9% CI half-width; SD in parentheses.

| Runtime / case | Before mean ± error (SD) | After mean ± error (SD) | Allocation before → after |
| --- | --- | --- | --- |
| net8.0 / Valid | 93.6911 ns ± 2.0308 ns (1.8002 ns) | 92.2532 ns ± 1.8409 ns (1.6319 ns) | 144 B → 144 B |
| net8.0 / WithTracestate | 128.6853 ns ± 8.5140 ns (7.1096 ns) | 115.4332 ns ± 2.7643 ns (2.4504 ns) | 192 B → 192 B |
| net8.0 / InvalidVersion | 31.5568 ns ± 2.3980 ns (2.2431 ns) | 26.3577 ns ± 0.3117 ns (0.2764 ns) | 0 B → 0 B |
| net8.0 / NoHeaders | 0.0380 ns ± 0.0378 ns (0.0353 ns) | 0.0162 ns ± 0.0099 ns (0.0088 ns) | 0 B → 0 B |
| net8.0 / NoListenerGuard | 0.7130 ns ± 0.2892 ns (0.2564 ns) | 0.5848 ns ± 0.0254 ns (0.0237 ns) | 0 B → 0 B |
| net10.0 / Valid | 68.7557 ns ± 3.2264 ns (2.5190 ns) | 62.9669 ns ± 1.2482 ns (1.1676 ns) | 144 B → 144 B |
| net10.0 / WithTracestate | 90.6914 ns ± 6.9683 ns (6.5181 ns) | 82.8804 ns ± 6.8096 ns (6.0365 ns) | 192 B → 192 B |
| net10.0 / InvalidVersion | 20.3400 ns ± 1.7011 ns (1.5912 ns) | 18.6221 ns ± 0.8368 ns (0.6987 ns) | 0 B → 0 B |
| net10.0 / NoHeaders | 0.0998 ns ± 0.0333 ns (0.0296 ns) | 0.0000 ns ± 0.0000 ns (0.0000 ns) | 0 B → 0 B |
| net10.0 / NoListenerGuard | 0.2868 ns ± 0.0669 ns (0.0593 ns) | 0.0931 ns ± 0.0451 ns (0.0421 ns) | 0 B → 0 B |

All parser point estimates improve; valid/tracestate allocation remains 144/192 B and invalid/no-header/no-listener allocation stays 0 B. No-header and no-listener values are below useful timing resolution; BDN flags zero measurements and a bimodal .NET 10 no-listener distribution, so no sub-nanosecond speed claim is made. The guard implementation is unchanged. No performance trade is accepted; original PR comparisons against 0992c526 remain above. No paid stress or end-to-end throughput/latency/CPU claim.

Before → after DLL SHA-256: netstandard2.0 14FCDBCF8BC90F3C5469B80B5A222F3CFCEF7631AE7770EB7313C1A0CB5E06BD → 0C0F59B3C1A738C95CBE74B0B9BF2A630EA057214D5066E4EA4B184C288F0579; net10.0 D84F8710030F83386D5897B6484F0016531B5EAF7E3A5D3E9AAE95E6032BD0DD → FA121D748B755CBE9ECDDBAFA746BF5F4243B8E7873F8FDDFD1B6A943E414118. Reports/fixture remain in .artifacts/bench-review-{before,after}-{net8.0,net10.0} and .artifacts/trace-bench.

Closes #3063





