### PR TITLE
test(benchmarks): cover share parsing and acknowledgement allocations

### DIFF
--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgementAllocationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgementAllocationBenchmarks.cs
@@ -1,0 +1,69 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Separates fresh acknowledgement accumulation from wire materialization.</summary>
+[MemoryDiagnoser]
+public class ShareAcknowledgementAllocationBenchmarks
+{
+    private readonly TopicPartition _partition = new("share-benchmark", 0);
+    private AcknowledgementTracker _pending = null!;
+
+    [Params(64, 1024)]
+    public int RecordCount { get; set; }
+
+    [Params(ShareAcknowledgementMode.Implicit, ShareAcknowledgementMode.Explicit)]
+    public ShareAcknowledgementMode Mode { get; set; }
+
+    [GlobalSetup]
+    public void Validate()
+    {
+        var tracker = Accumulate();
+        var wire = tracker.Flush();
+        if (tracker.HasPending || wire.Count != 1 || wire[_partition].Count != 1)
+            throw new InvalidOperationException("Acknowledgements did not form one bounded partition batch.");
+        var batch = wire[_partition][0];
+        if (batch.FirstOffset != 0 || batch.LastOffset != RecordCount - 1 || batch.AcknowledgeTypes.Length != RecordCount)
+            throw new InvalidOperationException("Acknowledgements did not cover every delivered offset.");
+        for (var index = 0; index < RecordCount; index++)
+        {
+            var expected = Mode == ShareAcknowledgementMode.Implicit ? AcknowledgeType.Accept : Disposition(index);
+            if (batch.AcknowledgeTypes[index] != (byte)expected)
+                throw new InvalidOperationException("An acknowledgement disposition changed.");
+        }
+    }
+
+    [IterationSetup(Target = nameof(MaterializeWireBatch))]
+    public void SetupPending() => _pending = Accumulate();
+
+    [Benchmark]
+    public bool AccumulateFreshBatch() => Accumulate().HasPending;
+
+    // Single invocation is intentional: Flush consumes the tracker. Allocation evidence is
+    // useful at this boundary; its short single-invocation timing is not an acceptance gate.
+    [Benchmark]
+    [InvocationCount(1)]
+    public int MaterializeWireBatch() => _pending.Flush()[_partition][0].AcknowledgeTypes.Length;
+
+    private AcknowledgementTracker Accumulate()
+    {
+        // Include fresh storage growth. Reusing warmed keys would conceal per-record costs.
+        var tracker = new AcknowledgementTracker();
+        for (var index = 0; index < RecordCount; index++)
+        {
+            if (Mode == ShareAcknowledgementMode.Implicit)
+                tracker.TrackDeliveredRecords(_partition, index, index);
+            else
+                tracker.Acknowledge(_partition, index, Disposition(index), requireTracked: false);
+        }
+        return tracker;
+    }
+
+    private static AcknowledgeType Disposition(int index) => (index % 3) switch
+    {
+        0 => AcknowledgeType.Accept,
+        1 => AcknowledgeType.Release,
+        _ => AcknowledgeType.Reject
+    };
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerAllocations.md
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerAllocations.md
@@ -1,0 +1,67 @@
+# Share-consumer allocation coverage
+
+These fixtures measure the production parser and acknowledgement tracker without Kafka. They provide the baseline for issues #3032 and #3103; they do not establish that share consumption is allocation-free.
+
+## Measured boundaries
+
+Every operation is **one partition batch**, containing `RecordCount` records. `Allocated` is bytes per batch, not bytes per message. No `OperationsPerInvoke` division hides list growth, per-record objects, header copies, or acknowledgement storage.
+
+| Method | Included | Excluded |
+| --- | --- | --- |
+| `ParseSynchronousBatch` | The actual `KafkaShareConsumer<int, int>.ParsePartitionRecords`, deserialization, result list, record/header objects, pooled batch disposal, and result traversal | Fixture generation, consumer construction, network requests, polling state machine, acknowledgement tracking |
+| `ParseWarmPreparedBatch` | The actual preparation-aware parser with a fresh cursor and empty result list, warm key/value preparers, batch disposal, and result traversal | As above; cold preparation and its durable input copies |
+| `TraverseRetainedBatch` | Synchronous traversal of already parsed public results, including keys, values, offsets, delivery counts, timestamps, and header data | Parsing and result creation |
+| `AccumulateFreshBatch` | A fresh production `AcknowledgementTracker`, storage growth, and delivery/acknowledgement of distinct offsets | Parsing, wire materialization, network requests, consumer renewal replay state |
+| `MaterializeWireBatch` | `Flush` on a populated production tracker, including replacement pending dictionary, wire arrays, sorting, and merging | Accumulation, which runs in iteration setup |
+
+The parsing fixtures use the library's allocation-free Int32 deserializer. The preparation-aware wrapper always succeeds synchronously and throws if cold preparation is unexpectedly requested. Protocol input comes from `RecordBatch.Write` and `Serializers.Int32`; no handwritten Kafka bytes are involved. The synchronous parser delegate is bound once in setup, without `MethodInfo.Invoke`, boxing, or argument arrays in the measured path.
+
+Two scales, 64 and 1024 records, reveal fixed batch costs and costs that grow with delivery count. Header cases use either no headers or two headers, including a null value. Setup validates both parser outputs after their internal batch disposal: record count, payloads, topic/partition, offset, timestamp, delivery count, header keys, values, and nullability.
+
+Implicit acknowledgements track each delivered offset as `PollAsync` does. Explicit mode acknowledges distinct offsets with alternating Accept, Release, and Reject, without implicit delivery tracking. Every accumulation invocation starts with empty storage; repeatedly overwriting a warmed dictionary key would miss the allocation defect. Setup checks every resulting wire disposition and verifies that flush clears pending state.
+
+`MaterializeWireBatch` consumes its prepared state, so it uses one invocation per iteration. This gives a separate allocation boundary, but its short iteration timings are sensitive to scheduling and are **not performance acceptance evidence**. BDN reports the expected minimum-iteration-time warning. Use an end-to-end batch/commit benchmark for timing acceptance.
+
+## Run
+
+From the repository root in an isolated worktree:
+
+```powershell
+dotnet run --project tools/Dekaf.Benchmarks --configuration Release --framework net10.0 -- --filter '*ShareConsumerParsingBenchmarks*' '*ShareAcknowledgementAllocationBenchmarks*' --job Dry --artifacts .artifacts/share-dry > share-dry.log 2>&1
+
+dotnet run --no-build --project tools/Dekaf.Benchmarks --configuration Release --framework net10.0 -- --filter '*ShareConsumerParsingBenchmarks.ParseSynchronousBatch*RecordCount: 64, HeaderCount: 0*' --job Default --artifacts .artifacts/share-representative > share-representative.log 2>&1
+
+dotnet run --no-build --project tools/Dekaf.Benchmarks --configuration Release --framework net10.0 -- --filter '*ShareConsumerParsingBenchmarks*' '*ShareAcknowledgementAllocationBenchmarks*' --job Short --artifacts .artifacts/share-short > share-short.log 2>&1
+```
+
+The full matrix contains 20 cases. Dry validates setup and execution only. Use Short for allocation investigation and default/longer measurement jobs for comparative timing after the experiment is stable. Reports are under each artifacts directory's `results` subdirectory. Retain the exact product SHA, runtime, machine, job, and raw reports with every comparison.
+
+## Acceptance limits
+
+This coverage isolates existing parser and tracker costs. It does not measure `PollAsync`'s asynchronous delivery overhead, cold schema preparation, Renew replay ownership, partial enumeration, retries, broker acknowledgement/redelivery behavior, CPU per message, or latency percentiles. Those remain implementation and acceptance requirements of #3103. Header materialization costs inside protocol decoding and ArrayPool misses remain included; pooled storage must not be assumed to eliminate allocations without measurement.
+
+Compare a saved exact baseline build against the candidate with identical inputs and settings. Preserve the compatibility API's behavior and performance. Extend these fixtures for the new batch API and add its per-record traversal/acknowledgement boundary explicitly: a combined batch average cannot prove zero per-message infrastructure allocation. Apply the repository's full Pareto and stress gates before accepting a product change.
+
+## Baseline recorded 2026-09-07
+
+Product source: `aefb825462cd6f6d6e956fca3374a12d98a0e128`. BenchmarkDotNet 0.15.8; .NET SDK 10.0.400; .NET 10.0.11, x64 RyuJIT, concurrent workstation GC; Windows 11 25H2; Intel Core i7-12700K (12 physical / 20 logical cores). No product source changed for these measurements.
+
+All 20 Dry cases and all 20 ShortRun cases completed with setup validation passing. ShortRun used one launch, three warmups, and three measured iterations. The representative default job (`ParseSynchronousBatch`, 64 records, no headers) measured **6.107 us ± 0.1185 us**, 5.73 KB allocated per batch (BDN's Error is the half-width of its 99.9% confidence interval). The ShortRun allocation results below are exact bytes per batch:
+
+| Records | Headers | Synchronous parser | Warm preparation-aware parser | Retained traversal |
+| ---: | ---: | ---: | ---: | ---: |
+| 64 | 0 | 5,872 B | 5,752 B | 0 B |
+| 64 | 2 | 12,528 B | 12,408 B | 0 B |
+| 1024 | 0 | 90,448 B | 90,328 B | 0 B |
+| 1024 | 2 | 451,256 B | 451,136 B | 0 B |
+
+| Records | Acknowledgement mode | Fresh accumulation | Wire materialization |
+| ---: | --- | ---: | ---: |
+| 64 | Implicit | 448 B | 560 B |
+| 64 | Explicit | 4,952 B | 3,040 B |
+| 1024 | Implicit | 448 B | 1,520 B |
+| 1024 | Explicit | 102,544 B | 36,832 B |
+
+The fixed 448 B implicit accumulation cost is batch storage for one contiguous offset range. Explicit accumulation grows with distinct offsets; it must not be described as a fixed batch cost. Likewise, the parser returns a newly allocated public record object per message and copies headers per message. At 64 records, the two-header case adds exactly 104 B per record. The 1024-record header case has additional costs beyond that copy; these measurements do not attribute all of them. ArrayPool retention/misses and protocol header materialization need separate investigation before claiming zero allocations.
+
+These numbers reproduce the existing defects and provide a baseline, **not a product performance PASS**. ShortRun timing intervals are broad, wire timings use a single invocation, and no CPU, latency, or stability acceptance was attempted. The raw BDN Markdown reports, including all timing/error/GC columns, are attached to the coverage PR alongside the exact product SHA. Re-measure baseline and candidate under the same conditions for #3103.

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerParsingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerParsingBenchmarks.cs
@@ -1,0 +1,189 @@
+using System.Buffers;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Metadata;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures one complete partition batch, separately from traversal of retained results.
+/// Fixture serialization and private-method delegate binding happen only during setup.
+/// </summary>
+[MemoryDiagnoser]
+public class ShareConsumerParsingBenchmarks
+{
+    private const long BaseOffset = 1000;
+    private const long BaseTimestamp = 1700000000000;
+    private KafkaShareConsumer<int, int> _synchronousConsumer = null!;
+    private KafkaShareConsumer<int, int> _preparedConsumer = null!;
+    private Func<TopicInfo, ShareFetchResponsePartition, int, List<ShareConsumeResult<int, int>>> _parse = null!;
+    private readonly TopicInfo _topic = new() { Name = "share-benchmark", Partitions = [] };
+    private ShareFetchResponsePartition _partition = null!;
+    private List<ShareConsumeResult<int, int>> _retained = null!;
+
+    [Params(64, 1024)]
+    public int RecordCount { get; set; }
+
+    [Params(0, 2)]
+    public int HeaderCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var records = new Record[RecordCount];
+        for (var index = 0; index < records.Length; index++)
+        {
+            var key = new ArrayBufferWriter<byte>();
+            var value = new ArrayBufferWriter<byte>();
+            Serializers.Int32.Serialize(index, ref key, default);
+            Serializers.Int32.Serialize(index + 1, ref value, default);
+            records[index] = new Record
+            {
+                OffsetDelta = index,
+                TimestampDelta = index,
+                Key = key.WrittenMemory,
+                Value = value.WrittenMemory,
+                Headers = HeaderCount == 0 ? null :
+                [
+                    new Header("kind", new byte[] { 42 }),
+                    new Header("nullable", (byte[]?)null)
+                ],
+                HeaderCount = HeaderCount
+            };
+        }
+
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var batch = new RecordBatch
+        {
+            BaseOffset = BaseOffset,
+            BaseTimestamp = BaseTimestamp,
+            Records = records
+        })
+        {
+            batch.Write(buffer);
+        }
+
+        _partition = new ShareFetchResponsePartition
+        {
+            PartitionIndex = 0,
+            CurrentLeader = new ShareFetchLeaderIdAndEpoch(),
+            RecordBytes = buffer.WrittenMemory,
+            AcquiredRecords =
+            [
+                new ShareFetchAcquiredRecords
+                {
+                    FirstOffset = BaseOffset,
+                    LastOffset = BaseOffset + RecordCount - 1,
+                    DeliveryCount = 3
+                }
+            ]
+        };
+        var options = new ShareConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            GroupId = "share-parsing-benchmark"
+        };
+        _synchronousConsumer = new KafkaShareConsumer<int, int>(options, Serializers.Int32, Serializers.Int32);
+        var prepared = new WarmInt32Deserializer();
+        _preparedConsumer = new KafkaShareConsumer<int, int>(options, prepared, prepared);
+        _parse = typeof(KafkaShareConsumer<int, int>)
+            .GetMethod("ParsePartitionRecords", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .CreateDelegate<Func<TopicInfo, ShareFetchResponsePartition, int, List<ShareConsumeResult<int, int>>>>(
+                _synchronousConsumer);
+
+        _retained = _parse(_topic, _partition, RecordCount);
+        Validate(_retained);
+        Validate(ParsePrepared());
+    }
+
+    [GlobalCleanup]
+    public async ValueTask Cleanup()
+    {
+        await _synchronousConsumer.DisposeAsync();
+        await _preparedConsumer.DisposeAsync();
+    }
+
+    [Benchmark]
+    public long ParseSynchronousBatch() => Traverse(_parse(_topic, _partition, RecordCount));
+
+    [Benchmark]
+    public long ParseWarmPreparedBatch() => Traverse(ParsePrepared());
+
+    [Benchmark]
+    public long TraverseRetainedBatch() => Traverse(_retained);
+
+    private List<ShareConsumeResult<int, int>> ParsePrepared()
+    {
+        // PollAsync starts each partition with an empty list and a fresh parser cursor.
+        var records = new List<ShareConsumeResult<int, int>>();
+        var state = new KafkaShareConsumer<int, int>.DeserializerPreparationParserState();
+        try
+        {
+            var pending = _preparedConsumer.ParsePartitionRecordsWithPreparation(
+                _topic, _partition, RecordCount, records, ref state, false, default);
+            if (pending is not null)
+                throw new InvalidOperationException("The warm deserializer unexpectedly requested preparation.");
+            return records;
+        }
+        finally
+        {
+            state.DisposeCurrentBatch();
+        }
+    }
+
+    private static long Traverse(List<ShareConsumeResult<int, int>> records)
+    {
+        long checksum = 0;
+        foreach (var record in records)
+        {
+            checksum += record.Offset + record.Key + record.Value + record.DeliveryCount + record.TimestampMs;
+            for (var index = 0; index < record.Headers.Count; index++)
+            {
+                var header = record.Headers[index];
+                checksum += header.Key.Length;
+                if (!header.IsValueNull)
+                    checksum += header.Value.Span[0];
+            }
+        }
+        return checksum;
+    }
+
+    private void Validate(List<ShareConsumeResult<int, int>> records)
+    {
+        if (records.Count != RecordCount)
+            throw new InvalidOperationException("The parser did not return the full acquired batch.");
+        for (var index = 0; index < records.Count; index++)
+        {
+            var record = records[index];
+            if (record.Topic != _topic.Name || record.Partition != 0 || record.Offset != BaseOffset + index
+                || record.Key != index || record.Value != index + 1 || record.DeliveryCount != 3
+                || record.TimestampMs != BaseTimestamp + index || record.Headers.Count != HeaderCount)
+                throw new InvalidOperationException("The parser changed record data or metadata.");
+            if (HeaderCount != 0
+                && (record.Headers[0].Key != "kind" || record.Headers[0].IsValueNull
+                    || (record.Headers[0].Value.Length != 1 || record.Headers[0].Value.Span[0] != 42)
+                    || record.Headers[1].Key != "nullable" || !record.Headers[1].IsValueNull))
+                throw new InvalidOperationException("The parser changed header data or nullability.");
+        }
+    }
+
+    private sealed class WarmInt32Deserializer : IDeserializer<int>, IAsyncDeserializerPreparer<int>
+    {
+        public int Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+            => Serializers.Int32.Deserialize(data, context);
+
+        public bool TryDeserialize(ReadOnlyMemory<byte> data, SerializationContext context, out int value)
+        {
+            value = Deserialize(data, context);
+            return true;
+        }
+
+        public ValueTask PrepareAsync(ReadOnlyMemory<byte> data, SerializationContext context,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("This benchmark models a warm deserializer.");
+    }
+}


### PR DESCRIPTION
Production share parsing had no benchmark coverage for public record/header allocations, and existing acknowledgement coverage reused a warmed offset. This adds reusable MemoryDiagnoser fixtures for both real parser paths and distinct acknowledgement offsets, separating retained traversal, fresh state growth, and wire materialization at 64/1024 records.

Setup uses library protocol serializers and validates decoded payloads, metadata, headers, and every acknowledgement disposition. No src changes. The parent allocation-free API work remains open in #3032/#3103.

Validation: all 20 Dry cases and all 20 ShortRun cases passed; one representative default-job case passed. Scoped simplification review and staged diff checks completed. The added benchmark files compiled without warnings. Kafka integration tests were not needed for these network-free benchmark fixtures; they remain required for the product implementation.

Exact baseline product SHA: `aefb825462cd6f6d6e956fca3374a12d98a0e128`. Environment and repeat commands are documented in `ShareConsumerAllocations.md`. Results are per partition batch. Implicit accumulation stays at 448 B; explicit accumulation grows from 4,952 B to 102,544 B. Headerless parsing allocates 5,872/90,448 B synchronously and 5,752/90,328 B through the warm preparation-aware path. Retained traversal is 0 B. These reproduce existing allocations; no product performance PASS is claimed. ShortRun timing is exploratory, and single-invocation wire timing is explicitly unsuitable for acceptance. Cold preparation, Renew ownership, asynchronous PollAsync delivery, and broker semantics remain in #3103.

Closes #3102

<details>
<summary>Representative default-job MemoryDiagnoser report</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host]     : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3


