### PR TITLE
chore(deps): upgrade Reservoir to 1.8.0 with portable policy contracts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,7 +52,7 @@
     <PackageVersion Include="OpenTelemetry.Api" Version="1.18.0" />
     <PackageVersion Include="Polyfill" Version="11.2.0" />
     <PackageVersion Include="protobuf-net.Reflection" Version="3.4.21" />
-    <PackageVersion Include="Reservoir" Version="1.6.7" />
+    <PackageVersion Include="Reservoir" Version="1.8.0" />
     <PackageVersion Include="SharpFuzz" Version="2.3.0" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="SSH.NET" Version="2026.0.0" />

--- a/src/Dekaf/Networking/PipeMemoryPool.cs
+++ b/src/Dekaf/Networking/PipeMemoryPool.cs
@@ -200,6 +200,9 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
     {
         public PooledMemoryOwner Create() => new(owner);
 
+        // The byte array has already been returned before its owner enters this pool.
+        public void Destroy(PooledMemoryOwner item) { }
+
         public bool TryReset(PooledMemoryOwner item) => true;
     }
 }

--- a/src/Dekaf/Networking/RentedBufferWriter.cs
+++ b/src/Dekaf/Networking/RentedBufferWriter.cs
@@ -127,6 +127,9 @@ internal sealed class RentedBufferWriter : IBufferWriter<byte>, IDisposable
     {
         public RentedBufferWriter Create() => new();
 
+        // Dispose releases or transfers the byte array before returning this wrapper.
+        public void Destroy(RentedBufferWriter writer) { }
+
         public bool TryReset(RentedBufferWriter writer)
         {
             writer._written = 0;

--- a/src/Dekaf/Producer/PartitionInflightTracker.cs
+++ b/src/Dekaf/Producer/PartitionInflightTracker.cs
@@ -168,6 +168,8 @@ internal sealed class InflightEntryPool
     private readonly struct InflightEntryPolicy(InflightEntryPool owner)
         : Reservoir.IPooledObjectPolicy<InflightEntry>, Reservoir.INonThrowingResetPolicy
     {
+        public void Destroy(InflightEntry item) { }
+
         public InflightEntry Create()
         {
             Interlocked.Increment(ref owner._misses);


### PR DESCRIPTION
Upgrade Reservoir from 1.6.7 to 1.8.0 and implement the portable destruction contract for three internal pool policies. The affected wrappers release their buffers before returning to the pool, so their destruction methods require no additional cleanup. Throwing-reset policies retain their exception-safe behavior.

Validation: both library targets build without warnings/errors; 481 pool/writer/inflight tests pass on each of .NET 10 and .NET 8. Performance acceptance is pending for this new version. The previous 1.7.0 rent/return regression remains recorded and is not waived.

Current evidence: [standard BenchmarkDotNet comparison](https://github.com/thomhurst/Dekaf/actions/runs/34406776845), [candidate and validation details](https://github.com/thomhurst/Dekaf/pull/3137#issuecomment-5608983010). Loaded evidence must also match 1.8.0 before merge.