### PR TITLE
fix(consumer): retain partition handler storage

### DIFF
--- a/docs/docs/consumer/partitioned-processing-api.md
+++ b/docs/docs/consumer/partitioned-processing-api.md
@@ -57,6 +57,34 @@ Dekaf starts one processor invocation for each assigned `TopicPartition`. Each
 processor receives only the ordered stream for that partition. Processors for
 different partitions run concurrently.
 
+## Record Storage Lifetime
+
+Record and batch handlers can read raw keys, raw values, and lazy headers across
+asynchronous suspension until the handler returns. Dekaf retains the owning fetch
+storage while records are queued or being processed. For the long-lived partition
+processor's `Messages` stream, each record remains valid until the enumerator
+advances or is disposed. Copy borrowed data if it must outlive that boundary.
+
+Custom deserializers may return slices of their input: that fetch storage follows
+the same lifetime. A deserializer's own reusable scratch buffer is not fetch
+storage; return an owned value instead of exposing scratch memory that the next
+deserialization will overwrite.
+
+Retention ends after completion, failure, or cancellation. A handler that ignores
+cancellation retains its active storage until it actually exits, even when the
+runtime's stop timeout has elapsed. Revoke and lost-assignment cleanup use the same
+ownership rules. Key ordering also retains the input backing a dictionary key
+until its key lane is removed.
+
+`MaxBufferedRecordsPerPartition` bounds the partition queue, not retained bytes.
+Partition ordering additionally holds the active handler batch (one record for a
+record handler). Key ordering additionally holds at most that many dispatched
+records, one record waiting for a dispatch permit, and one retained key per active
+key lane. One borrowed record can pin an entire fetch response and its decompressed
+record storage. Budget those buffers separately from consumer prefetch; fetch-size
+settings and compression affect their byte cost. Slow handlers do not accumulate
+an unbounded history of completed fetches.
+
 ## Ordering And Parallelism
 
 The processor callback is long-lived. It starts when a partition is assigned and

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -553,6 +553,16 @@ public readonly struct ConsumeResult<TKey, TValue>
     private readonly PendingFetchData? _headerOwner;
     private readonly int _headerGeneration;
 
+    // The fetch owns both the raw deserializer input and lazy headers. Reuse its existing
+    // reference instead of enlarging every result or allocating a per-record lease.
+    internal PendingFetchData? RetainStorage()
+    {
+        _headerOwner?.RetainForProcessing();
+        return _headerOwner;
+    }
+
+    internal void ReleaseStorage() => _headerOwner?.ReleaseAfterProcessing();
+
     /// <summary>
     /// Creates a new ConsumeResult with eager deserialization.
     /// Deserializes key and value immediately to avoid storing deserializer references in the struct.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -418,6 +418,14 @@ internal sealed class PendingFetchData : IDisposable
         public void Dispose() => owner.ReleaseReference();
     }
 
+    internal void RetainForProcessing()
+    {
+        Debug.Assert(Volatile.Read(ref _referenceCount) > 0);
+        Interlocked.Increment(ref _referenceCount);
+    }
+
+    internal void ReleaseAfterProcessing() => ReleaseReference();
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private string CreateActivityName()
     {
@@ -440,7 +448,7 @@ internal sealed class PendingFetchData : IDisposable
     internal int HeaderGeneration => Volatile.Read(ref _headerGeneration);
 
     internal bool IsHeaderGenerationActive(int generation) =>
-        Volatile.Read(ref _disposed) == 0 && Volatile.Read(ref _headerGeneration) == generation;
+        Volatile.Read(ref _referenceCount) > 0 && Volatile.Read(ref _headerGeneration) == generation;
 
     /// <summary>
     /// Gets the current record via direct array access, bypassing lazy record-list
@@ -831,13 +839,18 @@ internal sealed class PendingFetchData : IDisposable
         ReleaseReference();
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ReleaseReference()
     {
         var remaining = Interlocked.Decrement(ref _referenceCount);
         Debug.Assert(remaining >= 0, "PendingFetchData reference count underflow.");
-        if (remaining != 0)
-            return;
+        if (remaining == 0)
+            ReleaseStorage();
+    }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReleaseStorage()
+    {
         // Dispose all batches to mark them as disposed.
         // Indexing avoids boxing/enumerator allocation from the IReadOnlyList<T> interface.
         var batches = _batches;

--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -127,8 +127,15 @@ public static class PartitionedConsumerExtensions
         {
             while (context.TryReadMessage(out var message))
             {
-                await processor(handlerContext, message, cancellationToken).ConfigureAwait(false);
-                context.MarkProcessed(message);
+                try
+                {
+                    await processor(handlerContext, message, cancellationToken).ConfigureAwait(false);
+                    context.MarkProcessed(message);
+                }
+                finally
+                {
+                    message.ReleaseStorage();
+                }
             }
         }
     }
@@ -152,10 +159,18 @@ public static class PartitionedConsumerExtensions
                 continue;
 
             var records = batch.ToArray();
-            await processor(handlerContext, records, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await processor(handlerContext, records, cancellationToken).ConfigureAwait(false);
 
-            for (var i = 0; i < records.Length; i++)
-                context.MarkProcessed(records[i]);
+                for (var i = 0; i < records.Length; i++)
+                    context.MarkProcessed(records[i]);
+            }
+            finally
+            {
+                for (var i = 0; i < records.Length; i++)
+                    records[i].ReleaseStorage();
+            }
         }
     }
 
@@ -278,6 +293,10 @@ public sealed class PartitionProcessorContext<TKey, TValue>
     /// <summary>
     /// Gets the ordered message stream for this partition.
     /// </summary>
+    /// <remarks>
+    /// Borrowed key/value data and lazy headers remain valid until the enumerator advances
+    /// or is disposed. Copy borrowed data before retaining it beyond that boundary.
+    /// </remarks>
     public IAsyncEnumerable<ConsumeResult<TKey, TValue>> Messages => _lane.Messages;
 
     /// <summary>
@@ -1406,6 +1425,7 @@ internal sealed class PartitionLane<TKey, TValue>
     private readonly SortedSet<long> _completedOffsets = [];
     private readonly Dictionary<long, int> _leaderEpochs = [];
     private long? _nextOffsetToCommit;
+    private int _pendingOffsetInitialized;
     private long? _completedOffset;
     private long? _lastProcessedOffset;
     private int _lastCommittedLeaderEpoch = -1;
