### PR TITLE
test(perf): cover outbox commit notifications during recovery

### DIFF
--- a/.github/benchmarks/README.md
+++ b/.github/benchmarks/README.md
@@ -100,7 +100,9 @@ The workflow splits `dispatch-adjacent` into six jobs: one for each of the four
 loaded modes, one for all six micro cases, and one for all four shutdown cases.
 `dispatch-loaded-adjacent` uses just the four loaded jobs. `outbox-loaded` and
 `outbox-adjacent` each use four jobs, one per store/listener configuration.
-`outbox-recovery` uses four jobs for failure/lease-loss and listener off/on.
+`outbox-recovery` uses four jobs for #3085 (failure/lease-loss and listener off/on).
+For #3171 it uses two jobs with listeners off, validating the product's commit
+notifier during the same failure, lease-loss and loaded-shutdown workloads.
 Other suites retain one comparison job. There are no new dispatch inputs.
 
 Each job builds both pinned products and validates every selected case on both

--- a/.github/benchmarks/outbox-loaded/Harness.csproj
+++ b/.github/benchmarks/outbox-loaded/Harness.csproj
@@ -12,6 +12,9 @@
   <PropertyGroup Condition="'$(CandidateFixture)' == 'true'">
     <DefineConstants>$(DefineConstants);CANDIDATE</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(CommitNotificationsFixture)' == 'true'">
+    <DefineConstants>$(DefineConstants);OUTBOX_COMMIT_NOTIFICATIONS</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="$(ProductProject)" />

--- a/.github/benchmarks/outbox-loaded/Program.cs
+++ b/.github/benchmarks/outbox-loaded/Program.cs
@@ -8,6 +8,9 @@ using Dekaf.Admin;
 using Dekaf.Outbox;
 using Dekaf.Producer;
 using Microsoft.Extensions.Logging;
+#if OUTBOX_COMMIT_NOTIFICATIONS
+using Microsoft.Extensions.DependencyInjection;
+#endif
 
 internal static class Program
 {
@@ -54,7 +57,19 @@ internal static class Program
         // The baseline has no telemetry options. Publication inputs are identical.
         typeof(OutboxRelayOptions).GetProperty("MetricsName")?.SetValue(options, "loaded");
         typeof(OutboxRelayOptions).GetProperty("MetricsCollectionInterval")?.SetValue(options, TimeSpan.FromSeconds(1));
+#if OUTBOX_COMMIT_NOTIFICATIONS
+        // Resolve the product's notifier through its public registration. This container
+        // owns only the notifier; the manually constructed relay/publisher retain their
+        // existing lifetimes. The baseline has no notification API.
+        using var notificationServices = new ServiceCollection().AddDekafOutboxRelay(options).BuildServiceProvider();
+        var notifier = notificationServices.GetRequiredService<IOutboxNotifier>();
+        store.RowsCommitted = notifier.NotifyCommitted;
+        using var relay = new OutboxRelayService(store, publisher, options, new FailureLogger(store), null, notifier);
+        const bool notificationsEnabled = true;
+#else
         using var relay = new OutboxRelayService(store, publisher, options, new FailureLogger(store));
+        const bool notificationsEnabled = false;
+#endif
         using var sampling = new ManualResetEventSlim();
         var sampler = new Thread(() => store.Sample(sampling, metrics)) { IsBackground = true, Name = "outbox-observer" };
         sampler.Start();
@@ -105,6 +120,7 @@ internal static class Program
                 store.TotalCompleted, store.Pending, store.MetricQueries, metrics.Acknowledged,
                 store.InjectedFailures, store.RecoveredFailures, store.ObservedFailureLogs, LeaseLossScenario = leaseLoss,
                 store.ExpectedRetainedRows, store.ShutdownAcknowledged, store.ShutdownPublisherInFlight,
+                CommitNotificationsEnabled = notificationsEnabled, store.CommitNotifications,
                 metrics.Failures, metrics.GaugeSamples, ShutdownSeconds = shutdownSeconds,
                 Error = failure?.ToString() ?? store.Failure?.ToString()
             }));
@@ -149,6 +165,8 @@ internal class Store : IOutboxStore
     public int InjectedFailures;
     public int RecoveredFailures;
     public int ObservedFailureLogs;
+    public int CommitNotifications;
+    internal Action? RowsCommitted { get; set; }
     public bool FaultPending;
     private int _loadedShutdown;
     internal bool LoadedShutdown => Volatile.Read(ref _loadedShutdown) != 0;
