### PR TITLE
test(schema-registry): add finite-TTL cache comparison fixture

### DIFF
--- a/scripts/Compare-SchemaResolutionFiniteTtl.ps1
+++ b/scripts/Compare-SchemaResolutionFiniteTtl.ps1
@@ -1,0 +1,102 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$BeforeDll,
+    [Parameter(Mandatory)][string]$AfterDll,
+    [string]$Filter = '*SchemaResolutionFiniteTtl*',
+    [long]$Affinity = 4,
+    [switch]$Dry
+)
+$ErrorActionPreference = 'Stop'
+$repo = Split-Path $PSScriptRoot -Parent
+$before = (Resolve-Path -LiteralPath $BeforeDll).Path
+$after = (Resolve-Path -LiteralPath $AfterDll).Path
+$fixture = Join-Path $repo 'tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaResolutionFiniteTtlBenchmarks.cs'
+$output = Join-Path $repo ('.artifacts/finite-ttl-' + [guid]::NewGuid().ToString('N'))
+$harness = Join-Path $output 'harness'
+New-Item -ItemType Directory -Path $harness -Force | Out-Null
+
+# The nested solution bounds BDN project discovery. Preserve the friend assembly name.
+$project = @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <BaselineDll Condition="'$(BaselineDll)' == ''">AFTER_DLL</BaselineDll>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <Reference Include="Dekaf.SchemaRegistry"><HintPath>$(BaselineDll)</HintPath></Reference>
+    <Reference Include="Dekaf"><HintPath>CORE_DLL</HintPath></Reference>
+    <Compile Include="Program.cs" />
+    <Compile Include="FIXTURE_PATH" />
+  </ItemGroup>
+</Project>
+'@
+$project.Replace('AFTER_DLL', [System.Security.SecurityElement]::Escape($after)).
+    Replace('CORE_DLL', [System.Security.SecurityElement]::Escape((Join-Path (Split-Path $after -Parent) 'Dekaf.dll'))).
+    Replace('FIXTURE_PATH', [System.Security.SecurityElement]::Escape($fixture)) |
+    Set-Content (Join-Path $harness 'Dekaf.Benchmarks.csproj')
+
+@'
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using Perfolizer.Mathematics.OutlierDetection;
+
+var dry = args.Contains("--dry");
+var arguments = args.Where(value => value != "--dry").ToArray();
+var before = Environment.GetEnvironmentVariable("DEKAF_TTL_BEFORE_DLL")!;
+var after = Environment.GetEnvironmentVariable("DEKAF_TTL_AFTER_DLL")!;
+var affinity = long.Parse(Environment.GetEnvironmentVariable("DEKAF_TTL_AFFINITY")!);
+var common = (dry ? Job.Dry : Job.Default.WithWarmupCount(8).WithIterationCount(20))
+    .WithEnvironmentVariable("DOTNET_TieredCompilation", "0")
+    .WithAffinity(new IntPtr(affinity))
+    .WithOutlierMode(OutlierMode.DontRemove);
+var config = DefaultConfig.Instance
+    .AddJob(common.WithId("A-Before").WithArguments([new MsBuildArgument($"/p:BaselineDll=\"{before}\"")]).AsBaseline())
+    .AddJob(common.WithId("B-After").WithArguments([new MsBuildArgument($"/p:BaselineDll=\"{after}\"")]))
+    .AddJob(common.WithId("C-BeforeControl").WithArguments([new MsBuildArgument($"/p:BaselineDll=\"{before}\"")]));
+var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(arguments, config).ToArray();
+return summaries.Length == 0 || summaries.Any(summary => summary.HasCriticalValidationErrors ||
+    summary.Reports.Any(report => !report.Success)) ? 1 : 0;
+'@ | Set-Content (Join-Path $harness 'Program.cs')
+
+[ordered]@{
+    Before = $before
+    BeforeSha256 = (Get-FileHash -LiteralPath $before).Hash
+    After = $after
+    AfterSha256 = (Get-FileHash -LiteralPath $after).Hash
+    FixtureSha256 = (Get-FileHash -LiteralPath $fixture).Hash
+    Filter = $Filter
+    Affinity = $Affinity
+    TieredCompilation = 0
+    Dry = [bool]$Dry
+} | ConvertTo-Json | Set-Content (Join-Path $output 'inputs.json')
+
+$priorBefore = $env:DEKAF_TTL_BEFORE_DLL
+$priorAfter = $env:DEKAF_TTL_AFTER_DLL
+$priorAffinity = $env:DEKAF_TTL_AFFINITY
+Push-Location $harness
+try {
+    $env:DEKAF_TTL_BEFORE_DLL = $before
+    $env:DEKAF_TTL_AFTER_DLL = $after
+    $env:DEKAF_TTL_AFFINITY = $Affinity.ToString()
+    dotnet new sln --name Comparison --format sln *> (Join-Path $output 'setup.log')
+    if ($LASTEXITCODE -ne 0) { throw 'Solution creation failed.' }
+    dotnet sln Comparison.sln add Dekaf.Benchmarks.csproj *>> (Join-Path $output 'setup.log')
+    if ($LASTEXITCODE -ne 0) { throw 'Adding the comparison project failed.' }
+    dotnet build Dekaf.Benchmarks.csproj -c Release *> (Join-Path $output 'build.log')
+    if ($LASTEXITCODE -ne 0) { throw 'Comparison build failed.' }
+    $runArguments = @('--filter', $Filter, '--artifacts', '../results', '--exporters', 'fulljson', '--keepFiles')
+    if ($Dry) { $runArguments += '--dry' } else { $runArguments += '--apples' }
+    dotnet run -c Release --no-build --project Dekaf.Benchmarks.csproj -- @runArguments *> (Join-Path $output 'run.log')
+    if ($LASTEXITCODE -ne 0) { throw 'Comparison failed; inspect run.log.' }
+}
+finally {
+    Pop-Location
+    $env:DEKAF_TTL_BEFORE_DLL = $priorBefore
+    $env:DEKAF_TTL_AFTER_DLL = $priorAfter
+    $env:DEKAF_TTL_AFFINITY = $priorAffinity
+    Write-Output "Comparison artifacts: $output"
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaResolutionFiniteTtlBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaResolutionFiniteTtlBenchmarks.cs
@@ -1,0 +1,63 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.SchemaRegistry;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures the completed-cache work used when a finite migration-plan TTL expires.
+/// Expiration is represented by explicit invalidation; registry I/O, time checks, and
+/// cache construction are excluded. Cached lookups provide unchanged-path controls.
+/// </summary>
+[MemoryDiagnoser(displayGenColumns: false)]
+[GenericTypeArguments(typeof(int))]
+[GenericTypeArguments(typeof(object))]
+public class SchemaResolutionFiniteTtlBenchmarks<TValue>
+{
+    private readonly SchemaResolutionCache<TValue> _cache = new(16);
+    private readonly Schema _schema = new() { SchemaType = SchemaType.Json, SchemaString = "{}" };
+    private readonly string _subject = "finite-ttl-value";
+    private Task<TValue> _resolved = null!;
+    private TValue _value = default!;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _value = typeof(TValue) == typeof(int) ? (TValue)(object)42 : (TValue)new object();
+        _resolved = Task.FromResult(_value);
+        await Resolve();
+
+        // Warm the reusable eviction slot and verify each invocation really invalidates
+        // and publishes a completed value. Setup is outside the measured operation.
+        for (var i = 0; i < 32; i++)
+        {
+            if (!_cache.TryRemove(_subject, _schema, _value) || _cache.CachedEntryCount != 0)
+                throw new InvalidOperationException("The completed cache entry was not invalidated.");
+            var refreshed = Resolve();
+            if (!refreshed.IsCompletedSuccessfully)
+                throw new InvalidOperationException("The fixture must resolve synchronously.");
+            if (!EqualityComparer<TValue>.Default.Equals(await refreshed, _value) ||
+                _cache.CachedEntryCount != 1)
+                throw new InvalidOperationException("The refreshed cache entry was not published.");
+        }
+    }
+
+    [Benchmark]
+    public ValueTask<TValue> Refresh()
+    {
+        _cache.TryRemove(_subject, _schema, _value);
+        return Resolve();
+    }
+
+    [Benchmark]
+    public ValueTask<TValue> ResolveHit() => Resolve();
+
+    [Benchmark]
+    public TValue LookupHit()
+    {
+        _cache.TryGet(_subject, _schema, out var value);
+        return value;
+    }
+
+    private ValueTask<TValue> Resolve() => _cache.ResolveAsync(
+        _subject, _schema, _resolved, static (resolved, _, _) => resolved, CancellationToken.None);
+}

