### PR TITLE
fix(consumer): retry leader before resetting follower offsets

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1443,7 +1443,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     //      but never acquire _assignmentLock while holding it
     //   4. _autoCommitStartLock / _prefetchStartLock — guard background loop start/stop snapshots;
     //      never held while awaiting. When both are needed, acquire auto-commit before prefetch.
-    //   5. _partitionCacheLock / _fetchCacheLock — guard per-broker partition cache and fetch request
+    //   5. Offset reset acquires _coordinatorRevokedPartitionsPendingFetchClearLock, then
+    //      ClusterMetadata.UpdateLock, then (when invalidating routing) _partitionCacheLock.
+    //      Metadata writers never acquire consumer locks; preserve this direction.
+    //   6. _partitionCacheLock / _fetchCacheLock — guard per-broker partition cache and fetch request
     //      cache respectively; acquired under _assignmentLock (via InvalidatePartitionCache /
     //      InvalidateFetchRequestCache) and independently; never nested with each other
     private readonly SemaphoreSlim _initLock = new(1, 1);
@@ -1526,6 +1529,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private int _lastCoordinatorAssignmentVersion = -1;
     // Deterministic test seam for assignment/revocation snapshot races.
     internal Action? BeforeCoordinatorAssignmentSnapshotForTest { get; set; }
+    // Thread-local storage keeps the production consumer's instance layout unchanged.
+    [ThreadStatic]
+    internal static Action? BeforeOffsetResetCommitForTest;
     // Deterministic test seam for watermark creation/assignment races. Thread-local static
     // storage avoids changing the production consumer's instance layout.
     [ThreadStatic]
@@ -4498,7 +4504,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             _stuckFetchPositionTracker.Reset(tp);
                             if (partitionResponse.ErrorCode == ErrorCode.OffsetOutOfRange)
                             {
-                                await ResetOffsetOutOfRangeAsync(tp, fetchBufferEpoch, cancellationToken).ConfigureAwait(false);
+                                await HandleFetchOffsetOutOfRangeAsync(
+                                    tp, brokerId, requestMetadataSnapshot, fetchBufferEpoch, cancellationToken).ConfigureAwait(false);
                             }
                             else if (IsLeaderEpochRefreshError(partitionResponse.ErrorCode))
                             {
@@ -10871,7 +10878,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         _stuckFetchPositionTracker.Reset(tp);
                         if (partitionResponse.ErrorCode == ErrorCode.OffsetOutOfRange)
                         {
-                            await ResetOffsetOutOfRangeAsync(tp, fetchBufferEpoch, cancellationToken).ConfigureAwait(false);
+                            await HandleFetchOffsetOutOfRangeAsync(
+                                tp, brokerId, requestMetadataSnapshot, fetchBufferEpoch, cancellationToken).ConfigureAwait(false);
                         }
                         else if (IsLeaderEpochRefreshError(partitionResponse.ErrorCode))
                         {
@@ -11681,18 +11689,82 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             startsBatch);
     }
 
-    private async ValueTask ResetOffsetOutOfRangeAsync(
+    private ValueTask HandleFetchOffsetOutOfRangeAsync(
+        TopicPartition partition,
+        int brokerId,
+        ClusterMetadataSnapshot requestMetadataSnapshot,
+        int fetchBufferEpoch,
+        CancellationToken cancellationToken)
+    {
+        // Replica preferences were already cleared on the error. Classify the actual
+        // destination against the request snapshot, not that mutable preference: a
+        // follower's missing offset requires a leader retry at the unchanged position.
+        if (!requestMetadataSnapshot.PartitionsByTopicIndex.TryGetValue(partition.Topic, out var partitions)
+            || (uint)partition.Partition >= (uint)partitions.Length
+            || partitions[partition.Partition] is not { } requestLeader
+            || requestLeader.LeaderId != brokerId)
+        {
+            // Metadata may change after broker grouping without a preferred replica
+            // to clear. Rebuild routing before retrying the current leader.
+            InvalidatePartitionCache();
+            return default;
+        }
+
+        return ResetOffsetOutOfRangeAsync(
+            partition, fetchBufferEpoch, cancellationToken, expectedLeader: requestLeader,
+            expectedMetadataSnapshot: requestMetadataSnapshot);
+    }
+
+    private ValueTask ResetOffsetOutOfRangeAsync(
         TopicPartition partition,
         int fetchBufferEpoch,
         CancellationToken cancellationToken,
-        long allowedPendingFetchClearVersion = NoPendingFetchClearVersion)
+        long allowedPendingFetchClearVersion = NoPendingFetchClearVersion,
+        PartitionInfo? expectedLeader = null,
+        ClusterMetadataSnapshot? expectedMetadataSnapshot = null)
+    {
+        var policy = _options.AutoOffsetReset;
+        if (policy is not (AutoOffsetReset.Earliest or AutoOffsetReset.Latest))
+        {
+            if (policy == AutoOffsetReset.None)
+            {
+                // Deciding to throw needs the same atomic leader/assignment validation as a reset.
+                TryApplyOffsetReset(partition, fetchBufferEpoch, allowedPendingFetchClearVersion,
+                    resetOffset: null, expectedLeader, expectedMetadataSnapshot);
+                return default;
+            }
+
+            return ResolveOffsetOutOfRangeAsync(
+                partition, fetchBufferEpoch, allowedPendingFetchClearVersion,
+                expectedLeader, cancellationToken);
+        }
+
+        // Immediate resets need no clock or asynchronous lookup. Validate once under
+        // the position-write lock; duration lookups still validate before and after awaiting.
+        var resetOffset = policy == AutoOffsetReset.Earliest ? EarliestOffsetTimestamp : LatestOffsetTimestamp;
+        if (TryApplyOffsetReset(
+                partition, fetchBufferEpoch, allowedPendingFetchClearVersion,
+                resetOffset, expectedLeader, expectedMetadataSnapshot))
+        {
+            LogOffsetOutOfRangeReset(partition.Topic, partition.Partition, GetAutoOffsetResetName());
+        }
+        return default;
+    }
+
+    private async ValueTask ResolveOffsetOutOfRangeAsync(
+        TopicPartition partition,
+        int fetchBufferEpoch,
+        long allowedPendingFetchClearVersion,
+        PartitionInfo? expectedLeader,
+        CancellationToken cancellationToken)
     {
         // Reset fetch position based on auto.offset.reset policy. Without this, the
         // consumer would retry the same invalid offset forever.
         if (ShouldDropOffsetReset(
                 partition,
                 fetchBufferEpoch,
-                allowedPendingFetchClearVersion))
+                allowedPendingFetchClearVersion,
+                expectedLeader))
             return;
 
         var resetTimestamp = AutoOffsetResetStrategy.GetListOffsetsTimestamp(_options, DateTimeOffset.UtcNow, partition);