@@ -1474,6 +1494,14 @@ internal sealed class PartitionLane<TKey, TValue>
                 _failed(this, ex);
                 throw;
             }
+            finally
+            {
+                // A timed-out handler still owns its active records until it actually exits.
+                // StopAsync must not release these buffers while user code is running.
+                CompleteWriter();
+                while (_channel.Reader.TryRead(out var abandoned))
+                    abandoned.ReleaseStorage();
+            }
         });
     }
 
@@ -1482,8 +1510,12 @@ internal sealed class PartitionLane<TKey, TValue>
         if (Volatile.Read(ref _completed) != 0)
             return false;
 
+        result.RetainStorage();
         if (!_channel.Writer.TryWrite(result))
+        {
+            result.ReleaseStorage();
             return false;
+        }
 
         TrackPending(result);
         Interlocked.Increment(ref _bufferedCount);
@@ -1541,13 +1573,16 @@ internal sealed class PartitionLane<TKey, TValue>
 
     private void TrackPending(ConsumeResult<TKey, TValue> message)
     {
-        if (message.IsPartitionEof)
+        if (message.IsPartitionEof || Volatile.Read(ref _pendingOffsetInitialized) != 0)
             return;
 
         lock (_offsetGate)
         {
             if (!_nextOffsetToCommit.HasValue)
                 _nextOffsetToCommit = message.Offset;
+            // This lane never resets the pending offset. Subsequent records need no lock
+            // merely to rediscover that initialization has already happened.
+            Volatile.Write(ref _pendingOffsetInitialized, 1);
         }
     }
 
@@ -1644,7 +1679,16 @@ internal sealed class PartitionLane<TKey, TValue>
         while (await WaitToReadMessageAsync(cancellationToken).ConfigureAwait(false))
         {
             while (TryReadMessage(out var item))
-                yield return item;
+            {
+                try
+                {
+                    yield return item;
+                }
+                finally
+                {
+                    item.ReleaseStorage();
+                }
+            }
         }
     }
 
@@ -1703,8 +1747,16 @@ internal sealed class KeyOrderedPartitionDispatcher<TKey, TValue>
             {
                 while (_context.TryReadMessage(out var message))
                 {
-                    await _inFlight.WaitAsync(_processingCancellationToken).ConfigureAwait(false);
-                    Enqueue(message);
+                    try
+                    {
+                        await _inFlight.WaitAsync(_processingCancellationToken).ConfigureAwait(false);
+                        Enqueue(message);
+                    }
+                    catch
+                    {
+                        message.ReleaseStorage();
+                        throw;
+                    }
                     ThrowIfFailed();
                 }
             }
@@ -1716,8 +1768,21 @@ internal sealed class KeyOrderedPartitionDispatcher<TKey, TValue>
         }
         finally
         {
-            if (cancellationToken.IsCancellationRequested || _failure is not null)
+            try
+            {
+                if (!_tasks.IsEmpty)
+                    await linkedCancellation.CancelAsync().ConfigureAwait(false);
+            }
+            finally
+            {
                 await ObserveActiveLanesAsync().ConfigureAwait(false);
+
+                // Dispatch has stopped and every active handler has exited. Remaining key queues
+                // belong to failed/cancelled lanes and cannot be handed to user code anymore.
+                foreach (var lane in _lanes.Values)
+                    lane.ReleaseQueuedStorage();
+                _lanes.Clear();
+            }
         }
 
         ThrowIfFailed();
@@ -1735,6 +1800,7 @@ internal sealed class KeyOrderedPartitionDispatcher<TKey, TValue>
             {
                 lane = new KeyOrderedProcessingLane<TKey, TValue>(this, key);
                 _lanes.Add(key, lane);
+                lane.RetainKeyStorage(message);
             }
 
             shouldStart = lane.Enqueue(message);
@@ -1795,6 +1861,8 @@ internal sealed class KeyOrderedPartitionDispatcher<TKey, TValue>
         }
         finally
         {
+            for (var i = 0; i < batch.Count; i++)
+                batch[i].ReleaseStorage();
             _inFlight.Release(batch.Count);
         }
     }
@@ -1823,6 +1891,7 @@ internal sealed class KeyOrderedPartitionDispatcher<TKey, TValue>
                 && lane.IsIdle)
             {
                 _lanes.Remove(key);
+                lane.ReleaseKeyStorage();
             }
         }
     }
