### PR TITLE
fix(consumer): service commits under backpressure

### DIFF
--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Runtime.ExceptionServices;
 using System.Threading.Channels;
+using Dekaf.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 #if NETSTANDARD2_0
@@ -624,6 +625,9 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
     private readonly ConcurrentDictionary<Task, byte> _ignoreRestartTasks = [];
     private readonly List<TopicPartition> _partitionsToStop = [];
     private readonly Channel<RuntimeCommand<TKey, TValue>> _commands;
+    private AsyncAutoResetSignal? _capacitySignal;
+    private AsyncAutoResetSignal? _stopSignal;
+    private Queue<RuntimeCommand<TKey, TValue>>? _deferredCommands;
     private readonly CancellationTokenSource _failureCancellation = new();
     private readonly CancellationTokenSource _restartCancellation = new();
     private readonly object _failureGate = new();
@@ -768,6 +772,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
                 await StopScheduledRestartsAsync().ConfigureAwait(false);
                 _commands.Writer.TryComplete();
                 CompletePendingCommands();
+                _capacitySignal?.Dispose();
             }
         }
 
@@ -800,7 +805,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
     {
         var partitionArray = partitions as TopicPartition[] ?? partitions.ToArray();
         if (partitionArray.Length > 0)
-            _commands.Writer.TryWrite(RuntimeCommand<TKey, TValue>.AssignPartitions(partitionArray));
+            TryQueueCommand(RuntimeCommand<TKey, TValue>.AssignPartitions(partitionArray));
     }
 
     private void QueueStoppedPartitions(
@@ -809,7 +814,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
     {
         var partitionArray = partitions as TopicPartition[] ?? partitions.ToArray();
         if (partitionArray.Length > 0)
-            _commands.Writer.TryWrite(RuntimeCommand<TKey, TValue>.StopPartitions(partitionArray, stopReason));
+            TryQueueCommand(RuntimeCommand<TKey, TValue>.StopPartitions(partitionArray, stopReason));
     }
 
     private sealed class RuntimeRebalanceListener(
@@ -853,7 +858,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var command = RuntimeCommand<TKey, TValue>.Commit(lane, completion, cancellationToken);
 
-        if (!_commands.Writer.TryWrite(command))
+        if (!TryQueueCommand(command))
         {
             var exception = new InvalidOperationException("Partitioned processing runtime is not accepting commit requests.");
             return new ValueTask(Task.FromException(exception));
@@ -911,29 +916,63 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         _partitionsToStop.Clear();
     }
 
-    private async ValueTask RouteBatchAsync(
+    private ValueTask RouteBatchAsync(
         ConsumeBatch<TKey, TValue> batch,
         CancellationToken cancellationToken)
     {
         var partition = batch.TopicPartition;
         if (!_lanes.TryGetValue(partition, out var lane))
-            return;
+            return default;
 
-        foreach (var result in batch)
+        var records = batch.GetEnumerator();
+        while (records.MoveNext())
         {
-            while (!lane.TryEnqueue(result))
+            if (!lane.TryEnqueue(records.Current))
+                return RouteBackpressuredBatchAsync(records, lane, cancellationToken);
+
+            PauseIfNeeded(lane);
+        }
+
+        return default;
+    }
+
+    private async ValueTask RouteBackpressuredBatchAsync(
+        ConsumeBatch<TKey, TValue>.Enumerator records,
+        PartitionLane<TKey, TValue> lane,
+        CancellationToken cancellationToken)
+    {
+        var signal = _capacitySignal;
+        if (signal is null)
+        {
+            signal = new AsyncAutoResetSignal();
+            signal.RegisterShutdownToken(cancellationToken);
+            Volatile.Write(ref _capacitySignal, signal);
+        }
+
+        // Continue from the rejected record in one async state machine per batch.
+        // Publishing the signal before retrying closes the capacity/command race.
+        do
+        {
+            while (!lane.TryEnqueue(records.Current))
             {
                 PauseIfNeeded(lane);
-                var canWrite = await lane.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
                 await DrainCommandsAsync(cancellationToken).ConfigureAwait(false);
                 ThrowIfFailed();
 
-                if (!canWrite || !_lanes.TryGetValue(partition, out lane))
+                if (lane.IsCompleted
+                    || !_lanes.TryGetValue(lane.TopicPartition, out var currentLane)
+                    || !ReferenceEquals(currentLane, lane))
                     return;
+
+                if (lane.TryEnqueue(records.Current))
+                    break;
+
+                await signal.WaitAsync(Timeout.Infinite).ConfigureAwait(false);
             }
 
             PauseIfNeeded(lane);
         }
+        while (records.MoveNext());
     }
 
     private void StartLane(TopicPartition partition)
@@ -988,9 +1027,22 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
     private void OnLaneCapacityAvailable(PartitionLane<TKey, TValue> lane)
     {
         if (_options.BackpressureMode != PartitionBackpressureMode.PauseResume)
+        {
+            Volatile.Read(ref _capacitySignal)?.Signal();
             return;
+        }
 
-        _commands.Writer.TryWrite(RuntimeCommand<TKey, TValue>.Resume(lane));
+        TryQueueCommand(RuntimeCommand<TKey, TValue>.Resume(lane));
+    }
+
+    private bool TryQueueCommand(RuntimeCommand<TKey, TValue> command)
+    {
+        if (!_commands.Writer.TryWrite(command))
+            return false;
+
+        Volatile.Read(ref _capacitySignal)?.Signal();
+        Volatile.Read(ref _stopSignal)?.Signal();
+        return true;
     }
 
     private void OnLaneFailed(PartitionLane<TKey, TValue> lane, Exception exception)
@@ -1005,12 +1057,12 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
             return;
         }
 
-        _commands.Writer.TryWrite(RuntimeCommand<TKey, TValue>.StopFailed(lane, exception));
+        TryQueueCommand(RuntimeCommand<TKey, TValue>.StopFailed(lane, exception));
     }
 
     private async ValueTask DrainCommandsAsync(CancellationToken cancellationToken)
     {
-        while (_commands.Reader.TryRead(out var command))
+        while (TryReadCommand(out var command))
         {
             switch (command.Kind)
             {
@@ -1044,6 +1096,17 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
                     break;
             }
         }
+    }
+
+    private bool TryReadCommand(out RuntimeCommand<TKey, TValue> command)
+    {
+        if (_deferredCommands is { Count: > 0 })
+        {
+            command = _deferredCommands.Dequeue();
+            return true;
+        }
+
+        return _commands.Reader.TryRead(out command);
     }
 
     private async ValueTask CompleteCommitCommandAsync(
@@ -1156,7 +1219,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         TimeSpan delay)
     {
         await Task.Delay(delay, _restartCancellation.Token).ConfigureAwait(false);
-        _commands.Writer.TryWrite(RuntimeCommand<TKey, TValue>.RestartLane(partition));
+        TryQueueCommand(RuntimeCommand<TKey, TValue>.RestartLane(partition));
     }
 
     private void CompleteIgnoreRestartTask(Task task)
@@ -1179,11 +1242,13 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         bool commitProcessed,
         CancellationToken cancellationToken)
     {
-        var exception = await lane.StopAsync(
-            reason is PartitionStopReason.Failure or PartitionStopReason.Lost
-                ? PartitionStopPolicy.Cancel
-                : _options.StopPolicy,
-            _options.StopTimeout).ConfigureAwait(false);
+        var policy = reason is PartitionStopReason.Failure or PartitionStopReason.Lost
+            ? PartitionStopPolicy.Cancel
+            : _options.StopPolicy;
+        var stopping = lane.StopAsync(policy, _options.StopTimeout);
+        var exception = policy == PartitionStopPolicy.Drain && !stopping.IsCompleted
+            ? await DrainHandlerCommitsAsync(stopping.AsTask(), cancellationToken).ConfigureAwait(false)
+            : await stopping.ConfigureAwait(false);
 
         if (commitProcessed)
             await CommitLaneAsync(lane, cancellationToken).ConfigureAwait(false);
@@ -1193,6 +1258,48 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         {
             CaptureFailure(exception);
             _failureCancellation.Cancel();
+        }
+    }
+
+    private async ValueTask<Exception?> DrainHandlerCommitsAsync(
+        Task<Exception?> stopping,
+        CancellationToken cancellationToken)
+    {
+        using var signal = new AsyncAutoResetSignal();
+        using var commitCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (_options.StopTimeout != Timeout.InfiniteTimeSpan)
+            commitCancellation.CancelAfter(_options.StopTimeout);
+
+        Volatile.Write(ref _stopSignal, signal);
+        _ = stopping.ContinueWith(static (_, state) => ((AsyncAutoResetSignal)state!).Signal(),
+            signal, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        try
+        {
+            while (!stopping.IsCompleted)
+            {
+                while (!stopping.IsCompleted && _commands.Reader.TryRead(out var command))
+                {
+                    if (command.Kind == RuntimeCommandKind.Commit)
+                    {
+                        await CompleteCommitCommandAsync(command, commitCancellation.Token).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        // Preserve control-command order without starting replacement
+                        // lanes or recursively stopping partitions during this drain.
+                        (_deferredCommands ??= new Queue<RuntimeCommand<TKey, TValue>>()).Enqueue(command);
+                    }
+                }
+
+                if (!stopping.IsCompleted)
+                    await signal.WaitAsync(Timeout.Infinite).ConfigureAwait(false);
+            }
+
+            return await stopping.ConfigureAwait(false);
+        }
+        finally
+        {
+            Volatile.Write(ref _stopSignal, null);
         }
     }
 
@@ -1364,7 +1471,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
 
     private void CompletePendingCommands()
     {
-        while (_commands.Reader.TryRead(out var command))
+        while (TryReadCommand(out var command))
         {
             if (command.Kind == RuntimeCommandKind.Commit)
                 command.Completion!.TrySetCanceled();
@@ -1455,6 +1562,8 @@ internal sealed class PartitionLane<TKey, TValue>
     public TopicPartition TopicPartition { get; }
 
     public CancellationToken StoppingToken => _stopping.Token;
+
+    public bool IsCompleted => Volatile.Read(ref _completed) != 0;
 
     public IAsyncEnumerable<ConsumeResult<TKey, TValue>> Messages => ReadMessagesAsync(_stopping.Token);
 

--- a/tests/Dekaf.Tests.Integration/PartitionedBackpressureIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/PartitionedBackpressureIntegrationTests.cs
@@ -1,0 +1,119 @@
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("ConsumerGroup")]
+public sealed class PartitionedBackpressureIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task AwaitCapacity_HandlerCommitsReachBrokerWhileFullOrDraining(bool shutdown)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        var partition = new TopicPartition(topic, 0);
+        var groupId = $"backpressure-{Guid.NewGuid():N}";
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).BuildAsync();
+        for (var offset = 0; offset < 3; offset++)
+            await producer.ProduceAsync(topic, "key", offset.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        var thirdRecordRead = NewSignal();
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithQueuedMinMessages(1)
+            .WithValueDeserializer(new ThirdRecordDeserializer(thirdRecordRead))
+            .BuildAsync();
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).Build();
+        consumer.Subscribe(topic);
+
+        var allowCommit = NewSignal();
+        var firstCommitted = NewSignal();
+        var releaseFirst = NewSignal();
+        var allCommitted = NewSignal();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        using var stop = new CancellationTokenSource();
+        var running = consumer.RunPartitionedAsync(async (context, token) =>
+        {
+            await foreach (var record in context.Messages.WithCancellation(token))
+            {
+                if (record.Offset == 0)
+                    await allowCommit.Task.WaitAsync(token);
+                context.MarkProcessed(record);
+                await context.CommitProcessedAsync(token);
+                if (record.Offset == 0)
+                {
+                    firstCommitted.TrySetResult();
+                    if (!shutdown)
+                        await releaseFirst.Task.WaitAsync(token);
+                }
+                if (record.Offset == 2)
+                    allCommitted.TrySetResult();
+            }
+        }, new PartitionedProcessingOptions
+        {
+            BackpressureMode = PartitionBackpressureMode.AwaitCapacity,
+            MaxBufferedRecordsPerPartition = 1,
+            CommitPolicy = PartitionCommitPolicy.UserManaged,
+            StopPolicy = PartitionStopPolicy.Drain,
+            StopTimeout = TimeSpan.FromSeconds(10)
+        }, stop.Token).AsTask();
+
+        try
+        {
+            await thirdRecordRead.Task.WaitAsync(timeout.Token);
+            if (shutdown)
+                await stop.CancelAsync();
+            allowCommit.TrySetResult();
+
+            if (shutdown)
+            {
+                await Assert.That(async () => await running.WaitAsync(timeout.Token))
+                    .Throws<OperationCanceledException>();
+                var offsets = await admin.ListConsumerGroupOffsetsAsync(groupId, timeout.Token);
+                // Offset 2 was fetched but never appended to the full lane.
+                await Assert.That(offsets[partition]).IsEqualTo(2);
+            }
+            else
+            {
+                await firstCommitted.Task.WaitAsync(timeout.Token);
+                var offsets = await admin.ListConsumerGroupOffsetsAsync(groupId, timeout.Token);
+                await Assert.That(offsets[partition]).IsEqualTo(1);
+                await Assert.That(allCommitted.Task.IsCompleted).IsFalse();
+                releaseFirst.TrySetResult();
+                await allCommitted.Task.WaitAsync(timeout.Token);
+                offsets = await admin.ListConsumerGroupOffsetsAsync(groupId, timeout.Token);
+                await Assert.That(offsets[partition]).IsEqualTo(3);
+            }
+        }
+        finally
+        {
+            allowCommit.TrySetResult();
+            releaseFirst.TrySetResult();
+            await stop.CancelAsync();
+            try { await running; }
+            catch (OperationCanceledException) when (stop.IsCancellationRequested)
+            {
+                await Assert.That(running.IsCanceled).IsTrue();
+            }
+        }
+    }
+
+    private static TaskCompletionSource NewSignal() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private sealed class ThirdRecordDeserializer(TaskCompletionSource thirdRecordRead) : IDeserializer<string>
+    {
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            if (data.Span.SequenceEqual("2"u8))
+                thirdRecordRead.TrySetResult();
+            return Serializers.String.Deserialize(data, context);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedBackpressureTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedBackpressureTests.cs
@@ -208,7 +208,7 @@ public sealed class PartitionedBackpressureTests
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var running = consumer.RunPartitionedAsync(async (context, token) =>
         {
-            await foreach (var record in context.Messages.WithCancellation(token))
+            await foreach (var _ in context.Messages.WithCancellation(token))
             {
                 await consumer.ThirdRecordRead.Task.WaitAsync(token);
                 return;
@@ -253,7 +253,7 @@ public sealed class PartitionedBackpressureTests
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var running = consumer.RunPartitionedAsync(async (context, token) =>
         {
-            await foreach (var record in context.Messages.WithCancellation(token))
+            await foreach (var _ in context.Messages.WithCancellation(token))
             {
                 await trigger.Task.WaitAsync(token);
                 throw failure;

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedBackpressureTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedBackpressureTests.cs
@@ -1,0 +1,420 @@
+using System.Runtime.CompilerServices;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class PartitionedBackpressureTests
+{
+    [Test]
+    [Arguments(PartitionBackpressureMode.AwaitCapacity)]
+    [Arguments(PartitionBackpressureMode.PauseResume)]
+    public async Task FullQueue_HandlerCommitsWithoutReadingAhead(PartitionBackpressureMode mode)
+    {
+        var consumer = new FullBatchConsumer();
+        consumer.SetAssignment(new TopicPartition("backpressure", 0));
+        var requestCommit = NewSignal();
+        var unprocessedCommitReturned = NewSignal();
+        var markProcessed = NewSignal();
+        var processedCommitReturned = NewSignal();
+        var releaseFirst = NewSignal();
+        var allProcessed = NewSignal();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var running = consumer.RunPartitionedAsync(async (context, token) =>
+        {
+            await foreach (var record in context.Messages.WithCancellation(token))
+            {
+                if (record.Offset == 0)
+                {
+                    await requestCommit.Task.WaitAsync(token);
+                    await context.CommitProcessedAsync(token);
+                    unprocessedCommitReturned.TrySetResult();
+                    await markProcessed.Task.WaitAsync(token);
+                    context.MarkProcessed(record);
+                    await context.CommitProcessedAsync(token);
+                    processedCommitReturned.TrySetResult();
+                    await releaseFirst.Task.WaitAsync(token);
+                }
+                else
+                {
+                    context.MarkProcessed(record);
+                    if (record.Offset == 2)
+                        allProcessed.TrySetResult();
+                }
+            }
+        }, new PartitionedProcessingOptions
+        {
+            BackpressureMode = mode,
+            MaxBufferedRecordsPerPartition = 1,
+            CommitPolicy = PartitionCommitPolicy.UserManaged,
+            StopPolicy = PartitionStopPolicy.Cancel
+        }, timeout.Token).AsTask();
+
+        try
+        {
+            // Seeing offset 2 deserialized proves offset 1 was queued. Offset 0's
+            // handler cannot read again until both requested commits have returned.
+            await consumer.ThirdRecordRead.Task.WaitAsync(timeout.Token);
+            requestCommit.TrySetResult();
+            await unprocessedCommitReturned.Task.WaitAsync(timeout.Token);
+            await Assert.That(consumer.CommitCalls).IsEmpty();
+
+            markProcessed.TrySetResult();
+            await processedCommitReturned.Task.WaitAsync(timeout.Token);
+            await Assert.That(consumer.CommitCalls.Count).IsEqualTo(1);
+            await Assert.That(consumer.CommitCalls[0]).IsEquivalentTo(
+                new[] { new TopicPartitionOffset("backpressure", 0, 1) });
+            await Assert.That(allProcessed.Task.IsCompleted).IsFalse();
+
+            releaseFirst.TrySetResult();
+            await allProcessed.Task.WaitAsync(timeout.Token);
+        }
+        finally
+        {
+            await timeout.CancelAsync();
+            try { await running; }
+            catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+            {
+                await Assert.That(running.IsCanceled).IsTrue();
+            }
+        }
+    }
+
+    [Test]
+    [Arguments(PartitionBackpressureMode.AwaitCapacity, false)]
+    [Arguments(PartitionBackpressureMode.PauseResume, false)]
+    [Arguments(PartitionBackpressureMode.AwaitCapacity, true)]
+    [Arguments(PartitionBackpressureMode.PauseResume, true)]
+    public async Task FullQueue_DrainServicesHandlerCommits(
+        PartitionBackpressureMode mode, bool shutdown)
+    {
+        var partition = new TopicPartition("backpressure", 0);
+        var consumer = new FullBatchConsumer();
+        consumer.SetAssignment(partition);
+        var releaseFirst = NewSignal();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var stop = new CancellationTokenSource();
+        var running = consumer.RunPartitionedAsync(async (context, token) =>
+        {
+            await foreach (var record in context.Messages.WithCancellation(token))
+            {
+                if (record.Offset == 0)
+                    await releaseFirst.Task.WaitAsync(token);
+                context.MarkProcessed(record);
+                await context.CommitProcessedAsync(token);
+            }
+        }, new PartitionedProcessingOptions
+        {
+            BackpressureMode = mode,
+            MaxBufferedRecordsPerPartition = 1,
+            CommitPolicy = PartitionCommitPolicy.UserManaged,
+            StopPolicy = PartitionStopPolicy.Drain,
+            StopTimeout = TimeSpan.FromSeconds(1)
+        }, stop.Token).AsTask();
+
+        try
+        {
+            await consumer.ThirdRecordRead.Task.WaitAsync(timeout.Token);
+            if (shutdown)
+                await stop.CancelAsync();
+            else
+                consumer.RevokeFromCoordinator(partition);
+            releaseFirst.TrySetResult();
+
+            if (shutdown)
+            {
+                await Assert.That(async () => await running.WaitAsync(timeout.Token))
+                    .Throws<OperationCanceledException>();
+            }
+            else
+            {
+                var completed = await Task.WhenAny(consumer.BatchAdvanced.Task, running).WaitAsync(timeout.Token);
+                if (completed == running)
+                    await running;
+                await consumer.BatchAdvanced.Task.WaitAsync(timeout.Token);
+            }
+
+            await Assert.That(consumer.CommitCalls.Count).IsEqualTo(2);
+            await Assert.That(consumer.CommitCalls[0][0].Offset).IsEqualTo(1);
+            await Assert.That(consumer.CommitCalls[1][0].Offset).IsEqualTo(2);
+        }
+        finally
+        {
+            releaseFirst.TrySetResult();
+            await StopAsync(stop, running);
+        }
+    }
+
+    [Test]
+    [Arguments(PartitionBackpressureMode.AwaitCapacity, false)]
+    [Arguments(PartitionBackpressureMode.PauseResume, false)]
+    [Arguments(PartitionBackpressureMode.AwaitCapacity, true)]
+    [Arguments(PartitionBackpressureMode.PauseResume, true)]
+    public async Task FullQueue_RevokeOrLossStopsRouting(
+        PartitionBackpressureMode mode, bool lost)
+    {
+        var partition = new TopicPartition("backpressure", 0);
+        var consumer = new FullBatchConsumer();
+        consumer.SetAssignment(partition);
+        var keepHandler = NewSignal();
+        var delivered = new List<long>();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var running = consumer.RunPartitionedAsync(async (context, token) =>
+        {
+            await foreach (var record in context.Messages.WithCancellation(token))
+            {
+                delivered.Add(record.Offset);
+                context.MarkProcessed(record);
+                await keepHandler.Task.WaitAsync(token);
+            }
+        }, new PartitionedProcessingOptions
+        {
+            BackpressureMode = mode,
+            MaxBufferedRecordsPerPartition = 1,
+            CommitPolicy = PartitionCommitPolicy.CommitCompletedOnRevoke,
+            StopPolicy = PartitionStopPolicy.Cancel
+        }, timeout.Token).AsTask();
+
+        try
+        {
+            await consumer.ThirdRecordRead.Task.WaitAsync(timeout.Token);
+            if (lost)
+                consumer.LoseFromCoordinator(partition);
+            else
+                consumer.RevokeFromCoordinator(partition);
+
+            await consumer.BatchAdvanced.Task.WaitAsync(timeout.Token);
+            await Assert.That(delivered).IsEquivalentTo(new long[] { 0 });
+            await Assert.That(consumer.CommitCalls.Count).IsEqualTo(lost ? 0 : 1);
+            if (!lost)
+                await Assert.That(consumer.CommitCalls[0]).IsEquivalentTo(
+                    new[] { new TopicPartitionOffset("backpressure", 0, 1) });
+        }
+        finally
+        {
+            await StopAsync(timeout, running);
+        }
+    }
+
+    [Test]
+    [Arguments(PartitionBackpressureMode.AwaitCapacity)]
+    [Arguments(PartitionBackpressureMode.PauseResume)]
+    public async Task FullQueue_UnexpectedProcessorCompletionStopsRuntime(PartitionBackpressureMode mode)
+    {
+        var consumer = new FullBatchConsumer();
+        consumer.SetAssignment(new TopicPartition("backpressure", 0));
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var running = consumer.RunPartitionedAsync(async (context, token) =>
+        {
+            await foreach (var record in context.Messages.WithCancellation(token))
+            {
+                await consumer.ThirdRecordRead.Task.WaitAsync(token);
+                return;
+            }
+        }, new PartitionedProcessingOptions
+        {
+            BackpressureMode = mode,
+            MaxBufferedRecordsPerPartition = 1,
+            CommitPolicy = PartitionCommitPolicy.UserManaged,
+            StopPolicy = PartitionStopPolicy.Cancel
+        }, timeout.Token).AsTask();
+
+        try
+        {
+            await Assert.That(async () => await running.WaitAsync(timeout.Token))
+                .Throws<InvalidOperationException>().WithMessageContaining("completed before the partition stopped");
+            await Assert.That(consumer.CommitCalls).IsEmpty();
+        }
+        finally
+        {
+            await timeout.CancelAsync();
+            try { await running; }
+            catch (InvalidOperationException exception) when (exception.Message.Contains("completed before the partition stopped", StringComparison.Ordinal))
+            {
+                await Assert.That(running.IsFaulted).IsTrue();
+            }
+        }
+    }
+
+    [Test]
+    [Arguments(PartitionBackpressureMode.AwaitCapacity, false)]
+    [Arguments(PartitionBackpressureMode.PauseResume, false)]
+    [Arguments(PartitionBackpressureMode.AwaitCapacity, true)]
+    [Arguments(PartitionBackpressureMode.PauseResume, true)]
+    public async Task FullQueue_CancellationOrFailureStopsRuntime(
+        PartitionBackpressureMode mode, bool failHandler)
+    {
+        var consumer = new FullBatchConsumer();
+        consumer.SetAssignment(new TopicPartition("backpressure", 0));
+        var trigger = NewSignal();
+        var failure = new InvalidOperationException("backpressure handler failure");
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var running = consumer.RunPartitionedAsync(async (context, token) =>
+        {
+            await foreach (var record in context.Messages.WithCancellation(token))
+            {
+                await trigger.Task.WaitAsync(token);
+                throw failure;
+            }
+        }, new PartitionedProcessingOptions
+        {
+            BackpressureMode = mode,
+            MaxBufferedRecordsPerPartition = 1,
+            CommitPolicy = PartitionCommitPolicy.UserManaged,
+            StopPolicy = PartitionStopPolicy.Cancel
+        }, timeout.Token).AsTask();
+
+        try
+        {
+            await consumer.ThirdRecordRead.Task.WaitAsync(timeout.Token);
+            if (failHandler)
+            {
+                trigger.TrySetResult();
+                await Assert.That(async () => await running.WaitAsync(timeout.Token))
+                    .Throws<InvalidOperationException>().WithMessage(failure.Message);
+            }
+            else
+            {
+                await timeout.CancelAsync();
+                await Assert.That(async () => await running).Throws<OperationCanceledException>();
+            }
+        }
+        finally
+        {
+            await timeout.CancelAsync();
+            try { await running; }
+            catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+            {
+                await Assert.That(running.IsCanceled).IsTrue();
+            }
+            catch (InvalidOperationException exception) when (ReferenceEquals(exception, failure))
+            {
+                await Assert.That(failHandler).IsTrue();
+            }
+        }
+    }
+
+    [Test]
+    [Arguments(PartitionBackpressureMode.AwaitCapacity)]
+    [Arguments(PartitionBackpressureMode.PauseResume)]
+    public async Task FullQueue_ReassignmentWaitsForOldDrainAndDropsOldBatch(PartitionBackpressureMode mode)
+    {
+        var partition = new TopicPartition("backpressure", 0);
+        var consumer = new FullBatchConsumer();
+        consumer.SetAssignment(partition);
+        var releaseFirst = NewSignal();
+        var oldStopped = NewSignal();
+        var replacementStarted = NewSignal();
+        var replacementRecords = new System.Collections.Concurrent.ConcurrentQueue<long>();
+        var generation = 0;
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var running = consumer.RunPartitionedAsync(async (context, token) =>
+        {
+            var firstGeneration = Interlocked.Increment(ref generation) == 1;
+            if (!firstGeneration)
+            {
+                await Assert.That(oldStopped.Task.IsCompleted).IsTrue();
+                replacementStarted.TrySetResult();
+            }
+            try
+            {
+                await foreach (var record in context.Messages.WithCancellation(token))
+                {
+                    if (firstGeneration)
+                    {
+                        if (record.Offset == 0)
+                            await releaseFirst.Task.WaitAsync(token);
+                        context.MarkProcessed(record);
+                        await context.CommitProcessedAsync(token);
+                    }
+                    else
+                    {
+                        replacementRecords.Enqueue(record.Offset);
+                    }
+                }
+            }
+            finally
+            {
+                if (firstGeneration)
+                    oldStopped.TrySetResult();
+            }
+        }, new PartitionedProcessingOptions
+        {
+            BackpressureMode = mode,
+            MaxBufferedRecordsPerPartition = 1,
+            CommitPolicy = PartitionCommitPolicy.UserManaged,
+            StopPolicy = PartitionStopPolicy.Drain,
+            StopTimeout = TimeSpan.FromSeconds(1)
+        }, timeout.Token).AsTask();
+
+        try
+        {
+            await consumer.ThirdRecordRead.Task.WaitAsync(timeout.Token);
+            consumer.RevokeFromCoordinator(partition);
+            consumer.AssignFromCoordinator(partition);
+            await Assert.That(replacementStarted.Task.IsCompleted).IsFalse();
+            releaseFirst.TrySetResult();
+            await replacementStarted.Task.WaitAsync(timeout.Token);
+            await consumer.BatchAdvanced.Task.WaitAsync(timeout.Token);
+            await Assert.That(replacementRecords).IsEmpty();
+            await Assert.That(consumer.CommitCalls.Count).IsEqualTo(2);
+            await Assert.That(consumer.CommitCalls[1][0].Offset).IsEqualTo(2);
+        }
+        finally
+        {
+            releaseFirst.TrySetResult();
+            await StopAsync(timeout, running);
+        }
+    }
+
+    private static async Task StopAsync(CancellationTokenSource timeout, Task running)
+    {
+        await timeout.CancelAsync();
+        try { await running; }
+        catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+        {
+            await Assert.That(running.IsCanceled).IsTrue();
+        }
+    }
+
+    private static TaskCompletionSource NewSignal() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private sealed class FullBatchConsumer : PartitionedConsumerRuntimeTests.TestConsumer
+    {
+        public TaskCompletionSource ThirdRecordRead { get; } = NewSignal();
+        public TaskCompletionSource BatchAdvanced { get; } = NewSignal();
+
+        public override async IAsyncEnumerable<ConsumeBatch<string, string>> ConsumeBatchAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            using var pending = PendingFetchData.Create("backpressure", 0,
+            [
+                new RecordBatch
+                {
+                    Records =
+                    [
+                        new Record { OffsetDelta = 0, Value = "0"u8.ToArray() },
+                        new Record { OffsetDelta = 1, Value = "1"u8.ToArray() },
+                        new Record { OffsetDelta = 2, Value = "2"u8.ToArray() }
+                    ]
+                }
+            ]);
+            yield return new ConsumeBatch<string, string>(pending, Serializers.String,
+                new ThirdRecordDeserializer(ThirdRecordRead));
+            BatchAdvanced.TrySetResult();
+            await NewSignal().Task.WaitAsync(cancellationToken);
+        }
+    }
+
+    private sealed class ThirdRecordDeserializer(TaskCompletionSource thirdRecordRead) : IDeserializer<string>
+    {
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            if (data.Span.SequenceEqual("2"u8))
+                thirdRecordRead.TrySetResult();
+            return Serializers.String.Deserialize(data, context);
+        }
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionedBackpressureBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionedBackpressureBenchmarks.cs
@@ -36,6 +36,9 @@ public class PartitionedBackpressureBenchmarks
             MaxBufferedRecordsPerPartition = Capacity,
             CommitPolicy = PartitionCommitPolicy.UserManaged
         }, null);
+        // Bind the real routing/capacity paths without adding production visibility or
+        // a benchmark-only seam. Reflection stays in setup; private member renames fail
+        // here before measurement, so update these bindings when those members change.
         var runtimeType = _runtime.GetType();
         var capacityAvailable = runtimeType.GetMethod("OnLaneCapacityAvailable", BindingFlags.Instance | BindingFlags.NonPublic)!
             .CreateDelegate<Action<PartitionLane<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>>>(_runtime);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionedBackpressureBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionedBackpressureBenchmarks.cs
@@ -1,0 +1,120 @@
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using Dekaf;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+public class PartitionedBackpressureBenchmarks
+{
+    private const int Count = 1024;
+    private PartitionedConsumerRuntime<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _runtime = null!;
+    private PartitionLane<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _lane = null!;
+    private Func<ConsumeBatch<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>, CancellationToken, ValueTask> _route = null!;
+    private RecordBatch[] _batches = null!;
+    private Record[] _records = null!;
+    private readonly CancellationTokenSource _lifetime = new();
+    private readonly AutoResetEvent _start = new(false);
+    private readonly AutoResetEvent _complete = new(false);
+    private Thread? _reader;
+    private int _stopped;
+
+    [Params(1024, 1)]
+    public int Capacity { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // AwaitCapacity routing does not call the consumer. A null fixture dependency
+        // guarantees that no recording substitute or network work contaminates measurement.
+        _runtime = new(null!, static (_, _) => default, new PartitionedProcessingOptions
+        {
+            BackpressureMode = PartitionBackpressureMode.AwaitCapacity,
+            MaxBufferedRecordsPerPartition = Capacity,
+            CommitPolicy = PartitionCommitPolicy.UserManaged
+        }, null);
+        var runtimeType = _runtime.GetType();
+        var capacityAvailable = runtimeType.GetMethod("OnLaneCapacityAvailable", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .CreateDelegate<Action<PartitionLane<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>>>(_runtime);
+        var partition = new TopicPartition("backpressure", 0);
+        _lane = new(partition, Capacity, static (_, _) => default, capacityAvailable, static (_, error) => throw error);
+        var lanes = (Dictionary<TopicPartition, PartitionLane<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>>)
+            runtimeType.GetField("_lanes", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(_runtime)!;
+        lanes.Add(partition, _lane);
+        _route = runtimeType.GetMethod("RouteBatchAsync", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .CreateDelegate<Func<ConsumeBatch<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>, CancellationToken, ValueTask>>(_runtime);
+        _records = new Record[Count];
+        for (var index = 0; index < Count; index++)
+            _records[index] = new Record { OffsetDelta = index, Key = new byte[8], Value = new byte[128] };
+        _batches = new RecordBatch[1];
+        if (Capacity < Count)
+        {
+            _reader = new Thread(Read) { IsBackground = true };
+            _reader.Start();
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = Count)]
+    public void RouteBatch()
+    {
+        // ConsumeBatch is one existing 128-byte wrapper per 1024-record batch.
+        // MemoryDiagnoser rounds that amortized cost down; '-' is not zero total bytes.
+        var recordBatch = RecordBatch.RentFromPool();
+        recordBatch.Records = _records;
+        recordBatch.LastOffsetDelta = Count - 1;
+        _batches[0] = recordBatch;
+        using var pending = PendingFetchData.Create("backpressure", 0, _batches);
+        var batch = new ConsumeBatch<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+            pending, Serializers.RawBytes, Serializers.RawBytes);
+        if (_reader is not null)
+        {
+            _start.Set();
+            _route(batch, _lifetime.Token).AsTask().GetAwaiter().GetResult();
+            _complete.WaitOne();
+        }
+        else
+        {
+            _route(batch, _lifetime.Token).GetAwaiter().GetResult();
+            for (var index = 0; index < Count; index++)
+            {
+                if (!_lane.TryReadMessage(out var record)) throw new InvalidOperationException("Missing record");
+                record.ReleaseStorage();
+            }
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        Volatile.Write(ref _stopped, 1);
+        _start.Set();
+        _reader?.Join();
+        _lifetime.Cancel();
+        (_runtime.GetType().GetField("_capacitySignal", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(_runtime) as IDisposable)?.Dispose();
+        _lifetime.Dispose();
+        _start.Dispose();
+        _complete.Dispose();
+    }
+
+    private void Read()
+    {
+        while (_start.WaitOne())
+        {
+            if (Volatile.Read(ref _stopped) != 0) return;
+            for (var index = 0; index < Count; index++)
+            {
+                ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> record;
+                while (!_lane.TryReadMessage(out record))
+                {
+                    if (Volatile.Read(ref _stopped) != 0) return;
+                    Thread.SpinWait(1);
+                }
+                record.ReleaseStorage();
+            }
+            _complete.Set();
+        }
+    }
+}


### PR DESCRIPTION
A handler awaiting `CommitProcessedAsync` can deadlock when its partition queue is full: routing waits for capacity while the handler waits for the routing owner to service its commit. The same cycle occurs when a draining handler commits during revoke or shutdown. Both cases now complete without reading past an unprocessed record.

Routing uses a lazily initialized reusable capacity/command signal. The existing owner services commands while capacity is unavailable; no additional command reader or concurrent consumer caller is introduced. A synchronous routing fast path avoids an async state machine until a batch actually encounters backpressure. Drain waits service handler commits and defer control commands in FIFO order, so replacement lanes cannot start before the old handler stops. Lane identity checks discard leftover records from an old assignment.

Closes #3050

### Correctness validation

- Deterministic full-runtime reproduction failed on the baseline in both backpressure modes at the handler's first commit. The test holds offset 0, queues offset 1, and observes offset 2 being deserialized before requesting the commit. An unprocessed commit must return without committing anything; marking offset 0 then commits exactly offset 1 while the queue remains full.
- A second red test exposed the drain cycle in all four revoke/shutdown and backpressure-mode combinations. Eighteen new unit cases cover full-queue progress, cancellation, handler failure, unexpected processor completion, revoke, loss, shutdown, and deferred reassignment. Synchronization uses completion gates, not timing delays.
- All 1,091 Consumer namespace cases passed on each of net10.0 and net8.0: **2,182 unit cases**.
- **Seven Kafka 4.3.1 integration cases passed**, including two new real-broker commit cases plus existing partition-processing and storage-lifetime coverage. An independent admin client verifies committed offset 1 while the handler remains held, offset 3 after normal processing, and offset 2 after draining shutdown (the fetched third record was never appended).
- Unit, integration, and maintained benchmark builds passed with zero warnings/errors. Final `/simplify` review retained the measured synchronous fast path and reused the existing signal primitive. No public API or docs changes.

### Performance evidence and decision

Baseline: `5ad5f2c9f587976aed918201703cf07cf37000ef`. Candidate: `ba54c94d344e4b01696751dbf1cc1155f9e9c2e8`. These are local measurements; run URL, paid stress lane, dispatch shape, and profiling mode are not applicable. No paid workflow was dispatched.

The checked-in `PartitionedBackpressureBenchmarks` measures the real routing method and capacity callback with 1,024 raw-memory records per batch. Capacity 1 uses a dedicated queue reader; capacity 1,024 routes synchronously before draining. Reflection/delegate setup, payload creation, and lane construction are outside measurement. The borrowed record storage is retained/released normally. No mock-recording or broker cost is included.

BenchmarkDotNet 0.15.8, `[MemoryDiagnoser]`, InProcessEmitToolchain, Windows 11, i7-12700K, .NET SDK 10.0.400/runtime 10.0.11, Release, five warmups, 15 measured iterations, 250 ms iteration target. Before/after used saved product DLLs with identical fixture code and no overlapping builds/tests from this task. Error is the 99.9% confidence-interval half-width. Values below are ns per record, not broker message-latency percentiles.

Final maintained fixture:

| Capacity | Baseline mean ± error | Candidate mean ± error | Change | Baseline/candidate SD | Allocated column |
|---|---:|---:|---:|---:|---:|
| 1 | 396.4 ± 10.12 | 327.55 ± 7.823 | -17.4% | 8.98 / 6.533 | 7 B / - |
| 1,024 | 102.4 ± 0.66 | 92.62 ± 0.544 | -9.6% | 0.58 / 0.482 | - / - |

Capacity-1 iteration median/max improved from 394.590/411.954 to 328.594/337.175 ns. Capacity-1,024 median/max improved from 102.176/103.493 to 92.483/93.636 ns. Reciprocal fixture throughput improves approximately 21.0% and 10.6%, respectively. These are routing fixture measurements, not end-to-end Kafka throughput.

All earlier valid measurements are retained here to show the rejected candidate and host variation. The initial fixture differed from the final maintained fixture only in its benchmark class location/name and an added cleanup stop check in the reader's spin loop; compare within each fixture configuration.

| Initial fixture capacity | Baseline | Rejected inline async pump | Final split fast path |
|---|---:|---:|---:|
| 1 | 396.24 ± 23.827 ns | 350.9 ± 11.61 ns | 357.64 ± 24.954 ns |
| 1,024 | 95.30 ± 0.755 ns | 103.8 ± 0.59 ns | 87.88 ± 0.755 ns |

The inline candidate was rejected for its approximately 9% synchronous-path regression. Splitting the slow path removed that regression. Its capacity-1 difference versus the immediately preceding inline candidate was +1.9% with overlapping intervals and a multimodal sample; it was not labeled an improvement. Both runs of the split implementation improve both configurations against their matching baseline. The final fixture independently retains those gains. An earlier fixture attempt reused a disposed pooled batch and executed zero benchmarks; its setup was corrected before collecting these measurements.

Allocation accounting is explicit because BDN rounds amortized values below 0.5 B to `-`:

- A warmed 100-warmup/1,000-batch `GC.GetTotalAllocatedBytes(true)` probe measured pooled batch lifecycle at **0 B**, and synchronous routing at **128 B per 1,024-record batch**, unchanged in baseline, rejected, and final implementations. The existing `ConsumeBatch` reference-type wrapper accounts for that 128 B. There is no new per-record object or delegate.
- Saturated batch allocation measured **1,365.104 / 497.6 / 364.832 B per batch** for baseline / rejected / final. This varies with asynchronous completion frequency. The new async state machine is once per backpressured batch, not once per rejected record.
- Final BDN raw allocation counters were baseline 4,093,344 B / 622,592 records and candidate 364,736 B / 783,360 records for capacity 1; capacity 1,024 was 290,816 / 2,326,528 and 337,136 / 2,670,592. The nonzero amortized totals must not be described as zero overall allocation.
- Runtime construction changes from **4,864 to 4,888 B** (three reference fields, 24 B per runtime). The capacity signal is initialized once on first backpressure; the stop signal, cancellation registration, continuation, and optional deferred-command queue are per-stop/epoch costs. No new per-message allocation or task/thread-pool hop is introduced on the synchronous fast path.

Saved DLL SHA-256: baseline `BB269F6BA7334F2D07EB39316F676D8C92545170215E615829F515C5D54F952B`; rejected `C9DF3EFAB4153BFAA5E502C2B458DF0863DAB827758BA9E01ED65CDE04BCA558`; final `3F09F0F325174EC116A872B6488B32C14EE8E61341B7EF268F5BDFEB7F20DA4D`.

Decision: retain the split implementation based on reproduced deadlocks, passing regression/integration coverage, faster measured routing in both configurations, and unchanged per-record allocation behavior. Broker p50/p99/max latency, CPU per message, and long-duration stability were not measured here; iteration distributions are not substitutes for those metrics, and this report makes no end-to-end Pareto or stress-gate claim.
