### PR TITLE
fix(tests): wait for group coordinator and drive workload ingress with a manual clock

### DIFF
--- a/tests/Dekaf.Tests.Integration/ConsumerGroupOffsetQueryTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupOffsetQueryTests.cs
@@ -7,25 +7,27 @@ namespace Dekaf.Tests.Integration;
 public sealed class ConsumerGroupOffsetQueryTests(KafkaTestContainer kafka) : TransactionalKafkaIntegrationTest(kafka)
 {
     [Test]
-    public async Task CompleteOffsets_RoundTripMetadataEpochAndAbsentCommit()
+    public async Task CompleteOffsets_RoundTripMetadataEpochAndAbsentCommit(CancellationToken cancellationToken)
     {
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);
         var group = $"offset-query-{Guid.NewGuid():N}";
         var emptyGroup = $"empty-{Guid.NewGuid():N}";
         await using var admin = Kafka.CreateAdminClient().WithBootstrapServers(KafkaContainer.BootstrapServers).Build();
+        await WaitForGroupCoordinatorAsync(admin, group, cancellationToken);
+        await WaitForGroupCoordinatorAsync(admin, emptyGroup, cancellationToken);
         var checkpoint = new TopicPartitionOffset(topic, 0, 42, 0) { Metadata = "resume-checkpoint" };
-        await admin.AlterConsumerGroupOffsetsAsync(group, [checkpoint]);
+        await admin.AlterConsumerGroupOffsetsAsync(group, [checkpoint], cancellationToken);
         var results = await admin.ListConsumerGroupOffsetsAsync(new Dictionary<string, ListConsumerGroupOffsetsSpec>
         {
             [group] = new() { TopicPartitions = [new(topic, 0), new(topic, 1)] },
             [emptyGroup] = new()
-        });
+        }, cancellationToken: cancellationToken);
         await Assert.That(results[group].Offsets[new(topic, 0)].Offset).IsEqualTo(checkpoint);
         await Assert.That(results[group].Offsets[new(topic, 1)].Offset).IsNull();
         await Assert.That(results[group].Offsets[new(topic, 1)].ErrorCode).IsEqualTo(Protocol.ErrorCode.None);
         await Assert.That(results[emptyGroup].ErrorCode).IsEqualTo(Protocol.ErrorCode.None);
         await Assert.That(results[emptyGroup].Offsets).IsEmpty();
-        var legacy = await admin.ListConsumerGroupOffsetsAsync(group);
+        var legacy = await admin.ListConsumerGroupOffsetsAsync(group, cancellationToken);
         await Assert.That(legacy.Count).IsEqualTo(1);
         await Assert.That(legacy[new(topic, 0)]).IsEqualTo(42);
     }
@@ -33,40 +35,81 @@ public sealed class ConsumerGroupOffsetQueryTests(KafkaTestContainer kafka) : Tr
     [Test]
     [Arguments(true)]
     [Arguments(false)]
