### PR TITLE
Bound successful DNS address preferences

### DIFF
--- a/docs/docs/configuration/client-dns-lookup.md
+++ b/docs/docs/configuration/client-dns-lookup.md
@@ -33,6 +33,13 @@ var consumer = new ConsumerBuilder<string, string>()
 
 DNS is resolved on every reconnect, so changes in broker DNS records are picked up without recreating the client.
 
+Successful-address preferences are shared process-wide and retain at most 1,024
+`(hostname, port, lookup mode)` entries. Entries are grouped into 256 buckets of
+four, with the oldest entry in a bucket replaced when that bucket fills. Repeated
+successes update an existing entry without adding another. After eviction, the
+next connection uses the current DNS order; all-address fallback still applies.
+A remembered address is preferred only while it remains in the latest DNS result.
+
 ## Bootstrap resolution deadline
 
 KIP-909 gives initial bootstrap DNS failures a separate retry budget. A transient host-not-found response does not consume the metadata initialization retry cap or timeout. Dekaf retries with the configured reconnect backoff until one bootstrap name resolves, cancellation/disposal occurs, or the bootstrap deadline expires.

--- a/src/Dekaf/Networking/ClientDnsEndpointResolver.cs
+++ b/src/Dekaf/Networking/ClientDnsEndpointResolver.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
 
@@ -9,7 +8,10 @@ internal sealed class ClientDnsEndpointResolver
     public static ClientDnsEndpointResolver Default { get; } = new(new SystemDnsLookup());
 
     private readonly IDnsLookup _dnsLookup;
-    private readonly ConcurrentDictionary<EndpointCacheKey, IPAddress> _lastSuccessfulAddresses = new();
+    // Preferences are connection-time hints, not cached DNS results. Four entries per bucket
+    // bound retained hosts and lookup work; reused slots avoid allocations during steady churn.
+    private const int PreferenceBucketCount = 256;
+    private readonly PreferenceBucket?[] _successfulPreferences = new PreferenceBucket?[PreferenceBucketCount];
 
     public ClientDnsEndpointResolver(IDnsLookup dnsLookup)
     {
@@ -39,17 +41,40 @@ internal sealed class ClientDnsEndpointResolver
             addresses = await _dnsLookup.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
         }
 
-        var endpoints = addresses
-            .Where(IsSupportedAddress)
-            .Distinct()
-            .Select(ipAddress => new ClientDnsEndpoint(ipAddress, port, targetHost))
-            .ToArray();
-
-        if (endpoints.Length == 0)
+        if (addresses.Length == 0)
             return [];
 
+        if (addresses.Length == 1)
+            return IsSupportedAddress(addresses[0]) ? [new ClientDnsEndpoint(addresses[0], port, targetHost)] : [];
+
+        var seen = new HashSet<IPAddress>();
+        for (var index = 0; index < addresses.Length; index++)
+        {
+            var candidate = addresses[index];
+            if (IsSupportedAddress(candidate))
+                seen.Add(candidate);
+        }
+        if (seen.Count == 0)
+            return [];
+
+        // Size by unique supported addresses, then retain their original DNS order.
+        var endpoints = new ClientDnsEndpoint[seen.Count];
+        var count = 0;
+        for (var index = 0; index < addresses.Length; index++)
+        {
+            var candidate = addresses[index];
+            if (IsSupportedAddress(candidate) && seen.Remove(candidate))
+            {
+                endpoints[count++] = new ClientDnsEndpoint(candidate, port, targetHost);
+                if (count == endpoints.Length)
+                    break;
+            }
+        }
+
         var key = new EndpointCacheKey(host, port, lookup);
-        if (_lastSuccessfulAddresses.TryGetValue(key, out var lastSuccessful))
+        var hash = key.GetHashCode();
+        var bucket = Volatile.Read(ref _successfulPreferences[hash & (PreferenceBucketCount - 1)]);
+        if (bucket?.GetAddress(key, hash) is { } lastSuccessful)
             MoveAddressToFront(endpoints, lastSuccessful);
 
         return endpoints;