@@ -157,8 +175,21 @@ internal class Store : IOutboxStore
     public bool ShutdownPublisherInFlight;
     internal readonly TaskCompletionSource ShutdownEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
     internal readonly TaskCompletionSource ShutdownRelease = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    internal void BeginLoadedShutdown() => Volatile.Write(ref _loadedShutdown, 1);
+    internal void BeginLoadedShutdown()
+    {
+        Volatile.Write(ref _loadedShutdown, 1);
+        SignalCommittedRows();
+    }
     internal TaskCompletionSource? LeaseLoss;
+
+    private void SignalCommittedRows()
+    {
+        if (RowsCommitted is { } notify)
+        {
+            Interlocked.Increment(ref CommitNotifications);
+            notify();
+        }
+    }
 
     internal void InjectFailure()
     {
@@ -220,6 +251,7 @@ internal class Store : IOutboxStore
         }
         Volatile.Write(ref Pending, BatchCount);
         _started = Stopwatch.GetTimestamp();
+        SignalCommittedRows();
         return new(_rows);
     }
 

--- a/.github/benchmarks/outbox-loaded/RECOVERY.md
+++ b/.github/benchmarks/outbox-loaded/RECOVERY.md
@@ -1,11 +1,13 @@
 # Outbox failure, lease-loss and loaded shutdown comparison
 
-Use `suite=outbox-recovery` for PR #3085 after its normal-path micro and loaded
+Use `suite=outbox-recovery` for PR #3085 or #3171 after their normal-path
 comparisons. This extends the maintained Kafka workload and recorder; it adds
 fault injection and correctness checks, not a benchmark engine or profiler.
 
 Four independent jobs cover `legacy-failure` and `renewal-loss`, each with
-listeners off/on. Every job validates both products, then runs A1, B, A2
+listeners off/on for #3085. PR #3171 uses only two jobs, one for each failure mode
+with listeners off, since that product does not introduce the metrics API.
+Every job validates both products, then runs A1, B, A2
 sequentially on one Ubuntu VM with exact pins and a fresh broker for each phase.
 The same three-partition, 500-row, 1,000-byte payload batch is used throughout.
 Each process has a 20-second primer, 180-second warmup and 180-second measurement.
@@ -51,3 +53,16 @@ and the single final shutdown duration are diagnostic. The existing 30-second
 shutdown correctness deadline remains enforced. A successful collection proves
 coverage and correctness, not performance acceptance. Retain each raw screen and
 apply the main agent instructions to the combined normal and recovery evidence.
+
+For #3171, the candidate resolves its real notifier through public DI registration
+and passes it to the relay. The synthetic store sends one notification when a new
+logical batch becomes available, including the final shutdown batch. Retrying a
+retained batch does not count as another commit. Repeated notifications remain
+pending/coalesced during the busy relay and failure backoff. Recorded notification
+counts must equal completed logical batches plus the one retained shutdown batch;
+a missing/wrong notifier binding fails validation. The baseline uses its existing
+relay constructor because it has no notification API. Both sides keep the same
+10 ms polling override, payloads, faults, timing boundaries and work counts.
+This controls recovery behavior independently of the requested default polling
+tradeoff. EF transaction observation, idle discovery and normal per-row latency
+belong to #3171's separate shared SQLite/Kafka experiment.

--- a/.github/scripts/outbox_loaded_aba.py
+++ b/.github/scripts/outbox_loaded_aba.py
@@ -109,10 +109,25 @@ def validate_recovery(completion, phases, candidate, listener, recovery):
         raise ValueError('Incorrect failure telemetry')
 
 
-def validate(folder, warmup, measured, candidate, listener, recovery=False):
+def validate_notification_coverage(completion, notifications):
+    if completion.get('CommitNotificationsEnabled', False) != notifications:
+        raise ValueError('Incorrect commit-notification fixture binding')
+    expected = (completion['TotalCompleted'] + completion.get('ExpectedRetainedRows', 0)) // 500 if notifications else 0
+    if completion.get('CommitNotifications', 0) != expected or notifications and expected == 0:
+        raise ValueError('Missing or duplicated committed-batch notifications')
+
+
+def fixture_settings(pr, role):
+    if role not in ('A', 'B'):
+        raise ValueError('Unknown product role')
+    return dict(telemetry=role == 'B' and pr != 3171, notifications=role == 'B' and pr == 3171)
+
+
+def validate(folder, warmup, measured, candidate, listener, recovery=False, notifications=False):
     phases = {name: validate_phase(folder, name, seconds)
               for name, seconds in [('primer', 20), ('warmup', warmup), ('measured', measured)]}
     completion = json.loads((folder / 'completion.json').read_text(encoding='utf-8'))