-    public async Task StableOffsets_WaitForPendingTransactionAndObserveCommitOrAbort(bool commit)
+    public async Task StableOffsets_WaitForPendingTransactionAndObserveCommitOrAbort(bool commit, CancellationToken cancellationToken)
     {
         var topic = await KafkaContainer.CreateTestTopicAsync();
         var group = $"stable-offset-query-{Guid.NewGuid():N}";
         await using var admin = Kafka.CreateAdminClient().WithBootstrapServers(KafkaContainer.BootstrapServers).Build();
+        await WaitForGroupCoordinatorAsync(admin, group, cancellationToken);
         var before = new TopicPartitionOffset(topic, 0, 5, 0) { Metadata = "before" };
         var after = new TopicPartitionOffset(topic, 0, 9, 0) { Metadata = "transaction" };
-        await admin.AlterConsumerGroupOffsetsAsync(group, [before]);
+        await admin.AlterConsumerGroupOffsetsAsync(group, [before], cancellationToken);
         await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithTransactionalId($"offset-query-txn-{Guid.NewGuid():N}")
-            .BuildAsync();
-        await producer.InitTransactionsAsync();
+            .BuildAsync(cancellationToken);
+        await producer.InitTransactionsAsync(cancellationToken);
         await using var transaction = producer.BeginTransaction();
-        await transaction.SendOffsetsToTransactionAsync([after], group);
+        await transaction.SendOffsetsToTransactionAsync([after], group, cancellationToken);
 
         var specs = new Dictionary<string, ListConsumerGroupOffsetsSpec>
         {
             [group] = new() { TopicPartitions = [new(topic, 0)] }
         };
-        var unstable = await admin.ListConsumerGroupOffsetsAsync(specs);
+        var unstable = await admin.ListConsumerGroupOffsetsAsync(specs, cancellationToken: cancellationToken);
         await Assert.That(unstable[group].Offsets[new(topic, 0)].Offset).IsEqualTo(before);
         await Assert.That(async () => await admin.ListConsumerGroupOffsetsAsync(specs,
-            new ListConsumerGroupOffsetsOptions { RequireStable = true, TimeoutMs = 250 }))
+            new ListConsumerGroupOffsetsOptions { RequireStable = true, TimeoutMs = 250 }, cancellationToken))
             .Throws<KafkaTimeoutException>();
 
         var pending = admin.ListConsumerGroupOffsetsAsync(specs,
-            new ListConsumerGroupOffsetsOptions { RequireStable = true }).AsTask();
+            new ListConsumerGroupOffsetsOptions { RequireStable = true }, cancellationToken).AsTask();
         if (commit)
-            await transaction.CommitAsync();
+            await transaction.CommitAsync(cancellationToken);
         else
-            await transaction.AbortAsync();
+            await transaction.AbortAsync(cancellationToken);
         var stable = await pending;
         await Assert.That(stable[group].Offsets[new(topic, 0)].Offset).IsEqualTo(commit ? after : before);
         await Assert.That(stable[group].Offsets[new(topic, 0)].ErrorCode).IsEqualTo(Protocol.ErrorCode.None);
+    }
+
+    private static async Task WaitForGroupCoordinatorAsync(
+        IAdminClient admin, string group, CancellationToken cancellationToken)
+    {
+        // Topic creation only establishes topic readiness. A new group's offsets
+        // partition can still be loading when these offset-query tests begin.
+        // Wait using a read-only query; keep the tested mutations and stable-offset
+        // assertions outside this setup loop so their failures remain visible.
+        using var readiness = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        readiness.CancelAfter(TimeSpan.FromSeconds(30));
+        KafkaException? lastFailure = null;
+        try
+        {
+            while (true)
+            {
+                try
+                {
+                    var groups = await admin.DescribeConsumerGroupsAsync([group], readiness.Token);
+                    if (!groups.ContainsKey(group))
+                        throw new InvalidOperationException($"Coordinator description omitted group '{group}'.");
+                    return;
+                }
+                catch (GroupException exception) when (exception.ErrorCode == Protocol.ErrorCode.GroupIdNotFound)
+                {
+                    // A missing fresh group is expected once its coordinator is ready.
+                    return;
+                }
+                catch (KafkaException exception) when (exception.IsRetriable && exception.ErrorCode is
+                    Protocol.ErrorCode.CoordinatorNotAvailable or Protocol.ErrorCode.CoordinatorLoadInProgress)
+                {
+                    lastFailure = exception;
+                }
+                await Task.Delay(100, readiness.Token);
+            }
+        }
+        catch (OperationCanceledException) when (readiness.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException($"Group coordinator for '{group}' did not become ready within 30 seconds.", lastFailure);
+        }
     }
 }

--- a/tests/Dekaf.Tests.Unit/ManualTimeProvider.cs
+++ b/tests/Dekaf.Tests.Unit/ManualTimeProvider.cs
@@ -1,11 +1,11 @@
 using System.Threading.Channels;
 
-namespace Dekaf.Tests.Unit.Outbox;
+namespace Dekaf.Tests.Unit;
 
