### PR TITLE
fix(schema-registry): release invalidated resolution bookkeeping

### DIFF
--- a/src/Dekaf.SchemaRegistry/SchemaRegistryMigrationRunner.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryMigrationRunner.cs
@@ -13,7 +13,7 @@ internal sealed class SchemaRegistryMigrationRunner
     private readonly ISchemaRegistryClient _schemaRegistry;
     private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
     private readonly SchemaRegistryRuleExecutor? _schemaRuleExecutor;
-    private readonly SchemaResolutionCache<MigrationPlan> _plans = new();
+    private readonly SchemaResolutionCache<MigrationPlan> _plans;
     private readonly TimeSpan _timeout;
     private MigrationPlan? _lastPlan;
     private readonly long _latestCacheTtlMilliseconds;
@@ -36,6 +36,10 @@ internal sealed class SchemaRegistryMigrationRunner
         }
 
         _latestCacheTtlMilliseconds = (long)latestCacheTtlSecs * 1000;
+        // A zero TTL never reuses a completed plan. Coalesce pending resolutions only,
+        // avoiding cache publication/invalidation bookkeeping on every message.
+        _plans = new SchemaResolutionCache<MigrationPlan>(
+            SubjectSchemaIdCache.MaxCachedEntries, cacheCompletedResolutions: latestCacheTtlSecs != 0);
     }
 
     internal static (

--- a/src/Dekaf.SchemaRegistry/SchemaResolutionCache.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaResolutionCache.cs
@@ -5,11 +5,17 @@ namespace Dekaf.SchemaRegistry;
 
 internal sealed class SchemaResolutionCache<TValue>
 {
-    private readonly ConcurrentDictionary<SchemaResolutionKey, TValue> _cache =
-        new(SchemaResolutionKeyComparer.Instance);
+    private readonly ConcurrentDictionary<SchemaResolutionKey, TValue> _cache;
     private readonly ConcurrentDictionary<SchemaResolutionKey, Entry> _inFlight =
         new(SchemaResolutionKeyComparer.Instance);
-    private readonly ConcurrentQueue<KeyValuePair<SchemaResolutionKey, TValue>> _evictionQueue = new();
+    // Only completed-resolution mutations take this lock. Cached reads stay lock-free.
+    private readonly object _mutationLock = new();
+    private readonly Dictionary<SchemaResolutionKey, int> _evictionEntries;
+    private EvictionNode[] _evictionNodes;
+    private int _allocatedEntryCount;
+    private int _oldestEntry = -1;
+    private int _newestEntry = -1;
+    private int _freeEntry = -1;
     private readonly int _maxCachedEntries;
     private int _cacheCount;
 
@@ -17,10 +23,19 @@ internal sealed class SchemaResolutionCache<TValue>
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxCachedEntries);
         _maxCachedEntries = maxCachedEntries;
+        // Mutations already serialize below; extra dictionary write stripes add no concurrency.
+        _cache = new ConcurrentDictionary<SchemaResolutionKey, TValue>(
+            concurrencyLevel: 1, capacity: Math.Min(maxCachedEntries, 31), SchemaResolutionKeyComparer.Instance);
+        // Avoid repeated small-table growth while keeping sparse, large-capacity caches cheap.
+        var initialCapacity = Math.Min(maxCachedEntries, 16);
+        _evictionEntries = new Dictionary<SchemaResolutionKey, int>(
+            initialCapacity, SchemaResolutionKeyComparer.Instance);
+        _evictionNodes = new EvictionNode[initialCapacity];
     }
 
     internal int CachedEntryCount => Volatile.Read(ref _cacheCount);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal bool TryGet(string subject, Schema schema, out TValue value) =>
         _cache.TryGetValue(new SchemaResolutionKey(subject, schema, default), out value!);
 
@@ -29,11 +44,15 @@ internal sealed class SchemaResolutionCache<TValue>
         var entry = new KeyValuePair<SchemaResolutionKey, TValue>(
             new SchemaResolutionKey(subject, schema, default),
             value);