```
| Method                | RecordCount | HeaderCount | Mean     | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|---------------------- |------------ |------------ |---------:|----------:|----------:|-------:|-------:|----------:|
| ParseSynchronousBatch | 64          | 0           | 6.107 μs | 0.1185 μs | 0.1108 μs | 0.4425 | 0.0076 |   5.73 KB |

</details>

<details>
<summary>Complete ShortRun parser and acknowledgement reports</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host]   : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3
  ShortRun : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```
| Method                 | RecordCount | HeaderCount | Mean          | Error         | StdDev        | Gen0    | Gen1    | Allocated |
|----------------------- |------------ |------------ |--------------:|--------------:|--------------:|--------:|--------:|----------:|
| **ParseSynchronousBatch**  | **64**          | **0**           |   **6,079.75 ns** |   **1,808.18 ns** |     **99.113 ns** |  **0.4425** |  **0.0076** |    **5872 B** |
| ParseWarmPreparedBatch | 64          | 0           |   5,428.68 ns |   3,904.58 ns |    214.023 ns |  0.4349 |  0.0076 |    5752 B |
| TraverseRetainedBatch  | 64          | 0           |      79.66 ns |      17.17 ns |      0.941 ns |       - |       - |         - |
| **ParseSynchronousBatch**  | **64**          | **2**           |  **21,433.83 ns** |  **26,512.29 ns** |  **1,453.228 ns** |  **0.9460** |  **0.0305** |   **12528 B** |
| ParseWarmPreparedBatch | 64          | 2           |  18,859.36 ns |  20,100.51 ns |  1,101.777 ns |  0.9460 |  0.0305 |   12408 B |
| TraverseRetainedBatch  | 64          | 2           |     319.52 ns |     584.44 ns |     32.035 ns |       - |       - |         - |
| **ParseSynchronousBatch**  | **1024**        | **0**           | **125,959.24 ns** |  **50,917.54 ns** |  **2,790.962 ns** |  **6.8359** |  **1.5869** |   **90448 B** |
| ParseWarmPreparedBatch | 1024        | 0           |  81,112.32 ns | 108,985.84 ns |  5,973.881 ns |  6.8359 |  1.5869 |   90328 B |
| TraverseRetainedBatch  | 1024        | 0           |   1,295.41 ns |     367.08 ns |     20.121 ns |       - |       - |         - |
| **ParseSynchronousBatch**  | **1024**        | **2**           | **670,037.19 ns** | **377,788.83 ns** | **20,707.881 ns** | **34.1797** | **14.6484** |  **451256 B** |
| ParseWarmPreparedBatch | 1024        | 2           | 631,716.67 ns |  43,975.44 ns |  2,410.442 ns | 34.1797 | 13.6719 |  451136 B |
| TraverseRetainedBatch  | 1024        | 2           |   5,490.92 ns |     717.46 ns |     39.327 ns |       - |       - |         - |
```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.400
  [Host]   : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3
  ShortRun : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v3

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```
| Method               | InvocationCount | UnrollFactor | RecordCount | Mode     | Mean         | Error         | StdDev      | Gen0   | Gen1   | Allocated |
|--------------------- |---------------- |------------- |------------ |--------- |-------------:|--------------:|------------:|-------:|-------:|----------:|
| **AccumulateFreshBatch** | **Default**         | **16**           | **64**          | **Implicit** |     **728.1 ns** |     **776.64 ns** |    **42.57 ns** | **0.0334** |      **-** |     **448 B** |
| MaterializeWireBatch | 1               | 1            | 64          | Implicit |   3,000.0 ns |  13,155.74 ns |   721.11 ns |      - |      - |     560 B |
| **AccumulateFreshBatch** | **Default**         | **16**           | **64**          | **Explicit** |   **1,255.9 ns** |      **52.57 ns** |     **2.88 ns** | **0.3777** | **0.0038** |    **4952 B** |
| MaterializeWireBatch | 1               | 1            | 64          | Explicit |  11,266.7 ns |  26,395.67 ns | 1,446.84 ns |      - |      - |    3040 B |
| **AccumulateFreshBatch** | **Default**         | **16**           | **1024**        | **Implicit** |  **10,815.2 ns** |   **1,471.12 ns** |    **80.64 ns** | **0.0305** |      **-** |     **448 B** |
| MaterializeWireBatch | 1               | 1            | 1024        | Implicit |   3,100.0 ns |  11,097.22 ns |   608.28 ns |      - |      - |    1520 B |
| **AccumulateFreshBatch** | **Default**         | **16**           | **1024**        | **Explicit** |  **21,965.9 ns** |  **15,376.55 ns** |   **842.84 ns** | **7.8430** | **1.9531** |  **102544 B** |
| MaterializeWireBatch | 1               | 1            | 1024        | Explicit | 178,733.3 ns | 146,408.95 ns | 8,025.17 ns |      - |      - |   36832 B |
</details>
