### PR TITLE
fix(ci): correct stress A–B–A comparisons and evidence reports

### DIFF
--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -77,6 +77,8 @@ def _single_result(directory):
     results = envelope.get("results") if isinstance(envelope, dict) else None
     if not isinstance(results, list) or len(results) != 1:
         raise ValueError(f"Expected exactly one result in {files[0]}")
+    if not isinstance(results[0], dict):
+        raise ValueError(f"Expected a result object in {files[0]}")
     return results[0]
 
 
@@ -167,6 +169,16 @@ def _percent_change(value, baseline):
     if baseline == 0:
         return 0.0 if value == 0 else None
     return 100 * (value - baseline) / baseline
+
+
+def _validate_control_work(result, measurements):
+    if measurements["throughput"] <= 0 or measurements["medianThroughput"] <= 0:
+        raise ValueError("A baseline control requires positive delivered and median throughput")
+    completed = result.get("deliveredMessages")
+    if completed is None:
+        completed = (result.get("throughput") or {}).get("totalMessages")
+    if not _finite_number(completed) or completed <= 0:
+        raise ValueError("A baseline control requires positive completed messages")
 
 
 def _drift_percent(first, second):
@@ -287,6 +299,8 @@ def compare(
     candidate_b2 = (
         None if candidate_b2_result is None else _measurements(candidate_b2_result)
     )
+    _validate_control_work(baseline_a_result, baseline_a)
+    _validate_control_work(baseline_a2_result, baseline_a2)
     if _stability_breached(candidate_result) or (
         candidate_b2_result is not None and _stability_breached(candidate_b2_result)
     ):

--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -349,6 +349,23 @@ def compare(
         for metric in METRICS
     ]
 
+    latency_sample_counts = {
+        "baselineA": baseline_a_result["latency"]["count"],
+        "candidateB": candidate_result["latency"]["count"],
+        "baselineA2": baseline_a2_result["latency"]["count"],
+        "candidateB2": None if candidate_b2_result is None else candidate_b2_result["latency"]["count"],
+    }
+    # Aggregate maxima have no distribution or uncertainty information. Unequal numbers
+    # of draws can inflate a maximum or conceal a loss, so neither verdict is supported.
+    # Keep every observed maximum; never trim samples to manufacture equal coverage.
+    if len({count for count in latency_sample_counts.values() if count is not None}) != 1:
+        maximum = next(item for item in metrics if item["key"] == "max")
+        maximum["status"] = "inconclusive"
+        maximum["reason"] = (
+            "Aggregate maximum comparison requires equal latency sample counts; "
+            "unequal counts require separate uncertainty analysis. All observed maxima are retained."
+        )
+
     candidate_failed = _errors(candidate_result) > 0 or _delivery_mismatch(candidate_result)
     if candidate_b2_result is not None:
         candidate_failed = candidate_failed or (
@@ -372,12 +389,7 @@ def compare(
         or (candidate_b2_result is not None and _delivery_mismatch(candidate_b2_result)),
         "candidateSegments": 1 if candidate_b2_result is None else 2,
         "minimumLatencySamples": MIN_LATENCY_SAMPLES,
-        "latencySampleCounts": {
-            "baselineA": baseline_a_result["latency"]["count"],
-            "candidateB": candidate_result["latency"]["count"],
-            "baselineA2": baseline_a2_result["latency"]["count"],
-            "candidateB2": None if candidate_b2_result is None else candidate_b2_result["latency"]["count"],
-        },
+        "latencySampleCounts": latency_sample_counts,
         "identity": list(_identity(candidate_result)),
         "metrics": metrics,
     }
@@ -406,6 +418,9 @@ def markdown(comparison, baseline_sha, candidate_sha):
         f"Each segment requires at least {MIN_LATENCY_SAMPLES} latency samples. This conservative "
         "screening floor does not establish tail precision or comparable sampling coverage; "
         "those still require the workload's sampling design and uncertainty analysis.",
+        "The aggregate maximum gate requires equal sample counts across all segments. "
+        "Unequal counts make that metric INCONCLUSIVE, even when its raw value improves. "
+        "Equal counts alone do not establish independent sampling or maximum precision.",
         "",
         f"Baseline: `{baseline_sha}` · Candidate: `{candidate_sha}`",
     ]
@@ -466,6 +481,9 @@ def markdown(comparison, baseline_sha, candidate_sha):
             cells.append(f"{item['candidateDriftPercent']:.2f}%")
         cells.append(item["status"])
         lines.append("| " + " | ".join(cells) + " |")
+    for item in comparison["metrics"]:
+        if item.get("reason"):
+            lines.extend(["", f"{item['label']}: {item['reason']}"])
     if comparison["candidateErrors"] or comparison["candidateDeliveryMismatch"]:
         lines.extend(
             [

--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -355,16 +355,15 @@ def compare(
         "baselineA2": baseline_a2_result["latency"]["count"],
         "candidateB2": None if candidate_b2_result is None else candidate_b2_result["latency"]["count"],
     }
-    # Aggregate maxima have no distribution or uncertainty information. Unequal numbers
-    # of draws can inflate a maximum or conceal a loss, so neither verdict is supported.
-    # Keep every observed maximum; never trim samples to manufacture equal coverage.
-    if len({count for count in latency_sample_counts.values() if count is not None}) != 1:
-        maximum = next(item for item in metrics if item["key"] == "max")
-        maximum["status"] = "inconclusive"
-        maximum["reason"] = (
-            "Aggregate maximum comparison requires equal latency sample counts; "
-            "unequal counts require separate uncertainty analysis. All observed maxima are retained."
-        )
+    # A single observed maximum per segment cannot establish tail uncertainty, even
+    # with equal sample counts. Keep this protected metric gated so missing evidence
+    # prevents acceptance; neither a favorable nor an adverse raw extreme decides it.
+    maximum = next(item for item in metrics if item["key"] == "max")
+    maximum["status"] = "inconclusive"
+    maximum["reason"] = (
+        "Aggregate maxima lack an uncertainty-aware comparison, even with equal latency sample counts. "
+        "All observed maxima are retained; workload-level sampling and uncertainty evidence are required."
+    )
 
     candidate_failed = _errors(candidate_result) > 0 or _delivery_mismatch(candidate_result)
     if candidate_b2_result is not None:
@@ -418,9 +417,9 @@ def markdown(comparison, baseline_sha, candidate_sha):
         f"Each segment requires at least {MIN_LATENCY_SAMPLES} latency samples. This conservative "
         "screening floor does not establish tail precision or comparable sampling coverage; "
         "those still require the workload's sampling design and uncertainty analysis.",
-        "The aggregate maximum gate requires equal sample counts across all segments. "
-        "Unequal counts make that metric INCONCLUSIVE, even when its raw value improves. "
-        "Equal counts alone do not establish independent sampling or maximum precision.",
+        "The current aggregate result schema has no maximum-latency uncertainty evidence. "
+        "That protected metric remains INCONCLUSIVE for equal and unequal sample counts, "
+        "so this screen cannot return PASS. Other metric regressions and delivery failures still reject.",
         "",
         f"Baseline: `{baseline_sha}` · Candidate: `{candidate_sha}`",
     ]
@@ -502,6 +501,8 @@ def markdown(comparison, baseline_sha, candidate_sha):
             "The first INCONCLUSIVE permits one exact repeat. After a second, synthesize "
             "the evidence and improve the experiment or obtain maintainer direction; "
             "do not automatically repeat again.",
+            "An unchanged aggregate-only repeat cannot supply missing maximum uncertainty. "
+            "Improve the workload's sampling and uncertainty evidence before another acceptance run.",
         ]
     )
     return "\n".join(lines) + "\n"

--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -140,6 +140,8 @@ def _measurements(result):
     ]
     if missing:
         raise ValueError(f"Missing finite nonnegative metric(s): {', '.join(missing)}")
+    if measurements["cpu"] <= 0:
+        raise ValueError("CPU evidence requires positive CPU time per completed message")
     if any(measurements[key] <= 0 for key in ("p50", "p95", "p99", "max")):
         raise ValueError("Latency evidence requires positive latency quantiles and maximum")
     count = latency.get("count")

--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -11,6 +11,9 @@ from stress_report import cpu_micros_per_message, effective_rate, median_interva
 
 DEFAULT_TOLERANCE_PERCENT = 3.0
 DEFAULT_MAX_CONTROL_DRIFT_PERCENT = 10.0
+# Conservative aggregate-screen floor: 100 observations in the upper 1% by rank.
+# This does not establish independent samples, p99 precision, or complete coverage.
+MIN_LATENCY_SAMPLES = 10_000
 
 
 @dataclass(frozen=True)
@@ -142,6 +145,8 @@ def _measurements(result):
     count = latency.get("count")
     if not isinstance(count, int) or isinstance(count, bool) or count <= 0:
         raise ValueError("Latency evidence requires a positive integer sample count")
+    if count < MIN_LATENCY_SAMPLES:
+        raise ValueError(f"Aggregate screening requires at least {MIN_LATENCY_SAMPLES} latency samples per segment")
     return measurements
 
 
@@ -286,6 +291,14 @@ def compare(
            for value in (tolerance_percent, max_control_drift_percent)):
         raise ValueError("Comparison thresholds must be finite numbers and cannot be negative")
 