@@ -1880,13 +1949,15 @@ internal sealed class KeyOrderedProcessingLane<TKey, TValue>(
     KeyOrderedPartitionDispatcher<TKey, TValue> dispatcher,
     PartitionMessageKey<TKey> key)
 {
-    private readonly object _gate = new();
     private readonly Queue<ConsumeResult<TKey, TValue>> _queue = [];
+    // The dictionary key can borrow the first record's input. Keep it valid until removal,
+    // even after that record's handler returns while another same-key record is queued.
+    private PendingFetchData? _keyStorage;
     private bool _running;
 
     public bool Enqueue(ConsumeResult<TKey, TValue> message)
     {
-        lock (_gate)
+        lock (_queue)
         {
             _queue.Enqueue(message);
             if (_running)
@@ -1901,7 +1972,7 @@ internal sealed class KeyOrderedProcessingLane<TKey, TValue>(
     {
         get
         {
-            lock (_gate)
+            lock (_queue)
                 return !_running && _queue.Count == 0;
         }
     }
@@ -1914,7 +1985,7 @@ internal sealed class KeyOrderedProcessingLane<TKey, TValue>(
         {
             batch.Clear();
             var removeLane = false;
-            lock (_gate)
+            lock (_queue)
             {
                 while (batch.Count < dispatcher.MaxBatchSize && _queue.Count > 0)
                     batch.Add(_queue.Dequeue());
@@ -1932,10 +2003,20 @@ internal sealed class KeyOrderedProcessingLane<TKey, TValue>(
                 return;
             }
 
-            dispatcher.ProcessingCancellationToken.ThrowIfCancellationRequested();
             await dispatcher.ProcessBatchAsync(batch.ToArray()).ConfigureAwait(false);
         }
     }
+
+    internal void ReleaseQueuedStorage()
+    {
+        while (_queue.TryDequeue(out var message))
+            message.ReleaseStorage();
+        ReleaseKeyStorage();
+    }
+
+    internal void ReleaseKeyStorage() => Interlocked.Exchange(ref _keyStorage, null)?.ReleaseAfterProcessing();
+
+    internal void RetainKeyStorage(ConsumeResult<TKey, TValue> message) => _keyStorage = message.RetainStorage();
 }
 
 internal readonly struct PartitionMessageKey<TKey> : IEquatable<PartitionMessageKey<TKey>>

--- a/tests/Dekaf.Tests.Integration/PartitionedRecordLifetimeIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/PartitionedRecordLifetimeIntegrationTests.cs
@@ -105,6 +105,7 @@ public sealed class PartitionedRecordLifetimeIntegrationTests(KafkaTestContainer
             }
             catch (OperationCanceledException) when (stop.IsCancellationRequested)
             {
+                await Assert.That(run.IsCanceled).IsTrue();
             }
         }
     }

--- a/tests/Dekaf.Tests.Integration/PartitionedRecordLifetimeIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/PartitionedRecordLifetimeIntegrationTests.cs
@@ -1,0 +1,113 @@
+using System.Text;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("ConsumerGroup")]
+public sealed class PartitionedRecordLifetimeIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    [Arguments(PartitionedProcessingOrder.Partition, false)]
+    [Arguments(PartitionedProcessingOrder.Partition, true)]
+    [Arguments(PartitionedProcessingOrder.Key, false)]
+    [Arguments(PartitionedProcessingOrder.Key, true)]
+    public Task SuspendedHandler_RemainsValidAcrossFetchTurnover(PartitionedProcessingOrder ordering, bool raw)
+        => raw
+            ? VerifyTurnoverAsync(ordering, Serializers.RawBytes, static value => Encoding.UTF8.GetString(value.Span))
+            : VerifyTurnoverAsync(ordering, Serializers.String, static value => value);
+
+    private async Task VerifyTurnoverAsync<T>(PartitionedProcessingOrder ordering,
+        IDeserializer<T> deserializer, Func<T, string> decode)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .BuildAsync();
+        await using var consumer = await Kafka.CreateConsumer<T, T>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithKeyDeserializer(deserializer)
+            .WithValueDeserializer(deserializer)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithQueuedMinMessages(1)
+            .WithFetchMaxBytes(64 * 1024)
+            .WithMaxPartitionFetchBytes(64 * 1024)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Partitions.Assign(new TopicPartition(topic, 0), new TopicPartition(topic, 1));
+        var headers = new Headers { new Header("lifetime", "original-header"u8.ToArray()) };
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic, Partition = 0, Key = "original-key", Value = "original-value", Headers = headers
+        });
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        using var stop = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token);
+        var started = NewSignal();
+        var turnover = NewSignal();
+        var release = NewSignal();
+        var verified = NewSignal();
+        var turnedOverRecords = 0;
+        var run = consumer.RunPartitionedAsync(async (_, message, token) =>
+        {
+            if (message.Partition == 0)
+            {
+                started.TrySetResult();
+                await release.Task.WaitAsync(token);
+                await Assert.That(decode(message.Key!)).IsEqualTo("original-key");
+                await Assert.That(decode(message.Value)).IsEqualTo("original-value");
+                await Assert.That(Encoding.UTF8.GetString(message.Headers[0].Value.Span)).IsEqualTo("original-header");
+                verified.TrySetResult();
+            }
+            else if (Interlocked.Increment(ref turnedOverRecords) == 32)
+            {
+                turnover.TrySetResult();
+            }
+        }, new PartitionedProcessingOptions
+        {
+            Ordering = ordering,
+            BackpressureMode = PartitionBackpressureMode.AwaitCapacity,
+            CommitPolicy = PartitionCommitPolicy.UserManaged,
+            StopPolicy = PartitionStopPolicy.Cancel,
+            MaxBufferedRecordsPerPartition = 4
+        }, stop.Token).AsTask();
+
+        try
+        {
+            await started.Task.WaitAsync(timeout.Token);
+            // Produce only after the original fetch reaches its suspended handler. One MiB
+            // through 64 KiB fetches forces fresh broker responses while it remains active.
+            var value = new string('X', 32 * 1024);
+            for (var index = 0; index < 32; index++)
+            {
+                await producer.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic, Partition = 1, Key = "turnover", Value = value
+                }, timeout.Token);
+            }
+            await turnover.Task.WaitAsync(timeout.Token);
+            release.TrySetResult();
+            await Task.WhenAny(verified.Task, run).WaitAsync(timeout.Token);
+            if (run.IsCompleted)
+                await run;
+            await verified.Task.WaitAsync(timeout.Token);
+        }
+        finally
+        {
+            release.TrySetResult();
+            await stop.CancelAsync();
+            try
+            {
+                await run;
+            }
+            catch (OperationCanceledException) when (stop.IsCancellationRequested)
+            {
+            }
+        }
+    }
+
+    private static TaskCompletionSource NewSignal() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -1201,7 +1201,7 @@ public sealed class PartitionedConsumerRuntimeTests
             valueDeserializer: null);
     }
 
-    private sealed class TestConsumer :
+    internal class TestConsumer :
         IKafkaConsumer<string, string>,
         IConsumerPositions,
         IConsumerPartitions,
@@ -1368,7 +1368,7 @@ public sealed class PartitionedConsumerRuntimeTests
             }
         }
 
