### PR TITLE
fix(benchmarks): isolate diagnostics and bound latency recording

### DIFF
--- a/.github/benchmarks/HARNESS-RELIABILITY.md
+++ b/.github/benchmarks/HARNESS-RELIABILITY.md
@@ -1,0 +1,86 @@
+# Performance harness reliability
+
+These changes target `perf/pr-improve-20260908`, the shared harness used by the
+open PR performance investigations. They do not change product source, historical
+verdicts, acceptance tolerances, scheduled stress lanes, or paid-run limits.
+
+## Observer storage
+
+The four administrative probes previously reserved 65,536 16-byte histogram
+entries for each interval. A 480-second warmup plus a 180-second measurement
+reserved 662 MiB for those entries alone. Each interval also scanned up to one
+million dense tick counters, even when only a few hundred values occurred.
+
+The recorder now shares an archive capped at 4,194,304 entries (64 MiB) across all
+intervals, and drains only touched dense counters plus preallocated overflow
+buckets. The dense array, touched indices and overflow dictionary add separate,
+fixed storage. The per-interval limit remains 65,536 distinct ticks. No allocation
+is required while recording or draining. Exhausting either limit aborts the
+capture; it never rounds, drops, overwrites, or clips samples. The archive remains
+alive until reports are serialized. JSON retains exact tick/count arrays and all
+maxima. Both warmup and measured intervals use the same recorder.
+
+The existing copies of `Probe.cs` stay self-contained because historical drivers
+copy individual fixture directories into product checkouts. A test verifies that
+all four deployed copies match the recorder tested by TUnit.
+
+## CPU isolation and host evidence
+
+The wrapper in `.github/scripts/runner_resources.py` discovers physical core and
+socket IDs within the original allowed CPU set. SMT siblings stay on the same
+side. One physical core belongs to the client; remaining cores belong to harness
+infrastructure and Kafka. A runner with fewer than two physical cores is rejected.
+This preserves the existing loaded-workload allocation instead of silently changing
+concurrency or offered load.
+
+The wrapper and Python drivers run on infrastructure CPUs. Their subprocesses,
+including `docker stats`, inherit that mask. Measured processes explicitly select
+the client mask. Pool BenchmarkDotNet affinity no longer overrides the topology
+with hard-coded CPU 2. Original allowed CPUs are retained across nested drivers.
+In-process runtime samplers remain included in client CPU/allocation scope; this
+change does not claim to remove their cost or isolate the host kernel, Docker
+daemon, interrupts, or other VM activity.
+
+Every wrapped suite retains `runner-resources/plan.json`, raw one-second
+`series.jsonl`, and the child's exit code. Series include `/proc/stat` CPU and steal
+counters, memory and swap counters, CPU/memory/I/O pressure stall information,
+load, and available disk. These are host observations, not client CPU per message.
+Missing required counters fail before starting work; a later sampling failure
+terminates the workload and fails collection. A nonzero workload exit stays
+nonzero. Artifacts upload even when execution fails.
+
+## Identical-product calibration
+
+Dispatch the existing `benchmarks.yml` workflow from this harness revision with
+`suite=admin-calibration`, an existing administrative PR number (3128, 3129, 3136,
+or 3138), and identical full `baseline_sha` and `candidate_sha` values. Pin fresh
+main before dispatch. The selected PR determines the existing control matrix.
+
+Calibration builds the baseline fixture once without `CANDIDATE`, validates it,
+and uses that exact binary path for all A1/B/A2 launches. New APIs with no baseline
+equivalent are excluded. Each control runs consecutively in three fresh processes
+on one `ubuntu-latest` VM, with 480 seconds continuous workload warmup and 180
+seconds measurement per process. Both product inputs must match or collection
+fails before building. Budget 33 measured/warmup minutes per control case, plus
+builds and fixture validation. There is no automatic repetition.
+
+`calibration.json` reports the existing 3% throughput/CPU, 5% p50/p99/max, and
+1 B/call allocation screens, both control deltas, and control drift. A failed
+screen demonstrates that this capture cannot distinguish a product change at
+those limits. A successful screen is only a repeatability observation for that
+configuration; one triplet does not establish maximum-latency precision, loaded
+Kafka behavior, long-run stability, or a product performance PASS. JIT/GC and
+thread-pool transitions still need attribution using the retained runtime series.
+Do not remove maxima or widen tolerances to turn calibration green.
+
+## Validation
+
+`performance-harness-tests.yml` runs TUnit recorder tests, Python comparison and
+resource-wrapper tests, and a real Linux child-affinity/resource-capture smoke.
+Recorder tests independently verify counts, random interval histograms, exact
+long tails, immutable prior intervals, bounded failure, JSON compatibility, zero
+record/drain allocations, and the complete probe's report accounting.
+
+These checks validate harness correctness. They are not performance acceptance
+for any open product PR. New measurements retain their own product and harness
+pins and must not be pooled with previous observer or affinity configurations.

--- a/.github/benchmarks/admin-recorder-tests/Recorder.Tests.csproj
+++ b/.github/benchmarks/admin-recorder-tests/Recorder.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="TUnit" />
+    <Compile Include="../../../tools/AdminDescriptionEvidence/Probe.cs" Link="Probe.cs" />
+    <Compile Include="../../../tools/AdminDescriptionEvidence/PhaseEvents.cs" Link="PhaseEvents.cs" />
+    <Compile Include="../CompilationLog.cs" Link="CompilationLog.cs" />
+  </ItemGroup>
+</Project>

--- a/.github/benchmarks/admin-recorder-tests/RecorderTests.cs
+++ b/.github/benchmarks/admin-recorder-tests/RecorderTests.cs
@@ -1,0 +1,133 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Dekaf.Benchmarks;
+using TUnit.Assertions;
+using TUnit.Core;
+
+namespace Dekaf.Benchmarks;
+
+// Exercise the actual probe loop without a product revision or network dependency.
+public sealed class AdminFixture
+{
+    public object? Value { get; init; }
+    public ValueTask<object?> Call() => new(Value);
+}
+
+public sealed class RecorderTests
+{
+    [Test]
+    public async Task ExactTicksAndLongTailsSurviveIntervalReuse()
+    {
+        var histogram = new Probe.ExactHistogram(16);
+        long[] input = [0, 17, 17, 51, Stopwatch.Frequency, long.MaxValue, long.MaxValue];
+        foreach (var tick in input)
+            histogram.Record(tick);
+        var first = histogram.Drain();
+        histogram.Record(17);
+        histogram.Record(long.MaxValue);
+        var second = histogram.Drain();
+        foreach (var group in input.GroupBy(static tick => tick))
+            await Assert.That(first.Single(row => row.Ticks == group.Key).Count).IsEqualTo(group.LongCount());
+        await Assert.That(second.Sum(static row => row.Count)).IsEqualTo(2);
+        await Assert.That(first.Sum(static row => row.Count)).IsEqualTo(input.LongLength);
+        // Preserve the existing JSON array contract for replay validators.
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(first));
+        await Assert.That(json.RootElement.ValueKind).IsEqualTo(JsonValueKind.Array);
+        await Assert.That(json.RootElement.GetArrayLength()).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task RandomizedIntervalsMatchIndependentReference()
+    {
+        var histogram = new Probe.ExactHistogram(100_000);
+        var random = new Random(731);
+        var retained = new List<(ArraySegment<Probe.TickCount> Actual, Dictionary<long, long> Expected)>();
+        for (var interval = 0; interval < 30; interval++)
+        {
+            var expected = new Dictionary<long, long>();
+            for (var index = 0; index < 2000; index++)
+            {
+                var tick = index % 20 == 0 ? long.MaxValue - random.Next(20) : random.Next(300);
+                histogram.Record(tick);
+                expected[tick] = expected.GetValueOrDefault(tick) + 1;
+            }
+            retained.Add((histogram.Drain(), expected));
+        }
+        foreach (var (actual, expected) in retained)
+        {
+            await Assert.That(actual.Count).IsEqualTo(expected.Count);
+            foreach (var row in actual)
+                await Assert.That(row.Count).IsEqualTo(expected[row.Ticks]);
+        }
+    }
+
+    [Test]
+    public async Task ExhaustionRejectsCaptureWithoutOverwritingPriorSamples()
+    {
+        var histogram = new Probe.ExactHistogram(1);
+        histogram.Record(13);
+        var retained = histogram.Drain();
+        histogram.Record(29);
+        await Assert.That(() => histogram.Drain()).Throws<InvalidOperationException>();
+        await Assert.That(retained[0]).IsEqualTo(new Probe.TickCount(13, 1));
+    }
+
+    [Test]
+    public async Task IntervalOverflowRejectsNewBucketsButAllowsRepeatedSamples()
+    {
+        var histogram = new Probe.ExactHistogram(65536);
+        for (var tick = 0; tick < 65536; tick++)
+            histogram.Record(tick);
+        histogram.Record(0);
+        await Assert.That(() => histogram.Record(long.MaxValue)).Throws<InvalidOperationException>();
+        var retained = histogram.Drain();
+        await Assert.That(retained.Count).IsEqualTo(65536);
+        await Assert.That(retained.Sum(static row => row.Count)).IsEqualTo(65537);
+    }
+
+    [Test]
+    public async Task EmptyIntervalAndNegativeLatencyAreHandledExplicitly()
+    {
+        var histogram = new Probe.ExactHistogram(1);
+        await Assert.That(histogram.Drain().Count).IsEqualTo(0);
+        await Assert.That(() => histogram.Record(-1)).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task RecordAndDrainAllocateNothingAfterConstruction()
+    {
+        var histogram = new Probe.ExactHistogram(10000);
+        for (var index = 0; index < 100; index++)
+        {
+            histogram.Record(1);
+            histogram.Record(long.MaxValue);
+            _ = histogram.Drain();
+        }
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 1000; index++)
+        {
+            histogram.Record(1);
+            histogram.Record(long.MaxValue);
+            _ = histogram.Drain();
+        }
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CompleteProbePreservesCountsPercentilesAndIntervalBoundaries()
+    {
+        var captures = await Probe.CapturePhasesAsync(new AdminFixture(), [0.1, 0.1]);
+        foreach (var capture in captures)
+        {
+            var result = Probe.Complete(capture);
+            await Assert.That(result.Completed).IsGreaterThan(0);
+            await Assert.That(result.Latencies.Sum(static row => row.Count)).IsEqualTo(result.Completed);
+            await Assert.That(result.Intervals.Sum(static row => row.Latencies.Sum(static bucket => bucket.Count)))
+                .IsEqualTo(result.Completed);
+            await Assert.That(result.MaxNs).IsEqualTo(result.Latencies[^1].Ticks * 1e9 / Stopwatch.Frequency);
+            await Assert.That(result.P50Ns).IsLessThanOrEqualTo(result.P99Ns);
+            await Assert.That(result.P99Ns).IsLessThanOrEqualTo(result.MaxNs);
+        }
+    }
+}

--- a/.github/benchmarks/dispatch-aba/run.py
+++ b/.github/benchmarks/dispatch-aba/run.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import re
 import shutil
 import subprocess
+import sys
 import time
 import zipfile
 
@@ -18,24 +19,13 @@ DURATION = 120
 AFFINITY = {'consumer': '2,3', 'infrastructure': '0,1'}
 
 
-def select_affinity(rows):
-    cores = {}
-    for cpu, core, socket in rows:
-        cores.setdefault((socket, core), []).append(cpu)
-    if len(cores) < 2:
-        raise ValueError('At least two physical cores required for workload isolation')
-    groups = [sorted(cores[key]) for key in sorted(cores)]
-    return {'consumer': ','.join(map(str, groups[-1])),
-            'infrastructure': ','.join(str(cpu) for group in groups[:-1] for cpu in group)}
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'scripts'))
+from runner_resources import configure_affinity as configure_runner, select_affinity
 
 
 def configure_affinity():
