### PR TITLE
fix(tooling): preserve Redis-owned worktrees during cleanup

### DIFF
--- a/scripts/Merge-Pr.ps1
+++ b/scripts/Merge-Pr.ps1
@@ -68,7 +68,7 @@ if (-not $Worktree) {
     Write-Host "No isolated worktree found for branch '$headRef' (nothing to remove)."
     git -C $mainRepo worktree prune
 } else {
-    Remove-MergedWorktree -Repo $mainRepo -Worktree $Worktree -Label "#${Pr}"
+    Remove-MergedWorktree -Repo $mainRepo -Worktree $Worktree -Label "#${Pr}" -AllowCurrentOwner
 
     # A dirty worktree is intentionally preserved. Its local and remote branches are
     # also preserved so uncommitted work retains an upstream recovery point.

--- a/scripts/Remove-MergedWorktrees.ps1
+++ b/scripts/Remove-MergedWorktrees.ps1
@@ -29,13 +29,17 @@
 #   A failed `worktree remove` followed by `worktree prune` leaves a directory whose
 #   .git file points at a gitdir that no longer exists. Such dirs are invisible to
 #   `git worktree list`, so the sweep also scans the directories where worktrees are
-#   known to live and reaps any dir that provably WAS a worktree of this repo
+#   known to live and reports any dir that provably WAS a worktree of this repo
 #   (its .git file targets $mainRepo/.git/worktrees/* and that gitdir is gone).
+#   Preserve these directories: missing registration prevents verification of
+#   per-worktree ownership and uncommitted source.
 #   Dirs without a .git worktree marker (artifacts, scratch output) are never touched.
 #
 # Guards (never delete work):
 #   - skip the main checkout and anything inside it (.claude/worktrees is harness-managed)
 #   - skip locked worktrees (an agent session may still own them)
+#   - preserve Redis-owned worktrees; removal holds a temporary canonical lease
+#     for registered or convention-named work items, and fails closed on lock errors
 #   - skip a branch/tip that has an OPEN PR (branch reused for active work)
 #   - PRESERVE tracked changes and untracked files outside known generated directories
 #     or recognized root-level logs/PR notes covered by .gitignore
@@ -232,7 +236,7 @@ try {
         if ($parent) { $roots[$parent.ToLowerInvariant()] = $parent }
     }
 
-    $orphansRemoved = 0
+    $orphansPreserved = 0
     foreach ($root in $roots.Values) {
         if (-not (Test-Path -LiteralPath $root)) { continue }
         foreach ($dir in (Get-ChildItem -LiteralPath $root -Directory -Force -ErrorAction SilentlyContinue)) {
@@ -241,24 +245,17 @@ try {
             $marker = Join-Path $dir.FullName '.git'
             if (-not (Test-Path -LiteralPath $marker -PathType Leaf)) { continue }   # not a worktree (artifacts etc.) — leave alone
             $gitdir = ((Get-Content -LiteralPath $marker -TotalCount 1) -replace '^gitdir:\s*', '') -replace '\\', '/'
-            # Only reap dirs that provably WERE worktrees of THIS repo and whose
+            # Only report dirs that provably WERE worktrees of THIS repo and whose
             # registration is gone. A live marker (gitdir exists) is someone else's.
             if ($gitdir -notlike "$mainNorm/.git/worktrees/*") { continue }
             if (Test-Path -LiteralPath $gitdir) { continue }
-            if ($WhatIf) { Write-Host "sweep: WOULD remove orphaned dir $($dir.FullName) (dangling gitdir: $gitdir)"; continue }
-            Remove-Item -LiteralPath ('\\?\' + ($dir.FullName -replace '/', '\')) -Recurse -Force -ErrorAction SilentlyContinue
-            if (Test-Path -LiteralPath $dir.FullName) {
-                Write-Host "sweep: WARNING could not fully remove orphaned dir $($dir.FullName)"
-            }
-            else {
-                Write-Host "sweep: removed orphaned dir $($dir.FullName)"
-                $orphansRemoved++
-            }
+            Write-Host "sweep: preserving orphaned dir $($dir.FullName) (ownership and source cannot be verified; dangling gitdir: $gitdir)"
+            $orphansPreserved++
         }
     }
 
     if (-not $WhatIf) { git -C $mainRepo worktree prune }
-    Write-Host "sweep: removed $removed merged worktree(s), $orphansRemoved orphaned dir(s)."
+    Write-Host "sweep: removed $removed merged worktree(s), preserved $orphansPreserved orphaned dir(s)."
 }
 catch {
     Warn "unexpected sweep error (ignored, loop continues): $_"

--- a/scripts/Test-MergePrOwnership.ps1
+++ b/scripts/Test-MergePrOwnership.ps1
@@ -40,7 +40,7 @@ function gh {
 }
 
 try {
-    foreach ($scenario in @('owner', 'foreign-owner', 'unowned', 'unidentified', 'dirty-owner', 'renew-failure', 'status-failure')) {
+    foreach ($scenario in @('cleanup-failure', 'owner', 'foreign-owner', 'unowned', 'unidentified', 'dirty-owner', 'renew-failure', 'status-failure')) {
         $caseRoot = Join-Path $testRoot $scenario
         $repo = Join-Path $caseRoot 'repo'
         $remote = Join-Path $caseRoot 'remote.git'
@@ -55,6 +55,17 @@ try {
         Invoke-TestGit -C $repo config user.email 'merge-owner@example.invalid'
         Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'Merge-Pr.ps1') -Destination (Join-Path $repo 'scripts/Merge-Pr.ps1')
         Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'WorktreeCleanup.ps1') -Destination (Join-Path $repo 'scripts/WorktreeCleanup.ps1')
+        if ($scenario -eq 'cleanup-failure') {
+            # Inject an inspection failure after ownership has been acquired. The
+            # real wrapper must report merge success, preserve branches and release
+            # its temporary lease even when the guarded filesystem operation throws.
+            Add-Content -LiteralPath (Join-Path $repo 'scripts/WorktreeCleanup.ps1') -Value @'
+function Remove-MergedWorktreeCore {
+    param($Repo, $Worktree, $Label, $ExpectedHead, $ExpectedLockName, [switch]$WhatIf)
+    throw 'Injected cleanup inspection failure'
+}
+'@
+        }
         Set-Content -LiteralPath (Join-Path $repo 'scripts/Assert-PrGreen.ps1') -Value 'exit 0'
         $quotedCanonical = $AgentLocksScript.Replace("'", "''")
         $proxy = "& '$quotedCanonical' @args`nexit `$LASTEXITCODE"
@@ -70,7 +81,7 @@ try {
         Invoke-TestGit -C $worktree commit -m change
         Invoke-TestGit -C $worktree push -u origin $branch
         $leaseOwner = if ($scenario -eq 'foreign-owner') { "foreign-$owner" } else { $owner }
-        $claimed = $scenario -notin @('unowned', 'unidentified')
+        $claimed = $scenario -notin @('unowned', 'unidentified', 'cleanup-failure')
         if ($claimed) {
             & pwsh -NoProfile -File $AgentLocksScript acquire -LockName $lockName -OwnerId $leaseOwner -Worktree $worktree *> $null
             Assert ($LASTEXITCODE -eq 0) 'Cannot acquire isolated merge lease'
@@ -120,6 +131,10 @@ try {
                 & pwsh -NoProfile -File $AgentLocksScript release -LockName $lockName -OwnerId "competitor-$owner" *> $null
             }
             Assert ($competingExit -eq 3) "Merge released ownership too soon for $scenario"
+        }
+        else {
+            $state = & pwsh -NoProfile -File $AgentLocksScript status -LockName $lockName -OwnerId $owner
+            Assert ($state -eq 'FREE') "Merge left its temporary lease behind for $scenario"
         }
         Write-Host "OK merge ownership scenario: $scenario"
     }

--- a/scripts/Test-MergePrOwnership.ps1
+++ b/scripts/Test-MergePrOwnership.ps1
@@ -1,0 +1,138 @@
+# Executes the real merge wrapper against local Git remotes and isolated Redis keys.
+# Only GitHub's gate/merge responses are substituted; no real PR is merged.
+param([string]$AgentLocksScript)
+$ErrorActionPreference = 'Stop'
+if (-not $AgentLocksScript) {
+    $common = & git rev-parse --path-format=absolute --git-common-dir
+    $AgentLocksScript = Join-Path (Split-Path $common -Parent) 'scripts/AgentLocks.ps1'
+}
+$AgentLocksScript = (Resolve-Path -LiteralPath $AgentLocksScript).Path
+$suffix = [Guid]::NewGuid().ToString('N')
+$owner = "merge-owner-tests-$suffix"
+$previousOwner = $env:DEKAF_AGENT_LOCK_OWNER_ID
+$previousThread = $env:CODEX_THREAD_ID
+$env:DEKAF_AGENT_LOCK_OWNER_ID = $owner
+$testRoot = [IO.Path]::GetFullPath((Join-Path ([IO.Path]::GetTempPath()) "merge-owner-$suffix"))
+$tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath()).TrimEnd('\', '/') + [IO.Path]::DirectorySeparatorChar
+if (-not $testRoot.StartsWith($tempRoot, [StringComparison]::OrdinalIgnoreCase)) { throw 'Unsafe fixture root' }
+$leases = [Collections.Generic.List[object]]::new()
+
+function Assert([bool]$Condition, [string]$Message) { if (-not $Condition) { throw $Message } }
+function Invoke-TestGit {
+    & git.exe @args 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Git fixture command failed: $args" }
+}
+
+# Merge-Pr.ps1 resolves this function instead of contacting GitHub. Git operations
+# still execute against the fixture's real bare remote and isolated worktree.
+function gh {
+    if ($args[0] -eq 'pr' -and $args[1] -eq 'view') {
+        $global:LASTEXITCODE = 0
+        return $fixtureBranch
+    }
+    if ($args[0] -eq 'pr' -and $args[1] -eq 'merge') {
+        Invoke-TestGit -C $fixtureRepo merge --squash $fixtureBranch
+        Invoke-TestGit -C $fixtureRepo commit -m 'Fixture squash merge'
+        $global:LASTEXITCODE = 0
+        return
+    }
+    throw "Unexpected GitHub fixture call: $args"
+}
+
+try {
+    foreach ($scenario in @('owner', 'foreign-owner', 'unowned', 'unidentified', 'dirty-owner', 'renew-failure', 'status-failure')) {
+        $caseRoot = Join-Path $testRoot $scenario
+        $repo = Join-Path $caseRoot 'repo'
+        $remote = Join-Path $caseRoot 'remote.git'
+        $number = Get-Random -Minimum 1000000000 -Maximum 2000000000
+        $branch = "issue-$number-fixture"
+        $worktree = Join-Path $caseRoot "pr-$number-merge"
+        $lockName = "pr-$number"
+        New-Item -ItemType Directory -Path (Join-Path $repo 'scripts') -Force | Out-Null
+        Invoke-TestGit init --bare $remote
+        Invoke-TestGit init --initial-branch=main $repo
+        Invoke-TestGit -C $repo config user.name 'Merge Ownership Tests'
+        Invoke-TestGit -C $repo config user.email 'merge-owner@example.invalid'
+        Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'Merge-Pr.ps1') -Destination (Join-Path $repo 'scripts/Merge-Pr.ps1')
+        Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'WorktreeCleanup.ps1') -Destination (Join-Path $repo 'scripts/WorktreeCleanup.ps1')
+        Set-Content -LiteralPath (Join-Path $repo 'scripts/Assert-PrGreen.ps1') -Value 'exit 0'
+        $quotedCanonical = $AgentLocksScript.Replace("'", "''")
+        $proxy = "& '$quotedCanonical' @args`nexit `$LASTEXITCODE"
+        Set-Content -LiteralPath (Join-Path $repo 'scripts/AgentLocks.ps1') -Value $proxy
+        Set-Content -LiteralPath (Join-Path $repo 'README.md') -Value 'fixture'
+        Invoke-TestGit -C $repo add .
+        Invoke-TestGit -C $repo commit -m fixture
+        Invoke-TestGit -C $repo remote add origin $remote
+        Invoke-TestGit -C $repo push -u origin main
+        Invoke-TestGit -C $repo worktree add -b $branch $worktree HEAD
+        Set-Content -LiteralPath (Join-Path $worktree 'change.txt') -Value $scenario
+        Invoke-TestGit -C $worktree add change.txt
+        Invoke-TestGit -C $worktree commit -m change
+        Invoke-TestGit -C $worktree push -u origin $branch
+        $leaseOwner = if ($scenario -eq 'foreign-owner') { "foreign-$owner" } else { $owner }
+        $claimed = $scenario -notin @('unowned', 'unidentified')
+        if ($claimed) {
+            & pwsh -NoProfile -File $AgentLocksScript acquire -LockName $lockName -OwnerId $leaseOwner -Worktree $worktree *> $null
+            Assert ($LASTEXITCODE -eq 0) 'Cannot acquire isolated merge lease'
+            $leases.Add([pscustomobject]@{ Key = $lockName; Owner = $leaseOwner })
+        }
+        if ($scenario -eq 'dirty-owner') {
+            Set-Content -LiteralPath (Join-Path $worktree 'change.txt') -Value 'uncommitted source'
+        }
+        if ($scenario -eq 'renew-failure') {
+            $proxy = "if (`$args[0] -eq 'renew') { exit 4 }`n$proxy"
+            Set-Content -LiteralPath (Join-Path $repo 'scripts/AgentLocks.ps1') -Value $proxy
+        }
+        if ($scenario -eq 'status-failure') {
+            $proxy = "if (`$args[0] -eq 'status') { exit 1 }`n$proxy"
+            Set-Content -LiteralPath (Join-Path $repo 'scripts/AgentLocks.ps1') -Value $proxy
+        }
+        $script:fixtureRepo = $repo
+        $script:fixtureBranch = $branch
+        Push-Location $repo
+        try {
+            if ($scenario -eq 'unidentified') {
+                $env:DEKAF_AGENT_LOCK_OWNER_ID = $null
+                $env:CODEX_THREAD_ID = $null
+            }
+            & (Join-Path $repo 'scripts/Merge-Pr.ps1') -Pr $number -Worktree $worktree
+            Assert ($LASTEXITCODE -eq 0) 'Fixture merge wrapper failed'
+        }
+        finally {
+            $env:DEKAF_AGENT_LOCK_OWNER_ID = $owner
+            $env:CODEX_THREAD_ID = $previousThread
+            Pop-Location
+        }
+        Assert ((Get-Content -LiteralPath (Join-Path $repo 'change.txt')) -eq $scenario) 'Fixture merge did not complete'
+        $shouldRemove = $scenario -in @('owner', 'unowned', 'unidentified')
+        Assert ((Test-Path -LiteralPath $worktree) -ne $shouldRemove) "Wrong worktree retention for $scenario"
+        & git.exe -C $repo show-ref --verify --quiet "refs/heads/$branch"
+        Assert (($LASTEXITCODE -eq 0) -ne $shouldRemove) "Wrong local branch retention for $scenario"
+        & git.exe -C $repo ls-remote --exit-code origin "refs/heads/$branch" 2>$null | Out-Null
+        Assert (($LASTEXITCODE -eq 0) -ne $shouldRemove) "Wrong remote branch retention for $scenario"
+        if ($claimed) {
+            $state = & pwsh -NoProfile -File $AgentLocksScript status -LockName $lockName -OwnerId $leaseOwner
+            Assert ($state -eq 'HELD-BY-ME') "Merge changed the existing lease for $scenario"
+            # A competing claim must still fail after cleanup and branch deletion.
+            & pwsh -NoProfile -File $AgentLocksScript acquire -LockName $lockName -OwnerId "competitor-$owner" *> $null
+            $competingExit = $LASTEXITCODE
+            if ($competingExit -eq 0) {
+                & pwsh -NoProfile -File $AgentLocksScript release -LockName $lockName -OwnerId "competitor-$owner" *> $null
+            }
+            Assert ($competingExit -eq 3) "Merge released ownership too soon for $scenario"
+        }
+        Write-Host "OK merge ownership scenario: $scenario"
+    }
+}
+finally {
+    foreach ($lease in $leases) {
+        & pwsh -NoProfile -File $AgentLocksScript release -LockName $lease.Key -OwnerId $lease.Owner *> $null
+    }
+    $env:DEKAF_AGENT_LOCK_OWNER_ID = $previousOwner
+    $env:CODEX_THREAD_ID = $previousThread
+    if (Test-Path -LiteralPath $testRoot) {
+        $resolved = (Resolve-Path -LiteralPath $testRoot).Path
+        if (-not $resolved.StartsWith($tempRoot, [StringComparison]::OrdinalIgnoreCase)) { throw 'Unsafe fixture cleanup path' }
+        Remove-Item -LiteralPath $resolved -Recurse -Force
+    }
+}

--- a/scripts/Test-MergePrOwnership.ps1
+++ b/scripts/Test-MergePrOwnership.ps1
@@ -19,7 +19,7 @@ $leases = [Collections.Generic.List[object]]::new()
 
 function Assert([bool]$Condition, [string]$Message) { if (-not $Condition) { throw $Message } }
 function Invoke-TestGit {
-    & git.exe @args 2>&1 | Out-Null
+    & git @args 2>&1 | Out-Null
     if ($LASTEXITCODE -ne 0) { throw "Git fixture command failed: $args" }
 }
 
@@ -117,9 +117,9 @@ function Remove-MergedWorktreeCore {
         Assert ((Get-Content -LiteralPath (Join-Path $repo 'change.txt')) -eq $scenario) 'Fixture merge did not complete'
         $shouldRemove = $scenario -in @('owner', 'unowned', 'unidentified')
         Assert ((Test-Path -LiteralPath $worktree) -ne $shouldRemove) "Wrong worktree retention for $scenario"
-        & git.exe -C $repo show-ref --verify --quiet "refs/heads/$branch"
+        & git -C $repo show-ref --verify --quiet "refs/heads/$branch"
         Assert (($LASTEXITCODE -eq 0) -ne $shouldRemove) "Wrong local branch retention for $scenario"
-        & git.exe -C $repo ls-remote --exit-code origin "refs/heads/$branch" 2>$null | Out-Null
+        & git -C $repo ls-remote --exit-code origin "refs/heads/$branch" 2>$null | Out-Null
         Assert (($LASTEXITCODE -eq 0) -ne $shouldRemove) "Wrong remote branch retention for $scenario"
         if ($claimed) {
             $state = & pwsh -NoProfile -File $AgentLocksScript status -LockName $lockName -OwnerId $leaseOwner

--- a/scripts/Test-ReleasedWorktreeCleanup.ps1
+++ b/scripts/Test-ReleasedWorktreeCleanup.ps1
@@ -1,6 +1,7 @@
 # Local regression suite: requires Git, PowerShell 7 and Docker.
+param([string]$AgentLocksScript = (Join-Path $PSScriptRoot 'AgentLocks.ps1'))
 $ErrorActionPreference = 'Stop'
-$agentLocks = Join-Path $PSScriptRoot 'AgentLocks.ps1'
+$agentLocks = (Resolve-Path -LiteralPath $AgentLocksScript).Path
 $suffix = [Guid]::NewGuid().ToString('N')
 $testRoot = Join-Path ([IO.Path]::GetTempPath()) "released-worktree-tests-$suffix"
 $repo = Join-Path $testRoot 'repo'

--- a/scripts/Test-RemoveMergedWorktrees.ps1
+++ b/scripts/Test-RemoveMergedWorktrees.ps1
@@ -49,6 +49,25 @@ try {
     Set-Content -LiteralPath (Join-Path $openWorktree 'README.md') -Value 'open PR'
     git -C $openWorktree commit --quiet -am 'open PR'
     $openHead = git -C $openWorktree rev-parse HEAD
+    $orphan = Join-Path $testRoot 'pr-123-orphan'
+    New-Item -ItemType Directory -Path $orphan | Out-Null
+    Set-Content -LiteralPath (Join-Path $orphan '.git') -Value "gitdir: $repo/.git/worktrees/missing-registration"
+    Set-Content -LiteralPath (Join-Path $orphan 'NewFeature.cs') -Value 'untracked source'
+    Set-Content -LiteralPath (Join-Path $repo 'README.md') -Value 'new main commit outside merged PR records'
+    git -C $repo commit --quiet -am 'advance main'
+    $mainHead = git -C $repo rev-parse HEAD
+    git -C $repo update-ref refs/remotes/origin/main $mainHead
+    $owned = Join-Path $testRoot 'owned-detached'
+    git -C $repo worktree add --quiet --detach $owned $mainHead
+    git -C $repo config extensions.worktreeConfig true
+    git -C $owned config --worktree agent.lockName fixture-owned
+    New-Item -ItemType Directory -Path (Join-Path $repo 'scripts') | Out-Null
+    # Live Redis semantics are tested separately; this verifies sweep routing.
+    Set-Content -LiteralPath (Join-Path $repo 'scripts/AgentLocks.ps1') -Value @'
+param($Verb, $LockName, $OwnerId)
+if ($Verb -eq 'status') { 'HELD'; exit 0 }
+exit 3
+'@
     $mergedJson = @(
         foreach ($name in @('merged', 'dirty', 'divergent', 'open')) {
             @{ headRefName = $name; headRefOid = $baseHead }
@@ -74,6 +93,8 @@ try {
         Assert-True (Test-Path -LiteralPath $dirtyWorktree) 'Dirty worktree was removed.'
         Assert-True (Test-Path -LiteralPath $divergentWorktree) 'Divergent local commit was removed.'
         Assert-True (Test-Path -LiteralPath $openWorktree) 'Open PR worktree was removed.'
+        Assert-True (Test-Path -LiteralPath $owned) 'Redis-owned detached main checkout was removed.'
+        Assert-True (Test-Path -LiteralPath (Join-Path $orphan 'NewFeature.cs')) 'Orphan with unverifiable ownership/source was removed.'
         git -C $repo show-ref --verify --quiet refs/heads/merged
         Assert-True ($LASTEXITCODE -ne 0) 'Merged branch was not cleaned up.'
         git -C $repo show-ref --verify --quiet refs/heads/divergent

--- a/scripts/Test-WorktreeCleanup.ps1
+++ b/scripts/Test-WorktreeCleanup.ps1
@@ -21,10 +21,18 @@ try {
     git -C $repo init -b main --quiet
     git -C $repo config user.name 'Worktree Cleanup Test'
     git -C $repo config user.email 'worktree-cleanup@example.invalid'
+    # Ownership behavior has a separate live-Redis suite. Keep these filesystem
+    # guard tests independent of Docker and real work-item identities.
+    New-Item -ItemType Directory -Path (Join-Path $repo 'scripts') | Out-Null
+    Set-Content -LiteralPath (Join-Path $repo 'scripts/AgentLocks.ps1') -Value @'
+param($Verb, $LockName, $OwnerId)
+if ($Verb -eq 'status') { 'FREE' }
+exit 0
+'@
     Set-Content -LiteralPath (Join-Path $repo 'README.md') -Value '# fixture'
     Copy-Item -LiteralPath (Join-Path $PSScriptRoot '../.gitignore') -Destination (Join-Path $repo '.gitignore')
     Add-Content -LiteralPath (Join-Path $repo '.gitignore') -Value "`n.env`nignored-source/"
-    git -C $repo add README.md .gitignore
+    git -C $repo add README.md .gitignore scripts/AgentLocks.ps1
     git -C $repo commit --quiet -m 'fixture'
 
     git -C $repo worktree add --quiet -b issue-123-fresh-source $sourceWorktree

--- a/scripts/Test-WorktreeOwnershipCleanup.ps1
+++ b/scripts/Test-WorktreeOwnershipCleanup.ps1
@@ -17,7 +17,7 @@ $keys = [Collections.Generic.List[string]]::new()
 
 function Assert([bool]$Condition, [string]$Message) { if (-not $Condition) { throw $Message } }
 function Invoke-TestGit {
-    & git.exe @args 2>&1 | Out-Null
+    & git @args 2>&1 | Out-Null
     if ($LASTEXITCODE -ne 0) { throw "Git fixture command failed: $args" }
 }
 function Claim([string]$Key, [string]$Path) {

--- a/scripts/Test-WorktreeOwnershipCleanup.ps1
+++ b/scripts/Test-WorktreeOwnershipCleanup.ps1
@@ -1,0 +1,164 @@
+# Uses isolated Git repositories and unique Redis keys; requires PowerShell 7 and Docker.
+param([string]$AgentLocksScript)
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'WorktreeCleanup.ps1')
+if (-not $AgentLocksScript) {
+    $common = & git rev-parse --path-format=absolute --git-common-dir
+    $AgentLocksScript = Join-Path (Split-Path $common -Parent) 'scripts/AgentLocks.ps1'
+}
+$AgentLocksScript = (Resolve-Path -LiteralPath $AgentLocksScript).Path
+$suffix = [Guid]::NewGuid().ToString('N')
+$owner = "ownership-tests-$suffix"
+$testRoot = [IO.Path]::GetFullPath((Join-Path ([IO.Path]::GetTempPath()) "worktree-ownership-$suffix"))
+$temp = [IO.Path]::GetFullPath([IO.Path]::GetTempPath()).TrimEnd('\', '/') + [IO.Path]::DirectorySeparatorChar
+if (-not $testRoot.StartsWith($temp, [StringComparison]::OrdinalIgnoreCase)) { throw 'Unsafe fixture root' }
+$repo = Join-Path $testRoot 'repo'
+$keys = [Collections.Generic.List[string]]::new()
+
+function Assert([bool]$Condition, [string]$Message) { if (-not $Condition) { throw $Message } }
+function Invoke-TestGit {
+    & git.exe @args 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Git fixture command failed: $args" }
+}
+function Claim([string]$Key, [string]$Path) {
+    $keys.Add($Key)
+    $arguments = @('acquire', '-LockName', $Key, '-OwnerId', $owner)
+    if ($Path) { $arguments += @('-Worktree', $Path) }
+    & pwsh -NoProfile -File $AgentLocksScript @arguments *> $null
+    if ($LASTEXITCODE -ne 0) { throw 'Cannot acquire isolated test lease' }
+}
+function Release([string]$Key) {
+    & pwsh -NoProfile -File $AgentLocksScript release -LockName $Key -OwnerId $owner *> $null
+    if ($LASTEXITCODE -ne 0) { throw 'Cannot release isolated test lease' }
+}
+
+try {
+    New-Item -ItemType Directory -Path (Join-Path $repo 'scripts') -Force | Out-Null
+    Invoke-TestGit init --initial-branch=main $repo
+    Invoke-TestGit -C $repo config user.name 'Ownership Tests'
+    Invoke-TestGit -C $repo config user.email 'ownership-tests@example.invalid'
+    Set-Content -LiteralPath (Join-Path $repo '.gitignore') -Value "bin/`n.artifacts/"
+    Set-Content -LiteralPath (Join-Path $repo 'README.md') -Value 'fixture'
+    # The fixture's canonical endpoint delegates to this repository's canonical script.
+    $quotedScript = $AgentLocksScript.Replace("'", "''")
+    $proxy = "& '$quotedScript' @args`nexit `$LASTEXITCODE"
+    Set-Content -LiteralPath (Join-Path $repo 'scripts/AgentLocks.ps1') -Value $proxy
+    Invoke-TestGit -C $repo add .
+    Invoke-TestGit -C $repo commit -m fixture
+    Push-Location $repo
+    try {
+        $held = Join-Path $testRoot 'held-detached'
+        Invoke-TestGit -C $repo worktree add --detach $held HEAD
+        $key = "cleanup-test-$suffix-held"
+        Claim $key $held
+        Remove-MergedWorktree -Repo $repo -Worktree $held -Label 'owned detached fixture'
+        Assert (Test-Path -LiteralPath (Join-Path $held '.git')) 'Cleanup removed a detached checkout with a live Redis lease.'
+        $state = & pwsh -NoProfile -File $AgentLocksScript status -LockName $key -OwnerId $owner
+        Assert ($state -eq 'HELD-BY-ME') 'Cleanup changed the active owner lease.'
+        Remove-MergedWorktree -Repo $repo -Worktree $held -WhatIf
+        Assert (Test-Path -LiteralPath $held) 'Preview removed an owned checkout.'
+        Release $key
+        Assert (-not (Test-Path -LiteralPath $held)) 'Canonical owner release did not remove its clean checkout.'
+
+        # The standard directory identity protects creation before marker registration.
+        $number = Get-Random -Minimum 1000000000 -Maximum 2000000000
+        $pending = Join-Path $testRoot "pr-$number-before-marker"
+        Invoke-TestGit -C $repo worktree add --detach $pending HEAD
+        $key = "pr-$number"
+        Claim $key ''
+        Remove-MergedWorktree -Repo $repo -Worktree $pending -Label 'before marker fixture'
+        Assert (Test-Path -LiteralPath (Join-Path $pending '.git')) 'Cleanup removed a checkout before its marker was registered.'
+        Release $key
+
+        # Keep a released checkout with a Git lock, then make it eligible for cleanup.
+        $released = Join-Path $testRoot 'released-detached'
+        Invoke-TestGit -C $repo worktree add --detach $released HEAD
+        $key = "cleanup-test-$suffix-released"
+        Claim $key $released
+        Invoke-TestGit -C $repo worktree lock $released
+        Release $key
+        Invoke-TestGit -C $repo worktree unlock $released
+        Remove-MergedWorktree -Repo $repo -Worktree $released -WhatIf
+        Assert (Test-Path -LiteralPath $released) 'WhatIf removed a checkout.'
+        # Attempt a competing acquisition after cleanup acquires and immediately
+        # before it releases. Both must fail, with removal between those boundaries.
+        $raceLog = Join-Path $testRoot 'race.log'
+        $raceProxy = @'
+param($Verb, $LockName, $OwnerId)
+$canonical = '__CANONICAL__'
+$competitor = '__COMPETITOR__'
+function Try-CompetingClaim {
+    & pwsh -NoProfile -File $canonical acquire -LockName $LockName -OwnerId $competitor *> $null
+    $code = $LASTEXITCODE
+    if ($code -eq 0) {
+        & pwsh -NoProfile -File $canonical release -LockName $LockName -OwnerId $competitor *> $null
+    }
+    Add-Content -LiteralPath '__LOG__' -Value "$Verb competing=$code exists=$(Test-Path -LiteralPath '__WORKTREE__')"
+}
+if ($Verb -eq 'release') { Try-CompetingClaim }
+& pwsh -NoProfile -File $canonical $Verb -LockName $LockName -OwnerId $OwnerId *> $null
+$code = $LASTEXITCODE
+if ($Verb -eq 'acquire' -and $code -eq 0) { Try-CompetingClaim }
+exit $code
+'@
+        $raceProxy = $raceProxy.Replace('__CANONICAL__', $quotedScript).
+            Replace('__COMPETITOR__', "competitor-$suffix").
+            Replace('__LOG__', $raceLog.Replace("'", "''")).
+            Replace('__WORKTREE__', $released.Replace("'", "''"))
+        Set-Content -LiteralPath (Join-Path $repo 'scripts/AgentLocks.ps1') -Value $raceProxy
+        Remove-MergedWorktree -Repo $repo -Worktree $released
+        Set-Content -LiteralPath (Join-Path $repo 'scripts/AgentLocks.ps1') -Value $proxy
+        Assert (-not (Test-Path -LiteralPath $released)) 'Released checkout was not removed.'
+        $races = @(Get-Content -LiteralPath $raceLog)
+        Assert ($races.Count -eq 2 -and $races[0] -ceq 'acquire competing=3 exists=True' -and
+            $races[1] -ceq 'release competing=3 exists=False') 'Cleanup did not exclude competing ownership through removal.'
+        $state = & pwsh -NoProfile -File $AgentLocksScript status -LockName $key -OwnerId $owner
+        Assert ($state -eq 'FREE') 'Cleanup left its temporary lease behind.'
+
+        $unavailable = Join-Path $testRoot 'unavailable'
+        Invoke-TestGit -C $repo worktree add --detach $unavailable HEAD
+        Invoke-TestGit -C $unavailable config --worktree agent.lockName "cleanup-test-$suffix-unavailable"
+        Set-Content -LiteralPath (Join-Path $repo 'scripts/AgentLocks.ps1') -Value 'exit 2'
+        Remove-MergedWorktree -Repo $repo -Worktree $unavailable
+        Assert (Test-Path -LiteralPath $unavailable) 'Unavailable ownership check allowed removal.'
+        Remove-MergedWorktree -Repo $repo -Worktree $unavailable -WhatIf
+        Assert (Test-Path -LiteralPath $unavailable) 'Unavailable preview allowed removal.'
+        Set-Content -LiteralPath (Join-Path $repo 'scripts/AgentLocks.ps1') -Value $proxy
+
+        # Simulate a marker changing after acquisition; cleanup must release its
+        # original lease without removing the checkout under a different identity.
+        $changed = Join-Path $testRoot 'changed-marker'
+        Invoke-TestGit -C $repo worktree add --detach $changed HEAD
+        $key = "cleanup-test-$suffix-original"
+        Invoke-TestGit -C $changed config --worktree agent.lockName $key
+        $changedProxy = @'
+param($Verb, $LockName, $OwnerId)
+& pwsh -NoProfile -File '__CANONICAL__' $Verb -LockName $LockName -OwnerId $OwnerId *> $null
+$code = $LASTEXITCODE
+if ($Verb -eq 'acquire' -and $code -eq 0) {
+    git -C '__WORKTREE__' config --worktree agent.lockName changed-fixture-identity
+    if ($LASTEXITCODE -ne 0) { throw 'Cannot change fixture marker' }
+}
+exit $code
+'@
+        $changedProxy = $changedProxy.Replace('__CANONICAL__', $quotedScript).
+            Replace('__WORKTREE__', $changed.Replace("'", "''"))
+        Set-Content -LiteralPath (Join-Path $repo 'scripts/AgentLocks.ps1') -Value $changedProxy
+        Remove-MergedWorktree -Repo $repo -Worktree $changed
+        Assert (Test-Path -LiteralPath $changed) 'Changed ownership identity allowed removal.'
+        $state = & pwsh -NoProfile -File $AgentLocksScript status -LockName $key -OwnerId $owner
+        Assert ($state -eq 'FREE') 'Preserved checkout left cleanup ownership behind.'
+        Set-Content -LiteralPath (Join-Path $repo 'scripts/AgentLocks.ps1') -Value $proxy
+        Write-Host 'OK worktree ownership: live owner, creation window, canonical release, preview, unavailable endpoint, changed identity and competing acquisition throughout removal.'
+    }
+    finally {
+        foreach ($key in $keys) {
+            $state = & pwsh -NoProfile -File $AgentLocksScript status -LockName $key -OwnerId $owner
+            if ($state -eq 'HELD-BY-ME') { Release $key }
+        }
+        Pop-Location
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $testRoot) { Remove-Item -LiteralPath $testRoot -Recurse -Force }
+}

--- a/scripts/WorktreeCleanup.ps1
+++ b/scripts/WorktreeCleanup.ps1
@@ -117,13 +117,112 @@ function Test-WorktreeHeadMerged {
     return $LASTEXITCODE -eq 0
 }
 
+function Get-WorktreeCleanupLockName {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Worktree)
+
+    if (Test-Path -LiteralPath $Worktree) {
+        $enabled = git -C $Worktree config --local --bool --get extensions.worktreeConfig 2>$null
+        if ($LASTEXITCODE -notin @(0, 1)) { throw 'Cannot inspect worktree lock configuration.' }
+        # Without this extension --worktree aliases shared config, which can contain
+        # a legacy marker belonging to an entirely different checkout.
+        if ($enabled -eq 'true') {
+            $marker = git -C $Worktree config --worktree --get agent.lockName 2>$null
+            if ($LASTEXITCODE -notin @(0, 1)) { throw 'Cannot inspect worktree lock marker.' }
+            if ($marker) { return $marker.Trim() }
+        }
+    }
+
+    # Ownership is acquired before checkout. Protect the creation/registration gap
+    # using the work-item identity required by the issue/PR worktree convention.
+    $name = [IO.Path]::GetFileName($Worktree.TrimEnd('\', '/'))
+    if ($name -match '^(pr|issue)-(\d+)(?:-|$)') { return "$($Matches[1])-$($Matches[2])" }
+    return $null
+}
+
+function Invoke-WorktreeOwnershipCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Script,
+        [Parameter(Mandatory)][string]$Verb,
+        [Parameter(Mandatory)][string]$LockName,
+        [Parameter(Mandatory)][string]$OwnerId
+    )
+
+    $state = $null
+    if ($Verb -eq 'status') {
+        $state = (& pwsh -NoProfile -File $Script $Verb -LockName $LockName -OwnerId $OwnerId 2>$null | Out-String).Trim()
+    } else {
+        # Acquire prints an opaque token. Only the canonical script may store it;
+        # never include it (or arbitrary endpoint output) in cleanup diagnostics.
+        & pwsh -NoProfile -File $Script $Verb -LockName $LockName -OwnerId $OwnerId *> $null
+    }
+    return [pscustomobject]@{ ExitCode = $LASTEXITCODE; State = $state }
+}
+
 function Remove-MergedWorktree {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Repo,
+        [Parameter(Mandatory)][string]$Worktree,
+        [string]$Label = '',
+        [string]$ExpectedHead,
+        [switch]$WhatIf
+    )
+
+    try { $lockName = Get-WorktreeCleanupLockName -Worktree $Worktree }
+    catch {
+        Write-Host "Preserving worktree $Label : $Worktree (ownership identity is unreadable)"
+        return
+    }
+    if (-not $lockName) {
+        Remove-MergedWorktreeCore @PSBoundParameters
+        return
+    }
+
+    # Repo is the shared checkout, not a branch copy whose locking protocol may be old.
+    $agentLocks = Join-Path $Repo 'scripts/AgentLocks.ps1'
+    if (-not (Test-Path -LiteralPath $agentLocks)) {
+        Write-Host "Preserving worktree $Label : $Worktree (canonical ownership script is unavailable)"
+        return
+    }
+    $owner = "worktree-cleanup-$([Guid]::NewGuid().ToString('N'))"
+    $verb = if ($WhatIf) { 'status' } else { 'acquire' }
+    try { $result = Invoke-WorktreeOwnershipCommand -Script $agentLocks -Verb $verb -LockName $lockName -OwnerId $owner }
+    catch {
+        Write-Host "Preserving worktree $Label : $Worktree (ownership check failed)"
+        return
+    }
+    if ($result.ExitCode -ne 0 -or ($WhatIf -and $result.State -ne 'FREE')) {
+        Write-Host "Preserving worktree $Label : $Worktree (Redis ownership held or unavailable for $lockName)"
+        return
+    }
+
+    try {
+        Remove-MergedWorktreeCore @PSBoundParameters -ExpectedLockName $lockName
+    }
+    finally {
+        if (-not $WhatIf) {
+            # No -Worktree was supplied on acquire: release only this temporary lease.
+            # A competing owner cannot acquire the item between our check and removal.
+            $released = Invoke-WorktreeOwnershipCommand -Script $agentLocks -Verb release -LockName $lockName -OwnerId $owner
+            if ($released.ExitCode -ne 0) {
+                Write-Host "WARNING: could not release cleanup ownership for $lockName (exit $($released.ExitCode))"
+            }
+        }
+    }
+}
+
+# Called only after Remove-MergedWorktree has established cleanup ownership, or
+# determined this checkout has no registered/standard work-item identity.
+function Remove-MergedWorktreeCore {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$Repo,       # a checkout that is NOT the one being removed (main)
         [Parameter(Mandatory)][string]$Worktree,   # path to remove
         [string]$Label = '',                       # e.g. "#1234" for log lines
         [string]$ExpectedHead,
+        [string]$ExpectedLockName,
         [switch]$WhatIf
     )
 
@@ -183,6 +282,11 @@ function Remove-MergedWorktree {
 
     if ($WhatIf) {
         Write-Host "sweep: WOULD remove $Worktree -- $Label"
+        return
+    }
+
+    if ($ExpectedLockName -and (Get-WorktreeCleanupLockName -Worktree $Worktree) -cne $ExpectedLockName) {
+        Write-Host "Preserving worktree $Label : $Worktree (ownership identity changed during cleanup)"
         return
     }
 

--- a/scripts/WorktreeCleanup.ps1
+++ b/scripts/WorktreeCleanup.ps1
@@ -234,6 +234,9 @@ function Remove-MergedWorktree {
     try {
         Remove-MergedWorktreeCore @coreParameters -ExpectedLockName $lockName
     }
+    catch {
+        Write-Host "WARNING: worktree cleanup failed for $Label : $Worktree; any remaining checkout is preserved."
+    }
     finally {
         if (-not $WhatIf) {
             # No -Worktree was supplied on acquire: release only this temporary lease.

--- a/scripts/WorktreeCleanup.ps1
+++ b/scripts/WorktreeCleanup.ps1
@@ -146,16 +146,17 @@ function Invoke-WorktreeOwnershipCommand {
         [Parameter(Mandatory)][string]$Script,
         [Parameter(Mandatory)][string]$Verb,
         [Parameter(Mandatory)][string]$LockName,
-        [Parameter(Mandatory)][string]$OwnerId
+        [string]$OwnerId
     )
 
     $state = $null
+    $ownerArguments = if ($OwnerId) { @('-OwnerId', $OwnerId) } else { @() }
     if ($Verb -eq 'status') {
-        $state = (& pwsh -NoProfile -File $Script $Verb -LockName $LockName -OwnerId $OwnerId 2>$null | Out-String).Trim()
+        $state = (& pwsh -NoProfile -File $Script $Verb -LockName $LockName @ownerArguments 2>$null | Out-String).Trim()
     } else {
         # Acquire prints an opaque token. Only the canonical script may store it;
         # never include it (or arbitrary endpoint output) in cleanup diagnostics.
-        & pwsh -NoProfile -File $Script $Verb -LockName $LockName -OwnerId $OwnerId *> $null
+        & pwsh -NoProfile -File $Script $Verb -LockName $LockName @ownerArguments *> $null
     }
     return [pscustomobject]@{ ExitCode = $LASTEXITCODE; State = $state }
 }
@@ -167,16 +168,19 @@ function Remove-MergedWorktree {
         [Parameter(Mandatory)][string]$Worktree,
         [string]$Label = '',
         [string]$ExpectedHead,
+        [switch]$AllowCurrentOwner,
         [switch]$WhatIf
     )
 
+    $coreParameters = @{} + $PSBoundParameters
+    $coreParameters.Remove('AllowCurrentOwner')
     try { $lockName = Get-WorktreeCleanupLockName -Worktree $Worktree }
     catch {
         Write-Host "Preserving worktree $Label : $Worktree (ownership identity is unreadable)"
         return
     }
     if (-not $lockName) {
-        Remove-MergedWorktreeCore @PSBoundParameters
+        Remove-MergedWorktreeCore @coreParameters
         return
     }
 
@@ -185,6 +189,35 @@ function Remove-MergedWorktree {
     if (-not (Test-Path -LiteralPath $agentLocks)) {
         Write-Host "Preserving worktree $Label : $Worktree (canonical ownership script is unavailable)"
         return
+    }
+    $hasCurrentOwner = -not [string]::IsNullOrWhiteSpace($env:DEKAF_AGENT_LOCK_OWNER_ID) -or
+        -not [string]::IsNullOrWhiteSpace($env:CODEX_THREAD_ID)
+    if ($AllowCurrentOwner -and $hasCurrentOwner) {
+        try {
+            # Only the post-merge caller opts into using its own canonical identity.
+            # Sweeps always use a separate temporary owner and preserve live leases.
+            $current = Invoke-WorktreeOwnershipCommand -Script $agentLocks -Verb status -LockName $lockName
+            if ($current.ExitCode -eq 0 -and $current.State -eq 'HELD-BY-ME') {
+                if (-not $WhatIf) {
+                    # Validate the cached token and renew before removal; a stale or
+                    # nearly expired lease cannot authorize the cleanup operation.
+                    $renewed = Invoke-WorktreeOwnershipCommand -Script $agentLocks -Verb renew -LockName $lockName
+                    if ($renewed.ExitCode -ne 0) { throw 'Current cleanup ownership could not be renewed.' }
+                }
+                Remove-MergedWorktreeCore @coreParameters -ExpectedLockName $lockName
+                # The caller retains its lease through subsequent branch cleanup
+                # and releases it in its normal finally path.
+                return
+            }
+            if ($current.ExitCode -ne 0 -or $current.State -ne 'FREE') {
+                Write-Host "Preserving worktree $Label : $Worktree (current caller does not own $lockName or ownership is unavailable)"
+                return
+            }
+        }
+        catch {
+            Write-Host "Preserving worktree $Label : $Worktree (current ownership cleanup failed)"
+            return
+        }
     }
     $owner = "worktree-cleanup-$([Guid]::NewGuid().ToString('N'))"
     $verb = if ($WhatIf) { 'status' } else { 'acquire' }
@@ -199,7 +232,7 @@ function Remove-MergedWorktree {
     }
 
     try {
-        Remove-MergedWorktreeCore @PSBoundParameters -ExpectedLockName $lockName
+        Remove-MergedWorktreeCore @coreParameters -ExpectedLockName $lockName
     }
     finally {
         if (-not $WhatIf) {

--- a/scripts/WorktreeLifecycle.md
+++ b/scripts/WorktreeLifecycle.md
@@ -6,8 +6,15 @@ Local branches remain available for `git worktree add <path> <branch>`. Detached
 
 A crashed process or an expired Redis TTL cannot run release. `Remove-MergedWorktrees.ps1` remains the conservative fallback for merged work. No GitHub Actions job manages local disk.
 
+The sweep preserves live Redis ownership, including detached checkouts of main. It resolves the work-item identity from the per-worktree `agent.lockName` marker, or from a standard `pr-<N>-*` / `issue-<N>-*` directory before marker registration. For eligible worktrees, it acquires a temporary lease through the shared checkout's `AgentLocks.ps1`, keeps that lease through removal, then releases it. Ownership errors preserve the checkout. `-WhatIf` only reads ownership. Normal owner release still removes its own eligible checkout before releasing its lease.
+
+Directories with dangling Git registration are reported and preserved: the sweep cannot verify their ownership marker or uncommitted source. Inspect these directories and retain valuable evidence before manual cleanup.
+
 Run regression tests locally with PowerShell 7, Git and Docker:
 
 ```powershell
 pwsh scripts/Test-ReleasedWorktreeCleanup.ps1
+pwsh scripts/Test-WorktreeOwnershipCleanup.ps1
+pwsh scripts/Test-WorktreeCleanup.ps1
+pwsh scripts/Test-RemoveMergedWorktrees.ps1
 ```

--- a/scripts/WorktreeLifecycle.md
+++ b/scripts/WorktreeLifecycle.md
@@ -8,6 +8,8 @@ A crashed process or an expired Redis TTL cannot run release. `Remove-MergedWork
 
 The sweep preserves live Redis ownership, including detached checkouts of main. It resolves the work-item identity from the per-worktree `agent.lockName` marker, or from a standard `pr-<N>-*` / `issue-<N>-*` directory before marker registration. For eligible worktrees, it acquires a temporary lease through the shared checkout's `AgentLocks.ps1`, keeps that lease through removal, then releases it. Ownership errors preserve the checkout. `-WhatIf` only reads ownership. Normal owner release still removes its own eligible checkout before releasing its lease.
 
+After a successful merge, `Merge-Pr.ps1` opts into cleanup using the caller's existing ownership. The canonical script must report `HELD-BY-ME` and successfully renew the token-checked lease before removal. The lease remains held through worktree and branch cleanup; the caller releases it in its usual `finally` path. Another owner, an ownership error or a failed renewal preserves the checkout and branches. An unowned checkout still uses a temporary cleanup lease, including manual callers with no agent identity. Sweeps never opt into removing a live owner's checkout.
+
 Directories with dangling Git registration are reported and preserved: the sweep cannot verify their ownership marker or uncommitted source. Inspect these directories and retain valuable evidence before manual cleanup.
 
 Run regression tests locally with PowerShell 7, Git and Docker:
@@ -15,6 +17,8 @@ Run regression tests locally with PowerShell 7, Git and Docker:
 ```powershell
 pwsh scripts/Test-ReleasedWorktreeCleanup.ps1
 pwsh scripts/Test-WorktreeOwnershipCleanup.ps1
+pwsh scripts/Test-MergePrOwnership.ps1
+pwsh scripts/Test-MergePr.ps1
 pwsh scripts/Test-WorktreeCleanup.ps1
 pwsh scripts/Test-RemoveMergedWorktrees.ps1
 ```


### PR DESCRIPTION
An active detached checkout could be removed by the merged-worktree sweep while its Redis work-item lease remained live. Sweeps now acquire a temporary lease through the canonical shared-checkout `AgentLocks.ps1` and retain it through removal. Held ownership, unavailable ownership checks and a changed worktree marker preserve the checkout. Standard `pr-<N>-*` / `issue-<N>-*` directory identity also protects checkout creation before marker registration. Orphaned directories with dangling Git registration are reported and preserved.

Post-merge cleanup handles the caller's existing lease separately: `Merge-Pr.ps1` explicitly allows its own verified ownership, renews the token-checked lease, removes the clean worktree and then deletes merged branches. The caller retains that lease until its normal final release. Another owner's lease, dirty source or failed status/renewal preserves the checkout and branches. Unowned cleanup uses a temporary lease, including manual callers without an agent identity. A cleanup inspection exception now warns, preserves any remaining checkout and releases the temporary lease instead of escaping after the merge succeeded. Sweeps never opt into removing a live owner's checkout.

Closes #3139.

Validation on Windows with PowerShell 7, Git and local Docker/Redis:

- The original sweep defect and subsequent caller-lease collision were reproduced before their fixes; their source and red/green logs remain in the earlier archives below.
- The final exception regression test injects a filesystem-inspection failure after temporary ownership acquisition. Before the fix, the real wrapper reports a successful local squash merge and then throws. After the fix, it returns success, preserves the worktree and both branches, and leaves the temporary lease free.
- `Test-MergePrOwnership.ps1` passes eight scenarios: cleanup exception, current owner, foreign owner, unowned checkout, no agent identity, dirty source, failed renewal and failed status. It executes the real wrapper against isolated Git repositories/bare remotes and unique live Redis keys. GitHub gate/merge responses and the new inspection failure are substituted inside fixtures only. Worktree/local/remote branch outcomes are asserted; existing leases remain held and competing acquisition still fails after cleanup.
- `Test-WorktreeOwnershipCleanup.ps1` passes active ownership, pre-marker creation, canonical release, preview, unavailable endpoint, changed marker and competing acquisitions throughout removal.
- `Test-WorktreeCleanup.ps1`, `Test-RemoveMergedWorktrees.ps1`, `Test-ReleasedWorktreeCleanup.ps1` and `Test-MergePr.ps1` all pass on the final source, retaining existing filesystem, expected-head, dirty-source, Git-lock, foreign/main/harness, released ownership, branch and wrapper-ordering checks.
- Final changes reviewed for reuse and simplicity; `git diff --check` passes. No client `src/` changes; performance benchmarks are not applicable.

Exception-path validation at preceding head `2415d96174068654f85aa0f5254feb3518a20158`. Durable evidence: `C:/git/Dekaf-evidence/pr-3140/2415d96174068654f85aa0f5254feb3518a20158/`, outside removable worktrees. All 16 copied source/log files are SHA-256 verified against originals, with the committed source ZIP retained. `red.log` is the injected exception reproduction; `green.log` contains all eight successful final scenarios.

Earlier evidence remains at `C:/git/Dekaf-evidence/pr-3140/d7362499d37ef4f1390aff8cb63009fdde4ef39e/` (18 verified copied files plus source ZIP) and `C:/git/Dekaf-evidence/issue-3139/21ba3a6f36127f497510121276321cf48e28bf64/` (19 verified copied files plus source ZIP and metadata). Their initial fixture setup failures are explicitly distinguished from the actual defect reproductions. Tests remove only verified temporary fixture roots; no real active checkout or PR is removed/merged for validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worktree cleanup now verifies ownership and maintains temporary ownership protection during removal.
  * Cleanup can safely remove worktrees owned by the current process when explicitly permitted.

* **Bug Fixes**
  * Orphaned worktree directories are now preserved when ownership or source-state verification is unavailable.
  * Cleanup better protects active or modified worktrees from accidental removal.

* **Documentation**
  * Added guidance covering ownership-aware cleanup, retention rules, and dangling worktree registrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
The two ownership regression suites invoke Git portably and pass on both Linux (PowerShell 7.6.4, Git 2.43.0) and Windows (PowerShell 7.6.5, Git 2.39.0.windows.1), including all eight merge scenarios. Linux reproduction and final passing logs, exact source, image digest and copied-file SHA-256 inventory for head `0d703bdda304fc9c989f6abca98b47a07eb90f25` are retained at `C:/git/Dekaf-evidence/pr-3140/0d703bdda304fc9c989f6abca98b47a07eb90f25/`.