-        public async IAsyncEnumerable<ConsumeBatch<string, string>> ConsumeBatchAsync(
+        public virtual async IAsyncEnumerable<ConsumeBatch<string, string>> ConsumeBatchAsync(
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             Interlocked.Increment(ref _consumeBatchCalls);

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedRecordLifetimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedRecordLifetimeTests.cs
@@ -1,0 +1,453 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using Dekaf.Consumer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class PartitionedRecordLifetimeTests
+{
+    [Test]
+    public async Task FullOrCompletedQueue_DoesNotRetainRejectedRecords()
+    {
+        var acceptedMemory = new ReusedMemory();
+        var rejectedMemory = new ReusedMemory();
+        var acceptedPending = CreatePending(acceptedMemory);
+        var rejectedPending = CreatePending(rejectedMemory);
+        var acceptedBatch = new ConsumeBatch<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+            acceptedPending, Serializers.RawBytes, Serializers.RawBytes);
+        var rejectedBatch = new ConsumeBatch<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+            rejectedPending, Serializers.RawBytes, Serializers.RawBytes);
+        var accepted = acceptedBatch.GetEnumerator();
+        var rejected = rejectedBatch.GetEnumerator();
+        accepted.MoveNext();
+        rejected.MoveNext();
+        var lane = new PartitionLane<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+            new TopicPartition("lifetime", 0), 1, static (_, _) => default, static _ => { }, static (_, _) => { });
+
+        await Assert.That(lane.TryEnqueue(accepted.Current)).IsTrue();
+        for (var attempt = 0; attempt < 256; attempt++)
+            await Assert.That(lane.TryEnqueue(rejected.Current)).IsFalse();
+        rejectedPending.Dispose();
+        await Assert.That(rejectedMemory.DisposeCount).IsEqualTo(1);
+        acceptedPending.Dispose();
+        await Assert.That(acceptedMemory.DisposeCount).IsEqualTo(0);
+        await lane.StopAsync(PartitionStopPolicy.Cancel, TimeSpan.FromSeconds(1));
+        await Assert.That(lane.TryEnqueue(accepted.Current)).IsFalse();
+        await Assert.That(lane.TryReadMessage(out var message)).IsTrue();
+        message.ReleaseStorage();
+        await Assert.That(acceptedMemory.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(PartitionedProcessingOrder.Partition, PartitionBackpressureMode.AwaitCapacity)]
+    [Arguments(PartitionedProcessingOrder.Partition, PartitionBackpressureMode.PauseResume)]
+    [Arguments(PartitionedProcessingOrder.Key, PartitionBackpressureMode.AwaitCapacity)]
+    [Arguments(PartitionedProcessingOrder.Key, PartitionBackpressureMode.PauseResume)]
+    public async Task RawRecords_RemainValidAfterFetchAdvances(
+        PartitionedProcessingOrder ordering, PartitionBackpressureMode backpressure)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var handlerStarted = NewSignal();
+        var fetchAdvanced = NewSignal();
+        var releaseHandler = NewSignal();
+        var memory = new ReusedMemory();
+        var pending = CreatePending(memory);
+        var consumer = Substitute.For<IKafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>>();
+        consumer.Partitions.Assignment.Returns(new HashSet<TopicPartition> { new("lifetime", 0) });
+        consumer.ConsumeBatchAsync(Arg.Any<CancellationToken>()).Returns(call =>
+            Fetch(pending, handlerStarted, fetchAdvanced, call.Arg<CancellationToken>()));
+
+        var run = consumer.RunPartitionedAsync(async (_, message, token) =>
+        {
+            handlerStarted.TrySetResult();
+            await releaseHandler.Task.WaitAsync(token);
+            await Assert.That(Encoding.UTF8.GetString(message.Key.Span)).IsEqualTo("key");
+            await Assert.That(Encoding.UTF8.GetString(message.Value.Span)).IsEqualTo("original");
+            await Assert.That(Encoding.UTF8.GetString(message.Headers[0].Value.Span)).IsEqualTo("header");
+        }, new PartitionedProcessingOptions
+        {
+            Ordering = ordering,
+            BackpressureMode = backpressure,
+            CommitPolicy = PartitionCommitPolicy.UserManaged,
+            MaxBufferedRecordsPerPartition = 4
+        }, timeout.Token).AsTask();
+
+        try
+        {
+            await fetchAdvanced.Task.WaitAsync(timeout.Token);
+            await Assert.That(memory.DisposeCount).IsEqualTo(0);
+        }
+        finally
+        {
+            releaseHandler.TrySetResult();
+            await run;
+        }
+
+        await Assert.That(memory.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(PartitionedProcessingOrder.Partition, false)]
+    [Arguments(PartitionedProcessingOrder.Partition, true)]
+    [Arguments(PartitionedProcessingOrder.Key, false)]
+    [Arguments(PartitionedProcessingOrder.Key, true)]
+    public async Task StringBatches_HeadersRemainValidAndStorageIsReleased(
+        PartitionedProcessingOrder ordering, bool failHandler)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var handlerStarted = NewSignal();
+        var fetchAdvanced = NewSignal();
+        var releaseHandler = NewSignal();
+        var memory = new ReusedMemory();
+        var pending = CreatePending(memory);
+        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        consumer.Partitions.Assignment.Returns(new HashSet<TopicPartition> { new("lifetime", 0) });
+        consumer.ConsumeBatchAsync(Arg.Any<CancellationToken>()).Returns(call =>
+            FetchStrings(pending, handlerStarted, fetchAdvanced, call.Arg<CancellationToken>()));
+        var failure = new InvalidOperationException("handler failure");
+
+        var run = consumer.RunPartitionedBatchesAsync(async (_, messages, token) =>
+        {
+            handlerStarted.TrySetResult();
+            await releaseHandler.Task.WaitAsync(token);
+            await Assert.That(messages[0].Key).IsEqualTo("key");
+            await Assert.That(messages[0].Value).IsEqualTo("original");
+            await Assert.That(Encoding.UTF8.GetString(messages[0].Headers[0].Value.Span)).IsEqualTo("header");
+            if (failHandler)
+                throw failure;
+        }, new PartitionedProcessingOptions
+        {
+            Ordering = ordering,
+            CommitPolicy = PartitionCommitPolicy.UserManaged,
+            MaxBufferedRecordsPerPartition = 4
+        }, timeout.Token).AsTask();
+
+        try
+        {
+            await fetchAdvanced.Task.WaitAsync(timeout.Token);
+            await Assert.That(memory.DisposeCount).IsEqualTo(0);
+        }
+        finally
+        {
+            releaseHandler.TrySetResult();
+            if (failHandler)
+                await Assert.That(async () => await run).Throws<InvalidOperationException>();
+            else
+                await run;
+        }
+        await Assert.That(memory.DisposeCount).IsEqualTo(1);
+    }
+
+    private static async IAsyncEnumerable<ConsumeBatch<string, string>> FetchStrings(
+        PendingFetchData pending, TaskCompletionSource handlerStarted, TaskCompletionSource fetchAdvanced,
+        [EnumeratorCancellation] CancellationToken cancellationToken, bool keepOpen = false)
+    {
+        using (pending)
+        {
+            yield return new ConsumeBatch<string, string>(pending, Serializers.String, Serializers.String);
+            await handlerStarted.Task.WaitAsync(cancellationToken);
+        }
+        fetchAdvanced.TrySetResult();
+        if (keepOpen)
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+    }
+
+    [Test]
+    [Arguments(PartitionedProcessingOrder.Partition, false)]
+    [Arguments(PartitionedProcessingOrder.Partition, true)]
+    [Arguments(PartitionedProcessingOrder.Key, false)]
+    [Arguments(PartitionedProcessingOrder.Key, true)]
+    public async Task CancelledLane_ReleasesQueuedStorageAfterActiveHandlerExits(
+        PartitionedProcessingOrder ordering, bool ignoreCancellation)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var handlerStarted = NewSignal();
+        var fetchAdvanced = NewSignal();
+        var cancellationObserved = NewSignal();
+        var releaseHandler = NewSignal();
+        var memory = new ReusedMemory();
+        var pending = CreatePending(memory, recordCount: 4);
+        var consumer = Substitute.For<IKafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>>();
+        consumer.Partitions.Assignment.Returns(new HashSet<TopicPartition> { new("lifetime", 0) });
+        consumer.ConsumeBatchAsync(Arg.Any<CancellationToken>()).Returns(call =>
+            Fetch(pending, handlerStarted, fetchAdvanced, call.Arg<CancellationToken>()));
+
+        var run = consumer.RunPartitionedAsync(async (_, message, token) =>
+        {
+            using var registration = token.Register(() => cancellationObserved.TrySetResult());
+            handlerStarted.TrySetResult();
+            if (ignoreCancellation)
+                await releaseHandler.Task;
+            else
+                await releaseHandler.Task.WaitAsync(token);
+            await Assert.That(Encoding.UTF8.GetString(message.Value.Span)).IsEqualTo("original");
+        }, new PartitionedProcessingOptions
+        {
+            Ordering = ordering,
+            CommitPolicy = PartitionCommitPolicy.UserManaged,
+            BackpressureMode = PartitionBackpressureMode.AwaitCapacity,
+            StopPolicy = PartitionStopPolicy.Cancel,
+            StopTimeout = ignoreCancellation ? TimeSpan.FromMilliseconds(100) : TimeSpan.FromSeconds(5),
+            MaxBufferedRecordsPerPartition = 4
+        }, timeout.Token).AsTask();
+
+        try
+        {
+            await fetchAdvanced.Task.WaitAsync(timeout.Token);
+            if (ignoreCancellation)
+            {
+                await cancellationObserved.Task.WaitAsync(timeout.Token);
+                await Assert.That(async () => await run).Throws<TimeoutException>();
+                await Assert.That(memory.DisposeCount).IsEqualTo(0);
+            }
+            else
+            {
+                await run;
+            }
+        }
+        finally
+        {
+            releaseHandler.TrySetResult();
+        }
+
+        await memory.Disposed.Task.WaitAsync(timeout.Token);
+        await Assert.That(memory.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task PartitionStream_RetainsCurrentRecordUntilEnumeratorAdvances()
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var handlerStarted = NewSignal();
+        var fetchAdvanced = NewSignal();
+        var releaseHandler = NewSignal();
+        var memory = new ReusedMemory();
+        var pending = CreatePending(memory, recordCount: 3);
+        var consumer = Substitute.For<IKafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>>();
+        consumer.Partitions.Assignment.Returns(new HashSet<TopicPartition> { new("lifetime", 0) });
+        consumer.ConsumeBatchAsync(Arg.Any<CancellationToken>()).Returns(call =>
+            Fetch(pending, handlerStarted, fetchAdvanced, call.Arg<CancellationToken>()));
+
+        var run = consumer.RunPartitionedAsync(async (context, token) =>
+        {
+            await foreach (var message in context.Messages.WithCancellation(token))
+            {
+                handlerStarted.TrySetResult();
+                await releaseHandler.Task.WaitAsync(token);
+                await Assert.That(Encoding.UTF8.GetString(message.Value.Span)).IsEqualTo("original");
+                await Assert.That(Encoding.UTF8.GetString(message.Headers[0].Value.Span)).IsEqualTo("header");
+                context.MarkProcessed(message);
+            }
+        }, new PartitionedProcessingOptions
+        {
+            CommitPolicy = PartitionCommitPolicy.UserManaged,
+            MaxBufferedRecordsPerPartition = 4
+        }, timeout.Token).AsTask();
+
+        try
+        {
+            await fetchAdvanced.Task.WaitAsync(timeout.Token);
+            await Assert.That(memory.DisposeCount).IsEqualTo(0);
+        }
+        finally
+        {
+            releaseHandler.TrySetResult();
+            await run;
+        }
+        await Assert.That(memory.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Rebalance_ReleasesCancelledActiveAndQueuedStorage(bool lost)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var stop = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token);
+        var started = NewSignal();
+        var advanced = NewSignal();
+        var memory = new ReusedMemory();
+        var pending = CreatePending(memory, recordCount: 3);
+        var partition = new TopicPartition("lifetime", 0);
+        var consumer = new RebalanceConsumer(token => FetchStrings(pending, started, advanced, token, keepOpen: true));
+        consumer.SetAssignment(partition);
+        var run = consumer.RunPartitionedAsync(async (_, _, token) =>
+        {
+            started.TrySetResult();
+            await Task.Delay(Timeout.Infinite, token);
+        }, new PartitionedProcessingOptions
+        {
+            CommitPolicy = PartitionCommitPolicy.UserManaged,
+            BackpressureMode = PartitionBackpressureMode.AwaitCapacity,
+            StopPolicy = PartitionStopPolicy.Cancel,
+            MaxBufferedRecordsPerPartition = 4
+        }, stop.Token).AsTask();
+        try
+        {
+            await advanced.Task.WaitAsync(timeout.Token);
+            await Assert.That(memory.DisposeCount).IsEqualTo(0);
+            if (lost)
+                consumer.LoseFromCoordinator(partition);
+            else
+                consumer.RevokeFromCoordinator(partition);
+            await memory.Disposed.Task.WaitAsync(timeout.Token);
+            await Assert.That(memory.DisposeCount).IsEqualTo(1);
+        }
+        finally
+        {
+            await stop.CancelAsync();
+            try
+            {
+                await run;
+            }
+            catch (OperationCanceledException) when (stop.IsCancellationRequested)
+            {
+            }
+        }
+    }
+
+    private static async IAsyncEnumerable<ConsumeBatch<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>> Fetch(
+        PendingFetchData pending, TaskCompletionSource handlerStarted, TaskCompletionSource fetchAdvanced,
+        [EnumeratorCancellation] CancellationToken cancellationToken, bool keepOpen = false)
+    {
+        using (pending)
+        {
+            yield return new ConsumeBatch<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+                pending, Serializers.RawBytes, Serializers.RawBytes);
+            await handlerStarted.Task.WaitAsync(cancellationToken);
+        }
+        fetchAdvanced.TrySetResult();
+        if (keepOpen)
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+    }
+
+    [Test]
+    public async Task BorrowedDictionaryKey_OutlivesFirstRecordWhileSameKeyIsActive()
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var firstStarted = NewSignal();
+        var firstRelease = NewSignal();
+        var secondStarted = NewSignal();
+        var secondRelease = NewSignal();
+        var advanced = NewSignal();
+        var firstMemory = new ReusedMemory();
+        var secondMemory = new ReusedMemory();
+        var first = CreatePending(firstMemory);
+        var second = CreatePending(secondMemory, baseOffset: 1);
+        var consumer = Substitute.For<IKafkaConsumer<BorrowedKey, ReadOnlyMemory<byte>>>();
+        consumer.Partitions.Assignment.Returns(new HashSet<TopicPartition> { new("lifetime", 0) });
+        consumer.ConsumeBatchAsync(Arg.Any<CancellationToken>()).Returns(FetchBoth());
+
+        async IAsyncEnumerable<ConsumeBatch<BorrowedKey, ReadOnlyMemory<byte>>> FetchBoth()
+        {
+            using (first)
+            {
+                yield return new ConsumeBatch<BorrowedKey, ReadOnlyMemory<byte>>(first, new BorrowedKeyDeserializer(), Serializers.RawBytes);
+                await firstStarted.Task.WaitAsync(timeout.Token);
+            }
+            using (second)
+                yield return new ConsumeBatch<BorrowedKey, ReadOnlyMemory<byte>>(second, new BorrowedKeyDeserializer(), Serializers.RawBytes);
+            advanced.TrySetResult();
+        }
+
+        var run = consumer.RunPartitionedAsync(async (_, message, token) =>
+        {
+            var started = message.Offset == 0 ? firstStarted : secondStarted;
+            var release = message.Offset == 0 ? firstRelease : secondRelease;
+            started.TrySetResult();
+            await release.Task.WaitAsync(token);
+            await Assert.That(Encoding.UTF8.GetString(message.Key.Bytes.Span)).IsEqualTo("key");
+        }, new PartitionedProcessingOptions
+        {
+            Ordering = PartitionedProcessingOrder.Key,
+            CommitPolicy = PartitionCommitPolicy.UserManaged,
+            MaxBufferedRecordsPerPartition = 4
+        }, timeout.Token).AsTask();
+
+        try
+        {
+            await advanced.Task.WaitAsync(timeout.Token);
+            firstRelease.TrySetResult();
+            await secondStarted.Task.WaitAsync(timeout.Token);
+            await Assert.That(firstMemory.DisposeCount).IsEqualTo(0);
+            await Assert.That(secondMemory.DisposeCount).IsEqualTo(0);
+        }
+        finally
+        {
+            firstRelease.TrySetResult();
+            secondRelease.TrySetResult();
+            await run;
+        }
+        await Assert.That(firstMemory.DisposeCount).IsEqualTo(1);
+        await Assert.That(secondMemory.DisposeCount).IsEqualTo(1);
+    }
+
+    private static PendingFetchData CreatePending(ReusedMemory memory, int recordCount = 1, long baseOffset = 0)
+    {
+        var records = new Record[recordCount];
+        for (var index = 0; index < recordCount; index++)
+        {
+            records[index] = new Record
+            {
+                OffsetDelta = index,
+                Key = memory.Memory[..3],
+                Value = memory.Memory.Slice(3, 8),
+                Headers = [new Header("test", memory.Memory[11..])],
+                HeaderCount = 1
+            };
+        }
+        var batch = new RecordBatch
+        {
+            BaseOffset = baseOffset,
+            LastOffsetDelta = recordCount - 1,
+            Records = records
+        };
+        var pending = PendingFetchData.Create("lifetime", 0, [batch]);
+        pending.SetMemoryOwner(memory);
+        pending.EagerParseAll();
+        return pending;
+    }
+
+    private static TaskCompletionSource NewSignal() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    // Public so NSubstitute can construct the generic consumer proxy for this test key.
+    public readonly struct BorrowedKey(ReadOnlyMemory<byte> bytes) : IEquatable<BorrowedKey>
+    {
+        public ReadOnlyMemory<byte> Bytes => bytes;
+        public bool Equals(BorrowedKey other) => Bytes.Span.SequenceEqual(other.Bytes.Span);
+        public override bool Equals(object? obj) => obj is BorrowedKey other && Equals(other);
+        public override int GetHashCode() => Bytes.IsEmpty ? 0 : Bytes.Span[0];
+        public static bool operator ==(BorrowedKey left, BorrowedKey right) => left.Equals(right);
+        public static bool operator !=(BorrowedKey left, BorrowedKey right) => !left.Equals(right);
+    }
+
+    private sealed class BorrowedKeyDeserializer : IDeserializer<BorrowedKey>
+    {
+        public BorrowedKey Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) => new(data);
+    }
+
+    private sealed class RebalanceConsumer(Func<CancellationToken, IAsyncEnumerable<ConsumeBatch<string, string>>> fetch)
+        : PartitionedConsumerRuntimeTests.TestConsumer
+    {
+        public override IAsyncEnumerable<ConsumeBatch<string, string>> ConsumeBatchAsync(CancellationToken cancellationToken = default)
+            => fetch(cancellationToken);
+    }
+
+    private sealed class ReusedMemory : IPooledMemory
+    {
+        private readonly byte[] _bytes = "keyoriginalheader"u8.ToArray();
+        public ReadOnlyMemory<byte> Memory => _bytes;
+        public int DisposeCount;
+        public TaskCompletionSource Disposed { get; } = NewSignal();
+        public void Dispose()
+        {
+            Interlocked.Increment(ref DisposeCount);
+            _bytes.AsSpan().Fill((byte)'X');
+            Disposed.TrySetResult();
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedRecordLifetimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedRecordLifetimeTests.cs
@@ -15,31 +15,45 @@ public sealed class PartitionedRecordLifetimeTests
     {
         var acceptedMemory = new ReusedMemory();
         var rejectedMemory = new ReusedMemory();
-        var acceptedPending = CreatePending(acceptedMemory);
-        var rejectedPending = CreatePending(rejectedMemory);
-        var acceptedBatch = new ConsumeBatch<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
-            acceptedPending, Serializers.RawBytes, Serializers.RawBytes);
-        var rejectedBatch = new ConsumeBatch<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
-            rejectedPending, Serializers.RawBytes, Serializers.RawBytes);
-        var accepted = acceptedBatch.GetEnumerator();
-        var rejected = rejectedBatch.GetEnumerator();
-        accepted.MoveNext();
-        rejected.MoveNext();
         var lane = new PartitionLane<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
             new TopicPartition("lifetime", 0), 1, static (_, _) => default, static _ => { }, static (_, _) => { });