-    rows = []
-    for cpu in sorted(os.sched_getaffinity(0)):
-        topology = Path(f'/sys/devices/system/cpu/cpu{cpu}/topology')
-        rows.append((cpu, int((topology / 'core_id').read_text()),
-                     int((topology / 'physical_package_id').read_text())))
-    AFFINITY.update(select_affinity(rows))
+    rows, layout = configure_runner()
+    AFFINITY.update(layout)
     return rows
 
 
@@ -349,7 +339,8 @@ def micro(host, output, label, phase, smoke, cases=None):
     environment = dict(os.environ, DOTNET_TieredCompilation='0')
     for pattern, batch in CASES if cases is None else cases:
         folder = output / f'{phase}-micro-{pattern}-{batch}'
-        args = ['taskset', '-c', '2', 'dotnet', host, pattern, str(batch), folder]
+        cpu = min(map(int, AFFINITY['consumer'].split(',')))
+        args = ['taskset', '-c', str(cpu), 'dotnet', host, pattern, str(batch), folder]
         if smoke:
             args.append('--smoke')
         if label == 'B':

--- a/.github/benchmarks/dispatch-aba/test_run.py
+++ b/.github/benchmarks/dispatch-aba/test_run.py
@@ -36,6 +36,13 @@ class AffinityTests(unittest.TestCase):
 
 
 class MicroDriverTests(unittest.TestCase):
+    def test_micro_uses_detected_client_core(self):
+        with tempfile.TemporaryDirectory() as directory, \
+             patch.dict(run.AFFINITY, consumer='1,3', infrastructure='0,2'), \
+             patch.object(run, 'command', side_effect=lambda args, log, **kwargs: Path(log).write_text('smoke')) as launch:
+            run.micro(Path('host.dll'), Path(directory), 'B', 'Smoke', True, cases=[('Repeated', 1)])
+            self.assertEqual(launch.call_args.args[0][:3], ['taskset', '-c', '1'])
+
     def exercise(self, smoke, actual_count):
         with tempfile.TemporaryDirectory() as directory:
             def write_log(args, log, **kwargs):

--- a/.github/benchmarks/pool-reset/Program.cs
+++ b/.github/benchmarks/pool-reset/Program.cs
@@ -19,13 +19,16 @@ internal static class Program
     internal static bool Baseline;
     public static int Main(string[] args)
     {
+        var cpu = int.Parse(Environment.GetEnvironmentVariable("DEKAF_BENCHMARK_CPU") ?? "2");
+        if (cpu < 0 || cpu >= IntPtr.Size * 8)
+            throw new InvalidOperationException("DEKAF_BENCHMARK_CPU does not fit the process affinity mask.");
         Smoke = args.Contains("--smoke");
         Baseline = args.Contains("--baseline");
         Console.WriteLine(JsonSerializer.Serialize(new[] { typeof(Program).Assembly, typeof(PendingRequestPool).Assembly, typeof(Reservoir.ObjectPool<>).Assembly }
             .Select(a => new { a.FullName, a.Location, Sha256 = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(a.Location))) })));
         using var runtime = new RuntimeLogger(Path.Combine(args[0], "runtime.csv"));
         var config = DefaultConfig.Instance.WithArtifactsPath(args[0]).AddLogger(runtime).AddExporter(JsonExporter.Full)
