### PR TITLE
test(consumer): retain native classic coordinator diagnostics

### DIFF
--- a/tests/Dekaf.Tests.Integration/ConsumerCoordinatorFailoverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerCoordinatorFailoverIntegrationTests.cs
@@ -11,6 +11,9 @@ namespace Dekaf.Tests.Integration;
 [ClassDataSource<RackAwareKafkaContainer>(Shared = SharedType.PerTestSession)]
 public sealed class ConsumerCoordinatorFailoverIntegrationTests(RackAwareKafkaContainer kafka)
 {
+    private const int ClassicDiagnosticCapacity = 4096;
+    private readonly ConcurrentQueue<string> _classicDiagnostics = new();
+
     private const int PartitionCount = 6;
     private const int MessagesPerPartition = 20;
     private const int MessageCount = PartitionCount * MessagesPerPartition;
@@ -25,6 +28,13 @@ public sealed class ConsumerCoordinatorFailoverIntegrationTests(RackAwareKafkaCo
     /// was stuck on instead, and three of them still fit inside the test timeout.
     /// </summary>
     private static readonly TimeSpan ConvergenceTimeout = TimeSpan.FromSeconds(60);
+
+    [After(Test)]
+    public void PrintClassicDiagnostics()
+    {
+        if (!_classicDiagnostics.IsEmpty)
+            Console.WriteLine(string.Join(Environment.NewLine, _classicDiagnostics));
+    }
 
     [Test]
     [Timeout(240_000)]
@@ -478,7 +488,15 @@ public sealed class ConsumerCoordinatorFailoverIntegrationTests(RackAwareKafkaCo
             EnableAutoCommit = false,
             EnableAutoOffsetStore = false,
             SessionTimeoutMs = (int)SessionTimeout.TotalMilliseconds,
-            HeartbeatIntervalMs = 1_000
+            HeartbeatIntervalMs = 1_000,
+            // Keep native state changes for the next convergence failure. Native callbacks
+            // lack TUnit's execution context, so the owning test writes the bounded log later.
+            Debug = "cgrp,metadata,topic"
+        }).SetLogHandler((consumer, message) =>
+        {
+            _classicDiagnostics.Enqueue($"{DateTimeOffset.UtcNow:O} {message.Name} {message.Facility}: {message.Message}");
+            if (_classicDiagnostics.Count > ClassicDiagnosticCapacity)
+                _classicDiagnostics.TryDequeue(out _);
         });
         if (listener is not null)
         {

--- a/tests/Dekaf.Tests.Integration/ConsumerCoordinatorFailoverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerCoordinatorFailoverIntegrationTests.cs
@@ -32,8 +32,12 @@ public sealed class ConsumerCoordinatorFailoverIntegrationTests(RackAwareKafkaCo
     [After(Test)]
     public void PrintClassicDiagnostics()
     {
-        if (!_classicDiagnostics.IsEmpty)
-            Console.WriteLine(string.Join(Environment.NewLine, _classicDiagnostics));
+        var state = TestContext.Current?.Execution.Result?.State;
+        if (state is not (TestState.Failed or TestState.Timeout or TestState.Cancelled)
+            || _classicDiagnostics.IsEmpty)
+            return;
+
+        Console.WriteLine(string.Join(Environment.NewLine, _classicDiagnostics));
     }
 
     [Test]
@@ -495,6 +499,7 @@ public sealed class ConsumerCoordinatorFailoverIntegrationTests(RackAwareKafkaCo
         }).SetLogHandler((consumer, message) =>
         {
             _classicDiagnostics.Enqueue($"{DateTimeOffset.UtcNow:O} {message.Name} {message.Facility}: {message.Message}");
+            // Concurrent callbacks can briefly overshoot this target by the number of writers.
             if (_classicDiagnostics.Count > ClassicDiagnosticCapacity)
                 _classicDiagnostics.TryDequeue(out _);
         });


### PR DESCRIPTION
Classic coordinator failures currently report only an empty assignment and timeout. Native librdkafka callbacks lack TUnit's execution context, so writing directly from those callbacks did not put their state into the failed test's report. Capture the most recent 4096 cgrp/metadata/topic messages per test, with UTC timestamp and client identity, and emit them from the test's after hook only for failure, timeout, or cancellation. The callback only records messages and does not call consumer APIs.

This improves the next #3105 experiment. It does not claim a root cause or fix the original convergence failure. All assignment assertions, timeouts, broker operations, fixture concurrency, and non-diagnostic client configuration stay intact. No src changes.

Validation:

- Injected an intentional exception after initial classic assignment. The failed TUnit report contained 97,600 characters of diagnostics, including native CGRPSTATE, CGRPJOINSTATE, and METADATA messages with client identity. Removed the injected failure before final validation.
- All three classic coordinator cases passed on net10.0 and net8.0 with Kafka 4.3.1 (six executions).
- During investigation, the same diagnostic capture ran through all 167 Consumer-category tests successfully on Linux, .NET 10.0.11, Kafka 4.3.1, DOTNET_PROCESSOR_COUNT=4 / 16 parallel tests, source baseline `950c3fdd4f94086e2852b6a56052f9cc34df9de0`. The three classic cases retained 1034, 746, and 2284 native events respectively.
- Scoped simplification review and diff checks completed. Release builds had zero warnings/errors. No CI rerun was requested; #3105 remains open because the original failure has not been reproduced causally.

Closes #3108


### Review follow-up

Addressed review 5565814686 in `f71e2f5614dbdd40be388ddc4b501b00772f1392`. The after-hook now emits native diagnostics only for Failed, Timeout or Cancelled outcomes. Passing tests avoid the log join/output. The installed TUnit 1.66.16 public API is `TestContext.Current.Execution.Result`, rather than the review's illustrative direct Result property.

A temporary TUnit probe seeded the actual class's diagnostics queue and invoked its real after-hook from passing, intentionally failing and intentionally timing-out tests. On both net10.0 and net8.0, decoded HTML reports prove no sentinel output for the passing case and retained output for both unsuccessful cases (six executions). Expected deliberate failures were preserved as failures. The probe was removed from the test project before the final Release build, which passed with zero warnings/errors. The probe source, logs, reports and verification script were present when validation was recorded, but the merged-worktree sweep later removed this detached checkout. Those raw probe artifacts are no longer retained; the recorded six outcomes and final source commit remain in this PR. No broker operations or product source changed; existing real-broker evidence remains applicable. Final /simplify and diff checks completed.

The review's non-blocking queue observation is documented at the enqueue site: 4096 is a retention target, with transient overshoot bounded by concurrent writers. The thread-safe queue remains appropriate for these native callbacks, and no consumer API is called there. This does not claim an exact atomic capacity cap.

The original convergence investigation #3105 remains open. Awaiting the new CI/review cycle.