+        try
+        {
+            ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> accepted;
+            using (var acceptedPending = CreatePending(acceptedMemory))
+            {
+                using (var rejectedPending = CreatePending(rejectedMemory))
+                {
+                    var acceptedBatch = new ConsumeBatch<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+                        acceptedPending, Serializers.RawBytes, Serializers.RawBytes);
+                    var rejectedBatch = new ConsumeBatch<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+                        rejectedPending, Serializers.RawBytes, Serializers.RawBytes);
+                    var acceptedRecords = acceptedBatch.GetEnumerator();
+                    var rejectedRecords = rejectedBatch.GetEnumerator();
+                    acceptedRecords.MoveNext();
+                    rejectedRecords.MoveNext();
+                    accepted = acceptedRecords.Current;
 
-        await Assert.That(lane.TryEnqueue(accepted.Current)).IsTrue();
-        for (var attempt = 0; attempt < 256; attempt++)
-            await Assert.That(lane.TryEnqueue(rejected.Current)).IsFalse();
-        rejectedPending.Dispose();
-        await Assert.That(rejectedMemory.DisposeCount).IsEqualTo(1);
-        acceptedPending.Dispose();
-        await Assert.That(acceptedMemory.DisposeCount).IsEqualTo(0);
-        await lane.StopAsync(PartitionStopPolicy.Cancel, TimeSpan.FromSeconds(1));
-        await Assert.That(lane.TryEnqueue(accepted.Current)).IsFalse();
-        await Assert.That(lane.TryReadMessage(out var message)).IsTrue();
-        message.ReleaseStorage();
-        await Assert.That(acceptedMemory.DisposeCount).IsEqualTo(1);
+                    await Assert.That(lane.TryEnqueue(accepted)).IsTrue();
+                    for (var attempt = 0; attempt < 256; attempt++)
+                        await Assert.That(lane.TryEnqueue(rejectedRecords.Current)).IsFalse();
+                }
+                await Assert.That(rejectedMemory.DisposeCount).IsEqualTo(1);
+            }
+            await Assert.That(acceptedMemory.DisposeCount).IsEqualTo(0);
+            await lane.StopAsync(PartitionStopPolicy.Cancel, TimeSpan.FromSeconds(1));
+            await Assert.That(lane.TryEnqueue(accepted)).IsFalse();
+            var dequeued = lane.TryReadMessage(out var message);
+            if (dequeued)
+                message.ReleaseStorage();
+            await Assert.That(dequeued).IsTrue();
+            await Assert.That(acceptedMemory.DisposeCount).IsEqualTo(1);
+        }
+        finally
+        {
+            while (lane.TryReadMessage(out var remaining))
+                remaining.ReleaseStorage();
+        }
     }
 
     [Test]
