### PR TITLE
fix(producer): bound linger notifications across batch rotations

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3393,20 +3393,22 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         // Steady-state awaited appends land in a partition that is already queued, so a plain
         // read answers them; the exchange stays the single-enqueuer arbiter for the 0 -> 1
-        // transition. Every clear runs under pd.Lock alongside the batch detach (or in the
-        // linger sweep right before it takes pd.Lock), so an appender that reads 1 either
-        // has its record in a queued batch or in one the sweep is about to visit.
+        // transition. Only dequeue clears the flag, so batch rotation cannot duplicate
+        // an outstanding partition notification. An appender that reads 1 has its record
+        // in a queued partition or in one the sweep is about to visit.
         if (Volatile.Read(ref pd.LingerQueued) == 0
             && Interlocked.Exchange(ref pd.LingerQueued, 1) == 0)
         {
             _lingerPartitions.Enqueue(topicPartition);
-            if (signalLingerLoop
-                || (signalOnConcurrentSweep
-                    && ((observedSweepVersion & 1) != 0
-                        || Volatile.Read(ref _lingerSweepVersion) != observedSweepVersion)))
-            {
-                _lingerWakeupSignal.Signal();
-            }
+        }
+        // A queued notification can cover a replacement batch. Its new deadline or
+        // a concurrent sweep still requires a wakeup even when no enqueue is needed.
+        if (signalLingerLoop
+            || (signalOnConcurrentSweep
+                && ((observedSweepVersion & 1) != 0
+                    || Volatile.Read(ref _lingerSweepVersion) != observedSweepVersion)))
+        {
+            _lingerWakeupSignal.Signal();
         }
     }
 
@@ -3419,7 +3421,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void ClearLingerPartitionTracking(PartitionDeque pd)
     {
-        MarkLingerPartitionDequeued(pd);
+        // Detaching a batch does not remove its outstanding partition notification.
         Volatile.Write(ref pd.LingerDeferred, 0);
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -1111,6 +1111,53 @@ public class RecordAccumulatorReadyTests
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task LingerPartitionsQueue_FullBatchRotations_KeepOneNotificationPerPartition(bool appendFromSpans)
+    {
+        var accumulator = new RecordAccumulator(CreateTestOptions(batchSize: 256, lingerMs: 60_000));
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var drained = 0;
+        try
+        {
+            // Full batches rotate independently of the linger sweep. Leaving their
+            // notification queued must not enqueue another copy for each new batch.
+            for (var i = 0; i < 512; i++)
+            {
+                if (appendFromSpans)
+                {
+                    var appended = await accumulator.AppendFromSpansAsync("test-topic", 0,
+                        DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                        ReadOnlySpan<byte>.Empty, true, ReadOnlySpan<byte>.Empty, true,
+                        null, 0, null, CancellationToken.None);
+                    await Assert.That(appended).IsTrue();
+                }
+                else
+                {
+                    accumulator.TryAppendWithCompletion("test-topic", 0,
+                        DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                        PooledMemory.Null, PooledMemory.Null, null, 0, pool.Rent());
+                }
+                while (accumulator.TryDrainBatch(out var batch))
+                {
+                    batch!.CompleteSend(baseOffset: drained++, timestamp: DateTimeOffset.UtcNow);
+                    accumulator.OnBatchExitsPipeline(batch);
+                    accumulator.ReturnReadyBatch(batch);
+                }
+            }
+
+            await Assert.That(drained).IsGreaterThan(10);
+            var queue = GetPrivateField<ConcurrentQueue<TopicPartition>>(accumulator, "_lingerPartitions");
+            await Assert.That(queue.Count).IsEqualTo(1);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task LingerPartitionsQueue_SameCurrentBatch_QueuesOnce()
     {
         var options = CreateTestOptions(batchSize: 100_000, lingerMs: 10_000);


### PR DESCRIPTION
Full batch rotation cleared `LingerQueued` while the old partition notification was still in `_lingerPartitions`. Each replacement batch could enqueue another notification. A linger sweep then requeued duplicates against the same current batch, allowing queue segments and allocation rates to grow under sustained load.

Only physically dequeuing a notification now clears `LingerQueued`. Batch detach still clears deferred state. Deadline and concurrent-sweep wakeups run even when an existing notification covers the replacement batch, preserving prompt delivery and flush races.

Validation: a deterministic 512-append reproducer left 19 notifications for one partition before the fix. Both completion and span append paths now keep one notification. All 43 accumulator/deadline unit cases and three producer integration cases pass, including chunk boundaries, multi-topic delivery, and pooled response ownership. Existing concurrent linger and flush wakeup tests pass.

Found while investigating the open PR performance gates. Hosted diagnostic [A–B–A run 34268141808](https://github.com/thomhurst/Dekaf/actions/runs/34268141808), A `693a02e52b120ccd33ba1328843b0a052ec6766e`, B `9c3437ae5e080007c5f82b90f97a3f8e0c9fd2ba`, captured allocation stacks in all six early/late traces. `ConcurrentQueue<TopicPartition>` segment arrays reached 25,165,856 bytes each; late 30-second traces contained GiB of sampled segment allocations, with `RecordAccumulator.SealBatchesAsync` on the allocation stack. Profiling is diagnostic, not acceptance evidence for this fix.

Fresh-main baseline for this fix: `9c8db4c6ca413bcf4ba998db36a7db8b9ee4cdfc`. Matched Ubuntu A–B–A microbenchmark and loaded evidence are pending. No performance PASS claimed yet. This fixes shared producer behavior affecting several ongoing comparisons; it does not change their acceptance tolerances.