@@ -57,7 +82,16 @@ internal sealed class ClientDnsEndpointResolver
 
     public void MarkSuccessful(string host, int port, ClientDnsLookup lookup, IPAddress address)
     {
-        _lastSuccessfulAddresses[new EndpointCacheKey(host, port, lookup)] = address;
+        var key = new EndpointCacheKey(host, port, lookup);
+        var hash = key.GetHashCode();
+        var index = hash & (PreferenceBucketCount - 1);
+        var bucket = Volatile.Read(ref _successfulPreferences[index]);
+        if (bucket is null)
+        {
+            var created = new PreferenceBucket();
+            bucket = Interlocked.CompareExchange(ref _successfulPreferences[index], created, null) ?? created;
+        }
+        bucket.SetAddress(key, hash, address);
     }
 
     private static bool IsSupportedAddress(IPAddress address)
@@ -68,16 +102,67 @@ internal sealed class ClientDnsEndpointResolver
 
     private static void MoveAddressToFront(ClientDnsEndpoint[] endpoints, IPAddress address)
     {
-        var index = Array.FindIndex(endpoints, endpoint => endpoint.Address.Equals(address));
-        if (index <= 0)
-            return;
+        for (var index = 0; index < endpoints.Length; index++)
+        {
+            if (!endpoints[index].Address.Equals(address))
+                continue;
 
-        var selected = endpoints[index];
-        Array.Copy(endpoints, 0, endpoints, 1, index);
-        endpoints[0] = selected;
+            if (index > 0)
+            {
+                var selected = endpoints[index];
+                Array.Copy(endpoints, 0, endpoints, 1, index);
+                endpoints[0] = selected;
+            }
+            return;
+        }
     }
 
     private readonly record struct EndpointCacheKey(string Host, int Port, ClientDnsLookup Lookup);
+
+    private sealed class PreferenceBucket
+    {
+        private readonly PreferenceEntry[] _entries = new PreferenceEntry[4];
+        private int _count;
+        private int _next;
+
+        public IPAddress? GetAddress(EndpointCacheKey key, int hash)
+        {
+            // DNS preferences are consulted only while establishing connections. A bucket lock
+            // keeps a reused slot's endpoint key and address coherent for concurrent clients.
+            lock (this)
+            {
+                for (var index = 0; index < _count; index++)
+                {
+                    if (_entries[index].Hash == hash && _entries[index].Key == key)
+                        return _entries[index].Address;
+                }
+                return null;
+            }
+        }
+
+        public void SetAddress(EndpointCacheKey key, int hash, IPAddress address)
+        {
+            lock (this)
+            {
+                for (var index = 0; index < _count; index++)
+                {
+                    if (_entries[index].Hash == hash && _entries[index].Key == key)
+                    {
+                        _entries[index] = new PreferenceEntry(hash, key, address);
+                        return;
+                    }
+                }
+
+                // FIFO within the bucket: updating a preference does not consume another slot.
+                _entries[_next] = new PreferenceEntry(hash, key, address);
+                _next = (_next + 1) & 3;
+                if (_count < _entries.Length)
+                    _count++;
+            }
+        }
+    }
+
+    private readonly record struct PreferenceEntry(int Hash, EndpointCacheKey Key, IPAddress Address);
 }
 
 internal readonly record struct ClientDnsEndpoint(IPAddress Address, int Port, string TargetHost);

