### PR TITLE
fix(deps): preserve archived performance evidence

### DIFF
--- a/docs/performance-evidence/2026-09-07/pr-3117/evidence/global.json
+++ b/docs/performance-evidence/2026-09-07/pr-3117/evidence/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.400",
+    "version": "10.0.401",
     "rollForward": "latestPatch",
     "allowPrerelease": false
   },

--- a/docs/performance-evidence/2026-09-07/pr-3117/evidence/global.json
+++ b/docs/performance-evidence/2026-09-07/pr-3117/evidence/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.401",
+    "version": "10.0.400",
     "rollForward": "latestPatch",
     "allowPrerelease": false
   },

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
+      "description": "Preserve immutable performance evidence and its recorded dependency versions",
+      "matchFileNames": ["docs/performance-evidence/**"],
+      "enabled": false
+    },
+    {
       "description": "EF 8.x train pinned for the net8.0 TFM (Directory.Packages.props conditioned entry); 9+/10+ do not support net8.0",
       "matchPackageNames": [
         "/^Microsoft\\.EntityFrameworkCore\\./"


### PR DESCRIPTION
Renovate updated the SDK snapshot inside the historical PR #3117 performance evidence, invalidating its recorded SHA-256. Restore the snapshot byte-for-byte and disable dependency updates under `docs/performance-evidence/**`. The live SDK is already 10.0.401 on main.

Validation: Renovate's configuration validator passed (Windows RE2 unavailable; its documented RegExp fallback was used). The restored snapshot matches the existing manifest SHA-256 `89df56e469fe3ebcd4afbf792fa982192af39e415c8c8f5b8068dce7163cc22d`. Reviewed the final diff: only the Renovate configuration differs from main.

Validation log, configuration copy, and SHA-256 inventory: `C:/git/Dekaf-evidence/pr-3170/1e0e87568f99268b96767c100bf11a09db97122c`, outside removable worktrees.