+    results = [baseline_a_result, candidate_result, baseline_a2_result]
+    if candidate_b2_result is not None:
+        results.append(candidate_b2_result)
+    for result in results:
+        for field in ("throughput", "producerDeliveryDiagnostics"):
+            if not isinstance(result.get(field), dict):
+                raise ValueError(f"Expected a {field} object")
+
     identities = {
         _identity(baseline_a_result),
         _identity(candidate_result),
@@ -352,6 +365,7 @@ def compare(
         "candidateDeliveryMismatch": _delivery_mismatch(candidate_result)
         or (candidate_b2_result is not None and _delivery_mismatch(candidate_b2_result)),
         "candidateSegments": 1 if candidate_b2_result is None else 2,
+        "minimumLatencySamples": MIN_LATENCY_SAMPLES,
         "latencySampleCounts": {
             "baselineA": baseline_a_result["latency"]["count"],
             "candidateB": candidate_result["latency"]["count"],
@@ -383,6 +397,9 @@ def markdown(comparison, baseline_sha, candidate_sha):
         "This is an aggregate metric screen, not full PR performance acceptance. "
         "Runner/fixture identity, warmup and runtime activity, sampling uncertainty, "
         "hot-path MemoryDiagnoser evidence and sustained stability require separate validation.",
+        f"Each segment requires at least {MIN_LATENCY_SAMPLES} latency samples. This conservative "
+        "screening floor does not establish tail precision or comparable sampling coverage; "
+        "those still require the workload's sampling design and uncertainty analysis.",
         "",
         f"Baseline: `{baseline_sha}` · Candidate: `{candidate_sha}`",
     ]

--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -116,6 +116,8 @@ def _latency_ms(latency, key):
 
 def _measurements(result):
     latency = result.get("latency") or {}
+    if not isinstance(latency, dict):
+        raise ValueError("Expected a latency object")
     measurements = {
         "throughput": effective_rate(result),
         "medianThroughput": median_interval_rate(result),
@@ -135,6 +137,11 @@ def _measurements(result):
     ]
     if missing:
         raise ValueError(f"Missing finite nonnegative metric(s): {', '.join(missing)}")
+    if any(measurements[key] <= 0 for key in ("p50", "p95", "p99", "max")):
+        raise ValueError("Latency evidence requires positive latency quantiles and maximum")
+    count = latency.get("count")
+    if not isinstance(count, int) or isinstance(count, bool) or count <= 0:
+        raise ValueError("Latency evidence requires a positive integer sample count")
     return measurements
 
 
@@ -345,6 +352,12 @@ def compare(
         "candidateDeliveryMismatch": _delivery_mismatch(candidate_result)
         or (candidate_b2_result is not None and _delivery_mismatch(candidate_b2_result)),
         "candidateSegments": 1 if candidate_b2_result is None else 2,
+        "latencySampleCounts": {
+            "baselineA": baseline_a_result["latency"]["count"],
+            "candidateB": candidate_result["latency"]["count"],
+            "baselineA2": baseline_a2_result["latency"]["count"],
+            "candidateB2": None if candidate_b2_result is None else candidate_b2_result["latency"]["count"],
+        },
         "identity": list(_identity(candidate_result)),
         "metrics": metrics,
     }
@@ -383,8 +396,15 @@ def markdown(comparison, baseline_sha, candidate_sha):
         "allocation noise floor: 1.0 B/msg",
     ])
     two_candidates = comparison.get("candidateSegments", 1) == 2
+    sample_counts = comparison["latencySampleCounts"]
+    labels = "A / B / A2"
+    keys = ["baselineA", "candidateB", "baselineA2"]
     if two_candidates:
         lines[-1] += " · four segments (A-B-A-B): each candidate is gated separately"
