### PR TITLE
fix(ci): verify Claude executable before review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -75,6 +75,24 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Install verified Claude executable
+        id: claude-executable
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The native installer can report success without creating its launcher.
+          # Install the matching official Linux binary directly and verify it before
+          # the action uses it for plugin installation or review execution.
+          npm install --prefix "$RUNNER_TEMP/claude-code" --no-save --package-lock=false \
+            --ignore-scripts --no-audit --no-fund \
+            @anthropic-ai/claude-code-linux-x64@2.1.265
+          claude_executable="$RUNNER_TEMP/claude-code/node_modules/@anthropic-ai/claude-code-linux-x64/claude"
+          test -x "$claude_executable"
+          version="$("$claude_executable" --version)"
+          test "$version" = '2.1.265 (Claude Code)'
+          printf '%s\n' "$version"
+          printf 'path=%s\n' "$claude_executable" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@5ccc3a35a6367cdb8e6fbd0728287467540ecfe2 # v1
@@ -82,6 +100,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           GH_REPO: ${{ github.repository }}
         with:
+          path_to_claude_code_executable: ${{ steps.claude-executable.outputs.path }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The actor is the PR author, who by definition has no write access on a
           # fork PR. The action only honours this bypass when an explicit token is


### PR DESCRIPTION
Claude review jobs fail before reviewing code: the native installer reports success but leaves `/home/runner/.local/bin/claude` missing. The plugin setup then fails with `ENOENT`. This blocked the latest runs for #3083, #3129 and #3138 ([example](https://github.com/thomhurst/Dekaf/actions/runs/34284141628)); the same installer failure is tracked in [upstream issue #1290](https://github.com/anthropics/claude-code-action/issues/1290).

Install the official `@anthropic-ai/claude-code-linux-x64@2.1.265` binary in the runner's temporary directory, with package scripts disabled. Verify executable permission and the exact version, then pass its path through the action's supported `path_to_claude_code_executable` input. This keeps the action's current CLI version and bypasses the broken launcher installation. Review permissions, tools, model and plugin remain unchanged.

Validation: installed that exact package with scripts disabled in a fresh Linux Node 24 container; the executable returned `2.1.265 (Claude Code)`. The configured custom-executable input is present in the pinned action source. Hosted manual review will validate plugin installation and review execution.