@@ -306,6 +320,7 @@ public sealed class PartitionedRecordLifetimeTests
             }
             catch (OperationCanceledException) when (stop.IsCancellationRequested)
             {
+                await Assert.That(run.IsCanceled).IsTrue();
             }
         }
     }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionedStorageLifetimeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionedStorageLifetimeBenchmarks.cs
@@ -1,0 +1,98 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Measures queue ownership transfer without handler or commit-tracker allocations.</summary>
+[MemoryDiagnoser]
+public class PartitionedStorageLifetimeBenchmarks
+{
+    private PartitionLane<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _lane = null!;
+    private PendingFetchData _pending = null!;
+    private ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _record;
+    private readonly AutoResetEvent _start = new(false);
+    private readonly AutoResetEvent _complete = new(false);
+    private Thread _reader = null!;
+    private int _stopped;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _pending = PendingFetchData.Create("lifetime", 0,
+            [new RecordBatch { Records = [new Record { Key = new byte[8], Value = new byte[128] }] }]);
+        _pending.EagerParseAll();
+        var batch = new ConsumeBatch<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+            _pending, Serializers.RawBytes, Serializers.RawBytes);
+        var enumerator = batch.GetEnumerator();
+        enumerator.MoveNext();
+        _record = enumerator.Current;
+        _lane = new PartitionLane<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+            new TopicPartition("lifetime", 0), 1024, static (_, _) => default, static _ => { }, static (_, _) => { });
+        _reader = new Thread(ReadConcurrent) { IsBackground = true };
+        _reader.Start();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        Volatile.Write(ref _stopped, 1);
+        _start.Set();
+        _reader.Join();
+        _pending.Dispose();
+        _start.Dispose();
+        _complete.Dispose();
+    }
+
+    [Benchmark(OperationsPerInvoke = 1024)]
+    public void QueueAndComplete()
+    {
+        for (var index = 0; index < 1024; index++)
+            _lane.TryEnqueue(_record);
+        for (var index = 0; index < 1024; index++)
+        {
+            _lane.TryReadMessage(out var message);
+            message.ReleaseStorage();
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = 1024)]
+    public void QueueAndCompleteConcurrent()
+    {
+        _start.Set();
+        for (var index = 0; index < 1024; index++)
+        {
+            while (!_lane.TryEnqueue(_record))
+                Thread.SpinWait(1);
+        }
+        _complete.WaitOne();
+    }
+
+    [Benchmark]
+    public object CreateKeyLane() =>
+        new KeyOrderedProcessingLane<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(null!, default);
+
+    [Benchmark]
+    public void FetchLifecycle()
+    {
+        using var pending = PendingFetchData.Create("lifetime", 0, Array.Empty<RecordBatch>());
+    }
+
+    private void ReadConcurrent()
+    {
+        while (_start.WaitOne())
+        {
+            if (Volatile.Read(ref _stopped) != 0)
+                return;
+            for (var index = 0; index < 1024; index++)
+            {
+                ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> message;
+                while (!_lane.TryReadMessage(out message))
+                    Thread.SpinWait(1);
+                message.ReleaseStorage();
+            }
+            _complete.Set();
+        }
+    }
+}