--- a/tools/Dekaf.Benchmarks/FINITE-TTL.md
+++ b/tools/Dekaf.Benchmarks/FINITE-TTL.md
@@ -1,0 +1,40 @@
+# Finite-TTL cache comparison
+
+`SchemaResolutionFiniteTtlBenchmarks<TValue>` measures the completed-cache work that a finite migration-plan TTL triggers. `Refresh` invalidates and resolves one entry in a long-lived, prewarmed cache. `ResolveHit` and `LookupHit` are controls for the unchanged cached paths. Both integer and reference values are covered.
+
+The fixture excludes cache construction, registry I/O, wall-clock expiration checks, and migration-plan construction. It uses a completed resolver task and checks invalidation, synchronous resolution, publication, and entry count in setup. Refresh allocations are per invalidation/resolution, not per cached message. Results must not be presented as whole-deserializer latency or throughput.
+
+## Build exact inputs
+
+Build the schema registry project in two isolated worktrees at the exact product SHAs under comparison. Save each output separately:
+
+```powershell
+# Run each command in its corresponding source worktree.
+dotnet build src/Dekaf.SchemaRegistry -c Release -f net10.0 -o C:/tmp/dekaf-ttl-before
+dotnet build src/Dekaf.SchemaRegistry -c Release -f net10.0 -o C:/tmp/dekaf-ttl-after
+```
+
+For #3080 the immediately preceding and last accepted cache implementation is `0ff5e783794c5e9c3b24237b5901425caa4540c0`; the zero-TTL policy addition is `f585252137031e1d8e99d1c578cf10a6069e0c5b`. Compare those first. Their core Dekaf dependency is unchanged. The script isolates the Schema Registry DLL and uses the candidate's adjacent `Dekaf.dll`; do not use it to compare unrelated core changes.
+
+## Validate, then measure
+
+Run from the worktree containing this fixture. Use a quiet host, stop your own builds/tests before measurement, and choose an available physical core. `Affinity` is a logical-processor bitmask; the default `4` selects logical processor 2. It does not reserve that processor.
+
+```powershell
+pwsh scripts/Compare-SchemaResolutionFiniteTtl.ps1 -BeforeDll C:/tmp/dekaf-ttl-before/Dekaf.SchemaRegistry.dll -AfterDll C:/tmp/dekaf-ttl-after/Dekaf.SchemaRegistry.dll -Dry
+pwsh scripts/Compare-SchemaResolutionFiniteTtl.ps1 -BeforeDll C:/tmp/dekaf-ttl-before/Dekaf.SchemaRegistry.dll -AfterDll C:/tmp/dekaf-ttl-after/Dekaf.SchemaRegistry.dll -Filter '*<Int32>.Refresh*'
+```
+
+Omit `-Filter` to run all six fixture cases against all three jobs (18 cases). Dry results validate execution only.
+
+The script creates a unique directory under `.artifacts`, including the exact generated harness, input DLL and fixture SHA-256 hashes, setup/build/run logs, and full BenchmarkDotNet exports. Its nested solution prevents BenchmarkDotNet from accidentally selecting the main benchmark project with the same friend-assembly name. Failed generation or benchmark execution returns a failure instead of treating BenchmarkDotNet's empty report as success.
+
+Measurement uses separate processes with `DOTNET_TieredCompilation=0`, no outlier removal, 20 measured iterations, and `--apples` to use the same baseline-calibrated invocation count for every job. The jobs are before, candidate, and a repeated before control. Inspect the emitted job configuration: BenchmarkDotNet 0.15.8's apples mode overrides the configured eight warmups to one and disables overhead subtraction. These settings differ from the earlier in-process investigation and its absolute timings are not directly comparable.
+
+Check the generated executables' Schema Registry DLL hashes against `inputs.json`. Compare candidate results with both baseline jobs and the unchanged hit controls. Report means, confidence intervals, allocations, drift, and limitations; retain all results. Overlapping intervals, uncontrolled host activity, or a noisy baseline do not establish equivalence. No further identical run should be used to obtain a favorable verdict.
+
+The fixture can also run against the current source in the maintained suite:
+
+```powershell
+dotnet run --project tools/Dekaf.Benchmarks -c Release -- --filter '*SchemaResolutionFiniteTtl*' --job Dry
+```