-            .AddJob(Job.Default.WithToolchain(InProcessEmitToolchain.Instance).WithAffinity(new IntPtr(4))
+            .AddJob(Job.Default.WithToolchain(InProcessEmitToolchain.Instance).WithAffinity(new IntPtr(1L << cpu))
                 .WithWarmupCount(Smoke ? 1 : 30).WithIterationCount(Smoke ? 1 : 25)
                 .WithIterationTime(TimeInterval.FromMilliseconds(1000)).WithOutlierMode(OutlierMode.DontRemove));
         var summary = args.Contains("--recovery")

--- a/.github/scripts/admin_refresh.py
+++ b/.github/scripts/admin_refresh.py
@@ -9,6 +9,8 @@ import shutil
 import subprocess
 import sys
 
+from runner_resources import configure_affinity
+
 ROOT = Path.cwd()
 OUT = ROOT / 'evidence'
 PR = int(os.environ['PR'])
@@ -47,16 +49,22 @@ def execute():
         original = module(SOURCE / 'run_comparison.py', 'original')
         validator = original.validate_probe
         controls, added = original.CONTROLS, original.NEW_CASES
+    calibration = os.getenv('ADMIN_CALIBRATION') == '1'
+    if calibration and A != B:
+        raise ValueError('Calibration requires identical exact product SHAs')
     pilot = os.getenv('ADMIN_PILOT') == '1'
     warmup_seconds = 360 if pilot else 480
     measured_seconds = 60 if pilot else 180
+    if calibration:
+        added = []
     if pilot:
         # Diagnose the observed report/JIT transition before expanding a campaign.
         controls, added = controls[:1], []
     environment = dict(os.environ, DOTNET_TieredCompilation='1', DOTNET_TieredPGO='1', DOTNET_gcServer='0')
-    cpu = max(os.sched_getaffinity(0))
+    topology, affinity = configure_affinity()
+    cpu = max(map(int, affinity['consumer'].split(',')))
     probe_prefix = ['taskset', '-c', str(cpu), 'dotnet']
-    plan = dict(A=A, B=B, harness=subprocess.check_output(['git', 'rev-parse', 'HEAD'], text=True).strip(),
+    plan = dict(calibration=calibration, topology=topology, affinity=affinity, A=A, B=B, harness=subprocess.check_output(['git', 'rev-parse', 'HEAD'], text=True).strip(),
                 controls=controls, candidate_only=added, warmup_seconds=warmup_seconds, measured_seconds=measured_seconds,
                 warmup_rationale=('480 seconds continuous workload after observer heap preparation; previous 360-second captures '
                                   'retained helper/ConditionalWeakTable JIT near total seconds 382-400. Collect 180 seconds '
@@ -65,7 +73,7 @@ def execute():
                                   '360 seconds continuous workload after observer heap preparation; assess all measured runtime transitions'),
                 observer_preparation='After histogram allocation, two blocking compacting full GCs with finalizer waits before workload warmup; no forced GC during warmup or measurement',
                 pilot=pilot, report_aggregation='all overflow sorting and aggregation deferred until both captures finish',
-                histograms='Value-type buckets with 65536 preallocated entries per interval; overflow invalidates',
+                histograms='Exact ticks, touched buckets only; 65536 distinct ticks/interval, shared archive capped at 4194304 entries (64 MiB); exhaustion invalidates',
                 phase_transition='one continuous warmed call loop; no return/re-entry between warmup and measurement',
                 cpu_affinity=[cpu], jit_attribution='CLR MethodJittingStarted; identical observer in all phases',
                 phase_order='For each control workload, run A1 then B then A2 before starting the next workload',
@@ -79,7 +87,8 @@ def execute():
     run(['lscpu'], OUT / 'hardware.txt')
     run(['git', 'archive', '--format=zip', '--output=' + str(OUT / 'harness.zip'), 'HEAD'], OUT / 'archive-harness.log')
     hosts = {}
-    for label, sha in [('A', A), ('B', B)]:
+    revisions = [('A', A)] if calibration else [('A', A), ('B', B)]
+    for label, sha in revisions:
         product = ROOT / ('product-' + label)
         run(['git', 'worktree', 'add', '--detach', str(product), sha], OUT / f'checkout-{label}.log')
         run(['git', 'archive', '--format=zip', '--output=' + str(OUT / f'product-{label}.zip'), sha], OUT / f'archive-{label}.log')
@@ -96,6 +105,9 @@ def execute():
         shutil.copytree(binary.parent, OUT / 'binaries' / label)
         common.verify_copied_tree(binary.parent, OUT / 'binaries' / label)
     run(['dotnet', 'build-server', 'shutdown'], OUT / 'build-server-shutdown.log')
+    if calibration:
+        hosts['B'] = hosts['A']
+        shutil.copytree(OUT / 'binaries/A', OUT / 'binaries/B')
     for label, binary in hosts.items():
         for case in controls + (added if label == 'B' else []):
             destination = OUT / 'validation' / label / case.replace(':', '-')
@@ -110,7 +122,7 @@ def execute():
         for phase, label in [('A1', 'A'), ('B', 'B'), ('A2', 'A')]:
             destination = OUT / phase / case.replace(':', '-')
             binary = hosts[label]
-            capture = dict(case=case, phase=phase, product=A if label == 'A' else B,
+            capture = dict(case=case, phase=phase, product=A if label == 'A' else B, binary=str(binary),
                            started_utc=datetime.now(timezone.utc).isoformat())
             run(probe_prefix + [str(binary), 'probe', case, str(destination), str(warmup_seconds), str(measured_seconds)], destination / 'run.log', env=environment)
             capture['completed_utc'] = datetime.now(timezone.utc).isoformat()
@@ -119,7 +131,14 @@ def execute():
             validator(destination / 'warmup.json', warmup_seconds)
             observations[phase][case] = validator(destination / 'measured.json', measured_seconds)
             common.retain_loaded_binaries(destination / 'binaries.json', binary.parent, OUT / 'binaries' / label)
-    save(OUT / 'comparison.json', {case: common.compare(*(observations[phase][case] for phase in ['A1', 'B', 'A2'])) for case in controls})
+    comparisons = {case: common.compare(*(observations[phase][case] for phase in ['A1', 'B', 'A2'])) for case in controls}
+    save(OUT / 'comparison.json', comparisons)
+    if calibration:
+        save(OUT / 'calibration.json', {
+            'product_sha': A, 'binary': str(hosts['A']),
+            'point_estimates_within_declared_limits': all(row['point_estimates_within_declared_limits'] for row in comparisons.values()),
+            'verdict': 'DIAGNOSTIC ONLY: identical-product repeatability; never product acceptance',
+            'comparisons': comparisons})
     for case in added:
         destination = OUT / 'candidate-only' / case.replace(':', '-')
         run(probe_prefix + [str(hosts['B']), 'probe', case, str(destination), str(warmup_seconds), str(measured_seconds)], destination / 'run.log', env=environment)

--- a/.github/scripts/benchmark_aba.py
+++ b/.github/scripts/benchmark_aba.py
@@ -12,6 +12,8 @@ import sys
 from datetime import datetime, timezone
 from xml.sax.saxutils import escape
 
+from runner_resources import configure_affinity
+
 SUITES = {
     3082: ['*BinaryKeyDispatchBenchmarks*'],
     3083: ['*BatchReadBench*', '*BatchBoundBench*'],
@@ -86,8 +88,9 @@ def execute(args):
     subprocess.run(['git', 'merge-base', '--is-ancestor', args.baseline, args.candidate], check=True)
     workspace = Path(os.environ['RUNNER_TEMP']) / f'aba-{args.pr}'
     workspace.mkdir(exist_ok=False)
-    allowed_cpus = sorted(os.sched_getaffinity(0))
-    cpu = allowed_cpus[0]
+    topology, affinity = configure_affinity()
+    allowed_cpus = [row[0] for row in topology]
+    cpu = min(map(int, affinity['consumer'].split(',')))
     warmup_iterations = 130 if args.pr == 3116 else 50
     minimum_warmup_seconds = 120 if args.pr == 3116 else 20
     metadata = {'started_utc': now(), 'baseline_sha': args.baseline, 'candidate_sha': args.candidate,

--- a/.github/scripts/outbox_cycle_aba.py
+++ b/.github/scripts/outbox_cycle_aba.py
@@ -11,6 +11,8 @@ import re
 import shutil
 import subprocess
 
+from runner_resources import configure_affinity
+
 MODES = ('sync-off', 'pending-off', 'sync-on', 'pending-on',
          'renewal-sync-off', 'renewal-pending-off', 'renewal-sync-on', 'renewal-pending-on')
 PHASES = (('A1', 'A'), ('B', 'B'), ('A2', 'A'))
@@ -104,7 +106,8 @@ def execute(args):
         raise ValueError('The PR head changed before this campaign')
     workspace = Path(os.environ['RUNNER_TEMP']) / f'outbox-cycle-{os.environ["GITHUB_RUN_ID"]}'
     workspace.mkdir(exist_ok=False)
-    cpu = min(os.sched_getaffinity(0))
+    topology, affinity = configure_affinity()
+    cpu = min(map(int, affinity['consumer'].split(',')))
     environment = dict(os.environ, DOTNET_TieredCompilation='0', ABA_CPU=str(cpu), MSBUILDDISABLENODEREUSE='1')
     provenance = {'baseline_sha': args.baseline, 'candidate_sha': args.candidate,
                   'harness_sha': output(['git', 'rev-parse', 'HEAD']), 'started_utc': now(),

--- a/.github/scripts/pool_reset_aba.py
+++ b/.github/scripts/pool_reset_aba.py
@@ -1,6 +1,12 @@
 """Task-scoped exact-SHA comparison. Never merge this experimental branch."""
 from pathlib import Path
 import hashlib,json,os,shutil,subprocess,sys
+from runner_resources import configure_affinity
+
+TOPOLOGY, AFFINITY = configure_affinity()
+CLIENT_CPU = min(map(int, AFFINITY['consumer'].split(',')))
+os.environ['DEKAF_BENCHMARK_CPU'] = str(CLIENT_CPU)
+
 ROOT=Path.cwd()
 OUT=ROOT/"evidence"
 A=os.environ['BASELINE_SHA']
@@ -8,12 +14,16 @@ B=os.environ['CANDIDATE_SHA']
 FIXTURE=ROOT/".github/benchmarks/pool-reset"
 RECOVERY=os.environ.get('POOL_RECOVERY') == '1'
 def run(args,log,cwd=ROOT):
+    if args[0] == 'dotnet' and str(args[1]).endswith('.dll'):
+        args = ['taskset', '-c', str(CLIENT_CPU), *args]
     with log.open("w") as output:
         subprocess.run([str(x) for x in args],cwd=cwd,stdout=output,stderr=subprocess.STDOUT,check=True)
 if sys.argv[1]=="prepare":
     OUT.mkdir()
     subprocess.run(["git","merge-base","--is-ancestor",A,B],check=True)
     manifest=dict(A=A,B=B,harness=subprocess.check_output(["git","rev-parse","HEAD"],text=True).strip(),mainAtRun=subprocess.check_output(["git","ls-remote","origin","refs/heads/main"],text=True).strip(),imageVersion=os.getenv("ImageVersion"),imageOS=os.getenv("ImageOS"),runnerName=os.getenv("RUNNER_NAME"),settings={k:os.getenv(k) for k in ["DOTNET_TieredCompilation","DOTNET_TieredPGO","DOTNET_ReadyToRun"]})
+    manifest['affinity'] = AFFINITY
+    manifest['topology'] = TOPOLOGY
     manifest['recovery_probe'] = RECOVERY
     manifest['tiered_compilation'] = os.environ.get('DOTNET_TieredCompilation')
     (OUT/"manifest.json").write_text(json.dumps(manifest,indent=2))

--- a/.github/scripts/runner_resources.py
+++ b/.github/scripts/runner_resources.py
@@ -1,0 +1,103 @@
+"""Isolate harness subprocesses and retain Linux host pressure beside workload evidence."""
+import argparse
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import time
+
+
+def select_affinity(rows):
+    cores = {}
+    for cpu, core, socket in rows:
+        cores.setdefault((socket, core), []).append(cpu)
+    if len(cores) < 2:
+        raise ValueError('At least two physical cores required for workload isolation')
+    groups = [sorted(cores[key]) for key in sorted(cores)]
+    return {'consumer': ','.join(map(str, groups[-1])),
+            'infrastructure': ','.join(str(cpu) for group in groups[:-1] for cpu in group)}
+
+
+def topology():
+    # The wrapper pins descendants to infrastructure CPUs. Preserve the original allowed
+    # set so a nested driver can still discover and explicitly pin its measured child.
+    allowed = os.environ.get('DEKAF_RUNNER_CPUS')
+    cpus = sorted(map(int, allowed.split(','))) if allowed else sorted(os.sched_getaffinity(0))
+    rows = []
+    for cpu in cpus:
+        folder = Path(f'/sys/devices/system/cpu/cpu{cpu}/topology')
+        rows.append((cpu, int((folder / 'core_id').read_text()),
+                     int((folder / 'physical_package_id').read_text())))
+    return rows
+
+
+def configure_affinity():
+    rows = topology()
+    layout = select_affinity(rows)
+    os.environ['DEKAF_RUNNER_CPUS'] = ','.join(str(row[0]) for row in rows)
+    os.sched_setaffinity(0, set(map(int, layout['infrastructure'].split(','))))
+    return rows, layout
+
+
+def snapshot(proc=Path('/proc')):
+    # Raw counters allow later attribution without changing sample inclusion or tolerances.
+    values = {'monotonic_ns': time.monotonic_ns(), 'utc_ns': time.time_ns()}
+    for name in ('stat', 'meminfo', 'vmstat', 'loadavg', 'pressure/cpu', 'pressure/memory', 'pressure/io'):
+        values[name] = (proc / name).read_text()
+    disk = os.statvfs('.')
+    values['disk_available_bytes'] = disk.f_bavail * disk.f_frsize
+    values['sample_end_monotonic_ns'] = time.monotonic_ns()
+    return values
+
+
+def monitor(command, output):
+    output.mkdir(parents=True, exist_ok=False)
+    rows, layout = configure_affinity()
+    (output / 'plan.json').write_text(json.dumps({
+        'command': command, 'topology': rows, 'affinity': layout,
+        'image': os.getenv('ImageVersion'), 'interval_seconds': 1,
+        'scope': 'Host CPU/steal, memory/swap, PSI and disk; includes broker and infrastructure. '
+                 'Never substitute host CPU for client CPU per completed operation.'
+    }, indent=2))
+    child = None
+    try:
+        with (output / 'series.jsonl').open('w') as stream:
+            # Verify required counters before launching expensive work.
+            stream.write(json.dumps(snapshot()) + '\n')
+            stream.flush()
+            child = subprocess.Popen(command, start_new_session=True)
+            while True:
+                code = child.poll()
+                stream.write(json.dumps(snapshot()) + '\n')
+                stream.flush()
+                if code is not None:
+                    (output / 'completion.json').write_text(json.dumps({'exit_code': code}))
+                    return code
+                time.sleep(1)
+    finally:
+        if child is not None and child.poll() is None:
+            try:
+                os.killpg(child.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass  # The child may exit between poll and signal.
+            try:
+                child.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                try:
+                    os.killpg(child.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                child.wait()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('command', nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    command = args.command[1:] if args.command[:1] == ['--'] else args.command
+    if not command:
+        parser.error('A workload command is required after --')
+    sys.exit(monitor(command, args.output))

--- a/.github/scripts/test_admin_refresh.py
+++ b/.github/scripts/test_admin_refresh.py
@@ -1,0 +1,90 @@
+import importlib.util
+import os
+from pathlib import Path
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest.mock import Mock, patch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class CalibrationTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        with patch.dict(os.environ, PR='3128', BASELINE_SHA='a' * 40, CANDIDATE_SHA='a' * 40):
+            spec = importlib.util.spec_from_file_location('admin_refresh_test', ROOT / '.github/scripts/admin_refresh.py')
+            self.driver = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(self.driver)
+        self.driver.ROOT = self.root
+        self.driver.OUT = self.root / 'evidence'
+        self.driver.SOURCE = self.root / 'fixture'
+        self.driver.SOURCE.mkdir()
+        (self.driver.SOURCE / 'Runner.csproj').write_text('<Project/>')
+        helper = self.root / '.github/benchmarks/CompilationLog.cs'
+        helper.parent.mkdir(parents=True)
+        helper.write_text('// fixture')
+        self.commands = []
+        self.common = SimpleNamespace(
+            CONTROLS=['legacy:16'], NEW_CASES=['new:16'], validate_probe=Mock(return_value={}),
+            verify_copied_tree=Mock(), retain_loaded_binaries=Mock(),
+            compare=Mock(return_value={'point_estimates_within_declared_limits': False}))
+
+    def fake_run(self, command, log, **kwargs):
+        self.commands.append(list(map(str, command)))
+        if command[:2] == ['dotnet', 'build']:
+            output = Path(command[2]).parent / 'bin/Release/net10.0'
+            output.mkdir(parents=True)
+            (output / 'Dekaf.Benchmarks.dll').write_bytes(b'identical compiled fixture')
+
+    def execute(self, calibration):
+        with patch.dict(os.environ, ADMIN_CALIBRATION='1' if calibration else '0', ADMIN_PILOT='0'), \
+             patch.object(self.driver, 'configure_affinity', return_value=([], {'consumer': '2,3', 'infrastructure': '0,1'})), \
+             patch.object(self.driver, 'module', return_value=self.common), \
+             patch.object(self.driver, 'run', side_effect=self.fake_run), \
+             patch.object(self.driver.subprocess, 'check_output', return_value='a' * 40):
+            self.driver.execute()
+
+    def test_calibration_runs_one_binary_in_all_fresh_processes_and_skips_new_apis(self):
+        self.execute(True)
+        builds = [row for row in self.commands if row[:2] == ['dotnet', 'build']]
+        self.assertEqual(len(builds), 1)
+        self.assertIn('-p:Candidate=false', builds[0])
+        probes = [row for row in self.commands if 'probe' in row]
+        self.assertEqual(len(probes), 5)  # Two validation launches, then three measured launches.
+        self.assertEqual(len({row[4] for row in probes}), 1)
+        self.assertTrue(all(row[6] == 'legacy:16' for row in probes))
+        self.assertEqual([row[-2:] for row in probes], [['.2', '.2']] * 2 + [['480', '180']] * 3)
+        import json
+        report = json.loads((self.driver.OUT / 'calibration.json').read_text())
+        self.assertFalse(report['point_estimates_within_declared_limits'])
+        self.assertIn('never product acceptance', report['verdict'])
+
+    def test_calibration_rejects_different_product_before_build(self):
+        self.driver.B = 'b' * 40
+        with self.assertRaisesRegex(ValueError, 'identical exact product'):
+            self.execute(True)
+        self.assertEqual(self.commands, [])
+
+    def test_comparison_still_builds_both_fixtures_and_measures_candidate_only_cases(self):
+        self.driver.B = 'b' * 40
+        self.execute(False)
+        builds = [row for row in self.commands if row[:2] == ['dotnet', 'build']]
+        self.assertEqual(len(builds), 2)
+        self.assertIn('-p:Candidate=true', builds[1])
+        probes = [row for row in self.commands if 'probe' in row]
+        self.assertEqual(len({row[4] for row in probes}), 2)
+        self.assertEqual(probes[-1][6], 'new:16')
+        self.assertFalse((self.driver.OUT / 'calibration.json').exists())
+
+    def test_all_four_deployed_probes_match_the_tested_recorder(self):
+        probes = list(ROOT.glob('tools/Admin*Evidence/Probe.cs'))
+        self.assertEqual(len(probes), 4)
+        self.assertEqual(len({path.read_bytes() for path in probes}), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/scripts/test_runner_resources.py
+++ b/.github/scripts/test_runner_resources.py
@@ -1,0 +1,102 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import runner_resources as runner
+
+
+class RunnerTests(unittest.TestCase):
+    def test_smt_siblings_remain_together_across_sockets(self):
+        layout = runner.select_affinity([(0, 0, 0), (2, 0, 0), (1, 0, 1), (3, 0, 1)])
+        self.assertEqual(layout, {'consumer': '1,3', 'infrastructure': '0,2'})
+
+    def test_single_physical_core_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, 'two physical cores'):
+            runner.select_affinity([(0, 0, 0), (1, 0, 0)])
+
+    def test_driver_and_subprocesses_inherit_only_infrastructure_cpus(self):
+        rows = [(0, 0, 0), (1, 1, 0), (2, 0, 0), (3, 1, 0)]
+        with patch.object(runner, 'topology', return_value=rows), \
+             patch.object(os, 'sched_setaffinity', create=True) as pin, \
+             patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(runner.configure_affinity()[0], rows)
+            pin.assert_called_once_with(0, {0, 2})
+            self.assertEqual(os.environ['DEKAF_RUNNER_CPUS'], '0,1,2,3')
+
+    def test_snapshot_retains_raw_pressure_and_steal_counters(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for name in ('stat', 'meminfo', 'vmstat', 'loadavg', 'pressure/cpu', 'pressure/memory', 'pressure/io'):
+                path = root / name
+                path.parent.mkdir(exist_ok=True)
+                path.write_text(name + ' raw counters')
+            with patch.object(os, 'statvfs', create=True) as disk:
+                disk.return_value.f_bavail, disk.return_value.f_frsize = 7, 4096
+                result = runner.snapshot(root)
+            self.assertEqual(result['stat'], 'stat raw counters')
+            self.assertEqual(result['pressure/cpu'], 'pressure/cpu raw counters')
+            self.assertEqual(result['disk_available_bytes'], 7 * 4096)
+            (root / 'pressure/cpu').unlink()
+            with self.assertRaises(FileNotFoundError):
+                runner.snapshot(root)
+
+    def test_child_failure_remains_failure_and_samples_are_retained(self):
+        with tempfile.TemporaryDirectory() as directory, \
+             patch.object(runner, 'configure_affinity', return_value=([], {})), \
+             patch.object(runner, 'snapshot', return_value={'raw': 'sample'}):
+            output = Path(directory) / 'results'
+            code = runner.monitor([sys.executable, '-c', 'raise SystemExit(7)'], output)
+            self.assertEqual(code, 7)
+            self.assertEqual(json.loads((output / 'completion.json').read_text())['exit_code'], 7)
+            self.assertGreaterEqual(len((output / 'series.jsonl').read_text().splitlines()), 2)
+
+    def test_missing_counters_stop_before_workload_launch(self):
+        with tempfile.TemporaryDirectory() as directory, \
+             patch.object(runner, 'configure_affinity', return_value=([], {})), \
+             patch.object(runner, 'snapshot', side_effect=OSError('missing PSI')), \
+             patch.object(subprocess, 'Popen') as launch:
+            with self.assertRaisesRegex(OSError, 'missing PSI'):
+                runner.monitor(['workload'], Path(directory) / 'results')
+            launch.assert_not_called()
+
+    def test_sampling_failure_terminates_running_process_group(self):
+        with tempfile.TemporaryDirectory() as directory, \
+             patch.object(runner, 'configure_affinity', return_value=([], {})), \
+             patch.object(runner, 'snapshot', side_effect=[{'raw': 'sample'}, OSError('counter failed')]), \
+             patch.object(subprocess, 'Popen') as launch, \
+             patch.object(os, 'killpg', create=True) as stop:
+            child = launch.return_value
+            child.poll.return_value = None
+            child.pid = 123
+            with self.assertRaisesRegex(OSError, 'counter failed'):
+                runner.monitor(['workload'], Path(directory) / 'results')
+            stop.assert_called_once_with(123, runner.signal.SIGTERM)
+            child.wait.assert_called_once_with(timeout=5)
+
+
+def linux_smoke():
+    rows = runner.topology()
+    layout = runner.select_affinity(rows)
+    infrastructure = set(map(int, layout['infrastructure'].split(',')))
+    consumer = set(map(int, layout['consumer'].split(',')))
+    if set(os.sched_getaffinity(0)) != infrastructure:
+        raise RuntimeError('Harness did not inherit infrastructure affinity')
+    # A measured process must be able to use the reserved core, while its parent stays isolated.
+    command = ['taskset', '-c', layout['consumer'], sys.executable, '-c',
+               'import os,json; print(json.dumps(sorted(os.sched_getaffinity(0))))']
+    actual = set(json.loads(subprocess.check_output(command, text=True)))
+    if actual != consumer or actual & infrastructure:
+        raise RuntimeError('Measured child affinity differs or overlaps infrastructure')
+    print(json.dumps({'infrastructure': sorted(infrastructure), 'client': sorted(actual)}))
+
+
+if __name__ == '__main__':
+    if sys.argv[1:] == ['--linux-smoke']:
+        linux_smoke()
+    else:
+        unittest.main()

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,7 +9,7 @@ on:
       suite:
         required: true
         type: choice
-        options: [micro, pool, pool-recovery, admin, admin-pilot, dispatch, dispatch-adjacent, dispatch-loaded-adjacent, dispatch-loaded, dispatch-pilot, dispatch-record-pilot, share-loaded, outbox, outbox-loaded, outbox-adjacent, pool-loaded, pool-profile]
+        options: [micro, pool, pool-recovery, admin, admin-pilot, admin-calibration, dispatch, dispatch-adjacent, dispatch-loaded-adjacent, dispatch-loaded, dispatch-pilot, dispatch-record-pilot, share-loaded, outbox, outbox-loaded, outbox-adjacent, pool-loaded, pool-profile]
       baseline_sha:
         required: true
         description: Exact baseline SHA
@@ -21,7 +21,7 @@ permissions:
 jobs:
   compare:
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ (inputs.suite == 'admin' || inputs.suite == 'dispatch-adjacent' || inputs.suite == 'dispatch-loaded-adjacent') && 350 || 180 }}
+    timeout-minutes: ${{ (inputs.suite == 'admin' || inputs.suite == 'admin-calibration' || inputs.suite == 'dispatch-adjacent' || inputs.suite == 'dispatch-loaded-adjacent') && 350 || 180 }}
     env:
       BASELINE_SHA: ${{ inputs.baseline_sha }}
       CANDIDATE_SHA: ${{ inputs.candidate_sha }}
@@ -46,17 +46,17 @@ jobs:
         if: inputs.suite == 'micro'
         run: |
           python3 -m unittest discover -s .github/scripts -p test_benchmark_aba.py
-          python3 .github/scripts/benchmark_aba.py --pr "$PR" --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" --artifacts "$GITHUB_WORKSPACE/aba-results"
+          python3 .github/scripts/runner_resources.py --output runner-resources -- python3 .github/scripts/benchmark_aba.py --pr "$PR" --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" --artifacts "$GITHUB_WORKSPACE/aba-results"
       - name: Pool comparison
         if: inputs.suite == 'pool' || inputs.suite == 'pool-recovery'
         env:
           POOL_RECOVERY: ${{ inputs.suite == 'pool-recovery' && '1' || '0' }}
           DOTNET_TieredCompilation: ${{ inputs.suite == 'pool-recovery' && '0' || '1' }}
         run: |
-          python3 .github/scripts/pool_reset_aba.py prepare
-          python3 .github/scripts/pool_reset_aba.py A1
-          python3 .github/scripts/pool_reset_aba.py B
-          python3 .github/scripts/pool_reset_aba.py A2
+          python3 .github/scripts/runner_resources.py --output runner-resources/prepare -- python3 .github/scripts/pool_reset_aba.py prepare
+          python3 .github/scripts/runner_resources.py --output runner-resources/A1 -- python3 .github/scripts/pool_reset_aba.py A1
+          python3 .github/scripts/runner_resources.py --output runner-resources/B -- python3 .github/scripts/pool_reset_aba.py B
+          python3 .github/scripts/runner_resources.py --output runner-resources/A2 -- python3 .github/scripts/pool_reset_aba.py A2
       - name: Loaded pool comparison
         if: inputs.suite == 'pool-loaded' || inputs.suite == 'pool-profile'
         env:
@@ -65,28 +65,29 @@ jobs:
           python3 -m unittest discover -s .github/scripts -p test_pool_loaded_aba.py
           python3 -m unittest discover -s .github/benchmarks/pool-loaded/tests -p 'test_*.py'
           dotnet test --project .github/benchmarks/pool-loaded/tests/IntervalLatency.Tests.csproj -c Release
-          python3 .github/scripts/pool_loaded_aba.py
+          python3 .github/scripts/runner_resources.py --output runner-resources -- python3 .github/scripts/pool_loaded_aba.py
       - name: Outbox cycle comparison
         if: inputs.suite == 'outbox'
         run: |
           python3 -m unittest discover -s .github/scripts -p test_outbox_cycle_aba.py
-          python3 .github/scripts/outbox_cycle_aba.py --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" --artifacts "$GITHUB_WORKSPACE/aba-results"
+          python3 .github/scripts/runner_resources.py --output runner-resources -- python3 .github/scripts/outbox_cycle_aba.py --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" --artifacts "$GITHUB_WORKSPACE/aba-results"
       - name: Loaded outbox comparison
         if: inputs.suite == 'outbox-loaded' || inputs.suite == 'outbox-adjacent'
         env:
           OUTBOX_ADJACENT: ${{ inputs.suite == 'outbox-adjacent' && '1' || '0' }}
         run: |
           python3 -m unittest discover -s .github/scripts -p test_outbox_loaded_aba.py
-          python3 .github/scripts/outbox_loaded_aba.py
+          python3 .github/scripts/runner_resources.py --output runner-resources -- python3 .github/scripts/outbox_loaded_aba.py
       - name: Administrative direct-call comparison
-        if: inputs.suite == 'admin' || inputs.suite == 'admin-pilot'
+        if: inputs.suite == 'admin' || inputs.suite == 'admin-calibration' || inputs.suite == 'admin-pilot'
         env:
+          ADMIN_CALIBRATION: ${{ inputs.suite == 'admin-calibration' && '1' || '0' }}
           ADMIN_PILOT: ${{ inputs.suite == 'admin-pilot' && '1' || '0' }}
         run: |
           python3 -m unittest discover -s tools/AdminMutationEvidence -p test_validate_results.py
           python3 -m unittest discover -s tools/AdminShareOffsetEvidence -p test_comparison.py
           python3 -m unittest discover -s tools/AdminMemberRemovalEvidence -p test_comparison.py
-          python3 .github/scripts/admin_refresh.py
+          python3 .github/scripts/runner_resources.py --output runner-resources -- python3 .github/scripts/admin_refresh.py
       - name: Dispatch comparison with initialized coordinator
         if: inputs.suite == 'dispatch' || inputs.suite == 'dispatch-loaded' || inputs.suite == 'dispatch-pilot' || inputs.suite == 'dispatch-record-pilot'
         env:
@@ -99,12 +100,12 @@ jobs:
           if [[ "$DISPATCH_LOADED_ONLY" == 1 ]]; then extra_args+=(--loaded-only); fi
           if [[ "$DISPATCH_PILOT" == 1 ]]; then extra_args+=(--mode pending-batches); fi
           if [[ "$DISPATCH_STAGE_TIMING" == 1 ]]; then extra_args+=(--mode pending-records); fi
-          python3 .github/benchmarks/dispatch-aba/run.py --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" --output "$GITHUB_WORKSPACE/evidence" "${extra_args[@]}"
+          python3 .github/scripts/runner_resources.py --output runner-resources -- python3 .github/benchmarks/dispatch-aba/run.py --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" --output "$GITHUB_WORKSPACE/evidence" "${extra_args[@]}"
       - name: Completed share acknowledgement comparison
         if: inputs.suite == 'share-loaded'
         run: |
           python3 -m unittest discover -s .github/benchmarks/share-loaded -p 'test_*.py'
-          python3 .github/benchmarks/share-loaded/run.py --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" --output "$GITHUB_WORKSPACE/evidence"
+          python3 .github/scripts/runner_resources.py --output runner-resources -- python3 .github/benchmarks/share-loaded/run.py --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" --output "$GITHUB_WORKSPACE/evidence"
       - name: Full dispatch comparison with adjacent controls
         if: inputs.suite == 'dispatch-adjacent' || inputs.suite == 'dispatch-loaded-adjacent'
         env:
@@ -113,7 +114,7 @@ jobs:
           python3 -m unittest discover -s .github/benchmarks/dispatch-aba -p 'test_*.py'
           extra_args=()
           if [[ "$LOADED_ONLY" == 1 ]]; then extra_args+=(--loaded-only); fi
-          python3 .github/benchmarks/dispatch-aba/run_adjacent.py --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" --output "$GITHUB_WORKSPACE/evidence" "${extra_args[@]}"
+          python3 .github/scripts/runner_resources.py --output runner-resources -- python3 .github/benchmarks/dispatch-aba/run_adjacent.py --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" --output "$GITHUB_WORKSPACE/evidence" "${extra_args[@]}"
       - name: Record final main
         if: always()
         run: git ls-remote origin refs/heads/main > main-at-end.txt
@@ -125,5 +126,6 @@ jobs:
             aba-results/
             evidence/
             main-at-end.txt
+            runner-resources/
           include-hidden-files: true
           retention-days: 90

--- a/.github/workflows/performance-harness-tests.yml
+++ b/.github/workflows/performance-harness-tests.yml
@@ -1,0 +1,43 @@
+name: Performance harness tests
+on:
+  pull_request:
+    paths:
+      - '.github/benchmarks/**'
+      - '.github/scripts/**'
+      - '.github/workflows/benchmarks.yml'
+      - '.github/workflows/performance-harness-tests.yml'
+      - 'tools/Admin*Evidence/**'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68
+        with:
+          global-json-file: global.json
+      - name: Test recorder and comparison drivers
+        run: |
+          dotnet test --project .github/benchmarks/admin-recorder-tests/Recorder.Tests.csproj -c Release
+          for test in test_runner_resources.py test_admin_refresh.py test_benchmark_aba.py test_outbox_cycle_aba.py test_outbox_loaded_aba.py test_pool_loaded_aba.py; do
+            python3 -m unittest discover -s .github/scripts -p "$test"
+          done
+          python3 -m unittest discover -s .github/benchmarks/dispatch-aba -p 'test_*.py'
+          for project in AdminDescriptionEvidence AdminShareOffsetEvidence AdminMemberRemovalEvidence; do
+            python3 -m unittest discover -s "tools/$project" -p test_comparison.py
+          done
+          python3 -m unittest discover -s tools/AdminMutationEvidence -p test_validate_results.py
+      - name: Verify Linux affinity and resource capture
+        run: |
+          python3 .github/scripts/runner_resources.py --output resource-smoke -- python3 .github/scripts/test_runner_resources.py --linux-smoke
+      - name: Retain diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: performance-harness-tests
+          path: |
+            resource-smoke/
+            TestResults/

--- a/tools/AdminDescriptionEvidence/Probe.cs
+++ b/tools/AdminDescriptionEvidence/Probe.cs
@@ -6,6 +6,9 @@ namespace Dekaf.Benchmarks;
 
 public static class Probe
 {
+    private static readonly IComparer<TickCount> TickComparer =
+        Comparer<TickCount>.Create(static (left, right) => left.Ticks.CompareTo(right.Ticks));
+
     public static void SaveLoadedBinaries(string path)
     {
         var root = Path.GetFullPath(AppContext.BaseDirectory);
@@ -23,7 +26,7 @@ public static class Probe
     public sealed record Snapshot(double Seconds, long Completed, long CpuTicks, long AllocatedBytes,
         long HeapBytes, long RssBytes, int Gen0, int Gen1, int Gen2, long JitMethods,
         double JitMilliseconds, int ThreadPoolThreads, long PendingWorkItems);
-    public sealed record Interval(Snapshot Start, Snapshot End, List<TickCount> Latencies);
+    public sealed record Interval(Snapshot Start, Snapshot End, ArraySegment<TickCount> Latencies);
     public sealed record Capture(Snapshot Start, Snapshot End, List<Interval> Intervals)
     {
         public double Seconds => End.Seconds - Start.Seconds;
@@ -63,16 +66,11 @@ public static class Probe
             throw new ArgumentOutOfRangeException(nameof(durations));
         var captures = new Capture[durations.Length];
         var intervalSets = durations.Select(static seconds => new List<Interval>((int)Math.Ceiling(seconds) + 1)).ToArray();
-        // Retain raw exact-tick histograms without building a growing object graph
-        // during collection. Exceeding capacity invalidates the experiment.
-        const int histogramCapacity = 65536;
-        var histograms = durations.Select(static seconds => Enumerable.Range(0, (int)Math.Ceiling(seconds) + 1)
-            .Select(static _ => new List<TickCount>(histogramCapacity)).ToArray()).ToArray();
+        // Share bounded storage across intervals instead of reserving 1 MiB for every second.
+        var intervalCount = durations.Sum(static seconds => checked((int)Math.Ceiling(seconds) + 1));
+        var histogram = new ExactHistogram((int)Math.Min((long)intervalCount * 65536, 4_194_304));
         var phase = 0;
         var seconds = durations[phase];
-        // Exact tick buckets below one millisecond; sparse overflow preserves every longer tail.
-        var dense = new long[Math.Min(Stopwatch.Frequency / 1000, 1_000_000) + 1];
-        var overflow = new Dictionary<long, long>();
         var intervals = intervalSets[phase];
         using var process = Process.GetCurrentProcess();
         if (compilations is not null)
@@ -104,16 +102,13 @@ public static class Probe
             _ = await fixture.Call();
             var callEnd = Stopwatch.GetTimestamp();
             var ticks = callEnd - callStart;
-            if ((ulong)ticks < (ulong)dense.Length) dense[ticks]++;
-            else { overflow.TryGetValue(ticks, out var count); overflow[ticks] = count + 1; }
+            histogram.Record(ticks);
             completed++;
             var elapsed = Stopwatch.GetElapsedTime(started).TotalSeconds - first.Seconds;
             if (elapsed >= nextSnapshot || elapsed >= seconds)
             {
                 var snapshot = TakeSnapshot(process, started, completed);
-                var histogram = histograms[phase][intervals.Count];
-                DrainHistogram(dense, overflow, histogram);
-                intervals.Add(new(previous, snapshot, histogram));
+                intervals.Add(new(previous, snapshot, histogram.Drain()));
                 previous = snapshot;
                 nextSnapshot = Math.Floor(elapsed) + 1;
                 if (elapsed >= seconds)
@@ -144,7 +139,8 @@ public static class Probe
         var aggregate = new Dictionary<long, long>();
         // Sparse overflow buckets were retained unsorted during collection.
         foreach (var interval in intervals)
-            interval.Latencies.Sort(static (left, right) => left.Ticks.CompareTo(right.Ticks));
+            Array.Sort(interval.Latencies.Array!, interval.Latencies.Offset, interval.Latencies.Count,
+                TickComparer);
         foreach (var interval in intervals)
         foreach (var bucket in interval.Latencies)
         {
@@ -175,23 +171,71 @@ public static class Probe
         throw new InvalidOperationException("Percentile exceeds histogram population.");
     }
 
-    private static void DrainHistogram(long[] dense, Dictionary<long, long> overflow, List<TickCount> result)
+    // Single-writer recorder. Exact ticks and every maximum survive; exhaustion invalidates the capture.
+    internal sealed class ExactHistogram
     {
-        for (var tick = 0; tick < dense.Length; tick++)
+        private const int IntervalCapacity = 65536;
+        private readonly long[] _dense = new long[Math.Min(Stopwatch.Frequency / 1000, 1_000_000) + 1];
+        private readonly int[] _touched = new int[IntervalCapacity];
+        private readonly Dictionary<long, long> _overflow = new(IntervalCapacity);
+        private readonly TickCount[] _archive;
+        private int _touchedCount;
+        private int _used;
+
+        internal ExactHistogram(int capacity)
         {
-            if (dense[tick] == 0) continue;
-            if (result.Count == result.Capacity)
-                throw new InvalidOperationException("Preallocated histogram capacity exceeded.");
-            result.Add(new(tick, dense[tick]));
-            dense[tick] = 0;
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+            _archive = new TickCount[capacity];
         }
-        foreach (var pair in overflow)
+
+        internal void Record(long ticks)
         {
-            if (result.Count == result.Capacity)
-                throw new InvalidOperationException("Preallocated histogram capacity exceeded.");
-            result.Add(new(pair.Key, pair.Value));
+            ArgumentOutOfRangeException.ThrowIfNegative(ticks);
+            if (ticks < _dense.Length)
+            {
+                if (_dense[ticks] == 0)
+                {
+                    RequireIntervalSpace();
+                    _touched[_touchedCount++] = (int)ticks;
+                }
+                _dense[ticks]++;
+            }
+            else if (_overflow.TryGetValue(ticks, out var count))
+            {
+                _overflow[ticks] = count + 1;
+            }
+            else
+            {
+                RequireIntervalSpace();
+                _overflow.Add(ticks, 1);
+            }
         }
-        overflow.Clear();
+
+        private void RequireIntervalSpace()
+        {
+            if (_touchedCount + _overflow.Count == IntervalCapacity)
+                throw new InvalidOperationException("Preallocated interval histogram capacity exceeded.");
+        }
+
+        internal ArraySegment<TickCount> Drain()
+        {
+            var count = _touchedCount + _overflow.Count;
+            if (count > _archive.Length - _used)
+                throw new InvalidOperationException("Preallocated histogram archive capacity exceeded.");
+            var result = new ArraySegment<TickCount>(_archive, _used, count);
+            // Visit only observed tick values, not all one million possible values.
+            for (var index = 0; index < _touchedCount; index++)
+            {
+                var tick = _touched[index];
+                _archive[_used++] = new(tick, _dense[tick]);
+                _dense[tick] = 0;
+            }
+            foreach (var pair in _overflow)
+                _archive[_used++] = new(pair.Key, pair.Value);
+            _touchedCount = 0;
+            _overflow.Clear();
+            return result;
+        }
     }
 
     internal static Snapshot TakeSnapshot(Process process, long started, long completed)

--- a/tools/AdminMemberRemovalEvidence/Probe.cs
+++ b/tools/AdminMemberRemovalEvidence/Probe.cs
@@ -6,6 +6,9 @@ namespace Dekaf.Benchmarks;
 
 public static class Probe
 {
+    private static readonly IComparer<TickCount> TickComparer =
+        Comparer<TickCount>.Create(static (left, right) => left.Ticks.CompareTo(right.Ticks));
+
     public static void SaveLoadedBinaries(string path)
     {
         var root = Path.GetFullPath(AppContext.BaseDirectory);
@@ -23,7 +26,7 @@ public static class Probe
     public sealed record Snapshot(double Seconds, long Completed, long CpuTicks, long AllocatedBytes,
         long HeapBytes, long RssBytes, int Gen0, int Gen1, int Gen2, long JitMethods,
         double JitMilliseconds, int ThreadPoolThreads, long PendingWorkItems);
-    public sealed record Interval(Snapshot Start, Snapshot End, List<TickCount> Latencies);
+    public sealed record Interval(Snapshot Start, Snapshot End, ArraySegment<TickCount> Latencies);
     public sealed record Capture(Snapshot Start, Snapshot End, List<Interval> Intervals)
     {
         public double Seconds => End.Seconds - Start.Seconds;
@@ -63,16 +66,11 @@ public static class Probe
             throw new ArgumentOutOfRangeException(nameof(durations));
         var captures = new Capture[durations.Length];
         var intervalSets = durations.Select(static seconds => new List<Interval>((int)Math.Ceiling(seconds) + 1)).ToArray();
-        // Retain raw exact-tick histograms without building a growing object graph
-        // during collection. Exceeding capacity invalidates the experiment.
-        const int histogramCapacity = 65536;
-        var histograms = durations.Select(static seconds => Enumerable.Range(0, (int)Math.Ceiling(seconds) + 1)
-            .Select(static _ => new List<TickCount>(histogramCapacity)).ToArray()).ToArray();
+        // Share bounded storage across intervals instead of reserving 1 MiB for every second.
+        var intervalCount = durations.Sum(static seconds => checked((int)Math.Ceiling(seconds) + 1));
+        var histogram = new ExactHistogram((int)Math.Min((long)intervalCount * 65536, 4_194_304));
         var phase = 0;
         var seconds = durations[phase];
-        // Exact tick buckets below one millisecond; sparse overflow preserves every longer tail.
-        var dense = new long[Math.Min(Stopwatch.Frequency / 1000, 1_000_000) + 1];
-        var overflow = new Dictionary<long, long>();
         var intervals = intervalSets[phase];
         using var process = Process.GetCurrentProcess();
         if (compilations is not null)
@@ -104,16 +102,13 @@ public static class Probe
             _ = await fixture.Call();
             var callEnd = Stopwatch.GetTimestamp();
             var ticks = callEnd - callStart;
-            if ((ulong)ticks < (ulong)dense.Length) dense[ticks]++;
-            else { overflow.TryGetValue(ticks, out var count); overflow[ticks] = count + 1; }
+            histogram.Record(ticks);
             completed++;
             var elapsed = Stopwatch.GetElapsedTime(started).TotalSeconds - first.Seconds;
             if (elapsed >= nextSnapshot || elapsed >= seconds)
             {
                 var snapshot = TakeSnapshot(process, started, completed);
-                var histogram = histograms[phase][intervals.Count];
-                DrainHistogram(dense, overflow, histogram);
-                intervals.Add(new(previous, snapshot, histogram));
+                intervals.Add(new(previous, snapshot, histogram.Drain()));
                 previous = snapshot;
                 nextSnapshot = Math.Floor(elapsed) + 1;
                 if (elapsed >= seconds)
@@ -144,7 +139,8 @@ public static class Probe
         var aggregate = new Dictionary<long, long>();
         // Sparse overflow buckets were retained unsorted during collection.
         foreach (var interval in intervals)
-            interval.Latencies.Sort(static (left, right) => left.Ticks.CompareTo(right.Ticks));
+            Array.Sort(interval.Latencies.Array!, interval.Latencies.Offset, interval.Latencies.Count,
+                TickComparer);
         foreach (var interval in intervals)
         foreach (var bucket in interval.Latencies)
         {
@@ -175,23 +171,71 @@ public static class Probe
         throw new InvalidOperationException("Percentile exceeds histogram population.");
     }
 
-    private static void DrainHistogram(long[] dense, Dictionary<long, long> overflow, List<TickCount> result)
+    // Single-writer recorder. Exact ticks and every maximum survive; exhaustion invalidates the capture.
+    internal sealed class ExactHistogram
     {
-        for (var tick = 0; tick < dense.Length; tick++)
+        private const int IntervalCapacity = 65536;
+        private readonly long[] _dense = new long[Math.Min(Stopwatch.Frequency / 1000, 1_000_000) + 1];
+        private readonly int[] _touched = new int[IntervalCapacity];
+        private readonly Dictionary<long, long> _overflow = new(IntervalCapacity);
+        private readonly TickCount[] _archive;
+        private int _touchedCount;
+        private int _used;
+
+        internal ExactHistogram(int capacity)
         {
-            if (dense[tick] == 0) continue;
-            if (result.Count == result.Capacity)
-                throw new InvalidOperationException("Preallocated histogram capacity exceeded.");
-            result.Add(new(tick, dense[tick]));
-            dense[tick] = 0;
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+            _archive = new TickCount[capacity];
         }
-        foreach (var pair in overflow)
+
+        internal void Record(long ticks)
         {
-            if (result.Count == result.Capacity)
-                throw new InvalidOperationException("Preallocated histogram capacity exceeded.");
-            result.Add(new(pair.Key, pair.Value));
+            ArgumentOutOfRangeException.ThrowIfNegative(ticks);
+            if (ticks < _dense.Length)
+            {
+                if (_dense[ticks] == 0)
+                {
+                    RequireIntervalSpace();
+                    _touched[_touchedCount++] = (int)ticks;
+                }
+                _dense[ticks]++;
+            }
+            else if (_overflow.TryGetValue(ticks, out var count))
+            {
+                _overflow[ticks] = count + 1;
+            }
+            else
+            {
+                RequireIntervalSpace();
+                _overflow.Add(ticks, 1);
+            }
         }
-        overflow.Clear();
+
+        private void RequireIntervalSpace()
+        {
+            if (_touchedCount + _overflow.Count == IntervalCapacity)
+                throw new InvalidOperationException("Preallocated interval histogram capacity exceeded.");
+        }
+
+        internal ArraySegment<TickCount> Drain()
+        {
+            var count = _touchedCount + _overflow.Count;
+            if (count > _archive.Length - _used)
+                throw new InvalidOperationException("Preallocated histogram archive capacity exceeded.");
+            var result = new ArraySegment<TickCount>(_archive, _used, count);
+            // Visit only observed tick values, not all one million possible values.
+            for (var index = 0; index < _touchedCount; index++)
+            {
+                var tick = _touched[index];
+                _archive[_used++] = new(tick, _dense[tick]);
+                _dense[tick] = 0;
+            }
+            foreach (var pair in _overflow)
+                _archive[_used++] = new(pair.Key, pair.Value);
+            _touchedCount = 0;
+            _overflow.Clear();
+            return result;
+        }
     }
 
     internal static Snapshot TakeSnapshot(Process process, long started, long completed)

--- a/tools/AdminMutationEvidence/Probe.cs
+++ b/tools/AdminMutationEvidence/Probe.cs
@@ -6,6 +6,9 @@ namespace Dekaf.Benchmarks;
 
 public static class Probe
 {
+    private static readonly IComparer<TickCount> TickComparer =
+        Comparer<TickCount>.Create(static (left, right) => left.Ticks.CompareTo(right.Ticks));
+
     public static void SaveLoadedBinaries(string path)
     {
         var root = Path.GetFullPath(AppContext.BaseDirectory);
@@ -23,7 +26,7 @@ public static class Probe
     public sealed record Snapshot(double Seconds, long Completed, long CpuTicks, long AllocatedBytes,
         long HeapBytes, long RssBytes, int Gen0, int Gen1, int Gen2, long JitMethods,
         double JitMilliseconds, int ThreadPoolThreads, long PendingWorkItems);
-    public sealed record Interval(Snapshot Start, Snapshot End, List<TickCount> Latencies);
+    public sealed record Interval(Snapshot Start, Snapshot End, ArraySegment<TickCount> Latencies);
     public sealed record Capture(Snapshot Start, Snapshot End, List<Interval> Intervals)
     {
         public double Seconds => End.Seconds - Start.Seconds;
@@ -63,16 +66,11 @@ public static class Probe
             throw new ArgumentOutOfRangeException(nameof(durations));
         var captures = new Capture[durations.Length];
         var intervalSets = durations.Select(static seconds => new List<Interval>((int)Math.Ceiling(seconds) + 1)).ToArray();
-        // Retain raw exact-tick histograms without building a growing object graph
-        // during collection. Exceeding capacity invalidates the experiment.
-        const int histogramCapacity = 65536;
-        var histograms = durations.Select(static seconds => Enumerable.Range(0, (int)Math.Ceiling(seconds) + 1)
-            .Select(static _ => new List<TickCount>(histogramCapacity)).ToArray()).ToArray();
+        // Share bounded storage across intervals instead of reserving 1 MiB for every second.
+        var intervalCount = durations.Sum(static seconds => checked((int)Math.Ceiling(seconds) + 1));
+        var histogram = new ExactHistogram((int)Math.Min((long)intervalCount * 65536, 4_194_304));
         var phase = 0;
         var seconds = durations[phase];
-        // Exact tick buckets below one millisecond; sparse overflow preserves every longer tail.
-        var dense = new long[Math.Min(Stopwatch.Frequency / 1000, 1_000_000) + 1];
-        var overflow = new Dictionary<long, long>();
         var intervals = intervalSets[phase];
         using var process = Process.GetCurrentProcess();
         if (compilations is not null)
@@ -104,16 +102,13 @@ public static class Probe
             _ = await fixture.Call();
             var callEnd = Stopwatch.GetTimestamp();
             var ticks = callEnd - callStart;
-            if ((ulong)ticks < (ulong)dense.Length) dense[ticks]++;
-            else { overflow.TryGetValue(ticks, out var count); overflow[ticks] = count + 1; }
+            histogram.Record(ticks);
             completed++;
             var elapsed = Stopwatch.GetElapsedTime(started).TotalSeconds - first.Seconds;
             if (elapsed >= nextSnapshot || elapsed >= seconds)
             {
                 var snapshot = TakeSnapshot(process, started, completed);
-                var histogram = histograms[phase][intervals.Count];
-                DrainHistogram(dense, overflow, histogram);
-                intervals.Add(new(previous, snapshot, histogram));
+                intervals.Add(new(previous, snapshot, histogram.Drain()));
                 previous = snapshot;
                 nextSnapshot = Math.Floor(elapsed) + 1;
                 if (elapsed >= seconds)
@@ -144,7 +139,8 @@ public static class Probe
         var aggregate = new Dictionary<long, long>();
         // Sparse overflow buckets were retained unsorted during collection.
         foreach (var interval in intervals)
-            interval.Latencies.Sort(static (left, right) => left.Ticks.CompareTo(right.Ticks));
+            Array.Sort(interval.Latencies.Array!, interval.Latencies.Offset, interval.Latencies.Count,
+                TickComparer);
         foreach (var interval in intervals)
         foreach (var bucket in interval.Latencies)
         {
@@ -175,23 +171,71 @@ public static class Probe
         throw new InvalidOperationException("Percentile exceeds histogram population.");
     }
 
-    private static void DrainHistogram(long[] dense, Dictionary<long, long> overflow, List<TickCount> result)
+    // Single-writer recorder. Exact ticks and every maximum survive; exhaustion invalidates the capture.
+    internal sealed class ExactHistogram
     {
-        for (var tick = 0; tick < dense.Length; tick++)
+        private const int IntervalCapacity = 65536;
+        private readonly long[] _dense = new long[Math.Min(Stopwatch.Frequency / 1000, 1_000_000) + 1];
+        private readonly int[] _touched = new int[IntervalCapacity];
+        private readonly Dictionary<long, long> _overflow = new(IntervalCapacity);
+        private readonly TickCount[] _archive;
+        private int _touchedCount;
+        private int _used;
+
+        internal ExactHistogram(int capacity)
         {
-            if (dense[tick] == 0) continue;
-            if (result.Count == result.Capacity)
-                throw new InvalidOperationException("Preallocated histogram capacity exceeded.");
-            result.Add(new(tick, dense[tick]));
-            dense[tick] = 0;
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+            _archive = new TickCount[capacity];
         }
-        foreach (var pair in overflow)
+
+        internal void Record(long ticks)
         {
-            if (result.Count == result.Capacity)
-                throw new InvalidOperationException("Preallocated histogram capacity exceeded.");
-            result.Add(new(pair.Key, pair.Value));
+            ArgumentOutOfRangeException.ThrowIfNegative(ticks);
+            if (ticks < _dense.Length)
+            {
+                if (_dense[ticks] == 0)
+                {
+                    RequireIntervalSpace();
+                    _touched[_touchedCount++] = (int)ticks;
+                }
+                _dense[ticks]++;
+            }
+            else if (_overflow.TryGetValue(ticks, out var count))
+            {
+                _overflow[ticks] = count + 1;
+            }
+            else
+            {
+                RequireIntervalSpace();
+                _overflow.Add(ticks, 1);
+            }
         }
-        overflow.Clear();
+
+        private void RequireIntervalSpace()
+        {
+            if (_touchedCount + _overflow.Count == IntervalCapacity)
+                throw new InvalidOperationException("Preallocated interval histogram capacity exceeded.");
+        }
+
+        internal ArraySegment<TickCount> Drain()
+        {
+            var count = _touchedCount + _overflow.Count;
+            if (count > _archive.Length - _used)
+                throw new InvalidOperationException("Preallocated histogram archive capacity exceeded.");
+            var result = new ArraySegment<TickCount>(_archive, _used, count);
+            // Visit only observed tick values, not all one million possible values.
+            for (var index = 0; index < _touchedCount; index++)
+            {
+                var tick = _touched[index];
+                _archive[_used++] = new(tick, _dense[tick]);
+                _dense[tick] = 0;
+            }
+            foreach (var pair in _overflow)
+                _archive[_used++] = new(pair.Key, pair.Value);
+            _touchedCount = 0;
+            _overflow.Clear();
+            return result;
+        }
     }
 
     internal static Snapshot TakeSnapshot(Process process, long started, long completed)

--- a/tools/AdminShareOffsetEvidence/Probe.cs
+++ b/tools/AdminShareOffsetEvidence/Probe.cs
@@ -6,6 +6,9 @@ namespace Dekaf.Benchmarks;
 
 public static class Probe
 {
+    private static readonly IComparer<TickCount> TickComparer =
+        Comparer<TickCount>.Create(static (left, right) => left.Ticks.CompareTo(right.Ticks));
+
     public static void SaveLoadedBinaries(string path)
     {
         var root = Path.GetFullPath(AppContext.BaseDirectory);
@@ -23,7 +26,7 @@ public static class Probe
     public sealed record Snapshot(double Seconds, long Completed, long CpuTicks, long AllocatedBytes,
         long HeapBytes, long RssBytes, int Gen0, int Gen1, int Gen2, long JitMethods,
         double JitMilliseconds, int ThreadPoolThreads, long PendingWorkItems);
-    public sealed record Interval(Snapshot Start, Snapshot End, List<TickCount> Latencies);
+    public sealed record Interval(Snapshot Start, Snapshot End, ArraySegment<TickCount> Latencies);
     public sealed record Capture(Snapshot Start, Snapshot End, List<Interval> Intervals)
     {
         public double Seconds => End.Seconds - Start.Seconds;
@@ -63,16 +66,11 @@ public static class Probe
             throw new ArgumentOutOfRangeException(nameof(durations));
         var captures = new Capture[durations.Length];
         var intervalSets = durations.Select(static seconds => new List<Interval>((int)Math.Ceiling(seconds) + 1)).ToArray();
-        // Retain raw exact-tick histograms without building a growing object graph
-        // during collection. Exceeding capacity invalidates the experiment.
-        const int histogramCapacity = 65536;
-        var histograms = durations.Select(static seconds => Enumerable.Range(0, (int)Math.Ceiling(seconds) + 1)
-            .Select(static _ => new List<TickCount>(histogramCapacity)).ToArray()).ToArray();
+        // Share bounded storage across intervals instead of reserving 1 MiB for every second.
+        var intervalCount = durations.Sum(static seconds => checked((int)Math.Ceiling(seconds) + 1));
+        var histogram = new ExactHistogram((int)Math.Min((long)intervalCount * 65536, 4_194_304));
         var phase = 0;
         var seconds = durations[phase];
-        // Exact tick buckets below one millisecond; sparse overflow preserves every longer tail.
-        var dense = new long[Math.Min(Stopwatch.Frequency / 1000, 1_000_000) + 1];
-        var overflow = new Dictionary<long, long>();
         var intervals = intervalSets[phase];
         using var process = Process.GetCurrentProcess();
         if (compilations is not null)
@@ -104,16 +102,13 @@ public static class Probe
             _ = await fixture.Call();
             var callEnd = Stopwatch.GetTimestamp();
             var ticks = callEnd - callStart;
-            if ((ulong)ticks < (ulong)dense.Length) dense[ticks]++;
-            else { overflow.TryGetValue(ticks, out var count); overflow[ticks] = count + 1; }
+            histogram.Record(ticks);
             completed++;
             var elapsed = Stopwatch.GetElapsedTime(started).TotalSeconds - first.Seconds;
             if (elapsed >= nextSnapshot || elapsed >= seconds)
             {
                 var snapshot = TakeSnapshot(process, started, completed);
-                var histogram = histograms[phase][intervals.Count];
-                DrainHistogram(dense, overflow, histogram);
-                intervals.Add(new(previous, snapshot, histogram));
+                intervals.Add(new(previous, snapshot, histogram.Drain()));
                 previous = snapshot;
                 nextSnapshot = Math.Floor(elapsed) + 1;
                 if (elapsed >= seconds)
@@ -144,7 +139,8 @@ public static class Probe
         var aggregate = new Dictionary<long, long>();
         // Sparse overflow buckets were retained unsorted during collection.
         foreach (var interval in intervals)
-            interval.Latencies.Sort(static (left, right) => left.Ticks.CompareTo(right.Ticks));
+            Array.Sort(interval.Latencies.Array!, interval.Latencies.Offset, interval.Latencies.Count,
+                TickComparer);
         foreach (var interval in intervals)
         foreach (var bucket in interval.Latencies)
         {
@@ -175,23 +171,71 @@ public static class Probe
         throw new InvalidOperationException("Percentile exceeds histogram population.");
     }
 
-    private static void DrainHistogram(long[] dense, Dictionary<long, long> overflow, List<TickCount> result)
+    // Single-writer recorder. Exact ticks and every maximum survive; exhaustion invalidates the capture.
+    internal sealed class ExactHistogram
     {
-        for (var tick = 0; tick < dense.Length; tick++)
+        private const int IntervalCapacity = 65536;
+        private readonly long[] _dense = new long[Math.Min(Stopwatch.Frequency / 1000, 1_000_000) + 1];
+        private readonly int[] _touched = new int[IntervalCapacity];
+        private readonly Dictionary<long, long> _overflow = new(IntervalCapacity);
+        private readonly TickCount[] _archive;
+        private int _touchedCount;
+        private int _used;
+
+        internal ExactHistogram(int capacity)
         {
-            if (dense[tick] == 0) continue;
-            if (result.Count == result.Capacity)
-                throw new InvalidOperationException("Preallocated histogram capacity exceeded.");
-            result.Add(new(tick, dense[tick]));
-            dense[tick] = 0;
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+            _archive = new TickCount[capacity];
         }
-        foreach (var pair in overflow)
+
+        internal void Record(long ticks)
         {
-            if (result.Count == result.Capacity)
-                throw new InvalidOperationException("Preallocated histogram capacity exceeded.");
-            result.Add(new(pair.Key, pair.Value));
+            ArgumentOutOfRangeException.ThrowIfNegative(ticks);
+            if (ticks < _dense.Length)
+            {
+                if (_dense[ticks] == 0)
+                {
+                    RequireIntervalSpace();
+                    _touched[_touchedCount++] = (int)ticks;
+                }
+                _dense[ticks]++;
+            }
+            else if (_overflow.TryGetValue(ticks, out var count))
+            {
+                _overflow[ticks] = count + 1;
+            }
+            else
+            {
+                RequireIntervalSpace();
+                _overflow.Add(ticks, 1);
+            }
         }
-        overflow.Clear();
+
+        private void RequireIntervalSpace()
+        {
+            if (_touchedCount + _overflow.Count == IntervalCapacity)
+                throw new InvalidOperationException("Preallocated interval histogram capacity exceeded.");
+        }
+
+        internal ArraySegment<TickCount> Drain()
+        {
+            var count = _touchedCount + _overflow.Count;
+            if (count > _archive.Length - _used)
+                throw new InvalidOperationException("Preallocated histogram archive capacity exceeded.");
+            var result = new ArraySegment<TickCount>(_archive, _used, count);
+            // Visit only observed tick values, not all one million possible values.
+            for (var index = 0; index < _touchedCount; index++)
+            {
+                var tick = _touched[index];
+                _archive[_used++] = new(tick, _dense[tick]);
+                _dense[tick] = 0;
+            }
+            foreach (var pair in _overflow)
+                _archive[_used++] = new(pair.Key, pair.Value);
+            _touchedCount = 0;
+            _overflow.Clear();
+            return result;
+        }
     }
 
     internal static Snapshot TakeSnapshot(Process process, long started, long completed)


### PR DESCRIPTION
Shared performance investigations mix harness noise with product evidence: administrative probes reserve 662 MiB of interval histograms and scan up to one million counters each second, while unpinned diagnostics can compete with measured processes. Several benchmark paths also select a fixed logical CPU without respecting SMT topology.

This PR targets **`perf/pr-improve-20260908`**, the shared experimental harness used by the failing gates. Those drivers are not on `main`; targeting their branch makes the changes directly usable without importing unrelated experimental history into the product branch.

- Bound administrative histogram archive storage at 64 MiB and drain only observed tick values. Preserve exact ticks, all maxima, interval counts and existing JSON replay contracts; abort on capacity exhaustion.
- Pin Python drivers and their diagnostic subprocesses to infrastructure cores. Select client CPUs by physical-core/socket topology, including pool BenchmarkDotNet and dispatch microbenchmarks.
- Retain host CPU/steal, memory/swap, CPU/memory/I/O pressure and free-disk time series around every suite. Preserve workload failures and fail collection if required telemetry disappears.
- Add `admin-calibration`: the existing A1/B/A2 control matrix reuses one compiled baseline binary in three fresh processes. It rejects different product SHAs, retains existing warmup and limits, and reports diagnostic repeatability without setting any product gate to PASS.

Validation: 120 Python tests and 7 TUnit tests pass locally. All four actual administrative fixtures build and complete smoke runs; their existing replay validators accept every warmup/measured histogram and completion denominator. The pool fixture builds with zero warnings/errors. Hosted Ubuntu validation also passes: [run 34331301366](https://github.com/thomhurst/Dekaf/actions/runs/34331301366), including the recorder, comparison drivers, real process affinity and resource collection. Raw resource/test diagnostics are retained in its `performance-harness-tests` artifact.

No product source, acceptance tolerances, protected metrics, historical verdicts, or scheduled/paid stress coverage changes. In-process observers still count toward client CPU/allocation. One calibration triplet cannot prove maximum-latency precision or long-run stability; full product gates still require appropriate new-head evidence. No long calibration campaign has been run for this PR.

[Implementation, calibration instructions and measurement limits](https://github.com/thomhurst/Dekaf/blob/a54970ef12f308668589f9bc5c9b30793b7e1591/.github/benchmarks/HARNESS-RELIABILITY.md).

