### PR TITLE
test(producer): isolate completion metrics from concurrent tests

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/PooledCompletionSourceMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledCompletionSourceMetricsTests.cs
@@ -30,7 +30,10 @@ public sealed class PooledCompletionSourceMetricsTests
         var source = pool.Rent();
         CompleteCoreWithoutUpdatingSourceState(source);
 
-        await Assert.That(Complete(source, completionKind)).IsFalse();
+        var completed = Complete(source, completionKind);
+        listener.Dispose();
+
+        await Assert.That(completed).IsFalse();
         await Assert.That(Volatile.Read(ref inlineExceptions)).IsEqualTo(0);
         await Assert.That(Volatile.Read(ref sourceFaults)).IsEqualTo(1);
     }
@@ -59,13 +62,50 @@ public sealed class PooledCompletionSourceMetricsTests
             Timestamp = DateTimeOffset.UnixEpoch
         });
 
+        listener.Dispose();
+
         await Assert.That(completed).IsTrue();
         await Assert.That(Volatile.Read(ref recordedExceptions)).IsEqualTo(1);
         _ = awaiter.GetResult();
     }
 
+    [Test]
+    public async Task CompletionExceptionListener_IgnoresOtherThreads()
+    {
+        long inlineExceptions = 0;
+        long sourceFaults = 0;
+        using var listener = CreateCompletionExceptionListener((instrument, measurement) =>
+        {
+            if (instrument == "dekaf.producer.inline_continuation.exceptions")
+                Interlocked.Add(ref inlineExceptions, measurement);
+            else if (instrument == "dekaf.producer.completion_source.faults")
+                Interlocked.Add(ref sourceFaults, measurement);
+        });
+
+        // An ungrouped producer test can emit the same process-wide instruments
+        // while this listener is active. Emit deterministically on another thread.
+        var otherThread = new Thread(static () =>
+        {
+            DekafMetrics.InlineContinuationExceptions.Add(100);
+            DekafMetrics.CompletionSourceFaults.Add(100);
+        }) { IsBackground = true };
+        otherThread.Start();
+        var joined = otherThread.Join(TimeSpan.FromSeconds(10));
+
+        DekafMetrics.InlineContinuationExceptions.Add(1);
+        DekafMetrics.CompletionSourceFaults.Add(1);
+        listener.Dispose();
+
+        await Assert.That(joined).IsTrue();
+        await Assert.That(Volatile.Read(ref inlineExceptions)).IsEqualTo(1);
+        await Assert.That(Volatile.Read(ref sourceFaults)).IsEqualTo(1);
+    }
+
     private static MeterListener CreateCompletionExceptionListener(Action<string, long> onMeasurement)
     {
+        // These counters are emitted synchronously by the completion call. Scope
+        // observations to this thread; other producer tests also emit them.
+        var measurementThreadId = Environment.CurrentManagedThreadId;
         var listener = new MeterListener();
         listener.InstrumentPublished = (instrument, meterListener) =>
         {
@@ -78,7 +118,8 @@ public sealed class PooledCompletionSourceMetricsTests
         };
         listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
         {
-            onMeasurement(instrument.Name, measurement);
+            if (Environment.CurrentManagedThreadId == measurementThreadId)
+                onMeasurement(instrument.Name, measurement);
         });
         listener.Start();
         return listener;


### PR DESCRIPTION
Concurrent producer tests can emit completion-fault metrics into `PooledCompletionSourceMetricsTests`' process-wide listener, causing exact-count assertions to fail. Scope its synchronous measurements to the test's thread and dispose the listener before awaiting assertions. Add a deterministic foreign-thread emitter that fails before the fix (101 instead of 1) and passes afterward, while preserving all existing completion-result, exception, cancellation, and inline-failure assertions.

Validation: 50 focused tests pass on each of net10.0 and net8.0. The complete parallel net10.0 suite passes 9,372/9,372 on runtime 10.0.11, matching the runtime of the original failure. Release build: zero warnings/errors. Final diff reviewed for simplicity; only one test file changes, so production benchmarks and broker integration tests are not applicable.

Raw failing/passing logs, HTML reports, regression source, patch, and tested binaries are retained at `C:/git/Dekaf-evidence/issue-3172/bbf9335a51f110b5f0375df546b9375e1bb3d6f3/`. All 1,289 diagnostic/binary files were SHA-256 compared with their originals; `inventory.json` records them. The original full-suite failure remains archived through #3172. Avro allocation issue #3087 remains unresolved.

Closes #3172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that completion metrics emitted from other threads are ignored.
  * Updated metric assertions to occur after listeners are properly disposed.
  * Confirmed same-thread completion measurements continue to be counted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->