+        labels += " / B2"
+        keys.append("candidateB2")
+    lines.extend(["", f"Latency samples ({labels}): " + " / ".join(str(sample_counts[key]) for key in keys)])
+    if two_candidates:
         lines.extend(
             [
                 "",

--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -185,14 +185,17 @@ def _percent_change(value, baseline):
     return 100 * (value - baseline) / baseline
 
 
-def _validate_control_work(result, measurements):
+def _validate_control_rates(measurements):
     if measurements["throughput"] <= 0 or measurements["medianThroughput"] <= 0:
         raise ValueError("A baseline control requires positive delivered and median throughput")
+
+
+def _validate_completed_messages(result):
     completed = result.get("deliveredMessages")
     if completed is None:
         completed = (result.get("throughput") or {}).get("totalMessages")
-    if not _finite_number(completed) or completed <= 0:
-        raise ValueError("A baseline control requires positive completed messages")
+    if not isinstance(completed, int) or isinstance(completed, bool) or completed <= 0:
+        raise ValueError("A comparison segment requires positive integer completed messages")
 
 
 def _drift_percent(first, second):
@@ -300,6 +303,7 @@ def compare(
         for field in ("throughput", "producerDeliveryDiagnostics"):
             if not isinstance(result.get(field), dict):
                 raise ValueError(f"Expected a {field} object")
+        _validate_completed_messages(result)
 
     identities = {
         _identity(baseline_a_result),
@@ -321,8 +325,8 @@ def compare(
     candidate_b2 = (
         None if candidate_b2_result is None else _measurements(candidate_b2_result)
     )
-    _validate_control_work(baseline_a_result, baseline_a)
-    _validate_control_work(baseline_a2_result, baseline_a2)
+    _validate_control_rates(baseline_a)
+    _validate_control_rates(baseline_a2)
     if _stability_breached(candidate_result) or (
         candidate_b2_result is not None and _stability_breached(candidate_b2_result)
     ):
@@ -514,7 +518,8 @@ def main(argv=None):
             args.max_control_drift_percent,
             candidate_b2_result=None if not args.candidate_b2 else _single_result(args.candidate_b2),
         )
-    except (ValueError, OSError) as error:
+    # Helpers consume decoded JSON; malformed nested values can fail structurally.
+    except (ValueError, OSError, TypeError, AttributeError, OverflowError) as error:
         comparison = {"verdict": "inconclusive", "validationError": str(error), "metrics": []}
     report = markdown(comparison, args.baseline_sha, args.candidate_sha)
     print(report, end="")

--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -1,4 +1,4 @@
-"""Compare one stress candidate with bracketing exact-SHA baseline runs."""
+"""Screen aggregate stress metrics against bracketing exact-SHA baseline runs."""
 
 import argparse
 import json
@@ -50,7 +50,7 @@ METRICS = (
     # consumer lanes at ~2 KB/msg are unaffected because their 3% tolerance is ~60 B/msg.
     Metric("alloc", "Allocation", "B/msg", False, noise_floor=1.0),
     Metric("stability", "Steady/peak ratio", "ratio", True, floor=True),
-    Metric("max", "Latency max", "ms", False, gated=False),
+    Metric("max", "Latency max", "ms", False),
     Metric("averageRequest", "Average request", "KiB", True, gated=False),
 )
 
@@ -129,10 +129,10 @@ def _measurements(result):
     missing = [
         metric.label
         for metric in METRICS
-        if not _finite_number(measurements.get(metric.key))
+        if not _finite_number(measurements.get(metric.key)) or measurements[metric.key] < 0
     ]
     if missing:
-        raise ValueError(f"Missing finite metric(s): {', '.join(missing)}")
+        raise ValueError(f"Missing finite nonnegative metric(s): {', '.join(missing)}")
     return measurements
 
 
@@ -161,6 +161,24 @@ def _stability_breached(result):
     return _finite_number(ratio) and ratio < threshold
 
 
+def _percent_change(value, baseline):
+    # A nonzero value has no finite percentage change from zero. Keep it null in JSON
+    # and display n/a in Markdown; the gate uses absolute values, not this percentage.
+    if baseline == 0:
+        return 0.0 if value == 0 else None
+    return 100 * (value - baseline) / baseline
+
+
+def _drift_percent(first, second):
+    mean = (first + second) / 2
+    return 0.0 if mean == 0 else 100 * abs(second - first) / mean
+
+
+def _is_adverse(metric, candidate, control, tolerance_percent):
+    loss = control - candidate if metric.higher_is_better else candidate - control
+    return loss > metric.noise_floor and loss > control * tolerance_percent / 100
+
+
 def _metric_status(
     metric,
     baseline_a,
@@ -172,23 +190,12 @@ def _metric_status(
     candidate_b2=None,
 ):
     baseline_mean = (baseline_a + baseline_a2) / 2
-    if baseline_mean == 0:
-        raise ValueError(f"Baseline mean is zero for {metric.label}")
-
-    # With a second candidate segment the candidate value is the mean of both, the
-    # decisiveness overrides must hold for the weaker candidate sample, and candidate drift
-    # is gated exactly like control drift: two candidate samples that disagree by more than
-    # the cap cannot certify a bracketed delta any better than two disagreeing controls.
     candidate_samples = [candidate] if candidate_b2 is None else [candidate, candidate_b2]
     candidate_mean = sum(candidate_samples) / len(candidate_samples)
     candidate_drift_percent = (
-        0.0
-        if candidate_b2 is None or candidate_mean == 0
-        else 100 * abs(candidate_b2 - candidate) / abs(candidate_mean)
+        0.0 if candidate_b2 is None else _drift_percent(candidate, candidate_b2)
     )
-    candidate = candidate_mean
-    delta_percent = 100 * (candidate - baseline_mean) / baseline_mean
-    control_drift_percent = 100 * abs(baseline_a2 - baseline_a) / abs(baseline_mean)
+    control_drift_percent = _drift_percent(baseline_a, baseline_a2)
     control_spread = abs(baseline_a2 - baseline_a)
     noise_floor = metric.noise_floor
     if not metric.gated:
@@ -196,49 +203,28 @@ def _metric_status(
     elif metric.floor:
         status = floor_status
     else:
-        if metric.higher_is_better:
-            worse_than_both = max(candidate_samples) < min(baseline_a, baseline_a2) * (
-                1 - tolerance_percent / 100
-            ) and min(baseline_a, baseline_a2) - max(candidate_samples) > noise_floor
-            better_than_both = min(candidate_samples) >= max(baseline_a, baseline_a2)
-            adverse = delta_percent < -tolerance_percent and (
-                baseline_mean - candidate > noise_floor
-            )
-        else:
-            worse_than_both = min(candidate_samples) > max(baseline_a, baseline_a2) * (
-                1 + tolerance_percent / 100
-            ) and min(candidate_samples) - max(baseline_a, baseline_a2) > noise_floor
-            better_than_both = max(candidate_samples) <= min(baseline_a, baseline_a2)
-            adverse = delta_percent > tolerance_percent and (
-                candidate - baseline_mean > noise_floor
-            )
-        # A control spread inside the noise floor cannot make the comparison inconclusive:
-        # the controls agree to within what the metric can resolve.
+        # Means are descriptive only. Every candidate segment must meet the tolerance
+        # against each control; averaging cannot conceal a loss or conflicting samples.
+        adverse_pairs = [
+            _is_adverse(metric, sample, control, tolerance_percent)
+            for sample in candidate_samples
+            for control in (baseline_a, baseline_a2)
+        ]
         controls_disagree = (
             control_drift_percent > max_control_drift_percent
             and control_spread > noise_floor
         )
-
-        # Symmetric decisiveness overrides for noisy controls: a candidate worse than both
-        # bracketing controls by more than the tolerance is a regression no matter how far
-        # apart the controls sit, and a candidate at least as good as the better control
-        # cannot have regressed under any reading of the data — control drift only matters
-        # for candidates the controls actually bracket (run 29525842754: the candidate beat
-        # both controls on p99 yet was ruled inconclusive because the controls disagreed
-        # with each other by 12%).
-        if worse_than_both:
-            status = "regression"
-        elif better_than_both:
-            status = "pass"
-        elif controls_disagree:
-            status = "inconclusive"
-        elif (
+        candidates_disagree = (
             candidate_drift_percent > max_control_drift_percent
             and abs(candidate_samples[-1] - candidate_samples[0]) > noise_floor
-        ):
-            status = "inconclusive"
-        elif adverse:
+        )
+
+        # A loss beyond tolerance in every pairing remains grounds to reject. Otherwise
+        # drift or conflicting pairings cannot establish either acceptance or regression.
+        if all(adverse_pairs):
             status = "regression"
+        elif controls_disagree or candidates_disagree or any(adverse_pairs):
+            status = "inconclusive"
         else:
             status = "pass"
 
@@ -247,13 +233,21 @@ def _metric_status(
         "label": metric.label,
         "unit": metric.unit,
         "baselineA": baseline_a,
-        "candidate": candidate,
+        "candidate": candidate_mean,
         "candidateB": candidate_samples[0],
         "candidateB2": candidate_b2,
         "candidateDriftPercent": candidate_drift_percent,
         "baselineA2": baseline_a2,
         "baselineMean": baseline_mean,
-        "deltaPercent": delta_percent,
+        "deltaPercent": _percent_change(candidate_mean, baseline_mean),
+        "deltaVsBaselineAPercent": _percent_change(candidate, baseline_a),
+        "deltaVsBaselineA2Percent": _percent_change(candidate, baseline_a2),
+        "b2DeltaVsBaselineAPercent": (
+            None if candidate_b2 is None else _percent_change(candidate_b2, baseline_a)
+        ),
+        "b2DeltaVsBaselineA2Percent": (
+            None if candidate_b2 is None else _percent_change(candidate_b2, baseline_a2)
+        ),
         "controlDriftPercent": control_drift_percent,
         "noiseFloor": noise_floor,
         "status": status,
@@ -269,8 +263,9 @@ def compare(
     max_control_drift_percent=DEFAULT_MAX_CONTROL_DRIFT_PERCENT,
     candidate_b2_result=None,
 ):
-    if tolerance_percent < 0 or max_control_drift_percent < 0:
-        raise ValueError("Comparison thresholds cannot be negative")
+    if any(not _finite_number(value) or value < 0
+           for value in (tolerance_percent, max_control_drift_percent)):
+        raise ValueError("Comparison thresholds must be finite numbers and cannot be negative")
 
     identities = {
         _identity(baseline_a_result),
@@ -347,6 +342,10 @@ def _format_number(value):
     return f"{value:.3f}"
 
 
+def _format_percent(value):
+    return "n/a" if value is None else f"{value:+.2f}%"
+
+
 def markdown(comparison, baseline_sha, candidate_sha):
     verdict = comparison["verdict"].upper()
     lines = [
@@ -354,50 +353,62 @@ def markdown(comparison, baseline_sha, candidate_sha):
         "",
         f"**Verdict: {verdict}**",
         "",
-        f"Baseline: `{baseline_sha}` · Candidate: `{candidate_sha}` · "
+        "This is an aggregate metric screen, not full PR performance acceptance. "
+        "Runner/fixture identity, warmup and runtime activity, sampling uncertainty, "
+        "hot-path MemoryDiagnoser evidence and sustained stability require separate validation.",
+        "",
+        f"Baseline: `{baseline_sha}` · Candidate: `{candidate_sha}`",
+    ]
+    if comparison.get("validationError"):
+        lines.extend(["", f"Evidence validation failed: {comparison['validationError']}"])
+        return "\n".join(lines) + "\n"
+    lines.extend([
+        "",
         f"adverse tolerance: {comparison['tolerancePercent']:.1f}% · "
         f"maximum control drift: {comparison['maxControlDriftPercent']:.1f}% · "
         "allocation noise floor: 1.0 B/msg",
-    ]
+    ])
     two_candidates = comparison.get("candidateSegments", 1) == 2
     if two_candidates:
-        lines[-1] += " · four segments (A-B-A-B): candidate = mean of B and B2"
+        lines[-1] += " · four segments (A-B-A-B): each candidate is gated separately"
         lines.extend(
             [
                 "",
-                "| Metric | Baseline A | Candidate B | Baseline A2 | Candidate B2 | B mean vs control mean | Control drift | Candidate drift | Gate |",
-                "|---|---:|---:|---:|---:|---:|---:|---:|---|",
+                "| Metric | Baseline A | Candidate B | Baseline A2 | Candidate B2 | B vs A | B vs A2 | B2 vs A | B2 vs A2 | Control drift | Candidate drift | Gate |",
+                "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
             ]
         )
     else:
         lines.extend(
             [
                 "",
-                "| Metric | Baseline A | Candidate B | Baseline A2 | B vs mean | Control drift | Gate |",
-                "|---|---:|---:|---:|---:|---:|---|",
+                "| Metric | Baseline A | Candidate B | Baseline A2 | B vs A | B vs A2 | Control drift | Gate |",
+                "|---|---:|---:|---:|---:|---:|---:|---|",
             ]
         )
     for item in comparison["metrics"]:
+        cells = [
+            f"{item['label']} ({item['unit']})",
+            _format_number(item["baselineA"]),
+            _format_number(item["candidateB"]),
+            _format_number(item["baselineA2"]),
+        ]
         if two_candidates:
-            lines.append(
-                f"| {item['label']} ({item['unit']}) | "
-                f"{_format_number(item['baselineA'])} | "
-                f"{_format_number(item['candidateB'])} | "
-                f"{_format_number(item['baselineA2'])} | "
-                f"{_format_number(item['candidateB2'])} | "
-                f"{item['deltaPercent']:+.2f}% | "
-                f"{item['controlDriftPercent']:.2f}% | "
-                f"{item['candidateDriftPercent']:.2f}% | {item['status']} |"
-            )
-        else:
-            lines.append(
-                f"| {item['label']} ({item['unit']}) | "
-                f"{_format_number(item['baselineA'])} | "
-                f"{_format_number(item['candidate'])} | "
-                f"{_format_number(item['baselineA2'])} | "
-                f"{item['deltaPercent']:+.2f}% | "
-                f"{item['controlDriftPercent']:.2f}% | {item['status']} |"
-            )
+            cells.append(_format_number(item["candidateB2"]))
+        cells.extend([
+            _format_percent(item["deltaVsBaselineAPercent"]),
+            _format_percent(item["deltaVsBaselineA2Percent"]),
+        ])
+        if two_candidates:
+            cells.extend([
+                _format_percent(item["b2DeltaVsBaselineAPercent"]),
+                _format_percent(item["b2DeltaVsBaselineA2Percent"]),
+            ])
+        cells.append(f"{item['controlDriftPercent']:.2f}%")
+        if two_candidates:
+            cells.append(f"{item['candidateDriftPercent']:.2f}%")
+        cells.append(item["status"])
+        lines.append("| " + " | ".join(cells) + " |")
     if comparison["candidateErrors"] or comparison["candidateDeliveryMismatch"]:
         lines.extend(
             [
@@ -409,8 +420,13 @@ def markdown(comparison, baseline_sha, candidate_sha):
     lines.extend(
         [
             "",
-            "Acceptance requires PASS. REGRESSION rejects the candidate; "
-            "INCONCLUSIVE requires an exact repeat.",
+            "Percent changes from a zero control are n/a unless both values are zero. "
+            "Means in JSON are descriptive only; they do not decide the gate.",
+            "",
+            "REGRESSION rejects the measured candidate; INCONCLUSIVE does not establish acceptance. "
+            "The first INCONCLUSIVE permits one exact repeat. After a second, synthesize "
+            "the evidence and improve the experiment or obtain maintainer direction; "
+            "do not automatically repeat again.",
         ]
     )
     return "\n".join(lines) + "\n"
@@ -436,20 +452,23 @@ def main(argv=None):
     )
     args = parser.parse_args(argv)
 
-    comparison = compare(
-        _single_result(args.baseline_a),
-        _single_result(args.candidate),
-        _single_result(args.baseline_a2),
-        args.tolerance_percent,
-        args.max_control_drift_percent,
-        candidate_b2_result=None if not args.candidate_b2 else _single_result(args.candidate_b2),
-    )
+    try:
+        comparison = compare(
+            _single_result(args.baseline_a),
+            _single_result(args.candidate),
+            _single_result(args.baseline_a2),
+            args.tolerance_percent,
+            args.max_control_drift_percent,
+            candidate_b2_result=None if not args.candidate_b2 else _single_result(args.candidate_b2),
+        )
+    except (ValueError, OSError) as error:
+        comparison = {"verdict": "inconclusive", "validationError": str(error), "metrics": []}
     report = markdown(comparison, args.baseline_sha, args.candidate_sha)
     print(report, end="")
 
     output = Path(args.output)
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(json.dumps(comparison, indent=2) + "\n", encoding="utf-8")
+    output.write_text(json.dumps(comparison, indent=2, allow_nan=False) + "\n", encoding="utf-8")
     if args.summary:
         with Path(args.summary).open("a", encoding="utf-8") as handle:
             handle.write(report)

--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -518,15 +518,17 @@ def main(argv=None):
             args.max_control_drift_percent,
             candidate_b2_result=None if not args.candidate_b2 else _single_result(args.candidate_b2),
         )
-    # Helpers consume decoded JSON; malformed nested values can fail structurally.
+        serialized = json.dumps(comparison, indent=2, allow_nan=False) + "\n"
     except (ValueError, OSError, TypeError, AttributeError, OverflowError) as error:
+        # Invalid input or an unrepresentable comparison must not publish a pass.
         comparison = {"verdict": "inconclusive", "validationError": str(error), "metrics": []}
+        serialized = json.dumps(comparison, indent=2, allow_nan=False) + "\n"
     report = markdown(comparison, args.baseline_sha, args.candidate_sha)
     print(report, end="")
 
     output = Path(args.output)
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(json.dumps(comparison, indent=2, allow_nan=False) + "\n", encoding="utf-8")
+    output.write_text(serialized, encoding="utf-8")
     if args.summary:
         with Path(args.summary).open("a", encoding="utf-8") as handle:
             handle.write(report)

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -71,6 +71,79 @@ def result(
 
 
 class StressAbaComparisonTests(unittest.TestCase):
+    def test_zero_allocation_controls_are_valid(self):
+        for allocation, verdict in ((0, "pass"), (0.5, "pass"), (2, "regression")):
+            with self.subTest(allocation=allocation):
+                comparison = compare(
+                    result(allocation=0), result(allocation=allocation), result(allocation=0)
+                )
+                self.assertEqual(verdict, comparison["verdict"])
+                json.dumps(comparison, allow_nan=False)
+                self.assertIn("Allocation", markdown(comparison, "a" * 40, "b" * 40))
+
+    def test_maximum_latency_regression_is_gated(self):
+        comparison = compare(result(), result(maximum=60), result())
+        self.assertEqual("regression", comparison["verdict"])
+        maximum = next(metric for metric in comparison["metrics"] if metric["key"] == "max")
+        self.assertTrue(maximum["gated"])
+
+    def test_control_mean_cannot_hide_loss_against_one_control(self):
+        for a, b, a2 in (
+            (result(p99=100), result(p99=104), result(p99=104)),
+            (result(throughput=100), result(throughput=96), result(throughput=96)),
+        ):
+            with self.subTest(candidate=b):
+                self.assertEqual("inconclusive", compare(a, b, a2)["verdict"])
+
+    def test_candidate_mean_cannot_hide_loss_in_one_segment(self):
+        comparison = compare(
+            result(p99=100), result(p99=98), result(p99=100),
+            candidate_b2_result=result(p99=104),
+        )
+        self.assertEqual("inconclusive", comparison["verdict"])
+
+    def test_candidate_drift_cannot_pass_even_when_both_candidates_improve(self):
+        comparison = compare(
+            result(p99=100), result(p99=80), result(p99=100),
+            candidate_b2_result=result(p99=60),
+        )
+        self.assertEqual("inconclusive", comparison["verdict"])
+
+    def test_records_each_candidate_delta_against_each_control(self):
+        comparison = compare(
+            result(p99=100), result(p99=102), result(p99=104),
+            candidate_b2_result=result(p99=101),
+        )
+        p99 = next(metric for metric in comparison["metrics"] if metric["key"] == "p99")
+        self.assertAlmostEqual(2, p99["deltaVsBaselineAPercent"])
+        self.assertAlmostEqual(-100 * 2 / 104, p99["deltaVsBaselineA2Percent"])
+        self.assertAlmostEqual(1, p99["b2DeltaVsBaselineAPercent"])
+        self.assertAlmostEqual(-100 * 3 / 104, p99["b2DeltaVsBaselineA2Percent"])
+        report = markdown(comparison, "a" * 40, "b" * 40)
+        for column in ("B vs A", "B vs A2", "B2 vs A", "B2 vs A2"):
+            self.assertIn(column, report)
+
+    def test_nonfinite_thresholds_are_rejected(self):
+        for value in (float("nan"), float("inf"), True):
+            for name in ("tolerance_percent", "max_control_drift_percent"):
+                with self.subTest(value=value, name=name), self.assertRaises(ValueError):
+                    compare(result(), result(), result(), **{name: value})
+
+    def test_negative_metrics_are_rejected(self):
+        for option in ("throughput", "p99", "maximum", "cpu", "allocation"):
+            with self.subTest(option=option), self.assertRaisesRegex(ValueError, "nonnegative"):
+                compare(result(), result(**{option: -1}), result())
+
+    def test_zero_control_deltas_are_explicit_and_finite(self):
+        comparison = compare(result(allocation=0), result(allocation=2), result(allocation=0))
+        alloc = next(metric for metric in comparison["metrics"] if metric["key"] == "alloc")
+        self.assertIsNone(alloc["deltaVsBaselineAPercent"])
+        self.assertIsNone(alloc["deltaVsBaselineA2Percent"])
+        self.assertIsNone(alloc["deltaPercent"])
+        self.assertEqual(0, alloc["controlDriftPercent"])
+        report = markdown(comparison, "a" * 40, "b" * 40)
+        self.assertIn("| 0.000 | 2.000 | 0.000 | n/a | n/a |", report)
+
     def test_passes_pareto_safe_candidate(self):
         comparison = compare(
             result(throughput=100),
@@ -166,7 +239,7 @@ class StressAbaComparisonTests(unittest.TestCase):
         alloc = next(metric for metric in noisy["metrics"] if metric["key"] == "alloc")
         self.assertEqual("inconclusive", alloc["status"])
 
-    def test_four_segments_average_candidates_and_pass(self):
+    def test_four_segments_retain_descriptive_mean_and_pass(self):
         comparison = compare(
             result(100), result(104), result(100), candidate_b2_result=result(102)
         )
@@ -182,8 +255,7 @@ class StressAbaComparisonTests(unittest.TestCase):
         self.assertGreater(throughput["candidateDriftPercent"], 1.0)
 
     def test_four_segments_candidate_drift_is_inconclusive_like_control_drift(self):
-        # Candidates disagree by 20% while both controls agree: the mean sits above the
-        # controls but neither decisiveness override holds, so the metric is inconclusive.
+        # Candidates disagree while both controls agree; their mean cannot pass the gate.
         comparison = compare(
             result(100), result(95), result(100), candidate_b2_result=result(116)
         )
@@ -194,7 +266,7 @@ class StressAbaComparisonTests(unittest.TestCase):
         self.assertEqual("inconclusive", throughput["status"])
         self.assertEqual("inconclusive", comparison["verdict"])
 
-    def test_four_segments_decisive_overrides_need_both_candidates(self):
+    def test_four_segments_need_both_candidates_to_pass(self):
         both_better = compare(
             result(p99=15.0), result(p99=12.0), result(p99=16.0), candidate_b2_result=result(p99=13.0)
         )
@@ -224,21 +296,19 @@ class StressAbaComparisonTests(unittest.TestCase):
         self.assertIn("| Candidate B2 |", report)
         self.assertIn("Candidate drift", report)
 
-    def test_candidate_beating_both_noisy_controls_passes(self):
-        # Run 29525842754: candidate p99 (14.85ms) was better than both controls
-        # (17.25 / 15.25ms), yet 12.3% control drift ruled the metric inconclusive.
-        # A candidate at least as good as the better control cannot have regressed.
+    def test_candidate_beating_both_noisy_controls_remains_inconclusive(self):
+        # Improvement against noisy controls does not establish a valid experiment.
         comparison = compare(
             result(p99=17.25),
             result(p99=14.85),
             result(p99=15.25),
         )
 
-        self.assertEqual("pass", comparison["verdict"])
+        self.assertEqual("inconclusive", comparison["verdict"])
         p99 = next(
             metric for metric in comparison["metrics"] if metric["key"] == "p99"
         )
-        self.assertEqual("pass", p99["status"])
+        self.assertEqual("inconclusive", p99["status"])
         self.assertGreater(p99["controlDriftPercent"], 10.0)
 
     def test_bracketed_candidate_with_noisy_controls_stays_inconclusive(self):
@@ -377,6 +447,44 @@ class StressAbaComparisonTests(unittest.TestCase):
             self.assertEqual(0, exit_code)
             self.assertEqual("pass", json.loads(output.read_text())["verdict"])
             self.assertIn("Verdict: PASS", summary.read_text(encoding="utf-8"))
+            self.assertIn("not full PR performance acceptance", summary.read_text(encoding="utf-8"))
+
+    def test_main_retains_invalid_evidence_reason_in_both_outputs(self):
+        missing_metric = result()
+        del missing_metric["latency"]["maxUs"]
+        for invalid, expected in (
+            (None, "found 0"),
+            ("not json", "Expecting value"),
+            (json.dumps({"results": [missing_metric]}), "Latency max"),
+            (json.dumps({"results": [result(scenario="other")]}), "workload identity"),
+        ):
+            with self.subTest(expected=expected), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                for label in ("a", "b", "a2"):
+                    path = root / label
+                    path.mkdir()
+                    payload = invalid if label == "b" else json.dumps({"results": [result()]})
+                    if payload is not None:
+                        (path / "stress-test-results.json").write_text(payload, encoding="utf-8")
+                output = root / "comparison.json"
+                summary = root / "summary.md"
+                with contextlib.redirect_stdout(io.StringIO()):
+                    exit_code = main([
+                        "--baseline-a", str(root / "a"), "--candidate", str(root / "b"),
+                        "--baseline-a2", str(root / "a2"), "--baseline-sha", "a" * 40,
+                        "--candidate-sha", "b" * 40, "--output", str(output),
+                        "--summary", str(summary),
+                    ])
+                comparison = json.loads(output.read_text(encoding="utf-8"))
+                self.assertEqual(1, exit_code)
+                self.assertEqual("inconclusive", comparison["verdict"])
+                self.assertIn(expected, comparison["validationError"])
+                self.assertIn(expected, summary.read_text(encoding="utf-8"))
+
+    def test_report_does_not_prescribe_unlimited_repeats(self):
+        report = markdown(compare(result(90), result(100), result(110)), "a" * 40, "b" * 40)
+        self.assertIn("first INCONCLUSIVE permits one exact repeat", report)
+        self.assertIn("do not automatically repeat again", report)
 
 
 class StressAbaWorkflowTests(unittest.TestCase):

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -73,6 +73,81 @@ def result(
 
 
 class StressAbaComparisonTests(unittest.TestCase):
+    def test_unequal_sample_counts_cannot_decide_maximum_latency(self):
+        for second_candidate in (False, True):
+            for segment in range(4 if second_candidate else 3):
+                for maximum in (40, 50, 60):
+                    segments = [result(latency_count=20_000) for _ in range(4)]
+                    segments[1]["latency"]["maxUs"] = maximum * 1000
+                    segments[3]["latency"]["maxUs"] = maximum * 1000
+                    segments[segment]["latency"]["count"] = 20_001
+                    with self.subTest(second_candidate=second_candidate, segment=segment, maximum=maximum):
+                        comparison = compare(
+                            *segments[:3],
+                            candidate_b2_result=segments[3] if second_candidate else None,
+                        )
+                        self.assertEqual("inconclusive", comparison["verdict"])
+                        metric = next(item for item in comparison["metrics"] if item["key"] == "max")
+                        self.assertEqual("inconclusive", metric["status"])
+                        self.assertEqual(maximum, metric["candidateB"])
+                        self.assertIn("equal latency sample counts", metric["reason"])
+                        self.assertIn(metric["reason"], markdown(comparison, "a", "b"))
+
+    def test_unequal_sample_counts_preserve_other_regressions(self):
+        for candidate in (
+            result(latency_count=20_000, throughput=80),
+            result(latency_count=20_000, errors=1),
+            result(latency_count=20_000, delivered=999_999),
+        ):
+            with self.subTest(candidate=candidate):
+                comparison = compare(result(), candidate, result())
+                self.assertEqual("regression", comparison["verdict"])
+
+    def test_equal_sample_counts_keep_maximum_latency_gate(self):
+        for maximum, expected in ((40, "pass"), (50, "pass"), (60, "regression")):
+            with self.subTest(maximum=maximum):
+                comparison = compare(
+                    result(), result(maximum=maximum), result(),
+                    candidate_b2_result=result(maximum=maximum),
+                )
+                self.assertEqual(expected, comparison["verdict"])
+
+    def test_cli_retains_unequal_count_maxima_as_inconclusive(self):
+        for second_candidate in (False, True):
+            with self.subTest(second_candidate=second_candidate), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                for label in ("a", "b", "a2", "b2"):
+                    path = root / label
+                    path.mkdir()
+                    sample = result(maximum=60, latency_count=20_000) if label == "b" else result()
+                    (path / "stress-test-results.json").write_text(
+                        json.dumps({"results": [sample]}), encoding="utf-8"
+                    )
+                output = root / "comparison.json"
+                summary = root / "summary.md"
+                arguments = [
+                    "--baseline-a", str(root / "a"), "--candidate", str(root / "b"),
+                    "--baseline-a2", str(root / "a2"), "--baseline-sha", "a" * 40,
+                    "--candidate-sha", "b" * 40, "--output", str(output),
+                    "--summary", str(summary),
+                ]
+                if second_candidate:
+                    arguments.extend(["--candidate-b2", str(root / "b2")])
+                stdout = io.StringIO()
+                with contextlib.redirect_stdout(stdout):
+                    exit_code = main(arguments)
+                comparison = json.loads(output.read_text(encoding="utf-8"))
+                self.assertEqual(1, exit_code)
+                self.assertEqual("inconclusive", comparison["verdict"])
+                maximum = next(item for item in comparison["metrics"] if item["key"] == "max")
+                self.assertEqual((50, 60, 50), (
+                    maximum["baselineA"], maximum["candidateB"], maximum["baselineA2"],
+                ))
+                self.assertEqual(50 if second_candidate else None, maximum["candidateB2"])
+                for report in (stdout.getvalue(), summary.read_text(encoding="utf-8")):
+                    self.assertIn("Verdict: INCONCLUSIVE", report)
+                    self.assertIn(maximum["reason"], report)
+
     def test_zero_cpu_is_invalid_in_every_segment(self):
         for derived in (False, True):
             for segment in range(4):

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -603,6 +603,45 @@ class StressAbaComparisonTests(unittest.TestCase):
                 self.assertIn(expected, comparison["validationError"])
                 self.assertIn(expected, summary.read_text(encoding="utf-8"))
 
+    def test_serialization_failures_never_publish_a_pass(self):
+        invalid_results = [
+            {**result(), "durationMinutes": value}
+            for value in (float("inf"), float("-inf"), float("nan"))
+        ]
+        # Finite inputs can also overflow descriptive means in the comparison.
+        invalid_results.append(result(throughput=1e308))
+        for invalid in invalid_results:
+            for second_candidate in (False, True):
+                with self.subTest(invalid=invalid, second_candidate=second_candidate):
+                    with tempfile.TemporaryDirectory() as directory:
+                        root = Path(directory)
+                        for label in ("a", "b", "a2", "b2"):
+                            path = root / label
+                            path.mkdir()
+                            (path / "stress-test-results.json").write_text(
+                                json.dumps({"results": [invalid]}), encoding="utf-8"
+                            )
+                        output = root / "comparison.json"
+                        summary = root / "summary.md"
+                        arguments = [
+                            "--baseline-a", str(root / "a"), "--candidate", str(root / "b"),
+                            "--baseline-a2", str(root / "a2"), "--baseline-sha", "a" * 40,
+                            "--candidate-sha", "b" * 40, "--output", str(output),
+                            "--summary", str(summary),
+                        ]
+                        if second_candidate:
+                            arguments.extend(["--candidate-b2", str(root / "b2")])
+                        stdout = io.StringIO()
+                        with contextlib.redirect_stdout(stdout):
+                            exit_code = main(arguments)
+                        comparison = json.loads(output.read_text(encoding="utf-8"))
+                        self.assertEqual(1, exit_code)
+                        self.assertEqual("inconclusive", comparison["verdict"])
+                        self.assertIn("JSON compliant", comparison["validationError"])
+                        for report in (stdout.getvalue(), summary.read_text(encoding="utf-8")):
+                            self.assertIn("Verdict: INCONCLUSIVE", report)
+                            self.assertNotIn("Verdict: PASS", report)
+
     def test_candidates_require_completed_messages_despite_positive_cached_rates(self):
         for completed in (0, -1, True, 1.5, "100", float("nan")):
             for segment in (1, 3):

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -73,6 +73,37 @@ def result(
 
 
 class StressAbaComparisonTests(unittest.TestCase):
+    def assert_only_maximum_is_inconclusive(self, comparison):
+        self.assertEqual("inconclusive", comparison["verdict"])
+        for metric in comparison["metrics"]:
+            if metric["key"] == "max":
+                expected = "inconclusive"
+            elif metric["gated"]:
+                expected = "pass"
+            else:
+                expected = "recorded"
+            self.assertEqual(expected, metric["status"], metric["key"])
+
+    def test_equal_counts_cannot_establish_maximum_uncertainty(self):
+        for second_candidate in (False, True):
+            for count in (10_000, 1_000_000):
+                for maximum in (40, 50, 60):
+                    with self.subTest(second_candidate=second_candidate, count=count, maximum=maximum):
+                        comparison = compare(
+                            result(latency_count=count), result(maximum=maximum, latency_count=count),
+                            result(latency_count=count),
+                            candidate_b2_result=result(maximum=maximum, latency_count=count) if second_candidate else None,
+                        )
+                        self.assertEqual("inconclusive", comparison["verdict"])
+                        metric = next(item for item in comparison["metrics"] if item["key"] == "max")
+                        self.assertTrue(metric["gated"])
+                        self.assertEqual("inconclusive", metric["status"])
+                        self.assertEqual(maximum, metric["candidateB"])
+                        self.assertEqual(maximum if second_candidate else None, metric["candidateB2"])
+                        self.assertEqual(2 * (maximum - 50), metric["deltaVsBaselineAPercent"])
+                        self.assertIn("uncertainty", metric["reason"])
+                        self.assertIn(metric["reason"], markdown(comparison, "a", "b"))
+
     def test_unequal_sample_counts_cannot_decide_maximum_latency(self):
         for second_candidate in (False, True):
             for segment in range(4 if second_candidate else 3):
@@ -103,23 +134,23 @@ class StressAbaComparisonTests(unittest.TestCase):
                 comparison = compare(result(), candidate, result())
                 self.assertEqual("regression", comparison["verdict"])
 
-    def test_equal_sample_counts_keep_maximum_latency_gate(self):
-        for maximum, expected in ((40, "pass"), (50, "pass"), (60, "regression")):
+    def test_equal_sample_counts_keep_maximum_latency_unresolved(self):
+        for maximum in (40, 50, 60):
             with self.subTest(maximum=maximum):
                 comparison = compare(
                     result(), result(maximum=maximum), result(),
                     candidate_b2_result=result(maximum=maximum),
                 )
-                self.assertEqual(expected, comparison["verdict"])
+                self.assert_only_maximum_is_inconclusive(comparison)
 
-    def test_cli_retains_unequal_count_maxima_as_inconclusive(self):
-        for second_candidate in (False, True):
-            with self.subTest(second_candidate=second_candidate), tempfile.TemporaryDirectory() as directory:
+    def test_cli_retains_equal_and_unequal_count_maxima_as_inconclusive(self):
+        for second_candidate, count in ((False, 10_000), (False, 20_000), (True, 10_000), (True, 20_000)):
+            with self.subTest(second_candidate=second_candidate, count=count), tempfile.TemporaryDirectory() as directory:
                 root = Path(directory)
                 for label in ("a", "b", "a2", "b2"):
                     path = root / label
                     path.mkdir()
-                    sample = result(maximum=60, latency_count=20_000) if label == "b" else result()
+                    sample = result(maximum=60, latency_count=count) if label == "b" else result()
                     (path / "stress-test-results.json").write_text(
                         json.dumps({"results": [sample]}), encoding="utf-8"
                     )
@@ -162,7 +193,7 @@ class StressAbaComparisonTests(unittest.TestCase):
         segments = [result(cpu=None) for _ in range(4)]
         for segment in segments:
             segment["cpuTimeSeconds"] = 0.8
-        self.assertEqual("pass", compare(*segments[:3], candidate_b2_result=segments[3])["verdict"])
+        self.assert_only_maximum_is_inconclusive(compare(*segments[:3], candidate_b2_result=segments[3]))
 
     def test_zero_latency_is_invalid_in_every_segment(self):
         for field in ("p50Us", "p95Us", "p99Us", "maxUs"):
@@ -252,18 +283,20 @@ class StressAbaComparisonTests(unittest.TestCase):
                 self.assertIn("Verdict: INCONCLUSIVE", summary.read_text(encoding="utf-8"))
 
     def test_zero_allocation_controls_are_valid(self):
-        for allocation, verdict in ((0, "pass"), (0.5, "pass"), (2, "regression")):
+        for allocation, verdict in ((0, "inconclusive"), (0.5, "inconclusive"), (2, "regression")):
             with self.subTest(allocation=allocation):
                 comparison = compare(
                     result(allocation=0), result(allocation=allocation), result(allocation=0)
                 )
                 self.assertEqual(verdict, comparison["verdict"])
+                alloc = next(metric for metric in comparison["metrics"] if metric["key"] == "alloc")
+                self.assertEqual("regression" if allocation == 2 else "pass", alloc["status"])
                 json.dumps(comparison, allow_nan=False)
                 self.assertIn("Allocation", markdown(comparison, "a" * 40, "b" * 40))
 
-    def test_maximum_latency_regression_is_gated(self):
+    def test_adverse_raw_maximum_remains_gated_and_unresolved(self):
         comparison = compare(result(), result(maximum=60), result())
-        self.assertEqual("regression", comparison["verdict"])
+        self.assert_only_maximum_is_inconclusive(comparison)
         maximum = next(metric for metric in comparison["metrics"] if metric["key"] == "max")
         self.assertTrue(maximum["gated"])
 
@@ -324,20 +357,14 @@ class StressAbaComparisonTests(unittest.TestCase):
         report = markdown(comparison, "a" * 40, "b" * 40)
         self.assertIn("| 0.000 | 2.000 | 0.000 | n/a | n/a |", report)
 
-    def test_passes_pareto_safe_candidate(self):
+    def test_favorable_aggregates_still_require_maximum_uncertainty(self):
         comparison = compare(
             result(throughput=100),
             result(throughput=102, p50=6.8, p95=9.8, p99=14.8, cpu=0.79),
             result(throughput=101),
         )
 
-        self.assertEqual("pass", comparison["verdict"])
-        self.assertTrue(
-            all(
-                metric["status"] in {"pass", "recorded"}
-                for metric in comparison["metrics"]
-            )
-        )
+        self.assert_only_maximum_is_inconclusive(comparison)
 
     def test_rejects_candidate_worse_than_both_controls(self):
         comparison = compare(result(100), result(90), result(102))
@@ -373,7 +400,7 @@ class StressAbaComparisonTests(unittest.TestCase):
                     result(allocation=baseline_a2),
                 )
 
-                self.assertEqual("pass", comparison["verdict"])
+                self.assert_only_maximum_is_inconclusive(comparison)
                 alloc = next(
                     metric for metric in comparison["metrics"] if metric["key"] == "alloc"
                 )
@@ -387,7 +414,7 @@ class StressAbaComparisonTests(unittest.TestCase):
             result(allocation=0.6), result(allocation=0.9), result(allocation=0.6)
         )
 
-        self.assertEqual("pass", comparison["verdict"])
+        self.assert_only_maximum_is_inconclusive(comparison)
 
     def test_allocation_regression_above_noise_floor_still_rejected(self):
         # +2 B/msg above both controls is a real per-message allocation, floor or not.
@@ -419,12 +446,12 @@ class StressAbaComparisonTests(unittest.TestCase):
         alloc = next(metric for metric in noisy["metrics"] if metric["key"] == "alloc")
         self.assertEqual("inconclusive", alloc["status"])
 
-    def test_four_segments_retain_descriptive_mean_and_pass(self):
+    def test_four_segments_retain_descriptive_mean_without_acceptance(self):
         comparison = compare(
             result(100), result(104), result(100), candidate_b2_result=result(102)
         )
 
-        self.assertEqual("pass", comparison["verdict"])
+        self.assert_only_maximum_is_inconclusive(comparison)
         self.assertEqual(2, comparison["candidateSegments"])
         throughput = next(
             metric for metric in comparison["metrics"] if metric["key"] == "throughput"
@@ -519,7 +546,7 @@ class StressAbaComparisonTests(unittest.TestCase):
             result(throughput=1185, stability=0.906),
         )
 
-        self.assertEqual("pass", comparison["verdict"])
+        self.assert_only_maximum_is_inconclusive(comparison)
         stability = next(
             metric for metric in comparison["metrics"] if metric["key"] == "stability"
         )
@@ -624,9 +651,10 @@ class StressAbaComparisonTests(unittest.TestCase):
                     ]
                 )
 
-            self.assertEqual(0, exit_code)
-            self.assertEqual("pass", json.loads(output.read_text())["verdict"])
-            self.assertIn("Verdict: PASS", summary.read_text(encoding="utf-8"))
+            self.assertEqual(1, exit_code)
+            self.assert_only_maximum_is_inconclusive(json.loads(output.read_text(encoding="utf-8")))
+            self.assertIn("Verdict: INCONCLUSIVE", summary.read_text(encoding="utf-8"))
+            self.assertIn("screen cannot return PASS", summary.read_text(encoding="utf-8"))
             self.assertIn("not full PR performance acceptance", summary.read_text(encoding="utf-8"))
 
     def test_main_retains_invalid_evidence_reason_in_both_outputs(self):

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -25,6 +25,7 @@ def result(
     errors=0,
     delivered=None,
     scenario="producer",
+    latency_count=10_000,
 ):
     total_messages = 1_000_000
     if delivered is None:
@@ -43,6 +44,7 @@ def result(
             throughput if median_throughput is None else median_throughput
         ),
         "latency": {
+            "count": latency_count,
             "p50Us": p50 * 1000,
             "p95Us": p95 * 1000,
             "p99Us": p99 * 1000,
@@ -71,6 +73,42 @@ def result(
 
 
 class StressAbaComparisonTests(unittest.TestCase):
+    def test_zero_latency_is_invalid_in_every_segment(self):
+        for field in ("p50Us", "p95Us", "p99Us", "maxUs"):
+            for segment in range(4):
+                segments = [result() for _ in range(4)]
+                segments[segment]["latency"][field] = 0
+                with self.subTest(field=field, segment=segment), self.assertRaisesRegex(ValueError, "positive latency"):
+                    compare(*segments[:3], candidate_b2_result=segments[3])
+
+    def test_latency_sample_count_must_be_a_positive_integer(self):
+        for count in (0, -1, None, True, 1.5, float("nan"), "100"):
+            for segment in range(4):
+                segments = [result() for _ in range(4)]
+                segments[segment]["latency"]["count"] = count
+                with self.subTest(count=count, segment=segment), self.assertRaisesRegex(ValueError, "sample count"):
+                    compare(*segments[:3], candidate_b2_result=segments[3])
+
+    def test_missing_latency_count_is_not_inferred_from_positive_quantiles(self):
+        candidate = result()
+        del candidate["latency"]["count"]
+        with self.assertRaisesRegex(ValueError, "sample count"):
+            compare(result(), candidate, result())
+
+    def test_records_latency_sample_counts_for_all_segments(self):
+        comparison = compare(
+            result(latency_count=100), result(latency_count=200), result(latency_count=300),
+            candidate_b2_result=result(latency_count=400),
+        )
+        self.assertEqual(
+            {"baselineA": 100, "candidateB": 200, "baselineA2": 300, "candidateB2": 400},
+            comparison["latencySampleCounts"],
+        )
+        self.assertIn("Latency samples (A / B / A2 / B2): 100 / 200 / 300 / 400", markdown(comparison, "a", "b"))
+        single_candidate = compare(result(), result(), result())
+        self.assertIsNone(single_candidate["latencySampleCounts"]["candidateB2"])
+        self.assertIn("Latency samples (A / B / A2): 10000 / 10000 / 10000", markdown(single_candidate, "a", "b"))
+
     def test_zero_throughput_controls_are_invalid(self):
         for key in ("throughput", "median_throughput"):
             for control in (0, 2):
@@ -493,12 +531,16 @@ class StressAbaComparisonTests(unittest.TestCase):
     def test_main_retains_invalid_evidence_reason_in_both_outputs(self):
         missing_metric = result()
         del missing_metric["latency"]["maxUs"]
+        empty_latency = result(p50=0, p95=0, p99=0, maximum=0, latency_count=0)
         for invalid, expected in (
             (None, "found 0"),
             ("not json", "Expecting value"),
             (json.dumps({"results": [None]}), "Expected a result object"),
             (json.dumps({"results": [[]]}), "Expected a result object"),
             (json.dumps({"results": [missing_metric]}), "Latency max"),
+            (json.dumps({"results": [empty_latency]}), "positive latency"),
+            (json.dumps({"results": [result(latency_count=0)]}), "sample count"),
+            (json.dumps({"results": [{**result(), "latency": ["invalid"]}]}), "latency object"),
             (json.dumps({"results": [result(scenario="other")]}), "workload identity"),
         ):
             with self.subTest(expected=expected), tempfile.TemporaryDirectory() as directory:

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -558,6 +558,8 @@ class StressAbaComparisonTests(unittest.TestCase):
         missing_metric = result()
         del missing_metric["latency"]["maxUs"]
         empty_latency = result(p50=0, p95=0, p99=0, maximum=0, latency_count=0)
+        no_completed_work = result(delivered=0)
+        no_completed_work["throughput"]["totalMessages"] = 0
         for invalid, expected in (
             (None, "found 0"),
             ("not json", "Expecting value"),
@@ -568,9 +570,14 @@ class StressAbaComparisonTests(unittest.TestCase):
             (json.dumps({"results": [result(latency_count=0)]}), "sample count"),
             (json.dumps({"results": [result(latency_count=1)]}), "at least 10000 latency samples"),
             (json.dumps({"results": [result(cpu=0)]}), "positive CPU"),
+            (json.dumps({"results": [result(cpu=10**400)]}), "too large"),
+            (json.dumps({"results": [no_completed_work]}), "positive integer completed messages"),
             (json.dumps({"results": [{**result(), "latency": ["invalid"]}]}), "latency object"),
             (json.dumps({"results": [{**result(), "throughput": ["invalid"]}]}), "throughput object"),
             (json.dumps({"results": [{**result(), "producerDeliveryDiagnostics": ["invalid"]}]}), "producerDeliveryDiagnostics object"),
+            (json.dumps({"results": [{**result(), "producerDeliveryDiagnostics": {"brokerProduceRequests": [None]}}]}), "get"),
+            (json.dumps({"results": [{**result(), "throughput": {"totalErrors": "invalid"}}]}), "str"),
+            (json.dumps({"results": [{**result(), "brokerCount": []}]}), "unhashable"),
             (json.dumps({"results": [result(scenario="other")]}), "workload identity"),
         ):
             with self.subTest(expected=expected), tempfile.TemporaryDirectory() as directory:
@@ -595,6 +602,17 @@ class StressAbaComparisonTests(unittest.TestCase):
                 self.assertEqual("inconclusive", comparison["verdict"])
                 self.assertIn(expected, comparison["validationError"])
                 self.assertIn(expected, summary.read_text(encoding="utf-8"))
+
+    def test_candidates_require_completed_messages_despite_positive_cached_rates(self):
+        for completed in (0, -1, True, 1.5, "100", float("nan")):
+            for segment in (1, 3):
+                for legacy in (False, True):
+                    segments = [result() for _ in range(4)]
+                    segments[segment]["deliveredMessages"] = None if legacy else completed
+                    segments[segment]["throughput"]["totalMessages"] = completed
+                    with self.subTest(completed=completed, segment=segment, legacy=legacy):
+                        with self.assertRaisesRegex(ValueError, "positive integer completed messages"):
+                            compare(*segments[:3], candidate_b2_result=segments[3])
 
     def test_nested_result_objects_are_validated_in_every_segment(self):
         for field in ("throughput", "producerDeliveryDiagnostics"):

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -71,6 +71,47 @@ def result(
 
 
 class StressAbaComparisonTests(unittest.TestCase):
+    def test_zero_throughput_controls_are_invalid(self):
+        for key in ("throughput", "median_throughput"):
+            for control in (0, 2):
+                segments = [result(), result(), result()]
+                segments[control] = result(**{key: 0})
+                with self.subTest(key=key, control=control), self.assertRaisesRegex(ValueError, "positive.*throughput"):
+                    compare(*segments)
+
+    def test_controls_require_completed_messages_even_with_positive_cached_rates(self):
+        for control in (0, 2):
+            segments = [result(), result(), result()]
+            segments[control]["throughput"]["totalMessages"] = 0
+            segments[control]["deliveredMessages"] = 0
+            with self.subTest(control=control), self.assertRaisesRegex(ValueError, "completed messages"):
+                compare(*segments)
+
+    def test_zero_candidate_throughput_with_valid_controls_is_regression(self):
+        self.assertEqual("regression", compare(result(), result(throughput=0), result())["verdict"])
+
+    def test_main_retains_zero_work_controls_as_inconclusive(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for label in ("a", "b", "a2"):
+                path = root / label
+                path.mkdir()
+                payload = {"results": [result(throughput=0)]}
+                (path / "stress-test-results.json").write_text(json.dumps(payload), encoding="utf-8")
+            output, summary = root / "comparison.json", root / "summary.md"
+            with contextlib.redirect_stdout(io.StringIO()):
+                exit_code = main([
+                    "--baseline-a", str(root / "a"), "--candidate", str(root / "b"),
+                    "--baseline-a2", str(root / "a2"), "--baseline-sha", "a" * 40,
+                    "--candidate-sha", "b" * 40, "--output", str(output),
+                    "--summary", str(summary),
+                ])
+            self.assertEqual(1, exit_code)
+            comparison = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual("inconclusive", comparison["verdict"])
+            self.assertIn("positive", comparison["validationError"])
+            self.assertIn("Verdict: INCONCLUSIVE", summary.read_text(encoding="utf-8"))
+
     def test_zero_allocation_controls_are_valid(self):
         for allocation, verdict in ((0, "pass"), (0.5, "pass"), (2, "regression")):
             with self.subTest(allocation=allocation):
@@ -455,6 +496,8 @@ class StressAbaComparisonTests(unittest.TestCase):
         for invalid, expected in (
             (None, "found 0"),
             ("not json", "Expecting value"),
+            (json.dumps({"results": [None]}), "Expected a result object"),
+            (json.dumps({"results": [[]]}), "Expected a result object"),
             (json.dumps({"results": [missing_metric]}), "Latency max"),
             (json.dumps({"results": [result(scenario="other")]}), "workload identity"),
         ):

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -73,6 +73,22 @@ def result(
 
 
 class StressAbaComparisonTests(unittest.TestCase):
+    def test_zero_cpu_is_invalid_in_every_segment(self):
+        for derived in (False, True):
+            for segment in range(4):
+                segments = [result() for _ in range(4)]
+                segments[segment]["cpuMicrosPerMessage"] = None if derived else 0
+                segments[segment]["cpuTimeSeconds"] = 0
+                with self.subTest(derived=derived, segment=segment):
+                    with self.assertRaisesRegex(ValueError, "positive CPU"):
+                        compare(*segments[:3], candidate_b2_result=segments[3])
+
+    def test_positive_derived_cpu_remains_valid(self):
+        segments = [result(cpu=None) for _ in range(4)]
+        for segment in segments:
+            segment["cpuTimeSeconds"] = 0.8
+        self.assertEqual("pass", compare(*segments[:3], candidate_b2_result=segments[3])["verdict"])
+
     def test_zero_latency_is_invalid_in_every_segment(self):
         for field in ("p50Us", "p95Us", "p99Us", "maxUs"):
             for segment in range(4):
@@ -137,27 +153,28 @@ class StressAbaComparisonTests(unittest.TestCase):
     def test_zero_candidate_throughput_with_valid_controls_is_regression(self):
         self.assertEqual("regression", compare(result(), result(throughput=0), result())["verdict"])
 
-    def test_main_retains_zero_work_controls_as_inconclusive(self):
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            for label in ("a", "b", "a2"):
-                path = root / label
-                path.mkdir()
-                payload = {"results": [result(throughput=0)]}
-                (path / "stress-test-results.json").write_text(json.dumps(payload), encoding="utf-8")
-            output, summary = root / "comparison.json", root / "summary.md"
-            with contextlib.redirect_stdout(io.StringIO()):
-                exit_code = main([
-                    "--baseline-a", str(root / "a"), "--candidate", str(root / "b"),
-                    "--baseline-a2", str(root / "a2"), "--baseline-sha", "a" * 40,
-                    "--candidate-sha", "b" * 40, "--output", str(output),
-                    "--summary", str(summary),
-                ])
-            self.assertEqual(1, exit_code)
-            comparison = json.loads(output.read_text(encoding="utf-8"))
-            self.assertEqual("inconclusive", comparison["verdict"])
-            self.assertIn("positive", comparison["validationError"])
-            self.assertIn("Verdict: INCONCLUSIVE", summary.read_text(encoding="utf-8"))
+    def test_main_retains_zero_work_or_cpu_as_inconclusive(self):
+        for invalid in (result(throughput=0), result(cpu=0)):
+            with self.subTest(cpu=invalid["cpuMicrosPerMessage"]), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                for label in ("a", "b", "a2"):
+                    path = root / label
+                    path.mkdir()
+                    payload = {"results": [invalid]}
+                    (path / "stress-test-results.json").write_text(json.dumps(payload), encoding="utf-8")
+                output, summary = root / "comparison.json", root / "summary.md"
+                with contextlib.redirect_stdout(io.StringIO()):
+                    exit_code = main([
+                        "--baseline-a", str(root / "a"), "--candidate", str(root / "b"),
+                        "--baseline-a2", str(root / "a2"), "--baseline-sha", "a" * 40,
+                        "--candidate-sha", "b" * 40, "--output", str(output),
+                        "--summary", str(summary),
+                    ])
+                self.assertEqual(1, exit_code)
+                comparison = json.loads(output.read_text(encoding="utf-8"))
+                self.assertEqual("inconclusive", comparison["verdict"])
+                self.assertIn("positive", comparison["validationError"])
+                self.assertIn("Verdict: INCONCLUSIVE", summary.read_text(encoding="utf-8"))
 
     def test_zero_allocation_controls_are_valid(self):
         for allocation, verdict in ((0, "pass"), (0.5, "pass"), (2, "regression")):
@@ -550,6 +567,7 @@ class StressAbaComparisonTests(unittest.TestCase):
             (json.dumps({"results": [empty_latency]}), "positive latency"),
             (json.dumps({"results": [result(latency_count=0)]}), "sample count"),
             (json.dumps({"results": [result(latency_count=1)]}), "at least 10000 latency samples"),
+            (json.dumps({"results": [result(cpu=0)]}), "positive CPU"),
             (json.dumps({"results": [{**result(), "latency": ["invalid"]}]}), "latency object"),
             (json.dumps({"results": [{**result(), "throughput": ["invalid"]}]}), "throughput object"),
             (json.dumps({"results": [{**result(), "producerDeliveryDiagnostics": ["invalid"]}]}), "producerDeliveryDiagnostics object"),

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -95,16 +95,25 @@ class StressAbaComparisonTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "sample count"):
             compare(result(), candidate, result())
 
+    def test_undersampled_latency_is_invalid_in_every_segment(self):
+        for count in (1, 100, 1000, 9999):
+            for segment in range(4):
+                segments = [result() for _ in range(4)]
+                segments[segment]["latency"]["count"] = count
+                with self.subTest(count=count, segment=segment):
+                    with self.assertRaisesRegex(ValueError, "at least 10000 latency samples"):
+                        compare(*segments[:3], candidate_b2_result=segments[3])
+
     def test_records_latency_sample_counts_for_all_segments(self):
         comparison = compare(
-            result(latency_count=100), result(latency_count=200), result(latency_count=300),
-            candidate_b2_result=result(latency_count=400),
+            result(latency_count=10000), result(latency_count=20000), result(latency_count=30000),
+            candidate_b2_result=result(latency_count=40000),
         )
         self.assertEqual(
-            {"baselineA": 100, "candidateB": 200, "baselineA2": 300, "candidateB2": 400},
+            {"baselineA": 10000, "candidateB": 20000, "baselineA2": 30000, "candidateB2": 40000},
             comparison["latencySampleCounts"],
         )
-        self.assertIn("Latency samples (A / B / A2 / B2): 100 / 200 / 300 / 400", markdown(comparison, "a", "b"))
+        self.assertIn("Latency samples (A / B / A2 / B2): 10000 / 20000 / 30000 / 40000", markdown(comparison, "a", "b"))
         single_candidate = compare(result(), result(), result())
         self.assertIsNone(single_candidate["latencySampleCounts"]["candidateB2"])
         self.assertIn("Latency samples (A / B / A2): 10000 / 10000 / 10000", markdown(single_candidate, "a", "b"))
@@ -540,7 +549,10 @@ class StressAbaComparisonTests(unittest.TestCase):
             (json.dumps({"results": [missing_metric]}), "Latency max"),
             (json.dumps({"results": [empty_latency]}), "positive latency"),
             (json.dumps({"results": [result(latency_count=0)]}), "sample count"),
+            (json.dumps({"results": [result(latency_count=1)]}), "at least 10000 latency samples"),
             (json.dumps({"results": [{**result(), "latency": ["invalid"]}]}), "latency object"),
+            (json.dumps({"results": [{**result(), "throughput": ["invalid"]}]}), "throughput object"),
+            (json.dumps({"results": [{**result(), "producerDeliveryDiagnostics": ["invalid"]}]}), "producerDeliveryDiagnostics object"),
             (json.dumps({"results": [result(scenario="other")]}), "workload identity"),
         ):
             with self.subTest(expected=expected), tempfile.TemporaryDirectory() as directory:
@@ -565,6 +577,16 @@ class StressAbaComparisonTests(unittest.TestCase):
                 self.assertEqual("inconclusive", comparison["verdict"])
                 self.assertIn(expected, comparison["validationError"])
                 self.assertIn(expected, summary.read_text(encoding="utf-8"))
+
+    def test_nested_result_objects_are_validated_in_every_segment(self):
+        for field in ("throughput", "producerDeliveryDiagnostics"):
+            for value in (None, [], ["invalid"], "invalid", 1, False):
+                for segment in range(4):
+                    segments = [result() for _ in range(4)]
+                    segments[segment][field] = value
+                    with self.subTest(field=field, value=value, segment=segment):
+                        with self.assertRaisesRegex(ValueError, f"{field} object"):
+                            compare(*segments[:3], candidate_b2_result=segments[3])
 
     def test_report_does_not_prescribe_unlimited_repeats(self):
         report = markdown(compare(result(90), result(100), result(110)), "a" * 40, "b" * 40)


### PR DESCRIPTION
The stress A-B-A comparator could crash on zero allocation controls, hide a candidate loss behind the control mean, and report acceptance without adequate maximum-latency evidence. For example, p99 A/B/A2 values of 100/104/104 ms passed a 3% tolerance despite B losing 4% against A. That comparison now remains INCONCLUSIVE.

Compare each B and optional B2 segment against both controls. For resolved aggregate metrics, an adverse result beyond tolerance in every pairing rejects; conflicting pairings or material control/candidate drift remain INCONCLUSIVE. Existing numeric tolerances, allocation noise floor and absolute stability floor are preserved. Means remain descriptive only.

**Maximum latency stays protected and INCONCLUSIVE with the current aggregate schema, so this comparator cannot return PASS.** One raw maximum per segment has no uncertainty estimate, even with equal sample counts. Every maximum, delta, drift and sample count remains visible. Neither an improved raw extreme nor an adverse one establishes that metric's result. Independent metric regressions and delivery failures still reject. Workload-level sampling and uncertainty evidence are needed before maximum acceptance; repeating unchanged aggregate inputs cannot supply them. This supersedes the preceding equal-count prerequisite without trimming samples, inventing count tolerances, or waiving maximum latency.

Require positive integer completed-message counts and positive CPU/latency evidence in every segment, even when cached rates are present. Controls additionally require positive delivered/median rates. Each segment needs at least 10,000 latency samples; that conservative floor does not establish independence or tail precision. Zero allocation controls remain valid. Nonzero values relative to zero have JSON null / Markdown n/a percentage changes, with absolute values still deciding the applicable row.

Missing, malformed, nonfinite or inconsistent evidence produces retained INCONCLUSIVE JSON and Markdown with the reason and exit code 1. Strict JSON serialization completes before Markdown publication, including when finite inputs overflow descriptive results. The CLI handles structural failures at the evidence boundary.

This remains an aggregate metric screen, not full performance acceptance. Ubuntu runner/fixture identity, elapsed workload warmup, JIT attribution, hot-path MemoryDiagnoser, uncertainty and sustained stability still require their own evidence. No src/, stress workflow, paid/scheduled lane or existing performance gate-status changes.

Validation on `dc90973e60f9ee75f35a2f753af636de8c01172e`: all **225 Python tooling tests pass**. Twelve new equal-count cases first reproduce unsupported PASS/REGRESSION decisions across A/B/A2 and A/B/A2/B2, 10,000/1,000,000 samples and favorable/equal/adverse maxima. Existing formerly favorable fixtures now assert that maximum alone is unresolved and every other metric still passes its own screen; regression, invalid-evidence and delivery checks remain enforced. Four retained synthetic CLI cases demonstrate INCONCLUSIVE maximum results and independent CPU rejection with original inputs/JSON/Markdown/stdout. git diff --check and scoped simplification review pass.

Verified current archive: `C:/git/Dekaf-evidence/pr-3143/dc90973e60f9ee75f35a2f753af636de8c01172e/maximum-review-20260908` (61 files: exact source ZIP, tested Python sources, red/green logs, synthetic CLI inputs and reports). Synthetic fixtures are not measured performance evidence. An initial replay encountered Windows child-stdout encoding mismatch; its script and partial artifacts are retained, and the corrected replay explicitly sets UTF-8. No stress dispatch or timed performance claim.

Earlier [strict-serialization evidence](https://github.com/thomhurst/Dekaf/pull/3143#issuecomment-5581324286), [completion/structure evidence](https://github.com/thomhurst/Dekaf/pull/3143#issuecomment-5581203457), and [NaN execution evidence](https://github.com/thomhurst/Dekaf/pull/3143#issuecomment-5581614311) remain retained. The current maximum disposition replaces the former equal-count gate; it does not relabel historical performance results.
