### PR TITLE
test(telemetry): verify broker-received metric payloads

### DIFF
--- a/tests/Dekaf.Tests.Integration/ClientTelemetryReceiverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ClientTelemetryReceiverIntegrationTests.cs
@@ -1,0 +1,75 @@
+using Dekaf.Admin;
+using Dekaf.Diagnostics;
+using Dekaf.Telemetry;
+using Dekaf.Tests.Integration.Telemetry;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Telemetry")]
+[SupportsKafka(420)]
+[ClassDataSource<TelemetryReceiverKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class ClientTelemetryReceiverIntegrationTests(TelemetryReceiverKafkaContainer kafka)
+{
+    [Test]
+    [Arguments(42.0)]
+    [Arguments(84.0)]
+    [Timeout(90_000)]
+    public async Task Producer_BrokerReceivesBuiltInAndApplicationMetrics(
+        double applicationValue, CancellationToken cancellationToken)
+    {
+        const string applicationName = "com.example.telemetry.integration.depth";
+        const string builtinName = "org.apache.kafka.producer.connection.creation.total";
+        var clientId = $"telemetry-receiver-{Guid.NewGuid():N}";
+        await using var admin = kafka.CreateAdminClient();
+        await admin.IncrementalAlterConfigsAsync(new Dictionary<ConfigResource, IReadOnlyList<ConfigAlter>>
+        {
+            [new ConfigResource { Type = ConfigResourceType.ClientMetrics, Name = clientId }] =
+            [
+                ConfigAlter.Set("metrics", $"{applicationName},{builtinName}"),
+                ConfigAlter.Set("interval.ms", "1000"),
+                ConfigAlter.Set("match", $"client_id={clientId}")
+            ]
+        }, cancellationToken: cancellationToken);
+
+        var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId(clientId)
+            .RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+                applicationName, ApplicationTelemetryMetricKind.Gauge, () => applicationValue))
+            .BuildAsync(cancellationToken);
+        try
+        {
+            var identity = ((IKafkaClientInstanceIdentity)producer).ClientInstanceId;
+            await Assert.That(identity).IsNotNull();
+            var received = await kafka.WaitForPayloadAsync(clientId, payload =>
+            {
+                var metrics = Decode(payload);
+                return !payload.IsTerminating && metrics.Any(metric => metric.Name == applicationName)
+                    && metrics.Any(metric => metric.Name == builtinName);
+            }, cancellationToken);
+            await Assert.That(received.ClientInstanceId).IsEqualTo(identity!.Value);
+            await Assert.That(received.Data.Length).IsGreaterThan(0);
+            await Assert.That(received.ContentType).IsEqualTo("OTLP");
+            var decoded = Decode(received);
+            var application = decoded.Single(metric => metric.Name == applicationName);
+            var builtin = decoded.Single(metric => metric.Name == builtinName);
+            await Assert.That(application.Gauge.DataPoints.Single().AsDouble).IsEqualTo(applicationValue);
+            await Assert.That(builtin.Sum.IsMonotonic).IsTrue();
+            await Assert.That(builtin.Sum.DataPoints.Single().AsDouble).IsGreaterThan(0);
+
+            await producer.DisposeAsync();
+            var terminating = await kafka.WaitForPayloadAsync(clientId,
+                payload => payload.IsTerminating && Decode(payload).Any(metric => metric.Name == applicationName),
+                cancellationToken);
+            await Assert.That(terminating.ClientInstanceId).IsEqualTo(identity.Value);
+        }
+        finally
+        {
+            await producer.DisposeAsync();
+        }
+    }
+
+    private static Metric[] Decode(ReceivedTelemetry payload) => MetricsData.Parser.ParseFrom(payload.Data)
+        .ResourceMetrics.SelectMany(resource => resource.ScopeMetrics)
+        .SelectMany(scope => scope.Metrics).ToArray();
+}

--- a/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
+++ b/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
@@ -79,4 +79,8 @@
               GrpcServices="None" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="TelemetryReceiver/**" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Dekaf.Tests.Integration/Protos/telemetry_metrics.proto
