### PR TITLE
fix(testing): support application telemetry on in-memory share consumers

### DIFF
--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -1,13 +1,14 @@
 using System.Runtime.CompilerServices;
 using Dekaf.Serialization;
 using Dekaf.ShareConsumer;
+using Dekaf.Telemetry;
 
 namespace Dekaf.Testing;
 
 /// <summary>
 /// In-memory <see cref="IKafkaShareConsumer{TKey,TValue}"/> backed by an <see cref="InMemoryKafkaCluster"/>.
 /// </summary>
-public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TKey, TValue>
+public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TKey, TValue>, IApplicationTelemetryShareConsumer
 {
     private readonly object _gate = new();
     private readonly InMemoryKafkaCluster _cluster;
@@ -508,6 +509,24 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
                 Array.Clear(_commitRecords, 0, recordCount);
             }
         }
+    }
+
+    /// <summary>
+    /// Validates the registration without collecting or publishing telemetry.
+    /// </summary>
+    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+    {
+        ArgumentNullException.ThrowIfNull(metric);
+        ThrowIfDisposed();
+    }
+
+    /// <summary>
+    /// Validates the metric name without collecting or publishing telemetry.
+    /// </summary>
+    public void UnregisterMetricFromSubscription(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ThrowIfDisposed();
     }
 
     public async ValueTask CloseAsync(CancellationToken cancellationToken = default)

