### PR TITLE
test(producer): establish scaling backlog deterministically

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1604,40 +1604,79 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
     }
 
     [Test]
+    [Arguments(true)]
+    [Arguments(false)]
     [Timeout(120_000)]
-    public async Task SendLoopPressure_ScalesConnections_WhenCoalescingBacklogPersists(CancellationToken cancellationToken)
+    public async Task SendLoopPressure_ScalesConnections_WhenCoalescingBacklogPersists(
+        bool enableAdaptiveConnections, CancellationToken cancellationToken)
     {
         const int partitionCount = 8;
         const int batchCount = 512;
 
-        var options = CreateOptions(maxInFlight: 1);
+        var options = CreateOptions(maxInFlight: 1,
+            enableAdaptiveConnections: enableAdaptiveConnections, scaleCooldownMsOverride: 0);
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var firstWriteStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstWrite = new TaskCompletionSource<Task<ProduceResponse>>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var allAcknowledged = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var connection = new TestKafkaConnection();
         var sendCount = 0;
+        var acknowledgedCount = 0;
         connection.SendProducePipelinedAfterWrite = () =>
         {
-            Interlocked.Increment(ref sendCount);
+            if (Interlocked.Increment(ref sendCount) == 1)
+            {
+                firstWriteStarted.TrySetResult();
+                return new ValueTask<Task<ProduceResponse>>(releaseFirstWrite.Task);
+            }
+
             return new ValueTask<Task<ProduceResponse>>(
                 Task.FromResult(CreateSuccessResponseForPartitions("test-topic", partitionCount)));
         };
 
         var (pool, scaleRequested) = CreateScaleTrackingPool(connection);
-
-        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, count, error) =>
+        {
+            if (error is not null)
+                allAcknowledged.TrySetException(error);
+            else if (Interlocked.Add(ref acknowledgedCount, count) == batchCount)
+                allAcknowledged.TrySetResult();
+        });
 
         try
         {
-            for (var i = 0; i < batchCount; i++)
+            sender.Enqueue(CreateTestBatch(vtPool, "test-topic", partition: 0));
+            await firstWriteStarted.Task.WaitAsync(cancellationToken);
+
+            // Hold the first write until the entire backlog is queued. With maxInFlight=1,
+            // coalescing consumes at most four batches per pass, so 511 queued batches
+            // sustain more than the 100 pressure observations required for scaling.
+            for (var i = 1; i < batchCount; i++)
                 sender.Enqueue(CreateTestBatch(vtPool, "test-topic", i % partitionCount));
 
-            var targetCount = await scaleRequested.Task.WaitAsync(cancellationToken);
+            await Assert.That(Volatile.Read(ref sendCount)).IsEqualTo(1);
+            await Assert.That(scaleRequested.Task.IsCompleted).IsFalse();
+            releaseFirstWrite.SetResult(Task.FromResult(
+                CreateSuccessResponseForPartitions("test-topic", partitionCount)));
 
-            await Assert.That(targetCount).IsGreaterThan(1);
-            await Assert.That(Volatile.Read(ref sendCount)).IsGreaterThan(0);
+            await allAcknowledged.Task.WaitAsync(cancellationToken);
+            await Assert.That(Volatile.Read(ref acknowledgedCount)).IsEqualTo(batchCount);
+            if (enableAdaptiveConnections)
+            {
+                var targetCount = await scaleRequested.Task.WaitAsync(cancellationToken);
+                await Assert.That(targetCount).IsGreaterThan(1);
+            }
+            else
+            {
+                await Assert.That(scaleRequested.Task.IsCompleted).IsFalse();
+            }
         }
         finally
         {
+            releaseFirstWrite.TrySetResult(Task.FromResult(
+                CreateSuccessResponseForPartitions("test-topic", partitionCount)));
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await vtPool.DisposeAsync();


### PR DESCRIPTION
The scaling test could drain batches as they were enqueued, so its synchronous connection did not guarantee enough sustained backlog to trigger scaling. It now holds the first write, queues the remaining 511 batches, verifies no additional send or scaling occurred, and releases the write. At four batches per coalescing pass, the queued backlog exceeds the 100 pressure observations required for scaling.

The same scenario also runs with adaptive connections disabled. Both cases verify all 512 acknowledgements; enabled scaling retains the target-width assertion, while disabled scaling must not request a new connection. The existing cooldown override removes unrelated clock dependence. Timeout remains 120 seconds. Cleanup always releases the blocked write.

Validation:
- net10.0: all 1,292 Producer namespace tests passed.
- net8.0: both changed cases passed; 1,290 Producer cases passed and two existing throttle-clock cases failed. Investigation found zero-based fake clocks mixed with real batch timestamps above int.MaxValue milliseconds; tracked in #3093. The failed run was not rerun unchanged.
- Both changed cases passed under the same detailed runtime allocation-event provider used when the original timeout occurred (`Microsoft-Windows-DotNETRuntime:0x3200001:5`). This is diagnostic validation, not benchmark evidence.
- Final /simplify and git diff --check completed. This repairs an existing flaky test based on its captured failure and source-level race; no speculative red rerun was used. Product source is unchanged, so no integration or performance run applies.

Closes #3091