+++ b/tests/Dekaf.Tests.Integration/Protos/telemetry_metrics.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+package dekaf.testing.telemetry;
+option csharp_namespace = "Dekaf.Tests.Integration.Telemetry";
+
+// Wire-compatible subset of OpenTelemetry MetricsData. Unknown OTLP fields are preserved.
+message MetricsData { repeated ResourceMetrics resource_metrics = 1; }
+message ResourceMetrics { repeated ScopeMetrics scope_metrics = 2; }
+message ScopeMetrics { repeated Metric metrics = 2; }
+message Metric {
+  string name = 1;
+  oneof data { Gauge gauge = 5; Sum sum = 7; }
+}
+message Gauge { repeated NumberDataPoint data_points = 1; }
+message Sum {
+  repeated NumberDataPoint data_points = 1;
+  int32 aggregation_temporality = 2;
+  bool is_monotonic = 3;
+}
+message NumberDataPoint {
+  fixed64 start_time_unix_nano = 2;
+  fixed64 time_unix_nano = 3;
+  oneof value { double as_double = 4; sfixed64 as_int = 6; }
+  repeated KeyValue attributes = 7;
+}
+message KeyValue { string key = 1; AnyValue value = 2; }
+message AnyValue { string string_value = 1; }

--- a/tests/Dekaf.Tests.Integration/TelemetryReceiver/Dockerfile
+++ b/tests/Dekaf.Tests.Integration/TelemetryReceiver/Dockerfile
@@ -1,0 +1,8 @@
+ARG KAFKA_IMAGE=apache/kafka:4.3.1
+FROM ${KAFKA_IMAGE} AS kafka
+FROM eclipse-temurin:21-jdk AS compiler
+COPY --from=kafka /opt/kafka/libs /kafka-libs
+COPY RecordingTelemetryReporter.java /source/RecordingTelemetryReporter.java
+RUN mkdir /classes && javac -proc:none --release 17 -cp '/kafka-libs/*' -d /classes /source/RecordingTelemetryReporter.java && jar cf /receiver.jar -C /classes .
+FROM kafka
+COPY --from=compiler /receiver.jar /opt/kafka/libs/dekaf-test-telemetry-receiver.jar