### PR DESCRIPTION
Partitioned processing could advance and dispose a fetch while its records were still queued or awaiting a handler. Borrowed raw data could then reference reused memory, and reading lazy headers threw `ObjectDisposedException`. Retain the existing fetch owner when a record enters a lane and release it when its handler or stream iteration finishes.

Fixes #3056.

The ownership transfer covers rejected writes, partition and key ordering, record and batch handlers, stream enumeration, handler failures, cancellation, revoke/lost assignment, and shutdown. A handler that ignores cancellation keeps its storage until it actually exits, including after a stop timeout. Key lanes retain the input backing their dictionary key until removal. Custom deserializers may borrow their input; privately reused scratch buffers require an owned result. These lifetimes and the retained-buffer budget are documented.

No fields were added to `ConsumeResult`, and no per-record lease objects are allocated. The existing fetch reference count owns storage. A one-time pending-offset initialization flag removes the old repeated enqueue lock, and final fetch cleanup is separated from the inlined reference-release path. The private key queue itself supplies its existing synchronization, avoiding a separate gate object.

### Validation

- Seventeen new deterministic lifetime cases cover raw keys/values, strings and headers, both ordering/backpressure modes, failed batch handlers, cancellation, ignored cancellation through stop timeout, stream iteration, revoke/lost assignment, rejected queue writes, and a custom borrowed dictionary key surviving its first record.
- The initial four public-runtime reproductions failed on baseline with overwritten raw data. All final consumer unit tests pass: **1,073 on net10.0 and 1,073 on net8.0**.
- Four new real Kafka 4.3.1 tests hold a handler while another partition consumes 1 MiB through 64 KiB fetches. **Baseline: 4 failed with disposed lazy headers; candidate: 4 passed.** This proves broker-backed turnover and header lifetime; deterministic memory reuse in the unit fixture additionally proves raw-data corruption. The existing partitioned processing integration test also passes, including ordering and commits.
- Release library, unit, integration, and maintained benchmark builds pass with zero warnings/errors. Documentation production build passes and generated lifetime text was checked. `/simplify` review completed.
- The tested build and measured candidate snapshot have identical IL for all **15,900 method/constructor bodies**; differing DLL hashes reflect separate build outputs.