--- a/tests/Dekaf.Tests.Unit/Networking/DnsPreferenceLifetimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/DnsPreferenceLifetimeTests.cs
@@ -1,0 +1,92 @@
+using System.Net;
+using Dekaf.Networking;
+
+namespace Dekaf.Tests.Unit.Networking;
+
+public sealed class DnsPreferenceLifetimeTests
+{
+    private static readonly IPAddress First = IPAddress.Parse("192.0.2.10");
+    private static readonly IPAddress Second = IPAddress.Parse("192.0.2.11");
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task HostnameChurn_RetainsAtMost1024Preferences(bool concurrent)
+    {
+        var resolver = new ClientDnsEndpointResolver(new Lookup());
+        var hosts = Enumerable.Range(0, 4096).Select(index => $"broker-{index}.example").ToArray();
+        if (concurrent)
+            Parallel.For(0, hosts.Length, index => resolver.MarkSuccessful(hosts[index], 9092, ClientDnsLookup.UseAllDnsIps, Second));
+        else
+            foreach (var host in hosts)
+                resolver.MarkSuccessful(host, 9092, ClientDnsLookup.UseAllDnsIps, Second);
+
+        // Count externally observable preferences, independent of cache representation/hash collisions.
+        var retained = 0;
+        foreach (var host in hosts)
+        {
+            var endpoints = await resolver.ResolveAsync(host, 9092, ClientDnsLookup.UseAllDnsIps, default);
+            if (endpoints[0].Address.Equals(Second))
+                retained++;
+        }
+        await Assert.That(retained).IsGreaterThan(0);
+        await Assert.That(retained).IsLessThanOrEqualTo(1024);
+
+        resolver.MarkSuccessful("most-recent.example", 9092, ClientDnsLookup.UseAllDnsIps, Second);
+        var latest = await resolver.ResolveAsync("most-recent.example", 9092, ClientDnsLookup.UseAllDnsIps, default);
+        await Assert.That(latest[0].Address).IsEqualTo(Second);
+    }
+
+    [Test]
+    public async Task DuplicateAddresses_PreserveDnsOrderAndUniqueEndpoints()
+    {
+        var lookup = new Lookup { Addresses = [First, IPAddress.Parse("192.0.2.10"), Second, Second] };
+        var resolver = new ClientDnsEndpointResolver(lookup);
+        var endpoints = await resolver.ResolveAsync("duplicates.example", 9092, ClientDnsLookup.UseAllDnsIps, default);
+        await Assert.That(endpoints.Count).IsEqualTo(2);
+        await Assert.That(endpoints[0].Address).IsEqualTo(First);
+        await Assert.That(endpoints[1].Address).IsEqualTo(Second);
+
+        resolver.MarkSuccessful("duplicates.example", 9092, ClientDnsLookup.UseAllDnsIps, Second);
+        endpoints = await resolver.ResolveAsync("duplicates.example", 9092, ClientDnsLookup.UseAllDnsIps, default);
+        await Assert.That(endpoints.Count).IsEqualTo(2);
+        await Assert.That(endpoints[0].Address).IsEqualTo(Second);
+        await Assert.That(endpoints[1].Address).IsEqualTo(First);
+    }
+
+    [Test]
+    public async Task RepeatedSuccess_UpdatesExistingPreference()
+    {
+        var resolver = new ClientDnsEndpointResolver(new Lookup());
+        for (var index = 0; index < 10000; index++)
+            resolver.MarkSuccessful("stable.example", 9092, ClientDnsLookup.UseAllDnsIps, index % 2 == 0 ? First : Second);
+        var endpoints = await resolver.ResolveAsync("stable.example", 9092, ClientDnsLookup.UseAllDnsIps, default);
+        await Assert.That(endpoints[0].Address).IsEqualTo(Second);
+    }
+
+    [Test]
+    public async Task Preference_OnlyAppliesToCurrentDnsResultAndMatchingEndpoint()
+    {
+        var lookup = new Lookup();
+        var resolver = new ClientDnsEndpointResolver(lookup);
+        resolver.MarkSuccessful("alias.example", 9092, ClientDnsLookup.UseAllDnsIps, Second);
+        var otherPort = await resolver.ResolveAsync("alias.example", 9093, ClientDnsLookup.UseAllDnsIps, default);
+        var canonical = await resolver.ResolveAsync("alias.example", 9092, ClientDnsLookup.ResolveCanonicalBootstrapServersOnly, default);
+        await Assert.That(otherPort[0].Address).IsEqualTo(First);
+        await Assert.That(canonical[0].Address).IsEqualTo(First);
+        await Assert.That(canonical[0].TargetHost).IsEqualTo("canonical.example");
+
+        lookup.Addresses = [First];
+        var changed = await resolver.ResolveAsync("alias.example", 9092, ClientDnsLookup.UseAllDnsIps, default);
+        await Assert.That(changed.Count).IsEqualTo(1);
+        await Assert.That(changed[0].Address).IsEqualTo(First);
+    }
+
+    private sealed class Lookup : IDnsLookup
+    {
+        internal IPAddress[] Addresses { get; set; } = [First, Second];
+        public ValueTask<IPAddress[]> GetHostAddressesAsync(string host, CancellationToken cancellationToken) => ValueTask.FromResult(Addresses);
+        public ValueTask<IPHostEntry> GetHostEntryAsync(string host, CancellationToken cancellationToken) =>
+            ValueTask.FromResult(new IPHostEntry { HostName = "canonical.example", AddressList = Addresses });
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/DnsPreferenceCacheBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/DnsPreferenceCacheBenchmarks.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Networking;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Connection-time DNS preference maintenance for a stable broker set and hostname churn.
+/// DNS lookup is stubbed so network latency cannot hide cache costs.
+/// </summary>
+[MemoryDiagnoser]
+public class DnsPreferenceCacheBenchmarks
+{
+    private ClientDnsEndpointResolver _resolver = null!;
+    private string[] _hosts = null!;
+    private readonly IPAddress _successful = IPAddress.Parse("192.0.2.11");
+    private int _index;
+
+    [Params(32, 8192)]
+    public int HostCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _resolver = new ClientDnsEndpointResolver(new Lookup(_successful));
+        _hosts = new string[HostCount];
+        for (var index = 0; index < _hosts.Length; index++)
+        {
+            _hosts[index] = $"broker-{index}.example";
+            _resolver.MarkSuccessful(_hosts[index], 9092, ClientDnsLookup.UseAllDnsIps, _successful);
+        }
+    }
+
+    [Benchmark]
+    public void MarkSuccessful() => _resolver.MarkSuccessful(
+        _hosts[_index++ & (HostCount - 1)], 9092, ClientDnsLookup.UseAllDnsIps, _successful);
+
+    [Benchmark]
+    public IPAddress Resolve() => _resolver.ResolveAsync(
+        _hosts[_index++ & (HostCount - 1)], 9092, ClientDnsLookup.UseAllDnsIps, default).GetAwaiter().GetResult()[0].Address;
+
+    private sealed class Lookup(IPAddress successful) : IDnsLookup
+    {
+        private readonly IPAddress[] _addresses = [IPAddress.Parse("192.0.2.10"), successful];
+        public ValueTask<IPAddress[]> GetHostAddressesAsync(string host, CancellationToken cancellationToken) => ValueTask.FromResult(_addresses);
+        public ValueTask<IPHostEntry> GetHostEntryAsync(string host, CancellationToken cancellationToken) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
The process-wide DNS resolver previously retained every successful `(hostname, port, lookup mode)` indefinitely. Bound successful-address preferences to 256 lazily populated buckets with four reusable entries each (at most 1,024 retained endpoints). Each bucket uses FIFO replacement; repeated successes update the matching slot. A private bucket lock keeps keys and addresses coherent during concurrent connection attempts, with at most four comparisons and no cache-wide scan or timer.

Fresh DNS results remain authoritative: only an address still present can be moved to the front, and eviction restores the current DNS order with normal multi-address fallback. Canonical target hosts and endpoint-key distinctions are preserved. Endpoint construction now avoids iterator/closure allocations, preserves DNS order, and sizes its result by unique supported addresses, including duplicate-heavy answers.

Validation:
- Before implementation, sequential and concurrent 4,096-host regression cases both failed by retaining all 4,096 preferences.
- 83 DNS, bootstrap, and metadata-recovery tests passed on each of net10.0 and net8.0; includes deterministic bounds, repeated updates, duplicate ordering, endpoint isolation, canonical hosts, and changed DNS results.
- Four real Kafka DNS re-resolution tests: producer/consumer reconnect and bootstrap behavior.
- Documentation production build, Release benchmark build, `/simplify`, `git diff --check`.

Performance evidence: base `e26651c64b0467c3c8ba8d9890eb360f88c83e6f` → candidate `6d699645fa41a5880fa0e208fab08e52d3b7d55c`. BenchmarkDotNet 0.15.8 with MemoryDiagnoser; .NET 10.0.11, SDK 10.0.400, Windows 11 / i7-12700K. Identical benchmark bodies against saved assemblies, in-process with 5 warmups and 12 measured iterations; candidate DLL hash matched the harness-loaded DLL. DNS is stubbed to isolate cache/endpoint overhead. Stress lane, dispatch shape, paid run URL, duration and profiling mode: not applicable; no paid dispatch.

| Operation / host set | Baseline mean ± error (ns) | Candidate mean ± error (ns) | Mean delta | Bytes before → after |
| --- | ---: | ---: | ---: | ---: |
| MarkSuccessful / 32 stable hosts | 22.17 ± 0.177 | 18.77 ± 0.873 | -15.3% | 0 → 0 |
| Resolve / 32 stable hosts | 211.77 ± 7.385 | 151.92 ± 2.671 | -28.3% | 632 → 248 |
| MarkSuccessful / 8,192 rotating hosts | 28.34 ± 0.282 | 22.46 ± 0.194 | -20.7% | 0 → 0 |
| Resolve / 8,192 rotating hosts | 273.94 ± 13.875 | 90.30 ± 1.200 | -67.0% | 632 → 248 |

Errors are 99.9% confidence half-widths, not Kafka message latency percentiles. Standard deviations before → after (same row order): 0.117 → 0.682 ns; 5.766 → 1.932 ns; 0.187 → 0.140 ns; 10.033 → 0.868 ns. Resolve allocations are existing connection-establishment work, outside per-message produce/consume paths; preference maintenance stays 0 B after warmup. No end-to-end throughput, p50/p99/max delivery latency, CPU/message or long-duration stability claim is inferred from these microbenchmarks.

Separate fresh-process memory probe (same hostname construction; forced collections with the resolver kept alive):

| Distinct hosts | Allocated bytes before → after | Retained heap bytes before → after |
| --- | ---: | ---: |
| 32 | 15,264 → 12,256 | 11,160 → 12,216 |
| 100,000 | 19,296,792 → 6,448,408 | 13,297,136 → 114,744 |

The small-set retained footprint rises about 1 KiB from the fixed bucket table; hostname churn remains bounded instead of growing with process lifetime. The probe includes hostname-string allocations in both versions. Retained-heap values are whole-process deltas, not exact object graph sizes; randomized string hashing can slightly change bucket occupancy.

Candidate comparison: the first four-entry bucket prototype improved stable updates (18.51 ns) but regressed churn updates (32.65 ns versus the initial 29.27 ns baseline, 3 warmups/8 iterations), so it was rejected. Storing the full hash reduced churn updates to 22.90 ns (5/12) and stable updates to 17.76 ns, but resolver means remained 219.22/250.83 ns for 32/8,192 hosts. Replacing the reorder closure alone gave 222.65/261.24 ns and 608 B; endpoint iterator removal then brought these to 149.04/83.01 ns and 248 B. That one-pass prototype allocated its result by raw address count and was rejected for unnecessary duplicate-heavy answer memory. The final implementation sizes by distinct addresses, giving the final 151.92/90.30 ns and 248 B above; its stable resolution interval overlaps the one-pass prototype, while all four final operations improve over the accepted product baseline. No throughput/latency/allocation trade against that baseline is accepted.

Closes #3053