+    validate_notification_coverage(completion, notifications)
     if completion['Error'] is not None or completion['Pending'] != completion.get('ExpectedRetainedRows', 0):
         raise ValueError('Failed, incomplete or leftover work')
     validate_recovery(completion, phases, candidate, listener, recovery)
@@ -145,6 +160,10 @@ def execute():
     adjacent = os.environ.get('OUTBOX_ADJACENT') == '1'
     recovery = os.environ.get('SUITE') == 'outbox-recovery'
     shard = os.environ.get('PERFORMANCE_SHARD', 'all')
+    pr = int(os.environ['PR'])
+    if pr == 3171 and (not recovery or shard not in ('legacy-failure-off', 'renewal-loss-off')):
+        raise ValueError('PR 3171 requires its declared recovery shards without telemetry listeners')
+    features = {role: fixture_settings(pr, role) for role in ('A', 'B')}
     configs = configurations(shard, recovery)
     declared_warmup = 480 if adjacent else WARMUP
     dispatch = module(root / '.github/benchmarks/dispatch-aba/run.py', 'outbox_dispatch')
@@ -165,6 +184,7 @@ def execute():
             'main_at_start': main, 'primer_seconds': 20, 'warmup_seconds': declared_warmup, 'measured_seconds': MEASURED,
             'adjacent_controls': adjacent or shard != 'all', 'execution_plan': list(execution_plan(adjacent, shard, recovery)),
             'configs': configs, 'shard': shard, 'recovery': recovery, 'runner': 'ubuntu-latest', 'image': os.getenv('ImageVersion'),
+            'fixture_bindings': features,
             'topology': topology, 'affinity': dispatch.AFFINITY.copy(),
             'runtime': {'TieredCompilation': '1', 'TieredPGO': '1', 'ReadyToRun': '1', 'ServerGC': True},
             'run_url': f'https://github.com/{os.environ["GITHUB_REPOSITORY"]}/actions/runs/{os.environ["GITHUB_RUN_ID"]}',
@@ -184,7 +204,9 @@ def execute():
             shutil.copyfile(root / name, fixture / name)
         dispatch.command(['dotnet', 'build', fixture / 'Harness.csproj', '-c', 'Release', '--disable-build-servers',
                           f'-p:ProductProject={product}/src/Dekaf.Outbox/Dekaf.Outbox.csproj',
-                          f'-p:FixtureSource={fixture}', f'-p:CandidateFixture={str(label == "B").lower()}'],
+                          f'-p:FixtureSource={fixture}',
+                          f'-p:CandidateFixture={str(features[label]["telemetry"]).lower()}',
+                          f'-p:CommitNotificationsFixture={str(features[label]["notifications"]).lower()}'],
                          out / f'build-{label}.log', cwd=fixture)
         hosts[label] = fixture / 'bin/Release/net10.0/Harness.dll'
     dispatch.command(['dotnet', 'build-server', 'shutdown'], out / 'build-server-shutdown.log')
@@ -216,7 +238,8 @@ def execute():
                               'localhost:9092', folder / 'client', broker, store, listener, warmup, measured],
                              folder / 'client.log', timeout=20 + warmup + measured + 150,
                              env=dict(os.environ, DOTNET_TieredCompilation='1', DOTNET_TieredPGO='1', DOTNET_ReadyToRun='1'))
-            observations[phase][key] = validate(folder / 'client', warmup, measured, label == 'B', listener, recovery)
+            observations[phase][key] = validate(folder / 'client', warmup, measured, features[label]['telemetry'],
+                                                listener, recovery, features[label]['notifications'])
             (out / 'collection.json').write_text(json.dumps(observations, indent=2), encoding='utf-8')
         finally:
             stop.set()

--- a/.github/scripts/performance_shards.py
+++ b/.github/scripts/performance_shards.py
@@ -11,7 +11,7 @@ DISPATCH_MODES = ('sync-records', 'sync-batches', 'pending-records', 'pending-ba
 OUTBOX_CASES = ('legacy-off', 'legacy-on', 'renewal-off', 'renewal-on')
 
 
-def workloads(suite):
+def workloads(suite, pr=None):
     if suite in ('dispatch-adjacent', 'dispatch-loaded-adjacent'):
         groups = {mode: [f'loaded/{mode}'] for mode in DISPATCH_MODES}
         if suite == 'dispatch-adjacent':
@@ -21,8 +21,9 @@ def workloads(suite):
                                   for batch in (1, 16) for keys in (1, 2)]
         return groups
     if suite == 'outbox-recovery':
