### PR TITLE
fix(sasl): validate SCRAM challenges and bound hashing

### DIFF
--- a/docs/docs/security/sasl.md
+++ b/docs/docs/security/sasl.md
@@ -53,6 +53,23 @@ var producer = await Kafka.CreateProducer<string, string>()
     .BuildAsync();
 ```
 
+### Server iteration limit
+
+Dekaf rejects SCRAM challenges requesting more than **1,000,000 PBKDF2 iterations** before deriving the password key. This bounds server-requested authentication CPU work. Set a lower limit to match your broker credentials, or raise it deliberately for credentials configured above the default:
+
+```csharp
+var producer = await Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("kafka.example.com:9092")
+    .UseTls()
+    .WithSaslScramSha256("username", "password")
+    .WithSaslScramMaxIterations(8192)
+    .BuildAsync();
+```
+
+`WithSaslScramMaxIterations` is available on producer, consumer, share consumer, admin, and shared `KafkaClient` builders. Configure it on the shared client when connections are shared. Options objects and dependency injection configuration use `SaslScramMaxIterations`. The value must be positive; it limits both SCRAM hashes and delegation-token authentication, without changing the broker's iteration count.
+
+Malformed challenges, duplicate attributes, unsupported mandatory extensions, invalid encodings, and excessive iteration counts fail with `Dekaf.Errors.AuthenticationException`. Valid optional extensions are ignored, and server signatures use constant-time comparison. These checks follow the SCRAM message grammar and extension handling in [RFC 5802](https://datatracker.ietf.org/doc/html/rfc5802).
+
 ## SASL/GSSAPI (Kerberos)
 
 For Kerberos authentication:

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1101,6 +1101,7 @@ internal static class DekafOptionsBinding
             options.SaslCredentialProvider,
             builder.WithSaslOptions,
             builder.WithOAuthBearer);
+        builder.WithSaslScramMaxIterations(options.SaslScramMaxIterations);
         builder.WithSocketSendBufferBytes(options.SocketSendBufferBytes);
         builder.WithSocketReceiveBufferBytes(options.SocketReceiveBufferBytes);
         builder.WithValueTaskSourcePoolSize(options.ValueTaskSourcePoolSize);
@@ -1203,6 +1204,7 @@ internal static class DekafOptionsBinding
             options.SaslCredentialProvider,
             builder.WithSaslOptions,
             builder.WithOAuthBearer);
+        builder.WithSaslScramMaxIterations(options.SaslScramMaxIterations);
         if (options.ConsumerAwareRebalanceListener is not null)
             builder.WithRebalanceListener(options.ConsumerAwareRebalanceListener);
         else if (options.RebalanceListener is not null)
@@ -1282,6 +1284,7 @@ internal static class DekafOptionsBinding
                 options.SaslScramTokenAuth,
                 options.SaslCredentialProvider);
         }
+        builder.WithSaslScramMaxIterations(options.SaslScramMaxIterations);
 
         builder.WithMetadataRecoveryStrategy(options.MetadataRecoveryStrategy);
         builder.WithMetadataClusterCheck(options.MetadataClusterCheckEnabled);
@@ -1494,6 +1497,8 @@ internal static class DekafConfigurationBinding
         ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
         if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth, out var awsMskIam, out var saslScramTokenAuth))
             builder.WithSaslOptions(mechanism, username, password, gssapi, oauth, awsMskIam, saslScramTokenAuth: saslScramTokenAuth);
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.SaslScramMaxIterations), out var maxScramIterations))
+            builder.WithSaslScramMaxIterations(maxScramIterations);
         if (TryGetValue<int>(configuration, nameof(ProducerOptions.SocketSendBufferBytes), out var sendBuffer))
             builder.WithSocketSendBufferBytes(sendBuffer);
         if (TryGetValue<int>(configuration, nameof(ProducerOptions.SocketReceiveBufferBytes), out var receiveBuffer))
@@ -1624,6 +1629,8 @@ internal static class DekafConfigurationBinding
         ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
         if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth, out var awsMskIam, out var saslScramTokenAuth))
             builder.WithSaslOptions(mechanism, username, password, gssapi, oauth, awsMskIam, saslScramTokenAuth: saslScramTokenAuth);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.SaslScramMaxIterations), out var maxScramIterations))
+            builder.WithSaslScramMaxIterations(maxScramIterations);
         if (TryGetValue<bool>(configuration, nameof(ConsumerOptions.EnablePartitionEof), out var enablePartitionEof))
             builder.WithPartitionEof(enablePartitionEof);
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.SocketSendBufferBytes), out var sendBuffer))
@@ -1683,6 +1690,8 @@ internal static class DekafConfigurationBinding
         ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
         if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth, out var awsMskIam, out var saslScramTokenAuth))
             builder.WithSaslOptions(mechanism, username, password, gssapi, oauth, awsMskIam, saslScramTokenAuth: saslScramTokenAuth);
+        if (TryGetValue<int>(configuration, nameof(AdminClientOptions.SaslScramMaxIterations), out var maxScramIterations))
+            builder.WithSaslScramMaxIterations(maxScramIterations);
         if (TryGetValue<MetadataRecoveryStrategy>(configuration, nameof(AdminClientOptions.MetadataRecoveryStrategy), out var metadataRecoveryStrategy))
             builder.WithMetadataRecoveryStrategy(metadataRecoveryStrategy);
         if (TryGetValue<bool>(configuration, nameof(AdminClientOptions.MetadataClusterCheckEnabled), out var metadataClusterCheckEnabled))

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -83,6 +83,7 @@ public sealed partial class AdminClient :
                 SaslPassword = options.SaslPassword,
                 SaslCredentialProvider = options.SaslCredentialProvider,
                 SaslScramTokenAuth = options.SaslScramTokenAuth,
+                SaslScramMaxIterations = options.SaslScramMaxIterations,
                 GssapiConfig = options.GssapiConfig,
                 OAuthBearerConfig = options.OAuthBearerConfig,
                 OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
@@ -5955,6 +5956,23 @@ public sealed class AdminClientOptions
     public Func<CancellationToken, ValueTask<SaslCredentials>>? SaslCredentialProvider { get; init; }
     public bool SaslScramTokenAuth { get; init; }
 
+    private int _saslScramMaxIterations = ScramAuthenticator.DefaultMaxIterations;
+
+    /// <summary>
+    /// Maximum server-requested SCRAM PBKDF2 iterations. Defaults to 1,000,000.
+    /// Must be positive; raise deliberately when a broker uses a higher count.
+    /// Applies to both password and delegation-token SCRAM authentication.
+    /// </summary>
+    public int SaslScramMaxIterations
+    {
+        get => _saslScramMaxIterations;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+            _saslScramMaxIterations = value;
+        }
+    }
+
     /// <summary>
     /// GSSAPI (Kerberos) configuration. Required when <see cref="SaslMechanism"/> is
     /// <see cref="SaslMechanism.Gssapi"/>.
@@ -6041,6 +6059,7 @@ public sealed class AdminClientBuilder
     private string? _saslPassword;
     private Func<CancellationToken, ValueTask<SaslCredentials>>? _saslCredentialProvider;
     private bool _saslScramTokenAuth;
+    private int _saslScramMaxIterations = ScramAuthenticator.DefaultMaxIterations;
     private GssapiConfig? _gssapiConfig;
     private OAuthBearerConfig? _oauthConfig;
     private Func<CancellationToken, ValueTask<OAuthBearerToken>>? _oauthTokenProvider;
@@ -6205,6 +6224,16 @@ public sealed class AdminClientBuilder
         _saslPassword = password;
         _saslCredentialProvider = null;
         _saslScramTokenAuth = false;
+        return this;
+    }
+
+    /// <summary>Sets the maximum server-requested SCRAM PBKDF2 iteration count.</summary>
+    /// <param name="maxIterations">Positive limit; the default is 1,000,000.</param>
+    public AdminClientBuilder WithSaslScramMaxIterations(int maxIterations)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxIterations, 1);
+        _saslScramMaxIterations = maxIterations;
         return this;
     }
 
@@ -6719,6 +6748,7 @@ public sealed class AdminClientBuilder
             SaslPassword = _saslPassword,
             SaslCredentialProvider = _saslCredentialProvider,
             SaslScramTokenAuth = _saslScramTokenAuth,
+            SaslScramMaxIterations = _saslScramMaxIterations,
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,
             OAuthBearerTokenProvider = _oauthTokenProvider,

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -59,6 +59,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     private string? _saslPassword;
     private Func<CancellationToken, ValueTask<SaslCredentials>>? _saslCredentialProvider;
     private bool _saslScramTokenAuth;
+    private int _saslScramMaxIterations = ScramAuthenticator.DefaultMaxIterations;
     private GssapiConfig? _gssapiConfig;
     private OAuthBearerConfig? _oauthConfig;
     private Func<CancellationToken, ValueTask<OAuthBearerToken>>? _oauthTokenProvider;
@@ -664,6 +665,16 @@ public sealed class ProducerBuilder<TKey, TValue>
         _saslPassword = password;
         _saslCredentialProvider = null;
         _saslScramTokenAuth = false;
+        return this;
+    }
+
+    /// <summary>Sets the maximum server-requested SCRAM PBKDF2 iteration count.</summary>
+    /// <param name="maxIterations">Positive limit; the default is 1,000,000.</param>
+    public ProducerBuilder<TKey, TValue> WithSaslScramMaxIterations(int maxIterations)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxIterations, 1);
+        _saslScramMaxIterations = maxIterations;
         return this;
     }
 
@@ -1482,6 +1493,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             UsesClientOwnedDynamicSaslCredentials =
                 _clientInfrastructure?.UsesDynamicSaslCredentials == true,
             SaslScramTokenAuth = _saslScramTokenAuth,
+            SaslScramMaxIterations = _saslScramMaxIterations,
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,
             OAuthBearerTokenProvider = _oauthTokenProvider,
@@ -1659,6 +1671,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private string? _saslPassword;
     private Func<CancellationToken, ValueTask<SaslCredentials>>? _saslCredentialProvider;
     private bool _saslScramTokenAuth;
+    private int _saslScramMaxIterations = ScramAuthenticator.DefaultMaxIterations;
     private GssapiConfig? _gssapiConfig;
     private OAuthBearerConfig? _oauthConfig;
     private Func<CancellationToken, ValueTask<OAuthBearerToken>>? _oauthTokenProvider;
@@ -2247,6 +2260,16 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _saslPassword = password;
         _saslCredentialProvider = null;
         _saslScramTokenAuth = false;
+        return this;
+    }
+
+    /// <summary>Sets the maximum server-requested SCRAM PBKDF2 iteration count.</summary>
+    /// <param name="maxIterations">Positive limit; the default is 1,000,000.</param>
+    public ConsumerBuilder<TKey, TValue> WithSaslScramMaxIterations(int maxIterations)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxIterations, 1);
+        _saslScramMaxIterations = maxIterations;
         return this;
     }
 
@@ -3285,6 +3308,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             SaslPassword = _saslPassword,
             SaslCredentialProvider = _saslCredentialProvider,
             SaslScramTokenAuth = _saslScramTokenAuth,
+            SaslScramMaxIterations = _saslScramMaxIterations,
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,
             OAuthBearerTokenProvider = _oauthTokenProvider,
@@ -3441,6 +3465,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private string? _saslPassword;
     private Func<CancellationToken, ValueTask<SaslCredentials>>? _saslCredentialProvider;
     private bool _saslScramTokenAuth;
+    private int _saslScramMaxIterations = ScramAuthenticator.DefaultMaxIterations;
     private GssapiConfig? _gssapiConfig;
     private OAuthBearerConfig? _oauthConfig;
     private Func<CancellationToken, ValueTask<OAuthBearerToken>>? _oauthTokenProvider;
@@ -3794,6 +3819,16 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         return this;
     }
 
+    /// <summary>Sets the maximum server-requested SCRAM PBKDF2 iteration count.</summary>
+    /// <param name="maxIterations">Positive limit; the default is 1,000,000.</param>
+    public ShareConsumerBuilder<TKey, TValue> WithSaslScramMaxIterations(int maxIterations)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxIterations, 1);
+        _saslScramMaxIterations = maxIterations;
+        return this;
+    }
+
     public ShareConsumerBuilder<TKey, TValue> WithSaslScram256(
         Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
     {
@@ -4121,6 +4156,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             SaslPassword = _saslPassword,
             SaslCredentialProvider = _saslCredentialProvider,
             SaslScramTokenAuth = _saslScramTokenAuth,
+            SaslScramMaxIterations = _saslScramMaxIterations,
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,
             OAuthBearerTokenProvider = _oauthTokenProvider,

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -350,6 +350,23 @@ public sealed class ConsumerOptions
     /// </summary>
     public bool SaslScramTokenAuth { get; init; }
 
+    private int _saslScramMaxIterations = ScramAuthenticator.DefaultMaxIterations;
+
+    /// <summary>
+    /// Maximum server-requested SCRAM PBKDF2 iterations. Defaults to 1,000,000.
+    /// Must be positive; raise deliberately when a broker uses a higher count.
+    /// Applies to both password and delegation-token SCRAM authentication.
+    /// </summary>
+    public int SaslScramMaxIterations
+    {
+        get => _saslScramMaxIterations;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+            _saslScramMaxIterations = value;
+        }
+    }
+
     /// <summary>
     /// GSSAPI (Kerberos) configuration. Required when SaslMechanism is Gssapi.
     /// </summary>

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1660,6 +1660,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 SaslPassword = options.SaslPassword,
                 SaslCredentialProvider = options.SaslCredentialProvider,
                 SaslScramTokenAuth = options.SaslScramTokenAuth,
+                SaslScramMaxIterations = options.SaslScramMaxIterations,
                 GssapiConfig = options.GssapiConfig,
                 OAuthBearerConfig = options.OAuthBearerConfig,
                 OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -110,6 +110,7 @@ public sealed class KafkaClientBuilder
     private string? _saslPassword;
     private Func<CancellationToken, ValueTask<SaslCredentials>>? _saslCredentialProvider;
     private bool _saslScramTokenAuth;
+    private int _saslScramMaxIterations = ScramAuthenticator.DefaultMaxIterations;
     private GssapiConfig? _gssapiConfig;
     private OAuthBearerConfig? _oauthConfig;
     private Func<CancellationToken, ValueTask<OAuthBearerToken>>? _oauthTokenProvider;
@@ -328,6 +329,15 @@ public sealed class KafkaClientBuilder
         _saslPassword = password;
         _saslCredentialProvider = null;
         _saslScramTokenAuth = false;
+        return this;
+    }
+
+    /// <summary>Sets the maximum server-requested SCRAM PBKDF2 iteration count.</summary>
+    /// <param name="maxIterations">Positive limit; the default is 1,000,000.</param>
+    public KafkaClientBuilder WithSaslScramMaxIterations(int maxIterations)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxIterations, 1);
+        _saslScramMaxIterations = maxIterations;
         return this;
     }
 
@@ -636,6 +646,7 @@ public sealed class KafkaClientBuilder
             SaslPassword = _saslPassword,
             SaslCredentialProvider = _saslCredentialProvider,
             SaslScramTokenAuth = _saslScramTokenAuth,
+            SaslScramMaxIterations = _saslScramMaxIterations,
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,
             OAuthBearerTokenProvider = _oauthTokenProvider,
@@ -689,6 +700,23 @@ internal sealed class KafkaClientOptions
     public string? SaslPassword { get; init; }
     public Func<CancellationToken, ValueTask<SaslCredentials>>? SaslCredentialProvider { get; init; }
     public bool SaslScramTokenAuth { get; init; }
+
+    private int _saslScramMaxIterations = ScramAuthenticator.DefaultMaxIterations;
+
+    /// <summary>
+    /// Maximum server-requested SCRAM PBKDF2 iterations. Defaults to 1,000,000.
+    /// Must be positive; raise deliberately when a broker uses a higher count.
+    /// Applies to both password and delegation-token SCRAM authentication.
+    /// </summary>
+    public int SaslScramMaxIterations
+    {
+        get => _saslScramMaxIterations;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+            _saslScramMaxIterations = value;
+        }
+    }
     public GssapiConfig? GssapiConfig { get; init; }
     public OAuthBearerConfig? OAuthBearerConfig { get; init; }
     public Func<CancellationToken, ValueTask<OAuthBearerToken>>? OAuthBearerTokenProvider { get; init; }
@@ -845,6 +873,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         SaslPassword = options.SaslPassword,
         SaslCredentialProvider = options.SaslCredentialProvider,
         SaslScramTokenAuth = options.SaslScramTokenAuth,
+        SaslScramMaxIterations = options.SaslScramMaxIterations,
         GssapiConfig = options.GssapiConfig,
         OAuthBearerConfig = options.OAuthBearerConfig,
         OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -276,6 +276,7 @@ public sealed partial class ConnectionPool :
             SaslPassword = options.SaslPassword,
             SaslCredentialProvider = options.SaslCredentialProvider,
             SaslScramTokenAuth = options.SaslScramTokenAuth,
+            SaslScramMaxIterations = options.SaslScramMaxIterations,
             GssapiConfig = options.GssapiConfig,
             OAuthBearerTokenProvider = sharedProvider.GetTokenAsync,
             OAuthBearerToken = options.OAuthBearerToken,

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -3596,12 +3596,14 @@ public sealed partial class KafkaConnection :
             SaslMechanism.ScramSha256,
             username ?? throw new InvalidOperationException("SASL username not configured"),
             password ?? throw new InvalidOperationException("SASL password not configured"),
-            _options.SaslScramTokenAuth),
+            _options.SaslScramTokenAuth,
+            _options.SaslScramMaxIterations),
         SaslMechanism.ScramSha512 => new ScramAuthenticator(
             SaslMechanism.ScramSha512,
             username ?? throw new InvalidOperationException("SASL username not configured"),
             password ?? throw new InvalidOperationException("SASL password not configured"),
-            _options.SaslScramTokenAuth),
+            _options.SaslScramTokenAuth,
+            _options.SaslScramMaxIterations),
         SaslMechanism.Gssapi => new GssapiAuthenticator(
             _options.GssapiConfig ?? throw new InvalidOperationException("GSSAPI configuration not provided"),
             _resolvedTargetHost ?? _host),
@@ -4392,6 +4394,23 @@ public sealed class ConnectionOptions
     /// Whether SCRAM authentication uses Kafka delegation token credentials.
     /// </summary>
     public bool SaslScramTokenAuth { get; init; }
+
+    private int _saslScramMaxIterations = ScramAuthenticator.DefaultMaxIterations;
+
+    /// <summary>
+    /// Maximum server-requested SCRAM PBKDF2 iterations. Defaults to 1,000,000.
+    /// Must be positive; raise deliberately when a broker uses a higher count.
+    /// Applies to both password and delegation-token SCRAM authentication.
+    /// </summary>
+    public int SaslScramMaxIterations
+    {
+        get => _saslScramMaxIterations;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+            _saslScramMaxIterations = value;
+        }
+    }
 
     /// <summary>
     /// GSSAPI (Kerberos) configuration. Required when SaslMechanism is Gssapi.

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -530,6 +530,7 @@ public sealed partial class KafkaProducer<TKey, TValue> :
                 SaslPassword = options.SaslPassword,
                 SaslCredentialProvider = options.SaslCredentialProvider,
                 SaslScramTokenAuth = options.SaslScramTokenAuth,
+                SaslScramMaxIterations = options.SaslScramMaxIterations,
                 GssapiConfig = options.GssapiConfig,
                 OAuthBearerConfig = options.OAuthBearerConfig,
                 OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -535,6 +535,23 @@ public sealed class ProducerOptions
     /// </summary>
     public bool SaslScramTokenAuth { get; init; }
 
+    private int _saslScramMaxIterations = ScramAuthenticator.DefaultMaxIterations;
+
+    /// <summary>
+    /// Maximum server-requested SCRAM PBKDF2 iterations. Defaults to 1,000,000.
+    /// Must be positive; raise deliberately when a broker uses a higher count.
+    /// Applies to both password and delegation-token SCRAM authentication.
+    /// </summary>
+    public int SaslScramMaxIterations
+    {
+        get => _saslScramMaxIterations;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+            _saslScramMaxIterations = value;
+        }
+    }
+
     /// <summary>
     /// GSSAPI (Kerberos) configuration. Required when SaslMechanism is Gssapi.
     /// </summary>

--- a/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.net10.0.txt
@@ -625,3 +625,21 @@ Dekaf.Admin.NewPartitions.ReplicaAssignments.init -> void
 Dekaf.Admin.NewPartitions.TotalCount.get -> int
 Dekaf.Admin.NewPartitions.TotalCount.init -> void
 static Dekaf.Admin.AdminClientPartitionExpansionExtensions.CreatePartitionsAsync(this Dekaf.Admin.IAdminClient! adminClient, System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.NewPartitions!>! newPartitions, Dekaf.Admin.CreatePartitionsOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+
+Dekaf.Admin.AdminClientOptions.SaslScramMaxIterations.get -> int
+Dekaf.Admin.AdminClientOptions.SaslScramMaxIterations.init -> void
+Dekaf.Consumer.ConsumerOptions.SaslScramMaxIterations.get -> int
+Dekaf.Consumer.ConsumerOptions.SaslScramMaxIterations.init -> void
+Dekaf.Networking.ConnectionOptions.SaslScramMaxIterations.get -> int
+Dekaf.Networking.ConnectionOptions.SaslScramMaxIterations.init -> void
+Dekaf.Producer.ProducerOptions.SaslScramMaxIterations.get -> int
+Dekaf.Producer.ProducerOptions.SaslScramMaxIterations.init -> void
+Dekaf.ShareConsumer.ShareConsumerOptions.SaslScramMaxIterations.get -> int
+Dekaf.ShareConsumer.ShareConsumerOptions.SaslScramMaxIterations.init -> void
+Dekaf.Admin.AdminClientBuilder.WithSaslScramMaxIterations(int maxIterations) -> Dekaf.Admin.AdminClientBuilder!
+Dekaf.ConsumerBuilder<TKey, TValue>.WithSaslScramMaxIterations(int maxIterations) -> Dekaf.ConsumerBuilder<TKey, TValue>!
+Dekaf.KafkaClientBuilder.WithSaslScramMaxIterations(int maxIterations) -> Dekaf.KafkaClientBuilder!
+Dekaf.ProducerBuilder<TKey, TValue>.WithSaslScramMaxIterations(int maxIterations) -> Dekaf.ProducerBuilder<TKey, TValue>!
+Dekaf.ShareConsumerBuilder<TKey, TValue>.WithSaslScramMaxIterations(int maxIterations) -> Dekaf.ShareConsumerBuilder<TKey, TValue>!
+const Dekaf.Security.Sasl.ScramAuthenticator.DefaultMaxIterations = 1000000 -> int
+Dekaf.Security.Sasl.ScramAuthenticator.ScramAuthenticator(Dekaf.Security.Sasl.SaslMechanism mechanism, string! username, string! password, bool tokenAuth, int maxIterations) -> void

--- a/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.netstandard2.0.txt
@@ -625,3 +625,21 @@ Dekaf.Admin.NewPartitions.ReplicaAssignments.init -> void
 Dekaf.Admin.NewPartitions.TotalCount.get -> int
 Dekaf.Admin.NewPartitions.TotalCount.init -> void
 static Dekaf.Admin.AdminClientPartitionExpansionExtensions.CreatePartitionsAsync(this Dekaf.Admin.IAdminClient! adminClient, System.Collections.Generic.IReadOnlyDictionary<string!, Dekaf.Admin.NewPartitions!>! newPartitions, Dekaf.Admin.CreatePartitionsOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+
+Dekaf.Admin.AdminClientOptions.SaslScramMaxIterations.get -> int
+Dekaf.Admin.AdminClientOptions.SaslScramMaxIterations.init -> void
+Dekaf.Consumer.ConsumerOptions.SaslScramMaxIterations.get -> int
+Dekaf.Consumer.ConsumerOptions.SaslScramMaxIterations.init -> void
+Dekaf.Networking.ConnectionOptions.SaslScramMaxIterations.get -> int
+Dekaf.Networking.ConnectionOptions.SaslScramMaxIterations.init -> void
+Dekaf.Producer.ProducerOptions.SaslScramMaxIterations.get -> int
+Dekaf.Producer.ProducerOptions.SaslScramMaxIterations.init -> void
+Dekaf.ShareConsumer.ShareConsumerOptions.SaslScramMaxIterations.get -> int
+Dekaf.ShareConsumer.ShareConsumerOptions.SaslScramMaxIterations.init -> void
+Dekaf.Admin.AdminClientBuilder.WithSaslScramMaxIterations(int maxIterations) -> Dekaf.Admin.AdminClientBuilder!
+Dekaf.ConsumerBuilder<TKey, TValue>.WithSaslScramMaxIterations(int maxIterations) -> Dekaf.ConsumerBuilder<TKey, TValue>!
+Dekaf.KafkaClientBuilder.WithSaslScramMaxIterations(int maxIterations) -> Dekaf.KafkaClientBuilder!
+Dekaf.ProducerBuilder<TKey, TValue>.WithSaslScramMaxIterations(int maxIterations) -> Dekaf.ProducerBuilder<TKey, TValue>!
+Dekaf.ShareConsumerBuilder<TKey, TValue>.WithSaslScramMaxIterations(int maxIterations) -> Dekaf.ShareConsumerBuilder<TKey, TValue>!
+const Dekaf.Security.Sasl.ScramAuthenticator.DefaultMaxIterations = 1000000 -> int
+Dekaf.Security.Sasl.ScramAuthenticator.ScramAuthenticator(Dekaf.Security.Sasl.SaslMechanism mechanism, string! username, string! password, bool tokenAuth, int maxIterations) -> void

--- a/src/Dekaf/Security/Sasl/ScramAuthenticator.Validation.cs
+++ b/src/Dekaf/Security/Sasl/ScramAuthenticator.Validation.cs
@@ -1,0 +1,143 @@
+using Dekaf.Errors;
+
+namespace Dekaf.Security.Sasl;
+
+public sealed partial class ScramAuthenticator
+{
+    private static ParsedMessage ParseMessage(ReadOnlySpan<char> message, bool serverFirst)
+    {
+        var result = new ParsedMessage();
+        ulong seen = 0;
+        var attributeIndex = 0;
+        while (!message.IsEmpty)
+        {
+            var separator = message.IndexOf(',');
+            var part = separator < 0 ? message : message[..separator];
+            if (part.Length < 2 || part[1] != '=')
+                throw new AuthenticationException("Malformed SCRAM attribute");
+
+            var name = part[0];
+            var bit = name switch
+            {
+                >= 'A' and <= 'Z' => name - 'A',
+                >= 'a' and <= 'z' => name - 'a' + 26,
+                _ => -1
+            };
+            if (bit < 0)
+                throw new AuthenticationException("Invalid SCRAM attribute name");
+            if (name == 'm')
+                throw new AuthenticationException("Unsupported mandatory SCRAM extension");
+            var mask = 1UL << bit;
+            if ((seen & mask) != 0)
+                throw new AuthenticationException("Duplicate SCRAM attribute");
+            seen |= mask;
+
+            var value = part[2..];
+            var allowsEmptyBase64 = serverFirst
+                ? attributeIndex == 1 && name == 's'
+                : attributeIndex == 0 && name == 'v';
+            if (value.IndexOf('\0') >= 0 || (value.IsEmpty && !allowsEmptyBase64))
+                throw new AuthenticationException("Invalid SCRAM attribute value");
+            if (serverFirst && attributeIndex < 3 && name != "rsi"[attributeIndex])
+                throw new AuthenticationException("SCRAM server-first-message requires nonce, salt, and iterations in order");
+            if (!serverFirst && attributeIndex == 0 && name is not ('v' or 'e'))
+                throw new AuthenticationException("SCRAM server-final-message requires a verifier or error");
+            if (!serverFirst && attributeIndex > 0 && name is 'v' or 'e')
+                throw new AuthenticationException("SCRAM server-final-message cannot contain both verifier and error");
+
+            switch (name)
+            {
+                case 'r': result.Nonce = value; break;
+                case 's': result.Salt = value; break;
+                case 'i': result.Iterations = value; break;
+                case 'v': result.Verifier = value; break;
+                case 'e': result.Error = value; break;
+            }
+            attributeIndex++;
+            if (separator < 0)
+                break;
+            message = message[(separator + 1)..];
+            if (message.IsEmpty)
+                throw new AuthenticationException("Trailing separator in SCRAM server message");
+        }
+
+        if (attributeIndex < (serverFirst ? 3 : 1))
+            throw new AuthenticationException("Required SCRAM server attributes are missing");
+        return result;
+    }
+
+    private int ParseIterationCount(ReadOnlySpan<char> value)
+    {
+        if (value.IsEmpty || value[0] is < '1' or > '9')
+            throw new AuthenticationException("SCRAM iteration count must be a positive decimal integer");
+        var count = 0;
+        for (var index = 0; index < value.Length; index++)
+        {
+            var digit = value[index] - '0';
+            if ((uint)digit > 9 || count > (int.MaxValue - digit) / 10)
+                throw new AuthenticationException("Invalid or out-of-range SCRAM iteration count");
+            count = count * 10 + digit;
+        }
+        if (count > _maxIterations)
+            throw new AuthenticationException($"SCRAM iteration count {count} exceeds configured maximum {_maxIterations} (SaslScramMaxIterations)");
+        return count;
+    }
+
+    private static byte[] DecodeBase64(ReadOnlySpan<char> value, string error)
+    {
+        if ((value.Length & 3) != 0)
+            throw new AuthenticationException(error);
+        if (value.IsEmpty)
+            return Array.Empty<byte>();
+
+        var padding = 0;
+        if (value[^1] == '=')
+            padding = value[^2] == '=' ? 2 : 1;
+        var payloadLength = value.Length - padding;
+        var last = 0;
+        for (var index = 0; index < payloadLength; index++)
+        {
+            last = Base64Value(value[index]);
+            if (last < 0)
+                throw new AuthenticationException(error);
+        }
+        // RFC 5802 requires canonical base64, including zero unused padding bits.
+        if ((padding == 2 && (last & 15) != 0) || (padding == 1 && (last & 3) != 0))
+            throw new AuthenticationException(error);
+        return Convert.FromBase64String(value.ToString());
+    }
+
+    private static int Base64Value(char value) => value switch
+    {
+        >= 'A' and <= 'Z' => value - 'A',
+        >= 'a' and <= 'z' => value - 'a' + 26,
+        >= '0' and <= '9' => value - '0' + 52,
+        '+' => 62,
+        '/' => 63,
+        _ => -1
+    };
+
+    private static string GetServerError(ReadOnlySpan<char> error) => error switch
+    {
+        "invalid-encoding" => "invalid-encoding",
+        "extensions-not-supported" => "extensions-not-supported",
+        "invalid-proof" => "invalid-proof",
+        "channel-bindings-dont-match" => "channel-bindings-dont-match",
+        "server-does-support-channel-binding" => "server-does-support-channel-binding",
+        "channel-binding-not-supported" => "channel-binding-not-supported",
+        "unsupported-channel-binding-type" => "unsupported-channel-binding-type",
+        "unknown-user" => "unknown-user",
+        "invalid-username-encoding" => "invalid-username-encoding",
+        "no-resources" => "no-resources",
+        _ => "other-error"
+    };
+
+    private ref struct ParsedMessage
+    {
+        public ReadOnlySpan<char> Nonce;
+        public ReadOnlySpan<char> Salt;
+        public ReadOnlySpan<char> Iterations;
+        public ReadOnlySpan<char> Verifier;
+        public ReadOnlySpan<char> Error;
+    }
+}

--- a/src/Dekaf/Security/Sasl/ScramAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/ScramAuthenticator.cs
@@ -119,12 +119,10 @@ public sealed partial class ScramAuthenticator : ISaslAuthenticator
         ArgumentNullException.ThrowIfNull(challenge);
         try
         {
-            var challengeStr = ChallengeEncoding.GetString(challenge);
-
             return _state switch
             {
-                ScramState.ClientFirstSent => HandleServerFirst(challengeStr),
-                ScramState.ClientFinalSent => HandleServerFinal(challengeStr),
+                ScramState.ClientFirstSent => HandleServerFirst(ChallengeEncoding.GetString(challenge)),
+                ScramState.ClientFinalSent => HandleServerFinal(ChallengeEncoding.GetString(challenge)),
                 _ => throw new InvalidOperationException($"Unexpected state: {_state}")
             };
         }

--- a/src/Dekaf/Security/Sasl/ScramAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/ScramAuthenticator.cs
@@ -8,14 +8,19 @@ namespace Dekaf.Security.Sasl;
 /// SASL SCRAM (Salted Challenge Response Authentication Mechanism) authenticator.
 /// Implements RFC 5802 for SCRAM-SHA-256 and SCRAM-SHA-512.
 /// </summary>
-public sealed class ScramAuthenticator : ISaslAuthenticator
+public sealed partial class ScramAuthenticator : ISaslAuthenticator
 {
+    /// <summary>Default upper bound on server-requested PBKDF2 iterations.</summary>
+    public const int DefaultMaxIterations = 1_000_000;
+
+    private static readonly Encoding ChallengeEncoding = new UTF8Encoding(false, true);
     private readonly string _username;
     private readonly string _password;
     private readonly HashAlgorithmName _hashAlgorithm;
     private readonly int _hashSize;
     private readonly string _mechanismName;
     private readonly bool _tokenAuth;
+    private readonly int _maxIterations;
 
     private string? _clientNonce;
     private string? _clientFirstMessageBare;
@@ -28,7 +33,8 @@ public sealed class ScramAuthenticator : ISaslAuthenticator
         Initial,
         ClientFirstSent,
         ClientFinalSent,
-        Complete
+        Complete,
+        Failed
     }
 
     /// <summary>
@@ -37,8 +43,22 @@ public sealed class ScramAuthenticator : ISaslAuthenticator
     /// <param name="mechanism">The SCRAM mechanism (ScramSha256 or ScramSha512).</param>
     /// <param name="username">The username.</param>
     /// <param name="password">The password.</param>
+    /// <param name="tokenAuth">Whether to authenticate with a Kafka delegation token.</param>
     public ScramAuthenticator(SaslMechanism mechanism, string username, string password, bool tokenAuth = false)
+        : this(mechanism, username, password, tokenAuth, DefaultMaxIterations)
     {
+    }
+
+    /// <summary>Creates a SCRAM authenticator with a bound on server-requested hashing work.</summary>
+    /// <param name="mechanism">The SCRAM mechanism.</param>
+    /// <param name="username">The username or delegation token ID.</param>
+    /// <param name="password">The password or delegation token HMAC.</param>
+    /// <param name="maxIterations">Maximum accepted positive PBKDF2 iteration count.</param>
+    /// <param name="tokenAuth">Whether to authenticate with a Kafka delegation token.</param>
+    public ScramAuthenticator(SaslMechanism mechanism, string username, string password, bool tokenAuth, int maxIterations)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxIterations, 1);
+        _maxIterations = maxIterations;
         if (mechanism != SaslMechanism.ScramSha256 && mechanism != SaslMechanism.ScramSha512)
         {
             throw new ArgumentException("Mechanism must be ScramSha256 or ScramSha512", nameof(mechanism));
@@ -96,42 +116,48 @@ public sealed class ScramAuthenticator : ISaslAuthenticator
     /// <inheritdoc />
     public byte[]? EvaluateChallenge(byte[] challenge)
     {
-        var challengeStr = Encoding.UTF8.GetString(challenge);
-
-        return _state switch
+        ArgumentNullException.ThrowIfNull(challenge);
+        try
         {
-            ScramState.ClientFirstSent => HandleServerFirst(challengeStr),
-            ScramState.ClientFinalSent => HandleServerFinal(challengeStr),
-            _ => throw new InvalidOperationException($"Unexpected state: {_state}")
-        };
+            var challengeStr = ChallengeEncoding.GetString(challenge);
+
+            return _state switch
+            {
+                ScramState.ClientFirstSent => HandleServerFirst(challengeStr),
+                ScramState.ClientFinalSent => HandleServerFinal(challengeStr),
+                _ => throw new InvalidOperationException($"Unexpected state: {_state}")
+            };
+        }
+        catch (DecoderFallbackException)
+        {
+            _state = ScramState.Failed;
+            throw new AuthenticationException("Invalid UTF-8 in SCRAM server message");
+        }
+        catch (AuthenticationException)
+        {
+            _state = ScramState.Failed;
+            throw;
+        }
     }
 
     private byte[] HandleServerFirst(string serverFirstMessage)
     {
         // Parse server-first-message: r=<nonce>,s=<salt>,i=<iteration-count>
-        var parts = ParseMessage(serverFirstMessage);
-
-        if (!parts.TryGetValue("r", out var serverNonce))
+        var parts = ParseMessage(serverFirstMessage.AsSpan(), serverFirst: true);
+        var serverNonce = parts.Nonce;
+        if (serverNonce.Length <= _clientNonce!.Length || !serverNonce.StartsWith(_clientNonce.AsSpan(), StringComparison.Ordinal))
         {
-            throw new AuthenticationException("Server nonce not found in server-first-message");
+            throw new AuthenticationException("Server nonce must extend the client nonce");
         }
 
-        if (!serverNonce.StartsWith(_clientNonce!, StringComparison.Ordinal))
+        for (var index = 0; index < serverNonce.Length; index++)
         {
-            throw new AuthenticationException("Server nonce does not start with client nonce");
+            if (serverNonce[index] is < '!' or > '~')
+                throw new AuthenticationException("Invalid characters in SCRAM server nonce");
         }
 
-        if (!parts.TryGetValue("s", out var saltBase64))
-        {
-            throw new AuthenticationException("Salt not found in server-first-message");
-        }
-
-        if (!parts.TryGetValue("i", out var iterationsStr) || !int.TryParse(iterationsStr, out var iterations))
-        {
-            throw new AuthenticationException("Iteration count not found or invalid in server-first-message");
-        }
-
-        var salt = Convert.FromBase64String(saltBase64);
+        var iterations = ParseIterationCount(parts.Iterations);
+        var salt = DecodeBase64(parts.Salt, "Invalid SCRAM salt encoding");
 
         // Compute salted password using PBKDF2
         _saltedPassword = Rfc2898DeriveBytes.Pbkdf2(
@@ -144,7 +170,7 @@ public sealed class ScramAuthenticator : ISaslAuthenticator
         // Build client-final-message-without-proof
         // channel-binding: c=biws (base64 of "n,,")
         var channelBinding = "biws"; // base64("n,,")
-        var clientFinalMessageWithoutProof = $"c={channelBinding},r={serverNonce}";
+        var clientFinalMessageWithoutProof = $"c={channelBinding},r={serverNonce.ToString()}";
 
         // Build auth message
         _authMessage = $"{_clientFirstMessageBare},{serverFirstMessage},{clientFinalMessageWithoutProof}";
@@ -166,22 +192,22 @@ public sealed class ScramAuthenticator : ISaslAuthenticator
     private byte[]? HandleServerFinal(string serverFinalMessage)
     {
         // Parse server-final-message: v=<verifier> or e=<error>
-        var parts = ParseMessage(serverFinalMessage);
+        var parts = ParseMessage(serverFinalMessage.AsSpan(), serverFirst: false);
 
-        if (parts.TryGetValue("e", out var error))
+        if (!parts.Error.IsEmpty)
         {
-            throw new AuthenticationException($"SCRAM authentication failed: {error}");
+            // Unknown server errors are other-error, and arbitrary server text must not
+            // become a credential-bearing or multiline diagnostic.
+            throw new AuthenticationException($"SCRAM authentication failed: {GetServerError(parts.Error)}");
         }
 
-        if (!parts.TryGetValue("v", out var serverSignatureBase64))
-        {
-            throw new AuthenticationException("Server signature not found in server-final-message");
-        }
+        var actualServerSignature = DecodeBase64(parts.Verifier, "Invalid SCRAM server signature encoding");
+        if (actualServerSignature.Length != _hashSize)
+            throw new AuthenticationException("Invalid SCRAM server signature length");
 
         // Verify server signature
         var serverKey = Hmac(_saltedPassword!, "Server Key");
         var expectedServerSignature = Hmac(serverKey, _authMessage!);
-        var actualServerSignature = Convert.FromBase64String(serverSignatureBase64);
 
         if (!CryptographicOperations.FixedTimeEquals(expectedServerSignature, actualServerSignature))
         {
@@ -190,22 +216,6 @@ public sealed class ScramAuthenticator : ISaslAuthenticator
 
         _state = ScramState.Complete;
         return null;
-    }
-
-    private static Dictionary<string, string> ParseMessage(string message)
-    {
-        var result = new Dictionary<string, string>();
-        foreach (var part in message.Split(','))
-        {
-            var idx = part.IndexOf('=');
-            if (idx > 0)
-            {
-                var key = part[..idx];
-                var value = part[(idx + 1)..];
-                result[key] = value;
-            }
-        }
-        return result;
     }
 
     private static string GenerateNonce()

--- a/src/Dekaf/Security/Sasl/ScramAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/ScramAuthenticator.cs
@@ -168,7 +168,12 @@ public sealed partial class ScramAuthenticator : ISaslAuthenticator
         // Build client-final-message-without-proof
         // channel-binding: c=biws (base64 of "n,,")
         var channelBinding = "biws"; // base64("n,,")
+#if NET8_0_OR_GREATER
+        var clientFinalMessageWithoutProof = $"c={channelBinding},r={serverNonce}";
+#else
+        // The netstandard2.0 interpolation fallback cannot format a ref struct directly.
         var clientFinalMessageWithoutProof = $"c={channelBinding},r={serverNonce.ToString()}";
+#endif
 
         // Build auth message
         _authMessage = $"{_clientFirstMessageBare},{serverFirstMessage},{clientFinalMessageWithoutProof}";

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -108,6 +108,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 SaslPassword = options.SaslPassword,
                 SaslCredentialProvider = options.SaslCredentialProvider,
                 SaslScramTokenAuth = options.SaslScramTokenAuth,
+                SaslScramMaxIterations = options.SaslScramMaxIterations,
                 GssapiConfig = options.GssapiConfig,
                 OAuthBearerConfig = options.OAuthBearerConfig,
                 OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,

--- a/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
@@ -201,6 +201,23 @@ public sealed class ShareConsumerOptions
     /// </summary>
     public bool SaslScramTokenAuth { get; init; }
 
+    private int _saslScramMaxIterations = ScramAuthenticator.DefaultMaxIterations;
+
+    /// <summary>
+    /// Maximum server-requested SCRAM PBKDF2 iterations. Defaults to 1,000,000.
+    /// Must be positive; raise deliberately when a broker uses a higher count.
+    /// Applies to both password and delegation-token SCRAM authentication.
+    /// </summary>
+    public int SaslScramMaxIterations
+    {
+        get => _saslScramMaxIterations;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+            _saslScramMaxIterations = value;
+        }
+    }
+
     /// <summary>
     /// GSSAPI (Kerberos) configuration.
     /// </summary>

--- a/tests/Dekaf.Tests.Integration/Security/SaslAuthenticationTests.cs
+++ b/tests/Dekaf.Tests.Integration/Security/SaslAuthenticationTests.cs
@@ -17,6 +17,34 @@ namespace Dekaf.Tests.Integration.Security;
 [ClassDataSource<SaslKafkaContainer>(Shared = SharedType.PerTestSession)]
 public class SaslAuthenticationTests(SaslKafkaContainer saslKafka)
 {
+    [Test]
+    [Arguments(false, 4096)]
+    [Arguments(true, 4096)]
+    [Arguments(false, 4095)]
+    [Arguments(true, 4095)]
+    public async Task ScramIterationLimit_AcceptsBrokerAtLimitAndRejectsAbove(bool sha512, int limit)
+    {
+        var builder = Kafka.CreateAdminClient()
+            .WithBootstrapServers(saslKafka.BootstrapServers)
+            .WithSaslScramMaxIterations(limit);
+        if (sha512)
+            builder.WithSaslScramSha512(SaslKafkaContainer.SaslUsername, SaslKafkaContainer.SaslPassword);
+        else
+            builder.WithSaslScramSha256(SaslKafkaContainer.SaslUsername, SaslKafkaContainer.SaslPassword);
+        await using var admin = builder.Build();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        if (limit == 4096)
+        {
+            var topics = await admin.ListTopicsAsync(cancellationToken: timeout.Token);
+            await Assert.That(topics).IsNotNull();
+        }
+        else
+        {
+            await Assert.That(async () => await admin.ListTopicsAsync(cancellationToken: timeout.Token))
+                .Throws<AuthenticationException>().WithMessageContaining("SaslScramMaxIterations");
+        }
+    }
+
     // ==========================================
     // SASL/PLAIN Tests
     // ==========================================

--- a/tests/Dekaf.Tests.Unit/Builder/ConnectionBuilderOptionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConnectionBuilderOptionsTests.cs
@@ -11,6 +11,69 @@ namespace Dekaf.Tests.Unit.Builder;
 public sealed class ConnectionBuilderOptionsTests
 {
     [Test]
+    public async Task Builders_WithScramIterationLimit_ConfigureEveryConnectionPool()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092").WithSaslScramMaxIterations(8192).Build();
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092").WithGroupId("group")
+            .WithSaslScramMaxIterations(8192).Build();
+        await using var share = Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092").WithGroupId("group")
+            .WithSaslScramMaxIterations(8192).Build();
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers("localhost:9092").WithSaslScramMaxIterations(8192).Build();
+        await using var client = Kafka.Connect("localhost:9092", builder => builder.WithSaslScramMaxIterations(8192));
+        await using var sharedProducer = client.CreateProducer<string, string>().Build();
+
+        foreach (var instance in new object[] { producer, consumer, share, admin, sharedProducer })
+            await Assert.That(GetConnectionOptions(instance).SaslScramMaxIterations).IsEqualTo(8192);
+
+        await Assert.That(() => client.CreateProducer<string, string>().WithSaslScramMaxIterations(4096))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithSaslScramMaxIterations(4096))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(-1)]
+    public async Task Builders_WithInvalidScramIterationLimit_RejectImmediately(int limit)
+    {
+        await Assert.That(() => Kafka.CreateProducer<string, string>().WithSaslScramMaxIterations(limit))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => Kafka.CreateConsumer<string, string>().WithSaslScramMaxIterations(limit))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => Kafka.CreateShareConsumer<string, string>().WithSaslScramMaxIterations(limit))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => Kafka.CreateAdminClient().WithSaslScramMaxIterations(limit))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => new KafkaClientBuilder().WithSaslScramMaxIterations(limit))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task Options_ScramIterationLimit_DefaultsToOneMillionAndRejectsZero()
+    {
+        object[] defaults =
+        [
+            new ProducerOptions { BootstrapServers = ["localhost:9092"] },
+            new ConsumerOptions { BootstrapServers = ["localhost:9092"] },
+            new Dekaf.ShareConsumer.ShareConsumerOptions { BootstrapServers = ["localhost:9092"], GroupId = "group" },
+            new AdminClientOptions { BootstrapServers = ["localhost:9092"] },
+            new ConnectionOptions()
+        ];
+        foreach (var options in defaults)
+        {
+            var property = options.GetType().GetProperty("SaslScramMaxIterations")!;
+            await Assert.That((int)property.GetValue(options)!).IsEqualTo(1_000_000);
+            // Reflection is needed to exercise the same init-only option contract across all types.
+            await Assert.That(() => property.SetValue(options, 0)).Throws<TargetInvocationException>()
+                .WithInnerException<ArgumentOutOfRangeException>();
+        }
+    }
+
+    [Test]
     public async Task ProducerBuilder_WithConnectionOptions_ConfiguresConnectionPool()
     {
         RemoteCertificateValidationCallback callback = (_, _, _, errors) => errors == SslPolicyErrors.None;

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -893,6 +893,7 @@ public class DependencyInjectionTests
             SaslUsername = "producer-user",
             SaslPassword = "producer-password",
             SaslScramTokenAuth = true,
+            SaslScramMaxIterations = 8192,
             SaslCredentialProvider = credentialProvider
         };
 
@@ -919,6 +920,7 @@ public class DependencyInjectionTests
         await Assert.That(boundOptions.SaslUsername).IsEqualTo("producer-user");
         await Assert.That(boundOptions.SaslPassword).IsEqualTo("producer-password");
         await Assert.That(boundOptions.SaslScramTokenAuth).IsTrue();
+        await Assert.That(boundOptions.SaslScramMaxIterations).IsEqualTo(8192);
         await Assert.That((object?)boundOptions.SaslCredentialProvider).IsSameReferenceAs(credentialProvider);
     }
 
@@ -1428,6 +1430,7 @@ public class DependencyInjectionTests
             SaslUsername = "consumer-user",
             SaslPassword = "consumer-password",
             SaslScramTokenAuth = true,
+            SaslScramMaxIterations = 8192,
             SaslCredentialProvider = credentialProvider
         };
 
@@ -1454,6 +1457,7 @@ public class DependencyInjectionTests
         await Assert.That(boundOptions.SaslUsername).IsEqualTo("consumer-user");
         await Assert.That(boundOptions.SaslPassword).IsEqualTo("consumer-password");
         await Assert.That(boundOptions.SaslScramTokenAuth).IsTrue();
+        await Assert.That(boundOptions.SaslScramMaxIterations).IsEqualTo(8192);
         await Assert.That((object?)boundOptions.SaslCredentialProvider).IsSameReferenceAs(credentialProvider);
     }
 
@@ -1557,6 +1561,7 @@ public class DependencyInjectionTests
             SaslUsername = "admin-user",
             SaslPassword = "admin-password",
             SaslScramTokenAuth = true,
+            SaslScramMaxIterations = 8192,
             SaslCredentialProvider = credentialProvider
         };
 
@@ -1579,6 +1584,7 @@ public class DependencyInjectionTests
         await Assert.That(boundOptions.SaslUsername).IsEqualTo("admin-user");
         await Assert.That(boundOptions.SaslPassword).IsEqualTo("admin-password");
         await Assert.That(boundOptions.SaslScramTokenAuth).IsTrue();
+        await Assert.That(boundOptions.SaslScramMaxIterations).IsEqualTo(8192);
         await Assert.That((object?)boundOptions.SaslCredentialProvider).IsSameReferenceAs(credentialProvider);
     }
 
@@ -1729,6 +1735,7 @@ public class DependencyInjectionTests
             ["Kafka:Producers:Orders:SaslUsername"] = "user",
             ["Kafka:Producers:Orders:SaslPassword"] = "password",
             ["Kafka:Producers:Orders:SaslScramTokenAuth"] = "true",
+            ["Kafka:Producers:Orders:SaslScramMaxIterations"] = "8192",
             ["Kafka:Producers:Orders:SocketSendBufferBytes"] = "1024",
             ["Kafka:Producers:Orders:SocketReceiveBufferBytes"] = "2048",
             ["Kafka:Producers:Orders:ValueTaskSourcePoolSize"] = "128",
@@ -1785,6 +1792,7 @@ public class DependencyInjectionTests
         await Assert.That(options.SaslUsername).IsEqualTo("user");
         await Assert.That(options.SaslPassword).IsEqualTo("password");
         await Assert.That(options.SaslScramTokenAuth).IsTrue();
+        await Assert.That(options.SaslScramMaxIterations).IsEqualTo(8192);
         await Assert.That(options.SocketSendBufferBytes).IsEqualTo(1024);
         await Assert.That(options.SocketReceiveBufferBytes).IsEqualTo(2048);
         await Assert.That(options.ValueTaskSourcePoolSize).IsEqualTo(128);
@@ -1971,6 +1979,7 @@ public class DependencyInjectionTests
             ["Kafka:Consumers:Orders:SaslUsername"] = "user",
             ["Kafka:Consumers:Orders:SaslPassword"] = "password",
             ["Kafka:Consumers:Orders:SaslScramTokenAuth"] = "true",
+            ["Kafka:Consumers:Orders:SaslScramMaxIterations"] = "8192",
             ["Kafka:Consumers:Orders:EnablePartitionEof"] = "true",
             ["Kafka:Consumers:Orders:SocketSendBufferBytes"] = "4096",
             ["Kafka:Consumers:Orders:SocketReceiveBufferBytes"] = "8192",
@@ -2036,6 +2045,7 @@ public class DependencyInjectionTests
         await Assert.That(options.SaslUsername).IsEqualTo("user");
         await Assert.That(options.SaslPassword).IsEqualTo("password");
         await Assert.That(options.SaslScramTokenAuth).IsTrue();
+        await Assert.That(options.SaslScramMaxIterations).IsEqualTo(8192);
         await Assert.That(options.EnablePartitionEof).IsTrue();
         await Assert.That(options.SocketSendBufferBytes).IsEqualTo(4096);
         await Assert.That(options.SocketReceiveBufferBytes).IsEqualTo(8192);
@@ -2167,6 +2177,7 @@ public class DependencyInjectionTests
             ["Kafka:Admin:SaslUsername"] = "admin",
             ["Kafka:Admin:SaslPassword"] = "secret",
             ["Kafka:Admin:SaslScramTokenAuth"] = "true",
+            ["Kafka:Admin:SaslScramMaxIterations"] = "8192",
             ["Kafka:Admin:MetadataRecoveryStrategy"] = "None",
             ["Kafka:Admin:MetadataClusterCheckEnabled"] = "false",
             ["Kafka:Admin:MetadataRecoveryRebootstrapTriggerMs"] = "120000",
@@ -2196,6 +2207,7 @@ public class DependencyInjectionTests
         await Assert.That(options.SaslUsername).IsEqualTo("admin");
         await Assert.That(options.SaslPassword).IsEqualTo("secret");
         await Assert.That(options.SaslScramTokenAuth).IsTrue();
+        await Assert.That(options.SaslScramMaxIterations).IsEqualTo(8192);
         await Assert.That(options.MetadataRecoveryStrategy).IsEqualTo(MetadataRecoveryStrategy.None);
         await Assert.That(options.MetadataClusterCheckEnabled).IsFalse();
         await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(120000);

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/ScramConnectionPolicyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/ScramConnectionPolicyTests.cs
@@ -1,0 +1,83 @@
+using System.Reflection;
+using System.Text;
+using Dekaf.Errors;
+using Dekaf.Networking;
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Tests.Unit.Security.Sasl;
+
+public sealed class ScramConnectionPolicyTests
+{
+    [Test]
+    [Arguments(SaslMechanism.ScramSha256, false)]
+    [Arguments(SaslMechanism.ScramSha256, true)]
+    [Arguments(SaslMechanism.ScramSha512, false)]
+    [Arguments(SaslMechanism.ScramSha512, true)]
+    public async Task ConnectionFactory_RepeatedAttemptsHonorIterationLimit(
+        SaslMechanism mechanism, bool useCredentialProvider)
+    {
+        await using var connection = new KafkaConnection("localhost", 9092, options: new ConnectionOptions
+        {
+            SaslMechanism = mechanism,
+            SaslUsername = "user",
+            SaslPassword = "password",
+            SaslScramMaxIterations = 1,
+            SaslCredentialProvider = useCredentialProvider
+                ? static _ => new ValueTask<SaslCredentials>(new SaslCredentials("user", "password"))
+                : null
+        });
+        // Initial authentication and reauthentication use this same factory. Binding it
+        // avoids a network fixture and checks both fixed and provider-based credentials.
+        var create = typeof(KafkaConnection)
+            .GetMethod("CreateSaslAuthenticatorAsync", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .CreateDelegate<Func<CancellationToken, ValueTask<ISaslAuthenticator>>>(connection);
+
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            var rejected = await create(default);
+            var excessiveChallenge = CreateChallenge(rejected, 2);
+            await Assert.That(() => rejected.EvaluateChallenge(excessiveChallenge))
+                .Throws<AuthenticationException>();
+
+            var accepted = await create(default);
+            var validChallenge = CreateChallenge(accepted, 1);
+            await Assert.That(accepted.EvaluateChallenge(validChallenge)).IsNotNull();
+        }
+    }
+
+    [Test]
+    public async Task SharedOAuthProvider_ClonedOptionsPreserveScramIterationLimit()
+    {
+        var options = new ConnectionOptions
+        {
+            SaslMechanism = SaslMechanism.OAuthBearer,
+            SaslScramMaxIterations = 8192,
+            OAuthBearerConfig = new OAuthBearerConfig
+            {
+                TokenEndpointUrl = "http://localhost/token",
+                ClientId = "test-client"
+            }
+        };
+        var clone = typeof(ConnectionPool)
+            .GetMethod("ConfigureSharedOAuthBearerProvider", BindingFlags.Static | BindingFlags.NonPublic)!
+            .CreateDelegate<CloneOptions>();
+
+        var copied = clone(options, out var provider);
+        using (provider)
+        {
+            await Assert.That(ReferenceEquals(copied, options)).IsFalse();
+            await Assert.That(copied.SaslScramMaxIterations).IsEqualTo(8192);
+            await Assert.That(copied.OAuthBearerTokenProvider is not null).IsTrue();
+        }
+    }
+
+    private static byte[] CreateChallenge(ISaslAuthenticator authenticator, int iterations)
+    {
+        var initial = Encoding.UTF8.GetString(authenticator.GetInitialResponse());
+        var nonce = initial[(initial.IndexOf(",r=", StringComparison.Ordinal) + 3)..];
+        return Encoding.UTF8.GetBytes($"r={nonce}server,s=c2FsdA==,i={iterations}");
+    }
+
+    private delegate ConnectionOptions CloneOptions(
+        ConnectionOptions options, out OAuthBearerTokenProvider? provider);
+}

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/ScramValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/ScramValidationTests.cs
@@ -1,0 +1,260 @@
+using System.Security.Cryptography;
+using System.Text;
+using Dekaf.Errors;
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Tests.Unit.Security.Sasl;
+
+public class ScramValidationTests
+{
+    public static IEnumerable<(SaslMechanism Mechanism, string Challenge)> InvalidFirstMessages()
+    {
+        string[] challenges =
+        [
+            "m=unsupported,r={nonce}server,s=c2FsdA==,i=4096",
+            "r={nonce}server,s=c2FsdA==,i=4096,m=unsupported",
+            "r={nonce}server,s=c2FsdA==,i=4096,i=1",
+            "r={nonce}server,r={nonce}server,s=c2FsdA==,i=1",
+            "r={nonce}server,s=c2FsdA==,s=c2FsdA==,i=1",
+            "r={nonce}server,s=c2FsdA==,i=1,x=one,x=two",
+            "r={nonce}server,s=c2FsdA==,i=1,broken",
+            "r={nonce}server,s=c2FsdA==,i=1,",
+            ",r={nonce}server,s=c2FsdA==,i=1",
+            "r={nonce}server,,s=c2FsdA==,i=1",
+            "r={nonce}server,s=c2FsdA==,i=1,xx=value",
+            "r={nonce}server,s=c2FsdA==,i=1,x=",
+            "r={nonce}server,s=c2FsdA==,i=1,v=",
+            "r={nonce}server,s=c2FsdA==,i=1,x=bad\0value",
+            "s=c2FsdA==,i=1",
+            "r={nonce}server,i=1",
+            "r={nonce}server,s=c2FsdA==",
+            "s=c2FsdA==,r={nonce}server,i=1",
+            "r=wrong-nonce,s=c2FsdA==,i=1",
+            "r={nonce},s=c2FsdA==,i=1",
+            "r={nonce} space,s=c2FsdA==,i=1",
+            "r={nonce}server,s=invalid!,i=1",
+            "r={nonce}server,s=AB==,i=1",
+            "r={nonce}server,s=c2Fs dA==,i=1",
+            "r={nonce}server,s=c2FsdA=,i=1",
+            "r={nonce}server,s=c2FsdA==,i=0",
+            "r={nonce}server,s=c2FsdA==,i=-1",
+            "r={nonce}server,s=c2FsdA==,i=+1",
+            "r={nonce}server,s=c2FsdA==,i=01",
+            "r={nonce}server,s=c2FsdA==,i= 1",
+            "r={nonce}server,s=c2FsdA==,i=1 ",
+            "r={nonce}server,s=c2FsdA==,i=2147483648"
+        ];
+        foreach (var mechanism in new[] { SaslMechanism.ScramSha256, SaslMechanism.ScramSha512 })
+        {
+            foreach (var challenge in challenges)
+                yield return (mechanism, challenge);
+        }
+    }
+
+    [Test]
+    [MethodDataSource(nameof(InvalidFirstMessages))]
+    public async Task ServerFirst_RejectsMalformedMessage(SaslMechanism mechanism, string challenge)
+    {
+        var authenticator = new ScramAuthenticator(mechanism, "test-user", "test-password");
+        var first = Encoding.UTF8.GetString(authenticator.GetInitialResponse());
+        var nonce = first[(first.IndexOf(",r=", StringComparison.Ordinal) + 3)..];
+        var bytes = Encoding.UTF8.GetBytes(challenge.Replace("{nonce}", nonce));
+
+        await Assert.That(() => authenticator.EvaluateChallenge(bytes)).Throws<AuthenticationException>();
+        await Assert.That(authenticator.IsComplete).IsFalse();
+        await Assert.That(typeof(ScramAuthenticator).GetField("_saltedPassword",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!.GetValue(authenticator)).IsNull();
+    }
+
+    [Test]
+    [Arguments(SaslMechanism.ScramSha256, false)]
+    [Arguments(SaslMechanism.ScramSha256, true)]
+    [Arguments(SaslMechanism.ScramSha512, false)]
+    [Arguments(SaslMechanism.ScramSha512, true)]
+    public async Task ValidExchange_VerifiesBothProofsAndIgnoresOptionalExtensions(SaslMechanism mechanism, bool tokenAuth)
+    {
+        var exchange = new Exchange(mechanism, tokenAuth, firstExtensions: ",x=δ,X=other");
+        await Assert.That(exchange.ClientProof).IsEquivalentTo(exchange.ExpectedClientProof);
+        await Assert.That(exchange.ClientFirst.Contains(",tokenauth=true", StringComparison.Ordinal)).IsEqualTo(tokenAuth);
+        var result = exchange.Authenticator.EvaluateChallenge(Encoding.UTF8.GetBytes($"v={exchange.Signature},y=ignored"));
+        await Assert.That(result).IsNull();
+        await Assert.That(exchange.Authenticator.IsComplete).IsTrue();
+    }
+
+    public static IEnumerable<(SaslMechanism Mechanism, string Challenge)> InvalidFinalMessages()
+    {
+        string[] challenges =
+        [
+            "v={signature},v={signature}",
+            "v={signature},e=invalid-proof",
+            "e=invalid-proof,v={signature}",
+            "v={signature},m=unsupported",
+            "v={signature},x=one,x=two",
+            "v={signature},s=",
+            "v={signature},broken",
+            "v={signature},",
+            "x=one,v={signature}",
+            "v=invalid!",
+            "v=",
+            "v=AA==",
+            "e=",
+            ""
+        ];
+        foreach (var mechanism in new[] { SaslMechanism.ScramSha256, SaslMechanism.ScramSha512 })
+        {
+            foreach (var challenge in challenges)
+                yield return (mechanism, challenge);
+        }
+    }
+
+    [Test]
+    [MethodDataSource(nameof(InvalidFinalMessages))]
+    public async Task ServerFinal_RejectsMalformedMessage(SaslMechanism mechanism, string challenge)
+    {
+        var exchange = new Exchange(mechanism);
+        var bytes = Encoding.UTF8.GetBytes(challenge.Replace("{signature}", exchange.Signature));
+        await Assert.That(() => exchange.Authenticator.EvaluateChallenge(bytes)).Throws<AuthenticationException>();
+        await Assert.That(exchange.Authenticator.IsComplete).IsFalse();
+    }
+
+    [Test]
+    [Arguments(SaslMechanism.ScramSha256)]
+    [Arguments(SaslMechanism.ScramSha512)]
+    public async Task ServerFinal_RejectsNonCanonicalPaddingAndWrongSignature(SaslMechanism mechanism)
+    {
+        const string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        var exchange = new Exchange(mechanism);
+        var signature = exchange.Signature.ToCharArray();
+        var lastPayload = signature.Length - 1;
+        while (signature[lastPayload] == '=')
+            lastPayload--;
+        signature[lastPayload] = alphabet[alphabet.IndexOf(signature[lastPayload]) + 1];
+        var nonCanonical = new string(signature);
+        // Convert accepts these nonzero unused bits, but SCRAM requires canonical base64.
+        await Assert.That(Convert.FromBase64String(nonCanonical)).IsEquivalentTo(Convert.FromBase64String(exchange.Signature));
+        await Assert.That(() => exchange.Authenticator.EvaluateChallenge(Encoding.UTF8.GetBytes($"v={nonCanonical}")))
+            .Throws<AuthenticationException>();
+
+        foreach (var corruptFirstByte in new[] { true, false })
+        {
+            exchange = new Exchange(mechanism);
+            var incorrect = Convert.FromBase64String(exchange.Signature);
+            incorrect[corruptFirstByte ? 0 : incorrect.Length - 1] ^= 1;
+            await Assert.That(() => exchange.Authenticator.EvaluateChallenge(Encoding.UTF8.GetBytes($"v={Convert.ToBase64String(incorrect)}")))
+                .Throws<AuthenticationException>().WithMessageContaining("verification failed");
+        }
+    }
+
+    [Test]
+    [Arguments(SaslMechanism.ScramSha256, false)]
+    [Arguments(SaslMechanism.ScramSha256, true)]
+    [Arguments(SaslMechanism.ScramSha512, false)]
+    [Arguments(SaslMechanism.ScramSha512, true)]
+    public async Task Challenge_RejectsInvalidUtf8(SaslMechanism mechanism, bool serverFinal)
+    {
+        var authenticator = serverFinal ? new Exchange(mechanism).Authenticator
+            : new ScramAuthenticator(mechanism, "test-user", "test-password");
+        if (!serverFinal)
+            authenticator.GetInitialResponse();
+        await Assert.That(() => authenticator.EvaluateChallenge([0xff]))
+            .Throws<AuthenticationException>().WithMessageContaining("UTF-8");
+    }
+
+    [Test]
+    [Arguments(SaslMechanism.ScramSha256)]
+    [Arguments(SaslMechanism.ScramSha512)]
+    public async Task ServerError_DoesNotEchoUntrustedErrorText(SaslMechanism mechanism)
+    {
+        var exchange = new Exchange(mechanism);
+        await Assert.That(() => exchange.Authenticator.EvaluateChallenge("e=test-user test-password\nunsafe"u8.ToArray()))
+            .Throws<AuthenticationException>().WithMessage("SCRAM authentication failed: other-error");
+        await Assert.That(() => exchange.Authenticator.EvaluateChallenge(Encoding.UTF8.GetBytes($"v={exchange.Signature}")))
+            .Throws<InvalidOperationException>();
+        await Assert.That(exchange.Authenticator.IsComplete).IsFalse();
+    }
+
+    [Test]
+    [Arguments(SaslMechanism.ScramSha256, 1)]
+    [Arguments(SaslMechanism.ScramSha256, 16)]
+    [Arguments(SaslMechanism.ScramSha512, 1)]
+    [Arguments(SaslMechanism.ScramSha512, 16)]
+    public async Task ConfiguredMaximum_AllowsExactBoundary(SaslMechanism mechanism, int maximum)
+    {
+        var exchange = new Exchange(mechanism, iterations: maximum, maxIterations: maximum);
+        await Assert.That(exchange.ClientProof).IsEquivalentTo(exchange.ExpectedClientProof);
+        exchange.Authenticator.EvaluateChallenge(Encoding.UTF8.GetBytes($"v={exchange.Signature}"));
+        await Assert.That(exchange.Authenticator.IsComplete).IsTrue();
+    }
+
+    [Test]
+    [Arguments(SaslMechanism.ScramSha256, 16)]
+    [Arguments(SaslMechanism.ScramSha512, 16)]
+    [Arguments(SaslMechanism.ScramSha256, ScramAuthenticator.DefaultMaxIterations)]
+    [Arguments(SaslMechanism.ScramSha512, ScramAuthenticator.DefaultMaxIterations)]
+    public async Task ConfiguredMaximum_RejectsBeforeDerivingPassword(SaslMechanism mechanism, int maximum)
+    {
+        var authenticator = new ScramAuthenticator(mechanism, "test-user", "test-password", tokenAuth: false, maxIterations: maximum);
+        var first = Encoding.UTF8.GetString(authenticator.GetInitialResponse());
+        var nonce = first[(first.IndexOf(",r=", StringComparison.Ordinal) + 3)..];
+        var bytes = Encoding.UTF8.GetBytes($"r={nonce}server,s=c2FsdA==,i={maximum + 1}");
+        await Assert.That(() => authenticator.EvaluateChallenge(bytes)).Throws<AuthenticationException>()
+            .WithMessageContaining("SaslScramMaxIterations");
+        var passwordField = typeof(ScramAuthenticator).GetField("_saltedPassword", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        await Assert.That(passwordField.GetValue(authenticator)).IsNull();
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(-1)]
+    public async Task Constructor_RejectsInvalidMaximum(int maximum)
+    {
+        await Assert.That(() => new ScramAuthenticator(SaslMechanism.ScramSha256, "test-user", "test-password", false, maximum))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    [Arguments(SaslMechanism.ScramSha256)]
+    [Arguments(SaslMechanism.ScramSha512)]
+    public async Task EmptySalt_AcceptsCanonicalBase64Grammar(SaslMechanism mechanism)
+    {
+        var exchange = new Exchange(mechanism, emptySalt: true);
+        await Assert.That(exchange.ClientProof).IsEquivalentTo(exchange.ExpectedClientProof);
+        exchange.Authenticator.EvaluateChallenge(Encoding.UTF8.GetBytes($"v={exchange.Signature}"));
+        await Assert.That(exchange.Authenticator.IsComplete).IsTrue();
+    }
+
+    private sealed class Exchange
+    {
+        public ScramAuthenticator Authenticator { get; }
+        public string ClientFirst { get; }
+        public byte[] ClientProof { get; }
+        public byte[] ExpectedClientProof { get; }
+        public string Signature { get; }
+
+        public Exchange(SaslMechanism mechanism, bool tokenAuth = false, int iterations = 16,
+            int maxIterations = ScramAuthenticator.DefaultMaxIterations, string firstExtensions = "", bool emptySalt = false)
+        {
+            Authenticator = new ScramAuthenticator(mechanism, "test-user", "test-password", tokenAuth, maxIterations);
+            ClientFirst = Encoding.UTF8.GetString(Authenticator.GetInitialResponse());
+            var nonce = ClientFirst.Split(',').Single(static part => part.StartsWith("r=", StringComparison.Ordinal))[2..];
+            var salt = emptySalt ? Array.Empty<byte>() : "salt"u8.ToArray();
+            var serverFirst = $"r={nonce}server,s={Convert.ToBase64String(salt)},i={iterations}{firstExtensions}";
+            var final = Encoding.UTF8.GetString(Authenticator.EvaluateChallenge(Encoding.UTF8.GetBytes(serverFirst))!);
+            var proofStart = final.LastIndexOf(",p=", StringComparison.Ordinal);
+            ClientProof = Convert.FromBase64String(final[(proofStart + 3)..]);
+            var transcript = Encoding.UTF8.GetBytes($"{ClientFirst[3..]},{serverFirst},{final[..proofStart]}");
+            var algorithm = mechanism == SaslMechanism.ScramSha256 ? HashAlgorithmName.SHA256 : HashAlgorithmName.SHA512;
+            var size = mechanism == SaslMechanism.ScramSha256 ? 32 : 64;
+            var salted = Rfc2898DeriveBytes.Pbkdf2("test-password"u8.ToArray(), salt, iterations, algorithm, size);
+            byte[] Hmac(byte[] key, byte[] data) => mechanism == SaslMechanism.ScramSha256
+                ? HMACSHA256.HashData(key, data) : HMACSHA512.HashData(key, data);
+            var clientKey = Hmac(salted, "Client Key"u8.ToArray());
+            var storedKey = mechanism == SaslMechanism.ScramSha256 ? SHA256.HashData(clientKey) : SHA512.HashData(clientKey);
+            var clientSignature = Hmac(storedKey, transcript);
+            ExpectedClientProof = new byte[size];
+            for (var index = 0; index < size; index++)
+                ExpectedClientProof[index] = (byte)(clientKey[index] ^ clientSignature[index]);
+            Signature = Convert.ToBase64String(Hmac(Hmac(salted, "Server Key"u8.ToArray()), transcript));
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/ScramValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/ScramValidationTests.cs
@@ -73,10 +73,10 @@ public class ScramValidationTests
     [Arguments(SaslMechanism.ScramSha512, true)]
     public async Task ValidExchange_VerifiesBothProofsAndIgnoresOptionalExtensions(SaslMechanism mechanism, bool tokenAuth)
     {
-        var exchange = new Exchange(mechanism, tokenAuth, firstExtensions: ",x=δ,X=other");
+        var exchange = new Exchange(mechanism, tokenAuth, firstExtensions: ",x=δ漢🙂=other,X=other");
         await Assert.That(exchange.ClientProof).IsEquivalentTo(exchange.ExpectedClientProof);
         await Assert.That(exchange.ClientFirst.Contains(",tokenauth=true", StringComparison.Ordinal)).IsEqualTo(tokenAuth);
-        var result = exchange.Authenticator.EvaluateChallenge(Encoding.UTF8.GetBytes($"v={exchange.Signature},y=ignored"));
+        var result = exchange.Authenticator.EvaluateChallenge(Encoding.UTF8.GetBytes($"v={exchange.Signature},y=δ漢🙂=ignored"));
         await Assert.That(result).IsNull();
         await Assert.That(exchange.Authenticator.IsComplete).IsTrue();
     }
@@ -223,6 +223,43 @@ public class ScramValidationTests
         await Assert.That(exchange.Authenticator.IsComplete).IsTrue();
     }
 
+    [Test]
+    [Arguments(SaslMechanism.ScramSha256)]
+    [Arguments(SaslMechanism.ScramSha512)]
+    public async Task InvalidUtf8_BeforeInitialResponse_PreservesInitialState(SaslMechanism mechanism)
+    {
+        var authenticator = new ScramAuthenticator(mechanism, "test-user", "test-password");
+        await Assert.That(() => authenticator.EvaluateChallenge([0xff]))
+            .Throws<InvalidOperationException>().WithMessageContaining("Initial");
+        await Assert.That(authenticator.GetInitialResponse()).IsNotEmpty();
+        await Assert.That(authenticator.IsComplete).IsFalse();
+    }
+
+    [Test]
+    [Arguments(SaslMechanism.ScramSha256)]
+    [Arguments(SaslMechanism.ScramSha512)]
+    public async Task InvalidUtf8_AfterCompletion_PreservesCompleteState(SaslMechanism mechanism)
+    {
+        var exchange = new Exchange(mechanism);
+        exchange.Authenticator.EvaluateChallenge(Encoding.UTF8.GetBytes($"v={exchange.Signature}"));
+        await Assert.That(exchange.Authenticator.IsComplete).IsTrue();
+        await Assert.That(() => exchange.Authenticator.EvaluateChallenge([0xff]))
+            .Throws<InvalidOperationException>().WithMessageContaining("Complete");
+        await Assert.That(exchange.Authenticator.IsComplete).IsTrue();
+    }
+
+    [Test]
+    [Arguments(SaslMechanism.ScramSha256)]
+    [Arguments(SaslMechanism.ScramSha512)]
+    public async Task InvalidUtf8_AfterFailure_PreservesFailedState(SaslMechanism mechanism)
+    {
+        var authenticator = new ScramAuthenticator(mechanism, "test-user", "test-password");
+        authenticator.GetInitialResponse();
+        await Assert.That(() => authenticator.EvaluateChallenge([0xff])).Throws<AuthenticationException>();
+        await Assert.That(() => authenticator.EvaluateChallenge([0xff]))
+            .Throws<InvalidOperationException>().WithMessageContaining("Failed");
+        await Assert.That(authenticator.IsComplete).IsFalse();
+    }
     private sealed class Exchange
     {
         public ScramAuthenticator Authenticator { get; }


### PR DESCRIPTION
SCRAM previously generated a client proof for unsupported mandatory extensions and duplicate attributes, and passed invalid iteration counts into PBKDF2. Challenges now fail with `Dekaf.Errors.AuthenticationException` before key derivation when their grammar, nonce, salt, or iteration count is invalid.

The span parser validates attribute names/order/uniqueness, required fields, strict UTF-8, canonical base64 including padding bits, nonce extension, and positive ASCII iteration syntax. Optional extensions remain supported. Final messages require exactly one verifier or error; signature comparison remains `CryptographicOperations.FixedTimeEquals`. Protocol failure during an active exchange terminates it; calls outside an active exchange preserve state, and arbitrary server error text is not echoed into diagnostics. These rules follow [RFC 5802](https://datatracker.ietf.org/doc/html/rfc5802).

Server-requested hashing is capped at 1,000,000 iterations by default. `WithSaslScramMaxIterations` / `SaslScramMaxIterations` configure a positive limit on producer, consumer, share consumer, admin, shared-client, connection, and DI paths. Higher legitimate broker configurations can explicitly raise the limit. Both hashes and delegation tokens use the same policy. The existing four-parameter authenticator constructor remains binary compatible; a five-parameter overload accepts the limit.

Validation:

- TDD: the initial 62 malformed server-first cases produced 52 failures against the original implementation and passed after the fix. No deliberately expensive hashing request was executed.
- Final unit runs: 367 passed on each of net10.0 and net8.0 (253 SASL, 17 connection-builder, 97 DI tests). New SCRAM suite contains 116 cases, including independently calculated client/server proofs, both hashes, delegation-token exchanges, malformed first/final messages, UTF-8, padding bits, signature mismatch, terminal failure, empty canonical salt, and configurable boundaries. Malformed first messages assert that password derivation never occurred.
- Existing SASL integration class plus four new iteration-boundary cases: 19 passed against its dedicated `apache/kafka:4.0.2` fixture. Covers PLAIN, both SCRAM hashes, producer/consumer/admin interoperability, both delegation-token mechanisms, and broker 4,096 iterations accepted at limit 4,096 / rejected at 4,095.
- Release unit/integration builds and public API analyzers passed with zero warnings/errors. `npm run build --prefix docs` passed; generated SASL page contains the new configuration guidance.
- `/simplify` completed, including rejecting empty optional attributes consistently. No produce/consume per-message implementation changed.

Performance evidence: exact baseline `4d665a10867fb0624a18b3fc2b8c6a8584c391f3` → candidate `01c1de8ba0e6fd4e5b21d89c77fc58f7b4bbfe1d`. Local BenchmarkDotNet 0.15.8, `[MemoryDiagnoser]`, in-process, 5 warmups / 15 measured iterations, .NET 10.0.11 / SDK 10.0.400, Windows 11, i7-12700K. Identical task-scoped harness against saved before/after assemblies, sequential runs, 4,096 PBKDF2 iterations, no own builds/tests during measurements. No paid stress lane dispatched; lane/shape/duration/profiling/run URL: not applicable to these local connection-authentication benchmarks.

| Case | Baseline mean ± 99.9% CI half-width | Candidate mean ± 99.9% CI half-width | Mean delta | Allocated before → after |
|---|---:|---:|---:|---:|
| SHA-256 first challenge | 388.984 ± 11.576 µs | 375.313 ± 5.871 µs | -3.5% | 3,320 → 2,760 B |
| SHA-256 final verification | 880.9 ± 43.83 ns | 810.3 ± 15.89 ns | -8.0% | 776 → 504 B |
| SHA-512 first challenge | 1,580.921 ± 59.116 µs | 1,536.357 ± 16.341 µs | -2.8% | 3,711 → 3,151 B |
| SHA-512 final verification | 2,427.1 ± 115.68 ns | 2,312.4 ± 33.99 ns | -4.7% | 960 → 688 B |

First-challenge measurement uses the public constructor, random initial response, synthetic challenge construction, and `EvaluateChallenge`; shared fixture costs are included on both sides. Final verification binds `HandleServerFinal` once during setup with a valid independently generated signature, so it isolates parsing/verification and excludes UTF-8 decoding and public state dispatch. These are connection-time allocations, not per-message allocations. The SHA-512 first-challenge BDN totals include approximately 7 B/op of in-process measurement noise on both sides; the 560 B reduction is consistent across both hashes.

BDN iteration-mean median / maximum, baseline → candidate: SHA-256 first 386.111 / 408.245 → 374.419 / 388.179 µs; SHA-256 final 879.933 / 970.129 → 805.455 / 833.715 ns; SHA-512 first 1.574 / 1.702 → 1.529 / 1.571 ms; SHA-512 final 2.380 / 2.663 → 2.299 / 2.390 µs. These are iteration statistics, not application p50/p99/max latency. Broker throughput, message latency tails, CPU/message, and long-run stability were not measured or claimed. Most timing confidence intervals overlap; the allocation reductions are the strong result. No measured regression in the exercised authentication cases.

Separate warmed construction allocation probe (100 warmups, 1,000 instances) identifies the policy field's cold cost: authenticator stays 96 B; producer/consumer/share options stay 440/456/272 B; consumer/share builders stay 664/344 B. Admin options 224→232 B, connection options 216→224 B, producer builder 560→568 B, admin builder 328→336 B, shared-client builder 264→272 B. Those five +8 B costs occur once per configuration/builder instance, not per message or challenge.

Measured Dekaf.dll SHA-256: baseline `A09340D1AA74B460BFDB1CC8D8B2C3760D2FE040BFD56652A775BB8570683E8F`; candidate `83BB9FBB4F3CE2BBE7A040365A6980DAD1F01B225DFD8E3C5C17933FF963B162`. Harness-loaded assemblies matched these snapshots.

Review candidate: `7c0b3b701c02ae05b868f38329414318723b6bd3`.

Review fix: EvaluateChallenge selects an active state before decoding. Initial, Complete and Failed calls now retain InvalidOperationException and their state even when bytes contain malformed UTF-8. Decoding stays inside the existing two switch arms, so active authentication failures still terminate the exchange without a separate success-path state guard. Six new cases failed on 01c1de8 and pass after the fix; all 259 SASL unit cases pass on each of net8.0/net10.0, and all 19 SASL broker cases pass on net10.0 (537 total). Release builds and /simplify are clean.

Optional-extension compatibility is deliberate: RFC 5802 section 7 permits UTF-8 and equals signs in value-char. Expanded successful proof-verification tests cover 2/3/4-byte characters plus equals in first/final extensions. [RFC 5802 §7](https://datatracker.ietf.org/doc/html/rfc5802#section-7).

Review performance against exact preceding head 01c1de8ba0e6fd4e5b21d89c77fc58f7b4bbfe1d: BDN 0.15.8, MemoryDiagnoser, in-process 5 warmups / 15 iterations, .NET 10.0.11 / SDK 10.0.400, Windows 11 / i7-12700K, 4096 PBKDF2 iterations, same fixture against saved DLLs. Own tests/builds finished before measurements. The public final-verification fixture resets state through a precompiled delegate then calls EvaluateChallenge, so it measures the changed dispatch plus UTF-8 decoding; compare within this table, not against the earlier private-method final-verification benchmark.

| Case | Before mean ± error (SD) | Final mean ± error (SD) | Allocated before → final |
| --- | --- | --- | --- |
| ScramSha256 / FirstChallenge | 380,610.7 ns ± 8,626.44 ns (8,069.17 ns) | 370,317.4 ns ± 1,763.02 ns (1,376.45 ns) | 2760 B → 2760 B |
| ScramSha256 / PublicFinalVerification | 916.4 ns ± 56.36 ns (52.72 ns) | 865.5 ns ± 27.58 ns (23.03 ns) | 624 B → 624 B |
| ScramSha512 / FirstChallenge | 1,630,161.5 ns ± 130,458.77 ns (122,031.22 ns) | 1,540,808.0 ns ± 19,276.34 ns (17,087.97 ns) | 3150 B → 3149 B |
| ScramSha512 / PublicFinalVerification | 2,577.3 ns ± 193.02 ns (171.10 ns) | 2,343.4 ns ± 15.59 ns (13.82 ns) | 896 B → 896 B |

All point estimates improve (SHA-256 first/final -2.7%/-5.6%; SHA-512 -5.5%/-9.1%), with no allocation increase. Several timing intervals overlap, so these establish no material regression rather than a guaranteed speedup. SHA-512 first-challenge allocation varies by 1 B/op from in-process measurement noise; no product allocation was removed. These remain connection-time allocations. No message-path, broker throughput/p50/p99/max/CPU claim or paid stress dispatch.

The initial separate-guard design was also measured before /simplify moved decoding into the existing arms:

| Method                  | Mechanism   | Mean           | Error        | StdDev       | Gen0   | Allocated |
|------------------------ |------------ |---------------:|-------------:|-------------:|-------:|----------:|
| **FirstChallenge**          | **ScramSha256** |   **372,987.3 ns** | **14,088.94 ns** | **12,489.48 ns** |      **-** |    **2760 B** |
| PublicFinalVerification | ScramSha256 |       888.4 ns |     39.05 ns |     32.61 ns | 0.0477 |     624 B |
| **FirstChallenge**          | **ScramSha512** | **1,647,706.9 ns** | **50,269.94 ns** | **44,562.99 ns** |      **-** |    **3152 B** |
| PublicFinalVerification | ScramSha512 |     2,623.2 ns |    179.54 ns |    167.94 ns | 0.0648 |     896 B |
Its SHA-512 final timing was multimodal; it was not committed. Final means improve against that intermediate in all four cases. Full reports/fixture: .artifacts/bench-review-before, bench-review-after, bench-review-final, and scram-bench. DLL SHA-256 before EAD29AAD06F341D299D9349B34178051B4AA80145A5D040356ED8A412DE62188; intermediate 4151293A87B3A8D9998DCC280C2B98D010F2B9540F85B15C7E496129B1708423; final C0D4D74EC054376E0CFD8B36311DBE3B0272A90D4EF1A1680647FC58D024175D.

Additional review candidate: 3ce7e90d15e34a2c78cfad017499d8ce0c7a778a.

Removed the intermediate server-nonce string when formatting the client-final message on modern .NET. The netstandard2.0 fallback retains `ToString()`: removing it there produces CS0029 because that interpolation implementation cannot accept a ref struct. Both target-framework builds pass. Five additional unit cases verify the configured limit through the shared initial/re-authentication factory (both hashes, fixed/provider credentials, repeated attempts) and through OAuth connection-options cloning. All 264 SASL, 17 builder, and 97 DI cases pass on each of net10.0/net8.0; all 19 live SASL cases pass on net10.0. Release builds have zero warnings/errors. `/simplify` completed.

Expanded performance coverage uses the same nine-case fixture against three exact source states: original feature baseline `4d665a10867fb0624a18b3fc2b8c6a8584c391f3`, immediately preceding review head `7c0b3b701c02ae05b868f38329414318723b6bd3`, and this candidate. BDN 0.15.8, MemoryDiagnoser, in-process, 5 warmups / 15 measured iterations of 250 ms, .NET 10.0.11 / SDK 10.0.400, Windows 11 / i7-12700K. Sequential execution order was original → candidate → preceding head; no own builds/tests overlapped measurements. Local harness/reports are `.artifacts/review-bench` and `review-expanded-{before,after,previous}`. No paid stress dispatch; lane, dispatch shape, duration_minutes, profiling mode and workflow URL are not applicable.

| Case | Original mean ± error | Preceding head mean ± error | Candidate mean ± error | Candidate vs original / preceding |
|---|---:|---:|---:|---:|
| Typed producer binding | 134.6 ± 2.88 ns | 155.4 ± 18.34 ns | 149.1 ± 8.20 ns | +10.8% / -4.1% |
| Typed consumer binding | 147.9 ± 1.86 ns | 172.4 ± 21.43 ns | 159.6 ± 8.60 ns | +7.9% / -7.4% |
| Typed admin binding | 106.6 ± 3.17 ns | 114.8 ± 10.60 ns | 104.9 ± 1.38 ns | -1.6% / -8.6% |
| Configuration producer binding | 7,383.9 ± 144.09 ns | 8,200.9 ± 1,213.65 ns | 7,327.4 ± 90.84 ns | -0.8% / -10.7% |
| Configuration consumer binding | 7,845.0 ± 281.88 ns | 7,751.3 ± 176.71 ns | 7,876.4 ± 318.35 ns | +0.4% / +1.6% |
| Configuration admin binding | 3,798.9 ± 18.23 ns | 4,441.8 ± 496.17 ns | 3,897.6 ± 38.59 ns | +2.6% / -12.3% |
| OAuth options clone + provider disposal | 92.82 ± 9.97 ns | 93.73 ± 12.50 ns | 80.04 ± 2.04 ns | -13.8% / -14.6% |
| Connection factory + SHA-256 first challenge | 367.9 ± 2.02 µs | 376.2 ± 8.71 µs | 368.4 ± 1.00 µs | +0.1% / -2.1% |
| Connection factory + SHA-512 first challenge | 1,702.4 ± 155.52 µs | 1,581.2 ± 120.87 µs | 1,535.0 ± 12.56 µs | -9.8% / -2.9% |

Error is the 99.9% confidence-interval half-width. Binding/cloning code is unchanged between preceding head and candidate, so those columns also expose host/JIT variability; several preceding-head cases have wide intervals. No timing speedup is inferred from those controls. The original-baseline increases in typed producer/consumer binding and configuration admin binding are reported explicitly, not averaged away or labelled improvements. These are client-configuration operations; this table does not measure message throughput or latency.

| Cold operation | Original allocated | Preceding allocated | Candidate allocated |
|---|---:|---:|---:|
| Typed producer binding | 776 B | 784 B | 784 B |
| Typed consumer binding | 880 B | 880 B | 880 B |
| Typed admin binding | 552 B | 560 B | 560 B |
| Configuration producer binding | 21,017 B | 21,289 B | 21,289 B |
| Configuration consumer binding | 22,737 B | 22,873 B | 22,873 B |
| Configuration admin binding | 11,153 B | 11,297 B | 11,297 B |
| OAuth options clone + provider disposal | 848 B | 856 B | 856 B |

All six binding cases allocate a fresh builder and invoke the actual typed/configuration binding method through a delegate bound once in GlobalSetup. Prepared SCRAM options/configuration include username, password, mechanism and limit 8,192; original code lacks/ignores that new property. Positive validation runs through the real builder. Configuration is reused; service-provider construction and client worker startup are excluded. The +8 B builder/clone field costs and +272/+136/+144 B configuration-binding costs are bounded per configuration operation, not per message. Existing negative-limit tests cover rejection.

The clone benchmark executes the real `ConfigureSharedOAuthBearerProvider` and disposes each newly created provider without HTTP requests. Authentication performs two fresh attempts on one prepared connection through `CreateSaslAuthenticatorAsync`, with OperationsPerInvoke=2, then the public initial response and first challenge at 4,096 iterations. Initial auth and re-auth call that same factory. This exercises changed factory/derivation logic, not a socket exchange, re-authentication timer, or server-final signing. The previously reported public server-final benchmark remains applicable: this follow-up changes only first-challenge formatting.

BDN authentication allocations, original → preceding → candidate: SHA-256 3.25 → 2.70 → 2.60 KiB; SHA-512 3.63 → 3.10 → 3.00 KiB. A separate warmed allocation probe (40 warmup and 300 measured authentications, allocation counter sampled before formatting output) gives SHA-256 3,320 → 2,760 → 2,656 B and SHA-512 3,704.16 → 3,144.16 → 3,040 B. The 0.16 B differences are 48 B of one-off measurement noise across 300 operations. The nonce string removal saves 104 B per authentication on modern .NET, in addition to the original parser savings.

Authentication BDN iteration median/max, original → preceding → candidate: SHA-256 368.311/370.321 → 374.307/391.366 → 368.362/369.850 µs; SHA-512 1.651/2.018 → 1.548/1.866 → 1.533/1.553 ms. These are iteration means, not application p50/p99/max. CPU/message, broker throughput, message latency tails and long-run stability were not measured. Decision: the nonce-formatting follow-up reduces authentication allocation with no observed authentication timing regression; unchanged binding/clone paths retain preceding-head allocation. The new setting's measured cold configuration costs remain explicit. No blanket message-path Pareto claim or paid gate is inferred from this evidence.

Dekaf.dll SHA-256, original / preceding / candidate: `428C9F5832BB0426876A9945E263702AC37DCDF7661066079899CFA8E2710E33` / `316E05817CB332BFACDFCDA7044B1B5F512AAB017D78381071FDCDF0126B460B` / `FBD1C17AE172EC116C126CBC77EFEDED7B15FB314DA80CED9F3971FD4898D513`. Harness-loaded DLL hashes matched the snapshots.

Review cleanup: retain direct `ArgumentOutOfRangeException.ThrowIfLessThan` calls. That BCL helper already shares the positive-bound validation; another local wrapper would add indirection without removing option fields or builder plumbing, and preserving each caller's parameter name matters. The default remains centralized in `ScramAuthenticator.DefaultMaxIterations`.


Closes #3049




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum PBKDF2 iteration limits for SCRAM authentication across producer, consumer, share consumer, admin, and shared clients.
  * Added support for configuring the limit through client options, builders, and dependency injection.
  * SCRAM challenges exceeding the configured limit or containing malformed data are now rejected with an authentication error.

* **Documentation**
  * Documented SCRAM iteration limits, configuration options, validation behavior, and supported authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->