### PR TITLE
fix(share-consumer): retain borrowed payloads across polls

### DIFF
--- a/.github/scripts/performance_gate.py
+++ b/.github/scripts/performance_gate.py
@@ -57,7 +57,7 @@ COMPONENTS = {
                             'ConsumerBatchInterceptorBenchmarks', 'ConsumerFollowerOffsetRetryBenchmarks',
                             'PartitionedOffsetCompletionBenchmarks', 'PartitionedOffsetFragmentationBenchmarks', 'ConsumeResultEpochBenchmarks'),
     'src/Dekaf/ShareConsumer/': ('ShareConsumerParsingBenchmarks', 'ShareConsumerBorrowedParsingBenchmarks', 'ShareFetchResponseDecodingBenchmarks',
-                                 'ShareAcknowledgementTrackingBenchmarks',
+                                 'ShareAcknowledgementTrackingBenchmarks', 'ShareConsumerMultiBatchBenchmarks',
                                  'ShareConsumerPollBenchmarks', 'ShareConsumerIdleAssignmentBenchmarks', 'ShareConsumerMissingLeaderBenchmarks', 'ShareConsumerUnsubscribeBenchmarks', 'ShareConsumerSparsePollBenchmarks', 'ShareBatchAcknowledgementBenchmarks', 'ShareBatchScalingBenchmarks',
                                  'ShareBatchRenewalPollBenchmarks', 'ShareBatchPendingStateBenchmarks',
                                  'ShareBatchChunkedRenewalBenchmarks'),

--- a/.github/scripts/test_performance_gate.py
+++ b/.github/scripts/test_performance_gate.py
@@ -144,6 +144,12 @@ class SelectionTests(unittest.TestCase):
         selected = self.names(gate.select([path], root=REPO_ROOT))
         self.assertIn('ShareAcknowledgedOffsetsBenchmarks', selected)
 
+    def test_share_owner_paths_select_multi_batch_fixture(self):
+        for path in ('src/Dekaf/ShareConsumer/ShareRecordBatchOwner.cs', 'src/Dekaf/ShareConsumer/KafkaShareConsumer.cs'):
+            with self.subTest(path=path):
+                selected = self.names(gate.select([path], root=REPO_ROOT))
+                self.assertIn('ShareConsumerMultiBatchBenchmarks', selected)
+
     def test_any_product_change_runs_the_sentinels(self):
         selection = gate.select(['src/Dekaf/Admin/AdminClient.cs'], fixtures=self.fixtures)
         self.assertEqual(sorted(gate.SENTINELS), self.names(selection))

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -473,6 +473,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
     private IReadOnlyList<Record> _records = null!;
     private ReadOnlyMemory<byte> _rawRecordData;
     private byte[]? _pooledRecordData;
+    private ArrayPool<byte>? _recordDataPool;
     private Record[]? _parsedRecords;
     private int _parsedRecordsOffset;
     private bool _ownsParsedRecords;
@@ -702,7 +703,8 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         var pooledArray = _pooledRecordData;
         _pooledRecordData = null;
         if (pooledArray is not null)
-            ArrayPool<byte>.Shared.Return(pooledArray, clearArray: false);
+            (_recordDataPool ?? ArrayPool<byte>.Shared).Return(pooledArray, clearArray: false);
+        _recordDataPool = null;
 
         var parsedRecords = _parsedRecords;
         _parsedRecords = null;
@@ -728,6 +730,16 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         _ownsParsedRecords = false;
         _nextRecordParseOffset = 0;
         _headerRoutingPlan = null;
+    }
+
+    /// <summary>Transfers copied/decompressed payload storage before returning the batch metadata.</summary>
+    internal byte[]? DetachRecordData(out ArrayPool<byte> pool)
+    {
+        var data = _pooledRecordData;
+        pool = _recordDataPool ?? ArrayPool<byte>.Shared;
+        _pooledRecordData = null;
+        _recordDataPool = null;
+        return data;
     }
 
     /// <summary>
@@ -1020,6 +1032,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             item._records = null!;
             item._rawRecordData = default;
             item._pooledRecordData = null;
+            item._recordDataPool = null;
             item._parsedRecords = null;
             item._parsedRecordsOffset = 0;
             item._ownsParsedRecords = false;
@@ -1524,6 +1537,15 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         CompressionCodecRegistry? codecs,
         int availableBytes,
         bool checkCrcs)
+        => ReadCore(ref reader, codecs, availableBytes, checkCrcs, ArrayPool<byte>.Shared, borrowResponseMemory: true);
+
+    internal static RecordBatch ReadForShareConsumer(
+        ref KafkaProtocolReader reader, CompressionCodecRegistry? codecs, ArrayPool<byte> recordDataPool)
+        => ReadCore(ref reader, codecs, int.MaxValue, false, recordDataPool, borrowResponseMemory: false);
+
+    private static RecordBatch ReadCore(
+        ref KafkaProtocolReader reader, CompressionCodecRegistry? codecs, int availableBytes,
+        bool checkCrcs, ArrayPool<byte> recordDataPool, bool borrowResponseMemory)
     {
         if (availableBytes < TotalBatchHeaderSize)
         {
@@ -1592,13 +1614,13 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
 
         if (compression != CompressionType.None)
         {
-            // Decompress directly into an ArrayPool<byte>.Shared-backed writer, then
+            // Decompress directly into a writer backed by the selected array pool, then
             // detach the array for zero-copy handoff to the pooled RecordBatch.
             // This eliminates the previous decompress-to-scratch-then-copy pattern.
             var registry = codecs ?? CompressionCodecRegistry.Default;
             var codec = registry.GetCodec(compression);
             var estimatedSize = recordsLength * 4; // Estimate 4x expansion
-            using var decompressWriter = DetachableBufferWriter.Rent(ArrayPool<byte>.Shared, estimatedSize);
+            using var decompressWriter = DetachableBufferWriter.Rent(recordDataPool, estimatedSize);
             codec.Decompress(new ReadOnlySequence<byte>(rawRecordData), decompressWriter);
 
             // Transfer ownership of the pooled array — Dispose is a no-op after DetachBuffer.
@@ -1606,7 +1628,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             lazyRecordData = pooledArray.AsMemory(0, writtenLength);
             pooledRecordData = pooledArray;
         }
-        else if (ResponseParsingContext.HasPooledMemory)
+        else if (borrowResponseMemory && ResponseParsingContext.HasPooledMemory)
         {
             // Zero-copy: use the raw data directly from the pooled buffer
             // Mark that at least one batch used the pooled memory, so ownership
@@ -1620,7 +1642,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             // No pooled memory available (legacy path or not from network)
             // Use pooled array to avoid GC allocation from ToArray()
             var length = rawRecordData.Length;
-            var pooledArray = ArrayPool<byte>.Shared.Rent(length);
+            var pooledArray = recordDataPool.Rent(length);
             rawRecordData.Span.CopyTo(pooledArray);
             lazyRecordData = pooledArray.AsMemory(0, length);
             pooledRecordData = pooledArray;
@@ -1640,6 +1662,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         batch.ProducerEpoch = producerEpoch;
         batch.BaseSequence = baseSequence;
         batch.InitializeLazyRecords(lazyRecordData, pooledRecordData, recordCount);
+        batch._recordDataPool = ReferenceEquals(recordDataPool, ArrayPool<byte>.Shared) ? null : recordDataPool;
         return batch;
     }
 

--- a/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
@@ -63,6 +63,12 @@ public interface IKafkaShareConsumer<TKey, TValue> : IInitializableKafkaClient, 
     /// accepted automatically. In <see cref="ShareAcknowledgementMode.Explicit"/> mode, only
     /// records passed to <see cref="Acknowledge"/> are sent to the broker.
     /// </para>
+    /// <para>
+    /// Borrowed key/value memory and header value views remain valid until the next poll
+    /// round starts or this consumer is disposed, including after iterator disposal.
+    /// Acknowledge Renew before that boundary to retain borrowed storage for replay.
+    /// Copy borrowed data that must outlive delivery without renewal.
+    /// </para>
     /// </summary>
     IAsyncEnumerable<ShareConsumeResult<TKey, TValue>> PollAsync(CancellationToken cancellationToken = default);
 

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -42,6 +42,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     private readonly IAsyncDeserializerPreparer<TKey>? _keyDeserializerPreparer;
     private readonly IAsyncDeserializerPreparer<TValue>? _valueDeserializerPreparer;
     private readonly bool _hasDeserializerPreparers;
+    private readonly bool _inputIsolatedDeserializers;
     private readonly RecordHeaderRoutingPlan? _recordHeaderRoutingPlan;
     private readonly Headers? _recordHeaderDeserializationHeaders;
     private readonly IConnectionPool _connectionPool;
@@ -70,6 +71,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     private readonly bool _ownsInfrastructure;
     private volatile Task? _pendingReleaseTask;
     private Dictionary<RenewedRecordKey, RenewedRecordState>? _renewedRecords;
+    private readonly List<ShareRecordBatchOwner> _polledBatchOwners = [];
+    private Dictionary<TopicPartition, ShareRecordBatchOwner.Pool>? _recordBatchOwnerPools;
+    private int _recordBatchScopes;
+    private ShareRecordBufferPool? _recordBuffers;
     private int _acquisitionLockTimeoutMs = -1;
     private long _renewalRequestCount;
     private long _renewedRecordReplayCount;
@@ -165,6 +170,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         _acknowledgementCommitCallback = options.AcknowledgementCommitCallback;
         _keyDeserializer = RecordHeaderDeserializer.WrapIfNeeded(keyDeserializer);
         _valueDeserializer = RecordHeaderDeserializer.WrapIfNeeded(valueDeserializer);
+        _inputIsolatedDeserializers = _keyDeserializer is IInputIsolatedDeserializer
+            && _valueDeserializer is IInputIsolatedDeserializer;
         _recordHeaderRoutingPlan = RecordHeaderRoutingPlan.Create(
             _keyDeserializer,
             _valueDeserializer);
@@ -264,6 +271,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
 
     public IKafkaShareConsumer<TKey, TValue> Subscribe(params string[] topics)
     {
+        _recordBatchOwnerPools?.Clear();
         _subscriptionSnapshot = new HashSet<string>(topics);
         _coordinator.NotifyAssignmentChange();
         return this;
@@ -284,6 +292,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         _batchAcknowledgements?.Clear();
         _subscriptionSnapshot = new HashSet<string>();
         _coordinator.NotifyAssignmentChange();
+        _recordBatchOwnerPools?.Clear();
         _sessionManager.ResetAll();
         ClearRenewedRecords();
         return this;
@@ -299,6 +308,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
+            using var recordScope = BeginRecordBatchScope();
             if (_subscriptionSnapshot.Count == 0 || Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _disposed) != 0)
                 yield break;
 
@@ -355,128 +365,153 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             if (fetchedRecords is not null && _hostedProcessing)
                 _bufferedAcquisitionTimestamps ??= [];
 
-            // Parse records only after all broker bookkeeping is complete. This second broker scan
-            // is per poll, not per message, and avoids buffering records when no renewal is active.
-            foreach (var fetchResult in fetchResults)
+            var firstBufferedOwner = fetchedRecords is null ? -1 : _polledBatchOwners.Count;
+            try
             {
-                var response = fetchResult.Response;
-                if (response is null || response.ErrorCode != ErrorCode.None)
-                    continue;
-
-                // Process partition responses
-                foreach (var topicResponse in response.Responses)
+                // Parse records only after all broker bookkeeping is complete. This second broker scan
+                // is per poll, not per message, and avoids buffering records when no renewal is active.
+                foreach (var fetchResult in fetchResults)
                 {
-                    var topicInfo = _metadataManager.Metadata.GetTopic(topicResponse.TopicId);
-                    if (topicInfo is null)
+                    var response = fetchResult.Response;
+                    if (response is null || response.ErrorCode != ErrorCode.None)
                         continue;
 
-                    foreach (var partition in topicResponse.Partitions)
+                    // Process partition responses
+                    foreach (var topicResponse in response.Responses)
                     {
-                        if (partition.ErrorCode != ErrorCode.None)
-                        {
-                            LogPartitionFetchError(topicInfo.Name, partition.PartitionIndex,
-                                partition.ErrorCode);
-                            continue;
-                        }
-
-                        if (partition.RecordBytes.IsEmpty || partition.AcquiredRecords.Count == 0)
+                        var topicInfo = _metadataManager.Metadata.GetTopic(topicResponse.TopicId);
+                        if (topicInfo is null)
                             continue;
 
-                        // Parse all records from this partition eagerly (KafkaProtocolReader is a
-                        // ref struct and cannot be preserved across yield boundaries)
-                        var remainingRecordCount = _options.MaxPollRecords -
-                            (fetchedRecords?.Count ?? recordCount);
-                        List<ShareConsumeResult<TKey, TValue>> parsed;
-                        if (!_hasDeserializerPreparers)
+                        foreach (var partition in topicResponse.Partitions)
                         {
-                            parsed = ParsePartitionRecords(
-                                topicInfo,
-                                partition,
-                                remainingRecordCount);
-                        }
-                        else
-                        {
-                            parsed = [];
-                            var parserState = new DeserializerPreparationParserState();
-                            var hasRetainedKey = false;
-                            TKey? retainedKey = default;
-                            long? previousPreparationOffset = null;
-                            var previousPreparationComponent = default(SerializationComponent);
-                            var preparationAttempts = 0;
-                            try
+                            if (partition.ErrorCode != ErrorCode.None)
                             {
-                                while (true)
-                                {
-                                    var pendingPreparation = ParsePartitionRecordsWithPreparation(
-                                        topicInfo,
-                                        partition,
-                                        remainingRecordCount,
-                                        parsed,
-                                        ref parserState,
-                                        hasRetainedKey,
-                                        retainedKey);
-                                    if (pendingPreparation is null)
-                                        break;
-
-                                    if (previousPreparationOffset == pendingPreparation.Offset &&
-                                        previousPreparationComponent == pendingPreparation.Component)
-                                    {
-                                        if (preparationAttempts >= MaxDeserializerPreparationAttempts)
-                                        {
-                                            throw new InvalidOperationException(
-                                                "Deserializer remained unprepared after PrepareAsync completed.");
-                                        }
-                                    }
-                                    else
-                                    {
-                                        previousPreparationOffset = pendingPreparation.Offset;
-                                        previousPreparationComponent = pendingPreparation.Component;
-                                        preparationAttempts = 0;
-                                    }
-
-                                    preparationAttempts++;
-                                    await PrepareDeserializerAsync(pendingPreparation, cancellationToken)
-                                        .ConfigureAwait(false);
-                                    hasRetainedKey = pendingPreparation.HasRetainedKey;
-                                    retainedKey = pendingPreparation.RetainedKey;
-                                }
-                            }
-                            finally
-                            {
-                                parserState.DisposeCurrentBatch();
-                            }
-                        }
-
-                        var tp = new TopicPartition(topicInfo.Name, partition.PartitionIndex);
-                        if (fetchedRecords is not null && _hostedProcessing)
-                            _bufferedAcquisitionTimestamps![tp] = fetchResult.ReceivedTimestamp;
-
-                        foreach (var result in parsed)
-                        {
-                            if ((fetchedRecords?.Count ?? recordCount) >= _options.MaxPollRecords)
-                                break;
-
-                            RemoveRenewedRecord(result.Topic, result.Partition, result.Offset);
-
-                            if (fetchedRecords is not null)
-                            {
-                                fetchedRecords.Add(result);
+                                LogPartitionFetchError(topicInfo.Name, partition.PartitionIndex,
+                                    partition.ErrorCode);
                                 continue;
                             }
 
-                            // Track only records actually yielded to the consumer so implicit
-                            // acknowledgements do not include offsets truncated by MaxPollRecords.
-                            if (_options.AcknowledgementMode == ShareAcknowledgementMode.Implicit)
+                            if (partition.RecordBytes.IsEmpty || partition.AcquiredRecords.Count == 0)
+                                continue;
+
+                            // Parse all records from this partition eagerly (KafkaProtocolReader is a
+                            // ref struct and cannot be preserved across yield boundaries)
+                            var remainingRecordCount = _options.MaxPollRecords -
+                                (fetchedRecords?.Count ?? recordCount);
+                            List<ShareConsumeResult<TKey, TValue>> parsed;
+                            if (!_hasDeserializerPreparers)
                             {
-                                _ackTracker.TrackDeliveredRecords(tp, result.Offset, result.Offset);
+                                parsed = ParsePartitionRecords(
+                                    topicInfo,
+                                    partition,
+                                    remainingRecordCount);
+                            }
+                            else
+                            {
+                                parsed = [];
+                                var parserState = new DeserializerPreparationParserState();
+                                var hasRetainedKey = false;
+                                TKey? retainedKey = default;
+                                long? previousPreparationOffset = null;
+                                var previousPreparationComponent = default(SerializationComponent);
+                                var preparationAttempts = 0;
+                                var firstUndisclosedOwner = _polledBatchOwners.Count;
+                                try
+                                {
+                                    while (true)
+                                    {
+                                        var pendingPreparation = ParsePartitionRecordsWithPreparation(
+                                            topicInfo,
+                                            partition,
+                                            remainingRecordCount,
+                                            parsed,
+                                            ref parserState,
+                                            hasRetainedKey,
+                                            retainedKey);
+                                        if (pendingPreparation is null)
+                                            break;
+
+                                        if (previousPreparationOffset == pendingPreparation.Offset &&
+                                            previousPreparationComponent == pendingPreparation.Component)
+                                        {
+                                            if (preparationAttempts >= MaxDeserializerPreparationAttempts)
+                                            {
+                                                throw new InvalidOperationException(
+                                                    "Deserializer remained unprepared after PrepareAsync completed.");
+                                            }
+                                        }
+                                        else
+                                        {
+                                            previousPreparationOffset = pendingPreparation.Offset;
+                                            previousPreparationComponent = pendingPreparation.Component;
+                                            preparationAttempts = 0;
+                                        }
+
+                                        preparationAttempts++;
+                                        await PrepareDeserializerAsync(pendingPreparation, cancellationToken)
+                                            .ConfigureAwait(false);
+                                        hasRetainedKey = pendingPreparation.HasRetainedKey;
+                                        retainedKey = pendingPreparation.RetainedKey;
+                                    }
+                                }
+                                catch
+                                {
+                                    // No prepared results from this partition reached the caller.
+                                    ReleaseUndisclosedBatchOwners(firstUndisclosedOwner);
+                                    throw;
+                                }
+                                finally
+                                {
+                                    parserState.DisposeCurrentBatch();
+                                }
                             }
 
-                            recordCount++;
-                            _acquisitionStartedTimestamp = fetchResult.ReceivedTimestamp;
-                            yield return result;
+                            // Preparation may have suspended while disposal or close began.
+                            // Finish parsing with the live scope, but disclose no new records.
+                            if (Volatile.Read(ref _disposed) != 0 || Volatile.Read(ref _closed) != 0)
+                                yield break;
+
+                            var tp = new TopicPartition(topicInfo.Name, partition.PartitionIndex);
+                            if (fetchedRecords is not null && _hostedProcessing)
+                                _bufferedAcquisitionTimestamps![tp] = fetchResult.ReceivedTimestamp;
+
+                            foreach (var result in parsed)
+                            {
+                                if ((fetchedRecords?.Count ?? recordCount) >= _options.MaxPollRecords)
+                                    break;
+
+                                RemoveRenewedRecord(result.Topic, result.Partition, result.Offset);
+
+                                if (fetchedRecords is not null)
+                                {
+                                    fetchedRecords.Add(result);
+                                    continue;
+                                }
+
+                                // Track only records actually yielded to the consumer so implicit
+                                // acknowledgements do not include offsets truncated by MaxPollRecords.
+                                if (_options.AcknowledgementMode == ShareAcknowledgementMode.Implicit)
+                                {
+                                    _ackTracker.TrackDeliveredRecords(tp, result.Offset, result.Offset);
+                                }
+
+                                recordCount++;
+                                _acquisitionStartedTimestamp = fetchResult.ReceivedTimestamp;
+                                yield return result;
+                            }
                         }
                     }
                 }
+                firstBufferedOwner = -1;
+            }
+            finally
+            {
+                // A failed buffered poll has disclosed none of its new records. Release
+                // owners from earlier partitions as well as the partition that failed.
+                // Direct delivery retains its owners for records already yielded.
+                if (firstBufferedOwner >= 0)
+                    ReleaseUndisclosedBatchOwners(firstBufferedOwner);
             }
 
             var bufferedRecordCount = fetchedRecords?.Count ?? 0;
@@ -678,6 +713,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     {
         ThrowIfDisposed();
         SelectConsumptionMode(batch: false);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan((byte)type, (byte)AcknowledgeType.Renew);
 
         if (type == AcknowledgeType.Renew
             && _options.AcknowledgementMode != ShareAcknowledgementMode.Explicit)
@@ -686,6 +722,9 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 "Renew acknowledgements require explicit acknowledgement mode.");
         }
 
+        // Retain borrowed storage before queueing Renew; an expired record must
+        // fail without leaving a renewal acknowledgement behind.
+        TrackRenewalDisposition(record, type);
         record.AcknowledgeType = type;
         var tp = new TopicPartition(record.Topic, record.Partition);
         _ackTracker.Acknowledge(
@@ -693,8 +732,6 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             record.Offset,
             type,
             requireTracked: _options.AcknowledgementMode == ShareAcknowledgementMode.Implicit);
-
-        TrackRenewalDisposition(record, type);
     }
 
     public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