### Performance evidence

Baseline product SHA: `e26651c64b0467c3c8ba8d9890eb360f88c83e6f`. Candidate: this PR head. Local Windows 11 / Intel Core i7-12700K / .NET SDK 10.0.400, runtime 10.0.11 / BenchmarkDotNet 0.15.8. Saved Release DLLs, `--inProcess --warmupCount 5 --iterationCount 15`, `[MemoryDiagnoser]`; queue cases use 1,024 operations/invocation. DLL selection was hash-verified. No profiling or paid stress dispatch.

Final matching four-case baseline/candidate runs:

| Case | Baseline mean ± error | Candidate mean ± error | Mean delta | Allocated before → after |
|---|---:|---:|---:|---:|
| Queue and complete, same thread | 63.963 ± 1.3131 ns/record | 48.670 ± 0.3795 ns/record | -23.9% | **0 B → 0 B** |
| Queue and complete, separate producer/reader threads | 220.811 ± 3.8876 ns/record | 145.032 ± 16.8684 ns/record | -34.3% | **0 B → 0 B** |
| Create a key lane | 9.988 ± 0.2563 ns | 9.592 ± 1.5446 ns | -4.0% | 136 B → 112 B |
| Empty fetch rent/final disposal | 30.242 ± 0.2194 ns | 30.058 ± 0.4257 ns | -0.6% | **0 B → 0 B** |

Error is the half-width of the 99.9% confidence interval. Key-lane timing is bimodal and its intervals overlap; no timing improvement is claimed there or for final fetch disposal. A separate warmed allocation probe confirms key-lane allocation **136 → 112 B**, and partition-lane construction at capacity one **1,360 → 1,368 B**: an explicit **8 B one-time cost per partition lane** for initialization state, with no per-record allocation increase.

Retained bytes are a separate cost from allocations: each outstanding record can pin its whole fetch response and decompressed storage. The queue stays bounded; the documentation accounts for active handler batches, bounded key dispatch, a record waiting for a permit, and retained key identities. Storage is released when those owners finish, rather than keeping completed fetch history.

All measured iterations, including rejected candidates:

| Harness / candidate | Sequential ns | Concurrent ns | Key-lane ns / bytes | Decision |
|---|---:|---:|---:|---|
| Initial queue-only baseline | 65.30 ± 2.190 | — | — | Control |
| Initial retention | 75.57 ± 1.259 | — | — | Rejected: slower queue transfer |
| One-time offset initialization | 63.68 ± 2.021 | — | — | Broadened to concurrent and allocation controls |
| Three-case baseline | 52.70 ± 0.235 | 176.48 ± 10.445 | 10.81 ± 0.603 / 136 B | Control |
| Initialization + retained key identity | 56.441 ± 0.1155 | 127.542 ± 1.7646 | 9.065 ± 1.0191 / 112 B | Rejected: sequential regression despite concurrent improvement |
| Inlined release path, focused | 48.20 ± 0.507 | — | — | Proceeded to final matching four-case pair above |

Queue allocation remains 0 B throughout. Final focused/sequential intervals overlap; final concurrent timing overlaps the preceding candidate's interval and remains better than both measured baselines. Baseline timing varies across harness runs on this shared host, so these are local microbenchmark results, not broker throughput, end-to-end p50/p99/max latency, CPU, or long-duration stability claims. The final pair covers the affected queue and final-disposal operations without the rejected throughput trade.

Measured DLL SHA-256 identifiers (intermediate candidates were local source snapshots, not separate commits):

- Baseline: `6092D5262FDEEF4F3F47AC7283E719D659EF02CEBB5AB31B130157D179849A37`
- Initial retention: `92743ED94B251F89A677BC599C6D5204607A32D1CE9E92FE8EFDAEA473F0512E`
- Initialization fast path: `38E999EB6BA77CDA702207B3D14C8E0D2BF7EDD3B156CFBD225AE8D36B67C848`
- Retained key identity: `C291C00FA3FA664340A6124432DF8FEE61341ED7DCF3E6920F79AB801B15065E`
- Final inlined release: `C3AD550678F5729C03FF90417187FF1BE80089343F304EA8CF234F1E6C5A0EC4`

The maintained `PartitionedStorageLifetimeBenchmarks` contains the measured operations. The baseline harness uses the same operations without the new record-release calls, which did not exist in the baseline product.