@@ -11704,7 +11776,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 partition,
                 fetchBufferEpoch,
                 allowedPendingFetchClearVersion,
-                resetOffset))
+                resetOffset,
+                expectedLeader))
             return;
 
         LogOffsetOutOfRangeReset(partition.Topic, partition.Partition, GetAutoOffsetResetName());
@@ -11714,31 +11787,79 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         TopicPartition partition,
         int fetchBufferEpoch,
         long allowedPendingFetchClearVersion,
-        long resetOffset)
+        long? resetOffset,
+        PartitionInfo? expectedLeader,
+        ClusterMetadataSnapshot? expectedMetadataSnapshot = null)
     {
         // Keep the final validation and position write atomic with diverging-epoch staging.
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            if (ShouldDropOffsetReset(
-                    partition,
-                    fetchBufferEpoch,
-                    allowedPendingFetchClearVersion))
-                return false;
+            // Only an authoritative leader error needs metadata synchronization.
+            // Writers never take the consumer lock, so the order stays one-way.
+            // Successful fetches and follower retries do not enter this reset path.
+            var metadataLock = expectedLeader is null ? null : _metadataManager.Metadata.UpdateLock;
+            var metadataLockTaken = false;
+            try
+            {
+                if (metadataLock is not null)
+                    Monitor.Enter(metadataLock, ref metadataLockTaken);
+                if (ShouldDropOffsetReset(
+                        partition,
+                        fetchBufferEpoch,
+                        allowedPendingFetchClearVersion,
+                        expectedLeader, expectedMetadataSnapshot))
+                    return false;
 
-            _fetchPositions[partition] = resetOffset;
-            SetPosition(partition, resetOffset, dirty: false);
-            ClearLastConsumedLeaderEpoch(partition);
-            return true;
+                BeforeOffsetResetCommitForTest?.Invoke();
+                var offset = resetOffset ?? AutoOffsetResetStrategy.GetListOffsetsTimestamp(
+                    _options, DateTimeOffset.UtcNow, partition);
+                _fetchPositions[partition] = offset;
+                SetPosition(partition, offset, dirty: false);
+                ClearLastConsumedLeaderEpoch(partition);
+                return true;
+            }
+            finally
+            {
+                if (metadataLockTaken)
+                    Monitor.Exit(metadataLock!);
+            }
         }
     }
 
     private bool ShouldDropOffsetReset(
         TopicPartition partition,
         int fetchBufferEpoch,
-        long allowedPendingFetchClearVersion) =>
-        IsFetchBufferEpochStale(partition, fetchBufferEpoch)
-        || PendingFetchClearVersionChanged(partition, allowedPendingFetchClearVersion)
-        || !IsCurrentlyAssigned(partition);
+        long allowedPendingFetchClearVersion,
+        PartitionInfo? expectedLeader,
+        ClusterMetadataSnapshot? expectedMetadataSnapshot = null)
+    {
+        if (IsFetchBufferEpochStale(partition, fetchBufferEpoch)
+            || PendingFetchClearVersionChanged(partition, allowedPendingFetchClearVersion)
+            || !IsCurrentlyAssigned(partition))
+            return true;
+
+        if (expectedLeader is not null
+            && (expectedMetadataSnapshot is null
+                || !ReferenceEquals(_metadataManager.Metadata.CaptureSnapshot(), expectedMetadataSnapshot))
+            && !IsCurrentOffsetResetLeader(partition, expectedLeader))
+        {
+            // A leader change after request construction also invalidates cached
+            // broker grouping, including after an asynchronous duration lookup.
+            InvalidatePartitionCache();
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool IsCurrentOffsetResetLeader(TopicPartition partition, PartitionInfo expectedLeader)
+    {
+        // Recheck after an asynchronous duration-based lookup as well as before it.
+        var current = _metadataManager.Metadata.GetPartitionInfo(partition.Topic, partition.Partition);
+        return current is not null
+            && current.LeaderId == expectedLeader.LeaderId
+            && current.LeaderEpoch == expectedLeader.LeaderEpoch;
+    }
 
     private bool PendingFetchClearVersionChanged(
         TopicPartition partition,

--- a/src/Dekaf/Metadata/ClusterMetadata.cs
+++ b/src/Dekaf/Metadata/ClusterMetadata.cs
@@ -170,6 +170,10 @@ public sealed class ClusterMetadata
     private volatile ClusterMetadataSnapshot _snapshot = ClusterMetadataSnapshot.Empty;
     private readonly object _writeLock = new(); // Only needed for concurrent writes (rare)
 
+    // Cold recovery paths can couple leader validation to dependent state updates.
+    // Never await or call consumer code from a metadata writer while holding this lock.
+    internal object UpdateLock => _writeLock;
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal ClusterMetadataSnapshot CaptureSnapshot() => _snapshot;
 

--- a/tests/Dekaf.Tests.Integration/ConsumerFollowerOffsetRetryIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerFollowerOffsetRetryIntegrationTests.cs
@@ -1,0 +1,188 @@
+using Dekaf.Consumer;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Consumer")]
+[NotInParallel("RackAwareKafkaContainer")]
+[ClassDataSource<RackAwareKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class ConsumerFollowerOffsetRetryIntegrationTests(RackAwareKafkaContainer kafka)
+{
+    [Test]
+    [Arguments(AutoOffsetReset.Earliest)]
+    [Arguments(AutoOffsetReset.Latest)]
+    [Arguments(AutoOffsetReset.None)]
+    public async Task FollowerCannotServeOffset_LeaderRetryDoesNotReplayOrSkip(AutoOffsetReset reset)
+    {
+        var topic = await kafka.CreateTopicWithRemoteLeaderAndLocalFollowerAsync();
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithAcks(Acks.All).BuildAsync();
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic, Partition = 0, Key = "key", Value = "0"
+        });
+
+        var clientId = $"follower-offset-{Guid.NewGuid():N}";
+        var pool = new FollowerErrorPool(new ConnectionPool(clientId, new ConnectionOptions()), topic);
+        var servers = kafka.BootstrapServers.Split(',');
+        var metadata = new MetadataManager(pool, servers);
+        await using var consumer = new KafkaConsumer<string, string>(new ConsumerOptions
+        {
+            BootstrapServers = servers,
+            ClientId = clientId,
+            ClientRack = "rack-a",
+            AutoOffsetReset = reset,
+            EnableFetchSessions = false
+        }, Serializers.String, Serializers.String, pool, metadata);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        await consumer.InitializeAsync(timeout.Token);
+        consumer.IncrementalAssign([new TopicPartitionOffset(topic, 0, 0)]);
+
+        try
+        {
+            var first = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), timeout.Token);
+            await Assert.That(first).IsNotNull();
+            await Assert.That(first!.Value.Offset).IsEqualTo(0);
+            await pool.FollowerFetchStarted.Task.WaitAsync(timeout.Token);
+
+            // The real leader selected rack-local broker 2. Hold that broker's offset-1
+            // response until offsets 1 and 2 are acknowledged by the replicated cluster.
+            // Inject only its error; all metadata, leader fetches and records are real.
+            for (var offset = 1; offset <= 2; offset++)
+            {
+                await producer.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic, Partition = 0, Key = "key",
+                    Value = offset.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                }, timeout.Token);
+            }
+            pool.ReleaseFollowerError.TrySetResult();
+
+            for (var expected = 1; expected <= 2; expected++)
+            {
+                var record = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), timeout.Token);
+                await Assert.That(record).IsNotNull();
+                await Assert.That(record!.Value.Offset).IsEqualTo(expected);
+                await Assert.That(record.Value.Value).IsEqualTo(expected.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+            await Assert.That(await pool.LeaderRetried.Task.WaitAsync(timeout.Token)).IsEqualTo(1);
+            await Assert.That(consumer.GetPosition(new TopicPartition(topic, 0))).IsEqualTo(3);
+        }
+        finally
+        {
+            pool.ReleaseFollowerError.TrySetResult();
+            await timeout.CancelAsync();
+        }
+    }
+
+    private sealed class FollowerErrorPool(ConnectionPool inner, string topic) : IConnectionPool
+    {
+        private int _faultStarted;
+        private int _faultReturned;
+        public TaskCompletionSource FollowerFetchStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource ReleaseFollowerError { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource<long> LeaderRetried { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async ValueTask<IKafkaConnection> GetConnectionAsync(int brokerId, CancellationToken cancellationToken = default) =>
+            new FaultingConnection(this, await inner.GetConnectionAsync(brokerId, cancellationToken), brokerId);
+
+        public async ValueTask<IKafkaConnection> GetConnectionByIndexAsync(int brokerId, int index, CancellationToken cancellationToken = default) =>
+            new FaultingConnection(this, await inner.GetConnectionByIndexAsync(brokerId, index, cancellationToken), brokerId);
+
+        public ValueTask<IKafkaConnection> GetConnectionAsync(string host, int port, CancellationToken cancellationToken = default) =>
+            inner.GetConnectionAsync(host, port, cancellationToken);
+
+        public void RegisterBroker(int brokerId, string host, int port) => inner.RegisterBroker(brokerId, host, port);
+        public ValueTask<int> ScaleConnectionGroupAsync(int brokerId, int newCount, CancellationToken cancellationToken = default) =>
+            inner.ScaleConnectionGroupAsync(brokerId, newCount, cancellationToken);
+        public ValueTask<IKafkaConnection?> ShrinkConnectionGroupAsync(int brokerId, int newCount, CancellationToken cancellationToken = default) =>
+            inner.ShrinkConnectionGroupAsync(brokerId, newCount, cancellationToken);
+        public ValueTask RemoveConnectionAsync(int brokerId) => inner.RemoveConnectionAsync(brokerId);
+        public ValueTask CloseAllAsync() => inner.CloseAllAsync();
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+
+        private async ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            IKafkaConnection connection, int brokerId, TRequest request, short apiVersion, CancellationToken cancellationToken)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            if (request is FetchRequest fetch)
+            {
+                foreach (var requestedTopic in fetch.Topics)
+                {
+                    if (requestedTopic.Topic != topic)
+                        continue;
+                    foreach (var partition in requestedTopic.Partitions)
+                    {
+                        if (partition.Partition != 0)
+                            continue;
+                        if (brokerId == 2 && partition.FetchOffset == 1
+                            && Interlocked.CompareExchange(ref _faultStarted, 1, 0) == 0)
+                        {
+                            FollowerFetchStarted.TrySetResult();
+                            await ReleaseFollowerError.Task.WaitAsync(cancellationToken);
+                            Volatile.Write(ref _faultReturned, 1);
+                            return (TResponse)(object)new FetchResponse
+                            {
+                                Responses =
+                                [
+                                    new FetchResponseTopic
+                                    {
+                                        Topic = topic,
+                                        TopicId = requestedTopic.TopicId,
+                                        Partitions =
+                                        [
+                                            new FetchResponsePartition
+                                            {
+                                                PartitionIndex = 0,
+                                                ErrorCode = ErrorCode.OffsetOutOfRange,
+                                                HighWatermark = 3,
+                                                LastStableOffset = 3,
+                                                LogStartOffset = 0,
+                                                PreferredReadReplica = -1
+                                            }
+                                        ]
+                                    }
+                                ]
+                            };
+                        }
+                        if (brokerId == 1 && Volatile.Read(ref _faultReturned) != 0)
+                            LeaderRetried.TrySetResult(partition.FetchOffset);
+                    }
+                }
+            }
+            return await connection.SendAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+        }
+
+        private sealed class FaultingConnection(FollowerErrorPool owner, IKafkaConnection innerConnection, int brokerId) : IKafkaConnection
+        {
+            public int BrokerId => brokerId;
+            public string Host => innerConnection.Host;
+            public int Port => innerConnection.Port;
+            public bool IsConnected => innerConnection.IsConnected;
+            public ValueTask<TResponse> SendAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+                where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse =>
+                owner.SendAsync<TRequest, TResponse>(innerConnection, brokerId, request, apiVersion, cancellationToken);
+            public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+                where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse =>
+                innerConnection.SendFireAndForgetAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+            public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+                where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse =>
+                SendAsync<TRequest, TResponse>(request, apiVersion, cancellationToken).AsTask();
+            public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+                where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse =>
+                innerConnection.SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+            public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+                where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse =>
+                SendAsync<TRequest, TResponse>(request, apiVersion, cancellationToken).AsTask();
+            public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => innerConnection.ConnectAsync(cancellationToken);
+            public ValueTask DisposeAsync() => innerConnection.DisposeAsync();
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerFollowerOffsetRetryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerFollowerOffsetRetryTests.cs
@@ -1,0 +1,617 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed partial class ConsumerRackAwarenessTests
+{
+    [Test]
+    [Arguments(false, 0)]
+    [Arguments(true, 0)]
+    [Arguments(false, 1)]
+    [Arguments(true, 1)]
+    [Arguments(false, 2)]
+    [Arguments(true, 2)]
+    public async Task OffsetOutOfRange_MissingRequestLeaderRetriesBeforeApplyingNone(bool prefetch, int gap)
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var previousLeader = Substitute.For<IKafkaConnection>();
+        var currentLeader = Substitute.For<IKafkaConnection>();
+        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(previousLeader));
+        pool.GetConnectionByIndexAsync(2, 0, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(currentLeader));
+        await using var metadata = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadata, "rack-a", AutoOffsetReset.None);
+        consumer.Assign(Partition);
+        SetInitialFetchPosition(consumer, 42);
+        await Assert.That(await InvokeGroupPartitionsByBrokerAsync(consumer)).ContainsKey(1);
+
+        var recoveredMetadata = new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9093, Rack = "rack-b" },
+                new BrokerMetadata { NodeId = 2, Host = "broker-2", Port = 9094, Rack = "rack-a" }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = Topic,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = 2, LeaderEpoch = 6,
+                            ReplicaNodes = [1, 2], IsrNodes = [1, 2]
+                        }
+                    ]
+                }
+            ]
+        };
+        // Cover an absent topic, an out-of-range partition, and a null partition slot.
+        // Broker grouping precedes the gap; request construction observes the gap.
+        metadata.Metadata.Update(new MetadataResponse
+        {
+            Brokers = recoveredMetadata.Brokers,
+            Topics = gap == 0 ? [] :
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = Topic,
+                    Partitions = gap == 1 ? [] :
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None, PartitionIndex = 1, LeaderId = 2, LeaderEpoch = 6,
+                            ReplicaNodes = [1, 2], IsrNodes = [1, 2]
+                        }
+                    ]
+                }
+            ]
+        });
+        long retryOffset = -1;
+        previousLeader.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                metadata.Metadata.Update(recoveredMetadata);
+                return new ValueTask<FetchResponse>(CreateFetchResponse(-1, ErrorCode.OffsetOutOfRange));
+            });
+        currentLeader.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                retryOffset = call.Arg<FetchRequest>().Topics[0].Partitions[0].FetchOffset;
+                return new ValueTask<FetchResponse>(CreateFetchResponse(-1, ErrorCode.OffsetOutOfRange));
+            });
+
+        // An unverified broker cannot authorize either a reset or the None exception.
+        await InvokeReplicaFetchAsync(consumer, 1, prefetch);
+        await Assert.That(GetFetchPosition(consumer)).IsEqualTo(42);
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(42);
+        var routing = await InvokeGroupPartitionsByBrokerAsync(consumer);
+        await Assert.That(routing).ContainsKey(2);
+        await Assert.That(routing).DoesNotContainKey(1);
+        await Assert.That(async () => await InvokeReplicaFetchAsync(consumer, 2, prefetch))
+            .Throws<KafkaException>();
+        await Assert.That(retryOffset).IsEqualTo(42);
+        await Assert.That(GetFetchPosition(consumer)).IsEqualTo(42);
+    }
+
+    [Test]
+    [Arguments(AutoOffsetReset.Earliest, false)]
+    [Arguments(AutoOffsetReset.Latest, false)]
+    [Arguments(AutoOffsetReset.None, false)]
+    [Arguments(AutoOffsetReset.Earliest, true)]
+    [Arguments(AutoOffsetReset.Latest, true)]
+    [Arguments(AutoOffsetReset.None, true)]
+    public async Task OffsetOutOfRange_StaleLeaderRoutingRetriesCurrentLeaderBeforeReset(
+        AutoOffsetReset reset, bool prefetch)
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var previousLeader = Substitute.For<IKafkaConnection>();
+        var currentLeader = Substitute.For<IKafkaConnection>();
+        long previousLeaderOffset = -1;
+        long currentLeaderOffset = -1;
+        previousLeader.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                previousLeaderOffset = call.Arg<FetchRequest>().Topics[0].Partitions[0].FetchOffset;
+                return new ValueTask<FetchResponse>(CreateFetchResponse(-1, ErrorCode.OffsetOutOfRange));
+            });
+        currentLeader.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                currentLeaderOffset = call.Arg<FetchRequest>().Topics[0].Partitions[0].FetchOffset;
+                return new ValueTask<FetchResponse>(CreateFetchResponse(-1, ErrorCode.OffsetOutOfRange));
+            });
+        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(previousLeader));
+        pool.GetConnectionByIndexAsync(2, 0, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(currentLeader));
+        await using var metadata = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadata, "rack-a", reset);
+        consumer.Assign(Partition);
+        SetInitialFetchPosition(consumer, 42);
+
+        // Cache routing without ever selecting a preferred replica. Metadata changes
+        // after grouping selected broker 1, but before that fetch captures its snapshot.
+        var originalRouting = await InvokeGroupPartitionsByBrokerAsync(consumer);
+        await Assert.That(originalRouting).ContainsKey(1);
+        await Assert.That(metadata.TryUpdatePartitionLeader(Topic, 0, 2, 6)).IsTrue();
+        await InvokeReplicaFetchAsync(consumer, 1, prefetch);
+
+        await Assert.That(previousLeaderOffset).IsEqualTo(42);
+        await Assert.That(GetFetchPosition(consumer)).IsEqualTo(42);
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(42);
+        var retryRouting = await InvokeGroupPartitionsByBrokerAsync(consumer);
+        await Assert.That(retryRouting).ContainsKey(2);
+        await Assert.That(retryRouting).DoesNotContainKey(1);
+        if (reset == AutoOffsetReset.None)
+        {
+            await Assert.That(async () => await InvokeReplicaFetchAsync(consumer, 2, prefetch))
+                .Throws<KafkaException>();
+            await Assert.That(GetFetchPosition(consumer)).IsEqualTo(42);
+        }
+        else
+        {
+            await InvokeReplicaFetchAsync(consumer, 2, prefetch);
+            var expected = reset == AutoOffsetReset.Earliest ? -2L : -1L;
+            await Assert.That(GetFetchPosition(consumer)).IsEqualTo(expected);
+            await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(expected);
+        }
+        await Assert.That(currentLeaderOffset).IsEqualTo(42);
+    }
+
+    [Test]
+    [Arguments(AutoOffsetReset.Earliest, false)]
+    [Arguments(AutoOffsetReset.Latest, false)]
+    [Arguments(AutoOffsetReset.None, false)]
+    [Arguments(AutoOffsetReset.Earliest, true)]
+    [Arguments(AutoOffsetReset.Latest, true)]
+    [Arguments(AutoOffsetReset.None, true)]
+    public async Task FollowerOffsetOutOfRange_RetriesLeaderBeforeReset(
+        AutoOffsetReset reset, bool prefetch)
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var leader = Substitute.For<IKafkaConnection>();
+        var follower = Substitute.For<IKafkaConnection>();
+        var leaderReturnsError = false;
+        long leaderRequestedOffset = -1;
+        long followerRequestedOffset = -1;
+        leader.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                leaderRequestedOffset = call.Arg<FetchRequest>().Topics[0].Partitions[0].FetchOffset;
+                return new ValueTask<FetchResponse>(CreateFetchResponse(2,
+                    leaderReturnsError ? ErrorCode.OffsetOutOfRange : ErrorCode.None));
+            });
+        follower.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                followerRequestedOffset = call.Arg<FetchRequest>().Topics[0].Partitions[0].FetchOffset;
+                return new ValueTask<FetchResponse>(CreateFetchResponse(-1, ErrorCode.OffsetOutOfRange));
+            });
+        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>()).Returns(new ValueTask<IKafkaConnection>(leader));
+        pool.GetConnectionByIndexAsync(2, 0, Arg.Any<CancellationToken>()).Returns(new ValueTask<IKafkaConnection>(follower));
+        await using var metadata = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadata, "rack-a", reset);
+        consumer.Assign(Partition);
+        SetInitialFetchPosition(consumer, 42);
+
+        await InvokeReplicaFetchAsync(consumer, 1, prefetch);
+        await Assert.That(await InvokeGroupPartitionsByBrokerAsync(consumer)).ContainsKey(2);
+        await InvokeReplicaFetchAsync(consumer, 2, prefetch);
+
+        await Assert.That(followerRequestedOffset).IsEqualTo(42);
+        await Assert.That(GetFetchPosition(consumer)).IsEqualTo(42);
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(42);
+        await Assert.That(await InvokeGroupPartitionsByBrokerAsync(consumer)).ContainsKey(1);
+
+        leaderReturnsError = true;
+        if (reset == AutoOffsetReset.None)
+        {
+            await Assert.That(async () => await InvokeReplicaFetchAsync(consumer, 1, prefetch))
+                .Throws<KafkaException>();
+            await Assert.That(GetFetchPosition(consumer)).IsEqualTo(42);
+        }
+        else
+        {
+            await InvokeReplicaFetchAsync(consumer, 1, prefetch);
+            var expected = reset == AutoOffsetReset.Earliest ? -2L : -1L;
+            await Assert.That(GetFetchPosition(consumer)).IsEqualTo(expected);
+            await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(expected);
+        }
+        await Assert.That(leaderRequestedOffset).IsEqualTo(42);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task OffsetOutOfRange_UnrelatedMetadataRefreshStillAllowsLeaderReset(bool prefetch)
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        var started = NewFetchSignal();
+        var response = new TaskCompletionSource<FetchResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                started.TrySetResult();
+                return new ValueTask<FetchResponse>(response.Task);
+            });
+        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(connection));
+        await using var metadata = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadata, "rack-a", AutoOffsetReset.Latest);
+        consumer.Assign(Partition);
+        SetInitialFetchPosition(consumer, 42);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var snapshot = metadata.Metadata.CaptureSnapshot();
+        var fetch = InvokeReplicaFetchAsync(consumer, 1, prefetch).AsTask();
+        try
+        {
+            await started.Task.WaitAsync(timeout.Token);
+            // Replace the cluster snapshot while preserving this partition's leader and epoch.
+            metadata.Metadata.Update(new MetadataResponse
+            {
+                Brokers =
+                [
+                    new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9093, Rack = "rack-b" },
+                    new BrokerMetadata { NodeId = 2, Host = "broker-2", Port = 9094, Rack = "rack-a" }
+                ],
+                Topics = []
+            }, mergeTopics: true);
+            await Assert.That(ReferenceEquals(snapshot, metadata.Metadata.CaptureSnapshot())).IsFalse();
+        }
+        finally
+        {
+            response.TrySetResult(CreateFetchResponse(-1, ErrorCode.OffsetOutOfRange));
+            await fetch.WaitAsync(timeout.Token);
+        }
+        await Assert.That(GetFetchPosition(consumer)).IsEqualTo(-1);
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(-1);
+    }
+    [Test]
+    [Arguments(false, 1, 2, AutoOffsetReset.None)]
+    [Arguments(false, 1, 2, AutoOffsetReset.Earliest)]
+    [Arguments(false, 1, 2, AutoOffsetReset.Latest)]
+    [Arguments(true, 1, 2, AutoOffsetReset.None)]
+    [Arguments(true, 1, 2, AutoOffsetReset.Earliest)]
+    [Arguments(true, 1, 2, AutoOffsetReset.Latest)]
+    [Arguments(false, 2, 2, AutoOffsetReset.None)]
+    [Arguments(false, 2, 2, AutoOffsetReset.Earliest)]
+    [Arguments(false, 2, 2, AutoOffsetReset.Latest)]
+    [Arguments(true, 2, 2, AutoOffsetReset.None)]
+    [Arguments(true, 2, 2, AutoOffsetReset.Earliest)]
+    [Arguments(true, 2, 2, AutoOffsetReset.Latest)]
+    [Arguments(false, 1, 1, AutoOffsetReset.None)]
+    [Arguments(false, 1, 1, AutoOffsetReset.Earliest)]
+    [Arguments(false, 1, 1, AutoOffsetReset.Latest)]
+    [Arguments(true, 1, 1, AutoOffsetReset.None)]
+    [Arguments(true, 1, 1, AutoOffsetReset.Earliest)]
+    [Arguments(true, 1, 1, AutoOffsetReset.Latest)]
+    public async Task OffsetOutOfRange_ChangedLeaderOrEpochCannotReset(
+        bool prefetch, int requestedBroker, int newLeader, AutoOffsetReset reset)
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        var started = NewFetchSignal();
+        var response = new TaskCompletionSource<FetchResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                started.TrySetResult();
+                return new ValueTask<FetchResponse>(response.Task);
+            });
+        pool.GetConnectionByIndexAsync(requestedBroker, 0, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(connection));
+        await using var metadata = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadata, "rack-a", reset);
+        consumer.Assign(Partition);
+        SetInitialFetchPosition(consumer, 42);
+        // Populate routing before the response is held across the metadata change.
+        await Assert.That(await InvokeGroupPartitionsByBrokerAsync(consumer)).ContainsKey(1);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var fetch = InvokeReplicaFetchAsync(consumer, requestedBroker, prefetch).AsTask();
+        try
+        {
+            await started.Task.WaitAsync(timeout.Token);
+            await Assert.That(metadata.TryUpdatePartitionLeader(Topic, 0, newLeader, 6)).IsTrue();
+        }
+        finally
+        {
+            response.TrySetResult(CreateFetchResponse(-1, ErrorCode.OffsetOutOfRange));
+            await fetch.WaitAsync(timeout.Token);
+        }
+        await Assert.That(GetFetchPosition(consumer)).IsEqualTo(42);
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(42);
+        await Assert.That(await InvokeGroupPartitionsByBrokerAsync(consumer)).ContainsKey(newLeader);
+    }
+
+    [Test]
+    [Arguments(false, 1, 0, AutoOffsetReset.None)]
+    [Arguments(false, 1, 0, AutoOffsetReset.Earliest)]
+    [Arguments(false, 1, 0, AutoOffsetReset.Latest)]
+    [Arguments(true, 1, 0, AutoOffsetReset.None)]
+    [Arguments(true, 1, 0, AutoOffsetReset.Earliest)]
+    [Arguments(true, 1, 0, AutoOffsetReset.Latest)]
+    [Arguments(false, 2, 0, AutoOffsetReset.None)]
+    [Arguments(false, 2, 0, AutoOffsetReset.Earliest)]
+    [Arguments(false, 2, 0, AutoOffsetReset.Latest)]
+    [Arguments(true, 2, 0, AutoOffsetReset.None)]
+    [Arguments(true, 2, 0, AutoOffsetReset.Earliest)]
+    [Arguments(true, 2, 0, AutoOffsetReset.Latest)]
+    [Arguments(false, 1, 1, AutoOffsetReset.None)]
+    [Arguments(false, 1, 1, AutoOffsetReset.Earliest)]
+    [Arguments(false, 1, 1, AutoOffsetReset.Latest)]
+    [Arguments(true, 1, 1, AutoOffsetReset.None)]
+    [Arguments(true, 1, 1, AutoOffsetReset.Earliest)]
+    [Arguments(true, 1, 1, AutoOffsetReset.Latest)]
+    [Arguments(false, 2, 1, AutoOffsetReset.None)]
+    [Arguments(false, 2, 1, AutoOffsetReset.Earliest)]
+    [Arguments(false, 2, 1, AutoOffsetReset.Latest)]
+    [Arguments(true, 2, 1, AutoOffsetReset.None)]
+    [Arguments(true, 2, 1, AutoOffsetReset.Earliest)]
+    [Arguments(true, 2, 1, AutoOffsetReset.Latest)]
+    [Arguments(false, 1, 2, AutoOffsetReset.None)]
+    [Arguments(false, 1, 2, AutoOffsetReset.Earliest)]
+    [Arguments(false, 1, 2, AutoOffsetReset.Latest)]
+    [Arguments(true, 1, 2, AutoOffsetReset.None)]
+    [Arguments(true, 1, 2, AutoOffsetReset.Earliest)]
+    [Arguments(true, 1, 2, AutoOffsetReset.Latest)]
+    [Arguments(false, 2, 2, AutoOffsetReset.None)]
+    [Arguments(false, 2, 2, AutoOffsetReset.Earliest)]
+    [Arguments(false, 2, 2, AutoOffsetReset.Latest)]
+    [Arguments(true, 2, 2, AutoOffsetReset.None)]
+    [Arguments(true, 2, 2, AutoOffsetReset.Earliest)]
+    [Arguments(true, 2, 2, AutoOffsetReset.Latest)]
+    public async Task OffsetOutOfRange_StaleResponseCannotOverwriteSeekOrAssignment(
+        bool prefetch, int requestedBroker, int mutation, AutoOffsetReset reset)
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        var started = NewFetchSignal();
+        var response = new TaskCompletionSource<FetchResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                started.TrySetResult();
+                return new ValueTask<FetchResponse>(response.Task);
+            });
+        pool.GetConnectionByIndexAsync(requestedBroker, 0, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(connection));
+        await using var metadata = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadata, "rack-a", reset);
+        consumer.Assign(Partition);
+        SetInitialFetchPosition(consumer, 42);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var fetch = InvokeReplicaFetchAsync(consumer, requestedBroker, prefetch).AsTask();
+        try
+        {
+            await started.Task.WaitAsync(timeout.Token);
+            if (mutation == 0)
+            {
+                consumer.Seek(new TopicPartitionOffset(Topic, 0, 99));
+            }
+            else
+            {
+                consumer.Unassign();
+                if (mutation == 2)
+                {
+                    consumer.Assign(Partition);
+                    SetInitialFetchPosition(consumer, 99);
+                }
+            }
+        }
+        finally
+        {
+            response.TrySetResult(CreateFetchResponse(-1, ErrorCode.OffsetOutOfRange));
+            await fetch.WaitAsync(timeout.Token);
+        }
+        if (mutation == 1)
+        {
+            await Assert.That(consumer.GetPosition(Partition)).IsNull();
+            await Assert.That(FetchPositions(consumer)).DoesNotContainKey(Partition);
+        }
+        else
+        {
+            await Assert.That(GetFetchPosition(consumer)).IsEqualTo(99);
+            await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(99);
+        }
+    }
+
+    [Test]
+    [Arguments(false, false)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(true, true)]
+    public async Task OffsetOutOfRange_DurationLookupRechecksLeaderAndSeek(bool prefetch, bool seek)
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        var lookupStarted = NewFetchSignal();
+        var lookup = new TaskCompletionSource<ListOffsetsResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask<FetchResponse>(CreateFetchResponse(-1, ErrorCode.OffsetOutOfRange)));
+        connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                Arg.Any<ListOffsetsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                lookupStarted.TrySetResult();
+                return new ValueTask<ListOffsetsResponse>(lookup.Task);
+            });
+        // Offset-control requests use a separate connection index from fetches.
+        pool.GetConnectionByIndexAsync(1, Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new ValueTask<IKafkaConnection>(connection));
+        await using var metadata = CreateMetadataManager(pool);
+        metadata.SetApiVersion(ApiKey.ListOffsets, ListOffsetsRequest.LowestSupportedVersion, ListOffsetsRequest.HighestSupportedVersion);
+        await using var consumer = CreateConsumer(pool, metadata, "rack-a", AutoOffsetReset.ByDuration);
+        consumer.Assign(Partition);
+        SetInitialFetchPosition(consumer, 42);
+        await Assert.That(await InvokeGroupPartitionsByBrokerAsync(consumer)).ContainsKey(1);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var fetch = InvokeReplicaFetchAsync(consumer, 1, prefetch).AsTask();
+        try
+        {
+            await lookupStarted.Task.WaitAsync(timeout.Token);
+            if (seek)
+                consumer.Seek(new TopicPartitionOffset(Topic, 0, 99));
+            else
+                await Assert.That(metadata.TryUpdatePartitionLeader(Topic, 0, 2, 6)).IsTrue();
+        }
+        finally
+        {
+            lookup.TrySetResult(new ListOffsetsResponse
+            {
+                Topics =
+                [
+                    new ListOffsetsResponseTopic
+                    {
+                        Name = Topic,
+                        Partitions = [new ListOffsetsResponsePartition { PartitionIndex = 0, ErrorCode = ErrorCode.None, Offset = 10 }]
+                    }
+                ]
+            });
+            await fetch.WaitAsync(timeout.Token);
+        }
+        await Assert.That(GetFetchPosition(consumer)).IsEqualTo(seek ? 99 : 42);
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(seek ? 99 : 42);
+        await Assert.That(await InvokeGroupPartitionsByBrokerAsync(consumer)).ContainsKey(seek ? 1 : 2);
+    }
+
+    private static TaskCompletionSource NewFetchSignal() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    [Test]
+    [Arguments(false, AutoOffsetReset.Earliest)]
+    [Arguments(true, AutoOffsetReset.Earliest)]
+    [Arguments(false, AutoOffsetReset.Latest)]
+    [Arguments(true, AutoOffsetReset.Latest)]
+    [Arguments(false, AutoOffsetReset.ByDuration)]
+    [Arguments(true, AutoOffsetReset.ByDuration)]
+    [Arguments(false, AutoOffsetReset.None)]
+    [Arguments(true, AutoOffsetReset.None)]
+    public async Task OffsetOutOfRange_LeaderCannotChangeBetweenValidationAndCommit(bool prefetch, AutoOffsetReset reset)
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask<FetchResponse>(CreateFetchResponse(-1, ErrorCode.OffsetOutOfRange)));
+        connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                Arg.Any<ListOffsetsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask<ListOffsetsResponse>(new ListOffsetsResponse
+            {
+                Topics = [new ListOffsetsResponseTopic
+                {
+                    Name = Topic,
+                    Partitions = [new ListOffsetsResponsePartition { PartitionIndex = 0, ErrorCode = ErrorCode.None, Offset = 10 }]
+                }]
+            }));
+        pool.GetConnectionByIndexAsync(1, Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(connection));
+        await using var metadata = CreateMetadataManager(pool);
+        metadata.SetApiVersion(ApiKey.ListOffsets, ListOffsetsRequest.LowestSupportedVersion, ListOffsetsRequest.HighestSupportedVersion);
+        await using var consumer = CreateConsumer(pool, metadata, "rack-a", reset);
+        consumer.Assign(Partition);
+        SetInitialFetchPosition(consumer, 42);
+        var probes = 0;
+        var leaderChangedBeforeCommit = false;
+        // The mock transport and duration lookup complete synchronously. Run the
+        // cold-path hook on that same thread; a separate thread attempts publication.
+        await Task.Run(async () =>
+        {
+            KafkaConsumer<string, string>.BeforeOffsetResetCommitForTest = () =>
+            {
+                probes++;
+                var publisher = new Thread(() =>
+                {
+                    if (!Monitor.TryEnter(metadata.Metadata.UpdateLock))
+                        return;
+                    try
+                    {
+                        leaderChangedBeforeCommit = metadata.TryUpdatePartitionLeader(Topic, 0, 2, 6);
+                    }
+                    finally
+                    {
+                        Monitor.Exit(metadata.Metadata.UpdateLock);
+                    }
+                }) { IsBackground = true };
+                publisher.Start();
+                if (!publisher.Join(TimeSpan.FromSeconds(10)))
+                    throw new TimeoutException("Metadata publication probe did not finish.");
+            };
+            try
+            {
+                if (reset == AutoOffsetReset.None)
+                {
+                    await Assert.That(async () => await InvokeReplicaFetchAsync(consumer, 1, prefetch))
+                        .Throws<KafkaException>();
+                }
+                else
+                {
+                    await InvokeReplicaFetchAsync(consumer, 1, prefetch);
+                }
+            }
+            finally
+            {
+                KafkaConsumer<string, string>.BeforeOffsetResetCommitForTest = null;
+            }
+        });
+        await Assert.That(probes).IsEqualTo(1);
+        await Assert.That(leaderChangedBeforeCommit).IsFalse();
+        var expected = reset switch
+        {
+            AutoOffsetReset.Earliest => -2L,
+            AutoOffsetReset.Latest => -1L,
+            AutoOffsetReset.None => 42L,
+            _ => 10L
+        };
+        await Assert.That(GetFetchPosition(consumer)).IsEqualTo(expected);
+        await Assert.That(consumer.GetPosition(Partition)).IsEqualTo(expected);
+        // Publication must be possible again once the reset has committed.
+        await Assert.That(metadata.TryUpdatePartitionLeader(Topic, 0, 2, 6)).IsTrue();
+    }
+
+    private static ValueTask InvokeReplicaFetchAsync(KafkaConsumer<string, string> consumer, int brokerId, bool prefetch)
+    {
+        if (!prefetch)
+            return InvokeFetchFromBrokerAsync(consumer, brokerId, [Partition]);
+
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "PrefetchFromBrokerAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (ValueTask)method.Invoke(consumer,
+            [brokerId, new List<TopicPartition> { Partition }, 0, 1, 0, GetFetchBufferEpoch(consumer), CancellationToken.None])!;
+    }
+
+    private static void SetInitialFetchPosition(KafkaConsumer<string, string> consumer, long offset)
+    {
+        // Install initial state without staging Seek's pending-buffer-clear marker.
+        FetchPositions(consumer)[Partition] = offset;
+        typeof(KafkaConsumer<string, string>).GetMethod("SetPosition", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(consumer, [Partition, offset, false]);
+    }
+
+    private static long GetFetchPosition(KafkaConsumer<string, string> consumer) => FetchPositions(consumer)[Partition];
+
+    private static ConcurrentDictionary<TopicPartition, long> FetchPositions(KafkaConsumer<string, string> consumer) =>
+        (ConcurrentDictionary<TopicPartition, long>)typeof(KafkaConsumer<string, string>)
+            .GetField("_fetchPositions", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(consumer)!;
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerRackAwarenessTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerRackAwarenessTests.cs
@@ -10,7 +10,7 @@ using NSubstitute;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
-public sealed class ConsumerRackAwarenessTests
+public sealed partial class ConsumerRackAwarenessTests
 {
     private const string Topic = "rack-aware-topic";
     private static readonly TopicPartition Partition = new(Topic, 0);
@@ -293,13 +293,16 @@ public sealed class ConsumerRackAwarenessTests
     private static KafkaConsumer<string, string> CreateConsumer(
         IConnectionPool pool,
         MetadataManager metadataManager,
-        string? clientRack)
+        string? clientRack,
+        AutoOffsetReset autoOffsetReset = AutoOffsetReset.Latest)
         => new(
             new ConsumerOptions
             {
                 BootstrapServers = ["localhost:9092"],
                 ClientId = "test-consumer",
                 ClientRack = clientRack,
+                AutoOffsetReset = autoOffsetReset,
+                AutoOffsetResetDuration = autoOffsetReset == AutoOffsetReset.ByDuration ? TimeSpan.FromHours(1) : null,
                 EnableFetchSessions = false
             },
             Serializers.String,


### PR DESCRIPTION
A follower OFFSET_OUT_OF_RANGE retries the verified leader at the same position before applying AutoOffsetReset. Stale metadata cannot authorize a reset, and rejected stale resets invalidate cached routing.

Refs #3031.

The latest [standard A1/B/A2 job](https://github.com/thomhurst/Dekaf/actions/runs/34485303186/job/102897950903) accepts 37 measured cases but reports regressions in repeated 1 KB string deserialization and V12 topic-name correlation, plus an inconclusive controller refresh. This supersedes the earlier all-green screen; allocations are unchanged. Whole-PR acceptance remains blocked on those findings, compatible follower-recovery fixture coverage, and appropriate loaded recovery evidence. The [older loaded run](https://github.com/thomhurst/Dekaf/actions/runs/34150407955) was inconclusive.

Raw metrics and controls remain in GitHub job output/artifacts. Further work uses the existing benchmark/stress projects; no reports, logs or standalone harnesses are committed.


The compatible fixture is now in #3228 and synchronized here. All ten standard Dry cases pass on both revisions, with explicit baseline reset versus candidate preservation validation and equal position restoration for the controlled two-response case; 42 selector tests pass. Squashed onto main db15903f0; source patch-id remains accbab44cbe67b43567b6cd8a6d77c4c9ed8822c. This fixture/rebase update does not grant performance acceptance.