@@ -855,7 +892,15 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             return;
         _coordinator.NotifyAssignmentChange();
 
+        _recordBatchOwnerPools?.Clear();
         ClearRenewedRecords();
+        // An active iterator releases its scope when disposed/unwound, just like
+        // its response frames. This also cleans up direct internal parser callers.
+        if (_recordBatchScopes == 0)
+        {
+            ReleasePolledBatchOwners();
+            _recordBuffers?.Dispose();
+        }
 
         // Ensure close is called
         if (Volatile.Read(ref _closed) == 0)
@@ -1427,14 +1472,38 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     /// KafkaProtocolReader is a ref struct and cannot cross yield boundaries.
     /// Keep this no-preparer path isolated from the preparation-aware parser below: it is the
     /// established hot path and is covered by before/after allocation and throughput benchmarks.
+    /// ShareFetchResponse borrows frame bytes during response decoding. This later RecordBatch.Read
+    /// runs outside that parsing scope and copies into independent pooled batch storage, so a renewed
+    /// record retains its batch rather than the complete multi-partition response frame.
     /// </summary>
     private List<ShareConsumeResult<TKey, TValue>> ParsePartitionRecords(
         TopicInfo topicInfo,
         ShareFetchResponsePartition partition,
         int maxRecords)
     {
+        var firstUndisclosedOwner = _polledBatchOwners.Count;
+        try
+        {
+            return ParsePartitionRecordsCore(topicInfo, partition, maxRecords);
+        }
+        catch
+        {
+            // This eager call never returned its results. Release only its owners;
+            // earlier partition deliveries still borrow their storage until the next poll.
+            ReleaseUndisclosedBatchOwners(firstUndisclosedOwner);
+            throw;
+        }
+    }
+
+    private List<ShareConsumeResult<TKey, TValue>> ParsePartitionRecordsCore(
+        TopicInfo topicInfo,
+        ShareFetchResponsePartition partition,
+        int maxRecords)
+    {
         var results = new List<ShareConsumeResult<TKey, TValue>>();
 
+        // A parser call covers one partition; reuse its owner pool across source batches.
+        ShareRecordBatchOwner.Pool? ownerPool = null;
         var reader = new KafkaProtocolReader(partition.RecordBytes);
         var acquiredRecordIndex = 0;
         while (!reader.End && results.Count < maxRecords)
@@ -1442,13 +1511,15 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             RecordBatch batch;
             try
             {
-                batch = RecordBatch.Read(ref reader, _compressionCodecs);
+                batch = RecordBatch.ReadForShareConsumer(ref reader, _compressionCodecs,
+                    _recordBuffers ??= new ShareRecordBufferPool(_options.FetchMaxBytes));
             }
             catch (InsufficientDataException)
             {
                 break; // Partial batch
             }
 
+            ShareRecordBatchOwner? owner = null;
             try
             {
                 batch.ConfigureHeaderRouting(_recordHeaderRoutingPlan);
@@ -1516,7 +1587,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                             record.IsValueNull ? (ReadOnlyMemory<byte>?)null : record.Value);
                     }
 
-                    results.Add(new ShareConsumeResult<TKey, TValue>
+                    if (!_inputIsolatedDeserializers || headers.Length != 0)
+                        owner ??= RetainParsedBatch(
+                            ownerPool ??= GetRecordBatchOwnerPool(new TopicPartition(topicInfo.Name, partition.PartitionIndex)), batch);
+                    var result = new ShareConsumeResult<TKey, TValue>
                     {
                         Topic = topicInfo.Name,
                         Partition = partition.PartitionIndex,
@@ -1526,12 +1600,18 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                         Headers = headers,
                         TimestampMs = batch.BaseTimestamp + record.TimestampDelta,
                         DeliveryCount = deliveryCount
-                    });
+                    };
+                    if (owner is not null)
+                        result.AttachBatchOwner(owner);
+                    results.Add(result);
                 }
             }
             finally
             {
-                batch.DisposeAndReturnUnownedConsumerBatch();
+                if (owner is null)
+                    batch.DisposeAndReturnUnownedConsumerBatch();
+                else
+                    owner.CompleteParsing();
             }
         }
 
@@ -1549,6 +1629,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         bool hasRetainedKey,
         TKey? retainedKey)
     {
+        ShareRecordBatchOwner.Pool? ownerPool = null;
         while (results.Count < maxRecords)
         {
             if (parserState.CurrentBatch is null)
@@ -1560,7 +1641,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     partition.RecordBytes[parserState.NextBatchByteOffset..]);
                 try
                 {
-                    parserState.CurrentBatch = RecordBatch.Read(ref reader, _compressionCodecs);
+                    parserState.CurrentBatch = RecordBatch.ReadForShareConsumer(ref reader, _compressionCodecs,
+                        _recordBuffers ??= new ShareRecordBufferPool(_options.FetchMaxBytes));
                 }
                 catch (InsufficientDataException)
                 {
@@ -1690,7 +1772,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                         record.IsValueNull ? (ReadOnlyMemory<byte>?)null : record.Value);
                 }
 
-                results.Add(new ShareConsumeResult<TKey, TValue>
+                if (!_inputIsolatedDeserializers || headers.Length != 0)
+                    parserState.CurrentOwner ??= RetainParsedBatch(
+                        ownerPool ??= GetRecordBatchOwnerPool(new TopicPartition(topicInfo.Name, partition.PartitionIndex)), batch);
+                var result = new ShareConsumeResult<TKey, TValue>
                 {
                     Topic = topicInfo.Name,
                     Partition = partition.PartitionIndex,
@@ -1700,7 +1785,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     Headers = headers,
                     TimestampMs = batch.BaseTimestamp + record.TimestampDelta,
                     DeliveryCount = deliveryCount
-                });
+                };
+                if (parserState.CurrentOwner is { } owner)
+                    result.AttachBatchOwner(owner);
+                results.Add(result);
                 parserState.RecordIndex++;
                 hasRetainedKey = false;
                 retainedKey = default;
@@ -1823,13 +1911,18 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     internal struct DeserializerPreparationParserState
     {
         internal RecordBatch? CurrentBatch;
+        internal ShareRecordBatchOwner? CurrentOwner;
         internal int NextBatchByteOffset;
         internal int RecordIndex;
         internal int AcquiredRecordIndex;
 
         internal void DisposeCurrentBatch()
         {
-            CurrentBatch?.DisposeAndReturnUnownedConsumerBatch();
+            if (CurrentOwner is null)
+                CurrentBatch?.DisposeAndReturnUnownedConsumerBatch();
+            else
+                CurrentOwner.CompleteParsing();
+            CurrentOwner = null;
             CurrentBatch = null;
             RecordIndex = 0;
         }
@@ -2195,14 +2288,16 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         }
 
         var key = new RenewedRecordKey(record.Topic, record.Partition, record.Offset);