--- a/tests/Dekaf.Tests.Integration/TelemetryReceiver/README.md
+++ b/tests/Dekaf.Tests.Integration/TelemetryReceiver/README.md
@@ -1,0 +1,17 @@
+# Broker telemetry receiver fixture
+
+`TelemetryReceiverKafkaContainer` builds this test-only reporter against the exact Kafka image selected by `KAFKA_TEST_IMAGE_TAG` (default 4.3.1). Docker builds the Java classes with a JDK; the host needs Docker and the repository .NET SDK, not Java. The image and broker are owned and disposed by Testcontainers. Image construction has a five-minute deadline.
+
+The dedicated broker enables `metric.reporters=dekaf.testing.RecordingTelemetryReporter`. It copies the borrowed payload in Kafka's telemetry callback and serves captured exports at `/payloads` on a dynamically mapped port. Each line contains the client instance UUID, terminating flag, and Base64-encoded client ID, content type, and payload. HTTP reads retain exports so concurrent tests cannot consume one another's evidence. Captures live only for the fixture's lifetime.
+
+Tests create real `ClientMetrics` configuration resources with an exact `client_id` match and poll for their own exports with a 30-second bound. Kafka decompresses the payload before the callback and identifies its format as `OTLP`. `Protos/telemetry_metrics.proto` defines the wire-compatible subset needed to assert metric values, sums, gauges, attributes, and timestamps. It does not replace the production encoder.
+
+Run:
+
+```powershell
+dotnet test --project tests/Dekaf.Tests.Integration --configuration Release --framework net10.0 --treenode-filter "/*/*/ClientTelemetryReceiverIntegrationTests/*"
+```
+
+The `Telemetry` category already runs in the CI messaging group. Ordinary Kafka fixtures do not enable this reporter.
+
+References: [Kafka receiver API](https://github.com/apache/kafka/blob/4.3.1/clients/src/main/java/org/apache/kafka/server/telemetry/ClientTelemetryReceiver.java), [broker payload handling](https://github.com/apache/kafka/blob/4.3.1/clients/src/main/java/org/apache/kafka/common/requests/PushTelemetryRequest.java), [OTLP metrics schema](https://github.com/open-telemetry/opentelemetry-proto/blob/v1.9.0/opentelemetry/proto/metrics/v1/metrics.proto). The receiver interface is deprecated since Kafka 4.2 but remains available throughout the supported Kafka 4.x range; Kafka 5 will require the exporter API.

--- a/tests/Dekaf.Tests.Integration/TelemetryReceiver/RecordingTelemetryReporter.java
+++ b/tests/Dekaf.Tests.Integration/TelemetryReceiver/RecordingTelemetryReporter.java
@@ -1,0 +1,65 @@
+package dekaf.testing;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.server.telemetry.ClientTelemetry;
+import org.apache.kafka.server.telemetry.ClientTelemetryReceiver;
+
+// Test-only reporter. The broker decompresses telemetry before invoking this receiver.
+// Copy the borrowed payload before returning; HTTP reads never run on Kafka's request thread.
+@SuppressWarnings("removal")
+public final class RecordingTelemetryReporter implements MetricsReporter, ClientTelemetry {
+    private final ConcurrentLinkedQueue<String> payloads = new ConcurrentLinkedQueue<>();
+    private HttpServer server;
+
+    public void configure(Map<String, ?> configs) {
+        try {
+            server = HttpServer.create(new InetSocketAddress(8080), 0);
+            server.createContext("/payloads", exchange -> {
+                byte[] body = String.join("\n", payloads).getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=utf-8");
+                exchange.sendResponseHeaders(200, body.length);
+                try (var output = exchange.getResponseBody()) { output.write(body); }
+                finally { exchange.close(); }
+            });
+            server.start();
+        } catch (IOException error) {
+            throw new UncheckedIOException(error);
+        }
+    }
+
+    public ClientTelemetryReceiver clientReceiver() {
+        return (context, payload) -> {
+            ByteBuffer data = payload.data().duplicate();
+            byte[] copy = new byte[data.remaining()];
+            data.get(copy);
+            var id = payload.clientInstanceId();
+            payloads.add(new UUID(id.getMostSignificantBits(), id.getLeastSignificantBits()) + "\t"
+                + payload.isTerminating() + "\t" + encode(context.clientId()) + "\t"
+                + encode(payload.contentType()) + "\t" + Base64.getEncoder().encodeToString(copy));
+        };
+    }
+
+    private static String encode(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public void init(List<KafkaMetric> metrics) { }
+    public void metricChange(KafkaMetric metric) { }
+    public void metricRemoval(KafkaMetric metric) { }
+    public void close() {
+        if (server != null) server.stop(0);
+        payloads.clear();
+    }
+}

--- a/tests/Dekaf.Tests.Integration/TelemetryReceiverKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/TelemetryReceiverKafkaContainer.cs
@@ -1,0 +1,79 @@
+using System.Text;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Images;
+using Testcontainers.Kafka;
+
+namespace Dekaf.Tests.Integration;
+
+/// <summary>A dedicated broker that records real KIP-714 exports for telemetry tests.</summary>
+public sealed class TelemetryReceiverKafkaContainer : KafkaContainerDefault
+{
+    private readonly IFutureDockerImage _image = new ImageFromDockerfileBuilder()
+        .WithName($"apache/kafka:dekaf-telemetry-{Guid.NewGuid():N}")
+        .WithDockerfileDirectory(Path.Combine(AppContext.BaseDirectory, "TelemetryReceiver"))
+        .WithBuildArgument("KAFKA_IMAGE", $"apache/kafka:{ImageTag}")
+        .Build();
+    private readonly HttpClient _http = new();
+
+    public override string ContainerName => _image.FullName;
+
+    protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder) =>
+        base.ConfigureBuilder(builder)
+            .WithPortBinding(8080, true)
+            .WithEnvironment("KAFKA_METRIC_REPORTERS", "dekaf.testing.RecordingTelemetryReporter");
+
+    public override async Task InitializeAsync()
+    {
+        try
+        {
+            using var imageBuildTimeout = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+            await _image.CreateAsync(imageBuildTimeout.Token);
+            await base.InitializeAsync();
+            _http.BaseAddress = new UriBuilder("http", ContainerInstance!.Hostname,
+                ContainerInstance.GetMappedPublicPort(8080)).Uri;
+        }
+        catch
+        {
+            await DisposeAsync();
+            throw;
+        }
+    }
+
+    internal async Task<ReceivedTelemetry> WaitForPayloadAsync(
+        string clientId, Func<ReceivedTelemetry, bool> matches, CancellationToken cancellationToken)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(30));
+        while (true)
+        {
+            var text = await _http.GetStringAsync("payloads", timeout.Token);
+            foreach (var line in text.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var fields = line.Split('\t');
+                if (fields.Length != 5)
+                    throw new InvalidDataException("Malformed telemetry receiver output.");
+                if (DecodeText(fields[2]) != clientId)
+                    continue;
+                var payload = new ReceivedTelemetry(Guid.Parse(fields[0]), bool.Parse(fields[1]),
+                    DecodeText(fields[3]), Convert.FromBase64String(fields[4]));
+                if (matches(payload))
+                    return payload;
+            }
+            await Task.Delay(100, timeout.Token);
+        }
+    }
+
+    private static string DecodeText(string value) => Encoding.UTF8.GetString(Convert.FromBase64String(value));
+
+    public override async ValueTask DisposeAsync()
+    {
+        try { await base.DisposeAsync(); }
+        finally
+        {
+            _http.Dispose();
+            await _image.DisposeAsync();
+        }
+    }
+}
+
+internal sealed record ReceivedTelemetry(Guid ClientInstanceId, bool IsTerminating, string ContentType, byte[] Data);