+        listeners = ('off',) if pr == 3171 else ('off', 'on')
         return {f'{store}-{listener}': [f'{store}-{listener}']
-                for store in ('legacy-failure', 'renewal-loss') for listener in ('off', 'on')}
+                for store in ('legacy-failure', 'renewal-loss') for listener in listeners}
     if suite in ('outbox-loaded', 'outbox-adjacent'):
         return {case: [case] for case in OUTBOX_CASES}
     return {'all': []}
@@ -31,7 +32,7 @@ def workloads(suite):
 def campaign(pins):
     if pins.get('status') != 'VERIFIED':
         raise ValueError('Campaign requires verified pins')
-    return dict(pins=pins, run_id=os.environ.get('GITHUB_RUN_ID'), workloads=workloads(pins['suite']))
+    return dict(pins=pins, run_id=os.environ.get('GITHUB_RUN_ID'), workloads=workloads(pins['suite'], pins['pr']))
 
 
 def settings(suite):
@@ -47,7 +48,7 @@ def validate_campaign(plan, harness, baseline, candidate, pr, suite):
                     pr=pr, suite=suite, status='VERIFIED')
     if any(pins.get(key) != value for key, value in expected.items()):
         raise ValueError('Campaign pins differ from requested comparison')
-    if plan['workloads'] != workloads(suite):
+    if plan['workloads'] != workloads(suite, pr):
         raise ValueError('Campaign workload manifest differs from this harness')
     if plan['run_id'] != os.environ.get('GITHUB_RUN_ID'):
         raise ValueError('Campaign belongs to another workflow run')

--- a/.github/scripts/test_outbox_loaded_aba.py
+++ b/.github/scripts/test_outbox_loaded_aba.py
@@ -4,7 +4,8 @@ import struct
 import tempfile
 import unittest
 
-from outbox_loaded_aba import validate_phase, execution_plan, validate_recovery
+from outbox_loaded_aba import (validate_phase, execution_plan, validate_recovery,
+                               fixture_settings, validate_notification_coverage)
 
 
 class ExecutionPlanTests(unittest.TestCase):
@@ -89,10 +90,6 @@ class PhaseValidationTests(unittest.TestCase):
             validate_phase(self.root, 'measured', 2)
 
 
-if __name__ == '__main__':
-    unittest.main()
-
-
 class RecoveryValidationTests(unittest.TestCase):
     def setUp(self):
         self.phases = {name: {'Faults': 2} for name in ('primer', 'warmup', 'measured')}
@@ -132,3 +129,30 @@ class RecoveryValidationTests(unittest.TestCase):
         self.completion['ExpectedRetainedRows'] = 0
         with self.assertRaisesRegex(ValueError, 'retain its acknowledged rows'):
             validate_recovery(self.completion, self.phases, True, 'on', True)