### PR DESCRIPTION
Finite-TTL refresh comparisons previously existed only in temporary worktrees. This adds a maintained integer/reference-value fixture, unchanged cache-hit controls, and a script that compares exact saved Schema Registry DLLs in separate processes with a repeated baseline. The script records input hashes, preserves the generated harness/full reports, and fails on empty or unsuccessful BenchmarkDotNet results.

Refs #3080. **Finite-TTL performance acceptance remains unresolved; this PR does not close the issue or change product code.**

Validation: both exact source inputs build with zero warnings/errors; the final comparison script builds cleanly and executes all 18 Dry cases. Generated before/after DLL hashes match their recorded inputs. Scoped simplification review and diff checks pass. No TUnit test was added for this benchmark-only coverage change.

The new diagnostic design uses BenchmarkDotNet 0.15.8, MemoryDiagnoser, Windows 11 / i7-12700K, SDK 10.0.400 / runtime 10.0.11, separate processes, affinity mask 4, and `DOTNET_TieredCompilation=0`. Apples mode selects 2,097,152 invocations per integer-refresh iteration, 20 measured iterations, one effective warmup, no overhead subtraction, and no outlier removal. The configured eight warmups are overridden by apples mode; the documentation calls this out.

Exact immediately preceding/last accepted cache SHA: `0ff5e783794c5e9c3b24237b5901425caa4540c0`. Exact candidate: `f585252137031e1d8e99d1c578cf10a6069e0c5b`. Both affected cache/migration files are unchanged between that candidate and this PR's base `47bc43285`.