### PR DESCRIPTION
Existing telemetry integration coverage accepted brokers without a receiver, so it could pass without publishing any metric payload. This adds a dedicated Kafka broker with a test-only MetricsReporter/ClientTelemetryReceiver and verifies exports received by Kafka.

The fixture compiles its Java reporter against the selected Kafka image inside Docker, copies borrowed payload bytes, and exposes captured exports over a dynamically mapped HTTP endpoint. Exports retain client ID, instance UUID, content type, and terminating state. Captures are retained for concurrent readers and disappear with the fixture. Ordinary Kafka fixtures remain unchanged; Testcontainers owns the custom image and broker.

Two concurrent producer cases install exact-client broker subscriptions and publish different values for the same application metric. Tests decode actual OTLP bytes and verify the application value, built-in connection counter, client identity, and terminating export. A small generated protobuf subset handles decoding. The existing Telemetry CI category includes these tests; Java sources and Dockerfile accompany built/published test binaries.

Validation: both cases pass against Kafka 4.3.1 on net10.0 and net8.0 (four cases total). Release compilation succeeds without warnings/errors. The initial integration run caught an incorrect content-type expectation; Kafka's verified contract is `OTLP`, and that assertion was corrected before final validation. Final /simplify and git diff --check completed. No product source changed, so benchmark/stress evidence does not apply. Other broker versions and NativeAOT execution were not run locally.

The reporter uses the Kafka 4.x receiver API, deprecated since 4.2; a Kafka 5 upgrade will require the exporter API. Image builds have a five-minute deadline and payload waits have a 30-second deadline. The README documents reproduction, ownership, and source references.

Closes #3096

This completes the receiver prerequisite for #3033. Application telemetry #3097 and KIP-932 client metrics #3098 remain separate dependent deliverables; #3033 stays open.



## Current validation and diagnostic CI experiment

Rebased unchanged telemetry patch onto main `1e0b03b4a`, producing `c5e957ee043e4252b6d4f8c5b9bd4d66b24dab4a`. The patch against its base is identical before/after rebase; `git diff --check` passes. Both receiver cases pass again on net10.0 / Kafka 4.3.1.

Main now includes the bounded native classic-coordinator diagnostics from #3111. A new CI run can capture the missing cgrp/metadata/topic history if #3105 recurs. This is an improved diagnostic experiment; the original failed CI result remains evidence, and a passing run alone will not establish its cause or close #3105. Merge remains blocked pending that investigation.

Durable evidence archive: `C:/git/Dekaf-evidence/pr-3100/c5e957ee043e4252b6d4f8c5b9bd4d66b24dab4a`. Original/rebased test reports, logs, runtime binaries, image inputs, and source snapshots are archived outside removable worktrees with file inventories and SHA-256 verification. The original CI failure log is included. The custom Docker image itself is not archived; its Dockerfile/Java inputs and selected Kafka version are preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage confirming Kafka client metrics are delivered to a broker-side telemetry receiver.
  * Validates both custom application metrics and built-in Kafka metrics, including their values and metric properties.
  * Verifies that a terminating telemetry payload is emitted when a producer is disposed.
  * Added containerized test support for capturing and decoding OpenTelemetry metrics payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->