+
+
+class NotificationCoverageTests(unittest.TestCase):
+    def test_commit_product_uses_notifications_without_requiring_metrics_api(self):
+        self.assertEqual(dict(telemetry=False, notifications=False), fixture_settings(3171, 'A'))
+        self.assertEqual(dict(telemetry=False, notifications=True), fixture_settings(3171, 'B'))
+        self.assertEqual(dict(telemetry=True, notifications=False), fixture_settings(3085, 'B'))
+
+    def test_one_notification_per_new_batch_includes_shutdown_but_not_retries(self):
+        completion = dict(TotalCompleted=1500, ExpectedRetainedRows=500,
+                          CommitNotificationsEnabled=True, CommitNotifications=4)
+        validate_notification_coverage(completion, True)
+        for count in (0, 3, 5):
+            completion['CommitNotifications'] = count
+            with self.assertRaisesRegex(ValueError, 'committed-batch notifications'):
+                validate_notification_coverage(completion, True)
+
+    def test_disabled_or_missing_candidate_binding_is_not_coverage(self):
+        with self.assertRaisesRegex(ValueError, 'fixture binding'):
+            validate_notification_coverage(dict(TotalCompleted=500), True)
+        with self.assertRaisesRegex(ValueError, 'committed-batch notifications'):
+            validate_notification_coverage(dict(CommitNotifications=1), False)
+        validate_notification_coverage({}, False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/scripts/test_performance_shards.py
+++ b/.github/scripts/test_performance_shards.py
@@ -83,6 +83,20 @@ class ShardTests(unittest.TestCase):
             if suite not in ('dispatch-adjacent', 'dispatch-loaded-adjacent', 'outbox-loaded', 'outbox-adjacent', 'outbox-recovery'):
                 self.assertEqual(shards.workloads(suite), {'all': []})
 
+    def test_commit_recovery_uses_two_complete_jobs_without_duplicate_listener_modes(self):
+        pins = dict(status='VERIFIED', suite='outbox-recovery', pr=3171,
+                    harness_sha='a' * 40, baseline_sha='b' * 40, candidate_sha='c' * 40)
+        plan = shards.campaign(pins)
+        self.assertEqual({'legacy-failure-off', 'renewal-loss-off'}, set(plan['workloads']))
+        receipts = []
+        for shard in plan['workloads']:
+            self.evidence(plan, shard)
+            receipts.append(shards.complete(plan, shard, self.root))
+        self.assertEqual('COMPLETE', shards.aggregate(plan, receipts, 'success')['collection'])
+        with self.assertRaisesRegex(ValueError, 'Missing'):
+            shards.aggregate(plan, receipts[:1], 'success')
+        self.assertEqual(4, len(shards.workloads('outbox-recovery', 3085)))
+
     def test_unknown_and_incompatible_driver_selections_fail(self):
         for shard in ('typo', 'micro', 'shutdown'):
             with self.assertRaises(ValueError):

--- a/.github/scripts/test_verify_performance_pins.py
+++ b/.github/scripts/test_verify_performance_pins.py
@@ -55,6 +55,13 @@ class PinTests(unittest.TestCase):
                 self.verify(suite)
         self.assertEqual(self.calls, [])
 
+    def test_outbox_commit_recovery_still_verifies_exact_product_pins(self):
+        with patch.object(pins, 'command', side_effect=self.command):
+            result = pins.verify(self.harness, self.baseline, self.candidate, 3171,
+                                 'outbox-recovery', 'thomhurst/Dekaf', now=NOW)
+        self.assertEqual('VERIFIED', result['status'])
+        self.assertIn(('gh', 'api', 'repos/thomhurst/Dekaf/pulls/3171'), self.calls)
+
     def test_distinct_harness_and_product_pins_are_retained(self):
         result = self.verify()
         self.assertEqual(result['harness_sha'], self.harness)

--- a/.github/scripts/verify_performance_pins.py
+++ b/.github/scripts/verify_performance_pins.py
@@ -32,8 +32,8 @@ def verify(harness, baseline, candidate, pr, suite, repository, now=None):
         raise ValueError('A positive PR number and supported suite are required')
     if suite == 'micro-completion' and pr != 3083:
         raise ValueError('micro-completion covers PR 3083 only')
-    if suite == 'outbox-recovery' and pr != 3085:
-        raise ValueError('outbox-recovery covers PR 3085 only')
+    if suite == 'outbox-recovery' and pr not in (3085, 3171):
+        raise ValueError('outbox-recovery covers PRs 3085 and 3171 only')
     if not re.fullmatch(r'[\w.-]+/[\w.-]+', repository, flags=re.ASCII):
         raise ValueError('Expected owner/repository')
     if command('git', 'rev-parse', 'HEAD') != harness:


### PR DESCRIPTION
The maintained outbox recovery suite assumes the candidate introduces the relay metrics API, so it cannot build or validate the commit-notification product in #3171. Separate telemetry and notification fixture bindings, resolve the candidate's real notifier through public DI registration, and verify one notification per new logical batch, including retained shutdown work. Existing failure, lease-loss, completion, ordering and leftover-work checks remain enforced.

PR #3171 now plans two recovery jobs with listeners disabled. PR #3085 retains all four listener/failure combinations. Every job still requires dry validation followed by A1/B/A2 on one Ubuntu VM; collection never grants product performance acceptance. This harness-only prerequisite can land on main before dispatching #3171's recovery campaign.

Validation: 41 Python harness tests pass. The fixture builds without warnings against baseline `4db5fd12b5bcc4b920cf549920e178ebb489ad38`, notification candidate `4cc7d3e62526bdc1e20a0b2c86c20a289a1b5361`, and metrics candidate `eaf0890663846e6f85753d969f2645adc8f50499`. Five local Kafka dry runs pass full recorder validation: baseline and notification candidate in both failure modes, plus the metrics candidate with the listener enabled. Every injected fault recovers, shutdown retains exactly 500 acknowledged rows, and no publisher remains in flight. These 20/2/2-second local phases establish correctness only.

Evidence, original logs/reports, source and all three tested binary sets are retained at `C:/git/Dekaf-evidence/issue-3162-recovery/7846a87e237114cc1def67f4011dec0c25d67a19`. Its 107 copied files were SHA-256 compared with their originals; the manifest records both paths and hashes. Final diff reviewed for reuse, correctness and efficiency. No production source changes.

Refs #3162. Product acceptance remains tracked in #3171.