-        _renewedRecords ??= [];
-        if (_renewedRecords.TryGetValue(key, out var state))
+        if (_renewedRecords is not null && _renewedRecords.TryGetValue(key, out var state))
         {
             state.Record = record;
             state.Active = false;
         }
         else
-            _renewedRecords[key] = new RenewedRecordState(record);
+        {
+            var renewed = new RenewedRecordState(record);
+            (_renewedRecords ??= [])[key] = renewed;
+        }
 
         Interlocked.Increment(ref _renewalRequestCount);
         LogRenewalRequested(record.Topic, record.Partition, record.Offset);
@@ -2242,7 +2337,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     }
                     else
                     {
-                        _renewedRecords.Remove(key);
+                        ReleaseRenewedRecord(key);
                     }
                 }
             }
@@ -2286,6 +2381,22 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 continue;
             }
 
+            // A terminal CommitAsync inside the replay handler can remove the
+            // renewal state. Keep this delivery's payload alive until the next poll.
+            if (state.Record.BatchOwner is { RenewalPinned: false } owner)
+            {
+                owner.Retain();
+                try
+                {
+                    _polledBatchOwners.Add(owner);
+                    owner.RenewalPinned = true;
+                }
+                catch
+                {
+                    owner.Release();
+                    throw;
+                }
+            }
             records.Add(state.Record);
             if (records.Count == maxRecords)
                 break;
@@ -2299,7 +2410,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         if (_renewedRecords is null)
             return;
 
-        _renewedRecords.Remove(new RenewedRecordKey(topic, partition, offset));
+        ReleaseRenewedRecord(new RenewedRecordKey(topic, partition, offset));
         if (_renewedRecords.Count == 0)
             _renewedRecords = null;
     }
@@ -2323,13 +2434,87 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             return;
 
         foreach (var key in removed)
-            _renewedRecords.Remove(key);
+            ReleaseRenewedRecord(key);
 
         if (_renewedRecords.Count == 0)
             _renewedRecords = null;
     }
 
-    private void ClearRenewedRecords() => _renewedRecords = null;
+    private void ReleaseRenewedRecord(RenewedRecordKey key)
+    {
+        if (_renewedRecords!.Remove(key, out var state))
+            state.Release();
+    }
+
+    private void ClearRenewedRecords()
+    {
+        if (_renewedRecords is null)
+            return;
+        foreach (var state in _renewedRecords.Values)
+            state.Release();
+        _renewedRecords = null;
+    }
+
+    private ShareRecordBatchOwner.Pool GetRecordBatchOwnerPool(TopicPartition partition)
+    {
+        _recordBatchOwnerPools ??= new();
+        if (!_recordBatchOwnerPools.TryGetValue(partition, out var pool))
+        {
+            pool = new ShareRecordBatchOwner.Pool(partition);
+            _recordBatchOwnerPools.Add(partition, pool);
+        }
+        return pool;
+    }
+
+    private ShareRecordBatchOwner RetainParsedBatch(ShareRecordBatchOwner.Pool pool, RecordBatch batch)
+    {
+        var owner = pool.Rent(batch);
+        _polledBatchOwners.Add(owner);
+        return owner;
+    }
+
+    internal RecordBatchScope BeginRecordBatchScope()
+    {
+        // Keep the last delivery valid between iterator disposal and the next poll,
+        // so callers can acknowledge Renew after consuming a single record.
+        ReleasePolledBatchOwners();
+        _recordBatchScopes++;
+        return new RecordBatchScope(this);
+    }
+
+    private void ReleaseUndisclosedBatchOwners(int firstOwner)
+    {
+        for (var index = _polledBatchOwners.Count - 1; index >= firstOwner; index--)
+        {
+            var owner = _polledBatchOwners[index];
+            _polledBatchOwners.RemoveAt(index);
+            owner.RenewalPinned = false;
+            owner.Release();
+        }
+    }
+
+    private void ReleasePolledBatchOwners()
+    {
+        foreach (var owner in _polledBatchOwners)
+        {
+            owner.RenewalPinned = false;
+            owner.Release();
+        }
+        _polledBatchOwners.Clear();
+    }
+
+    internal readonly struct RecordBatchScope(KafkaShareConsumer<TKey, TValue> consumer) : IDisposable
+    {
+        public void Dispose()
+        {
+            consumer._recordBatchScopes--;
+            if (consumer._recordBatchScopes == 0 && Volatile.Read(ref consumer._disposed) != 0)
+            {
+                consumer.ReleasePolledBatchOwners();
+                consumer._recordBuffers?.Dispose();
+            }
+        }
+    }
 
     /// <summary>
     /// Groups acknowledgement data by leader broker.
@@ -2452,11 +2637,33 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
 
     private readonly record struct RenewedRecordKey(string Topic, int Partition, long Offset);
 
-    private sealed class RenewedRecordState(ShareConsumeResult<TKey, TValue> record)
+    private sealed class RenewedRecordState
     {
-        internal ShareConsumeResult<TKey, TValue> Record { get; set; } = record;
-        // The sign stores pending/active state in the timestamp, replacing the bool and its
-        // padding instead of adding another per-record field. Zero means no confirmed renewal.
+        private ShareConsumeResult<TKey, TValue> _record;
+
+        internal RenewedRecordState(ShareConsumeResult<TKey, TValue> record)
+        {
+            record.BatchOwner?.Retain();
+            _record = record;
+        }
+
+        internal ShareConsumeResult<TKey, TValue> Record
+        {
+            get => _record;
+            set
+            {
+                if (!ReferenceEquals(_record.BatchOwner, value.BatchOwner))
+                {
+                    value.BatchOwner?.Retain();
+                    _record.BatchOwner?.Release();
+                }
+                _record = value;
+            }
+        }
+
+        internal void Release() => _record.BatchOwner?.Release();
+        // Preserve the receipt timestamp used by hosted handlers without adding
+        // another field for pending/active state.
         internal long ReceiptTimestamp { get; set; }
         internal bool Active
         {

--- a/src/Dekaf/ShareConsumer/ShareConsumeResult.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumeResult.cs
@@ -7,17 +7,60 @@ namespace Dekaf.ShareConsumer;
 /// Unlike the regular consumer's <c>ConsumeResult</c> (a readonly struct), this is a class
 /// because the acknowledgement state is mutable between poll and commit.
 /// </summary>
+/// <remarks>
+/// Deserializers that borrow their input, and header value views, remain valid for the
+/// current poll round and after iterator disposal, until the next poll round starts or
+/// the consumer is disposed. Copy them before keeping them beyond that boundary.
+/// Renew acknowledgements made before that boundary retain the payload for subsequent replay delivery.
+/// </remarks>
 public sealed class ShareConsumeResult<TKey, TValue>
 {
+    // The batch owner also stores the topic. Reuse this reference slot so payload
+    // ownership does not add a field/allocation to every delivered record.
+    private object _topicOrBatchOwner = null!;
+    private byte _acknowledgement = (byte)AcknowledgeType.Accept;
+    private int _partitionOrGeneration;
+
+    internal ShareRecordBatchOwner? BatchOwner
+    {
+        get
+        {
+            if (_topicOrBatchOwner is not ShareRecordBatchOwner owner)
+                return null;
+            if (unchecked((uint)~_partitionOrGeneration) != owner.Generation)
+                throw new InvalidOperationException("Cannot renew a record after its borrowed payload lifetime has ended.");
+            return owner;
+        }
+    }
+
+    internal void AttachBatchOwner(ShareRecordBatchOwner owner)
+    {
+        // Owners keep immutable partition metadata, freeing the existing partition
+        // word for a generation without growing any generic record layout. The
+        // complement keeps ordinary nonnegative partition reads on the fast path.
+        _partitionOrGeneration = ~unchecked((int)owner.Generation);
+        _topicOrBatchOwner = owner;
+    }
+
     /// <summary>
     /// The topic this record was consumed from.
     /// </summary>
-    public required string Topic { get; init; }
+    public required string Topic
+    {
+        get => _topicOrBatchOwner is ShareRecordBatchOwner owner ? owner.Topic : (string)_topicOrBatchOwner;
+        init => _topicOrBatchOwner = value;
+    }
 
     /// <summary>
     /// The partition this record was consumed from.
     /// </summary>
-    public required int Partition { get; init; }
+    public required int Partition
+    {
+        get => _partitionOrGeneration < 0 && _topicOrBatchOwner is ShareRecordBatchOwner owner
+            ? owner.Partition
+            : _partitionOrGeneration;
+        init => _partitionOrGeneration = value;
+    }
 
     /// <summary>
     /// The offset of this record within the partition.
@@ -60,5 +103,13 @@ public sealed class ShareConsumeResult<TKey, TValue>
     /// The acknowledgement state for this record. Defaults to Accept.
     /// Updated via <see cref="IKafkaShareConsumer{TKey,TValue}.Acknowledge"/>.
     /// </summary>
-    internal AcknowledgeType AcknowledgeType { get; set; } = AcknowledgeType.Accept;
+    internal AcknowledgeType AcknowledgeType
+    {
+        get => (AcknowledgeType)_acknowledgement;
+        set
+        {
+            System.Diagnostics.Debug.Assert((byte)value <= (byte)AcknowledgeType.Renew);
+            _acknowledgement = (byte)value;
+        }
+    }
 }

--- a/src/Dekaf/ShareConsumer/ShareRecordBatchOwner.cs
+++ b/src/Dekaf/ShareConsumer/ShareRecordBatchOwner.cs
@@ -1,0 +1,124 @@
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.ShareConsumer;
+
+/// <summary>Owns parsed payload storage for one poll and any renewed records from that batch.</summary>
+internal sealed class ShareRecordBatchOwner
+{
+    internal const uint MaximumGeneration = int.MaxValue;
+    // One reference belongs to the parser, one to the poll scope. Renewals add
+    // references only when requested; ordinary delivery needs no per-record counter.
+    private int _references;
+    // A replay snapshot retains each owner once, even when records are interleaved.
+    internal bool RenewalPinned;
+    private RecordBatch? _batch;
+    private byte[]? _payload;
+    private ArrayPool<byte>? _payloadPool;
+    private readonly Pool _pool;
+
+    private ShareRecordBatchOwner(TopicPartition partition, Pool pool)
+    {
+        Topic = partition.Topic;
+        Partition = partition.Partition;
+        _pool = pool;
+    }
+
+    // Metadata never changes: results retained past their payload lifetime still expose it.
+    internal string Topic { get; }
+    internal int Partition { get; }
+    internal uint Generation { get; private set; }
+
+    internal void Retain()
+    {
+        // IKafkaShareConsumer requires serialized access to its operations.
+        if (_references == 0)
+            throw new InvalidOperationException("Cannot renew a record after its borrowed payload lifetime has ended.");
+        _references++;
+    }
+
+    internal void Release()
+    {
+        if (--_references != 0)
+            return;
+        var batch = _batch;
+        _batch = null;
+        batch?.DisposeAndReturnUnownedConsumerBatch();
+        var payload = _payload;
+        var payloadPool = _payloadPool;
+        _payload = null;
+        _payloadPool = null;
+        if (payload is not null)
+            payloadPool!.Return(payload);
+        // Never wrap the generation: an arbitrarily old result must not become valid
+        // again. Only exhaustion of the full generation retires an owner.
+        if (Generation != MaximumGeneration)
+            _pool.Return(this);
+        else
+            _pool.RetireOwner();
+    }
+
+    internal void CompleteParsing()
+    {
+        var batch = _batch!;
+        _payload = batch.DetachRecordData(out _payloadPool);
+        _batch = null;
+        batch.DisposeAndReturnUnownedConsumerBatch();
+        Release();
+    }
+
+    // Consumer operations already serialize owner references and pool access.
+    internal sealed class Pool(TopicPartition partition)
+    {
+        private ShareRecordBatchOwner?[] _available = new ShareRecordBatchOwner?[128];
+        private int _availableCount;
+        private int _ownerCount;
+        private long _misses;
+
+        internal int MaxPoolSize => _available.Length;
+        internal long Misses => _misses;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal ShareRecordBatchOwner Rent(RecordBatch batch)
+        {
+            ShareRecordBatchOwner owner;
+            if (_availableCount == 0)
+            {
+                owner = Create();
+            }
+            else
+            {
+                var index = --_availableCount;
+                owner = _available[index]!;
+                _available[index] = null;
+            }
+            owner.Generation++;
+            owner._references = 2;
+            owner._batch = batch;
+            return owner;
+        }
+
+        private ShareRecordBatchOwner Create()
+        {
+            // Serialized consumer access means this count includes both pooled owners
+            // and owners retained by a poll or renewal. Grow only on a pool miss;
+            // ordinary rents/returns add no counter or capacity check per batch.
+            if (_ownerCount == _available.Length)
+            {
+                // A miss means every slot is empty; no retained references need copying.
+                _available = new ShareRecordBatchOwner?[
+                    _available.Length <= int.MaxValue / 2 ? _available.Length * 2 : int.MaxValue];
+            }
+            var owner = new ShareRecordBatchOwner(partition, this);
+            _ownerCount++;
+            _misses++;
+            return owner;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void Return(ShareRecordBatchOwner owner) => _available[_availableCount++] = owner;
+
+        internal void RetireOwner() => _ownerCount--;
+    }
+}

--- a/src/Dekaf/ShareConsumer/ShareRecordBufferPool.cs
+++ b/src/Dekaf/ShareConsumer/ShareRecordBufferPool.cs
@@ -1,0 +1,68 @@
+using System.Buffers;
+using System.Numerics;
+
+namespace Dekaf.ShareConsumer;
+
+/// <summary>
+/// Caches copied/decompressed payload arrays across serialized share-consumer operations.
+/// Retained array capacity is bounded by one configured fetch; outstanding borrowed arrays are
+/// never reclaimed to satisfy the cache limit. Disposal drops late returns into the shared pool.
+/// </summary>
+internal sealed class ShareRecordBufferPool(int maximumRetainedBytes) : ArrayPool<byte>, IDisposable
+{
+    private readonly Stack<byte[]>?[] _buckets = new Stack<byte[]>?[31];
+    private int _retainedBytes;
+    private bool _disposed;
+
+    internal int RetainedBytes => _retainedBytes;
+
+    public override byte[] Rent(int minimumLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(minimumLength);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (minimumLength > 0 && minimumLength <= maximumRetainedBytes && minimumLength <= 1 << 30)
+        {
+            var bucket = BitOperations.Log2(BitOperations.RoundUpToPowerOf2((uint)Math.Max(16, minimumLength)));
+            if (_buckets[bucket] is { Count: > 0 } arrays)
+            {
+                var array = arrays.Pop();
+                _retainedBytes -= array.Length;
+                return array;
+            }
+        }
+        return Shared.Rent(minimumLength);
+    }
+
+    public override void Return(byte[] array, bool clearArray = false)
+    {
+        ArgumentNullException.ThrowIfNull(array);
+        if (array.Length == 0)
+            return;
+        if (_disposed || array.Length > maximumRetainedBytes - _retainedBytes || array.Length > 1 << 30)
+        {
+            Shared.Return(array, clearArray);
+            return;
+        }
+        if (clearArray)
+            Array.Clear(array, 0, array.Length);
+        var bucket = BitOperations.Log2((uint)array.Length);
+        (_buckets[bucket] ??= new Stack<byte[]>()).Push(array);
+        _retainedBytes += array.Length;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        foreach (var arrays in _buckets)
+        {
+            if (arrays is null)
+                continue;
+            while (arrays.Count != 0)
+                Shared.Return(arrays.Pop());
+        }
+        Array.Clear(_buckets, 0, _buckets.Length);
+        _retainedBytes = 0;
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ShareConsumerCloseTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerCloseTests.cs
@@ -1,4 +1,5 @@
 using Dekaf.Admin;
+using Dekaf.Serialization;
 using Dekaf.ShareConsumer;
 
 namespace Dekaf.Tests.Integration;
@@ -8,6 +9,84 @@ namespace Dekaf.Tests.Integration;
 [NotInParallel("ShareConsumerKafka42")]
 public class ShareConsumerCloseTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
+    [Test]
+    public async Task Dispose_DuringPreparation_StopsDeliveryAndReleasesAcquisitions()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var group = $"share-dispose-preparation-{Guid.NewGuid():N}";
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).Build();
+        await admin.IncrementalAlterConfigsAsync(new Dictionary<ConfigResource, IReadOnlyList<ConfigAlter>>
+        {
+            [new ConfigResource { Type = ConfigResourceType.Group, Name = group }] =
+                [ConfigAlter.Set("share.auto.offset.reset", "earliest")]
+        });
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).BuildAsync();
+        await ShareConsumerTestHelper.ProduceAsync(producer, topic, count: 2);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var preparer = new PausedPreparer();
+        await using var first = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId(group)
+            .WithValueDeserializer(preparer).BuildAsync();
+        first.Subscribe(topic);
+        await using (var poll = first.PollAsync(timeout.Token).GetAsyncEnumerator())
+        {
+            var pending = poll.MoveNextAsync().AsTask();
+            bool delivered;
+            try
+            {
+                await preparer.Entered.Task.WaitAsync(timeout.Token);
+                await first.DisposeAsync();
+            }
+            finally
+            {
+                preparer.Release.TrySetResult();
+                delivered = await pending.WaitAsync(timeout.Token);
+            }
+            await Assert.That(delivered).IsFalse();
+        }
+
+        await using var second = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId(group).BuildAsync();
+        second.Subscribe(topic);
+        var values = new List<string?>();
+        await foreach (var record in second.PollAsync(timeout.Token))
+        {
+            values.Add(record.Value);
+            second.Acknowledge(record);
+            if (values.Count == 2)
+                break;
+        }
+        string?[] expected = ["value-0", "value-1"];
+        await Assert.That(values).IsEquivalentTo(expected);
+        await second.CommitAsync(timeout.Token);
+    }
+
+    private sealed class PausedPreparer : IDeserializer<string>, IAsyncDeserializerPreparer<string>
+    {
+        private bool _prepared;
+        internal TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) =>
+            Serializers.String.Deserialize(data, context);
+
+        public bool TryDeserialize(ReadOnlyMemory<byte> data, SerializationContext context, out string value)
+        {
+            value = _prepared ? Deserialize(data, context) : string.Empty;
+            return _prepared;
+        }
+
+        public async ValueTask PrepareAsync(ReadOnlyMemory<byte> data, SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            Entered.TrySetResult();
+            await Release.Task.WaitAsync(cancellationToken);
+            _prepared = true;
+        }
+    }
+
     [Test]
     [Arguments(false, false)]
     [Arguments(false, true)]

--- a/tests/Dekaf.Tests.Integration/ShareConsumerOwnershipLoadTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerOwnershipLoadTests.cs
@@ -1,0 +1,104 @@
+using System.Buffers.Binary;
+using System.Globalization;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("ShareConsumer")]
+[SupportsKafka(430)]
+[NotInParallel("ShareConsumerKafka42")]
+public class ShareConsumerOwnershipLoadTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    [Arguments(32)]
+    [Arguments(128 * 1024)]
+    public async Task RenewedBorrowedRecord_SurvivesSustainedMultiPartitionFetches(int payloadSize)
+    {
+        const int rounds = 64;
+        const int recordsPerRound = 16;
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 4);
+        await using var producer = await Kafka.CreateProducer<string, byte[]>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).BuildAsync();
+        await using var consumer = await Kafka.CreateShareConsumer<string, ReadOnlyMemory<byte>>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId($"share-ownership-load-{Guid.NewGuid():N}")
+            .WithValueDeserializer(Serializers.RawBytes)
+            .WithAcknowledgementMode(ShareAcknowledgementMode.Explicit)
+            .WithMaxPollRecords(recordsPerRound).WithFetchMaxBytes(256 * 1024).WithFetchMaxWaitMs(25)
+            .BuildAsync();
+        consumer.Subscribe(topic);
+        await ShareConsumerTestHelper.PrimeShareConsumerAsync(consumer);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        var received = new HashSet<int>();
+        ShareConsumeResult<string, ReadOnlyMemory<byte>>? retained = null;
+        var retainedId = -1;
+        for (var round = 0; round < rounds; round++)
+        {
+            for (var index = 0; index < recordsPerRound; index++)
+            {
+                var id = round * recordsPerRound + index;
+                var value = new byte[payloadSize];
+                value.AsSpan().Fill((byte)id);
+                BinaryPrimitives.WriteInt32LittleEndian(value, id);
+                // Each awaited delivery creates another broker batch. The large case
+                // crosses the native response threshold and repeatedly reuses storage.
+                await producer.ProduceAsync(new ProducerMessage<string, byte[]>
+                {
+                    Topic = topic, Partition = id % 4, Key = id.ToString(CultureInfo.InvariantCulture),
+                    Value = value, Headers = Headers.Create("identity", id.ToString(CultureInfo.InvariantCulture))
+                }, timeout.Token);
+            }
+
+            await foreach (var record in consumer.PollAsync(timeout.Token))
+            {
+                var id = int.Parse(record.Key!, CultureInfo.InvariantCulture);
+                await AssertPayloadAsync(record, id, payloadSize);
+                // Renew submissions use acknowledgement-only ShareFetch requests.
+                // Requeueing Renew on every local replay would prevent fresh acquisition.
+                // The existing renewal stays active until the next round's commit.
+                if (ReferenceEquals(record, retained)) continue;
+
+                await Assert.That(received.Add(id)).IsTrue();
+                if (retained is null)
+                {
+                    retained = record;
+                    retainedId = id;
+                    consumer.Acknowledge(record, AcknowledgeType.Renew);
+                }
+                else
+                {
+                    consumer.Acknowledge(record, AcknowledgeType.Accept);
+                    await AssertPayloadAsync(retained, retainedId, payloadSize);
+                }
+                if (received.Count == (round + 1) * recordsPerRound) break;
+            }
+
+            // Iterator disposal preserves this poll's views. Repeated Renew extends
+            // the original batch lifetime while unrelated batches cycle through pools.
+            consumer.Acknowledge(retained!, AcknowledgeType.Renew);
+            await consumer.CommitAsync(timeout.Token);
+            await AssertPayloadAsync(retained!, retainedId, payloadSize);
+        }
+
+        await Assert.That(received.Count).IsEqualTo(rounds * recordsPerRound);
+        consumer.Acknowledge(retained!, AcknowledgeType.Accept);
+        await consumer.CommitAsync(timeout.Token);
+        await consumer.CloseAsync(timeout.Token);
+    }
+
+    private static async ValueTask AssertPayloadAsync(
+        ShareConsumeResult<string, ReadOnlyMemory<byte>> record, int id, int payloadSize)
+    {
+        await Assert.That(record.Value.Length).IsEqualTo(payloadSize);
+        await Assert.That(BinaryPrimitives.ReadInt32LittleEndian(record.Value.Span)).IsEqualTo(id);
+        await Assert.That(record.Value.Span[sizeof(int)..].IndexOfAnyExcept((byte)id)).IsEqualTo(-1);
+        // Producer tracing can inject additional headers. Validate the application
+        // header by identity, including its borrowed value after other batches parse.
+        var header = record.Headers.Single(static item => item.Key == "identity");
+        await Assert.That(System.Text.Encoding.UTF8.GetString(header.Value.Span))
+            .IsEqualTo(id.ToString(CultureInfo.InvariantCulture));
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
@@ -21,6 +21,51 @@ namespace Dekaf.Tests.Integration;
 public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]