--- a/src/Dekaf.Testing/PublicAPI.Unshipped.txt
+++ b/src/Dekaf.Testing/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Dekaf.Testing.InMemoryShareConsumer<TKey, TValue>.RegisterMetricForSubscription(Dekaf.Telemetry.ApplicationTelemetryMetric! metric) -> void
+Dekaf.Testing.InMemoryShareConsumer<TKey, TValue>.UnregisterMetricFromSubscription(string! name) -> void
 Dekaf.Testing.InMemoryConsumer<TKey, TValue>.GetCurrentLag(Dekaf.TopicPartition partition) -> long?
 Dekaf.Testing.InMemoryConsumer<TKey, TValue>.QueryCurrentLagAsync(Dekaf.TopicPartition partition, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<long?>
 Dekaf.Testing.InMemoryAdminClient.DeleteTopicsAsync(System.Collections.Generic.IEnumerable<System.Guid>! topicIds, Dekaf.Admin.DeleteTopicsOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryShareTelemetryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryShareTelemetryTests.cs
@@ -1,0 +1,79 @@
+using Dekaf.ShareConsumer;
+using Dekaf.Telemetry;
+using Dekaf.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dekaf.Tests.Unit.Testing;
+
+public class InMemoryShareTelemetryTests
+{
+    [Test]
+    public async Task Registration_ThroughDependencyInjection_SupportsApplicationTelemetry()
+    {
+        var services = new ServiceCollection();
+        services.AddDekafInMemory();
+        await using var provider = services.BuildServiceProvider();
+        var consumer = provider.GetRequiredService<IKafkaShareConsumer<string, string>>();
+        var metric = new ApplicationTelemetryMetric("app.queue.depth", ApplicationTelemetryMetricKind.Gauge,
+            static () => throw new InvalidOperationException("The in-memory consumer must not observe metrics."));
+
+        consumer.RegisterMetricForSubscription(metric);
+        consumer.UnregisterMetricFromSubscription(metric.Name);
+        await Assert.That(consumer is IApplicationTelemetryShareConsumer).IsTrue();
+    }
+
+    [Test]
+    public async Task Registration_ThroughShareConsumerInterface_DoesNotObserveMetrics()
+    {
+        await using IKafkaShareConsumer<string, string> consumer =
+            new InMemoryShareConsumer<string, string>(new InMemoryKafkaCluster());
+        var observations = 0;
+        var metric = new ApplicationTelemetryMetric("app.queue.depth", ApplicationTelemetryMetricKind.Gauge,
+            () => ++observations);
+
+        consumer.RegisterMetricForSubscription(metric);
+        consumer.RegisterMetricForSubscription(metric);
+        consumer.UnregisterMetricFromSubscription(metric.Name);
+        consumer.UnregisterMetricFromSubscription("app.missing");
+        await consumer.CloseAsync();
+
+        await Assert.That(observations).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Registration_RejectsNullMetric()
+    {
+        await using IKafkaShareConsumer<string, string> consumer =
+            new InMemoryShareConsumer<string, string>(new InMemoryKafkaCluster());
+
+        Assert.Throws<ArgumentNullException>(() => consumer.RegisterMetricForSubscription(null!));
+    }
+
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments(" ")]
+    public async Task Unregistration_RejectsInvalidName(string? name)
+    {
+        await using IKafkaShareConsumer<string, string> consumer =
+            new InMemoryShareConsumer<string, string>(new InMemoryKafkaCluster());
+
+        if (name is null)
+            Assert.Throws<ArgumentNullException>(() => consumer.UnregisterMetricFromSubscription(name!));
+        else
+            Assert.Throws<ArgumentException>(() => consumer.UnregisterMetricFromSubscription(name));
+    }
+
+    [Test]
+    public async Task RegistrationAndUnregistration_AfterDisposal_Throw()
+    {
+        IKafkaShareConsumer<string, string> consumer =
+            new InMemoryShareConsumer<string, string>(new InMemoryKafkaCluster());
+        var metric = new ApplicationTelemetryMetric("app.queue.depth", ApplicationTelemetryMetricKind.Gauge,
+            static () => 0);
+        await consumer.DisposeAsync();
+
+        Assert.Throws<ObjectDisposedException>(() => consumer.RegisterMetricForSubscription(metric));
+        Assert.Throws<ObjectDisposedException>(() => consumer.UnregisterMetricFromSubscription(metric.Name));
+    }
+}


### PR DESCRIPTION
Application telemetry registration through `IKafkaShareConsumer` throws `NotSupportedException` when an application switches to the first-party `InMemoryShareConsumer`. Implement the optional capability with argument/disposal validation and no-op behavior matching the other in-memory clients. Callbacks are never observed. Add public API entries and interface/DI regression tests.

Closes #3120

Follow-up to the blocking review in #3119: https://github.com/thomhurst/Dekaf/pull/3119#issuecomment-5570014937. That PR merged while this fix was being validated.

Validation:
- Six cases fail on the previous implementation with `NotSupportedException`; all 423 in-memory tests pass on each of net8.0 and net10.0, including seven new cases.
- `Dekaf.Testing` builds for both supported frameworks with zero warnings/errors. Final simplification review follows existing test-double patterns without adding state.
- Task-scoped BenchmarkDotNet 0.15.8 `[MemoryDiagnoser]`, .NET 10.0.11, Windows 11, i7-12700K, in-process, five warmups and 15 measured 250 ms iterations: registration 0.0796 +/- 0.0259 ns; removal 0.4477 +/- 0.0848 ns; both 0 B per call. These no-op methods inline heavily; timings are near benchmark overhead and registration was bimodal. Allocation evidence only; no latency-improvement claim. A before timing is inapplicable because registration previously threw.

Measurements used c0b1db53d9098744aa4fa072bcf4b8ca6b09eb57 before the merged-PR follow-up was cherry-picked onto main. The candidate product and unit-test sources are identical; the only tree difference is an unrelated telemetry-receiver Dockerfile dependency update. This PR changes no polling, networking, or collection code. No new broker run or paid stress run was used for this test-double-only fix.

Durable evidence: `D:/git/Dekaf-evidence/pr-3119/c0b1db53d9098744aa4fa072bcf4b8ca6b09eb57`. The inventory verifies 2,613 copied files (1,145,853,413 bytes) against their original SHA-256 hashes: source snapshots, fixture source, loaded candidate binaries, raw test/build logs, and raw benchmark reports. The red log is retained; its original runner was rebuilt and that original red binary is not retained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * In-memory share consumers now support application telemetry metric subscription operations.
  * Added support for registering and unregistering telemetry metrics with input and disposal-state validation.

* **Bug Fixes**
  * Ensured in-memory consumers do not collect or publish telemetry callbacks during metric subscription tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->