### PR TITLE
fix(ci): bound BenchmarkDotNet comparison project discovery

### DIFF
--- a/.github/benchmarks/aba/Performance.sln
+++ b/.github/benchmarks/aba/Performance.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.Benchmarks", "Dekaf.Benchmarks.csproj", "{E92242FF-48AF-40D2-9E09-351E239B15EA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E92242FF-48AF-40D2-9E09-351E239B15EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E92242FF-48AF-40D2-9E09-351E239B15EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E92242FF-48AF-40D2-9E09-351E239B15EA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E92242FF-48AF-40D2-9E09-351E239B15EA}.Debug|x64.Build.0 = Debug|Any CPU
+		{E92242FF-48AF-40D2-9E09-351E239B15EA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E92242FF-48AF-40D2-9E09-351E239B15EA}.Debug|x86.Build.0 = Debug|Any CPU
+		{E92242FF-48AF-40D2-9E09-351E239B15EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E92242FF-48AF-40D2-9E09-351E239B15EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E92242FF-48AF-40D2-9E09-351E239B15EA}.Release|x64.ActiveCfg = Release|Any CPU
+		{E92242FF-48AF-40D2-9E09-351E239B15EA}.Release|x64.Build.0 = Release|Any CPU
+		{E92242FF-48AF-40D2-9E09-351E239B15EA}.Release|x86.ActiveCfg = Release|Any CPU
+		{E92242FF-48AF-40D2-9E09-351E239B15EA}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/.github/benchmarks/aba/README.md
+++ b/.github/benchmarks/aba/README.md
@@ -7,6 +7,8 @@ normal project into each product checkout. BenchmarkDotNet handles builds,
 process isolation, timing, allocation measurement and exports. The copied
 directory includes `Directory.Build.props`/`.targets` stop-files so the fixture
 host does not import the product checkout's repository build settings.
+The copied `Performance.sln` bounds BenchmarkDotNet's project discovery to this
+directory, avoiding other `Dekaf.Benchmarks.csproj` files in the product checkout.
 
 Fixture differences required for a fresh-main comparison:
 

--- a/.github/workflows/performance-harness-tests.yml
+++ b/.github/workflows/performance-harness-tests.yml
@@ -74,6 +74,21 @@ jobs:
           if dotnet run -c Release --no-build -- --job Dry --filter '*DoesNotExist*' --artifacts "$results/empty" > "$results/empty.log" 2>&1; then
             echo 'An empty selection returned success'; exit 1
           fi
+      - name: Verify copied comparison project discovery
+        env:
+          ABA_PR: '3158'
+          ABA_ROLE: A
+          MSBUILDDISABLENODEREUSE: '1'
+          DOTNET_CLI_USE_MSBUILD_SERVER: '0'
+        run: |
+          results="$GITHUB_WORKSPACE/.artifacts/comparison-discovery"
+          mkdir -p "$results"
+          cp -R .github/benchmarks/aba .performance
+          cp global.json Directory.Packages.props .performance/
+          cd .performance
+          dotnet build Dekaf.Benchmarks.csproj -c Release --disable-build-servers > "$results/build.log" 2>&1
+          dotnet run --project Dekaf.Benchmarks.csproj -c Release --no-build -- --job Dry --filter '*ShareResponseFrameBench*' --artifacts "$results/dry" > "$results/dry.log" 2>&1
+          jq -s -e '[.[].Benchmarks[]] | length == 6 and all(.[]; .Statistics.N == 1)' "$results/dry/results/"*-report-full.json
       - name: Verify Linux client and broker affinity
         run: |
           python3 .github/scripts/test_runner_affinity.py --linux-smoke
@@ -86,4 +101,5 @@ jobs:
           path: |
             .artifacts/admin-smoke/
             .artifacts/bdn-smoke/
+            .artifacts/comparison-discovery/
             TestResults/


### PR DESCRIPTION
The copied comparison project fails before timing because BenchmarkDotNet finds multiple `Dekaf.Benchmarks.csproj` files under the repository solution root. Add a local `Performance.sln` so normal BenchmarkDotNet discovery stays inside the copied `.performance` directory.

The existing harness test workflow now dry-runs the actual copied fixture layout and requires all six share-response cases. No benchmark engine, profiler, product code, or measurement settings change.

Validation: Release build succeeded; all six BenchmarkDotNet Dry cases completed using the copied fixture with both existing repository benchmark projects present.