+    [Arguments(32)]
+    [Arguments(128 * 1024)]
+    public async Task ShareConsumer_BorrowedPayloadsAndHeaders_SurviveParsingOtherBatches(int payloadSize)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).BuildAsync();
+        await using var consumer = await Kafka.CreateShareConsumer<string, ReadOnlyMemory<byte>>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId($"share-borrow-{Guid.NewGuid():N}")
+            .WithValueDeserializer(Serializers.RawBytes)
+            .WithAcknowledgementMode(ShareAcknowledgementMode.Explicit).WithMaxPollRecords(2)
+            .BuildAsync();
+        consumer.Subscribe(topic);
+        await ShareConsumerTestHelper.PrimeShareConsumerAsync(consumer);
+
+        var values = new[] { new string('a', payloadSize), new string('b', payloadSize) };
+        for (var index = 0; index < values.Length; index++)
+        {
+            // Await delivery so each record is a separate broker batch.
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic, Partition = 0, Key = index.ToString(), Value = values[index],
+                Headers = Headers.Create("test", values[index])
+            });
+        }
+
+        var received = new HashSet<int>();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await foreach (var record in consumer.PollAsync(timeout.Token))
+        {
+            var index = int.Parse(record.Key!);
+            await Assert.That(received.Add(index)).IsTrue();
+            await Assert.That(System.Text.Encoding.UTF8.GetString(record.Value.Span)).IsEqualTo(values[index]);
+            var header = record.Headers.Single(static header => header.Key == "test");
+            await Assert.That(System.Text.Encoding.UTF8.GetString(header.Value.Span)).IsEqualTo(values[index]);
+            consumer.Acknowledge(record);
+            await consumer.CommitAsync(timeout.Token);
+            await Assert.That(System.Text.Encoding.UTF8.GetString(record.Value.Span)).IsEqualTo(values[index]);
+            if (received.Count == values.Length)
+                break;
+        }
+        await Assert.That(received.Count).IsEqualTo(values.Length);
+    }
+
+    [Test]
     [Arguments(1)]
     [Arguments(4)]
     public async Task ShareConsumer_NativeResponsePayload_RemainsReadable(int messageCount)
@@ -646,8 +691,8 @@ public class ShareConsumerAdminTests(KafkaTestContainer kafka) : KafkaIntegratio
 /// </summary>
 internal static class ShareConsumerTestHelper
 {
-    internal static async Task PrimeShareConsumerAsync(
-        IKafkaShareConsumer<string, string> consumer)
+    internal static async Task PrimeShareConsumerAsync<TKey, TValue>(
+        IKafkaShareConsumer<TKey, TValue> consumer)
     {
         using var pollCts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         var pollTask = PollUntilCanceledAsync(consumer, pollCts.Token);
@@ -681,8 +726,8 @@ internal static class ShareConsumerTestHelper
         await producer.FlushAsync();
     }
 
-    private static async Task PollUntilCanceledAsync(
-        IKafkaShareConsumer<string, string> consumer, CancellationToken cancellationToken)
+    private static async Task PollUntilCanceledAsync<TKey, TValue>(
+        IKafkaShareConsumer<TKey, TValue> consumer, CancellationToken cancellationToken)
     {
         try
         {
@@ -695,8 +740,8 @@ internal static class ShareConsumerTestHelper
         }
     }
 
-    private static async Task WaitForShareAssignmentAsync(
-        IKafkaShareConsumer<string, string> consumer, TimeSpan timeout)
+    private static async Task WaitForShareAssignmentAsync<TKey, TValue>(
+        IKafkaShareConsumer<TKey, TValue> consumer, TimeSpan timeout)
     {
         var startedAt = Stopwatch.GetTimestamp();
         while (Stopwatch.GetElapsedTime(startedAt) < timeout)

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
@@ -199,7 +199,9 @@ public sealed class ShareConsumerConnectionOwnershipTests
     }
 
     [Test]
-    public async Task SendShareFetchForPartitionsAsync_RetriesRetriableTopLevelError()
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task SendShareFetchForPartitionsAsync_DisposesRetriableResponseBeforeRefresh(bool cancelDuringRefresh)
     {
         var options = new ShareConsumerOptions
         {
@@ -209,6 +211,16 @@ public sealed class ShareConsumerConnectionOwnershipTests
             RetryBackoffMs = 0,
             RetryBackoffMaxMs = 0
         };
+        using var cancellation = new CancellationTokenSource();
+        var memory = new TrackingMemory();
+        using var rejected = new ShareFetchResponse
+        {
+            ErrorCode = ErrorCode.CoordinatorLoadInProgress,
+            Responses = [],
+            NodeEndpoints = [],
+            PooledMemoryOwner = memory
+        };
+        var disposalsAtRefresh = -1;
         var connection = new LeaseTrackingConnection(
             new ApiVersion(
                 ApiKey.ShareFetch,
@@ -219,14 +231,15 @@ public sealed class ShareConsumerConnectionOwnershipTests
                 MetadataRequest.LowestSupportedVersion,
                 MetadataRequest.HighestSupportedVersion))
         {
+            OnMetadataRequest = () =>
+            {
+                disposalsAtRefresh = memory.Disposals;
+                if (cancelDuringRefresh)
+                    cancellation.Cancel();
+            },
             ShareFetchResponses = new Queue<ShareFetchResponse>(
             [
-                new ShareFetchResponse
-                {
-                    ErrorCode = ErrorCode.CoordinatorLoadInProgress,
-                    Responses = [],
-                    NodeEndpoints = []
-                },
+                rejected,
                 new ShareFetchResponse
                 {
                     ErrorCode = ErrorCode.None,
@@ -248,11 +261,20 @@ public sealed class ShareConsumerConnectionOwnershipTests
             metadataManager);
         SetMemberId(consumer, "member-1");
 
-        var sendTask = InvokeSendShareFetchForPartitionsAsync(consumer);
+        var sendTask = InvokeSendShareFetchForPartitionsAsync(consumer, cancellation.Token);
 
-        await sendTask;
+        if (cancelDuringRefresh)
+            await Assert.That(async () => await sendTask).Throws<OperationCanceledException>();
+        else
+            await sendTask;
 
-        await Assert.That(connection.ShareFetchSendCount).IsEqualTo(2);
+        await Assert.That(disposalsAtRefresh).IsEqualTo(1);
+        await Assert.That(memory.Disposals).IsEqualTo(1);
+        await Assert.That(rejected.PooledMemoryOwner).IsNull();
+        rejected.Dispose();
+        await Assert.That(memory.Disposals).IsEqualTo(1);
+
+        await Assert.That(connection.ShareFetchSendCount).IsEqualTo(cancelDuringRefresh ? 1 : 2);
         await Assert.That(connection.LeaseCount).IsEqualTo(0);
     }
 
@@ -327,7 +349,8 @@ public sealed class ShareConsumerConnectionOwnershipTests
     }
 
     private static Task InvokeSendShareFetchForPartitionsAsync(
-        KafkaShareConsumer<string, string> consumer)
+        KafkaShareConsumer<string, string> consumer,
+        CancellationToken cancellationToken = default)
     {
         var method = typeof(KafkaShareConsumer<string, string>).GetMethod(
             "SendShareFetchForPartitionsAsync",
@@ -338,7 +361,7 @@ public sealed class ShareConsumerConnectionOwnershipTests
                 1,
                 new List<TopicPartition> { new("topic", 0) },
                 null,
-                CancellationToken.None
+                cancellationToken
             ])!;
     }
 
@@ -360,6 +383,13 @@ public sealed class ShareConsumerConnectionOwnershipTests
         GroupId = "share-group",
         ConnectionsPerBroker = 2
     };