| Integer refresh | Mean ± 99.9% CI half-width | SD | Iteration median / max | Allocation | Derived operations/s |
|---|---:|---:|---:|---:|---:|
| Before | 406.313 ± 19.713 ns | 22.701 ns | 402.584 / 463.534 ns | 448 B | 2.461 M |
| Candidate | 431.500 ± 36.000 ns | 41.457 ns | 411.883 / 539.716 ns | 448 B | 2.317 M |
| Repeated before | 398.004 ± 10.567 ns | 12.168 ns | 392.920 / 439.059 ns | 448 B | 2.513 M |

Candidate mean is +6.20% against the first baseline and +8.42% against the repeat; baseline drift is -2.05%. These overlapping, noisy intervals establish neither equivalence nor a causal regression. The earlier same-SHA results in #3080 remain inconclusive, including the original +2.2% integer comparison and the +7.3% reference-value comparison. Different fixture/JIT/process settings prevent pooling their absolute timings with this run.

A process audit found unrelated host activity and another agent's follower-offset benchmarks. Its previous run ended before this timed invocation, but additional comparison work appeared afterward; no exclusive/quiet-host guarantee exists. This is diagnostic evidence only. No identical repeat, reference-refresh timing, or cached-hit acceptance run follows this inconclusive result on this busy host. The remaining cases are smoke-validated only. No broker throughput, application p50/p99/max, CPU/message, or stability measurement was made. Iteration percentiles above are not application latency percentiles. No paid lane, dispatch shape, duration-based stress gate, profiling mode, or workflow URL applies.

Input SHA-256:
- Before: `A5904B289FCCED4D2C7A274B48B9CFF4BB4BC4C3B9AF1F587A2FC260EB141E58`
- Candidate: `079CDC3F32B8E10158BE92AD8E60C88994885B1C269E64AA2E0DBFF729627500`

Reproduction: `tools/Dekaf.Benchmarks/FINITE-TTL.md`. Local full reports: `C:/git/Dekaf-worktrees/issue-3080-finite-ttl-evidence/.artifacts/integer-refresh`. Final script smoke run: `.artifacts/finite-ttl-955792cb1ad546efa9ee00ba10ad29df`. The timed run uses the same benchmark methods and job settings as the checked-in script; its earlier harness lacked only the new script's generated-input manifest and failure exit handling.

