### PR TITLE
docs(agents): archive validation evidence before worktree cleanup

### DIFF
--- a/.agents/skills/issue-pr-loop/SKILL.md
+++ b/.agents/skills/issue-pr-loop/SKILL.md
@@ -81,6 +81,10 @@ Merge requires an open, ready-for-review PR; `MERGEABLE` and `CLEAN`; every appl
 
 Use current repository rules/instructions for approval requirements. Historical merges without approval do not prove approval is optional; inaccessible protection APIs do not prove no protection exists.
 
+Archive validation evidence when first citing it in a PR, outside every removable worktree. Use a durable directory alongside the shared checkout and `Dekaf-worktrees`, organized by PR number and measured SHA, or a durable uploaded artifact. Include raw benchmark/test reports, experiment inputs and hashes, fixture/probe sources, and loaded binaries needed to reproduce or reanalyze the evidence. Include both head-branch and detached review checkouts.
+
+Before invoking the merge wrapper, verify the archived file inventory and SHA-256 hashes against the originals, then update the PR with the durable location. `.artifacts`, `bin`, `TestResults`, and similar generated directories inside a worktree are disposable under [WorktreeCleanup.ps1](../../../scripts/WorktreeCleanup.ps1); another worker's merge or sweep can remove them. If archival fails, defer the merge and take another item. If evidence is already lost, correct its retention claim explicitly; a rerun is new evidence, not recovery of deleted results.
+
 ```powershell
 pwsh scripts/Merge-Pr.ps1 -Pr <N> -Worktree $worktree
 ```

--- a/.agents/skills/issue-pr-loop/SKILL.md
+++ b/.agents/skills/issue-pr-loop/SKILL.md
@@ -81,7 +81,7 @@ Merge requires an open, ready-for-review PR; `MERGEABLE` and `CLEAN`; every appl
 
 Use current repository rules/instructions for approval requirements. Historical merges without approval do not prove approval is optional; inaccessible protection APIs do not prove no protection exists.
 
-Archive validation evidence when first citing it in a PR, outside every removable worktree. Use a durable directory alongside the shared checkout and `Dekaf-worktrees`, organized by PR number and measured SHA, or a durable uploaded artifact. Include raw benchmark/test reports, experiment inputs and hashes, fixture/probe sources, and loaded binaries needed to reproduce or reanalyze the evidence. Include both head-branch and detached review checkouts.
+Archive validation evidence when first citing it in a PR, outside every removable worktree. Use a durable directory alongside the shared checkout and its worktree root, organized by PR number and measured SHA, or a durable uploaded artifact. Include raw benchmark/test reports, experiment inputs and hashes, fixture/probe sources, and loaded binaries needed to reproduce or reanalyze the evidence. Include both head-branch and detached review checkouts.
 
 Before invoking the merge wrapper, verify the archived file inventory and SHA-256 hashes against the originals, then update the PR with the durable location. `.artifacts`, `bin`, `TestResults`, and similar generated directories inside a worktree are disposable under [WorktreeCleanup.ps1](../../../scripts/WorktreeCleanup.ps1); another worker's merge or sweep can remove them. If archival fails, defer the merge and take another item. If evidence is already lost, correct its retention claim explicitly; a rerun is new evidence, not recovery of deleted results.
 


### PR DESCRIPTION
Merged-worktree cleanup removes .artifacts, bin and TestResults. Validation evidence cited by a PR can therefore disappear after merge, including evidence from detached review checkouts. Require archival when evidence is first cited, verify the inventory and SHA-256 hashes before merge, and publish the durable location before invoking the existing merge wrapper. Missing archives defer a merge; lost evidence must be disclosed rather than replaced by a rerun presented as recovery.

Validation: reviewed the rule against WorktreeCleanup.ps1, verified the relative source link and ordering before the merge command, and passed git diff --check. Skill-creator and scoped simplification reviews complete. Instructions only; no runtime tests apply. Cleanup behavior remains unchanged.

Closes #3114
