### PR TITLE
test(benchmarks): isolate partitioned dispatch allocation costs

### DIFF
--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionedDispatchBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionedDispatchBenchmarks.cs
@@ -1,0 +1,184 @@
+using System.Buffers.Binary;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Compares the production handler paths over one bounded partition lifetime.</summary>
+[MemoryDiagnoser]
+public class PartitionedDispatchBenchmarks
+{
+    private const int RecordCount = 128;
+    private readonly bool[] _seen = new bool[RecordCount];
+    private readonly long[] _lastByKey = new long[RecordCount];
+    private ConsumeResult<int, int>[] _records = null!;
+    private PartitionProcessor<int, int> _processor = null!;
+    private TaskCompletionSource? _release;
+    private int _handled;
+
+    [ParamsAllValues]
+    public DispatchScenario Scenario { get; set; }
+
+    [Params(false, true)]
+    public bool SuspendFirstHandler { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        var distinct = Scenario is DispatchScenario.KeyRecordsDistinct or DispatchScenario.KeyBatchesDistinct;
+        _records = PartitionedBenchmarkInput.CreateRecords(RecordCount, distinct);
+        var options = new PartitionedProcessingOptions
+        {
+            Ordering = Scenario is DispatchScenario.PartitionRecords or DispatchScenario.PartitionBatches
+                ? PartitionedProcessingOrder.Partition : PartitionedProcessingOrder.Key,
+            MaxBufferedRecordsPerPartition = RecordCount,
+            MaxConcurrentHandlersPerPartition = 1,
+            MaxHandlerBatchSize = 16
+        };
+        var batches = Scenario is DispatchScenario.PartitionBatches
+            or DispatchScenario.KeyBatchesRepeated or DispatchScenario.KeyBatchesDistinct;
+        var factory = typeof(PartitionedConsumerExtensions).GetMethod(
+            batches ? "CreateBatchProcessor" : "CreateRecordProcessor", BindingFlags.NonPublic | BindingFlags.Static)!
+            .MakeGenericMethod(typeof(int), typeof(int));
+        Delegate handler = batches
+            ? (PartitionBatchProcessor<int, int>)HandleBatch
+            : (PartitionRecordProcessor<int, int>)HandleRecord;
+        _processor = (PartitionProcessor<int, int>)factory.Invoke(null, [handler, options])!;
+        await Dispatch();
+    }
+
+    [Benchmark(OperationsPerInvoke = RecordCount)]
+    public async ValueTask<long> Dispatch()
+    {
+        Array.Clear(_seen);
+        Array.Fill(_lastByKey, -1);
+        _handled = 0;
+        _release = SuspendFirstHandler ? new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously) : null;
+        var lane = PartitionedBenchmarkInput.CreateLane(RecordCount);
+        foreach (var record in _records)
+        {
+            if (!lane.TryEnqueue(record))
+                throw new InvalidOperationException("The bounded input did not fit in the partition queue.");
+        }
+
+        // Complete the input without starting PartitionLane's Task.Run wrapper. The actual
+        // processor factories still own handler dispatch, storage release and commit tracking.
+        await lane.StopAsync(PartitionStopPolicy.Drain, Timeout.InfiniteTimeSpan);
+        var processing = _processor(new PartitionProcessorContext<int, int>(lane), CancellationToken.None);
+        var suspended = !processing.IsCompleted && _handled != 0;
+        _release?.TrySetResult();
+        await processing.AsTask().WaitAsync(TimeSpan.FromSeconds(30));
+        if (SuspendFirstHandler && !suspended)
+            throw new InvalidOperationException("The first handler did not suspend dispatch.");
+        var checkpoint = lane.GetCommitOffset();
+        if (_handled != RecordCount || checkpoint is not { Offset: RecordCount, LeaderEpoch: 7 }
+            || lane.TryReadMessage(out _))
+            throw new InvalidOperationException("Dispatch lost records or produced an incorrect checkpoint.");
+        return checkpoint.Value.Offset;
+    }
+
+    private ValueTask HandleRecord(PartitionRecordProcessorContext<int, int> context,
+        ConsumeResult<int, int> record, CancellationToken cancellationToken)
+    {
+        var first = _handled == 0;
+        Observe(record);
+        return first && _release is not null ? new ValueTask(_release.Task) : default;
+    }
+
+    private ValueTask HandleBatch(PartitionBatchProcessorContext<int, int> context,
+        IReadOnlyList<ConsumeResult<int, int>> records, CancellationToken cancellationToken)
+    {
+        var first = _handled == 0;
+        for (var index = 0; index < records.Count; index++)
+            Observe(records[index]);
+        return first && _release is not null ? new ValueTask(_release.Task) : default;
+    }
+
+    private void Observe(ConsumeResult<int, int> record)
+    {
+        var offset = checked((int)record.Offset);
+        if (_seen[offset] || record.Offset <= _lastByKey[record.Key])
+            throw new InvalidOperationException("A record was duplicated or its key was processed out of order.");
+        _seen[offset] = true;
+        _lastByKey[record.Key] = record.Offset;
+        _handled++;
+    }
+
+    public enum DispatchScenario
+    {
+        PartitionRecords,
+        PartitionBatches,
+        KeyRecordsRepeated,
+        KeyRecordsDistinct,
+        KeyBatchesRepeated,
+        KeyBatchesDistinct
+    }
+}
+
+/// <summary>Separates partition construction and completion tracking from handler scheduling.</summary>
+[MemoryDiagnoser]
+public class PartitionedOffsetTrackingBenchmarks
+{
+    private const int RecordCount = 128;
+    private ConsumeResult<int, int>[] _records = null!;
+
+    [GlobalSetup]
+    public void Setup() => _records = PartitionedBenchmarkInput.CreateRecords(RecordCount, distinct: false);
+
+    // All three rows use the same denominator: one partition lifetime / 128 records.
+    [Benchmark(OperationsPerInvoke = RecordCount)]
+    public object CreatePartition() => PartitionedBenchmarkInput.CreateLane(RecordCount);
+
+    [Benchmark(OperationsPerInvoke = RecordCount)]
+    public long CompleteInOrder()
+    {
+        var lane = PartitionedBenchmarkInput.CreateLane(RecordCount);
+        foreach (var record in _records)
+            lane.MarkProcessed(record);
+        return CheckCheckpoint(lane);
+    }
+
+    [Benchmark(OperationsPerInvoke = RecordCount)]
+    public long CompleteOutOfOrder()
+    {
+        var lane = PartitionedBenchmarkInput.CreateLane(RecordCount);
+        // Establish the low watermark, then leave offset 1 outstanding until all later
+        // completions have accumulated. This exercises the real gap-tracking collections.
+        lane.MarkProcessed(_records[0]);
+        for (var index = RecordCount - 1; index >= 1; index--)
+            lane.MarkProcessed(_records[index]);
+        return CheckCheckpoint(lane);
+    }
+
+    private static long CheckCheckpoint(PartitionLane<int, int> lane)
+    {
+        var checkpoint = lane.GetCommitOffset();
+        if (checkpoint is not { Offset: RecordCount, LeaderEpoch: 7 })
+            throw new InvalidOperationException("Completion tracking produced an incorrect checkpoint.");
+        return checkpoint.Value.Offset;
+    }
+}
+
+internal static class PartitionedBenchmarkInput
+{
+    internal static PartitionLane<int, int> CreateLane(int capacity) => new(
+        new TopicPartition("dispatch", 0), capacity,
+        static (_, _) => default, static _ => { }, static (_, _) => { });
+
+    internal static ConsumeResult<int, int>[] CreateRecords(int count, bool distinct)
+    {
+        var records = new ConsumeResult<int, int>[count];
+        for (var index = 0; index < count; index++)
+        {
+            var key = new byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32BigEndian(key, distinct ? index : 0);
+            records[index] = new ConsumeResult<int, int>("dispatch", 0, index,
+                key, false, key, false, null, 0, TimestampType.CreateTime, 7,
+                Serializers.Int32, Serializers.Int32);
+        }
+        return records;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionedDispatchBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionedDispatchBenchmarks.cs
@@ -2,7 +2,6 @@ using System.Buffers.Binary;
 using System.Reflection;
 using BenchmarkDotNet.Attributes;
 using Dekaf.Consumer;
-using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;

--- a/tools/Dekaf.Benchmarks/PARTITIONED-DISPATCH.md
+++ b/tools/Dekaf.Benchmarks/PARTITIONED-DISPATCH.md
@@ -1,0 +1,36 @@
+# Partitioned dispatch allocation coverage
+
+These fixtures separate the operations involved in #3078. They provide a durable comparison surface for scheduler changes, not a performance acceptance verdict.
+
+| Fixture | Measured work | Unit |
+|---|---|---|
+| `PartitionedDispatchBenchmarks` | Production partition/key record/batch processors, input queue, completion tracking, and bounded partition lifetime | One of 128 records |
+| `PartitionedOffsetTrackingBenchmarks` | Partition creation alone, then creation plus ordered or out-of-order `MarkProcessed` calls | One of 128 records; creation row is an amortized control |
+| Existing `PartitionedStorageLifetimeBenchmarks.QueueAndComplete` | Reused queue transfer with borrowed fetch storage, without handlers or completion tracking | One of 1,024 records |
+| Existing `PartitionedStorageLifetimeBenchmarks.QueueAndCompleteConcurrent` | Same storage transfer with a dedicated reader thread | One of 1,024 records |
+
+Dispatch cases cover partition records, partition batches, repeated-key records/batches, and distinct-key records/batches. Keys are integers so equality is already correct on the baseline; binary comparison costs belong to #3048. Each case runs with synchronous handlers and with its first handler suspended by a `TaskCompletionSource`. One concurrent handler makes the blocked-first-handler shape deterministic: key dispatch can queue all 128 records before the gate opens. Synchronous repeated keys exercise idle-lane removal and recreation instead of coalescing queued work. Handler batches contain at most 16 records.
+
+The fixture binds the real private `CreateRecordProcessor`/`CreateBatchProcessor` factories once in `GlobalSetup`. Reflection, input deserialization, and validation-array allocation are outside measurement. No production dispatch implementation is copied into the fixture. A factory signature change must update the binding; it must not silently substitute a benchmark-only implementation.
+
+Each measured invocation creates a bounded partition lane, enqueues the prepared records, completes its writer, invokes the production processor, and waits for its completion. It bypasses the runtime's outer broker loop and `PartitionLane.Start` task wrapper. The handler checks duplicate delivery and per-key order; completion checks all 128 records, an empty queue, next offset 128, and leader epoch 7. A suspended first handler must actually suspend processing. All work completes before another invocation starts; the completion wait has a 30-second deadline.
+
+The reported allocations include lane/channel/collection construction, production handler contexts and tracking, and benchmark coordination. Suspended cases include one completion source, asynchronous continuation/wait costs, and the benchmark's own async coordinator per 128 records. Validation arrays are reused, and batch observation uses indexed access to avoid adding an interface-enumerator allocation. Inputs have no borrowed storage; use the existing storage fixture to measure that separately. These are bounded partition lifetimes, not a claim about a warmed, indefinitely running dispatcher.
+
+The offset fixture deliberately constructs a fresh partition for each invocation so resetting state cannot bypass production invariants. Its out-of-order case completes offset 0, then 127 down to 1, leaving the low gap open while the real tracking collections grow. Construction is explicit in all three rows. Do not subtract unrelated timing means or treat one allocation difference as exhaustive stack attribution. Use allocation tracing when the source and component comparisons do not identify a cost.
+
+## Run and compare
+
+Run from an isolated worktree. No Kafka broker is required. Use a unique artifacts directory for each run:
+
+```powershell
+dotnet build tools/Dekaf.Benchmarks -c Release
+dotnet run --project tools/Dekaf.Benchmarks -c Release --no-build -- --filter '*PartitionedDispatchBenchmarks*' '*PartitionedOffsetTrackingBenchmarks*' '*PartitionedStorageLifetimeBenchmarks.QueueAndComplete*' --job Dry --artifacts .artifacts/partitioned-dry
+dotnet run --project tools/Dekaf.Benchmarks -c Release --no-build -- --filter '*PartitionedDispatchBenchmarks*' '*PartitionedOffsetTrackingBenchmarks*' '*PartitionedStorageLifetimeBenchmarks.QueueAndComplete*' --job Short --exporters fulljson --artifacts .artifacts/partitioned-short
+```
+
+The filters select 17 cases: 12 dispatch, three tracking, and two existing transfer cases. Dry validates execution only. Short results support initial allocation diagnosis; use the default job and appropriate controls for acceptance-quality timing.
+
+For a product comparison, build the identical fixture in separate worktrees at the immediately preceding exact product SHA and candidate SHA. Record both SHAs, the fixture and loaded `Dekaf.dll` hashes, SDK/runtime, machine, job parameters, and all reports. Preserve the same processor binding and inputs; if an internal signature requires an adapter, record and inspect that difference. Compare matching cases against the last accepted baseline and repeated unchanged controls on a quiet host. Shared-host measurements cannot establish timing equivalence.
+
+Report per-record allocations and explicit amortized lifetime costs together. This suite does not establish application p50/p99/max latency, CPU per message, broker throughput, sustained stability, handler concurrency above one, cancellation, rebalance correctness, or offset-gap correctness across missing Kafka records. The production optimization in #3107 must supply those correctness tests and protected-metric evidence in addition to these benchmarks. A zero-byte transfer row never establishes zero-byte whole dispatch.


### PR DESCRIPTION
The existing key-dispatch measurements combined handler scheduling, queue transfer and completion tracking, and the repeated-key workload depended on whether its first handler suspended. Add maintained coverage that exercises the actual production processor factories for partition/key record and batch handling with synchronous and blocked-first-handler variants.

The 12 dispatch cases validate each delivery once, per-key order, complete input drain, next offset 128 and leader epoch 7. Reflection is confined to setup. Three separate completion-tracking cases isolate construction and ordered/out-of-order MarkProcessed work; the guide reuses the existing two queue/storage transfer cases. Inputs are prepared outside measurement; partition construction and benchmark coordination remain explicitly included per 128 records. No source behavior changes.

Validation: Release benchmark build has zero warnings/errors. All 17 Dry cases passed; final simplification review moved the suspension assertion after awaiting processing so a failed fixture assertion cannot abandon in-flight work. All 12 affected dispatch cases then passed again. Batch observation uses indexed access and adds no interface-enumerator allocation. No new TUnit test is needed for this benchmark-only change; each invocation contains semantic checks. git diff --check passed.

This closes only the maintained coverage prerequisite. The complete scheduler optimization, allocation attribution and protected-metric acceptance remain in #3107; #3078 stays open. This suite does not establish handler concurrency above one, broker throughput, CPU/message, application completion percentiles, cancellation/rebalance correctness, or sustained stability. No paid stress lane or acceptance verdict is claimed.

Closes #3106

### Diagnostic baseline

Fixture commit `c9ec9236019560005b8124643ae3532e8c6d9499`, product source unchanged from main `602b8c76ac1e895fe8d897821f65bb62da47afde` (`src/Dekaf` tree `b23e27cd0469b032759095770b827119c0ebdda2`). Windows 11 25H2 / i7-12700K / SDK 10.0.400 / .NET 10.0.11 / BenchmarkDotNet 0.15.8, separate generated processes, MemoryDiagnoser, no profiler or affinity override. The shared host was not reserved; these data do not establish timing equivalence or a protected-metric PASS.

A representative default-job synchronous repeated-key record case completed 40 measured iterations: **414.590 ± 8.112 ns/record, SD 14.420 ns, 1,132 B/record**. The following ShortRun baseline (three warmups, three measured iterations) completed all 17 cases. Error is the 99.9% confidence-interval half-width. Its broad timing intervals are retained, not treated as performance acceptance. Default and Short jobs differ; no direct timing equivalence is asserted.

| Case | Mean ± error (ns/record) | Allocated B/record |
|---|---:|---:|
| PartitionedDispatchBenchmarks.Dispatch(SuspendFirstHandler: False, Scenario: PartitionRecords) | 123.204 ± 107.879 | 236 |
| PartitionedDispatchBenchmarks.Dispatch(SuspendFirstHandler: False, Scenario: PartitionBatches) | 127.841 ± 102.449 | 337 |
| PartitionedDispatchBenchmarks.Dispatch(SuspendFirstHandler: False, Scenario: KeyRecordsRepeated) | 552.089 ± 833.281 | 1132 |
| PartitionedDispatchBenchmarks.Dispatch(SuspendFirstHandler: False, Scenario: KeyRecordsDistinct) | 480.559 ± 635.480 | 1132 |
| PartitionedDispatchBenchmarks.Dispatch(SuspendFirstHandler: False, Scenario: KeyBatchesRepeated) | 538.210 ± 649.742 | 2452 |
| PartitionedDispatchBenchmarks.Dispatch(SuspendFirstHandler: False, Scenario: KeyBatchesDistinct) | 531.887 ± 554.866 | 2452 |
| PartitionedDispatchBenchmarks.Dispatch(SuspendFirstHandler: True, Scenario: PartitionRecords) | 172.302 ± 284.991 | 241 |
| PartitionedDispatchBenchmarks.Dispatch(SuspendFirstHandler: True, Scenario: PartitionBatches) | 145.847 ± 33.440 | 341 |
| PartitionedDispatchBenchmarks.Dispatch(SuspendFirstHandler: True, Scenario: KeyRecordsRepeated) | 387.337 ± 251.209 | 553 |
| PartitionedDispatchBenchmarks.Dispatch(SuspendFirstHandler: True, Scenario: KeyRecordsDistinct) | 1645.892 ± 2054.615 | 2211 |
| PartitionedDispatchBenchmarks.Dispatch(SuspendFirstHandler: True, Scenario: KeyBatchesRepeated) | 325.233 ± 559.038 | 540 |
| PartitionedDispatchBenchmarks.Dispatch(SuspendFirstHandler: True, Scenario: KeyBatchesDistinct) | 2055.609 ± 876.167 | 3531 |
| PartitionedOffsetTrackingBenchmarks.CreatePartition | 0.679 ± 0.606 | 10 |
| PartitionedOffsetTrackingBenchmarks.CompleteInOrder | 33.696 ± 27.956 | 59 |
| PartitionedOffsetTrackingBenchmarks.CompleteOutOfOrder | 91.256 ± 193.503 | 137 |
| PartitionedStorageLifetimeBenchmarks.QueueAndComplete | 60.909 ± 10.364 | 0 |
| PartitionedStorageLifetimeBenchmarks.QueueAndCompleteConcurrent | 150.810 ± 283.805 | 0 |

The synchronous repeated/distinct cases have the same allocations because an immediately completed key lane is removed before the next record arrives. Holding the first handler changes this: repeated-key record/batch allocations are 553/540 B per record; distinct-key record/batch allocations are 2,211/3,531 B per record. These are workload comparisons, not before/after product improvements. The queue rows report 0 B at BDN counter precision; that does not imply zero allocations for dispatch. The 10 B construction control and 59/137 B completion rows include one fresh lane per 128 records and expose completion-tracking cost separately. Integer allocation output and asynchronous coordination can vary slightly between jobs; no difference is attributed to one allocation stack without further evidence.

Source inspection identifies the next attribution targets: production record completion calls SortedSet.Add; partition batches allocate batch.ToArray(); key dispatch creates lane queues/lists/tasks/continuations and calls batch.ToArray() for each handler invocation. The new cases isolate these paths but do not replace allocation-stack attribution for #3107.

Fixture file SHA-256: `66C4A42BE14F5016A7C169E16F3560ECDB1382AB0493E8E23307EE1103FE4CC8`. Actual generated executable dependency hashes are recorded separately: default-job Dekaf.dll `DAAC20A722F8078BC8F64B899B2F8E7B94FDC6799BEA52213318453ABF13E7FD`; ShortRun Dekaf.dll `2394C4BDADAA04ED9AE8B0181B3C65E276734695505DD3DBD83756D9FB8E5CD3`. Both builds use the unchanged product source; the binary hashes are not presented as identical.

The local build logs, Dry runs, full JSON exports, generated harnesses and loaded binaries were present when this evidence was recorded, but Merge-Pr.ps1 removed their worktree after merging on 2026-09-07. The raw files are no longer retained at the previously cited path. The fixture commits and numerical/hash evidence above remain in Git/GitHub; raw measurements cannot be independently reanalyzed from those summaries. No replacement run is presented as recovery of the original evidence. Future product comparisons require new exact-input evidence and durable archival before cleanup.



Review comment 5565784442 is addressed in `0243a09a6d7662c200309039a35cd8d782119057`: removed the unused Dekaf.Protocol.Records import. Release benchmark build passes with zero warnings/errors; git diff --check passes. The one-line cleanup changes no benchmark method, fixture input, or product source, so no additional measurement was run. The recorded measurements and file hashes remain explicitly tied to fixture commit c9ec9236019560005b8124643ae3532e8c6d9499. Awaiting the new CI/review cycle.


