### PR TITLE
feat(admin): add unified group listing

### DIFF
--- a/docs/docs/admin/group-listing.md
+++ b/docs/docs/admin/group-listing.md
@@ -1,0 +1,95 @@
+---
+sidebar_position: 3
+description: "List Kafka groups by group type, protocol, and state."
+---
+
+# Group inventory
+
+`ListGroupsAsync` lists groups across brokers and retains the broker's `GroupType`,
+`ProtocolType`, and `State`. Import `Dekaf.Admin` to call the extension on an
+`IAdminClient`:
+
+```csharp
+using Dekaf;
+using Dekaf.Admin;
+
+await using IAdminClient admin = Kafka.CreateAdminClient()
+    .WithBootstrapServers("localhost:9092")
+    .Build();
+
+var inventory = await admin.ListGroupsAsync();
+var connect = await admin.ListGroupsAsync(new ListGroupsOptions
+{
+    Types = ["classic"],
+    ProtocolTypes = ["connect"]
+});
+var emptyConsumers = await admin.ListConsumerGroupsAsync(
+    new ListConsumerGroupsOptions { States = ["Empty"] });
+```
+
+Group type identifies the coordinator's group model. Protocol identifies the
+application using that model. They are separate fields:
+
+| Group type | Protocol | Meaning |
+| --- | --- | --- |
+| `classic` | `consumer` | Classic consumer group |
+| `classic` | empty string | Simple consumer group with committed offsets |
+| `consumer` | `consumer` | Modern consumer group |
+| `classic` | `connect` | Kafka Connect group |
+| `share` | `share` | Share group |
+| `streams` | `streams` | Streams group |
+
+The inventory preserves unknown future types and protocol strings unchanged.
+It does not coerce them into a consumer group or a fixed enum. Group IDs are
+case-sensitive and occur at most once in a result. Ordering is unspecified.
+Listing brokers concurrently is not an atomic cluster snapshot: a coordinator
+move can produce duplicate or stale entries. Filtering precedes deduplication
+so a nonmatching stale entry cannot hide a matching entry from another broker.
+
+## Filters and compatibility
+
+`States`, `Types`, and `ProtocolTypes` combine with AND. Values within each list
+combine with OR. A null or empty list imposes no restriction. State and type
+comparisons ignore case; protocol comparisons are ordinal and case-sensitive.
+`ProtocolTypes = [""]` selects simple groups. Empty state/type values and null
+elements are rejected.
+
+Each destination connection negotiates `ListGroups` independently. A nonempty
+state filter requires version 4; a nonempty type filter requires version 5.
+An unsupported requested filter throws `KafkaException` with
+`ErrorCode.UnsupportedVersion`, including the broker and negotiated version.
+Protocol filtering runs on returned results. Without a type filter, older
+responses remain usable: `GroupType` is null before version 5 and `State` is
+null before version 4. An unavailable field is never guessed from the protocol.
+A broker error fails the operation rather than returning a partial inventory.
+
+The existing convenience methods use the same filtering and aggregation rules:
+
+- `ListConsumerGroupsAsync` selects `classic` or `consumer` groups with protocol
+  `consumer` or an empty string. **This corrects earlier behavior that also
+  returned Connect, Share, Streams, and other non-consumer groups.**
+- `ListShareGroupsAsync` selects type `share`.
+- `ListStreamsGroupsAsync` selects type `streams`.
+
+These convenience methods require version 5 because their group-type selection
+must be reliable. Use an unfiltered `ListGroupsAsync` inventory to inspect an
+older response. Filters are also applied locally, protecting callers from
+nonmatching rows in a broker response.
+
+`IGroupListingAdminClient` is an optional capability implemented by Dekaf's
+`AdminClient` and `InMemoryAdminClient`. Existing third-party `IAdminClient`
+implementations need no new member. Calling the extension on an implementation
+without this capability throws `NotSupportedException`.
+
+## In-memory testing
+
+`InMemoryAdminClient` distinguishes consumer membership history, simple
+offset-only groups, Share groups, and Streams groups created by a successful
+`AlterStreamsGroupOffsetsAsync`. Removing the last Streams offset retains the
+empty group's type until group deletion. Listing no longer presents every
+in-memory consumer group as a Streams group. The fake models active groups as
+`Stable` and inactive groups as `Empty`; it does not simulate broker rebalance
+states or custom Classic protocols.
+
+See [KIP-1043](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/305171038/KIP-1043%2BAdministration%2Bof%2Bgroups)
+for the distinction between group type and protocol.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -87,6 +87,7 @@ const sidebars = {
         'admin/transaction-remediation',
         'admin/replica-log-directories',
         'admin/streams-group-management',
+        'admin/group-listing',
       ],
     },
     {

--- a/src/Dekaf.Testing/InMemoryAdminClient.GroupListing.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.GroupListing.cs
@@ -1,0 +1,39 @@
+using Dekaf.Admin;
+
+namespace Dekaf.Testing;
+
+public sealed partial class InMemoryAdminClient : IGroupListingAdminClient
+{
+    private static readonly string[] ConsumerGroupTypes = ["consumer", "classic"];
+    private static readonly string[] ConsumerProtocolTypes = ["consumer", ""];
+    private static readonly string[] ShareGroupTypes = ["share"];
+    private static readonly string[] StreamsGroupTypes = ["streams"];
+
+    public ValueTask<IReadOnlyList<GroupListing>> ListGroupsAsync(
+        ListGroupsOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        ListGroupsCoreAsync(options?.States, options?.Types, options?.ProtocolTypes, cancellationToken);
+
+    private async ValueTask<IReadOnlyList<GroupListing>> ListGroupsCoreAsync(
+        IReadOnlyList<string>? states, IReadOnlyList<string>? types, IReadOnlyList<string>? protocols,
+        CancellationToken cancellationToken)
+    {
+        AdminClient.ValidateGroupFilters(states, types, protocols);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        await ApplyAdminFaultAsync(cancellationToken).ConfigureAwait(false);
+        var inventory = _cluster.ListGroupInventory();
+        if (states is not { Count: > 0 } && types is not { Count: > 0 } && protocols is not { Count: > 0 })
+            return inventory;
+        var result = new List<GroupListing>();
+        for (var i = 0; i < inventory.Count; i++)
+        {
+            var group = inventory[i];
+            if (AdminClient.MatchesGroupFilter(states, group.State, StringComparison.OrdinalIgnoreCase) &&
+                AdminClient.MatchesGroupFilter(types, group.GroupType, StringComparison.OrdinalIgnoreCase) &&
+                AdminClient.MatchesGroupFilter(protocols, group.ProtocolType, StringComparison.Ordinal))
+                result.Add(group);
+        }
+        return result;
+    }
+}

--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -339,25 +339,10 @@ public sealed partial class InMemoryAdminClient :
         return result;
     }
 
-    public async ValueTask<IReadOnlyList<GroupListing>> ListConsumerGroupsAsync(
+    public ValueTask<IReadOnlyList<GroupListing>> ListConsumerGroupsAsync(
         ListConsumerGroupsOptions? options = null,
-        CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        ThrowIfDisposed();
-        await ApplyAdminFaultAsync(cancellationToken).ConfigureAwait(false);
-
-        IReadOnlyList<GroupListing> result = _cluster.ListGroups()
-            .Select(groupId => new GroupListing
-            {
-                GroupId = groupId,
-                ProtocolType = "consumer",
-                State = "Stable"
-            })
-            .ToArray();
-
-        return result;
-    }
+        CancellationToken cancellationToken = default) =>
+        ListGroupsCoreAsync(options?.States, ConsumerGroupTypes, ConsumerProtocolTypes, cancellationToken);
 
     public async ValueTask DeleteConsumerGroupsAsync(
         IEnumerable<string> groupIds,
@@ -1394,25 +1379,10 @@ public sealed partial class InMemoryAdminClient :
         return result;
     }
 
-    public async ValueTask<IReadOnlyList<GroupListing>> ListStreamsGroupsAsync(
+    public ValueTask<IReadOnlyList<GroupListing>> ListStreamsGroupsAsync(
         ListStreamsGroupsOptions? options = null,
-        CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        ThrowIfDisposed();
-        await ApplyAdminFaultAsync(cancellationToken).ConfigureAwait(false);
-
-        IReadOnlyList<GroupListing> result = _cluster.ListGroups()
-            .Select(groupId => new GroupListing
-            {
-                GroupId = groupId,
-                ProtocolType = "streams",
-                State = "Stable"
-            })
-            .ToArray();
-
-        return result;
-    }
+        CancellationToken cancellationToken = default) =>
+        ListGroupsCoreAsync(options?.States, StreamsGroupTypes, null, cancellationToken);
 
     public async ValueTask<IReadOnlyDictionary<string, ShareGroupDescription>> DescribeShareGroupsAsync(
         IEnumerable<string> groupIds,
@@ -1447,35 +1417,10 @@ public sealed partial class InMemoryAdminClient :
         return result;
     }
 
-    public async ValueTask<IReadOnlyList<GroupListing>> ListShareGroupsAsync(
+    public ValueTask<IReadOnlyList<GroupListing>> ListShareGroupsAsync(
         ListShareGroupsOptions? options = null,
-        CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        ThrowIfDisposed();
-        await ApplyAdminFaultAsync(cancellationToken).ConfigureAwait(false);
-
-        var groups = _cluster.ListShareGroups();
-        var result = new List<GroupListing>(groups.Count);
-        foreach (var group in groups)
-        {
-            var state = group.HasActiveMembers ? "Stable" : "Empty";
-            if (options?.States is { Count: > 0 } states &&
-                !states.Contains(state, StringComparer.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            result.Add(new GroupListing
-            {
-                GroupId = group.GroupId,
-                ProtocolType = "share",
-                State = state
-            });
-        }
-
-        return result;
-    }
+        CancellationToken cancellationToken = default) =>
+        ListGroupsCoreAsync(options?.States, ShareGroupTypes, null, cancellationToken);
 
     public async ValueTask<IReadOnlyDictionary<string, DeleteShareGroupResult>> DeleteShareGroupsAsync(
         IEnumerable<string> groupIds,

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.GroupListing.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.GroupListing.cs
@@ -1,0 +1,53 @@
+using Dekaf.Admin;
+
+namespace Dekaf.Testing;
+
+public sealed partial class InMemoryKafkaCluster
+{
+    // Only administrative Streams offset creation allocates this set. Consumer delivery
+    // does not need to maintain a second per-message or per-membership registry.
+    private HashSet<string>? _streamsGroupIds;
+
+    internal IReadOnlyList<GroupListing> ListGroupInventory()
+    {
+        lock (_gate)
+        {
+            var ids = new HashSet<string>(_consumerGroupOffsets.Keys, StringComparer.Ordinal);
+            ids.UnionWith(_consumerGroupGenerations.Keys);
+            if (_streamsGroupIds is not null)
+                ids.UnionWith(_streamsGroupIds);
+            var result = new List<GroupListing>(ids.Count);
+            foreach (var id in ids)
+            {
+                var streams = _streamsGroupIds?.Contains(id) == true;
+                var consumer = _consumerGroupGenerations.ContainsKey(id);
+                var active = _consumerGroupMembers.TryGetValue(id, out var members) && members.Count > 0;
+                var (type, protocol) = (streams, consumer) switch
+                {
+                    (true, _) => ("streams", "streams"),
+                    (_, true) => ("consumer", "consumer"),
+                    _ => ("classic", "")
+                };
+                result.Add(new GroupListing
+                {
+                    GroupId = id,
+                    GroupType = type,
+                    ProtocolType = protocol,
+                    State = active ? "Stable" : "Empty"
+                });
+            }
+            foreach (var share in ListShareGroups())
+            {
+                if (!ids.Add(share.GroupId))
+                    continue;
+                result.Add(new GroupListing
+                {
+                    GroupId = share.GroupId, GroupType = "share", ProtocolType = "share",
+                    State = share.HasActiveMembers ? "Stable" : "Empty"
+                });
+            }
+            result.Sort(static (left, right) => StringComparer.Ordinal.Compare(left.GroupId, right.GroupId));
+            return result;
+        }
+    }
+}

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -18,7 +18,7 @@ internal readonly record struct InMemoryShareGroupListing(
 /// <summary>
 /// Shared in-memory topic, partition, offset, and group-offset store.
 /// </summary>
-public sealed class InMemoryKafkaCluster
+public sealed partial class InMemoryKafkaCluster
 {
     private readonly object _gate = new();
     private readonly Dictionary<string, TopicState> _topics = new(StringComparer.Ordinal);
@@ -1361,6 +1361,8 @@ public sealed class InMemoryKafkaCluster
                 groupOffsets[partition] = offset;
                 results[partition] = ErrorCode.None;
             }
+            if (groupOffsets is not null)
+                (_streamsGroupIds ??= new HashSet<string>(StringComparer.Ordinal)).Add(groupId);
             return results;
         }
     }
@@ -1748,7 +1750,8 @@ public sealed class InMemoryKafkaCluster
     {
         var existed = _consumerGroupOffsets.Remove(groupId);
         var hadGeneration = _consumerGroupGenerations.TryRemove(groupId, out _);
-        return hadGeneration || existed;
+        var hadStreamsType = _streamsGroupIds?.Remove(groupId) == true;
+        return hadGeneration || existed || hadStreamsType;
     }
 
     private Dictionary<long, ShareGroupMemberRegistration>? GetShareLeasePartition(

--- a/src/Dekaf.Testing/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.Testing/PublicAPI.Unshipped.txt
@@ -104,3 +104,4 @@ Dekaf.Testing.KafkaFaultScope.KafkaFaultScope(Dekaf.Testing.KafkaFaultOperation 
 Dekaf.Testing.KafkaFaultScope.Operation.get -> Dekaf.Testing.KafkaFaultOperation
 Dekaf.Testing.KafkaFaultScope.Partition.get -> int?
 Dekaf.Testing.KafkaFaultScope.Topic.get -> string?
+Dekaf.Testing.InMemoryAdminClient.ListGroupsAsync(Dekaf.Admin.ListGroupsOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Dekaf.Admin.GroupListing!>!>

--- a/src/Dekaf/Admin/AdminClient.GroupListing.cs
+++ b/src/Dekaf/Admin/AdminClient.GroupListing.cs
@@ -1,0 +1,137 @@
+using System.Runtime.CompilerServices;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Admin;
+
+public sealed partial class AdminClient : IGroupListingAdminClient
+{
+    private static readonly string[] ConsumerGroupTypes = ["consumer", "classic"];
+    private static readonly string[] ConsumerProtocolTypes = ["consumer", ""];
+    private static readonly string[] ShareGroupTypes = ["share"];
+    private static readonly string[] StreamsGroupTypes = ["streams"];
+
+    public ValueTask<IReadOnlyList<GroupListing>> ListGroupsAsync(
+        ListGroupsOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        ListGroupsCoreAsync(options?.States, options?.Types, options?.ProtocolTypes, cancellationToken);
+
+    private async ValueTask<IReadOnlyList<GroupListing>> ListGroupsCoreAsync(
+        IReadOnlyList<string>? states,
+        IReadOnlyList<string>? types,
+        IReadOnlyList<string>? protocols,
+        CancellationToken cancellationToken)
+    {
+        ValidateGroupFilters(states, types, protocols);
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        return await WithRetryAsync<IReadOnlyList<GroupListing>>(async () =>
+        {
+            var brokers = _metadataManager.Metadata.GetBrokers();
+            if (brokers.Count == 0)
+                throw new InvalidOperationException("No brokers available");
+
+            // Listing is an administrative operation. Fan out once per broker, not per group.
+            var pending = new Task<ListGroupsResponse>[brokers.Count];
+            for (var i = 0; i < brokers.Count; i++)
+                pending[i] = ListBrokerGroupsAsync(brokers[i].NodeId, states, types, cancellationToken);
+            var responses = await Task.WhenAll(pending).ConfigureAwait(false);
+
+            var capacity = 0;
+            foreach (var response in responses)
+                capacity = checked(capacity + response.Groups.Count);
+            // Broker responses already give an upper bound. Avoid repeatedly growing
+            // the inventory and deduplication buffers for large administrative listings.
+#if NETSTANDARD2_0
+            // The capacity constructor is unavailable in the compatibility target.
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+#else
+            var seen = new HashSet<string>(capacity, StringComparer.Ordinal);
+#endif
+            var result = new List<GroupListing>(capacity);
+            foreach (var response in responses)
+            {
+                for (var i = 0; i < response.Groups.Count; i++)
+                {
+                    var group = response.Groups[i];
+                    // Filter before deduplication: a stale nonmatching coordinator response
+                    // must not hide a matching response from the current coordinator.
+                    if (!MatchesGroupFilter(states, group.GroupState, StringComparison.OrdinalIgnoreCase) ||
+                        !MatchesGroupFilter(types, group.GroupType, StringComparison.OrdinalIgnoreCase) ||
+                        !MatchesGroupFilter(protocols, group.ProtocolType, StringComparison.Ordinal) ||
+                        !seen.Add(group.GroupId))
+                        continue;
+
+                    result.Add(new GroupListing
+                    {
+                        GroupId = group.GroupId,
+                        GroupType = group.GroupType,
+                        ProtocolType = group.ProtocolType,
+                        State = group.GroupState
+                    });
+                }
+            }
+            return result;
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<ListGroupsResponse> ListBrokerGroupsAsync(int brokerId,
+        IReadOnlyList<string>? states, IReadOnlyList<string>? types, CancellationToken cancellationToken)
+    {
+        using var lease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken).ConfigureAwait(false);
+        var connection = lease.Connection;
+        var version = _metadataManager.GetNegotiatedApiVersion(connection, ApiKey.ListGroups,
+            ListGroupsRequest.LowestSupportedVersion, ListGroupsRequest.HighestSupportedVersion);
+        if (states is { Count: > 0 } && version < 4)
+            throw new KafkaException(ErrorCode.UnsupportedVersion,
+                $"Group state filtering requires ListGroups v4; broker {brokerId} negotiated v{version}.");
+        if (types is { Count: > 0 } && version < 5)
+            throw new KafkaException(ErrorCode.UnsupportedVersion,
+                $"Group type filtering requires ListGroups v5; broker {brokerId} negotiated v{version}.");
+
+        var response = await connection.SendAsync<ListGroupsRequest, ListGroupsResponse>(new ListGroupsRequest
+        {
+            StatesFilter = states,
+            TypesFilter = types
+        }, version, cancellationToken).ConfigureAwait(false);
+        if (response.ErrorCode != ErrorCode.None)
+            throw new KafkaException(response.ErrorCode, $"ListGroups failed on broker {brokerId}: {response.ErrorCode}");
+        return response;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool MatchesGroupFilter(IReadOnlyList<string>? filter, string? value, StringComparison comparison)
+    {
+        if (filter is not { Count: > 0 })
+            return true;
+        if (value is null)
+            return false;
+        for (var i = 0; i < filter.Count; i++)
+        {
+            if (string.Equals(filter[i], value, comparison))
+                return true;
+        }
+        return false;
+    }
+
+    internal static void ValidateGroupFilters(IReadOnlyList<string>? states,
+        IReadOnlyList<string>? types, IReadOnlyList<string>? protocols)
+    {
+        if (states is not null)
+        {
+            for (var i = 0; i < states.Count; i++)
+                ArgumentException.ThrowIfNullOrWhiteSpace(states[i], nameof(states));
+        }
+        if (types is not null)
+        {
+            for (var i = 0; i < types.Count; i++)
+                ArgumentException.ThrowIfNullOrWhiteSpace(types[i], nameof(types));
+        }
+        if (protocols is not null)
+        {
+            for (var i = 0; i < protocols.Count; i++)
+                ArgumentNullException.ThrowIfNull(protocols[i], nameof(protocols));
+        }
+    }
+}

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -1404,75 +1404,10 @@ public sealed partial class AdminClient :
         return result;
     }
 
-    public async ValueTask<IReadOnlyList<GroupListing>> ListConsumerGroupsAsync(
+    public ValueTask<IReadOnlyList<GroupListing>> ListConsumerGroupsAsync(
         ListConsumerGroupsOptions? options = null,
-        CancellationToken cancellationToken = default)
-    {
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-
-        var opts = options ?? new ListConsumerGroupsOptions();
-
-        return await WithRetryAsync<IReadOnlyList<GroupListing>>(async () =>
-        {
-            var brokers = _metadataManager.Metadata.GetBrokers();
-            if (brokers.Count == 0)
-            {
-                throw new InvalidOperationException("No brokers available");
-            }
-
-            // Query all brokers since each only knows about groups it coordinates
-            var seenGroupIds = new HashSet<string>();
-            var result = new List<GroupListing>();
-
-            foreach (var broker in brokers)
-            {
-                using var connectionLease = await _connectionPool.LeaseConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
-                var connection = connectionLease.Connection;
-                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                    connection,
-                    Protocol.ApiKey.ListGroups,
-                    ListGroupsRequest.LowestSupportedVersion,
-                    ListGroupsRequest.HighestSupportedVersion);
-                var request = new ListGroupsRequest
-                {
-                    StatesFilter = apiVersion >= 4 ? opts.States : null
-                };
-
-                var response = await connection.SendAsync<ListGroupsRequest, ListGroupsResponse>(
-                    request,
-                    apiVersion,
-                    cancellationToken).ConfigureAwait(false);
-
-                if (response.ErrorCode != Protocol.ErrorCode.None)
-                {
-                    throw new KafkaException(response.ErrorCode,
-                        $"ListConsumerGroups failed on broker {broker.NodeId}: {response.ErrorCode}");
-                }
-
-                foreach (var group in response.Groups)
-                {
-                    if (!seenGroupIds.Add(group.GroupId))
-                        continue;
-
-                    // Client-side state filtering if broker doesn't support v4+
-                    if (apiVersion < 4 && opts.States is { Count: > 0 } && group.GroupState is not null)
-                    {
-                        if (!opts.States.Contains(group.GroupState, StringComparer.OrdinalIgnoreCase))
-                            continue;
-                    }
-
-                    result.Add(new GroupListing
-                    {
-                        GroupId = group.GroupId,
-                        ProtocolType = group.ProtocolType,
-                        State = group.GroupState
-                    });
-                }
-            }
-
-            return result;
-        }, cancellationToken).ConfigureAwait(false);
-    }
+        CancellationToken cancellationToken = default) =>
+        ListGroupsCoreAsync(options?.States, ConsumerGroupTypes, ConsumerProtocolTypes, cancellationToken);
 
     public async ValueTask<ListTransactionsResult> ListTransactionsAsync(
         ListTransactionsOptions? options = null,
@@ -4658,82 +4593,10 @@ public sealed partial class AdminClient :
         }, cancellationToken).ConfigureAwait(false);
     }
 
-    public async ValueTask<IReadOnlyList<GroupListing>> ListStreamsGroupsAsync(
+    public ValueTask<IReadOnlyList<GroupListing>> ListStreamsGroupsAsync(
         ListStreamsGroupsOptions? options = null,
-        CancellationToken cancellationToken = default)
-    {
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-
-        var opts = options ?? new ListStreamsGroupsOptions();
-
-        return await WithRetryAsync<IReadOnlyList<GroupListing>>(async () =>
-        {
-            var brokers = _metadataManager.Metadata.GetBrokers();
-            if (brokers.Count == 0)
-            {
-                throw new InvalidOperationException("No brokers available");
-            }
-
-            var responses = await Task.WhenAll(brokers.Select(async broker =>
-            {
-                using var connectionLease = await _connectionPool.LeaseConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
-                var connection = connectionLease.Connection;
-                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                    connection,
-                    Protocol.ApiKey.ListGroups,
-                    ListGroupsRequest.LowestSupportedVersion,
-                    ListGroupsRequest.HighestSupportedVersion);
-                var request = new ListGroupsRequest
-                {
-                    StatesFilter = apiVersion >= 4 ? opts.States : null,
-                    TypesFilter = apiVersion >= 5 ? ["streams"] : null
-                };
-
-                var response = await connection.SendAsync<ListGroupsRequest, ListGroupsResponse>(
-                    request,
-                    apiVersion,
-                    cancellationToken).ConfigureAwait(false);
-
-                if (response.ErrorCode != Protocol.ErrorCode.None)
-                {
-                    throw new KafkaException(response.ErrorCode,
-                        $"ListStreamsGroups failed on broker {broker.NodeId}: {response.ErrorCode}");
-                }
-
-                return (Response: response, ApiVersion: apiVersion);
-            })).ConfigureAwait(false);
-
-            var seenGroupIds = new HashSet<string>();
-            var result = new List<GroupListing>();
-
-            foreach (var (response, apiVersion) in responses)
-            {
-                foreach (var group in response.Groups)
-                {
-                    if (apiVersion < 5 || !string.Equals(group.GroupType, "streams", StringComparison.OrdinalIgnoreCase))
-                        continue;
-
-                    if (!seenGroupIds.Add(group.GroupId))
-                        continue;
-
-                    if (apiVersion < 4 && opts.States is { Count: > 0 } && group.GroupState is not null)
-                    {
-                        if (!opts.States.Contains(group.GroupState, StringComparer.OrdinalIgnoreCase))
-                            continue;
-                    }
-
-                    result.Add(new GroupListing
-                    {
-                        GroupId = group.GroupId,
-                        ProtocolType = group.ProtocolType,
-                        State = group.GroupState
-                    });
-                }
-            }
-
-            return result;
-        }, cancellationToken).ConfigureAwait(false);
-    }
+        CancellationToken cancellationToken = default) =>
+        ListGroupsCoreAsync(options?.States, StreamsGroupTypes, null, cancellationToken);
 
     private static StreamsGroupDescription MapStreamsGroupDescription(StreamsGroupDescribeGroup group)
     {
@@ -4945,86 +4808,10 @@ public sealed partial class AdminClient :
         }, cancellationToken).ConfigureAwait(false);
     }
 
-    public async ValueTask<IReadOnlyList<GroupListing>> ListShareGroupsAsync(
+    public ValueTask<IReadOnlyList<GroupListing>> ListShareGroupsAsync(
         ListShareGroupsOptions? options = null,
-        CancellationToken cancellationToken = default)
-    {
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-
-        var opts = options ?? new ListShareGroupsOptions();
-
-        return await WithRetryAsync<IReadOnlyList<GroupListing>>(async () =>
-        {
-            var brokers = _metadataManager.Metadata.GetBrokers();
-            if (brokers.Count == 0)
-            {
-                throw new InvalidOperationException("No brokers available");
-            }
-
-            // Fan out to all brokers in parallel
-            var responses = await Task.WhenAll(brokers.Select(async broker =>
-            {
-                using var connectionLease = await _connectionPool.LeaseConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
-                var connection = connectionLease.Connection;
-                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                    connection,
-                    Protocol.ApiKey.ListGroups,
-                    ListGroupsRequest.LowestSupportedVersion,
-                    ListGroupsRequest.HighestSupportedVersion);
-                var request = new ListGroupsRequest
-                {
-                    StatesFilter = apiVersion >= 4 ? opts.States : null,
-                    TypesFilter = apiVersion >= 5 ? ["share"] : null
-                };
-
-                var response = await connection.SendAsync<ListGroupsRequest, ListGroupsResponse>(
-                    request,
-                    apiVersion,
-                    cancellationToken).ConfigureAwait(false);
-
-                if (response.ErrorCode != Protocol.ErrorCode.None)
-                {
-                    throw new KafkaException(response.ErrorCode,
-                        $"ListShareGroups failed on broker {broker.NodeId}: {response.ErrorCode}");
-                }
-
-                return (Response: response, ApiVersion: apiVersion);
-            })).ConfigureAwait(false);
-
-            // Merge and deduplicate results
-            var seenGroupIds = new HashSet<string>();
-            var result = new List<GroupListing>();
-
-            foreach (var (response, apiVersion) in responses)
-            {
-                foreach (var group in response.Groups)
-                {
-                    // Filter to share groups only (client-side for pre-v5 brokers)
-                    if (apiVersion < 5 && !string.Equals(group.GroupType, "share", StringComparison.OrdinalIgnoreCase))
-                        continue;
-
-                    if (!seenGroupIds.Add(group.GroupId))
-                        continue;
-
-                    // Client-side state filtering if broker doesn't support v4+
-                    if (apiVersion < 4 && opts.States is { Count: > 0 } && group.GroupState is not null)
-                    {
-                        if (!opts.States.Contains(group.GroupState, StringComparer.OrdinalIgnoreCase))
-                            continue;
-                    }
-
-                    result.Add(new GroupListing
-                    {
-                        GroupId = group.GroupId,
-                        ProtocolType = group.ProtocolType,
-                        State = group.GroupState
-                    });
-                }
-            }
-
-            return result;
-        }, cancellationToken).ConfigureAwait(false);
-    }
+        CancellationToken cancellationToken = default) =>
+        ListGroupsCoreAsync(options?.States, ShareGroupTypes, null, cancellationToken);
 
     public async ValueTask<IReadOnlyDictionary<string, DeleteShareGroupResult>> DeleteShareGroupsAsync(
         IEnumerable<string> groupIds,

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -740,13 +740,15 @@ public sealed class FeatureUpdateResultInfo
 }
 
 /// <summary>
-/// Consumer group listing.
+/// Group listing, including its coordination type and application protocol.
 /// </summary>
 public sealed class GroupListing
 {
     public required string GroupId { get; init; }
     public string? ProtocolType { get; init; }
     public string? State { get; init; }
+    /// <summary>Broker-reported type, preserved verbatim, including unknown future values. Null when the broker's ListGroups version predates v5.</summary>
+    public string? GroupType { get; init; }
 }
 
 /// <summary>

--- a/src/Dekaf/Admin/IGroupListingAdminClient.cs
+++ b/src/Dekaf/Admin/IGroupListingAdminClient.cs
@@ -1,0 +1,41 @@
+namespace Dekaf.Admin;
+
+/// <summary>Optional admin capability for listing every group type (KIP-1043).</summary>
+public interface IGroupListingAdminClient
+{
+    /// <summary>Lists groups across brokers, retaining their type and protocol.</summary>
+    ValueTask<IReadOnlyList<GroupListing>> ListGroupsAsync(
+        ListGroupsOptions? options = null,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Filters for a unified group inventory. Filters combine with AND; values within a filter combine with OR.</summary>
+public sealed class ListGroupsOptions
+{
+    /// <summary>Group states, compared without case. Null or empty includes all states. Requires ListGroups v4.</summary>
+    public IReadOnlyList<string>? States { get; init; }
+
+    /// <summary>Group types, such as classic, consumer, share, or streams, compared without case. Null or empty includes all types. Requires ListGroups v5.</summary>
+    public IReadOnlyList<string>? Types { get; init; }
+
+    /// <summary>Exact protocol strings. An empty string selects offset-only simple groups; null or an empty list includes all protocols.</summary>
+    public IReadOnlyList<string>? ProtocolTypes { get; init; }
+}
+
+/// <summary>Unified group listing for admin clients.</summary>
+public static class AdminClientGroupListingExtensions
+{
+    /// <summary>Lists groups using the client's optional unified inventory capability.</summary>
+    /// <exception cref="NotSupportedException">The client does not implement <see cref="IGroupListingAdminClient"/>.</exception>
+    public static ValueTask<IReadOnlyList<GroupListing>> ListGroupsAsync(
+        this IAdminClient adminClient,
+        ListGroupsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(adminClient);
+        return adminClient is IGroupListingAdminClient listing
+            ? listing.ListGroupsAsync(options, cancellationToken)
+            : throw new NotSupportedException(
+                $"Admin client type '{adminClient.GetType().FullName}' does not support unified group listing.");
+    }
+}

--- a/src/Dekaf/PublicAPI.Unshipped.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.txt
@@ -1,0 +1,15 @@
+Dekaf.Admin.AdminClient.ListGroupsAsync(Dekaf.Admin.ListGroupsOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Dekaf.Admin.GroupListing!>!>
+Dekaf.Admin.AdminClientGroupListingExtensions
+Dekaf.Admin.GroupListing.GroupType.get -> string?
+Dekaf.Admin.GroupListing.GroupType.init -> void
+Dekaf.Admin.IGroupListingAdminClient
+Dekaf.Admin.IGroupListingAdminClient.ListGroupsAsync(Dekaf.Admin.ListGroupsOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Dekaf.Admin.GroupListing!>!>
+Dekaf.Admin.ListGroupsOptions
+Dekaf.Admin.ListGroupsOptions.ListGroupsOptions() -> void
+Dekaf.Admin.ListGroupsOptions.ProtocolTypes.get -> System.Collections.Generic.IReadOnlyList<string!>?
+Dekaf.Admin.ListGroupsOptions.ProtocolTypes.init -> void
+Dekaf.Admin.ListGroupsOptions.States.get -> System.Collections.Generic.IReadOnlyList<string!>?
+Dekaf.Admin.ListGroupsOptions.States.init -> void
+Dekaf.Admin.ListGroupsOptions.Types.get -> System.Collections.Generic.IReadOnlyList<string!>?
+Dekaf.Admin.ListGroupsOptions.Types.init -> void
+static Dekaf.Admin.AdminClientGroupListingExtensions.ListGroupsAsync(this Dekaf.Admin.IAdminClient! adminClient, Dekaf.Admin.ListGroupsOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Dekaf.Admin.GroupListing!>!>

--- a/tests/Dekaf.Tests.Integration/AdminGroupListingTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdminGroupListingTests.cs
@@ -1,0 +1,192 @@
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Streams;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("ConsumerGroup")]
+[SupportsKafka(420)]
+public sealed class AdminGroupListingTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task MixedInventory_PreservesTypesAndFiltersEveryConvenience()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var prefix = $"inventory-{Guid.NewGuid():N}-";
+        await using var client = Kafka.Connect(KafkaContainer.BootstrapServers);
+        await using var admin = client.CreateAdminClient().Build();
+        await admin.AlterConsumerGroupOffsetsAsync(prefix + "simple", [new TopicPartitionOffset(topic, 0, 0)]);
+        await using var producer = await client.CreateProducer<string, string>().BuildAsync();
+        await producer.ProduceAsync(topic, "key", "value");
+        await using var consumer = await client.CreateConsumer<string, string>()
+            .WithGroupId(prefix + "consumer").WithAutoOffsetReset(AutoOffsetReset.Earliest).BuildAsync();
+        consumer.Subscribe(topic);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var consumed = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), timeout.Token);
+        await Assert.That(consumed).IsNotNull();
+
+        await using var share = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId(prefix + "share").BuildAsync();
+        share.Subscribe(topic);
+        await ShareConsumerTestHelper.PrimeShareConsumerAsync(share);
+        await using var streams = client.CreateStreamsGroupMember(new StreamsGroupMemberOptions { GroupId = prefix + "streams" });
+        await streams.InitializeAsync();
+        await streams.JoinAsync(new StreamsGroupMemberUpdate
+        {
+            ProcessId = "listing-process", ActiveTasks = [], StandbyTasks = [], WarmupTasks = [], ClientTags = [],
+            Topology = new Dekaf.Streams.StreamsGroupTopology
+            {
+                Epoch = 0,
+                Subtopologies = [new Dekaf.Streams.StreamsGroupSubtopology
+                {
+                    SubtopologyId = "0", SourceTopics = [topic], SourceTopicRegex = [], StateChangelogTopics = [],
+                    RepartitionSinkTopics = [], RepartitionSourceTopics = [], CopartitionGroups = []
+                }]
+            }
+        });
+
+        await using var pool = new ConnectionPool("connect-listing-test",
+            new ConnectionOptions { RequestTimeout = TimeSpan.FromSeconds(30) }, loggerFactory: null);
+        var endpoint = BootstrapServerList.Parse(KafkaContainer.BootstrapServers);
+        var bootstrap = await pool.GetConnectionAsync(endpoint.Host, endpoint.Port, timeout.Token);
+        var findVersion = ((IKafkaCapabilityProvider)bootstrap).Capabilities.NegotiateVersion(ApiKey.FindCoordinator,
+            FindCoordinatorRequest.LowestSupportedVersion, FindCoordinatorRequest.HighestSupportedVersion);
+        var found = await bootstrap.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+            new() { Key = prefix + "connect", KeyType = CoordinatorType.Group }, findVersion, timeout.Token);
+        var coordinator = found.Coordinators.Single();
+        await Assert.That(coordinator.ErrorCode).IsEqualTo(ErrorCode.None);
+        pool.RegisterBroker(coordinator.NodeId, coordinator.Host, coordinator.Port);
+        var connection = await pool.GetConnectionAsync(coordinator.NodeId, timeout.Token);
+        var joined = await connection.SendAsync<TestJoinGroupRequest, TestJoinGroupResponse>(
+            new(prefix + "connect", ""), 5, timeout.Token);
+        if (joined.ErrorCode == ErrorCode.MemberIdRequired)
+            joined = await connection.SendAsync<TestJoinGroupRequest, TestJoinGroupResponse>(
+                new(prefix + "connect", joined.MemberId), 5, timeout.Token);
+        await Assert.That(joined.ErrorCode).IsEqualTo(ErrorCode.None);
+        try
+        {
+            var all = (await admin.ListGroupsAsync(cancellationToken: timeout.Token))
+                .Where(group => group.GroupId.StartsWith(prefix, StringComparison.Ordinal)).ToArray();
+            await Assert.That(all.Select(group => (group.GroupId[prefix.Length..], group.GroupType, group.ProtocolType)))
+                .IsEquivalentTo(new (string, string?, string?)[]
+                {
+                    ("simple", "classic", ""), ("consumer", "consumer", "consumer"),
+                    ("share", "share", "share"), ("streams", "streams", "streams"), ("connect", "classic", "connect")
+                });
+            var classic = await admin.ListGroupsAsync(new ListGroupsOptions
+            {
+                Types = ["classic"], ProtocolTypes = ["connect"],
+                States = [all.Single(group => group.GroupId == prefix + "connect").State!.ToLowerInvariant()]
+            }, timeout.Token);
+            await Assert.That(classic.Any(group => group.GroupId == prefix + "connect")).IsTrue();
+            await Assert.That(classic.All(static group => group.ProtocolType == "connect" && group.GroupType == "classic")).IsTrue();
+            var consumers = await admin.ListConsumerGroupsAsync(cancellationToken: timeout.Token);
+            await Assert.That(consumers.Where(group => group.GroupId.StartsWith(prefix, StringComparison.Ordinal))
+                .Select(group => group.GroupId[prefix.Length..])).IsEquivalentTo(["consumer", "simple"]);
+            var shares = await admin.ListShareGroupsAsync(cancellationToken: timeout.Token);
+            await Assert.That(shares.Where(group => group.GroupId.StartsWith(prefix, StringComparison.Ordinal))
+                .Select(group => group.GroupId[prefix.Length..])).IsEquivalentTo(["share"]);
+            var streamGroups = await admin.ListStreamsGroupsAsync(cancellationToken: timeout.Token);
+            await Assert.That(streamGroups.Where(group => group.GroupId.StartsWith(prefix, StringComparison.Ordinal))
+                .Select(group => group.GroupId[prefix.Length..])).IsEquivalentTo(["streams"]);
+        }
+        finally
+        {
+            var left = await connection.SendAsync<TestLeaveGroupRequest, TestLeaveGroupResponse>(
+                new(prefix + "connect", joined.MemberId), 3, CancellationToken.None);
+            await Assert.That(left.ErrorCode).IsEqualTo(ErrorCode.None);
+        }
+    }
+
+    // Test-only Classic coordination creates a non-consumer protocol group. These codecs
+    // follow Apache Kafka 4.3.1 JoinGroup v5 and LeaveGroup v3 message schemas.
+    private sealed class TestJoinGroupRequest(string groupId, string memberId) : IKafkaRequest<TestJoinGroupResponse>
+    {
+        public static ApiKey ApiKey => ApiKey.JoinGroup;
+        public static short LowestSupportedVersion => 5;
+        public static short HighestSupportedVersion => 5;
+        public static bool IsFlexibleVersion(short version) => false;
+        public static short GetRequestHeaderVersion(short version) => 1;
+        public static short GetResponseHeaderVersion(short version) => 0;
+        public void Write(ref KafkaProtocolWriter writer, short version)
+        {
+            writer.WriteString(groupId);
+            writer.WriteInt32(60_000);
+            writer.WriteInt32(60_000);
+            writer.WriteString(memberId);
+            writer.WriteString((string?)null);
+            writer.WriteString("connect");
+            writer.WriteInt32(1);
+            writer.WriteString("listing-test");
+            writer.WriteBytes([]);
+        }
+    }
+
+    private sealed class TestJoinGroupResponse : IKafkaResponse
+    {
+        public static ApiKey ApiKey => ApiKey.JoinGroup;
+        public static short LowestSupportedVersion => 5;
+        public static short HighestSupportedVersion => 5;
+        public required ErrorCode ErrorCode { get; init; }
+        public required string MemberId { get; init; }
+        public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+        {
+            _ = reader.ReadInt32();
+            var error = (ErrorCode)reader.ReadInt16();
+            _ = reader.ReadInt32();
+            _ = reader.ReadString();
+            _ = reader.ReadString();
+            var memberId = reader.ReadString()!;
+            var members = reader.ReadInt32();
+            for (var i = 0; i < members; i++)
+            {
+                _ = reader.ReadString();
+                _ = reader.ReadString();
+                _ = reader.ReadBytes();
+            }
+            return new TestJoinGroupResponse { ErrorCode = error, MemberId = memberId };
+        }
+    }
+
+    private sealed class TestLeaveGroupRequest(string groupId, string memberId) : IKafkaRequest<TestLeaveGroupResponse>
+    {
+        public static ApiKey ApiKey => ApiKey.LeaveGroup;
+        public static short LowestSupportedVersion => 3;
+        public static short HighestSupportedVersion => 3;
+        public static bool IsFlexibleVersion(short version) => false;
+        public static short GetRequestHeaderVersion(short version) => 1;
+        public static short GetResponseHeaderVersion(short version) => 0;
+        public void Write(ref KafkaProtocolWriter writer, short version)
+        {
+            writer.WriteString(groupId);
+            writer.WriteInt32(1);
+            writer.WriteString(memberId);
+            writer.WriteString((string?)null);
+        }
+    }
+
+    private sealed class TestLeaveGroupResponse : IKafkaResponse
+    {
+        public static ApiKey ApiKey => ApiKey.LeaveGroup;
+        public static short LowestSupportedVersion => 3;
+        public static short HighestSupportedVersion => 3;
+        public required ErrorCode ErrorCode { get; init; }
+        public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+        {
+            _ = reader.ReadInt32();
+            var error = (ErrorCode)reader.ReadInt16();
+            var members = reader.ReadInt32();
+            for (var i = 0; i < members; i++)
+            {
+                _ = reader.ReadString();
+                _ = reader.ReadString();
+                var memberError = (ErrorCode)reader.ReadInt16();
+                if (memberError != ErrorCode.None) error = memberError;
+            }
+            return new TestLeaveGroupResponse { ErrorCode = error };
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientGroupListingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientGroupListingTests.cs
@@ -1,0 +1,336 @@
+using Dekaf.Admin;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+public class AdminClientGroupListingTests
+{
+    [Test]
+    public async Task ConsumerListing_ExcludesOtherProtocolsAndTypes_ButIncludesSimpleConsumers()
+    {
+        var (admin, connections) = CreateAdmin();
+        await using var adminDisposal = admin;
+        var groups = new ListGroupsResponseGroup[]
+        {
+            Group("modern", "Consumer", "consumer"),
+            Group("classic", "Classic", "consumer"),
+            Group("simple", "Classic", ""),
+            Group("connect", "Classic", "connect"),
+            Group("share", "Share", "share"),
+            Group("streams", "Streams", "streams"),
+            Group("future", "Future", "consumer")
+        };
+        foreach (var connection in connections.Values)
+            Respond(connection, groups);
+
+        var result = await admin.ListConsumerGroupsAsync();
+
+        await Assert.That(result.Select(static group => group.GroupId))
+            .IsEquivalentTo(["modern", "classic", "simple"]);
+    }
+
+    private static ListGroupsResponseGroup Group(string id, string? type, string? protocol, string state = "Stable") => new()
+    {
+        GroupId = id, GroupType = type, ProtocolType = protocol, GroupState = state
+    };
+
+    [Test]
+    public async Task UnifiedListing_PreservesUnknownTypesAndCombinesFiltersBeforeDeduplication()
+    {
+        var (admin, connections) = CreateAdmin();
+        await using var adminDisposal = admin;
+        Respond(connections[1],
+        [
+            Group("moving", "Classic", "connect", "Empty"),
+            Group("modern", "Consumer", "consumer"),
+            Group("future", "FutureV2", "custom")
+        ]);
+        Respond(connections[2],
+        [
+            Group("moving", "Classic", "connect"),
+            Group("future", "FutureV2", "custom"),
+            Group("wrong-protocol", "Classic", "consumer")
+        ]);
+        var result = await admin.ListGroupsAsync(new ListGroupsOptions
+        {
+            States = ["stable"], Types = ["classic", "futurev2"], ProtocolTypes = ["connect", "custom"]
+        });
+        await Assert.That(result.Select(static group => group.GroupId)).IsEquivalentTo(["future", "moving"]);
+        await Assert.That(result.Single(static group => group.GroupId == "future").GroupType).IsEqualTo("FutureV2");
+        await Assert.That(result.Single(static group => group.GroupId == "moving").State).IsEqualTo("Stable");
+        await connections[1].Received(1).SendAsync<ListGroupsRequest, ListGroupsResponse>(
+            Arg.Is<ListGroupsRequest>(request => request.StatesFilter!.Count == 1 && request.TypesFilter!.Count == 2),
+            5, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    [Arguments((short)3, false)]
+    [Arguments((short)4, true)]
+    public async Task UnsupportedFilter_ThrowsBeforeSendingRequest(short version, bool filterType)
+    {
+        var (admin, connections) = CreateAdmin(version);
+        await using var adminDisposal = admin;
+        var options = filterType ? new ListGroupsOptions { Types = ["Consumer"] }
+            : new ListGroupsOptions { States = ["Stable"] };
+        await Assert.That(async () => await admin.ListGroupsAsync(options)).Throws<KafkaException>();
+        foreach (var connection in connections.Values)
+            await connection.DidNotReceiveWithAnyArgs().SendAsync<ListGroupsRequest, ListGroupsResponse>(default!, default, default);
+    }
+
+    [Test]
+    [Arguments((short)3)]
+    [Arguments((short)4)]
+    public async Task OlderResponse_LeavesTypeUnavailableAndStillFiltersProtocol(short version)
+    {
+        var (admin, connections) = CreateAdmin(version);
+        await using var adminDisposal = admin;
+        Respond(connections[1], [Group("connect", null, "connect"), Group("consumer", null, "consumer")]);
+        var result = await admin.ListGroupsAsync(new ListGroupsOptions { ProtocolTypes = ["connect"] });
+        await Assert.That(result.Count).IsEqualTo(1);
+        await Assert.That(result[0].GroupId).IsEqualTo("connect");
+        await Assert.That(result[0].GroupType).IsNull();
+    }
+
+    [Test]
+    public async Task ProtocolFilters_AreExactAndDistinguishEmptyFromUnavailable()
+    {
+        var (admin, connections) = CreateAdmin();
+        await using var adminDisposal = admin;
+        Respond(connections[1],
+        [
+            Group("simple", "Classic", ""), Group("missing", "Classic", null),
+            Group("upper", "Classic", "Connect"), Group("lower", "Classic", "connect")
+        ]);
+        var result = await admin.ListGroupsAsync(new ListGroupsOptions { ProtocolTypes = ["", "Connect"] });
+        await Assert.That(result.Select(static group => group.GroupId)).IsEquivalentTo(["simple", "upper"]);
+    }
+
+    [Test]
+    public async Task EmptyFilters_IncludeAllTypesAndCaseDistinctGroupIds()
+    {
+        var (admin, connections) = CreateAdmin();
+        await using var adminDisposal = admin;
+        Respond(connections[1], [Group("id", "Classic", "consumer"), Group("ID", "FutureV2", "custom")]);
+        Respond(connections[2], [Group("id", "Classic", "consumer")]);
+        var result = await admin.ListGroupsAsync(new ListGroupsOptions { States = [], Types = [], ProtocolTypes = [] });
+        await Assert.That(result.Select(static group => group.GroupId)).IsEquivalentTo(["id", "ID"]);
+        await Assert.That(result.Select(static group => group.GroupType!)).IsEquivalentTo(["Classic", "FutureV2"]);
+    }
+
+    [Test]
+    public async Task ShareAndStreamsConveniences_DefensivelyFilterBrokerResults()
+    {
+        var (admin, connections) = CreateAdmin();
+        await using var adminDisposal = admin;
+        Respond(connections[1],
+        [
+            Group("share", "Share", "share"), Group("streams", "Streams", "streams"),
+            Group("consumer", "Consumer", "consumer")
+        ]);
+        var share = await admin.ListShareGroupsAsync();
+        var streams = await admin.ListStreamsGroupsAsync();
+        await Assert.That(share.Select(static group => group.GroupId)).IsEquivalentTo(["share"]);
+        await Assert.That(streams.Select(static group => group.GroupId)).IsEquivalentTo(["streams"]);
+        await Assert.That(share[0].GroupType).IsEqualTo("Share");
+        await Assert.That(streams[0].GroupType).IsEqualTo("Streams");
+    }
+
+    [Test]
+    public async Task Extension_PreservesCustomAdminCompatibility()
+    {
+        var legacy = Substitute.For<IAdminClient>();
+        await Assert.That(async () => await legacy.ListGroupsAsync()).Throws<NotSupportedException>();
+        var capable = Substitute.For<IAdminClient, IGroupListingAdminClient>();
+        var expected = new GroupListing { GroupId = "future", GroupType = "FutureV2" };
+        ((IGroupListingAdminClient)capable).ListGroupsAsync(null, default)
+            .Returns(new ValueTask<IReadOnlyList<GroupListing>>([expected]));
+        var result = await capable.ListGroupsAsync();
+        await Assert.That(result[0]).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments((short)4, true)]
+    [Arguments((short)3, false)]
+    public async Task FilterCapability_IsCheckedOnEachDestination(short secondVersion, bool filterType)
+    {
+        var (admin, connections) = CreateAdmin(secondVersion: secondVersion);
+        await using var adminDisposal = admin;
+        var options = filterType ? new ListGroupsOptions { Types = ["Consumer"] }
+            : new ListGroupsOptions { States = ["Stable"] };
+        await Assert.That(async () => await admin.ListGroupsAsync(options))
+            .Throws<KafkaException>();
+        await connections[1].Received(1).SendAsync<ListGroupsRequest, ListGroupsResponse>(
+            Arg.Any<ListGroupsRequest>(), 5, Arg.Any<CancellationToken>());
+        await connections[2].DidNotReceiveWithAnyArgs().SendAsync<ListGroupsRequest, ListGroupsResponse>(default!, default, default);
+    }
+
+    [Test]
+    [Arguments((short)3)]
+    [Arguments((short)4)]
+    public async Task ConvenienceTypeFilters_RejectOlderResponses(short version)
+    {
+        var (admin, _) = CreateAdmin(version);
+        await using var adminDisposal = admin;
+        await Assert.That(async () => await admin.ListConsumerGroupsAsync()).Throws<KafkaException>();
+        await Assert.That(async () => await admin.ListShareGroupsAsync()).Throws<KafkaException>();
+        await Assert.That(async () => await admin.ListStreamsGroupsAsync()).Throws<KafkaException>();
+    }
+
+    [Test]
+    public async Task BrokersAreQueriedConcurrentlyAndAllResultsAreObserved()
+    {
+        var (admin, connections) = CreateAdmin();
+        await using var adminDisposal = admin;
+        var pending = new TaskCompletionSource<ListGroupsResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        connections[1].SendAsync<ListGroupsRequest, ListGroupsResponse>(Arg.Any<ListGroupsRequest>(),
+                Arg.Any<short>(), Arg.Any<CancellationToken>()).Returns(new ValueTask<ListGroupsResponse>(pending.Task));
+        connections[2].SendAsync<ListGroupsRequest, ListGroupsResponse>(Arg.Any<ListGroupsRequest>(),
+                Arg.Any<short>(), Arg.Any<CancellationToken>()).Returns(_ =>
+            {
+                secondStarted.TrySetResult();
+                return new ValueTask<ListGroupsResponse>(new ListGroupsResponse { Groups = [Group("second", "Consumer", "consumer")] });
+            });
+        var operation = admin.ListGroupsAsync();
+        try
+        {
+            await secondStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await Assert.That(operation.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            pending.TrySetResult(new ListGroupsResponse { Groups = [Group("first", "Share", "share")] });
+        }
+        var result = await operation;
+        await Assert.That(result.Select(static group => group.GroupId)).IsEquivalentTo(["first", "second"]);
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(2)]
+    public async Task InvalidFilters_AreRejectedBeforeBrokerQueries(int filter)
+    {
+        var (admin, connections) = CreateAdmin();
+        await using var adminDisposal = admin;
+        var options = filter switch
+        {
+            0 => new ListGroupsOptions { States = [" "] },
+            1 => new ListGroupsOptions { Types = [""] },
+            _ => new ListGroupsOptions { ProtocolTypes = [null!] }
+        };
+        await Assert.That(async () => await admin.ListGroupsAsync(options)).Throws<ArgumentException>();
+        foreach (var connection in connections.Values)
+            await connection.DidNotReceiveWithAnyArgs().SendAsync<ListGroupsRequest, ListGroupsResponse>(default!, default, default);
+    }
+
+    [Test]
+    public async Task BrokerFailure_DoesNotReturnPartialInventory()
+    {
+        var (admin, connections) = CreateAdmin();
+        await using var adminDisposal = admin;
+        Respond(connections[1], [Group("valid", "Consumer", "consumer")]);
+        connections[2].SendAsync<ListGroupsRequest, ListGroupsResponse>(Arg.Any<ListGroupsRequest>(),
+                Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<ListGroupsResponse>(new ListGroupsResponse
+            {
+                Groups = [], ErrorCode = ErrorCode.ClusterAuthorizationFailed
+            }));
+        var error = await Assert.That(async () => await admin.ListGroupsAsync()).Throws<KafkaException>();
+        await Assert.That(error!.ErrorCode).IsEqualTo(ErrorCode.ClusterAuthorizationFailed);
+    }
+
+    [Test]
+    public async Task CallerCancellation_ReachesEveryBroker()
+    {
+        var (admin, connections) = CreateAdmin();
+        await using var adminDisposal = admin;
+        using var cancellation = new CancellationTokenSource();
+        foreach (var connection in connections.Values)
+        {
+            connection.SendAsync<ListGroupsRequest, ListGroupsResponse>(Arg.Any<ListGroupsRequest>(),
+                    Arg.Any<short>(), Arg.Any<CancellationToken>())
+                .Returns(call => new ValueTask<ListGroupsResponse>(WaitForCancellationAsync(call.ArgAt<CancellationToken>(2))));
+        }
+        var operation = admin.ListGroupsAsync(cancellationToken: cancellation.Token);
+        cancellation.Cancel();
+        await Assert.That(async () => await operation).Throws<OperationCanceledException>();
+
+        static async Task<ListGroupsResponse> WaitForCancellationAsync(CancellationToken token)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            throw new InvalidOperationException("Cancellation did not throw.");
+        }
+    }
+
+    private static void Respond(IKafkaConnection connection, IReadOnlyList<ListGroupsResponseGroup> groups) =>
+        connection.SendAsync<ListGroupsRequest, ListGroupsResponse>(Arg.Any<ListGroupsRequest>(),
+                Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<ListGroupsResponse>(new ListGroupsResponse { Groups = groups }));
+
+    private static (AdminClient Admin, Dictionary<int, IKafkaConnection> Connections) CreateAdmin(short version = 5, short? secondVersion = null)
+    {
+        var connections = new Dictionary<int, IKafkaConnection>();
+        var destinations = new Dictionary<int, IKafkaConnection>();
+        for (var id = 1; id <= 2; id++)
+        {
+            var connection = Substitute.For<IKafkaConnection>();
+            connection.BrokerId.Returns(id);
+            connection.Host.Returns("localhost");
+            connection.Port.Returns(9091 + id);
+            connection.IsConnected.Returns(true);
+            Respond(connection, []);
+            connections.Add(id, connection);
+            destinations.Add(id, secondVersion.HasValue
+                ? new CapabilityConnection(connection, id == 2 ? secondVersion.Value : version)
+                : connection);
+        }
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(call => new ValueTask<IKafkaConnection>(destinations[call.ArgAt<int>(0)]));
+        pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(destinations[1]));
+        var metadata = new MetadataManager(pool, ["localhost:9092"]);
+        metadata.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 },
+                new BrokerMetadata { NodeId = 2, Host = "localhost", Port = 9093 }
+            ],
+            ClusterId = "listing-test", ControllerId = 1, Topics = []
+        });
+        metadata.SetApiVersion(ApiKey.ListGroups, version, version);
+        return (new AdminClient(new AdminClientOptions { BootstrapServers = ["localhost:9092"] }, pool, metadata), connections);
+    }
+
+    private sealed class CapabilityConnection(IKafkaConnection inner, short version) : IKafkaConnection, IKafkaCapabilityProvider
+    {
+        public int BrokerId => inner.BrokerId;
+        public string Host => inner.Host;
+        public int Port => inner.Port;
+        public bool IsConnected => true;
+        public KafkaConnectionCapabilities Capabilities { get; } = KafkaConnectionCapabilities.Create(new ApiVersionsResponse
+        {
+            ErrorCode = ErrorCode.None, ApiKeys = [new ApiVersion(ApiKey.ListGroups, 3, version)]
+        });
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse =>
+            inner.SendAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => default;
+        public ValueTask DisposeAsync() => default;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientStreamsGroupTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientStreamsGroupTests.cs
@@ -47,7 +47,7 @@ public sealed class AdminClientStreamsGroupTests
             States = ["Stable"]
         });
 
-        await Assert.That(result.Select(g => g.GroupId)).IsEquivalentTo(["streams-a", "streams-b"]);
+        await Assert.That(result.Select(g => g.GroupId)).IsEquivalentTo(["streams-a"]);
         await connections[1].Received(1).SendAsync<ListGroupsRequest, ListGroupsResponse>(
             Arg.Is<ListGroupsRequest>(r =>
                 r != null && r.StatesFilter!.Count == 1 &&

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryGroupListingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryGroupListingTests.cs
@@ -1,0 +1,70 @@
+using Dekaf.Admin;
+using Dekaf.Testing;
+
+namespace Dekaf.Tests.Unit.Testing;
+
+public sealed class InMemoryGroupListingTests
+{
+    [Test]
+    public async Task InventoryAndConveniences_PreserveGroupFamiliesAndEmptyHistory()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("input");
+        await using var concrete = new InMemoryAdminClient(cluster);
+        IAdminClient admin = concrete;
+        await admin.AlterConsumerGroupOffsetsAsync("simple", [new TopicPartitionOffset("input", 0, 0)]);
+        cluster.RegisterConsumerGroupMember("consumer", "member", [new TopicPartition("input", 0)], out var registration);
+        cluster.RegisterShareGroupMember("share", "member");
+        await admin.AlterStreamsGroupOffsetsAsync("streams", [new TopicPartitionOffset("input", 0, 0)]);
+
+        var inventory = await admin.ListGroupsAsync();
+        await Assert.That(inventory.Select(static group => (group.GroupId, group.GroupType, group.ProtocolType)))
+            .IsEquivalentTo(new (string, string?, string?)[]
+            {
+                ("simple", "classic", ""), ("consumer", "consumer", "consumer"),
+                ("share", "share", "share"), ("streams", "streams", "streams")
+            });
+        await Assert.That((await admin.ListConsumerGroupsAsync()).Select(static group => group.GroupId))
+            .IsEquivalentTo(["simple", "consumer"]);
+        await Assert.That((await admin.ListShareGroupsAsync()).Select(static group => group.GroupId)).IsEquivalentTo(["share"]);
+        await Assert.That((await admin.ListStreamsGroupsAsync()).Select(static group => group.GroupId)).IsEquivalentTo(["streams"]);
+
+        cluster.UnregisterConsumerGroupMember("consumer", "member", registration);
+        await admin.DeleteStreamsGroupOffsetsAsync("streams", [new TopicPartition("input", 0)]);
+        var empty = await admin.ListGroupsAsync(new ListGroupsOptions
+        {
+            States = ["empty"], Types = ["consumer", "streams"], ProtocolTypes = ["consumer", "streams"]
+        });
+        await Assert.That(empty.Select(static group => group.GroupId)).IsEquivalentTo(["consumer", "streams"]);
+        // Earlier results remain snapshots after membership changes.
+        await Assert.That(inventory.Single(static group => group.GroupId == "consumer").State).IsEqualTo("Stable");
+        await admin.DeleteStreamsGroupsAsync(["streams"]);
+        await admin.DeleteConsumerGroupsAsync(["consumer"]);
+        await Assert.That((await admin.ListGroupsAsync()).Select(static group => group.GroupId)).IsEquivalentTo(["simple", "share"]);
+    }
+
+    [Test]
+    public async Task ProtocolFilter_DistinguishesEmptyAndExactCase()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("input");
+        await using var admin = new InMemoryAdminClient(cluster);
+        await admin.AlterConsumerGroupOffsetsAsync("simple", [new TopicPartitionOffset("input", 0, 0)]);
+        cluster.RegisterConsumerGroupMember("consumer", "member", [], out _);
+        await Assert.That((await admin.ListGroupsAsync(new ListGroupsOptions { ProtocolTypes = [""] }))
+            .Select(static group => group.GroupId)).IsEquivalentTo(["simple"]);
+        await Assert.That(await admin.ListGroupsAsync(new ListGroupsOptions { ProtocolTypes = ["Consumer"] })).IsEmpty();
+    }
+
+    [Test]
+    public async Task CancellationAndDisposal_AreHonored()
+    {
+        var admin = new InMemoryAdminClient(new InMemoryKafkaCluster());
+        using var canceled = new CancellationTokenSource();
+        canceled.Cancel();
+        await Assert.That(async () => await admin.ListGroupsAsync(cancellationToken: canceled.Token))
+            .Throws<OperationCanceledException>();
+        await admin.DisposeAsync();
+        await Assert.That(async () => await admin.ListGroupsAsync()).Throws<ObjectDisposedException>();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -157,11 +157,9 @@ public sealed class InMemoryKafkaClusterTests
         cluster.CreateTopic("input");
         IAdminClient admin = new InMemoryAdminClient(cluster);
         const string groupId = "empty-streams";
-        await using var consumer = new InMemoryConsumer<string, string>(
-            cluster,
-            new InMemoryConsumerOptions { GroupId = groupId });
-        consumer.Subscribe("input");
-        consumer.Unsubscribe();
+        var partition = new TopicPartition("input", 0);
+        await admin.AlterStreamsGroupOffsetsAsync(groupId, [new TopicPartitionOffset("input", 0, 0)]);
+        await admin.DeleteStreamsGroupOffsetsAsync(groupId, [partition]);
 
         var groupsBeforeDeletion = await admin.ListStreamsGroupsAsync();
         var deletedGroups = await admin.DeleteStreamsGroupsAsync([groupId]);


### PR DESCRIPTION
Unified group inventory now preserves the broker's group type separately from its protocol. `ListConsumerGroupsAsync` previously returned non-consumer groups; it now includes modern/classic consumers and simple offset-only groups while excluding Connect, Share, Streams, and unknown future types. Existing Share and Streams convenience methods use the same broker aggregation and filtering.

The additive `IGroupListingAdminClient` capability and `IAdminClient` extension preserve third-party implementations. Filters combine with AND, values within a filter with OR; state/type matching ignores case and protocol matching is ordinal. Unknown types remain verbatim in unified results. Requested state/type filters reject unsupported versions on each actual destination connection. Broker queries run concurrently, failures do not return partial inventories, and filtering precedes case-sensitive ID deduplication. The in-memory implementation tracks the supported group families and empty Streams history. Public API baselines and the documentation explain the intentional consumer-only correction and older-version behavior.

Closes #3027

Validation:

- Red test reproduced the consumer-listing bug against the unchanged product: expected 3 consumer groups, received all 7 mixed groups.
- 820 Admin/Testing TUnit tests passed on .NET 10; 820 passed on .NET 8 using the netstandard2.0 core asset. Builds completed with zero warnings/errors.
- Kafka 4.3.1 integration creates real modern Consumer, simple offset-only Classic, Share, Streams, and Classic/Connect groups. It verifies raw types/protocols, combined filters, and all three convenience listings. Passed again after the final changes. The test-only Classic join/leave codecs follow Apache's message schemas; no legacy coordination API was added to the library.
- Deterministic unit coverage includes mixed broker versions, unknown types, exact protocol matching, empty protocol versus unavailable protocol, combined filters, stale duplicates, concurrent broker queries, cancellation, authorization failure, optional-capability compatibility, and fake lifecycle snapshots.
- `/simplify` reviewed the final implementation for shared behavior, allocation costs, and disposal/cancellation. `git diff --check` passed.
- Documentation: `npm ci --prefix docs` and `npm run build --prefix docs`.

Performance evidence is scoped to administrative listing after response decoding. No produce/consume/serialization path changed. These are allocations per inventory query, not per Kafka message. No paid stress run was dispatched; network throughput, request p99, CPU/message, and long-duration stability were not measured and are not claimed by these microbenchmarks.

Candidate commit: `4483096bc7596717cee5a73f14b5cc90e0a6f4c8`. Baseline product SHA: `b06620e46dc4cf5551c098c4d5c1fa1024d214ca`. One cached mock broker returns 10 or 1,000 prebuilt matching groups. The fixture calls the full existing Consumer and Share admin listing APIs, including initialization checks, retry wrapper, version negotiation, aggregation, mapping, and deduplication. Setup creates responses once; the handwritten connection does not record invocations or allocate response objects. `--validate` checks all four result counts before measurement; a BDN Dry run checked execution. The identical harness executable loads explicitly copied saved product DLLs. Runs were serial, with no overlapping builds/tests from this agent.

BenchmarkDotNet 0.15.8, .NET 10.0.11, SDK 10.0.400, Windows 11, Intel i7-12700K; InProcessEmitToolchain, 5 warmups, 15 measurement iterations. Reports below retain uncertainty and allocation columns. Baseline was measured before development candidates and again as a control. The first candidate was rejected for larger-inventory time/allocation regressions. Pre-sizing result/deduplication buffers reduced allocation; direct string comparison and ordering the common modern consumer type first then removed the remaining filter cost. The netstandard2.0 asset retains its existing HashSet growth because that target lacks the capacity constructor; it still pre-sizes the result list. .NET 8 performance was not measured.

Final candidate versus the first / later baseline:

| Case | Final mean | Mean delta vs first / later baseline | Allocation, baseline to final | Allocation delta |
| --- | ---: | ---: | ---: | ---: |
| Consumer, 10 groups | 288.4 ns | -32.05% / -36.92% | 1,752 to 1,328 B | -24.20% |
| Share, 10 groups | 292.1 ns | -26.50% / -37.01% | 2,120 to 1,328 B | -37.36% |
| Consumer, 1,000 groups | 19.7523 us | -4.57% / -5.80% | 130,016 to 78,608 B | -39.54% |
| Share, 1,000 groups | 18.6975 us | -18.66% / -20.40% | 130,384 to 78,608 B | -39.71% |

Against the immediately preceding pre-sized candidate, final means change by -8.12%, -12.07%, -9.89%, and -0.08% in the table order; each query also removes 64 B. Against the baseline, reciprocal query-rate estimates improve by 47.16%, 36.04%, 4.79%, and 22.94%, respectively; these describe synchronous mock queries, not Kafka message throughput.

The 1,000-group Consumer timing intervals overlap, so its speedup is not treated as established. The allocation reduction is deterministic; the final run does not show a material regression against either baseline or the preceding candidate. BDN median/max values below describe iteration-average operation costs, not end-to-end Kafka latency percentiles. No control result is averaged into a pass.

Saved Dekaf.dll SHA-256:

- Baseline: `7E9701D795AC446049A74C75F0424E0E6EF9F32A8CFAF2BA2E91E5A009A3E08A`
- First candidate: `421D334D8ED2B1CBD8D3FD1ADB113073A235F2E05F0494CB182DA1ECE55C23F4`
- Pre-sized candidate: `A147ED30B3A8AF63538C536B9E237E71A2059D9CC663CBBCFE6299878D0E5335`
- Final measured candidate: `A03DA943ACBA1CF4ABE8DE35E70A0B74813D946A8259AC6BB61818303E52F5D9`
- Final build after adding the netstandard2.0 constructor guard: `F24A94BBFFA6661F985FE5A8FDE7678207C324327EAB2201496669E334E61010`. All 15,643 compiled .NET 10 method IL bodies are identical to the final measured DLL; the guard changes only the compatibility target.
- Unchanged Dekaf.Abstractions.dll: `DC866B673029D1C8639C27641903D0476A6BCCABAA5AAF2A0CF41CA7836CEAD8`

<details><summary>Full report: baseline</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Toolchain=InProcessEmitToolchain  IterationCount=15  WarmupCount=5  

```
| Method   | Groups | Mean        | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|--------- |------- |------------:|----------:|----------:|-------:|-------:|----------:|
| **Consumer** | **10**     |    **424.4 ns** |  **13.74 ns** |  **12.85 ns** | **0.1340** | **0.0005** |   **1.71 KB** |
| Share    | 10     |    397.4 ns |  12.57 ns |  10.49 ns | 0.1621 | 0.0005 |   2.07 KB |
| **Consumer** | **1000**   | **20,697.5 ns** | **855.61 ns** | **800.34 ns** | **9.9487** | **2.4719** | **126.97 KB** |
| Share    | 1000   | 22,987.5 ns | 850.95 ns | 754.35 ns | 9.9487 | 2.1973 | 127.33 KB |

Iteration statistics, ordered Consumer 10, Share 10, Consumer 1000, Share 1000:
```text
Min = 406.998 ns, Q1 = 414.047 ns, Median = 424.607 ns, Q3 = 431.086 ns, Max = 451.256 ns
Min = 388.124 ns, Q1 = 390.287 ns, Median = 392.699 ns, Q3 = 401.812 ns, Max = 424.337 ns
Min = 19.683 us, Q1 = 20.201 us, Median = 20.418 us, Q3 = 21.269 us, Max = 22.535 us
Min = 22.160 us, Q1 = 22.495 us, Median = 22.706 us, Q3 = 23.209 us, Max = 24.641 us
``` 
</details>

<details><summary>Full report: candidate</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Toolchain=InProcessEmitToolchain  IterationCount=15  WarmupCount=5  

```
| Method   | Groups | Mean        | Error     | StdDev    | Gen0    | Gen1   | Allocated |
|--------- |------- |------------:|----------:|----------:|--------:|-------:|----------:|
| **Consumer** | **10**     |    **395.4 ns** |   **7.86 ns** |   **6.57 ns** |  **0.1483** | **0.0005** |    **1.9 KB** |
| Share    | 10     |    383.6 ns |   7.55 ns |   6.31 ns |  0.1483 | 0.0005 |    1.9 KB |
| **Consumer** | **1000**   | **24,746.2 ns** | **851.95 ns** | **796.91 ns** | **10.5591** | **2.3193** | **134.89 KB** |
| Share    | 1000   | 21,848.4 ns | 449.11 ns | 398.13 ns | 10.5591 | 2.3193 | 134.89 KB |

Iteration statistics, ordered Consumer 10, Share 10, Consumer 1000, Share 1000:
```text
Min = 390.012 ns, Q1 = 391.300 ns, Median = 392.586 ns, Q3 = 393.203 ns, Max = 408.607 ns
Min = 375.902 ns, Q1 = 378.523 ns, Median = 382.439 ns, Q3 = 387.672 ns, Max = 396.554 ns
Min = 23.325 us, Q1 = 24.284 us, Median = 24.774 us, Q3 = 25.374 us, Max = 25.976 us
Min = 21.418 us, Q1 = 21.581 us, Median = 21.715 us, Q3 = 21.982 us, Max = 22.816 us
``` 
</details>

<details><summary>Full report: candidate2</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Toolchain=InProcessEmitToolchain  IterationCount=15  WarmupCount=5  

```
| Method   | Groups | Mean        | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|--------- |------- |------------:|----------:|----------:|-------:|-------:|----------:|
| **Consumer** | **10**     |    **313.9 ns** |  **11.95 ns** |  **11.18 ns** | **0.1063** |      **-** |   **1.36 KB** |
| Share    | 10     |    332.2 ns |  33.07 ns |  30.93 ns | 0.1063 |      - |   1.36 KB |
| **Consumer** | **1000**   | **21,920.6 ns** | **945.06 ns** | **837.77 ns** | **6.0120** | **1.4954** |  **76.83 KB** |
| Share    | 1000   | 18,712.6 ns | 648.13 ns | 574.55 ns | 6.0120 | 1.4954 |  76.83 KB |

Iteration statistics, ordered Consumer 10, Share 10, Consumer 1000, Share 1000:
```text
Min = 303.676 ns, Q1 = 304.772 ns, Median = 306.221 ns, Q3 = 323.740 ns, Max = 336.179 ns
Min = 286.067 ns, Q1 = 312.791 ns, Median = 322.927 ns, Q3 = 346.501 ns, Max = 396.345 ns
Min = 20.504 us, Q1 = 21.287 us, Median = 22.048 us, Q3 = 22.320 us, Max = 23.285 us
Min = 17.641 us, Q1 = 18.404 us, Median = 18.653 us, Q3 = 18.937 us, Max = 20.038 us
``` 
</details>

<details><summary>Full report: baseline-after</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Toolchain=InProcessEmitToolchain  IterationCount=15  WarmupCount=5  

```
| Method   | Groups | Mean        | Error       | StdDev      | Gen0   | Gen1   | Allocated |
|--------- |------- |------------:|------------:|------------:|-------:|-------:|----------:|
| **Consumer** | **10**     |    **457.2 ns** |    **32.32 ns** |    **30.23 ns** | **0.1335** |      **-** |   **1.71 KB** |
| Share    | 10     |    463.7 ns |    78.52 ns |    73.45 ns | 0.1621 |      - |   2.07 KB |
| **Consumer** | **1000**   | **20,967.9 ns** |   **900.45 ns** |   **703.01 ns** | **9.9487** | **2.4719** | **126.97 KB** |
| Share    | 1000   | 23,490.0 ns | 2,465.22 ns | 2,185.35 ns | 9.9487 | 2.1973 | 127.33 KB |

Iteration statistics, ordered Consumer 10, Share 10, Consumer 1000, Share 1000:
```text
Min = 413.086 ns, Q1 = 434.480 ns, Median = 461.234 ns, Q3 = 473.314 ns, Max = 508.934 ns
Min = 392.852 ns, Q1 = 397.155 ns, Median = 439.949 ns, Q3 = 521.355 ns, Max = 585.277 ns
Min = 20.246 us, Q1 = 20.491 us, Median = 20.804 us, Q3 = 21.101 us, Max = 22.410 us
Min = 21.602 us, Q1 = 21.965 us, Median = 22.642 us, Q3 = 24.213 us, Max = 29.045 us
``` 
</details>

<details><summary>Full report: candidate3</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Toolchain=InProcessEmitToolchain  IterationCount=15  WarmupCount=5  

```
| Method   | Groups | Mean        | Error       | StdDev      | Gen0   | Gen1   | Allocated |
|--------- |------- |------------:|------------:|------------:|-------:|-------:|----------:|
| **Consumer** | **10**     |    **288.4 ns** |    **11.35 ns** |    **10.06 ns** | **0.1016** |      **-** |    **1.3 KB** |
| Share    | 10     |    292.1 ns |    14.63 ns |    13.69 ns | 0.1016 |      - |    1.3 KB |
| **Consumer** | **1000**   | **19,752.3 ns** | **1,532.72 ns** | **1,358.72 ns** | **6.0120** | **1.0986** |  **76.77 KB** |
| Share    | 1000   | 18,697.5 ns |   940.41 ns |   785.29 ns | 6.0120 | 1.0986 |  76.77 KB |

Iteration statistics, ordered Consumer 10, Share 10, Consumer 1000, Share 1000:
```text
Min = 280.546 ns, Q1 = 282.323 ns, Median = 283.552 ns, Q3 = 293.861 ns, Max = 312.750 ns
Min = 278.208 ns, Q1 = 280.323 ns, Median = 286.000 ns, Q3 = 303.084 ns, Max = 316.808 ns
Min = 17.914 us, Q1 = 18.860 us, Median = 19.337 us, Q3 = 20.286 us, Max = 22.467 us
Min = 17.549 us, Q1 = 18.209 us, Median = 18.704 us, Q3 = 19.095 us, Max = 20.015 us
``` 
</details>

<details><summary>Reproducible temporary benchmark fixture</summary>


Directory.Build.props
```
<Project>
  <PropertyGroup><TargetFramework>net10.0</TargetFramework><OutputType>Exe</OutputType><ImplicitUsings>enable</ImplicitUsings><Nullable>enable</Nullable><AssemblyName>Dekaf.Benchmarks</AssemblyName><ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally></PropertyGroup>
</Project>

```

Directory.Build.targets
```
<Project />

```

Directory.Packages.props
```
<Project><PropertyGroup><ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally></PropertyGroup></Project>

```

ListingBench.csproj
```
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup><ProductPath Condition="'$(ProductPath)' == ''">../baseline</ProductPath></PropertyGroup>
  <ItemGroup>
    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
    <FrameworkReference Include="Microsoft.AspNetCore.App" />
    <Reference Include="Dekaf"><HintPath>$(ProductPath)/Dekaf.dll</HintPath></Reference>
    <Reference Include="Dekaf.Abstractions"><HintPath>$(ProductPath)/Dekaf.Abstractions.dll</HintPath></Reference>
  </ItemGroup>
</Project>

```

Program.cs
```
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using Dekaf.Admin;
using Dekaf.Metadata;
using Dekaf.Networking;
using Dekaf.Protocol;
using Dekaf.Protocol.Messages;

if (args.Contains("--validate"))
{
    foreach (var count in new[] { 10, 1000 })
    {
        var benchmark = new ListingBenchmarks { Groups = count };
        benchmark.Setup();
        if ((await benchmark.Consumer()).Count != count || (await benchmark.Share()).Count != count)
            throw new Exception("Wrong listing count");
        benchmark.Cleanup();
    }
    Console.WriteLine("Validated 10/1000 groups, Consumer and Share listings.");
    return;
}
BenchmarkSwitcher.FromAssembly(typeof(ListingBenchmarks).Assembly).Run(args);

[MemoryDiagnoser]
public class ListingBenchmarks
{
    [Params(10, 1000)] public int Groups { get; set; }
    private AdminClient _consumer = null!;
    private AdminClient _share = null!;
    [GlobalSetup] public void Setup()
    {
        _consumer = Create("consumer", "consumer");
        _share = Create("share", "share");
    }
    private AdminClient Create(string type, string protocol)
    {
        var response = new ListGroupsResponse
        {
            Groups = Enumerable.Range(0, Groups).Select(i => new ListGroupsResponseGroup
            {
                GroupId = $"group-{i}", GroupType = type, ProtocolType = protocol, GroupState = "Stable"
            }).ToArray()
        };
        var pool = new Pool(new Connection(response));
        var metadata = new MetadataManager(pool, ["localhost:9092"]);
        metadata.Metadata.Update(new MetadataResponse
        {
            Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
            ClusterId = "listing-bench", ControllerId = 1, Topics = []
        });
        metadata.SetApiVersion(ApiKey.ListGroups, 5, 5);
        return new AdminClient(new AdminClientOptions { BootstrapServers = ["localhost:9092"] }, pool, metadata);
    }
    [Benchmark] public ValueTask<IReadOnlyList<GroupListing>> Consumer() => _consumer.ListConsumerGroupsAsync();
    [Benchmark] public ValueTask<IReadOnlyList<GroupListing>> Share() => _share.ListShareGroupsAsync();
    [GlobalCleanup] public void Cleanup()
    {
        _consumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
        _share.DisposeAsync().AsTask().GetAwaiter().GetResult();
    }
}

internal sealed class Pool(IKafkaConnection connection) : IConnectionPool
{
    public ValueTask<IKafkaConnection> GetConnectionAsync(int brokerId, CancellationToken cancellationToken = default) => new(connection);
    public ValueTask<IKafkaConnection> GetConnectionAsync(string host, int port, CancellationToken cancellationToken = default) => new(connection);
    public ValueTask<IKafkaConnection> GetConnectionByIndexAsync(int brokerId, int index, CancellationToken cancellationToken = default) => new(connection);
    public void RegisterBroker(int brokerId, string host, int port) { }
    public ValueTask<int> ScaleConnectionGroupAsync(int brokerId, int newCount, CancellationToken cancellationToken = default) => new(1);
    public ValueTask<IKafkaConnection?> ShrinkConnectionGroupAsync(int brokerId, int newCount, CancellationToken cancellationToken = default) => new((IKafkaConnection?)null);
    public ValueTask RemoveConnectionAsync(int brokerId) => default;
    public ValueTask CloseAllAsync() => default;
    public ValueTask DisposeAsync() => default;
}

internal sealed class Connection(ListGroupsResponse response) : IKafkaConnection
{
    public int BrokerId => 1;
    public string Host => "localhost";
    public int Port => 9092;
    public bool IsConnected => true;
    public ValueTask<TResponse> SendAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
        where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse
    {
        if (request is not ListGroupsRequest || apiVersion != 5) throw new InvalidOperationException("Unexpected request");
        return new((TResponse)(IKafkaResponse)response);
    }
    public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
        where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
    public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
        where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
    public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
        where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
    public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
        where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
    public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => default;
    public ValueTask DisposeAsync() => default;
}

```

Place the fixture outside the product projects, with saved baseline assemblies in `../baseline`. Build once in Release. For each run, explicitly copy the desired `Dekaf.dll` and identical `Dekaf.Abstractions.dll` into the executable directory, verify SHA-256, run `--validate`, then:

```powershell
dotnet bin/Release/net10.0/Dekaf.Benchmarks.dll --filter '*' --inProcess --warmupCount 5 --iterationCount 15 --artifacts <unique-result-directory>
```
</details>