-        if (!((ICollection<KeyValuePair<SchemaResolutionKey, TValue>>)_cache).Remove(entry))
-            return false;
+        lock (_mutationLock)
+        {
+            if (!((ICollection<KeyValuePair<SchemaResolutionKey, TValue>>)_cache).Remove(entry))
+                return false;
 
-        Interlocked.Decrement(ref _cacheCount);
-        return true;
+            RemoveEvictionEntry(entry.Key);
+            Volatile.Write(ref _cacheCount, _cacheCount - 1);
+            return true;
+        }
     }
 
     internal ValueTask<TValue> ResolveAsync<TState>(
@@ -142,41 +161,74 @@ internal sealed class SchemaResolutionCache<TValue>
 
     private void CacheSuccessfulResolution(SchemaResolutionKey key, TValue value)
     {
-        if (!_cache.TryAdd(key, value))
-            return;
+        lock (_mutationLock)
+        {
+            if (!_cache.TryAdd(key, value))
+                return;
 
-        Interlocked.Increment(ref _cacheCount);
-        _evictionQueue.Enqueue(new KeyValuePair<SchemaResolutionKey, TValue>(key, value));
-        TrimOverflow();
+            if (_cacheCount == _maxCachedEntries)
+            {
+                var oldest = _evictionNodes[_oldestEntry].Key;
+                _cache.TryRemove(oldest, out _);
+                RemoveEvictionEntry(oldest);
+            }
+            else
+            {
+                Volatile.Write(ref _cacheCount, _cacheCount + 1);
+            }
+
+            int index;
+            if (_freeEntry >= 0)
+            {
+                index = _freeEntry;
+                _freeEntry = _evictionNodes[index].Next;
+            }
+            else
+            {
+                if (_allocatedEntryCount == _evictionNodes.Length)
+                {
+                    var newCapacity = _evictionNodes.Length <= _maxCachedEntries / 2
+                        ? _evictionNodes.Length * 2
+                        : _maxCachedEntries;
+                    Array.Resize(ref _evictionNodes, newCapacity);
+                }
+                index = _allocatedEntryCount++;
+            }
+
+            _evictionNodes[index] = new EvictionNode { Key = key, Previous = _newestEntry, Next = -1 };
+            if (_newestEntry >= 0)
+                _evictionNodes[_newestEntry].Next = index;
+            else
+                _oldestEntry = index;
+            _newestEntry = index;
+            _evictionEntries.Add(key, index);
+        }
     }
 
-    private void TrimOverflow()
+    private void RemoveEvictionEntry(SchemaResolutionKey key)
     {
-        while (true)
-        {
-            var count = Volatile.Read(ref _cacheCount);
-            if (count <= _maxCachedEntries)
-                return;
+        var removed = _evictionEntries.Remove(key, out var index);
+        System.Diagnostics.Debug.Assert(removed);
+        ref var node = ref _evictionNodes[index];
+        if (node.Previous >= 0)
+            _evictionNodes[node.Previous].Next = node.Next;
+        else
+            _oldestEntry = node.Next;
+        if (node.Next >= 0)
+            _evictionNodes[node.Next].Previous = node.Previous;
+        else
+            _newestEntry = node.Previous;
+        // Reuse bounded bookkeeping storage without retaining invalidated schemas or subjects.
+        node = default;
+        node.Next = _freeEntry;
+        _freeEntry = index;
+    }
 
-            if (Interlocked.CompareExchange(ref _cacheCount, count - 1, count) != count)
-                continue;
-
-            var removed = false;
-            while (_evictionQueue.TryDequeue(out var oldest))
-            {
-                if (((ICollection<KeyValuePair<SchemaResolutionKey, TValue>>)_cache).Remove(oldest))
-                {
-                    removed = true;
-                    break;
-                }
-            }
-
-            if (!removed)
-            {
-                Interlocked.Increment(ref _cacheCount);
-                return;
-            }
-        }
+    private struct EvictionNode
+    {
+        internal SchemaResolutionKey Key;
+        internal int Previous;
+        internal int Next;
     }
 
     private sealed class Entry
@@ -201,6 +253,9 @@ internal sealed class SchemaResolutionCache<TValue>
 
         private static Task<TValue> ObserveFault(Task<TValue> task)
         {
+            if (task.IsCompletedSuccessfully)
+                return task;
+
             _ = task.ContinueWith(
                 static completed => _ = completed.Exception,
                 CancellationToken.None,

--- a/src/Dekaf.SchemaRegistry/SchemaResolutionCache.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaResolutionCache.cs
@@ -17,20 +17,27 @@ internal sealed class SchemaResolutionCache<TValue>
     private int _newestEntry = -1;
     private int _freeEntry = -1;
     private readonly int _maxCachedEntries;
+    private readonly bool _cacheCompletedResolutions;
     private int _cacheCount;
 
     internal SchemaResolutionCache(int maxCachedEntries = SubjectSchemaIdCache.MaxCachedEntries)
+        : this(maxCachedEntries, cacheCompletedResolutions: true)
+    {
+    }
+
+    internal SchemaResolutionCache(int maxCachedEntries, bool cacheCompletedResolutions)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxCachedEntries);
         _maxCachedEntries = maxCachedEntries;
+        _cacheCompletedResolutions = cacheCompletedResolutions;
         // Mutations already serialize below; extra dictionary write stripes add no concurrency.
         _cache = new ConcurrentDictionary<SchemaResolutionKey, TValue>(
             concurrencyLevel: 1, capacity: Math.Min(maxCachedEntries, 31), SchemaResolutionKeyComparer.Instance);
         // Avoid repeated small-table growth while keeping sparse, large-capacity caches cheap.
-        var initialCapacity = Math.Min(maxCachedEntries, 16);
+        var initialCapacity = cacheCompletedResolutions ? Math.Min(maxCachedEntries, 16) : 0;
         _evictionEntries = new Dictionary<SchemaResolutionKey, int>(
             initialCapacity, SchemaResolutionKeyComparer.Instance);
-        _evictionNodes = new EvictionNode[initialCapacity];
+        _evictionNodes = initialCapacity == 0 ? [] : new EvictionNode[initialCapacity];
     }
 
     internal int CachedEntryCount => Volatile.Read(ref _cacheCount);
@@ -41,6 +48,9 @@ internal sealed class SchemaResolutionCache<TValue>
 
     internal bool TryRemove(string subject, Schema schema, TValue value)
     {
+        if (!_cacheCompletedResolutions)
+            return false;
+
         var entry = new KeyValuePair<SchemaResolutionKey, TValue>(
             new SchemaResolutionKey(subject, schema, default),
             value);
@@ -161,6 +171,9 @@ internal sealed class SchemaResolutionCache<TValue>
 
     private void CacheSuccessfulResolution(SchemaResolutionKey key, TValue value)
     {
+        if (!_cacheCompletedResolutions)
+            return;
+
         lock (_mutationLock)
         {
             if (!_cache.TryAdd(key, value))

--- a/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
+++ b/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PublishAot)' == 'true'">
+    <DefineConstants>$(DefineConstants);NATIVEAOT</DefineConstants>
     <!-- Full integration publish roots tests that intentionally exercise reflection-based APIs. -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2026;IL2104;IL3050;IL3053</WarningsNotAsErrors>
   </PropertyGroup>

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryRuleIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryRuleIntegrationTests.cs
@@ -284,22 +284,24 @@ public sealed class SchemaRegistryRuleIntegrationTests(KafkaWithSchemaRegistryCo
         for (var index = 0; index < 32; index++)
             await Assert.That(deserializer.Deserialize(wire, CreateContext(topic))).IsEqualTo("payload|v2");
 
+#if !NATIVEAOT
+        // NativeAOT retains the migration/payload checks above; private layout inspection is JIT-only.
         var flags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic;
         var runner = deserializer.GetType().GetField("_migrationRunner", flags)!.GetValue(deserializer)!;
         var plans = runner.GetType().GetField("_plans", flags)!.GetValue(runner)!;
-        var queue = plans.GetType().GetField("_evictionQueue", flags);
-        if (queue is not null)
+        var oldest = (int)plans.GetType().GetField("_oldestEntry", flags)!.GetValue(plans)!;
+        if (latestCacheTtlSecs == 0)
         {
-            await Assert.That(((System.Collections.ICollection)queue.GetValue(plans)!).Count).IsEqualTo(1);
+            await Assert.That(oldest).IsEqualTo(-1);
         }
         else
         {
-            var oldest = (int)plans.GetType().GetField("_oldestEntry", flags)!.GetValue(plans)!;
             var nodes = (Array)plans.GetType().GetField("_evictionNodes", flags)!.GetValue(plans)!;
             await Assert.That(oldest).IsGreaterThanOrEqualTo(0);
             var node = nodes.GetValue(oldest)!;
             await Assert.That((int)node.GetType().GetField("Next", flags)!.GetValue(node)!).IsEqualTo(-1);
         }
+#endif
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryRuleIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryRuleIntegrationTests.cs
@@ -228,13 +228,16 @@ public sealed class SchemaRegistryRuleIntegrationTests(KafkaWithSchemaRegistryCo
     }
 
     [Test]
-    public async Task RegisteredMigrationRules_UseLatestVersion_ExecutesUpgradePath()
+    [Arguments(-1)]
+    [Arguments(0)]
+    public async Task RegisteredMigrationRules_UseLatestVersion_ExecutesUpgradePath(int latestCacheTtlSecs)
     {
         var topic = await testInfra.CreateTestTopicAsync();
         var subject = $"{topic}-value";
         using var registryClient = new SchemaRegistryClient(new SchemaRegistryConfig
         {
-            Url = testInfra.RegistryUrl
+            Url = testInfra.RegistryUrl,
+            LatestCacheTtlSecs = latestCacheTtlSecs
         });
         var v1 = new Schema
         {
@@ -277,6 +280,26 @@ public sealed class SchemaRegistryRuleIntegrationTests(KafkaWithSchemaRegistryCo
 
         await Assert.That(result).IsEqualTo("payload|v2");
         await Assert.That(calls).IsEquivalentTo(["Upgrade:MigrationV1->MigrationV2"]);
+
+        for (var index = 0; index < 32; index++)
+            await Assert.That(deserializer.Deserialize(wire, CreateContext(topic))).IsEqualTo("payload|v2");
+
+        var flags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic;
+        var runner = deserializer.GetType().GetField("_migrationRunner", flags)!.GetValue(deserializer)!;
+        var plans = runner.GetType().GetField("_plans", flags)!.GetValue(runner)!;
+        var queue = plans.GetType().GetField("_evictionQueue", flags);
+        if (queue is not null)
+        {
+            await Assert.That(((System.Collections.ICollection)queue.GetValue(plans)!).Count).IsEqualTo(1);
+        }
+        else
+        {
+            var oldest = (int)plans.GetType().GetField("_oldestEntry", flags)!.GetValue(plans)!;
+            var nodes = (Array)plans.GetType().GetField("_evictionNodes", flags)!.GetValue(plans)!;
+            await Assert.That(oldest).IsGreaterThanOrEqualTo(0);
+            var node = nodes.GetValue(oldest)!;
+            await Assert.That((int)node.GetType().GetField("Next", flags)!.GetValue(node)!).IsEqualTo(-1);
+        }
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryMigrationTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryMigrationTests.cs
@@ -631,7 +631,7 @@ public sealed class SchemaRegistryMigrationTests
         var plans = typeof(SchemaRegistryMigrationRunner).GetField(
             "_plans", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!.GetValue(runner)!;
         await Assert.That(registry.LatestCount).IsEqualTo(100);
-        await Assert.That(SchemaResolutionCacheLifetimeTests.BookkeepingCount(plans)).IsEqualTo(1);
+        await Assert.That(SchemaResolutionCacheLifetimeTests.BookkeepingCount(plans)).IsEqualTo(ttlSeconds == 0 ? 0 : 1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryMigrationTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryMigrationTests.cs
@@ -604,6 +604,37 @@ public sealed class SchemaRegistryMigrationTests
     }
 
     [Test]
+    [Arguments(0)]
+    [Arguments(60)]
+    public async Task LatestPlanRefresh_DoesNotRetainExpiredBookkeeping(int ttlSeconds)
+    {
+        var registry = new MigrationRegistryClient { LatestCacheTtlSecs = ttlSeconds };
+        var schema = CreateSchema("v1");
+        var schemaId = registry.Register("orders-value", schema);
+        var runner = new SchemaRegistryMigrationRunner(registry, ruleExecutor: null, TimeSpan.FromSeconds(1));
+        var payload = "payload"u8.ToArray();
+        var lastPlanField = typeof(SchemaRegistryMigrationRunner).GetField(
+            "_lastPlan", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        for (var index = 0; index < 100; index++)
+        {
+            runner.Transform(payload, schemaId, "orders-value", schema, SerializationContext, SchemaRegistryPayloadFormat.Json);
+            if (ttlSeconds != 0)
+            {
+                // Move the existing plan's timestamp past expiry without timing-dependent waits.
+                var plan = lastPlanField.GetValue(runner)!;
+                plan.GetType().GetField("<CreatedAtMilliseconds>k__BackingField",
+                        System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                    .SetValue(plan, Environment.TickCount64 - ttlSeconds * 1_000L - 1);
+            }
+        }
+
+        var plans = typeof(SchemaRegistryMigrationRunner).GetField(
+            "_plans", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!.GetValue(runner)!;
+        await Assert.That(registry.LatestCount).IsEqualTo(100);
+        await Assert.That(SchemaResolutionCacheLifetimeTests.BookkeepingCount(plans)).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task DeletedVersionLookup_DefaultImplementation_FailsClosed()
     {
         ISchemaRegistryClient registry = new MockSchemaRegistryClient();

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaResolutionCacheLifetimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaResolutionCacheLifetimeTests.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Dekaf.SchemaRegistry;
@@ -7,6 +6,36 @@ namespace Dekaf.Tests.Unit.SchemaRegistry;
 
 public class SchemaResolutionCacheLifetimeTests
 {
+    [Test]
+    public async Task CompletedCachingDisabled_CoalescesPendingWorkWithoutRetainingResults()
+    {
+        var cache = new SchemaResolutionCache<object>(4, cacheCompletedResolutions: false);
+        var schema = new Schema { SchemaString = "{}", SchemaType = SchemaType.Json };
+        var release = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        Task<object> ResolvePending(int _, string subject, Schema requested)
+        {
+            Interlocked.Increment(ref calls);
+            return release.Task;
+        }
+
+        var first = cache.ResolveAsync("subject", schema, 0, ResolvePending, CancellationToken.None);
+        var second = cache.ResolveAsync("subject", schema, 0, ResolvePending, CancellationToken.None);
+        await Assert.That(calls).IsEqualTo(1);
+        var value = new object();
+        release.SetResult(value);
+        await Assert.That(ReferenceEquals(await first, value)).IsTrue();
+        await Assert.That(ReferenceEquals(await second, value)).IsTrue();
+        var next = await Resolve(cache, "subject", schema);
+
+        await Assert.That(ReferenceEquals(next, value)).IsFalse();
+        await Assert.That(cache.TryGet("subject", schema, out _)).IsFalse();
+        await Assert.That(cache.TryRemove("subject", schema, next)).IsFalse();
+        await Assert.That(cache.CachedEntryCount).IsEqualTo(0);
+        await Assert.That(BookkeepingCount(cache)).IsEqualTo(0);
+        await Assert.That(PooledEntryCount(cache)).IsEqualTo(0);
+    }
+
     [Test]
     [Arguments(1)]
     [Arguments(3)]
@@ -109,10 +138,6 @@ public class SchemaResolutionCacheLifetimeTests
     internal static int BookkeepingCount(object cache)
     {
         var flags = BindingFlags.Instance | BindingFlags.NonPublic;
-        var queue = cache.GetType().GetField("_evictionQueue", flags);
-        if (queue is not null)
-            return ((ICollection)queue.GetValue(cache)!).Count;
-
         var nodes = (Array)cache.GetType().GetField("_evictionNodes", flags)!.GetValue(cache)!;
         var index = (int)cache.GetType().GetField("_oldestEntry", flags)!.GetValue(cache)!;
         var count = 0;
@@ -128,8 +153,8 @@ public class SchemaResolutionCacheLifetimeTests
 
     private static int PooledEntryCount(object cache)
     {
-        var field = cache.GetType().GetField("_allocatedEntryCount", BindingFlags.Instance | BindingFlags.NonPublic);
-        return field is null ? 0 : (int)field.GetValue(cache)! - BookkeepingCount(cache);
+        var field = cache.GetType().GetField("_allocatedEntryCount", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (int)field.GetValue(cache)! - BookkeepingCount(cache);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaResolutionCacheLifetimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaResolutionCacheLifetimeTests.cs
@@ -1,0 +1,154 @@
+using System.Collections;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Dekaf.SchemaRegistry;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public class SchemaResolutionCacheLifetimeTests
+{
+    [Test]
+    [Arguments(1)]
+    [Arguments(3)]
+    public async Task RepeatedInvalidation_ReleasesValuesAndBookkeeping(int keyCount)
+    {
+        var cache = new SchemaResolutionCache<object>(4);
+        var references = PopulateAndInvalidate(cache, keyCount);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        await Assert.That(cache.CachedEntryCount).IsEqualTo(0);
+        await Assert.That(BookkeepingCount(cache)).IsEqualTo(0);
+        await Assert.That(PooledEntryCount(cache)).IsLessThanOrEqualTo(4);
+        foreach (var reference in references)
+            await Assert.That(reference.IsAlive).IsFalse();
+        GC.KeepAlive(cache);
+    }
+
+    [Test]
+    public async Task StaleRemoval_DoesNotRemoveReplacementOrEvictStableEntry()
+    {
+        var cache = new SchemaResolutionCache<object>(2);
+        var schema = new Schema { SchemaString = "{}", SchemaType = SchemaType.Json };
+        var stable = await Resolve(cache, "stable", schema);
+        var previous = await Resolve(cache, "refresh", schema);
+        for (var index = 0; index < 1_000; index++)
+        {
+            await Assert.That(cache.TryRemove("refresh", schema, previous)).IsTrue();
+            var replacement = await Resolve(cache, "refresh", schema);
+            await Assert.That(cache.TryRemove("refresh", schema, previous)).IsFalse();
+            await Assert.That(cache.TryGet("refresh", schema, out var current)).IsTrue();
+            await Assert.That(ReferenceEquals(current, replacement)).IsTrue();
+            previous = replacement;
+        }
+
+        await Assert.That(cache.TryGet("stable", schema, out var retained)).IsTrue();
+        await Assert.That(ReferenceEquals(stable, retained)).IsTrue();
+        await Assert.That(cache.CachedEntryCount).IsEqualTo(2);
+        await Assert.That(BookkeepingCount(cache)).IsEqualTo(2);
+    }
+
+    [Test]
+    [Arguments(8)]
+    [Arguments(33)]
+    public async Task ConcurrentInvalidationAndOverflow_KeepBookkeepingBounded(int capacity)
+    {
+        var cache = new SchemaResolutionCache<object>(capacity);
+        var schema = new Schema { SchemaString = "{}", SchemaType = SchemaType.Json };
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var workers = new Task[16];
+        for (var index = 0; index < workers.Length; index++)
+        {
+            var subject = $"subject-{index}";
+            workers[index] = Task.Run(async () =>
+            {
+                await gate.Task;
+                for (var cycle = 0; cycle < 100; cycle++)
+                {
+                    var value = await Resolve(cache, subject, schema);
+                    cache.TryRemove(subject, schema, value);
+                }
+            });
+        }
+
+        gate.SetResult();
+        await Task.WhenAll(workers);
+        await Assert.That(cache.CachedEntryCount).IsEqualTo(0);
+        await Assert.That(BookkeepingCount(cache)).IsEqualTo(0);
+        for (var index = 0; index < capacity * 2; index++)
+            await Resolve(cache, $"overflow-{index}", schema);
+        await Assert.That(cache.CachedEntryCount).IsEqualTo(capacity);
+        await Assert.That(BookkeepingCount(cache)).IsEqualTo(capacity);
+        await Assert.That(PooledEntryCount(cache)).IsEqualTo(0);
+        for (var index = 0; index < capacity * 2; index++)
+            await Assert.That(cache.TryGet($"overflow-{index}", schema, out _)).IsEqualTo(index >= capacity);
+    }
+
+    [Test]
+    public async Task RemoveMiddleEntry_ReusePreservesInsertionOrder()
+    {
+        var cache = new SchemaResolutionCache<object>(3);
+        var schema = new Schema { SchemaString = "{}", SchemaType = SchemaType.Json };
+        await Resolve(cache, "first", schema);
+        var middle = await Resolve(cache, "middle", schema);
+        await Resolve(cache, "last", schema);
+        await Assert.That(cache.TryRemove("middle", schema, middle)).IsTrue();
+        await Resolve(cache, "replacement", schema);
+        await Resolve(cache, "overflow", schema);
+
+        await Assert.That(cache.TryGet("first", schema, out _)).IsFalse();
+        await Assert.That(cache.TryGet("middle", schema, out _)).IsFalse();
+        await Assert.That(cache.TryGet("last", schema, out _)).IsTrue();
+        await Assert.That(cache.TryGet("replacement", schema, out _)).IsTrue();
+        await Assert.That(cache.TryGet("overflow", schema, out _)).IsTrue();
+        await Assert.That(BookkeepingCount(cache)).IsEqualTo(3);
+    }
+
+    internal static int BookkeepingCount(object cache)
+    {
+        var flags = BindingFlags.Instance | BindingFlags.NonPublic;
+        var queue = cache.GetType().GetField("_evictionQueue", flags);
+        if (queue is not null)
+            return ((ICollection)queue.GetValue(cache)!).Count;
+
+        var nodes = (Array)cache.GetType().GetField("_evictionNodes", flags)!.GetValue(cache)!;
+        var index = (int)cache.GetType().GetField("_oldestEntry", flags)!.GetValue(cache)!;
+        var count = 0;
+        while (index >= 0)
+        {
+            if (++count > nodes.Length)
+                throw new InvalidOperationException("Cycle in eviction bookkeeping.");
+            var node = nodes.GetValue(index)!;
+            index = (int)node.GetType().GetField("Next", flags)!.GetValue(node)!;
+        }
+        return count;
+    }
+
+    private static int PooledEntryCount(object cache)
+    {
+        var field = cache.GetType().GetField("_allocatedEntryCount", BindingFlags.Instance | BindingFlags.NonPublic);
+        return field is null ? 0 : (int)field.GetValue(cache)! - BookkeepingCount(cache);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference[] PopulateAndInvalidate(SchemaResolutionCache<object> cache, int keyCount)
+    {
+        var references = new WeakReference[2_000];
+        for (var index = 0; index < references.Length / 2; index++)
+        {
+            var schema = new Schema { SchemaString = "{}", SchemaType = SchemaType.Json };
+            var subject = $"subject-{index % keyCount}";
+            var value = Resolve(cache, subject, schema).Result;
+            references[index * 2] = new WeakReference(value);
+            references[index * 2 + 1] = new WeakReference(schema);
+            if (!cache.TryRemove(subject, schema, value))
+                throw new InvalidOperationException("Expected the resolved entry to be removed.");
+        }
+        return references;
+    }
+
+    private static ValueTask<object> Resolve(SchemaResolutionCache<object> cache, string subject, Schema schema) =>
+        cache.ResolveAsync(subject, schema, 0, static (_, _, _) => Task.FromResult(new object()), CancellationToken.None);
+}


### PR DESCRIPTION
Repeated schema-resolution invalidation removed the active entry but retained its key and value in an eviction queue. Below capacity, nothing drained that queue: 1,000 resolve/remove cycles retained 1,000 obsolete entries. Finite latest-schema TTLs could trigger the same retention through migration-plan refresh; the default TTL of -1 does not periodically refresh.

Completed resolutions with nonzero TTLs use a bounded indexed FIFO with reusable slots. A zero TTL coalesces pending resolutions without publishing completed plans, so per-message refresh bypasses the completed-cache mutation lock entirely. Conditional invalidation removes its FIFO entry immediately and clears retained schema/subject references. One mutation lock covers removal, publication, eviction, and slot reuse; no resolver or await runs under it. Cache hits retain the original value layout and lock-free dictionary lookup. Pending/faulted resolution tasks remain observed; already-successful tasks skip an unnecessary fault-only continuation.

Validation:
- Six initial regression cases failed before the fix, including zero/finite migration TTL and 1,000-entry retention reproductions.
- 1,275 net8.0 and 1,272 net10.0 schema registry unit cases pass. Coverage includes collected values/schema objects, repeated replacement, stale conditional removals, concurrent turnover, FIFO ordering, slot reuse, and growth to a non-power-of-two capacity.
- Both real-registry migration cases pass with TTL -1/0, each performing 33 deserializations. Fixture: Kafka 4.0.2 and Schema Registry 7.9.0.
- Normal Release builds: zero warnings/errors. NativeAOT analyzer build (`dotnet build -p:PublishAot=true`) passes with zero errors and 87 allowed trim/reflection warnings; native linking/runtime remains for CI. Private-layout assertions are JIT-only; NativeAOT retains all migration/payload assertions and both TTL cases. `/simplify` and diff checks complete.

Original implementation performance evidence: exact base b2580c3b23b71152cd5fe6be8121340a3abdb8b1 → candidate 0ff5e783794c5e9c3b24237b5901425caa4540c0, same temporary fixture and settings throughout: BenchmarkDotNet 0.15.8, MemoryDiagnoser, .NET 10.0.11 / SDK 10.0.400, Windows 11, i7-12700K, in-process, five warmups and 15 iterations. Cold cases contain 128 operations per cache instance; construction is included equally and amortized, preventing the baseline leak from growing throughout calibration. Cached requests use preallocated schemas/delegates/results. No paid stress run or broker throughput/p50/p99/max/CPU-per-message measurement was performed for this cache lifecycle change.

Measured results (mean ± 99.9% CI half-width; SD in parentheses):

| Case | Base | Final | Allocation before → after |
| --- | --- | --- | --- |
| Integer cache hit | 34.74 ± 0.212 ns (0.177) | 35.12 ± 0.493 ns (0.437) | 0 B → 0 B |
| Integer TryGet | 31.35 ± 0.087 ns (0.077) | 32.18 ± 0.304 ns (0.269) | 0 B → 0 B |
| Refresh/remove | 389.96 ± 15.361 ns (14.369) | 354.92 ± 6.961 ns (6.170) | 605 B → 402 B |
| Overflow | 381.53 ± 30.271 ns (25.278) | 344.44 ± 3.705 ns (3.093) | 548 B → 402 B |

Cold refresh improves 9.0% in this DLL comparison and allocation falls 33.6%; overflow improves 9.7% and allocation falls 26.6%. These allocations are per resolution/invalidation, not per cached message. Integer hit/TryGet shifts are +0.38 ns / +0.83 ns; no hit-path speed claim is made.

Additional same-process value-shape controls used the unchanged baseline cache source under a renamed type, alongside the candidate DLL:

| Case | Before | Final | Allocated both |
| --- | --- | --- | --- |
| Reference-valued hit | 35.23 ± 0.236 ns (0.197) | 34.08 ± 0.379 ns (0.336) | 0 B |
| Actual SubjectSchemaIdCacheValue hit | 42.72 ± 0.670 ns (0.560) | 40.88 ± 0.667 ns (0.521) | 0 B |
| Reference TryGet, before explicit inlining | 31.99 ± 0.734 ns (0.651) | 35.20 ± 1.217 ns (1.138) | 0 B |
| Reference TryGet, with explicit inlining | 30.19 ± 0.298 ns (0.249) | 32.09 ± 0.839 ns (0.785) | 0 B |

The renamed-source reference-lookup comparison remained sensitive to comparison layout and host timing. Rather than calling that a pass, the final lookup control loads the exact saved before/after DLLs into separate AssemblyLoadContexts in one process. Identical compiled expression delegates warm and invoke each private cache; no reflection or setup occurs in measured calls. This yields 33.40 ± 0.379 ns (SD 0.336) → 34.04 ± 0.312 ns (SD 0.276), +0.64 ns / 1.9%, with 0 B for both and overlapping confidence intervals. Together with unchanged cache-value layout/read algorithm and zero allocation across value shapes, this finds no material lookup regression; the point increase is recorded, not rounded into a speedup. The wrapper affects absolute times, so compare only within that pair.

The original implementation's last edit adds AggressiveInlining to TryGet. Other final implementation measurements above remain unchanged by that attribute. Final schema registry DLL SHA-256: 8CFCFEE10DAE5AE535134D22DFF3A8C2F7AF799039D75A0FD96126DC22F7D6AD; prior final-layout DLL used for the broader cases: E41E022BD716A42F3D149E5EE1A6AF4F90ACE90981AF3956766649F63A0F6738; base DLL: 455F82A602E63F159B9D47E985FE5B8BB378BA9876F44BD6DF2FCBAAC44E29D1.

<details>
<summary>Rejected designs and all intermediate controls</summary>

All rows use the settings above. Timing columns are mean ns; allocations are refresh/overflow B. Full CI/SD reports remain in the isolated worktree `.artifacts/bench-*` directories. None of these rejected candidates was committed or dispatched to paid runners.

| Design/report | Hit | TryGet | Refresh | Overflow | Cold allocation |
| --- | ---: | ---: | ---: | ---: | --- |
| Base DLL / before | 34.74 | 31.35 | 389.96 | 381.53 | 605 / 548 |
| Linked-list bookkeeping / after | 33.85 | 33.62 | 385.81 | 398.21 | 518 / 557 |
| Pre-sized linked list / sized | 36.06 | 32.79 | 390.97 | 397.42 | 524 / 552 |
| Indexed FIFO / indexed | 34.81 | 32.36 | 395.38 | 398.50 | 528 / 549 |
| Single write stripe / stripe | 33.75 | 29.86 | 380.45 | 391.17 | 522 / 522 |
| Renamed-source base / paired | 35.67 | 31.96 | 358.29 | 366.96 | 605 / 552 |
| Stripe candidate / paired | 35.39 | 32.34 | 421.46 | 392.46 | 522 / 522 |
| Wrapped cache value / unified | 33.58 | 32.24 | 401.65 | 346.50 | 522 / 522 |
| Wrapped value, successful-task fast path / observer | 34.96 | 30.83 | 365.53 | 315.43 | 402 / 402 |
| Original value layout, successful-task fast path / plain | 35.12 | 32.28 | 354.92 | 344.44 | 402 / 402 |

The first designs added cold allocation and/or showed unresolved timing costs. The paired stripe run was inconclusive for timing (refresh 358.29 ± 4.969 → 421.46 ± 26.061 ns), not accepted as a performance pass. The wrapped-value design was rejected outright after representative schema-ID cache hits regressed 42.52 ± 1.086 → 46.22 ± 1.035 ns (+9%, both 0 B). Restoring the original value layout removes that trade: the final equivalent pair improves 42.72 → 40.88 ns. Successful completed tasks skip the otherwise unnecessary 120 B fault-only continuation; pending and failed tasks retain fault observation.

Local fixtures/reports: `.artifacts/cache-bench`, `bench-before`, `bench-after`, `bench-sized`, `bench-indexed`, `bench-stripe`, `bench-paired`, `bench-unified`, `bench-observer`, `bench-value-shapes`, `bench-plain`, `bench-inlined`, and `bench-saved-lookup`.
</details>

Review changes in `f585252137031e1d8e99d1c578cf10a6069e0c5b`:
- `LatestCacheTtlSecs=0` now retains only pending resolutions. Completed plans bypass publication/removal locks and allocate no FIFO storage. The existing single-plan preparation handoff remains intact. A deterministic coalescing test verifies shared pending work, subsequent refresh, and zero retained entries.
- Removed obsolete eviction-queue reflection fallbacks. NativeAOT retains both functional migration cases; only private-layout inspection is omitted during AOT compilation. This fixes IL2075 from job https://github.com/thomhurst/Dekaf/actions/runs/34038772317/job/101502039311 without suppressing that diagnostic.

Review performance comparison against immediately preceding head `0ff5e783794c5e9c3b24237b5901425caa4540c0` uses the same BDN settings above and saved DLLs. Candidate DLL SHA-256: `16E56E2B1D3F81E25A22C671879E4CFDBA86DBAF6FC26D20E3889302F26632D3`.

| Case | Previous head, mean ± error (SD), ns | Review candidate, mean ± error (SD), ns | Allocation before → after |
| --- | --- | --- | --- |
| Cached hit | 35.46 ± 0.284 (0.266) | 35.31 ± 0.318 (0.282) | 0 B → 0 B |
| Cached TryGet | 30.89 ± 0.282 (0.250) | 30.45 ± 0.183 (0.153) | 0 B → 0 B |
| Zero-TTL resolution/remove policy | 356.52 ± 3.214 (2.849) | 206.42 ± 1.703 (1.422) | 402 B → 325 B |
| Finite-TTL refresh control | 356.52 ± 3.214 (2.849) | 364.22 ± 1.929 (1.506) | 402 B → 402 B |

The zero-TTL policy fixture resolves and invalidates 128 times per cache, including amortized construction on both sides. It measures cache-policy overhead, not registry I/O or full deserialization. Forced fresh resolution already allocates in this path; the fix reduces it by 19.2% and time by 42.1%, while cached paths stay at zero bytes. The finite-TTL control initially showed +2.2%; a subsequent exact prior-DLL control measured 384.1 ± 19.18 ns (SD 17.94), with BDN reporting a bimodal distribution. That noisy control is not a performance pass.

The subsequent same-process control (previous-head source renamed alongside the candidate DLL) remained noisy: 366.8 ± 40.61 ns (SD 36.00) → 405.7 ± 45.92 ns (SD 42.95), both 402 B. Changing the experiment to CPU affinity mask 1 gave 463.6 ± 157.9 ns (SD 147.7) → 361.8 ± 53.03 ns (SD 44.28), both 402 B. The sign reverses and errors expand; neither control is treated as a pass. No more identical local runs were launched. Cached-path and zero-TTL improvements are measured, but finite-TTL timing acceptance remains inconclusive pending a quieter controlled measurement; do not merge on these noisy controls alone. No paid stress dispatch or broker-level metric claims.

Review reports: `.artifacts/bench-review-before`, `bench-review-after`, `bench-review-before-control`, `bench-review-paired`, `bench-review-pinned`. Full 2,547 registry unit cases and both real-registry integration cases pass; 31 focused cases pass again after the final test-helper cleanup.

Additional experimental-design control (same f585252 candidate, no source changes): exact saved 0ff5/f585 DLLs loaded into separate AssemblyLoadContexts in one process; prewarmed long-lived reference-valued caches, identical compiled resolve/remove delegates, and no constructor/reflection work in measured calls. BDN 0.15.8, MemoryDiagnoser, in-process 5 warmups / 15 iterations, same host/runtime as above, default CPU affinity. Before 389.6 ± 9.44 ns (SD 7.89), after 418.1 ± 22.14 ns (SD 20.71), +7.3%; both 456 B per forced resolution. BDN flags a multimodal candidate distribution. These wrapper-inclusive reference-value results are comparable only within this pair, not directly to earlier integer batch figures. This control still does not establish a Pareto-safe finite-TTL result. The merge blocker remains; no further local repeats were launched. Fixture/report: .artifacts/cache-bench/SavedDllRefreshBenchmarks.cs and .artifacts/bench-review-steady-dll.

Closes #3057





