### PR TITLE
test(producer): align throttle clocks with batch timestamps

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -3922,7 +3922,8 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
         var throttleWaitStarted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseThrottleWait = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var timestamp = 0L;
+        // Batch creation uses Stopwatch timestamps; keep the fake clock in that domain.
+        var timestamp = Stopwatch.GetTimestamp();
         var acknowledgements = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var acknowledgementCount = 0;
         var sender = CreateSender(
@@ -3963,7 +3964,7 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             await Assert.That(await throttleWaitStarted.Task).IsEqualTo(throttleTimeMs);
             await Assert.That(sendSignals[2].Task.IsCompleted).IsFalse();
 
-            Volatile.Write(ref timestamp, Stopwatch.Frequency);
+            Interlocked.Add(ref timestamp, Stopwatch.Frequency);
             releaseThrottleWait.SetResult();
 
             await sendSignals[2].Task.WaitAsync(cancellationToken);
@@ -4003,7 +4004,8 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         var throttleWaitStarted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseThrottleWait = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var observedThrottleTimes = new List<int>();
-        var timestamp = 0L;
+        // Batch creation uses Stopwatch timestamps; keep the fake clock in that domain.
+        var timestamp = Stopwatch.GetTimestamp();
         var acknowledgements = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var acknowledgementCount = 0;
 
@@ -4037,7 +4039,7 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             await Assert.That(requestedDelayMs).IsEqualTo(throttleTimeMs);
             await Assert.That(sendSignals[1].Task.IsCompleted).IsFalse();
 
-            Volatile.Write(ref timestamp, Stopwatch.Frequency);
+            Interlocked.Add(ref timestamp, Stopwatch.Frequency);
             releaseThrottleWait.SetResult();
 
             await sendSignals[1].Task.WaitAsync(cancellationToken);


### PR DESCRIPTION
Two broker-throttle tests mixed an injected timestamp of zero with batches created using the real Stopwatch clock. On hosts whose counter exceeds int.MaxValue milliseconds, deadline conversion produced a 1 ms wait on net8.0 instead of the expected 250 ms. net10.0 happened to hide the fixture defect by saturating the out-of-range conversion.

Both fixtures now start their fake clock at Stopwatch.GetTimestamp() and advance one second relative to that origin. The exact 250 ms assertion, blocked-send assertion, delivery checks, and existing timeout remain intact.

Validation:
- Both tests failed in the preceding net8.0 producer run with `Expected to be 250 but found 1`; both pass after this correction.
- An isolated probe using the exact deadline conversion measured zero-origin delays above 2,243,273,147 ms: net8.0 returned 1 ms; net10.0 returned int.MaxValue. Using the batch timestamp as origin yielded a 30,000 ms deadline and 250 ms throttle wait on both runtimes. This establishes the clock-domain cause rather than relying on an unchanged rerun.
- All 1,291 Producer namespace cases passed on each of net8.0 and net10.0 (2,582 total).
- Final /simplify review and git diff --check completed. Product source is unchanged; no integration or performance measurement applies.

Closes #3093