-internal sealed class ManualLeaseTimeProvider : TimeProvider
+internal sealed class ManualTimeProvider : TimeProvider
 {
     private readonly object _gate = new();
-    private readonly List<LeaseTimer> _timers = [];
+    private readonly List<ManualTimer> _timers = [];
     private readonly Channel<TimeSpan> _scheduled = Channel.CreateUnbounded<TimeSpan>();
     private long _ticks = TimeSpan.TicksPerSecond;
 
@@ -15,7 +15,7 @@ internal sealed class ManualLeaseTimeProvider : TimeProvider
 
     public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
     {
-        var timer = new LeaseTimer(this, callback, state);
+        var timer = new ManualTimer(this, callback, state);
         lock (_gate)
             _timers.Add(timer);
         timer.Change(dueTime, period);
@@ -30,7 +30,7 @@ internal sealed class ManualLeaseTimeProvider : TimeProvider
 
     public void Advance(TimeSpan elapsed)
     {
-        List<LeaseTimer> due = [];
+        List<ManualTimer> due = [];
         lock (_gate)
         {
             Interlocked.Add(ref _ticks, elapsed.Ticks);
@@ -48,7 +48,7 @@ internal sealed class ManualLeaseTimeProvider : TimeProvider
             timer.Invoke();
     }
 
-    private sealed class LeaseTimer(ManualLeaseTimeProvider owner, TimerCallback callback, object? state) : ITimer
+    private sealed class ManualTimer(ManualTimeProvider owner, TimerCallback callback, object? state) : ITimer
     {
         internal long Due { get; set; } = long.MaxValue;
         internal TimeSpan Period { get; private set; }

--- a/tests/Dekaf.Tests.Unit/Outbox/OutboxLeaseRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/Outbox/OutboxLeaseRenewalTests.cs
@@ -11,7 +11,7 @@ public sealed class OutboxLeaseRenewalTests
     [Test]
     public async Task Dispose_ThrowingRenewalCancellation_StillDisposesSource()
     {
-        var time = new ManualLeaseTimeProvider();
+        var time = new ManualTimeProvider();
         using var relay = CreateRelay(new RenewableStore(time), new Publisher(), time);
         using var cancellation = new CancellationTokenSource();
         using var registration = cancellation.Token.Register(static () => throw new InvalidOperationException("callback failed"));
@@ -26,7 +26,7 @@ public sealed class OutboxLeaseRenewalTests
     [Test]
     public async Task SlowPublish_RenewsBeyondOriginalExpiry_PeerCannotTakeOver()
     {
-        var time = new ManualLeaseTimeProvider();
+        var time = new ManualTimeProvider();
         var store = new RenewableStore(time);
         var publisher = new PausedPublisher();
         using var relay = CreateRelay(store, publisher, time);
@@ -56,7 +56,7 @@ public sealed class OutboxLeaseRenewalTests
     [Test]
     public async Task ExpiredLease_TakenByPeer_OriginalPublishIsObservedButRowsRetained()
     {
-        var time = new ManualLeaseTimeProvider();
+        var time = new ManualTimeProvider();
         var store = new RenewableStore(time);
         var publisher = new PausedPublisher();
         using var relay = CreateRelay(store, publisher, time);
@@ -84,7 +84,7 @@ public sealed class OutboxLeaseRenewalTests
     [Test]
     public async Task FetchNearLeaseBoundary_RenewsBeforeStartingPublisher()
     {
-        var time = new ManualLeaseTimeProvider();
+        var time = new ManualTimeProvider();
         var store = new RenewableStore(time) { FetchDuration = TimeSpan.FromSeconds(29) };
         var publisher = new PausedPublisher();
         using var relay = CreateRelay(store, publisher, time);
@@ -107,7 +107,7 @@ public sealed class OutboxLeaseRenewalTests
     [Test]
     public async Task RenewalResponseAfterOldExpiry_RetainsRowsDespiteSuccessfulStoreResponse()
     {
-        var time = new ManualLeaseTimeProvider();
+        var time = new ManualTimeProvider();
         var store = new RenewableStore(time) { RenewalDuration = TimeSpan.FromSeconds(21) };
         var publisher = new PausedPublisher();
         using var relay = CreateRelay(store, publisher, time);
@@ -133,7 +133,7 @@ public sealed class OutboxLeaseRenewalTests
     [Test]
     public async Task SynchronousPublisherCrossesExpiry_RetainsRows()
     {
-        var time = new ManualLeaseTimeProvider();
+        var time = new ManualTimeProvider();
         var store = new RenewableStore(time);
         using var relay = CreateRelay(store,
             new Publisher(() => time.Advance(TimeSpan.FromSeconds(31))), time);
@@ -152,7 +152,7 @@ public sealed class OutboxLeaseRenewalTests
     [Test]
     public async Task WholePublishBudgetExceeded_FaultsRelayWithoutMarkingRows()
     {
-        var time = new ManualLeaseTimeProvider();
+        var time = new ManualTimeProvider();
         var store = new RenewableStore(time);
         using var relay = new OutboxRelayService(store,
             new Publisher(() => time.Advance(TimeSpan.FromSeconds(6))),
@@ -167,7 +167,7 @@ public sealed class OutboxLeaseRenewalTests
     [Test]
     public async Task FailedRenewal_DoesNotPublishAnotherBucketFromStaleProbe()
     {
-        var time = new ManualLeaseTimeProvider();
+        var time = new ManualTimeProvider();
         var store = new RenewableStore(time)
         {
             Buckets = [0, 1], FetchDuration = TimeSpan.FromSeconds(10), RenewalSucceeds = false
@@ -195,7 +195,7 @@ public sealed class OutboxLeaseRenewalTests
     [Arguments(20, false)]
     public async Task LegacyStore_ReservesWholePublishBudgetAfterFetch(int acquisitionSeconds, bool canPublish)
     {
-        var time = new ManualLeaseTimeProvider();
+        var time = new ManualTimeProvider();
         var inner = new RenewableStore(time)
         {
             FetchDuration = TimeSpan.FromSeconds(26),
@@ -313,7 +313,7 @@ public sealed class OutboxLeaseRenewalTests
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
-    private sealed class RenewableStore(ManualLeaseTimeProvider time) : IOutboxStore, IOutboxLeaseRenewalStore
+    private sealed class RenewableStore(ManualTimeProvider time) : IOutboxStore, IOutboxLeaseRenewalStore
     {
         private readonly object _gate = new();
         private readonly OutboxMessage[] _batch = [new()

--- a/tests/Dekaf.Tests.Unit/StressTests/ProducerWorkloadTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ProducerWorkloadTests.cs
@@ -15,6 +15,8 @@ public sealed class ProducerWorkloadTests
     [Arguments(true)]
     public async Task FinalFireAppend_IsDrainedOrReportsDeadlineBeforeMeasurementStops(bool drainExpires)
     {
+        var time = new ManualTimeProvider();
+        var duration = TimeSpan.FromMilliseconds(100);
         var directory = Path.Join(Path.GetTempPath(), "dekaf-workload-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
         try
@@ -37,7 +39,12 @@ public sealed class ProducerWorkloadTests
             producer.ProduceAsync("test", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(ValueTask.FromResult(default(RecordMetadata)));
             producer.FireAsync("test", Arg.Any<string>(), Arg.Any<string>())
-                .Returns(_ => new ValueTask(admission.Task));
+                .Returns(_ =>
+                {
+                    // Expire ingress only after the final append is actually in flight.
+                    time.Advance(duration);
+                    return new ValueTask(admission.Task);
+                });
             var flushes = 0;
             producer.FlushAsync(Arg.Any<CancellationToken>()).Returns(_ =>
             {
@@ -50,8 +57,8 @@ public sealed class ProducerWorkloadTests
                 return new ValueTask(finalDelivery.Task);
             });
             var run = ProducerWorkload.RunAsync(producer, options, "Dekaf", "producer", throughput, new LatencyTracker(),
-                TimeSpan.FromMilliseconds(100), awaitDelivery: false, CancellationToken.None,
-                drainTimeout: TimeSpan.FromSeconds(drainExpires ? 1 : 5));
+                duration, awaitDelivery: false, CancellationToken.None,
+                drainTimeout: TimeSpan.FromSeconds(drainExpires ? 1 : 5), ingressTimeProvider: time);
             try
             {
                 await firstFlush.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -104,6 +111,8 @@ public sealed class ProducerWorkloadTests
     [Arguments(true)]
     public async Task DrainTimeout_ReturnsSerializableFailureWithRuntimeSamples(bool confluent)
     {
+        var time = new ManualTimeProvider();
+        var duration = TimeSpan.FromMilliseconds(100);
         var directory = Path.Join(Path.GetTempPath(), "dekaf-workload-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
         try
@@ -127,6 +136,7 @@ public sealed class ProducerWorkloadTests
                     .Returns(async call =>
                     {
                         deliveryToken = call.Arg<CancellationToken>();
+                        time.Advance(duration);
                         await Task.Delay(Timeout.InfiniteTimeSpan, deliveryToken);
                         return new ConfluentKafka.DeliveryResult<string, string>();
                     });
@@ -138,20 +148,25 @@ public sealed class ProducerWorkloadTests
                     return 1;
                 });
                 run = ProducerWorkload.RunAsync(producer, options, "Confluent", "producer-async", throughput, new LatencyTracker(),
-                    TimeSpan.FromMilliseconds(100), awaitDelivery: true, CancellationToken.None, drainTimeout: TimeSpan.FromMilliseconds(100));
+                    duration, awaitDelivery: true, CancellationToken.None, drainTimeout: TimeSpan.FromMilliseconds(100), ingressTimeProvider: time);
             }
             else
             {
                 var producer = Substitute.For<IKafkaProducer<string, string>>();
                 producer.ProduceAsync("test", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-                    .Returns(call => new ValueTask<RecordMetadata>(WaitForCancellationAsync(call.Arg<CancellationToken>())));
+                    .Returns(call =>
+                    {
+                        var pending = WaitForCancellationAsync(call.Arg<CancellationToken>());
+                        time.Advance(duration);
+                        return new ValueTask<RecordMetadata>(pending);
+                    });
                 producer.FlushAsync(Arg.Any<CancellationToken>()).Returns(call =>
                 {
                     throughput.TakeSample();
                     return new ValueTask(Task.Delay(Timeout.InfiniteTimeSpan, call.Arg<CancellationToken>()));
                 });
                 run = ProducerWorkload.RunAsync(producer, options, "Dekaf", "producer-async", throughput, new LatencyTracker(),
-                    TimeSpan.FromMilliseconds(100), awaitDelivery: true, CancellationToken.None, drainTimeout: TimeSpan.FromMilliseconds(100));
+                    duration, awaitDelivery: true, CancellationToken.None, drainTimeout: TimeSpan.FromMilliseconds(100), ingressTimeProvider: time);
             }
             var result = await run.WaitAsync(TimeSpan.FromSeconds(5));
             await Assert.That(result.Throughput.TotalErrors).IsGreaterThan(0);
@@ -251,6 +266,8 @@ public sealed class ProducerWorkloadTests
     [Arguments(true)]
     public async Task FireAndForget_StopsIngressAndWaitsForSampledDeliveryAfterFlush(bool confluent)
     {
+        var time = new ManualTimeProvider();
+        var duration = TimeSpan.FromMilliseconds(100);
         var directory = Path.Join(Path.GetTempPath(), "dekaf-workload-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
         try
@@ -286,6 +303,7 @@ public sealed class ProducerWorkloadTests
                         return;
                     }
                     // Keep unsampled sends under backpressure until ingress expires.
+                    time.Advance(duration);
                     throw new ConfluentKafka.ProduceException<string, string>(
                         new ConfluentKafka.Error(ConfluentKafka.ErrorCode.Local_QueueFull),
                         new ConfluentKafka.DeliveryResult<string, string>());
@@ -297,7 +315,7 @@ public sealed class ProducerWorkloadTests
                         Error = new ConfluentKafka.Error(ConfluentKafka.ErrorCode.NoError)
                     });
                 run = ProducerWorkload.RunAsync(producer, options, "Confluent", "producer", throughput, latency,
-                    TimeSpan.FromMilliseconds(100), awaitDelivery: false, CancellationToken.None);
+                    duration, awaitDelivery: false, CancellationToken.None, ingressTimeProvider: time);
             }
             else
             {
@@ -307,7 +325,11 @@ public sealed class ProducerWorkloadTests
                 producer.ProduceAsync("test", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                     .Returns(_ => new ValueTask<RecordMetadata>(sampledDelivery.Task));
                 producer.FireAsync("test", Arg.Any<string>(), Arg.Any<string>())
-                    .Returns(_ => new ValueTask(bufferedSend.Task));
+                    .Returns(_ =>
+                    {
+                        time.Advance(duration);
+                        return new ValueTask(bufferedSend.Task);
+                    });
                 producer.FlushAsync(Arg.Any<CancellationToken>()).Returns(_ =>
                 {
                     bufferedSend.TrySetResult();
@@ -316,7 +338,7 @@ public sealed class ProducerWorkloadTests
                 });
                 completeDelivery = () => sampledDelivery.TrySetResult(default);
                 run = ProducerWorkload.RunAsync(producer, options, "Dekaf", "producer", throughput, latency,
-                    TimeSpan.FromMilliseconds(100), awaitDelivery: false, CancellationToken.None);
+                    duration, awaitDelivery: false, CancellationToken.None, ingressTimeProvider: time);
             }
             try
             {
@@ -349,6 +371,8 @@ public sealed class ProducerWorkloadTests
     [Arguments(true, true)]
     public async Task AwaitedSend_StopsIngressBeforeFinalDeliveryAndRecordsOutcome(bool confluent, bool fails)
     {
+        var time = new ManualTimeProvider();
+        var duration = TimeSpan.FromSeconds(1);
         var client = confluent ? "Confluent" : "Dekaf";
         var directory = Path.Join(Path.GetTempPath(), "dekaf-workload-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
@@ -376,7 +400,11 @@ public sealed class ProducerWorkloadTests
                 var delivery = new TaskCompletionSource<ConfluentKafka.DeliveryResult<string, string>>(TaskCreationOptions.RunContinuationsAsynchronously);
                 var producer = Substitute.For<ConfluentKafka.IProducer<string, string>>();
                 producer.ProduceAsync("test", Arg.Any<ConfluentKafka.Message<string, string>>(), Arg.Any<CancellationToken>())
-                    .Returns(delivery.Task);
+                    .Returns(_ =>
+                    {
+                        time.Advance(duration);
+                        return delivery.Task;
+                    });
                 producer.Flush(Arg.Any<TimeSpan>()).Returns(_ => { flushStarted.TrySetResult(); return 0; });
                 completeDelivery = () =>
                 {
@@ -385,14 +413,18 @@ public sealed class ProducerWorkloadTests
                     else delivery.TrySetResult(new ConfluentKafka.DeliveryResult<string, string>());
                 };
                 run = ProducerWorkload.RunAsync(producer, options, client, "producer-async-idempotent", throughput, latency,
-                    TimeSpan.FromSeconds(1), awaitDelivery: true, CancellationToken.None);
+                    duration, awaitDelivery: true, CancellationToken.None, ingressTimeProvider: time);
             }
             else
             {
                 var delivery = new TaskCompletionSource<RecordMetadata>(TaskCreationOptions.RunContinuationsAsynchronously);
                 var producer = Substitute.For<IKafkaProducer<string, string>>();
                 producer.ProduceAsync("test", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-                    .Returns(_ => new ValueTask<RecordMetadata>(delivery.Task));
+                    .Returns(_ =>
+                    {
+                        time.Advance(duration);
+                        return new ValueTask<RecordMetadata>(delivery.Task);
+                    });
                 producer.FlushAsync(Arg.Any<CancellationToken>()).Returns(_ =>
                 {
                     flushStarted.TrySetResult();
@@ -404,7 +436,7 @@ public sealed class ProducerWorkloadTests
                     else delivery.TrySetResult(default);
                 };
                 run = ProducerWorkload.RunAsync(producer, options, client, "producer-async-idempotent", throughput, latency,
-                    TimeSpan.FromSeconds(1), awaitDelivery: true, CancellationToken.None);
+                    duration, awaitDelivery: true, CancellationToken.None, ingressTimeProvider: time);
             }
 
             try

--- a/tools/Dekaf.StressTests/Scenarios/ProducerWorkload.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerWorkload.cs
@@ -11,12 +11,13 @@ internal static class ProducerWorkload
     internal static Task<ProducerWorkloadResult> RunAsync(
         IKafkaProducer<string, string> producer, StressTestOptions options, string client, string scenario,
         ThroughputTracker throughput, LatencyTracker latency, TimeSpan duration,
-        bool awaitDelivery, CancellationToken cancellationToken, TimeSpan? drainTimeout = null) =>
+        bool awaitDelivery, CancellationToken cancellationToken, TimeSpan? drainTimeout = null,
+        TimeProvider? ingressTimeProvider = null) =>
         MeasureAsync(options, throughput, latency, duration, client, scenario,
             (ingress, delivery) => ProduceDekafAsync(producer, options, throughput, latency, awaitDelivery, ingress, delivery),
             (timeout, token) => StressTestHelpers.FlushWithinDeadlineAsync(producer, throughput, timeout, token),
             !awaitDelivery, drainTimeout ?? StressTestHelpers.OperationTimeout, cancellationToken,
-            () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options));
+            () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options), ingressTimeProvider);
 
     // Separate overloads keep calls to each client direct inside the loop. Delegates below
     // run once per load phase, never once per message.
@@ -66,11 +67,13 @@ internal static class ProducerWorkload
     internal static Task<ProducerWorkloadResult> RunAsync(
         ConfluentKafka.IProducer<string, string> producer, StressTestOptions options, string client, string scenario,
         ThroughputTracker throughput, LatencyTracker latency, TimeSpan duration,
-        bool awaitDelivery, CancellationToken cancellationToken, TimeSpan? drainTimeout = null) =>
+        bool awaitDelivery, CancellationToken cancellationToken, TimeSpan? drainTimeout = null,
+        TimeProvider? ingressTimeProvider = null) =>
         MeasureAsync(options, throughput, latency, duration, client, scenario,
             (ingress, delivery) => ProduceConfluentAsync(producer, options, throughput, latency, awaitDelivery, ingress, delivery),
             (timeout, _) => { ConfluentStressTestHelpers.FlushWithTimeout(producer, throughput, timeout); return Task.CompletedTask; },
-            !awaitDelivery, drainTimeout ?? StressTestHelpers.OperationTimeout, cancellationToken);
+            !awaitDelivery, drainTimeout ?? StressTestHelpers.OperationTimeout, cancellationToken,
+            ingressTimeProvider: ingressTimeProvider);
 
     private static async Task ProduceConfluentAsync(
         ConfluentKafka.IProducer<string, string> producer, StressTestOptions options,
@@ -121,7 +124,8 @@ internal static class ProducerWorkload
         StressTestOptions options, ThroughputTracker throughput, LatencyTracker latency, TimeSpan duration, string client, string scenario,
         Func<CancellationToken, CancellationToken, Task> produce, Func<TimeSpan, CancellationToken, Task> drain,
         bool flushAfterAdmission, TimeSpan drainTimeout, CancellationToken cancellationToken,
-        Func<ProducerDeliveryDiagnosticsSnapshot?>? captureProducerDiagnostics = null)
+        Func<ProducerDeliveryDiagnosticsSnapshot?>? captureProducerDiagnostics = null,
+        TimeProvider? ingressTimeProvider = null)
     {
         if (throughput.Warmup is not null)
         {
@@ -134,7 +138,9 @@ internal static class ProducerWorkload
         using var delivery = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         using var sampling = new CancellationTokenSource();
         throughput.Start();
-        var stopIngress = StopIngressAsync(ingress, duration);
+        // Tests control only ingress expiry; measurements and delivery deadlines
+        // retain their real clocks. Normal runs use the system monotonic clock.
+        var stopIngress = StopIngressAsync(ingress, duration, ingressTimeProvider ?? TimeProvider.System);
         using var watchdog = options.ProgressWatchdog.Track(throughput, client, scenario, captureProducerDiagnostics);
         var sampler = StressTestHelpers.RunSamplerAsync(throughput, sampling.Token);
         var resources = StressTestHelpers.RunResourceMonitorAsync(sampling.Token);
@@ -200,17 +206,17 @@ internal static class ProducerWorkload
 
     // Timer callbacks can arrive slightly before their nominal duration. Recheck an
     // elapsed monotonic clock instead of counting an early timer as full workload warmup.
-    private static async Task StopIngressAsync(CancellationTokenSource ingress, TimeSpan duration)
+    private static async Task StopIngressAsync(CancellationTokenSource ingress, TimeSpan duration, TimeProvider timeProvider)
     {
-        var started = Stopwatch.GetTimestamp();
+        var started = timeProvider.GetTimestamp();
         try
         {
             while (!ingress.IsCancellationRequested)
             {
-                var remaining = duration - Stopwatch.GetElapsedTime(started);
+                var remaining = duration - timeProvider.GetElapsedTime(started);
                 if (remaining <= TimeSpan.Zero) break;
                 var delay = remaining < TimeSpan.FromMilliseconds(1) ? TimeSpan.FromMilliseconds(1) : remaining;
-                await Task.Delay(delay, ingress.Token).ConfigureAwait(false);
+                await Task.Delay(delay, timeProvider, ingress.Token).ConfigureAwait(false);
             }
             ingress.Cancel();
         }


### PR DESCRIPTION
Two intermittent CI failures came from timing the tests did not control.

`ConsumerGroupOffsetQueryTests` altered and listed offsets for freshly named groups immediately after topic creation. A new group's offsets partition can still be loading, so the first mutation failed with `CoordinatorNotAvailable` or `CoordinatorLoadInProgress`. The tests now wait with a bounded, read-only `DescribeConsumerGroupsAsync` loop (100 ms interval, 30 s cap) that treats `GroupIdNotFound` as ready and retries only those two retriable coordinator codes. The tested mutations and stable-offset assertions stay outside the loop so their failures remain visible. The tests also accept and forward the TUnit cancellation token.

`ProducerWorkloadTests` relied on a real 100 ms ingress window elapsing while mocked producer calls were still being wired, so a slow runner could expire ingress before the intended blocked append was in flight. `ProducerWorkload.RunAsync` gains an optional `ingressTimeProvider` used only by `StopIngressAsync`, once per load phase; the default is `TimeProvider.System`, and measurement counters, sampling and drain deadlines keep their real clocks. Each test advances a `ManualTimeProvider` only from inside the mocked call it expects to be blocked. `ManualLeaseTimeProvider` moves out of the Outbox namespace as the shared `ManualTimeProvider`; `OutboxLeaseRenewalTests` use the renamed type unchanged.

No `src/` changes. The stress-tool change adds one optional parameter resolved once per phase and nothing per message.

These changes were authored in #3161 and are carried forward unchanged. That PR's administrative recorder attribution, EventPipe clock anchor and sampler-control suites are superseded by #3164, which removed the custom samplers and set the standard-tooling policy.

Validation on this head: `ProducerWorkloadTests` and `OutboxLeaseRenewalTests` pass on net10.0 (28 tests) and net8.0 (13 tests); `ConsumerGroupOffsetQueryTests` pass against a real Kafka Testcontainer (3 tests). Both classes ran with the MTP tree-node filter from the repository build guide.

https://claude.ai/code/session_011biLs37i4rzbUonakn33cT
