### PR TITLE
feat(share-consumer): publish registered application telemetry metrics

### DIFF
--- a/docs/docs/consumer/share-consumers.md
+++ b/docs/docs/consumer/share-consumers.md
@@ -208,7 +208,7 @@ using Dekaf.ShareConsumer;
 using Dekaf.Telemetry;
 
 long completed = 0;
-await using var consumer = Kafka.CreateShareConsumer<string, string>()
+await using var consumer = await Kafka.CreateShareConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("jobs")
     .RegisterMetricForSubscription(new ApplicationTelemetryMetric(

--- a/docs/docs/consumer/share-consumers.md
+++ b/docs/docs/consumer/share-consumers.md
@@ -204,6 +204,7 @@ Common builder options beyond the connection/TLS/SASL settings shared with other
 Share consumers can publish application counters and gauges through [broker-side telemetry](../observability#broker-side-telemetry-kip-714). Register metrics on the builder or on a running consumer:
 
 ```csharp
+using System.Threading;
 using Dekaf.ShareConsumer;
 using Dekaf.Telemetry;
 

--- a/docs/docs/consumer/share-consumers.md
+++ b/docs/docs/consumer/share-consumers.md
@@ -199,6 +199,35 @@ Common builder options beyond the connection/TLS/SASL settings shared with other
 | `WithSessionTimeoutMs` | 45000 | Coordinator removes the member without a heartbeat within this window |
 | `WithHeartbeatIntervalMs` | 3000 | Initial heartbeat interval (broker may adjust) |
 
+## Application telemetry
+
+Share consumers can publish application counters and gauges through [broker-side telemetry](../observability#broker-side-telemetry-kip-714). Register metrics on the builder or on a running consumer:
+
+```csharp
+using Dekaf.ShareConsumer;
+using Dekaf.Telemetry;
+
+long completed = 0;
+await using var consumer = Kafka.CreateShareConsumer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .WithGroupId("jobs")
+    .RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+        "com.example.jobs.completed", ApplicationTelemetryMetricKind.Counter,
+        () => Interlocked.Read(ref completed)))
+    .BuildAsync();
+
+consumer.RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+    "com.example.jobs.queue.depth", ApplicationTelemetryMetricKind.Gauge,
+    () => 42));
+consumer.UnregisterMetricFromSubscription("com.example.jobs.queue.depth");
+```
+
+The broker's client-metrics configuration selects metric name prefixes, collection interval, compression, and counter temporality. Supply a cumulative monotonic value for a counter; Dekaf computes deltas when requested. Observation callbacks run on the telemetry background loop, so keep them fast, non-blocking, and safe to call alongside application work. Metrics outside requested prefixes are not observed.
+
+Registering the same name replaces its previous metric and resets counter history. Removing a missing name does nothing. Builders snapshot registrations for each built consumer; `ShareConsumerOptions.ApplicationMetrics` also supplies initial registrations. Metric attributes are copied when the metric is created. Registration and removal after consumer disposal throw `ObjectDisposedException`.
+
+Runtime methods use the optional `IApplicationTelemetryShareConsumer` capability. Existing implementations of `IKafkaShareConsumer<TKey, TValue>` remain compatible; the extension methods throw `NotSupportedException` when that capability is absent. A supported broker receives the encoded application metrics under the client's assigned instance identity, including the final telemetry push during shutdown.
+
 ## Thread Safety
 
 `IKafkaShareConsumer<TKey, TValue>` is **not thread-safe**. Call `Subscribe`, `PollAsync`, `Acknowledge`, `CommitAsync`, and `Unsubscribe` from a single thread or with external synchronization. Run multiple consumer instances for parallelism — that is the point of share groups.

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -3493,6 +3493,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private int _bootstrapResolveTimeoutMs = 120000;
     private IRetryPolicy? _retryPolicy;
     private readonly List<string> _topicsToSubscribe = [];
+    private readonly Dictionary<string, ApplicationTelemetryMetric> _applicationMetrics = new(StringComparer.Ordinal);
 
     public ShareConsumerBuilder()
     {
@@ -4063,6 +4064,22 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         return this;
     }
 
+    /// <summary>Registers an application metric on built consumers. The same name replaces its previous registration.</summary>
+    public ShareConsumerBuilder<TKey, TValue> RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+    {
+        ArgumentNullException.ThrowIfNull(metric);
+        _applicationMetrics[metric.Name] = metric;
+        return this;
+    }
+
+    /// <summary>Removes an application metric from this builder. Missing names are ignored.</summary>
+    public ShareConsumerBuilder<TKey, TValue> UnregisterMetricFromSubscription(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        _applicationMetrics.Remove(name);
+        return this;
+    }
+
     public ShareConsumerBuilder<TKey, TValue> WithRetryPolicy(IRetryPolicy retryPolicy)
     {
         _retryPolicy = retryPolicy;
@@ -4167,7 +4184,8 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             ClientDnsLookup = _clientDnsLookup,
             MetadataClusterCheckEnabled = _metadataClusterCheckEnabled,
             BootstrapResolveTimeoutMs = _bootstrapResolveTimeoutMs,
-            RetryPolicy = _retryPolicy
+            RetryPolicy = _retryPolicy,
+            ApplicationMetrics = _applicationMetrics.Count > 0 ? _applicationMetrics.Values.ToArray() : []
         };
 
         var consumer = _clientInfrastructure is null

--- a/src/Dekaf/PublicAPI.Unshipped.txt
+++ b/src/Dekaf/PublicAPI.Unshipped.txt
@@ -13,3 +13,14 @@ Dekaf.Admin.ListGroupsOptions.States.init -> void
 Dekaf.Admin.ListGroupsOptions.Types.get -> System.Collections.Generic.IReadOnlyList<string!>?
 Dekaf.Admin.ListGroupsOptions.Types.init -> void
 static Dekaf.Admin.AdminClientGroupListingExtensions.ListGroupsAsync(this Dekaf.Admin.IAdminClient! adminClient, Dekaf.Admin.ListGroupsOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Dekaf.Admin.GroupListing!>!>
+
+Dekaf.ShareConsumer.IApplicationTelemetryShareConsumer
+Dekaf.ShareConsumer.IApplicationTelemetryShareConsumer.RegisterMetricForSubscription(Dekaf.Telemetry.ApplicationTelemetryMetric! metric) -> void
+Dekaf.ShareConsumer.IApplicationTelemetryShareConsumer.UnregisterMetricFromSubscription(string! name) -> void
+Dekaf.ShareConsumer.ShareConsumerOptions.ApplicationMetrics.get -> System.Collections.Generic.IReadOnlyList<Dekaf.Telemetry.ApplicationTelemetryMetric!>!
+Dekaf.ShareConsumer.ShareConsumerOptions.ApplicationMetrics.init -> void
+Dekaf.ShareConsumer.ShareConsumerTelemetryExtensions
+Dekaf.ShareConsumerBuilder<TKey, TValue>.RegisterMetricForSubscription(Dekaf.Telemetry.ApplicationTelemetryMetric! metric) -> Dekaf.ShareConsumerBuilder<TKey, TValue>!
+Dekaf.ShareConsumerBuilder<TKey, TValue>.UnregisterMetricFromSubscription(string! name) -> Dekaf.ShareConsumerBuilder<TKey, TValue>!
+static Dekaf.ShareConsumer.ShareConsumerTelemetryExtensions.RegisterMetricForSubscription<TKey, TValue>(this Dekaf.ShareConsumer.IKafkaShareConsumer<TKey, TValue>! consumer, Dekaf.Telemetry.ApplicationTelemetryMetric! metric) -> void
+static Dekaf.ShareConsumer.ShareConsumerTelemetryExtensions.UnregisterMetricFromSubscription<TKey, TValue>(this Dekaf.ShareConsumer.IKafkaShareConsumer<TKey, TValue>! consumer, string! name) -> void

--- a/src/Dekaf/ShareConsumer/IApplicationTelemetryShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/IApplicationTelemetryShareConsumer.cs
@@ -1,0 +1,40 @@
+using Dekaf.Telemetry;
+
+namespace Dekaf.ShareConsumer;
+
+/// <summary>Optional share-consumer capability for application metrics in broker telemetry subscriptions.</summary>
+public interface IApplicationTelemetryShareConsumer
+{
+    /// <summary>Registers a metric for broker-requested prefixes. The same name replaces its previous registration.</summary>
+    /// <remarks>The observation callback runs only during a subscribed telemetry collection.</remarks>
+    void RegisterMetricForSubscription(ApplicationTelemetryMetric metric);
+
+    /// <summary>Removes a metric registration. Missing names are ignored.</summary>
+    void UnregisterMetricFromSubscription(string name);
+}
+
+/// <summary>Application telemetry registration through a share consumer's optional capability.</summary>
+public static class ShareConsumerTelemetryExtensions
+{
+    /// <summary>Registers or replaces an application metric for broker telemetry subscriptions.</summary>
+    /// <exception cref="NotSupportedException">The consumer does not implement <see cref="IApplicationTelemetryShareConsumer"/>.</exception>
+    public static void RegisterMetricForSubscription<TKey, TValue>(
+        this IKafkaShareConsumer<TKey, TValue> consumer, ApplicationTelemetryMetric metric)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        if (consumer is not IApplicationTelemetryShareConsumer telemetry)
+            throw new NotSupportedException("The share consumer does not support application telemetry registration.");
+        telemetry.RegisterMetricForSubscription(metric);
+    }
+
+    /// <summary>Removes an application metric registration. Missing names are ignored.</summary>
+    /// <exception cref="NotSupportedException">The consumer does not implement <see cref="IApplicationTelemetryShareConsumer"/>.</exception>
+    public static void UnregisterMetricFromSubscription<TKey, TValue>(
+        this IKafkaShareConsumer<TKey, TValue> consumer, string name)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        if (consumer is not IApplicationTelemetryShareConsumer telemetry)
+            throw new NotSupportedException("The share consumer does not support application telemetry registration.");
+        telemetry.UnregisterMetricFromSubscription(name);
+    }
+}

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Telemetry.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Telemetry.cs
@@ -1,0 +1,20 @@
+using Dekaf.Telemetry;
+
+namespace Dekaf.ShareConsumer;
+
+internal sealed partial class KafkaShareConsumer<TKey, TValue>
+{
+    /// <inheritdoc />
+    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+    {
+        ThrowIfDisposed();
+        _telemetryMetricCollector.RegisterMetricForSubscription(metric);
+    }
+
+    /// <inheritdoc />
+    public void UnregisterMetricFromSubscription(string name)
+    {
+        ThrowIfDisposed();
+        _telemetryMetricCollector.UnregisterMetricFromSubscription(name);
+    }
+}

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -28,6 +28,7 @@ namespace Dekaf.ShareConsumer;
 /// </summary>
 internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     IKafkaShareConsumer<TKey, TValue>,
+    IApplicationTelemetryShareConsumer,
     IKafkaClientInstanceIdentity,
     IKafkaClientStatusProvider
 {
@@ -47,6 +48,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     private readonly AcknowledgementTracker _ackTracker = new();
     private readonly CompressionCodecRegistry _compressionCodecs;
     private readonly ClientTelemetryManager _telemetryManager;
+    private readonly ClientTelemetryMetricCollector _telemetryMetricCollector;
     private readonly ILogger _logger;
     private readonly ShareAcknowledgementCommitCallback? _acknowledgementCommitCallback;
 
@@ -183,11 +185,14 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaShareConsumer<TKey, TValue>>.Instance;
 
         _compressionCodecs = CompressionCodecRegistry.Default;
+        _telemetryMetricCollector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.ShareConsumer);
+        _telemetryMetricCollector.RegisterMetricsForSubscription(options.ApplicationMetrics);
         _telemetryManager = new ClientTelemetryManager(
             _connectionPool,
             _metadataManager,
             loggerFactory?.CreateLogger<ClientTelemetryManager>(),
-            payloadProvider: EmptyClientTelemetryPayloadProvider.Instance);
+            metricCollector: _telemetryMetricCollector,
+            compressionCodecs: _compressionCodecs);
 
         _coordinator = new ShareConsumerCoordinator(
             options,

--- a/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
@@ -1,6 +1,7 @@
 using System.Net.Security;
 using Dekaf.Networking;
 using Dekaf.Retry;
+using Dekaf.Telemetry;
 using Dekaf.Security;
 using Dekaf.Security.Sasl;
 
@@ -13,6 +14,11 @@ namespace Dekaf.ShareConsumer;
 public sealed class ShareConsumerOptions
 {
     private TimeSpan? _connectionTimeoutMax;
+
+    /// <summary>Application metrics registered when the consumer is constructed.</summary>
+    /// <remarks>Registrations are snapshotted by the consumer. Only broker-requested prefixes are collected.</remarks>
+    public IReadOnlyList<ApplicationTelemetryMetric> ApplicationMetrics { get; init; } = [];
+
 
     /// <summary>
     /// Bootstrap servers (host:port,host:port).

--- a/src/Dekaf/Telemetry/ClientTelemetryMetricCollector.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryMetricCollector.cs
@@ -8,7 +8,8 @@ internal enum ClientTelemetryClientRole
 {
     Producer,
     Consumer,
-    Admin
+    Admin,
+    ShareConsumer
 }
 
 internal enum ClientTelemetryMetricKind
@@ -89,7 +90,7 @@ internal sealed class ClientTelemetryMetricCollector
                 ClientTelemetryMetricNames.ConsumerNodeRequestLatencyMax,
                 ClientTelemetryMetricNames.ConsumerFetchThrottleTimeAvg,
                 ClientTelemetryMetricNames.ConsumerFetchThrottleTimeMax),
-            ClientTelemetryClientRole.Admin => (null, null, null, null, null),
+            ClientTelemetryClientRole.Admin or ClientTelemetryClientRole.ShareConsumer => (null, null, null, null, null),
             _ => throw new ArgumentOutOfRangeException(nameof(role), role, "Unsupported telemetry client role")
         };
     }

--- a/tests/Dekaf.Tests.Integration/ClientTelemetryReceiverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ClientTelemetryReceiverIntegrationTests.cs
@@ -1,6 +1,7 @@
 using Dekaf.Admin;
 using Dekaf.Diagnostics;
 using Dekaf.Telemetry;
+using Dekaf.ShareConsumer;
 using Dekaf.Tests.Integration.Telemetry;
 
 namespace Dekaf.Tests.Integration;
@@ -66,6 +67,61 @@ public sealed class ClientTelemetryReceiverIntegrationTests(TelemetryReceiverKaf
         finally
         {
             await producer.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Arguments(42.0)]
+    [Arguments(84.0)]
+    [Timeout(90_000)]
+    public async Task ShareConsumer_BrokerReceivesApplicationMetric(
+        double applicationValue, CancellationToken cancellationToken)
+    {
+        const string applicationName = "com.example.telemetry.share.depth";
+        var clientId = $"share-telemetry-receiver-{Guid.NewGuid():N}";
+        await using var admin = kafka.CreateAdminClient();
+        await admin.IncrementalAlterConfigsAsync(new Dictionary<ConfigResource, IReadOnlyList<ConfigAlter>>
+        {
+            [new ConfigResource { Type = ConfigResourceType.ClientMetrics, Name = clientId }] =
+            [
+                ConfigAlter.Set("metrics", applicationName),
+                ConfigAlter.Set("interval.ms", "1000"),
+                ConfigAlter.Set("match", $"client_id={clientId}")
+            ]
+        }, cancellationToken: cancellationToken);
+
+        var consumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId(clientId)
+            .WithGroupId($"share-telemetry-{Guid.NewGuid():N}")
+            .RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+                applicationName, ApplicationTelemetryMetricKind.Gauge, () => applicationValue,
+                new Dictionary<string, string> { ["tenant"] = clientId }))
+            .BuildAsync(cancellationToken);
+        try
+        {
+            var identity = ((IKafkaClientInstanceIdentity)consumer).ClientInstanceId;
+            await Assert.That(identity).IsNotNull();
+            var received = await kafka.WaitForPayloadAsync(clientId,
+                payload => !payload.IsTerminating && Decode(payload).Any(metric => metric.Name == applicationName),
+                cancellationToken);
+            await Assert.That(received.ClientInstanceId).IsEqualTo(identity!.Value);
+            await Assert.That(received.ContentType).IsEqualTo("OTLP");
+            var application = Decode(received).Single(metric => metric.Name == applicationName);
+            var point = application.Gauge.DataPoints.Single();
+            await Assert.That(point.AsDouble).IsEqualTo(applicationValue);
+            await Assert.That(point.Attributes.Single(attribute => attribute.Key == "tenant").Value.StringValue)
+                .IsEqualTo(clientId);
+
+            await consumer.DisposeAsync();
+            var terminating = await kafka.WaitForPayloadAsync(clientId,
+                payload => payload.IsTerminating && Decode(payload).Any(metric => metric.Name == applicationName),
+                cancellationToken);
+            await Assert.That(terminating.ClientInstanceId).IsEqualTo(identity.Value);
+        }
+        finally
+        {
+            await consumer.DisposeAsync();
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Builder/ShareConsumerTelemetryRegistrationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ShareConsumerTelemetryRegistrationTests.cs
@@ -1,0 +1,95 @@
+using System.Reflection;
+using Dekaf.ShareConsumer;
+using Dekaf.Telemetry;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Builder;
+
+public sealed class ShareConsumerTelemetryRegistrationTests
+{
+    [Test]
+    public async Task Builder_ReplacesRemovesAndSnapshotsRegistrations()
+    {
+        var original = Metric("com.example.share.depth", 1);
+        var replacement = Metric(original.Name, 2);
+        var removed = Metric("com.example.share.removed", 3);
+        var builder = Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092").WithGroupId("telemetry");
+        await Assert.That(builder.RegisterMetricForSubscription(original)).IsSameReferenceAs(builder);
+        await using var first = builder.Build();
+        await Assert.That(builder.RegisterMetricForSubscription(replacement)
+            .RegisterMetricForSubscription(removed).UnregisterMetricFromSubscription(removed.Name)
+            .UnregisterMetricFromSubscription("missing")).IsSameReferenceAs(builder);
+        await using var second = builder.Build();
+        var firstOptions = Options(first);
+        var secondOptions = Options(second);
+        await Assert.That(firstOptions.ApplicationMetrics).HasSingleItem();
+        await Assert.That(firstOptions.ApplicationMetrics[0]).IsSameReferenceAs(original);
+        await Assert.That(secondOptions.ApplicationMetrics).HasSingleItem();
+        await Assert.That(secondOptions.ApplicationMetrics[0]).IsSameReferenceAs(replacement);
+        await Assert.That(firstOptions.ApplicationMetrics).IsNotSameReferenceAs(secondOptions.ApplicationMetrics);
+    }
+
+    [Test]
+    public async Task Registration_ValidatesNullMetricAndDisposedConsumer()
+    {
+        var builder = Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092").WithGroupId("telemetry");
+        await Assert.That(() => builder.RegisterMetricForSubscription(null!)).Throws<ArgumentNullException>();
+        var consumer = builder.Build();
+        try
+        {
+            await Assert.That(consumer is IApplicationTelemetryShareConsumer).IsTrue();
+            await Assert.That(() => consumer.RegisterMetricForSubscription(null!)).Throws<ArgumentNullException>();
+            consumer.UnregisterMetricFromSubscription("missing");
+        }
+        finally
+        {
+            await consumer.DisposeAsync();
+        }
+        await Assert.That(() => consumer.RegisterMetricForSubscription(Metric("com.example.share.depth", 1)))
+            .Throws<ObjectDisposedException>();
+        await Assert.That(() => consumer.UnregisterMetricFromSubscription("missing"))
+            .Throws<ObjectDisposedException>();
+    }
+
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments(" ")]
+    public async Task Removal_ValidatesMetricName(string? name)
+    {
+        var builder = Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092").WithGroupId("telemetry");
+        await Assert.That(() => builder.UnregisterMetricFromSubscription(name!)).Throws<ArgumentException>();
+        await using var consumer = builder.Build();
+        await Assert.That(() => consumer.UnregisterMetricFromSubscription(name!)).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task OptionalCapability_PreservesExistingInterfaceImplementers()
+    {
+        var legacyConsumer = Substitute.For<IKafkaShareConsumer<string, string>>();
+        await Assert.That(() => legacyConsumer.RegisterMetricForSubscription(Metric("com.example.share.depth", 1)))
+            .Throws<NotSupportedException>();
+        await Assert.That(() => legacyConsumer.UnregisterMetricFromSubscription("com.example.share.depth"))
+            .Throws<NotSupportedException>();
+    }
+
+    [Test]
+    public async Task Extensions_RejectNullConsumer()
+    {
+        IKafkaShareConsumer<string, string> consumer = null!;
+        await Assert.That(() => consumer.RegisterMetricForSubscription(Metric("com.example.share.depth", 1)))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => consumer.UnregisterMetricFromSubscription("com.example.share.depth"))
+            .Throws<ArgumentNullException>();
+    }
+
+    private static ApplicationTelemetryMetric Metric(string name, double value) =>
+        new(name, ApplicationTelemetryMetricKind.Gauge, () => value);
+
+    private static ShareConsumerOptions Options(IKafkaShareConsumer<string, string> consumer) =>
+        (ShareConsumerOptions)consumer.GetType().GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(consumer)!;
+}

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -62,6 +62,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Protocol\ResponseFixtures\*.bin" />
     <Protobuf Include="Protos\*.proto" ProtoRoot="Protos" GrpcServices="None" />
+    <Protobuf Include="..\Dekaf.Tests.Integration\Protos\telemetry_metrics.proto"
+              ProtoRoot="..\Dekaf.Tests.Integration\Protos"
+              Link="Protos\telemetry_metrics.proto" GrpcServices="None" />
     <Protobuf Include="Protos\confluent\*.proto" ProtoRoot="Protos" GrpcServices="None" />
     <EmbeddedResource Include="SchemaRegistry\IdentityFixtures\*.json" />
   </ItemGroup>

--- a/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.ShareConsumer.cs
+++ b/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.ShareConsumer.cs
@@ -1,0 +1,224 @@
+using System.Buffers;
+using System.Reflection;
+using Dekaf.Compression;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.ShareConsumer;
+using Dekaf.Telemetry;
+using Dekaf.Tests.Integration.Telemetry;
+
+namespace Dekaf.Tests.Unit.Telemetry;
+
+public sealed partial class ClientTelemetryManagerTests
+{
+    [Test]
+    public async Task ShareConsumer_TerminatingPushContainsRegisteredApplicationMetric()
+    {
+        const string name = "com.example.share.depth";
+        await using var context = new TelemetryTestContext(shareConsumerOptions: new ShareConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            GroupId = "share-telemetry",
+            ApplicationMetrics = [new ApplicationTelemetryMetric(name, ApplicationTelemetryMetricKind.Gauge, () => 42)]
+        });
+        var identity = Guid.NewGuid();
+        context.Connection.Enqueue(Subscription(identity, 7, 60000, requestedMetrics: ["com.example.share."]));
+        await context.Manager.StartAsync();
+        await context.ShareConsumer!.CloseAsync();
+        var pushes = context.Connection.RequestsOfType<PushTelemetryRequest>();
+        await Assert.That(pushes).HasSingleItem();
+        var push = pushes[0];
+        await Assert.That(push.ClientInstanceId).IsEqualTo(identity);
+        await Assert.That(push.Terminating).IsTrue();
+        var decoded = DecodeShareMetrics(push);
+        await Assert.That(decoded).HasSingleItem();
+        await Assert.That(decoded[0].Name).IsEqualTo(name);
+        await Assert.That(decoded[0].Gauge.DataPoints.Single().AsDouble).IsEqualTo(42);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task ShareConsumer_CountersFollowSubscriptionTemporality(bool delta)
+    {
+        double value = 3;
+        await using var context = new TelemetryTestContext(shareConsumerOptions: ShareOptions(
+            new ApplicationTelemetryMetric("com.example.share.count", ApplicationTelemetryMetricKind.Counter, () => value)));
+        context.Connection.Enqueue(Subscription(Guid.NewGuid(), 7, 60000,
+            deltaTemporality: delta, requestedMetrics: ["com.example.share."]));
+        await context.Manager.StartAsync();
+        await PushShareMetricsAsync(context);
+        value = 8;
+        await PushShareMetricsAsync(context);
+        var pushes = context.Connection.RequestsOfType<PushTelemetryRequest>();
+        var first = DecodeShareMetrics(pushes[0]).Single().Sum;
+        var second = DecodeShareMetrics(pushes[1]).Single().Sum;
+        await Assert.That(first.IsMonotonic).IsTrue();
+        await Assert.That(first.AggregationTemporality).IsEqualTo(delta ? 1 : 2);
+        await Assert.That(first.DataPoints.Single().AsDouble).IsEqualTo(3);
+        await Assert.That(second.DataPoints.Single().AsDouble).IsEqualTo(delta ? 5 : 8);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task ShareConsumer_RequestedPrefixesControlObservation(bool emptySubscription)
+    {
+        var requestedCalls = 0;
+        var excludedCalls = 0;
+        await using var context = new TelemetryTestContext(shareConsumerOptions: ShareOptions());
+        context.ShareConsumer!.RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+            "com.example.share.depth", ApplicationTelemetryMetricKind.Gauge, () => ++requestedCalls));
+        context.ShareConsumer.RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+            "com.example.other.depth", ApplicationTelemetryMetricKind.Gauge, () => ++excludedCalls));
+        context.Connection.Enqueue(Subscription(Guid.NewGuid(), 7, 60000,
+            requestedMetrics: emptySubscription ? [] : ["com.example.share."]));
+        await context.Manager.StartAsync();
+        await PushShareMetricsAsync(context);
+        var metrics = DecodeShareMetrics(context.Connection.RequestsOfType<PushTelemetryRequest>().Single());
+        await Assert.That(requestedCalls).IsEqualTo(emptySubscription ? 0 : 1);
+        await Assert.That(excludedCalls).IsEqualTo(0);
+        await Assert.That(metrics.Length).IsEqualTo(emptySubscription ? 0 : 1);
+        if (!emptySubscription)
+            await Assert.That(metrics[0].Name).IsEqualTo("com.example.share.depth");
+    }
+
+    [Test]
+    public async Task ShareConsumer_ReplacementAndRemovalResetCounterHistory()
+    {
+        const string name = "com.example.share.count";
+        await using var context = new TelemetryTestContext(shareConsumerOptions: ShareOptions(
+            new ApplicationTelemetryMetric(name, ApplicationTelemetryMetricKind.Counter, () => 10)));
+        context.Connection.Enqueue(Subscription(Guid.NewGuid(), 7, 60000, requestedMetrics: [name]));
+        await context.Manager.StartAsync();
+        await PushShareMetricsAsync(context);
+        context.ShareConsumer!.RegisterMetricForSubscription(
+            new ApplicationTelemetryMetric(name, ApplicationTelemetryMetricKind.Counter, () => 20));
+        await PushShareMetricsAsync(context);
+        context.ShareConsumer.UnregisterMetricFromSubscription(name);
+        context.ShareConsumer.UnregisterMetricFromSubscription("missing");
+        await PushShareMetricsAsync(context);
+        context.ShareConsumer.RegisterMetricForSubscription(
+            new ApplicationTelemetryMetric(name, ApplicationTelemetryMetricKind.Counter, () => 30));
+        await PushShareMetricsAsync(context);
+        var pushes = context.Connection.RequestsOfType<PushTelemetryRequest>();
+        await Assert.That(DecodeShareMetrics(pushes[0]).Single().Sum.DataPoints.Single().AsDouble).IsEqualTo(10);
+        await Assert.That(DecodeShareMetrics(pushes[1]).Single().Sum.DataPoints.Single().AsDouble).IsEqualTo(20);
+        await Assert.That(pushes[2].Metrics.IsEmpty).IsTrue();
+        await Assert.That(DecodeShareMetrics(pushes[3]).Single().Sum.DataPoints.Single().AsDouble).IsEqualTo(30);
+    }
+
+    [Test]
+    public async Task ShareConsumer_OptionsAndAttributesAreSnapshottedPerClient()
+    {
+        const string name = "com.example.share.depth";
+        var attributes = new Dictionary<string, string> { ["team"] = "first" };
+        var metric = new ApplicationTelemetryMetric(name, ApplicationTelemetryMetricKind.Gauge, () => 42, attributes);
+        var optionsMetrics = new List<ApplicationTelemetryMetric> { metric };
+        await using var first = new TelemetryTestContext(shareConsumerOptions: new ShareConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"], GroupId = "first", ApplicationMetrics = optionsMetrics
+        });
+        attributes["team"] = "changed";
+        optionsMetrics[0] = new ApplicationTelemetryMetric(name, ApplicationTelemetryMetricKind.Gauge, () => 99);
+        await using var second = new TelemetryTestContext(shareConsumerOptions: ShareOptions(
+            new ApplicationTelemetryMetric(name, ApplicationTelemetryMetricKind.Gauge, () => 7,
+                new Dictionary<string, string> { ["team"] = "second" })));
+        foreach (var context in new[] { first, second })
+        {
+            context.Connection.Enqueue(Subscription(Guid.NewGuid(), 7, 60000, requestedMetrics: [name]));
+            await context.Manager.StartAsync();
+            await PushShareMetricsAsync(context);
+        }
+        var firstPoint = DecodeShareMetrics(first.Connection.RequestsOfType<PushTelemetryRequest>().Single())
+            .Single().Gauge.DataPoints.Single();
+        var secondPoint = DecodeShareMetrics(second.Connection.RequestsOfType<PushTelemetryRequest>().Single())
+            .Single().Gauge.DataPoints.Single();
+        await Assert.That(firstPoint.AsDouble).IsEqualTo(42);
+        await Assert.That(firstPoint.Attributes.Single().Value.StringValue).IsEqualTo("first");
+        await Assert.That(secondPoint.AsDouble).IsEqualTo(7);
+        await Assert.That(secondPoint.Attributes.Single().Value.StringValue).IsEqualTo("second");
+    }
+
+    [Test]
+    [Arguments((sbyte)0)]
+    [Arguments((sbyte)1)]
+    public async Task ShareConsumer_PushUsesNegotiatedCompression(sbyte compression)
+    {
+        await using var context = new TelemetryTestContext(shareConsumerOptions: ShareOptions(
+            new ApplicationTelemetryMetric("com.example.share.depth", ApplicationTelemetryMetricKind.Gauge, () => 42)));
+        context.Connection.Enqueue(Subscription(Guid.NewGuid(), 7, 60000,
+            acceptedCompressionTypes: [compression], requestedMetrics: ["com.example.share."]));
+        await context.Manager.StartAsync();
+        await PushShareMetricsAsync(context);
+        var push = context.Connection.RequestsOfType<PushTelemetryRequest>().Single();
+        await Assert.That(push.CompressionType).IsEqualTo(compression);
+        await Assert.That(DecodeShareMetrics(push).Single().Gauge.DataPoints.Single().AsDouble).IsEqualTo(42);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task ShareConsumer_OverlargePayloadUsesExistingEmptyFallback(bool brokerRejects)
+    {
+        await using var context = new TelemetryTestContext(shareConsumerOptions: ShareOptions(
+            new ApplicationTelemetryMetric("com.example.share.depth", ApplicationTelemetryMetricKind.Gauge, () => 42)));
+        context.Connection.Enqueue(Subscription(Guid.NewGuid(), 7, 60000,
+            telemetryMaxBytes: brokerRejects ? 1024 : 1, requestedMetrics: ["com.example.share."]));
+        if (brokerRejects)
+            context.Connection.Enqueue(new PushTelemetryResponse { ErrorCode = ErrorCode.TelemetryTooLarge });
+        await context.Manager.StartAsync();
+        await PushShareMetricsAsync(context);
+        var pushes = context.Connection.RequestsOfType<PushTelemetryRequest>();
+        await Assert.That(pushes.Count).IsEqualTo(brokerRejects ? 2 : 1);
+        await Assert.That(pushes[^1].Metrics.IsEmpty).IsTrue();
+        if (brokerRejects)
+            await Assert.That(DecodeShareMetrics(pushes[0])).HasSingleItem();
+    }
+
+    [Test]
+    public async Task ShareConsumer_UnsupportedTelemetryNeverObservesApplicationMetrics()
+    {
+        var calls = 0;
+        await using var context = new TelemetryTestContext(shareConsumerOptions: ShareOptions(
+            new ApplicationTelemetryMetric("com.example.share.depth", ApplicationTelemetryMetricKind.Gauge, () => ++calls)));
+        context.Connection.Enqueue(new GetTelemetrySubscriptionsResponse
+        {
+            ErrorCode = ErrorCode.UnsupportedVersion
+        });
+        await context.Manager.StartAsync();
+        await context.ShareConsumer!.CloseAsync();
+        await Assert.That(context.Manager.IsDisabled).IsTrue();
+        await Assert.That(context.Connection.RequestsOfType<PushTelemetryRequest>()).IsEmpty();
+        await Assert.That(calls).IsEqualTo(0);
+    }
+
+    private static ShareConsumerOptions ShareOptions(params ApplicationTelemetryMetric[] metrics) => new()
+    {
+        BootstrapServers = ["localhost:9092"], GroupId = "share-telemetry", ApplicationMetrics = metrics
+    };
+
+    private static async Task PushShareMetricsAsync(TelemetryTestContext context)
+    {
+        var subscription = (ClientTelemetrySubscription)typeof(ClientTelemetryManager)
+            .GetField("_subscription", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(context.Manager)!;
+        var pending = (ValueTask<ErrorCode>)typeof(ClientTelemetryManager)
+            .GetMethod("PushTelemetryAsync", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(context.Manager, [subscription, false, CancellationToken.None])!;
+        await Assert.That(await pending).IsEqualTo(ErrorCode.None);
+    }
+
+    private static Metric[] DecodeShareMetrics(PushTelemetryRequest push)
+    {
+        var bytes = push.Metrics;
+        if (!bytes.IsEmpty && push.CompressionType != 0)
+        {
+            var decompressed = new ArrayBufferWriter<byte>();
+            CompressionCodecRegistry.Default.GetCodec((Dekaf.Protocol.Records.CompressionType)push.CompressionType)
+                .Decompress(new ReadOnlySequence<byte>(bytes), decompressed);
+            bytes = decompressed.WrittenMemory;
+        }
+        return MetricsData.Parser.ParseFrom(bytes.ToArray()).ResourceMetrics
+            .SelectMany(resource => resource.ScopeMetrics).SelectMany(scope => scope.Metrics).ToArray();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
@@ -7,11 +7,13 @@ using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Telemetry;
+using Dekaf.ShareConsumer;
+using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Unit.Telemetry;
 
 [NotInParallel]
-public sealed class ClientTelemetryManagerTests
+public sealed partial class ClientTelemetryManagerTests
 {
     [Test]
     public async Task StartAsync_FetchesSubscriptionAndStoresIds()
@@ -413,7 +415,8 @@ public sealed class ClientTelemetryManagerTests
         public TelemetryTestContext(
             ClientTelemetryMetricCollector? metricCollector = null,
             CompressionCodecRegistry? compressionCodecs = null,
-            IClientTelemetryPayloadProvider? payloadProvider = null)
+            IClientTelemetryPayloadProvider? payloadProvider = null,
+            ShareConsumerOptions? shareConsumerOptions = null)
         {
             _pool = new TestConnectionPool();
             _metadataManager = new MetadataManager(_pool, ["localhost:9092"]);
@@ -435,19 +438,33 @@ public sealed class ClientTelemetryManagerTests
                 Topics = []
             });
 
-            Manager = new ClientTelemetryManager(
-                _pool,
-                _metadataManager,
-                metricCollector: metricCollector,
-                compressionCodecs: compressionCodecs,
-                payloadProvider: payloadProvider);
+            if (shareConsumerOptions is null)
+            {
+                Manager = new ClientTelemetryManager(
+                    _pool,
+                    _metadataManager,
+                    metricCollector: metricCollector,
+                    compressionCodecs: compressionCodecs,
+                    payloadProvider: payloadProvider);
+            }
+            else
+            {
+                ShareConsumer = new KafkaShareConsumer<string, string>(
+                    shareConsumerOptions, Serializers.String, Serializers.String, _pool, _metadataManager);
+                Manager = (ClientTelemetryManager)typeof(KafkaShareConsumer<string, string>)
+                    .GetField("_telemetryManager", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .GetValue(ShareConsumer)!;
+            }
         }
 
+        public KafkaShareConsumer<string, string>? ShareConsumer { get; }
         public ClientTelemetryManager Manager { get; }
         public TestKafkaConnection Connection => _pool.Connection;
 
         public async ValueTask DisposeAsync()
         {
+            if (ShareConsumer is not null)
+                await ShareConsumer.DisposeAsync();
             await Manager.DisposeAsync().ConfigureAwait(false);
             await _metadataManager.DisposeAsync().ConfigureAwait(false);
             await _pool.DisposeAsync().ConfigureAwait(false);


### PR DESCRIPTION
Share consumers previously negotiated telemetry but always sent empty metric payloads. They now use the existing collector and OTLP provider to publish registered application metrics. Runtime registration uses an optional capability so existing `IKafkaShareConsumer<TKey, TValue>` implementations remain compatible. Builder and options registrations are snapshotted per consumer; replacement, removal, validation, and disposal follow the existing client conventions.

Closes #3097

Parent #3033 remains open. Built-in KIP-932 share metrics remain the separate dependent issue #3098.

### Validation

- The terminating-payload regression test first failed with the old empty provider, then passed with the normal provider.
- 236 related telemetry, share-consumer, acknowledgement, session, and group unit cases passed on each of .NET 10 and .NET 8. Coverage decodes actual pushed OTLP payloads and checks requested prefixes, delta/cumulative counters, replacement/reset/removal, isolated attributes, negotiated compression, both payload-limit paths, terminating pushes, and disabled telemetry.
- Four Kafka 4.3.1 receiver integration cases passed, including two share consumers. The receiver asserts each registered value, attributes, assigned client instance identity, and terminating push; unavailable telemetry cannot produce conditional success.
- Core library built across all configured frameworks with zero warnings/errors. All 468 C# documentation snippets compile after correcting the missing await found by CI. Documentation build and `git diff --check` passed. API baselines and usage documentation are included. Final review reused the existing collector/provider and receiver decoder.

### Source-path performance evidence

Exact preceding product: `820702193190087e0e497788add0419300adb938`. Measured candidate: `9f5dc78bb4cb41a9c47e0e5c2f1b5a0108a7fe53`. Current head `67834e197f9a01890a5ff1e0694b9e7f7baad040` changes only documentation (await/import fixes); both commits have identical product source tree `4428ec3108293c88c12ca036753477932942d9e7`. BenchmarkDotNet 0.15.8 with `[MemoryDiagnoser]`, .NET 10.0.11 / SDK 10.0.400, Windows 11, i7-12700K; in-process, 5 warmups, 15 iterations at 250 ms. All 23 cases completed in 173.61 seconds. One identical compiled fixture loads each saved product separately; `BeforeControl` repeats the exact baseline delegate. No concurrent build/test workload was started by this worker during measurement.

Parsing controls use 1,024 records and the maintained synchronous/warm-prepared parsing fixture. Times are mean microseconds per batch; allocation is the reported total per batch, identical across the three variants at displayed precision.

| Parser / headers | Before | Candidate | Before control | Candidate delta vs before / control | Allocation per batch |
|---|---:|---:|---:|---:|---:|
| Synchronous / 0 | 162.8 | 162.3 | 167.3 | -0.31% / -2.99% | 88.33 KB |
| Warm prepared / 0 | 132.3 | 132.6 | 136.0 | +0.23% / -2.50% | 88.21 KB |
| Synchronous / 2 | 906.2 | 874.6 | 887.5 | -3.49% / -1.45% | 440.70 KB |
| Warm prepared / 2 | 849.7 | 844.4 | 846.7 | -0.62% / -0.27% | 440.58 KB |

No parsing slowdown is established against both controls. These existing class-based parsers already allocate per record; this PR does not claim zero total allocation or implement parent #3032. No parsing, acknowledgement, fetch, or per-message telemetry hook changes are introduced.

The new functionality has explicit cold/per-push costs. Collection measurements invoke the actual consumer's collector/provider pipeline, excluding network framing, compression, and I/O. `UnsubscribedPush` means an existing subscription with an empty requested-metric list; disabled telemetry does not invoke collection at all.

| Operation | Before mean / bytes | Candidate mean / bytes | Before control mean / bytes |
|---|---:|---:|---:|
| Disconnected construction + disposal | 11.808 us / 26,440 B | 12.895 us / 30,144 B | 12.382 us / 26,440 B |
| Collection, no requested prefixes | 7.273 ns / 32 B | 58.803 ns / 32 B | 7.221 ns / 32 B |
| Collection, requested prefix but no registrations | 7.466 ns / 32 B | 859.084 ns / 64 B | 7.071 ns / 32 B |
| Collection, one registered gauge | Unavailable | 1.268 us / 2.38 KB | Unavailable |
| Collection, sixteen registered gauges | Unavailable | 5.585 us / 24.73 KB | Unavailable |

The collector adds 3,704 B once per consumer and approximately 0.51–1.09 us construction/disposal time relative to the two controls. The empty-prefix collection adds about 52 ns; a subscribed empty collection adds about 852 ns and 32 B per push. Registered metric payloads contain 59/892 bytes for 1/16 gauges. These costs belong to construction or broker-paced collection, not each consumed message. Construction and some short measurements show multimodal distributions; raw errors and distributions are retained. This is scoped source-path evidence, not a duration-based stress/Pareto result or a claim about end-to-end p50/p99/max latency or CPU per message. No paid stress run was dispatched.

Evidence is archived outside removable worktrees at `D:/git/Dekaf-evidence/pr-3119/9f5dc78bb4cb41a9c47e0e5c2f1b5a0108a7fe53/`: raw reports/logs, test and build outputs, exact source snapshots, fixture and comparison sources, dependencies, and loaded binaries. `inventory.json` records each copied file's SHA-256 verified against its original. `current-state.md` is an earlier working note; this description and `validation-summary.md` describe the completed run.

Loaded `Dekaf.dll` SHA-256:
- Before: `F11E84139A851ADEEF6BB078397A5976986468AA593633BF3FB4AAF75076C45D`
- Candidate: `8AF8B77CD06050DABD0407E4AF39672DA6E3BF7D517504E33769BF7BE8D75827`

Reproduce using the archived comparison binary after setting `DEKAF_SHARE_TELEMETRY_EVIDENCE` to the archive root: `dotnet comparison/bin/Release/net10.0/TelemetryComparison.dll --filter '*' --inProcess --warmupCount 5 --iterationCount 15 --iterationTime 250 --artifacts <new-output-directory>`. `--validate` checks payload presence and matching parsing checksums before measurement.

Documentation correction evidence (failed CI log, successful local snippet compilation, exact source, runner binaries, verified SHA-256 inventory): `D:/git/Dekaf-evidence/pr-3119/a2de0e28b960316410fa1209334f2f628cd936c5/`.


Documentation review follow-up `67834e197f9a01890a5ff1e0694b9e7f7baad040` adds the explicit `System.Threading` import. All 468 snippets compile through the maintained shared-context harness, and the production documentation build passes. Product source remains `4428ec3108293c88c12ca036753477932942d9e7`; the existing measurements still describe the same library. Validation, exact documentation source/render, and review dispositions are archived with 12 original-verified SHA-256 entries at `D:/git/Dekaf-evidence/pr-3119/67834e197f9a01890a5ff1e0694b9e7f7baad040/`. The compiled snippet runner is retained in the linked a2de0e28 archive. The periodic-push allocation concern is addressed in reply 3949255934; no per-message allocation contract or measurement has been waived.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added application telemetry support for share consumers.
  * Register and unregister subscription metrics through the builder or consumer APIs.
  * Metrics support broker delivery, filtering, compression, and terminating telemetry on shutdown.
* **Documentation**
  * Added guidance for configuring and using application telemetry with share consumers.
* **Bug Fixes**
  * Improved handling of unsupported telemetry capabilities and metric replacement or removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