+
+    private sealed class TrackingMemory : IPooledMemory
+    {
+        public ReadOnlyMemory<byte> Memory => ReadOnlyMemory<byte>.Empty;
+        public int Disposals { get; private set; }
+        public void Dispose() => Disposals++;
+    }
 
     private sealed class LeaseTrackingConnection(params ApiVersion[] versions) :
         IKafkaConnection,
@@ -383,6 +413,7 @@ public sealed class ShareConsumerConnectionOwnershipTests
         public int LeaseCountDuringSend { get; private set; }
         public int ShareFetchSendCount { get; private set; }
         public int ShareAcknowledgeSendCount { get; private set; }
+        public Action? OnMetadataRequest { get; init; }
         public Queue<ShareFetchResponse>? ShareFetchResponses { get; init; }
         public ShareAcknowledgeResponse? ShareAcknowledgeResponse { get; init; }
 
@@ -418,6 +449,8 @@ public sealed class ShareConsumerConnectionOwnershipTests
             where TResponse : IKafkaResponse
         {
             LeaseCountDuringSend = LeaseCount;
+            if (request is MetadataRequest)
+                OnMetadataRequest?.Invoke();
             IKafkaResponse response = request switch
             {
                 ShareGroupHeartbeatRequest => new ShareGroupHeartbeatResponse

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRecordPoolingTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRecordPoolingTests.cs
@@ -74,14 +74,261 @@ public sealed class ShareConsumerRecordPoolingTests
     }
 
     [Test]
+    public async Task NextPoll_ReusedOwnerRejectsStaleRenewal()
+    {
+        var consumer = CreateBorrowedConsumer(out var metadata);
+        await using var metadataScope = metadata;
+        await using var consumerScope = consumer;
+        ShareConsumeResult<string, ReadOnlyMemory<byte>> original;
+        using (consumer.BeginRecordBatchScope())
+            original = ParseBorrowedRecords(consumer, "first")[0];
+        var owner = original.BatchOwner;
+        using (consumer.BeginRecordBatchScope())
+        {
+            var current = ParseBorrowedRecords(consumer, "other")[0];
+            await Assert.That(current.BatchOwner).IsSameReferenceAs(owner);
+            await Assert.That(original.Topic).IsEqualTo("topic");
+            await Assert.That(original.DeliveryCount).IsEqualTo(1);
+            await Assert.That(() => consumer.Acknowledge(original, AcknowledgeType.Renew))
+                .Throws<InvalidOperationException>();
+            await Assert.That(original.AcknowledgeType).IsEqualTo(AcknowledgeType.Accept);
+            await Assert.That(System.Text.Encoding.UTF8.GetString(current.Value.Span)).IsEqualTo("other");
+            await Assert.That(() => consumer.Acknowledge(current, (AcknowledgeType)255))
+                .Throws<ArgumentOutOfRangeException>();
+            await Assert.That(current.BatchOwner).IsSameReferenceAs(owner);
+            await Assert.That(current.AcknowledgeType).IsEqualTo(AcknowledgeType.Accept);
+            consumer.Acknowledge(current, AcknowledgeType.Renew);
+        }
+    }
+
+    [Test]
     [NotInParallel]
-    public async Task ParsePartitionRecords_DeserializerThrows_ReturnsBatchToPool()
+    public async Task ParsePartitionRecords_TwoBatches_PreservesBorrowedValuesAndHeaders()
+    {
+        var consumer = CreateBorrowedConsumer(out var metadata);
+        await using var metadataScope = metadata;
+        await using var consumerScope = consumer;
+        using var recordScope = consumer.BeginRecordBatchScope();
+        var records = ParseBorrowedRecords(consumer, "first", "other");
+
+        await Assert.That(records.Count).IsEqualTo(2);
+        await Assert.That(System.Text.Encoding.UTF8.GetString(records[0].Value.Span)).IsEqualTo("first");
+        await Assert.That(System.Text.Encoding.UTF8.GetString(records[0].Headers[0].Value.Span)).IsEqualTo("first");
+        await Assert.That(System.Text.Encoding.UTF8.GetString(records[1].Value.Span)).IsEqualTo("other");
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task CompletedParsing_ReleasesMaterializedRecordsButRetainsPayload(bool prepared)
+    {
+        var consumer = CreateBorrowedConsumer(out var metadata);
+        await using var metadataScope = metadata;
+        await using var consumerScope = consumer;
+        using var recordScope = consumer.BeginRecordBatchScope();
+        var records = ParseBorrowedRecords(consumer, prepared, "first", "other");
+
+        for (var index = 0; index < records.Count; index++)
+        {
+            var owner = records[index].BatchOwner!;
+            var batch = typeof(ShareRecordBatchOwner)
+                .GetField("_batch", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(owner);
+            await Assert.That(batch).IsNull();
+            var expected = index == 0 ? "first" : "other";
+            await Assert.That(System.Text.Encoding.UTF8.GetString(records[index].Value.Span)).IsEqualTo(expected);
+            await Assert.That(System.Text.Encoding.UTF8.GetString(records[index].Headers[0].Value.Span)).IsEqualTo(expected);
+        }
+    }
+
+    [Test]
+    public async Task Dispose_ReturnsCachedPayloadsAfterResubscription()
+    {
+        var consumer = CreateBorrowedConsumer(out var metadata);
+        await using var metadataScope = metadata;
+        await using var consumerScope = consumer;
+        using (consumer.BeginRecordBatchScope())
+            _ = ParseBorrowedRecords(consumer, "first");
+        using (consumer.BeginRecordBatchScope()) { }
+        var pool = (ShareRecordBufferPool)consumer.GetType()
+            .GetField("_recordBuffers", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(consumer)!;
+        await Assert.That(pool.RetainedBytes).IsGreaterThan(0);
+        consumer.Subscribe("topic");
+        using (consumer.BeginRecordBatchScope())
+            _ = ParseBorrowedRecords(consumer, "other");
+        await consumer.DisposeAsync();
+        await Assert.That(pool.RetainedBytes).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task RenewedReplay_TerminalAcknowledgement_KeepsPayloadUntilNextPoll()
+    {
+        var consumer = CreateBorrowedConsumer(out var metadata);
+        await using var metadataScope = metadata;
+        await using var consumerScope = consumer;
+        ShareConsumeResult<string, ReadOnlyMemory<byte>> record;
+        using (consumer.BeginRecordBatchScope())
+        {
+            record = ParseBorrowedRecords(consumer, "first")[0];
+        }
+        // Consuming a single record disposes its iterator before acknowledging it.
+        consumer.Acknowledge(record, AcknowledgeType.Renew);
+        ApplyAcknowledgement(consumer, AcknowledgeType.Renew);
+
+        var replayScope = consumer.BeginRecordBatchScope();
+        var buffers = (ShareRecordBufferPool)consumer.GetType()
+            .GetField("_recordBuffers", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(consumer)!;
+        int returnedBeforeScopeEnd;
+        int returnedAtScopeEnd;
+        string payload;
+        try
+        {
+            var getActive = consumer.GetType().GetMethod("GetActiveRenewedRecords",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var replay = (List<ShareConsumeResult<string, ReadOnlyMemory<byte>>>)getActive.Invoke(consumer,
+                [new HashSet<TopicPartition> { new("topic", 0) }, 10])!;
+            await Assert.That(replay[0]).IsSameReferenceAs(record);
+            try
+            {
+                ApplyAcknowledgement(consumer, AcknowledgeType.Accept);
+                payload = System.Text.Encoding.UTF8.GetString(replay[0].Value.Span);
+            }
+            finally
+            {
+                returnedBeforeScopeEnd = buffers.RetainedBytes;
+            }
+        }
+        finally
+        {
+            replayScope.Dispose();
+            using var nextPoll = consumer.BeginRecordBatchScope();
+            returnedAtScopeEnd = buffers.RetainedBytes;
+        }
+
+        await Assert.That(payload).IsEqualTo("first");
+        await Assert.That(returnedBeforeScopeEnd).IsEqualTo(0);
+        await Assert.That(returnedAtScopeEnd).IsGreaterThan(0);
+        await Assert.That(record.Topic).IsEqualTo("topic");
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task RenewAfterNextPollStarts_ThrowsWithoutQueueingAcknowledgement()
+    {
+        var consumer = CreateBorrowedConsumer(out var metadata);
+        await using var metadataScope = metadata;
+        await using var consumerScope = consumer;
+        ShareConsumeResult<string, ReadOnlyMemory<byte>> record;
+        using (consumer.BeginRecordBatchScope())
+            record = ParseBorrowedRecords(consumer, "first")[0];
+        using var nextPoll = consumer.BeginRecordBatchScope();
+
+        await Assert.That(() => consumer.Acknowledge(record, AcknowledgeType.Renew))
+            .Throws<InvalidOperationException>();
+        var tracker = (AcknowledgementTracker)consumer.GetType()
+            .GetField("_ackTracker", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(consumer)!;
+        await Assert.That(tracker.HasPending).IsFalse();
+    }
+
+    private static void ApplyAcknowledgement(
+        KafkaShareConsumer<string, ReadOnlyMemory<byte>> consumer, AcknowledgeType type)
+    {
+        var method = consumer.GetType().GetMethod("ApplySuccessfulAcknowledgements",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>> acknowledgements = new()
+        {
+            [new TopicPartition("topic", 0)] = [new AcknowledgementBatchData(0, 0, [(byte)type])]
+        };
+        method.Invoke(consumer, [acknowledgements, 0L]);
+    }
+
+    private static KafkaShareConsumer<string, ReadOnlyMemory<byte>> CreateBorrowedConsumer(
+        out MetadataManager metadata, IDeserializer<ReadOnlyMemory<byte>>? valueDeserializer = null)
+    {
+        var options = new ShareConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"], GroupId = "share-borrowed-records",
+            AcknowledgementMode = ShareAcknowledgementMode.Explicit
+        };
+        var pool = Substitute.For<IConnectionPool>();
+        metadata = new MetadataManager(pool, options.BootstrapServers);
+        return new KafkaShareConsumer<string, ReadOnlyMemory<byte>>(
+            options, Serializers.String, valueDeserializer ?? Serializers.RawBytes, pool, metadata);
+    }
+
+    private static List<ShareConsumeResult<string, ReadOnlyMemory<byte>>> ParseBorrowedRecords(
+        KafkaShareConsumer<string, ReadOnlyMemory<byte>> consumer, params string[] values)
+        => ParseBorrowedRecords(consumer, false, values);
+
+    private static List<ShareConsumeResult<string, ReadOnlyMemory<byte>>> ParseBorrowedRecords(
+        KafkaShareConsumer<string, ReadOnlyMemory<byte>> consumer, bool prepared, params string[] values)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        for (var offset = 0; offset < values.Length; offset++)
+        {
+            var payload = System.Text.Encoding.UTF8.GetBytes(values[offset]);
+            using var batch = new RecordBatch
+            {
+                BaseOffset = offset,
+                Records = [new Record
+                {
+                    IsKeyNull = true,
+                    Value = payload,
+                    Headers = [new Header("test", payload)],
+                    HeaderCount = 1
+                }]
+            };
+            batch.Write(buffer);
+        }
+
+        var topic = new TopicInfo { Name = "topic", Partitions = [] };
+        var partition = new ShareFetchResponsePartition
+        {
+            PartitionIndex = 0,
+            CurrentLeader = new ShareFetchLeaderIdAndEpoch(),
+            RecordBytes = buffer.WrittenMemory,
+            AcquiredRecords = [new ShareFetchAcquiredRecords
+            {
+                FirstOffset = 0, LastOffset = values.Length - 1, DeliveryCount = 1
+            }]
+        };
+        if (prepared)
+        {
+            var records = new List<ShareConsumeResult<string, ReadOnlyMemory<byte>>>();
+            var state = new KafkaShareConsumer<string, ReadOnlyMemory<byte>>.DeserializerPreparationParserState();
+            try
+            {
+                if (consumer.ParsePartitionRecordsWithPreparation(topic, partition, values.Length,
+                    records, ref state, false, null) is not null)
+                    throw new InvalidOperationException("The raw deserializer must not require preparation.");
+                return records;
+            }
+            finally
+            {
+                state.DisposeCurrentBatch();
+            }
+        }
+        var parse = typeof(KafkaShareConsumer<string, ReadOnlyMemory<byte>>).GetMethod(
+            "ParsePartitionRecords", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (List<ShareConsumeResult<string, ReadOnlyMemory<byte>>>)parse.Invoke(consumer,
+            [topic, partition, values.Length])!;
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(1)]
+    [NotInParallel]
+    public async Task ParsePartitionRecords_DeserializerThrows_ReturnsBatchToPool(int successfulRecords)
     {
         var buffer = new ArrayBufferWriter<byte>();
         using var source = new RecordBatch
         {
             BaseOffset = 17,
-            Records = [new Record { IsKeyNull = true, Value = "value"u8.ToArray() }]
+            Records =
+            [
+                new Record { IsKeyNull = true, Value = "first"u8.ToArray() },
+                new Record { OffsetDelta = 1, IsKeyNull = true, Value = "second"u8.ToArray() }
+            ]
         };
         source.Write(buffer);
 
@@ -93,10 +340,12 @@ public sealed class ShareConsumerRecordPoolingTests
         var pool = Substitute.For<IConnectionPool>();
         await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
         var valueDeserializer = Substitute.For<IDeserializer<string>>();
+        var calls = 0;
         valueDeserializer.Deserialize(
                 Arg.Any<ReadOnlyMemory<byte>>(),
                 Arg.Any<SerializationContext>())
-            .Returns(_ => throw new InvalidOperationException("Deserializer failure"));
+            .Returns(_ => calls++ < successfulRecords ? "value"
+                : throw new InvalidOperationException("Deserializer failure"));
         await using var consumer = new KafkaShareConsumer<string, string>(
             options,
             Serializers.String,
@@ -125,12 +374,12 @@ public sealed class ShareConsumerRecordPoolingTests
                         new ShareFetchAcquiredRecords
                         {
                             FirstOffset = 17,
-                            LastOffset = 17,
+                            LastOffset = 18,
                             DeliveryCount = 1
                         }
                     ]
                 },
-                1
+                2
             ]);
         }
         catch (TargetInvocationException exception)
@@ -144,6 +393,48 @@ public sealed class ShareConsumerRecordPoolingTests
 
         await Assert.That(thrown?.InnerException).IsTypeOf<InvalidOperationException>();
         await Assert.That(returnedBatchCount).IsEqualTo(1);
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task ParsePartitionRecords_LaterBatchFails_ReleasesUndisclosedOwnersOnly()
+    {
+        var valueDeserializer = Substitute.For<IDeserializer<ReadOnlyMemory<byte>>>();
+        valueDeserializer.Deserialize(Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<SerializationContext>())
+            .Returns(call => call.ArgAt<ReadOnlyMemory<byte>>(0).Span.SequenceEqual("failure"u8)
+                ? throw new InvalidOperationException("Deserializer failure")
+                : call.ArgAt<ReadOnlyMemory<byte>>(0));
+        var consumer = CreateBorrowedConsumer(out var metadata, valueDeserializer);
+        await using var metadataScope = metadata;
+        await using var consumerScope = consumer;
+        var delivered = ParseBorrowedRecords(consumer, "retained")[0];
+
+        TargetInvocationException? thrown = null;
+        int failedCallReturns;
+        RecordBatch.BeginTrackingPoolReturnsForCurrentThread();
+        try
+        {
+            ParseBorrowedRecords(consumer, "first", "failure");
+        }
+        catch (TargetInvocationException exception)
+        {
+            thrown = exception;
+        }
+        finally
+        {
+            failedCallReturns = RecordBatch.EndTrackingPoolReturnsForCurrentThread();
+        }
+
+        await Assert.That(thrown?.InnerException).IsTypeOf<InvalidOperationException>();
+        await Assert.That(failedCallReturns).IsEqualTo(2);
+        await Assert.That(System.Text.Encoding.UTF8.GetString(delivered.Value.Span)).IsEqualTo("retained");
+        await Assert.That(System.Text.Encoding.UTF8.GetString(delivered.Headers[0].Value.Span)).IsEqualTo("retained");
+
+        var buffers = (ShareRecordBufferPool)consumer.GetType()
+            .GetField("_recordBuffers", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(consumer)!;
+        var cachedBeforeNextPoll = buffers.RetainedBytes;
+        using (consumer.BeginRecordBatchScope()) { }
+        await Assert.That(buffers.RetainedBytes).IsGreaterThan(cachedBeforeNextPoll);
     }
 
     [Test]
@@ -363,6 +654,7 @@ public sealed class ShareConsumerRecordPoolingTests
         var parserState = new KafkaShareConsumer<string, string>
             .DeserializerPreparationParserState();
 
+        var recordScope = consumer.BeginRecordBatchScope();
         RecordBatch.BeginTrackingPoolReturnsForCurrentThread();
         int returnedBatchCount;
         try
@@ -406,6 +698,8 @@ public sealed class ShareConsumerRecordPoolingTests
         finally
         {
             parserState.DisposeCurrentBatch();
+            recordScope.Dispose();
+            using var nextPoll = consumer.BeginRecordBatchScope();
             returnedBatchCount = RecordBatch.EndTrackingPoolReturnsForCurrentThread();
         }
 

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.Lifetime.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.Lifetime.cs
@@ -1,0 +1,127 @@
+using System.Buffers;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public sealed partial class ShareConsumerRenewalTests
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Poll_DisposeDuringPreparation_DefersFrameReturnUntilParserUnwinds(bool multipleBatches)
+    {
+        var response = CreateFetchResponse(0, 42, 1);
+        if (multipleBatches)
+        {
+            var bytes = new ArrayBufferWriter<byte>();
+            foreach (var offset in new[] { 42L, 43L })
+                bytes.Write(CreateFetchResponse(0, offset, 1).Responses[0].Partitions[0].RecordBytes.Span);
+            response = new ShareFetchResponse
+            {
+                ErrorCode = ErrorCode.None, NodeEndpoints = [],
+                Responses = [new ShareFetchResponseTopic
+                {
+                    TopicId = TopicId,
+                    Partitions = [new ShareFetchResponsePartition
+                    {
+                        PartitionIndex = 0, CurrentLeader = new(), RecordBytes = bytes.WrittenMemory,
+                        AcquiredRecords = [new ShareFetchAcquiredRecords
+                        {
+                            FirstOffset = 42, LastOffset = 43, DeliveryCount = 1
+                        }]
+                    }]
+                }]
+            };
+        }
+        var frame = OwnResponse(response);
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2) { ShareFetchResponses = new([response]) };
+        var preparer = new PausedDeserializerPreparer();
+        await using var fixture = CreateFixture(connection, maxPollRecords: 2, valueDeserializer: preparer);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        using var stop = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await using var poll = fixture.Consumer.PollAsync(stop.Token).GetAsyncEnumerator();
+        var pending = poll.MoveNextAsync().AsTask();
+        try
+        {
+            await preparer.Entered.Task.WaitAsync(stop.Token);
+            await fixture.Consumer.DisposeAsync();
+            await Assert.That(frame.Disposed).IsFalse();
+        }
+        finally
+        {
+            preparer.Release.TrySetResult();
+        }
+        await Assert.That(await pending).IsFalse();
+        await Assert.That(frame.Disposed).IsTrue();
+        var owners = (List<ShareRecordBatchOwner>)typeof(KafkaShareConsumer<string, string>)
+            .GetField("_polledBatchOwners", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(fixture.Consumer)!;
+        await Assert.That(owners.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Poll_RenewedBatch_PinsOncePerRound()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2, supportShareFetch: true)
+        {
+            ShareFetchResponses = new([CreateFetchResponse(0, 42, 4)])
+        };
+        await using var fixture = CreateFixture(connection, maxPollRecords: 4);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        var records = new List<ShareConsumeResult<string, string>>();
+        using var stop = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await using (var poll = fixture.Consumer.PollAsync(stop.Token).GetAsyncEnumerator())
+        {
+            for (var index = 0; index < 4; index++)
+            {
+                await Assert.That(await poll.MoveNextAsync()).IsTrue();
+                records.Add(poll.Current);
+            }
+        }
+        foreach (var record in records)
+            fixture.Consumer.Acknowledge(record, AcknowledgeType.Renew);
+        ApplySuccessfulAcknowledgements(fixture.Consumer, FlushPendingAcknowledgements(fixture.Consumer));
+        var owners = (List<ShareRecordBatchOwner>)fixture.Consumer.GetType()
+            .GetField("_polledBatchOwners", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(fixture.Consumer)!;
+        var assignment = new HashSet<TopicPartition> { new("topic", 0) };
+        for (var round = 0; round < 2; round++)
+        {
+            using var scope = fixture.Consumer.BeginRecordBatchScope();
+            await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment).Count).IsEqualTo(4);
+            await Assert.That(owners.Count).IsEqualTo(1);
+            // Rebuilding the replay snapshot in the same round must not add pins.
+            await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment).Count).IsEqualTo(4);
+            await Assert.That(owners.Count).IsEqualTo(1);
+        }
+        foreach (var record in records)
+            fixture.Consumer.Acknowledge(record, AcknowledgeType.Accept);
+        await fixture.Consumer.CommitAsync(stop.Token);
+        await Assert.That(records[0].BatchOwner).IsNotNull();
+        using (fixture.Consumer.BeginRecordBatchScope())
+            await Assert.That(owners.Count).IsEqualTo(0);
+    }
+
+    private static PoisonedFrame OwnResponse(ShareFetchResponse response)
+    {
+        var frame = new PoisonedFrame(response.Responses[0].Partitions[0].RecordBytes);
+        response.PooledMemoryOwner = frame;
+        return frame;
+    }
+
+    private sealed class PoisonedFrame(ReadOnlyMemory<byte> bytes) : IPooledMemory
+    {
+        public ReadOnlyMemory<byte> Memory => bytes;
+        internal bool Disposed { get; private set; }
+        public void Dispose()
+        {
+            if (Disposed) throw new InvalidOperationException("Response frame returned twice.");
+            Disposed = true;
+            if (MemoryMarshal.TryGetArray(bytes, out var array)) array.AsSpan().Fill(0xcc);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -1079,6 +1079,121 @@ public sealed partial class ShareConsumerRenewalTests
         await Assert.That(batch.LastOffset).IsEqualTo(42);
     }
 
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Poll_PreparedParsingFails_ReleasesUndisclosedPayload(bool failDuringPreparation)
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = CreateFetchResponse(0, 42, recordCount: 2)
+        };
+        var preparer = new FailingAfterFirstRecordPreparer(failDuringPreparation);
+        await using var fixture = CreateFixture(connection, valueDeserializer: preparer);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        var owners = (List<ShareRecordBatchOwner>)typeof(KafkaShareConsumer<string, string>)
+            .GetField("_polledBatchOwners", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(fixture.Consumer)!;
+        preparer.CaptureOwner = () => owners[0];
+        await using var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator();
+
+        await Assert.That(async () => await poll.MoveNextAsync()).Throws<InvalidOperationException>();
+
+        await Assert.That(owners.Count).IsEqualTo(0);
+        await Assert.That(preparer.UndisclosedOwner).IsNotNull();
+        await Assert.That(() => preparer.UndisclosedOwner!.Retain()).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    [Arguments(false, false)]
+    [Arguments(false, true)]
+    [Arguments(true, false)]
+    [Arguments(true, true)]
+    public async Task Poll_LaterPartitionFails_ReleasesBufferedOwnersAndPreservesDeliveries(
+        bool buffered, bool failDuringPreparation)
+    {
+        var firstConnection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = CreateFetchResponse(0, 100)
+        };
+        var secondConnection = new CapturingConnection(ApiKey.ShareFetch, 2, brokerId: 2)
+        {
+            ShareFetchResponse = CreateFetchResponse(1, 200)
+        };
+        var preparer = new FailingAfterFirstRecordPreparer(failDuringPreparation);
+        await using var fixture = CreateFixture(firstConnection, secondConnection: secondConnection,
+            valueDeserializer: preparer);
+        PrepareForPoll(fixture.Consumer, new TopicPartition("topic", 0), new TopicPartition("topic", 1));
+        fixture.Consumer.Subscribe("topic");
+        var renewed = CreateRecord();
+        if (buffered)
+        {
+            fixture.Consumer.Acknowledge(renewed, AcknowledgeType.Renew);
+            ApplySuccessfulAcknowledgements(fixture.Consumer, RenewalAcknowledgements());
+            FlushPendingAcknowledgements(fixture.Consumer);
+        }
+        var owners = (List<ShareRecordBatchOwner>)typeof(KafkaShareConsumer<string, string>)
+            .GetField("_polledBatchOwners", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(fixture.Consumer)!;
+        preparer.CaptureOwner = () => owners[0];
+        await using var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator();
+        ShareConsumeResult<string, string>? delivered = null;
+        if (!buffered)
+        {
+            await Assert.That(await poll.MoveNextAsync()).IsTrue();
+            delivered = poll.Current;
+            await Assert.That(delivered.Offset).IsEqualTo(100);
+        }
+
+        await Assert.That(async () => await poll.MoveNextAsync()).Throws<InvalidOperationException>();
+
+        await Assert.That(preparer.UndisclosedOwner).IsNotNull();
+        await Assert.That(owners.Count).IsEqualTo(buffered ? 0 : 1);
+        if (buffered)
+        {
+            await Assert.That(() => preparer.UndisclosedOwner!.Retain()).Throws<InvalidOperationException>();
+            var active = GetActiveRenewedRecords(fixture.Consumer, new HashSet<TopicPartition> { new("topic", 0) });
+            await Assert.That(active).HasSingleItem();
+            await Assert.That(ReferenceEquals(active[0], renewed)).IsTrue();
+        }
+        else
+        {
+            preparer.UndisclosedOwner!.Retain();
+            preparer.UndisclosedOwner.Release();
+            await Assert.That(delivered!.Value).IsEqualTo("new-value");
+        }
+    }
+
+    private sealed class FailingAfterFirstRecordPreparer(bool failDuringPreparation)
+        : IDeserializer<string>, IAsyncDeserializerPreparer<string>
+    {
+        private int _calls;
+        internal Func<ShareRecordBatchOwner> CaptureOwner { get; set; } = null!;
+        internal ShareRecordBatchOwner? UndisclosedOwner { get; private set; }
+
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) =>
+            Serializers.String.Deserialize(data, context);
+
+        public bool TryDeserialize(ReadOnlyMemory<byte> data, SerializationContext context, out string value)
+        {
+            if (_calls++ == 0)
+            {
+                value = Deserialize(data, context);
+                return true;
+            }
+            UndisclosedOwner = CaptureOwner();
+            if (!failDuringPreparation)
+                throw new InvalidOperationException("Deserializer failure");
+            value = string.Empty;
+            return false;
+        }
+
+        public ValueTask PrepareAsync(ReadOnlyMemory<byte> data, SerializationContext context,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromException(new InvalidOperationException("Preparation failure"));
+    }
+
     private static Fixture CreateFixture(
         CapturingConnection connection,
         ShareAcknowledgementMode acknowledgementMode = ShareAcknowledgementMode.Explicit,

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareRecordBatchOwnerTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareRecordBatchOwnerTests.cs
@@ -1,0 +1,211 @@
+using Dekaf.Protocol.Records;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public sealed class ShareRecordBatchOwnerTests
+{
+    [Test]
+    [NotInParallel]
+    public async Task WarmOwnerReuse_DoesNotAllocateAcrossManyPolls()
+    {
+        var pool = new ShareRecordBatchOwner.Pool(new TopicPartition("topic", 0));
+        for (var index = 0; index < 64; index++)
+        {
+            var owner = pool.Rent(RecordBatch.RentFromPool());
+            owner.Release();
+            owner.Release();
+        }
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 10000; index++)
+        {
+            var owner = pool.Rent(RecordBatch.RentFromPool());
+            owner.Release();
+            owner.Release();
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        await Assert.That(allocated).IsEqualTo(0L);
+        await Assert.That(pool.Misses).IsEqualTo(1L);
+    }
+
+    [Test]
+    [Arguments(500, 0, 512)]
+    [Arguments(1024, 128, 2048)]
+    public async Task MultiplePolls_RetainAllOwnersIncludingRenewedBatches(int batchCount, int renewedCount, int expectedCapacity)
+    {
+        var pool = new ShareRecordBatchOwner.Pool(new TopicPartition("topic", 0));
+        var renewed = new ShareRecordBatchOwner[renewedCount];
+        for (var index = 0; index < renewed.Length; index++)
+        {
+            var owner = pool.Rent(RecordBatch.RentFromPool());
+            owner.Retain();
+            owner.Release();
+            owner.Release();
+            renewed[index] = owner;
+        }
+
+        var owners = new ShareRecordBatchOwner[batchCount];
+        try
+        {
+            for (var poll = 0; poll < 70; poll++)
+            {
+                for (var index = 0; index < owners.Length; index++)
+                    owners[index] = pool.Rent(RecordBatch.RentFromPool());
+                foreach (var owner in owners)
+                {
+                    owner.Release();
+                    owner.Release();
+                }
+                Array.Clear(owners);
+                await Assert.That(pool.Misses).IsEqualTo((long)batchCount + renewedCount);
+                await Assert.That(pool.MaxPoolSize).IsEqualTo(expectedCapacity);
+            }
+        }
+        finally
+        {
+            foreach (var owner in owners)
+            {
+                if (owner is null)
+                    continue;
+                owner.Release();
+                owner.Release();
+            }
+            foreach (var owner in renewed)
+                owner.Release();
+        }
+    }
+
+    [Test]
+    public async Task Reuse_PreservesMetadataAndRejectsStaleOwner()
+    {
+        var pool = new ShareRecordBatchOwner.Pool(new TopicPartition("topic", 0));
+        var originalOwner = pool.Rent(RecordBatch.RentFromPool());
+        var original = CreateRecord(short.MinValue);
+        original.AttachBatchOwner(originalOwner);
+        originalOwner.Release();
+        originalOwner.Release();
+
+        var owner = pool.Rent(RecordBatch.RentFromPool());
+        try
+        {
+            var current = CreateRecord(short.MaxValue);
+            current.AttachBatchOwner(owner);
+            await Assert.That(owner).IsSameReferenceAs(originalOwner);
+            await Assert.That(original.Topic).IsEqualTo("topic");
+            await Assert.That(original.Partition).IsEqualTo(0);
+            await Assert.That(current.Partition).IsEqualTo(0);
+            await Assert.That(original.DeliveryCount).IsEqualTo((int)short.MinValue);
+            await Assert.That(current.DeliveryCount).IsEqualTo((int)short.MaxValue);
+            await Assert.That(current.BatchOwner).IsSameReferenceAs(owner);
+            foreach (var type in Enum.GetValues<AcknowledgeType>())
+            {
+                current.AcknowledgeType = type;
+                await Assert.That(current.AcknowledgeType).IsEqualTo(type);
+                await Assert.That(current.BatchOwner).IsSameReferenceAs(owner);
+            }
+            await Assert.That(() => { _ = original.BatchOwner; }).Throws<InvalidOperationException>();
+        }
+        finally
+        {
+            owner.Release();
+            owner.Release();
+        }
+    }
+
+    [Test]
+    public async Task Renewal_KeepsOwnerOutOfPool()
+    {
+        var pool = new ShareRecordBatchOwner.Pool(new TopicPartition("topic", 0));
+        var owner = pool.Rent(RecordBatch.RentFromPool());
+        owner.Retain();
+        owner.Release();
+        owner.Release();
+        var next = pool.Rent(RecordBatch.RentFromPool());
+        try
+        {
+            await Assert.That(next).IsNotSameReferenceAs(owner);
+        }
+        finally
+        {
+            owner.Release();
+            next.Release();
+            next.Release();
+        }
+    }
+
+    [Test]
+    public async Task ExhaustedGeneration_RetiresOwnerInsteadOfWrapping()
+    {
+        var pool = new ShareRecordBatchOwner.Pool(new TopicPartition("topic", 0));
+        var first = pool.Rent(RecordBatch.RentFromPool());
+        typeof(ShareRecordBatchOwner).GetProperty("Generation",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(first, ShareRecordBatchOwner.MaximumGeneration - 1);
+        first.Release();
+        first.Release();
+        var current = pool.Rent(RecordBatch.RentFromPool());
+        await Assert.That(current).IsSameReferenceAs(first);
+        await Assert.That(current.Generation).IsEqualTo(ShareRecordBatchOwner.MaximumGeneration);
+        current.Release();
+        current.Release();
+
+        var next = pool.Rent(RecordBatch.RentFromPool());
+        try
+        {
+            await Assert.That(next).IsNotSameReferenceAs(first);
+            await Assert.That(next.Generation).IsEqualTo(1u);
+            await Assert.That(first.Retain).Throws<InvalidOperationException>();
+        }
+        finally
+        {
+            next.Release();
+            next.Release();
+        }
+    }
+
+    [Test]
+    [Arguments(int.MinValue, 1u)]
+    [Arguments(-1, (uint)int.MaxValue - 1)]
+    [Arguments(int.MaxValue, (uint)int.MaxValue)]
+    public async Task GenerationStorage_PreservesFullPartitionAndDeliveryMetadata(int partition, uint generation)
+    {
+        var pool = new ShareRecordBatchOwner.Pool(new TopicPartition("topic", partition));
+        var owner = pool.Rent(RecordBatch.RentFromPool());
+        typeof(ShareRecordBatchOwner).GetProperty("Generation",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(owner, generation);
+        var record = CreateRecord(int.MaxValue, partition);
+        await Assert.That(record.Partition).IsEqualTo(partition);
+        record.AttachBatchOwner(owner);
+        try
+        {
+            await Assert.That(record.Partition).IsEqualTo(partition);
+            await Assert.That(record.DeliveryCount).IsEqualTo(int.MaxValue);
+            await Assert.That(record.BatchOwner).IsSameReferenceAs(owner);
+        }
+        finally
+        {
+            owner.Release();
+            owner.Release();
+        }
+        await Assert.That(record.Topic).IsEqualTo("topic");
+        await Assert.That(record.Partition).IsEqualTo(partition);
+    }
+
+    [Test]
+    [Arguments(int.MinValue)]
+    [Arguments(-1)]
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(int.MaxValue)]
+    public async Task CallerCreatedRecord_PreservesFullDeliveryCount(int count)
+    {
+        var record = CreateRecord(count);
+        await Assert.That(record.DeliveryCount).IsEqualTo(count);
+    }
+
+    private static ShareConsumeResult<int, int> CreateRecord(int deliveryCount, int partition = 0) => new()
+    {
+        Topic = "topic", Partition = partition, Offset = 7, Value = 42, DeliveryCount = deliveryCount
+    };
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareRecordBufferPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareRecordBufferPoolTests.cs
@@ -1,0 +1,116 @@
+using System.Buffers;
+using Dekaf.Compression;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public sealed class ShareRecordBufferPoolTests
+{
+    [Test]
+    [Arguments(CompressionType.None)]
+    [Arguments(CompressionType.Gzip)]
+    public async Task BatchPayload_SurvivesMaterializedRecordCleanupAndPoolDisposal(CompressionType compression)
+    {
+        var bytes = new ArrayBufferWriter<byte>();
+        byte[] payload = [10, 20, 30, 40];
+        using (var source = new RecordBatch
+        {
+            Records = [new Record { IsKeyNull = true, Value = payload,
+                Headers = [new Header("key", payload)], HeaderCount = 1 }]
+        })
+            source.Write(bytes, compression);
+        using var pool = new ShareRecordBufferPool(1024 * 1024);
+        var reader = new KafkaProtocolReader(bytes.WrittenMemory);
+        var batch = RecordBatch.ReadForShareConsumer(ref reader, null, pool);
+        var owners = new ShareRecordBatchOwner.Pool(new TopicPartition("topic", 0));
+        var owner = owners.Rent(batch);
+        try
+        {
+            var record = batch.Records[0];
+            var headerValue = record.Headers![0].Value;
+            owner.CompleteParsing();
+            pool.Dispose();
+            await Assert.That(record.Value.ToArray()).IsEquivalentTo(payload);
+            await Assert.That(headerValue.ToArray()).IsEquivalentTo(payload);
+        }
+        finally
+        {
+            owner.Release();
+        }
+        await Assert.That(pool.RetainedBytes).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CacheLimit_DoesNotReclaimOutstandingPayloads()
+    {
+        using var pool = new ShareRecordBufferPool(32);
+        var first = pool.Rent(16);
+        var second = pool.Rent(16);
+        var outstanding = pool.Rent(16);
+        outstanding[0] = 42;
+        pool.Return(first);
+        pool.Return(second);
+        await Assert.That(pool.RetainedBytes).IsEqualTo(32);
+        await Assert.That(outstanding[0]).IsEqualTo((byte)42);
+        pool.Return(outstanding);
+        await Assert.That(pool.RetainedBytes).IsEqualTo(32);
+        var reused = pool.Rent(16);
+        await Assert.That(reused).IsSameReferenceAs(second);
+        pool.Return(reused);
+    }
+
+    [Test]
+    public async Task Dispose_ClearsCacheAndDoesNotRetainLateReturns()
+    {
+        var pool = new ShareRecordBufferPool(64);
+        var retained = pool.Rent(16);
+        var outstanding = pool.Rent(16);
+        pool.Return(retained);
+        pool.Dispose();
+        pool.Return(outstanding);
+        pool.Dispose();
+        await Assert.That(pool.RetainedBytes).IsEqualTo(0);
+        await Assert.That(() => pool.Rent(16)).Throws<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task Rent_RoundsUpAndReturnCanClearPayload()
+    {
+        using var pool = new ShareRecordBufferPool(128);
+        var array = pool.Rent(17);
+        array[0] = 42;
+        pool.Return(array, clearArray: true);
+        var reused = pool.Rent(31);
+        await Assert.That(reused).IsSameReferenceAs(array);
+        await Assert.That(reused[0]).IsEqualTo((byte)0);
+        pool.Return(reused);
+        pool.Return(pool.Rent(0));
+        await Assert.That(pool.RetainedBytes).IsEqualTo(32);
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task WarmCache_ReusesMoreThanSharedPoolDepthWithoutAllocating()
+    {
+        using var pool = new ShareRecordBufferPool(1024 * 16);
+        var arrays = new byte[1024][];
+        for (var round = 0; round < 2; round++)
+        {
+            for (var index = 0; index < arrays.Length; index++)
+                arrays[index] = pool.Rent(16);
+            foreach (var array in arrays)
+                pool.Return(array);
+        }
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < arrays.Length; index++)
+            arrays[index] = pool.Rent(16);
+        foreach (var array in arrays)
+            pool.Return(array);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        await Assert.That(allocated).IsEqualTo(0L);
+        await Assert.That(pool.RetainedBytes).IsEqualTo(1024 * 16);
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerMultiBatchBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerMultiBatchBenchmarks.cs
@@ -1,0 +1,154 @@
+using System.Buffers;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Metadata;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Parses and consumes one partition containing many single-record producer batches.
+/// Borrowed values keep every batch owner alive until the poll boundary. Each operation
+/// includes parsing, traversal and poll cleanup; serialization and binding happen in setup.
+/// </summary>
+[MemoryDiagnoser]
+public class ShareConsumerMultiBatchBenchmarks
+{
+    private KafkaShareConsumer<int, ReadOnlyMemory<byte>> _consumer = null!;
+    private Func<TopicInfo, ShareFetchResponsePartition, int, List<ShareConsumeResult<int, ReadOnlyMemory<byte>>>> _parse = null!;
+    private Action _release = null!;
+    private readonly TopicInfo _topic = new() { Name = "share-multi-batch", Partitions = [] };
+    private ShareFetchResponsePartition _partition = null!;
+
+    [Params(1, 500, 1024)]
+    public int BatchCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        for (var index = 0; index < BatchCount; index++)
+        {
+            var key = new ArrayBufferWriter<byte>();
+            var value = new ArrayBufferWriter<byte>();
+            Serializers.Int32.Serialize(index, ref key, default);
+            // Identical borrowed values let the historical parser run this fixture even
+            // though it returns batch storage early. Ownership tests use distinct values
+            // to detect that corruption; this fixture compares allocation and parse costs.
+            Serializers.Int32.Serialize(42, ref value, default);
+            using var batch = new RecordBatch
+            {
+                BaseOffset = index,
+                BaseTimestamp = 1700000000000,
+                Records = [new Record { Key = key.WrittenMemory, Value = value.WrittenMemory }]
+            };
+            batch.Write(buffer);
+        }
+
+        _partition = new ShareFetchResponsePartition
+        {
+            PartitionIndex = 0,
+            CurrentLeader = new ShareFetchLeaderIdAndEpoch(),
+            RecordBytes = buffer.WrittenMemory,
+            AcquiredRecords = [new ShareFetchAcquiredRecords
+            {
+                FirstOffset = 0,
+                LastOffset = BatchCount - 1,
+                DeliveryCount = 1
+            }]
+        };
+        _consumer = new KafkaShareConsumer<int, ReadOnlyMemory<byte>>(
+            new ShareConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                GroupId = "multi-batch-benchmark",
+                MaxPollRecords = BatchCount
+            }, Serializers.Int32, Serializers.RawBytes);
+        _parse = typeof(KafkaShareConsumer<int, ReadOnlyMemory<byte>>)
+            .GetMethod("ParsePartitionRecords", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .CreateDelegate<Func<TopicInfo, ShareFetchResponsePartition, int, List<ShareConsumeResult<int, ReadOnlyMemory<byte>>>>>(_consumer);
+        _release = typeof(KafkaShareConsumer<int, ReadOnlyMemory<byte>>)
+            .GetMethod("ReleasePolledBatchOwners", BindingFlags.Instance | BindingFlags.NonPublic)?
+            .CreateDelegate<Action>(_consumer) ?? (static () => { });
+
+        Validate(_parse(_topic, _partition, BatchCount));
+        Validate(ParsePrepared());
+    }
+
+    private void Validate(List<ShareConsumeResult<int, ReadOnlyMemory<byte>>> records)
+    {
+        try
+        {
+            if (records.Count != BatchCount)
+                throw new InvalidOperationException("Incomplete multi-batch poll.");
+            for (var index = 0; index < records.Count; index++)
+            {
+                var record = records[index];
+                if (record.Partition != _partition.PartitionIndex || record.Offset != index || record.Key != index ||
+                    Serializers.Int32.Deserialize(record.Value, default) != 42)
+                    throw new InvalidOperationException("Borrowed multi-batch payload was corrupted.");
+            }
+        }
+        finally
+        {
+            _release();
+        }
+    }
+
+    [Benchmark]
+    public long ParseBorrowedPoll()
+    {
+        try
+        {
+            var records = _parse(_topic, _partition, BatchCount);
+            long checksum = 0;
+            foreach (var record in records)
+                checksum += record.Partition + record.Offset + record.Key + record.Value.Span[3];
+            return checksum;
+        }
+        finally
+        {
+            _release();
+        }
+    }
+
+    [Benchmark]
+    public long ParsePreparedBorrowedPoll()
+    {
+        try
+        {
+            var records = ParsePrepared();
+            long checksum = 0;
+            foreach (var record in records)
+                checksum += record.Partition + record.Offset + record.Key + record.Value.Span[3];
+            return checksum;
+        }
+        finally
+        {
+            _release();
+        }
+    }
+
+    private List<ShareConsumeResult<int, ReadOnlyMemory<byte>>> ParsePrepared()
+    {
+        var records = new List<ShareConsumeResult<int, ReadOnlyMemory<byte>>>();
+        var state = new KafkaShareConsumer<int, ReadOnlyMemory<byte>>.DeserializerPreparationParserState();
+        try
+        {
+            if (_consumer.ParsePartitionRecordsWithPreparation(_topic, _partition, BatchCount,
+                records, ref state, false, default) is not null)
+                throw new InvalidOperationException("The raw deserializer must not require preparation.");
+            return records;
+        }
+        finally
+        {
+            state.DisposeCurrentBatch();
+        }
+    }
+
+    [GlobalCleanup]
+    public async ValueTask Cleanup() => await _consumer.DisposeAsync();
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerParsingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerParsingBenchmarks.cs
@@ -333,7 +333,7 @@ public class ShareConsumerParsingBenchmarks
         long checksum = 0;
         foreach (var record in records)
         {
-            checksum += record.Offset + record.Key + record.Value + record.DeliveryCount + record.TimestampMs;
+            checksum += record.Partition + record.Offset + record.Key + record.Value + record.DeliveryCount + record.TimestampMs;
             for (var index = 0; index < record.Headers.Count; index++)
             {
                 var header = record.Headers[index];

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerRenewalReplayBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerRenewalReplayBenchmarks.cs
@@ -1,0 +1,96 @@
+using System.Buffers;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Metadata;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures a replay snapshot and the next poll's owner release, with actual borrowed
+/// records retained by successful Renew acknowledgements. Serialization, initial parsing
+/// and acknowledgement activation happen once. Results are per snapshot, not per record.
+/// </summary>
+[MemoryDiagnoser]
+public class ShareConsumerRenewalReplayBenchmarks
+{
+    private KafkaShareConsumer<int, ReadOnlyMemory<byte>> _consumer = null!;
+    private Func<IReadOnlySet<TopicPartition>, int, List<ShareConsumeResult<int, ReadOnlyMemory<byte>>>> _replay = null!;
+    private readonly HashSet<TopicPartition> _assignment = [new("renewal-benchmark", 0)];
+    private int _recordCount;
+
+    [Params(1, 64)]
+    public int RecordsPerBatch { get; set; }
+
+    [Params(1, 16)]
+    public int BatchCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _recordCount = RecordsPerBatch * BatchCount;
+        var bytes = new ArrayBufferWriter<byte>();
+        for (var batchIndex = 0; batchIndex < BatchCount; batchIndex++)
+        {
+            var records = new Record[RecordsPerBatch];
+            for (var index = 0; index < records.Length; index++)
+                records[index] = new Record { OffsetDelta = index, IsKeyNull = true, Value = new byte[32] };
+            using var batch = new RecordBatch { BaseOffset = batchIndex * RecordsPerBatch, Records = records };
+            batch.Write(bytes);
+        }
+        _consumer = new KafkaShareConsumer<int, ReadOnlyMemory<byte>>(new ShareConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"], GroupId = "renewal-benchmark",
+            AcknowledgementMode = ShareAcknowledgementMode.Explicit
+        }, Serializers.Int32, Serializers.RawBytes);
+        var type = _consumer.GetType();
+        var parse = type.GetMethod("ParsePartitionRecords", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .CreateDelegate<Func<TopicInfo, ShareFetchResponsePartition, int,
+                List<ShareConsumeResult<int, ReadOnlyMemory<byte>>>>>(_consumer);
+        var partition = new ShareFetchResponsePartition
+        {
+            PartitionIndex = 0, CurrentLeader = new(), RecordBytes = bytes.WrittenMemory,
+            AcquiredRecords = [new ShareFetchAcquiredRecords
+            {
+                FirstOffset = 0, LastOffset = _recordCount - 1, DeliveryCount = 1
+            }]
+        };
+        using (_consumer.BeginRecordBatchScope())
+        {
+            var parsed = parse(new TopicInfo { Name = "renewal-benchmark", Partitions = [] }, partition, _recordCount);
+            if (parsed.Count != _recordCount || parsed[0].BatchOwner is null)
+                throw new InvalidOperationException("Renewal replay requires actual borrowed batch ownership.");
+            // Interleave batches to expose deduplication that only remembers the last owner.
+            for (var index = 0; index < RecordsPerBatch; index++)
+                for (var batchIndex = 0; batchIndex < BatchCount; batchIndex++)
+                    _consumer.Acknowledge(parsed[batchIndex * RecordsPerBatch + index], AcknowledgeType.Renew);
+        }
+        var tracker = (AcknowledgementTracker)type.GetField("_ackTracker", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(_consumer)!;
+        var acknowledgements = tracker.Flush();
+        type.GetMethod("ApplySuccessfulAcknowledgements", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(_consumer, [acknowledgements, 0L]);
+        _replay = type.GetMethod("GetActiveRenewedRecords", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .CreateDelegate<Func<IReadOnlySet<TopicPartition>, int,
+                List<ShareConsumeResult<int, ReadOnlyMemory<byte>>>>>(_consumer);
+        if (Replay() != 32L * _recordCount)
+            throw new InvalidOperationException("Renewed payloads must remain available across poll rounds.");
+    }
+
+    [Benchmark]
+    public long Replay()
+    {
+        using var scope = _consumer.BeginRecordBatchScope();
+        var records = _replay(_assignment, _recordCount);
+        long bytes = 0;
+        foreach (var record in records)
+            bytes += record.Value.Length;
+        return bytes;
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup() => await _consumer.DisposeAsync();
+}


### PR DESCRIPTION
Classic share parsing keeps borrowed values and headers valid through the poll boundary and explicit Renew/replay. Previously, returning a parsed batch could recycle its payload while a delivered record still referenced it. Failed parsing releases undisclosed owners while preserving delivered records; stale renewal is rejected before acknowledgement is queued.

Parsing transfers copied/decompressed payload bytes to a batch owner and immediately returns RecordBatch metadata, Record[] and header arrays. A consumer-local payload cache retains at most FetchMaxBytes of array capacity; cache metadata and outstanding borrowed storage are additional. Owners use a partition-local array stack and generation checks under the serialized-consumer contract. Disposal keeps the payload cache alive until suspended parsing unwinds, then releases owners and cached arrays. Preparation stops disclosing records after close/disposal. Renewal replay pins each batch once per poll round, including interleaved records.

Ownership bookkeeping is amortized per batch, partition and poll. Attaching/checking ownership adds per-record CPU work without additional per-record allocation or synchronization. Renewal replay adds one flag check per record and retains/releases once per batch; its existing snapshot-list allocation is unchanged. The close/disposal check runs once per parsed partition. Owner-pool metadata is retained for encountered partitions until Subscribe/Unsubscribe/Dispose; assignment churn can therefore grow metadata even though the payload cache is byte-bounded. Trimming it requires a measured lifecycle change to avoid exchanging retained memory for repeated allocations.

**Do not merge: reproduced timing loss and loaded acceptance remain unresolved.** [Gate 34607767112](https://github.com/thomhurst/Dekaf/actions/runs/34607767112), measuring current head `19a204fda44136fff245287f28c456bf72e3d6c7` against main `fd351550b1a54b92cae941e8f020814c3049f365`, reproduces cold borrowed preparation at 64 records/two headers: 20.23 us versus 14.90/15.30 us controls (+35.7%/+32.2%, first +32.5%/+32.0%). Allocation is 760 B in all three. The other eleven cases in that class pass. Original tables, exports and logs from artifact 10268529968 were downloaded and inspected. No protected-metric tradeoff is approved.
Predecessor run 34601650396's pending-state failure is an invalid measurement, not a regression: the added renewal fixture cannot compile against the old baseline's ownership APIs, so fallback uses the original baseline fixtures. Those subtract invocation overhead and produce zero medians; the candidate uses EvaluateOverhead(false). Fresh main already contains the same EvaluateOverhead(false) setting, preserved by this rebase. No tolerance, comparison rule or workflow was changed and no failed gate was manually rerun.

Validation for `19a204fda44136fff245287f28c456bf72e3d6c7`, one commit on main `fd351550b1a54b92cae941e8f020814c3049f365`:

- Release solution build passes with zero warnings/errors; 560 selected unit tests pass on each of net10.0 and net8.0.
- All six Kafka 4.3.1 close/ownership cases pass, including disposal during preparation, partial-close outcomes, and renewed borrowed payloads/headers under sustained four-partition traffic at 32 B and 128 KiB.
- All 45 selector tests, artifact policy and whitespace checks pass. Range-diff review confirms ownership changes remain intact alongside main's idle wakeups, missing-leader recovery and closed/disposed checks. Fresh CI and subsequent bot review are required.
- No new local benchmark was run for this rebase. Predecessor lifecycle validation at 19c5f093b includes four-case Dry/Short renewal measurements before/after against b3f399c88: allocations remain 64/184/568/8248 B per snapshot. Local timing was diagnostic only, and the fixture may be candidate-only in the hosted gate because main lacks its ownership APIs.

Exact final source, 1,974 individually SHA-256-verified test binary files, reports and experiment inputs are retained outside removable worktrees at `D:/Dekaf-evidence/pr-3158/19a204fda44136fff245287f28c456bf72e3d6c7`. Raw current review/build/test logs and downloaded gate artifacts with a file/hash inventory are at `D:/Dekaf-evidence/pr-3158/review-20260911-1400`. Prior generated benchmark workers and lifecycle evidence remain at `C:/git/Dekaf-evidence/pr-3158/lifecycle-followup`, attributed to their measured revisions. No evidence artifacts are committed.

[Loaded run 34545104693](https://github.com/thomhurst/Dekaf/actions/runs/34545104693) used consumer-1b, cheap, five minutes/sample, full_run=false, baseline e36d75cd and candidate f07f3e29. The initial attempt was INCONCLUSIVE from changing thread-pool size; its single exact repeat was INCONCLUSIVE during setup. No third identical or new paid run was dispatched. A changed experiment must establish steady state and concurrent-broker memory behavior. Hosted share acceptance also depends on classic overflow #3244/#3248. Integration correctness does not establish loaded acceptance.


Later local profiling against the same main/head completed four maintained cold cases per revision. Both instrumented runs show changing thread-pool targets; sampled thread time is not CPU-per-message evidence and does not dismiss the current hosted regression. Exact source, verified loaded binaries, traces, reports and analysis are retained at D:/Dekaf-evidence/pr-3158/cold-preparation-profile-20260911. No product change, new CI dispatch or paid stress run resulted from this investigation.

