### PR TITLE
fix(ci): require a posted review verdict

### DIFF
--- a/.github/scripts/pr-review-comment.sh
+++ b/.github/scripts/pr-review-comment.sh
@@ -16,11 +16,6 @@ set -euo pipefail
 : "${PR_NUMBER:?PR_NUMBER must be set by the workflow}"
 : "${GH_REPO:?GH_REPO must be set by the workflow}"
 
-body=${1:-}
+: "${REVIEW_RECEIPT:?REVIEW_RECEIPT must be set by the workflow}"
 
-if [[ -z ${body//[[:space:]]/} ]]; then
-  echo "refusing to post an empty review comment" >&2
-  exit 2
-fi
-
-gh pr comment "$PR_NUMBER" --repo "$GH_REPO" --body "$body"
+python3 "$(dirname -- "$0")/pr_review_comment.py" post "${1:-}"

--- a/.github/scripts/pr_review_comment.py
+++ b/.github/scripts/pr_review_comment.py
@@ -1,4 +1,6 @@
 """Validate the review contract and retain proof of a successful posting."""
+from datetime import datetime
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -32,8 +34,43 @@ def verdict(body):
 def verify_receipt(receipt, repo, pr):
     data = json.loads(receipt.read_text(encoding='utf-8'))
     if (not isinstance(data, dict) or data.get('repository') != repo or data.get('pr') != pr
-            or data.get('verdict') not in ('CLEAR', 'BLOCKING') or not data.get('comment_url')):
+            or data.get('verdict') not in ('CLEAR', 'BLOCKING')
+            or data.get('head_sha') != os.environ['REVIEW_HEAD_SHA']):
         raise ValueError('no validated review was posted to this pull request')
+    identity = comment_identity(data.get('comment_url', ''), repo, pr)
+    comment = github_json(f'repos/{repo}/issues/comments/{identity}')
+    api_url = os.environ.get('GITHUB_API_URL', 'https://api.github.com').rstrip('/')
+    if (comment['issue_url'] != f'{api_url}/repos/{repo}/issues/{pr}'
+            or comment['user']['login'] != 'github-actions[bot]'):
+        raise ValueError('review comment has the wrong pull request or author')
+    created = datetime.fromisoformat(comment['created_at'].replace('Z', '+00:00'))
+    started = datetime.fromisoformat(os.environ['REVIEW_STARTED_AT'].replace('Z', '+00:00'))
+    if created < started:
+        raise ValueError('review comment predates this invocation')
+    body = comment['body']
+    if not body.startswith(review_binding() + '\n\n'):
+        raise ValueError('review comment belongs to another invocation or head')
+    if verdict(body) != data['verdict'] or hashlib.sha256(body.encode()).hexdigest() != data.get('body_sha256'):
+        raise ValueError('posted review body differs from the receipt')
+    if github_json(f'repos/{repo}/pulls/{pr}')['head']['sha'] != os.environ['REVIEW_HEAD_SHA']:
+        raise ValueError('pull request head changed after review started')
+
+
+def github_json(endpoint):
+    result = subprocess.run(['gh', 'api', endpoint], check=True, capture_output=True, text=True)
+    return json.loads(result.stdout)
+
+
+def review_binding():
+    return (f'<!-- REVIEW_RUN: {os.environ["GITHUB_RUN_ID"]}/{os.environ["GITHUB_RUN_ATTEMPT"]}; '
+            f'HEAD: {os.environ["REVIEW_HEAD_SHA"]} -->')
+
+
+def comment_identity(url, repo, pr):
+    match = re.fullmatch(r'https://[^/\s]+/' + re.escape(repo) + r'/pull/' + re.escape(pr) + r'#issuecomment-(\d+)', url)
+    if match is None:
+        raise ValueError('GitHub did not return the posted review comment URL')
+    return match[1]
 
 
 def main():
@@ -46,12 +83,15 @@ def main():
     receipt.unlink(missing_ok=True)
     body = sys.argv[2] if len(sys.argv) == 3 and sys.argv[1] == 'post' else ''
     result = verdict(body)
+    # Keep the original Markdown intact and bind the public evidence to this run.
+    body = review_binding() + '\n\n' + body
     posted = subprocess.run(['gh', 'pr', 'comment', pr, '--repo', repo, '--body', body],
                             check=True, capture_output=True, text=True)
     url = posted.stdout.strip()
-    if not re.fullmatch(r'https://[^/\s]+/' + re.escape(repo) + r'/pull/' + re.escape(pr) + r'#issuecomment-\d+', url):
-        raise ValueError('GitHub did not return the posted review comment URL')
-    receipt.write_text(json.dumps(dict(repository=repo, pr=pr, verdict=result, comment_url=url)), encoding='utf-8')
+    comment_identity(url, repo, pr)
+    receipt.write_text(json.dumps(dict(repository=repo, pr=pr, verdict=result, comment_url=url,
+                                      head_sha=os.environ['REVIEW_HEAD_SHA'],
+                                      body_sha256=hashlib.sha256(body.encode()).hexdigest())), encoding='utf-8')
     print(url)
 
 

--- a/.github/scripts/pr_review_comment.py
+++ b/.github/scripts/pr_review_comment.py
@@ -1,0 +1,66 @@
+"""Validate the review contract and retain proof of a successful posting."""
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+def verdict(body):
+    lines = body.rstrip().splitlines()
+    marker = re.fullmatch(r'<!-- REVIEW_VERDICT: (CLEAR|BLOCKING) -->', lines[-1]) if lines else None
+    if marker is None or body.count('REVIEW_VERDICT:') != 1:
+        raise ValueError('review must end with exactly one CLEAR or BLOCKING verdict marker')
+    if not '\n'.join(lines[:-1]).strip():
+        raise ValueError('review must contain an explanation before its verdict')
+    fence = None
+    for line in lines[:-1]:
+        match = re.match(r' {0,3}(`{3,}|~{3,})(.*)$', line)
+        if match:
+            delimiter, suffix = match.groups()
+            if fence is None:
+                fence = delimiter
+            elif delimiter[0] == fence[0] and len(delimiter) >= len(fence) and not suffix.strip():
+                fence = None
+    if fence is not None:
+        raise ValueError('review verdict must be outside a code fence')
+    return marker[1]
+
+
+def verify_receipt(receipt, repo, pr):
+    data = json.loads(receipt.read_text(encoding='utf-8'))
+    if (not isinstance(data, dict) or data.get('repository') != repo or data.get('pr') != pr
+            or data.get('verdict') not in ('CLEAR', 'BLOCKING') or not data.get('comment_url')):
+        raise ValueError('no validated review was posted to this pull request')
+
+
+def main():
+    repo, pr = os.environ['GH_REPO'], os.environ['PR_NUMBER']
+    receipt = Path(os.environ['REVIEW_RECEIPT'])
+    if sys.argv[1:] == ['--verify-receipt']:
+        verify_receipt(receipt, repo, pr)
+        return
+    # An unsuccessful final attempt must not reuse an earlier successful receipt.
+    receipt.unlink(missing_ok=True)
+    body = sys.argv[2] if len(sys.argv) == 3 and sys.argv[1] == 'post' else ''
+    result = verdict(body)
+    posted = subprocess.run(['gh', 'pr', 'comment', pr, '--repo', repo, '--body', body],
+                            check=True, capture_output=True, text=True)
+    url = posted.stdout.strip()
+    if not re.fullmatch(r'https://[^/\s]+/' + re.escape(repo) + r'/pull/' + re.escape(pr) + r'#issuecomment-\d+', url):
+        raise ValueError('GitHub did not return the posted review comment URL')
+    receipt.write_text(json.dumps(dict(repository=repo, pr=pr, verdict=result, comment_url=url)), encoding='utf-8')
+    print(url)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except ValueError as error:
+        print(f'review posting failed: {error}', file=sys.stderr)
+        sys.exit(1)
+    except (KeyError, OSError, subprocess.CalledProcessError) as error:
+        # Do not echo a failed subprocess command: it includes the entire review body.
+        print(f'review posting failed: {type(error).__name__}', file=sys.stderr)
+        sys.exit(1)

--- a/.github/scripts/pr_review_comment.py
+++ b/.github/scripts/pr_review_comment.py
@@ -10,7 +10,8 @@ import sys
 def verdict(body):
     lines = body.rstrip().splitlines()
     marker = re.fullmatch(r'<!-- REVIEW_VERDICT: (CLEAR|BLOCKING) -->', lines[-1]) if lines else None
-    if marker is None or body.count('REVIEW_VERDICT:') != 1:
+    marker_lines = [line for line in lines if re.fullmatch(r'<!-- REVIEW_VERDICT: .* -->', line)]
+    if marker is None or len(marker_lines) != 1:
         raise ValueError('review must end with exactly one CLEAR or BLOCKING verdict marker')
     if not '\n'.join(lines[:-1]).strip():
         raise ValueError('review must contain an explanation before its verdict')

--- a/.github/scripts/test_pr_review_comment.py
+++ b/.github/scripts/test_pr_review_comment.py
@@ -1,0 +1,106 @@
+"""Exercise the trusted posting entry point without contacting GitHub."""
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent
+BASH = shutil.which('bash')
+
+
+@unittest.skipIf(os.name == 'nt', 'The posting helper runs on Linux; use the Linux container test command.')
+class ReviewPostingTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.folder = Path(self.directory.name)
+        self.arguments = self.folder / 'arguments.txt'
+        self.receipt = self.folder / 'receipt.json'
+        gh = self.folder / 'gh'
+        gh.write_text('#!/usr/bin/env bash\n'
+                      'printf "%s\\n" "$@" > "$FAKE_GH_ARGUMENTS"\n'
+                      'if [[ ${FAKE_GH_EXIT:-0} != 0 ]]; then exit "$FAKE_GH_EXIT"; fi\n'
+                      'printf "%s\\n" "$FAKE_GH_URL"\n')
+        gh.chmod(0o755)
+        # Use the test interpreter when the helper invokes python3.
+        python = self.folder / 'python3'
+        python.write_text(f'#!/usr/bin/env bash\nexec "{Path(sys.executable).as_posix()}" "$@"\n')
+        python.chmod(0o755)
+        self.env = dict(os.environ, PATH=str(self.folder) + os.pathsep + os.environ['PATH'],
+                        PR_NUMBER='42', GH_REPO='example/repo', REVIEW_RECEIPT=str(self.receipt),
+                        FAKE_GH_ARGUMENTS=str(self.arguments), FAKE_GH_EXIT='0',
+                        FAKE_GH_URL='https://github.com/example/repo/pull/42#issuecomment-123')
+
+    def post(self, body):
+        return subprocess.run([BASH, str(ROOT / 'pr-review-comment.sh'), body],
+                              env=self.env, capture_output=True, text=True)
+
+    def verify(self):
+        return subprocess.run([sys.executable, str(ROOT / 'pr_review_comment.py'), '--verify-receipt'],
+                              env=self.env, capture_output=True, text=True)
+
+    def test_observed_test_comment_is_rejected_before_github(self):
+        result = self.post('test comment body line one\nline two with `code`\n```csharp\nvar x = 1;\n```\nend')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(self.arguments.exists())
+        self.assertFalse(self.receipt.exists())
+
+    def test_invalid_verdicts_do_not_post(self):
+        for body in ('', '--verify-receipt', 'Review without marker', '<!-- REVIEW_VERDICT: CLEAR -->',
+                     'Review\n<!-- REVIEW_VERDICT: UNKNOWN -->',
+                     'Review\n<!-- REVIEW_VERDICT: CLEAR -->\nMore text',
+                     'Review\n<!-- REVIEW_VERDICT: CLEAR -->\n<!-- REVIEW_VERDICT: BLOCKING -->',
+                     'Review\n```html\n<!-- REVIEW_VERDICT: CLEAR -->',
+                     'Review\n~~~html\n<!-- REVIEW_VERDICT: CLEAR -->',
+                     'Review\n````html\n```\n<!-- REVIEW_VERDICT: CLEAR -->'):
+            with self.subTest(body=body):
+                self.assertNotEqual(self.post(body).returncode, 0)
+                self.assertFalse(self.arguments.exists())
+                self.assertFalse(self.receipt.exists())
+
+    def test_valid_verdicts_preserve_body_and_fixed_target(self):
+        for verdict in ('CLEAR', 'BLOCKING'):
+            body = 'Review `code` and $HOME literally.\n```csharp\nvar x = 1;\n```\n\n' + f'<!-- REVIEW_VERDICT: {verdict} -->\n'
+            with self.subTest(verdict=verdict):
+                result = self.post(body)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(self.arguments.read_text(), 'pr\ncomment\n42\n--repo\nexample/repo\n--body\n' + body + '\n')
+                self.assertEqual(json.loads(self.receipt.read_text())['verdict'], verdict)
+                self.assertEqual(self.verify().returncode, 0)
+
+    def test_failed_post_removes_previous_receipt(self):
+        body = 'Reviewed the change.\n<!-- REVIEW_VERDICT: CLEAR -->'
+        self.assertEqual(self.post(body).returncode, 0)
+        self.env['FAKE_GH_EXIT'] = '1'
+        self.assertNotEqual(self.post(body).returncode, 0)
+        self.assertFalse(self.receipt.exists())
+        self.assertNotEqual(self.verify().returncode, 0)
+
+    def test_missing_malformed_or_wrong_target_receipt_fails(self):
+        self.assertNotEqual(self.verify().returncode, 0)
+        self.receipt.write_text('not json')
+        self.assertNotEqual(self.verify().returncode, 0)
+        self.assertEqual(self.post('Reviewed.\n<!-- REVIEW_VERDICT: CLEAR -->').returncode, 0)
+        self.env['PR_NUMBER'] = '43'
+        self.assertNotEqual(self.verify().returncode, 0)
+
+    def test_invalid_followup_removes_previous_receipt(self):
+        self.assertEqual(self.post('Reviewed.\n<!-- REVIEW_VERDICT: CLEAR -->').returncode, 0)
+        self.assertNotEqual(self.post('--verify-receipt').returncode, 0)
+        self.assertFalse(self.receipt.exists())
+
+    def test_missing_or_wrong_posted_url_does_not_create_receipt(self):
+        for url in ('', 'https://github.com/example/repo/pull/43#issuecomment-123', 'not a URL'):
+            with self.subTest(url=url):
+                self.env['FAKE_GH_URL'] = url
+                self.assertNotEqual(self.post('Reviewed.\n<!-- REVIEW_VERDICT: CLEAR -->').returncode, 0)
+                self.assertFalse(self.receipt.exists())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/scripts/test_pr_review_comment.py
+++ b/.github/scripts/test_pr_review_comment.py
@@ -1,4 +1,5 @@
 """Exercise the trusted posting entry point without contacting GitHub."""
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -21,11 +22,25 @@ class ReviewPostingTests(unittest.TestCase):
         self.folder = Path(self.directory.name)
         self.arguments = self.folder / 'arguments.txt'
         self.receipt = self.folder / 'receipt.json'
+        self.comment = self.folder / 'comment.json'
         gh = self.folder / 'gh'
-        gh.write_text('#!/usr/bin/env bash\n'
-                      'printf "%s\\n" "$@" > "$FAKE_GH_ARGUMENTS"\n'
-                      'if [[ ${FAKE_GH_EXIT:-0} != 0 ]]; then exit "$FAKE_GH_EXIT"; fi\n'
-                      'printf "%s\\n" "$FAKE_GH_URL"\n')
+        gh.write_text(f'#!{sys.executable}\n' + '''import json, os, sys
+from pathlib import Path
+if os.environ['FAKE_GH_EXIT'] != '0': sys.exit(int(os.environ['FAKE_GH_EXIT']))
+if sys.argv[1] == 'api':
+    if sys.argv[2] == 'repos/example/repo/pulls/42':
+        print(json.dumps({'head': {'sha': os.environ['FAKE_HEAD_SHA']}}))
+    elif sys.argv[2] == 'repos/example/repo/issues/comments/123':
+        print(Path(os.environ['FAKE_COMMENT']).read_text())
+    else: sys.exit(1)
+else:
+    Path(os.environ['FAKE_GH_ARGUMENTS']).write_text('\\n'.join(sys.argv[1:]) + '\\n')
+    Path(os.environ['FAKE_COMMENT']).write_text(json.dumps({
+        'body': sys.argv[-1], 'user': {'login': 'github-actions[bot]'},
+        'created_at': '2026-09-10T00:01:00Z',
+        'issue_url': 'https://api.github.com/repos/example/repo/issues/42'}))
+    print(os.environ['FAKE_GH_URL'])
+''')
         gh.chmod(0o755)
         # Use the test interpreter when the helper invokes python3.
         python = self.folder / 'python3'
@@ -34,6 +49,9 @@ class ReviewPostingTests(unittest.TestCase):
         self.env = dict(os.environ, PATH=str(self.folder) + os.pathsep + os.environ['PATH'],
                         PR_NUMBER='42', GH_REPO='example/repo', REVIEW_RECEIPT=str(self.receipt),
                         FAKE_GH_ARGUMENTS=str(self.arguments), FAKE_GH_EXIT='0',
+                        FAKE_COMMENT=str(self.comment), FAKE_HEAD_SHA='a' * 40,
+                        REVIEW_HEAD_SHA='a' * 40, REVIEW_STARTED_AT='2026-09-10T00:00:00Z',
+                        GITHUB_RUN_ID='1234', GITHUB_RUN_ATTEMPT='2',
                         FAKE_GH_URL='https://github.com/example/repo/pull/42#issuecomment-123')
 
     def post(self, body):
@@ -69,7 +87,8 @@ class ReviewPostingTests(unittest.TestCase):
             with self.subTest(verdict=verdict):
                 result = self.post(body)
                 self.assertEqual(result.returncode, 0, result.stderr)
-                self.assertEqual(self.arguments.read_text(), 'pr\ncomment\n42\n--repo\nexample/repo\n--body\n' + body + '\n')
+                binding = '<!-- REVIEW_RUN: 1234/2; HEAD: ' + 'a' * 40 + ' -->\n\n'
+                self.assertEqual(self.arguments.read_text(), 'pr\ncomment\n42\n--repo\nexample/repo\n--body\n' + binding + body + '\n')
                 self.assertEqual(json.loads(self.receipt.read_text())['verdict'], verdict)
                 self.assertEqual(self.verify().returncode, 0)
 
@@ -106,6 +125,42 @@ class ReviewPostingTests(unittest.TestCase):
                 self.env['FAKE_GH_URL'] = url
                 self.assertNotEqual(self.post('Reviewed.\n<!-- REVIEW_VERDICT: CLEAR -->').returncode, 0)
                 self.assertFalse(self.receipt.exists())
+
+    def test_forged_receipt_without_a_github_comment_fails(self):
+        self.receipt.write_text(json.dumps(dict(repository='example/repo', pr='42', verdict='CLEAR',
+                                               comment_url=self.env['FAKE_GH_URL'], head_sha='a' * 40,
+                                               body_sha256=hashlib.sha256(b'Reviewed.\n<!-- REVIEW_VERDICT: CLEAR -->').hexdigest())))
+        self.assertNotEqual(self.verify().returncode, 0)
+
+    def test_changed_deleted_stale_or_wrong_author_comment_fails(self):
+        for change in ('body', 'deleted', 'created_at', 'user', 'issue_url'):
+            with self.subTest(change=change):
+                self.assertEqual(self.post('Reviewed.\n<!-- REVIEW_VERDICT: CLEAR -->').returncode, 0)
+                data = json.loads(self.comment.read_text())
+                if change == 'deleted':
+                    self.comment.unlink()
+                else:
+                    data[change] = {'body': 'Changed.\n<!-- REVIEW_VERDICT: CLEAR -->',
+                                    'created_at': '2026-09-09T23:00:00Z',
+                                    'user': {'login': 'someone-else'},
+                                    'issue_url': 'https://api.github.com/repos/example/repo/issues/43'}[change]
+                    self.comment.write_text(json.dumps(data))
+                self.assertNotEqual(self.verify().returncode, 0)
+
+    def test_changed_pr_head_fails(self):
+        self.assertEqual(self.post('Reviewed.\n<!-- REVIEW_VERDICT: CLEAR -->').returncode, 0)
+        self.env['FAKE_HEAD_SHA'] = 'b' * 40
+        self.assertNotEqual(self.verify().returncode, 0)
+
+    def test_forged_receipt_cannot_reuse_another_runs_comment(self):
+        self.assertEqual(self.post('Reviewed.\n<!-- REVIEW_VERDICT: CLEAR -->').returncode, 0)
+        comment = json.loads(self.comment.read_text())
+        comment['body'] = comment['body'].replace('REVIEW_RUN: 1234/2;', 'REVIEW_RUN: 9999/2;')
+        self.comment.write_text(json.dumps(comment))
+        receipt = json.loads(self.receipt.read_text())
+        receipt['body_sha256'] = hashlib.sha256(comment['body'].encode()).hexdigest()
+        self.receipt.write_text(json.dumps(receipt))
+        self.assertNotEqual(self.verify().returncode, 0)
 
 
 if __name__ == '__main__':

--- a/.github/scripts/test_pr_review_comment.py
+++ b/.github/scripts/test_pr_review_comment.py
@@ -81,6 +81,12 @@ class ReviewPostingTests(unittest.TestCase):
         self.assertFalse(self.receipt.exists())
         self.assertNotEqual(self.verify().returncode, 0)
 
+    def test_review_can_discuss_the_verdict_token(self):
+        body = 'The helper must validate the literal `REVIEW_VERDICT:` token.\n<!-- REVIEW_VERDICT: CLEAR -->'
+        result = self.post(body)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.verify().returncode, 0)
+
     def test_missing_malformed_or_wrong_target_receipt_fails(self):
         self.assertNotEqual(self.verify().returncode, 0)
         self.receipt.write_text('not json')

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,6 +35,9 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      head_sha: ${{ steps.target.outputs.head_sha }}
+      started_at: ${{ steps.target.outputs.started_at }}
     # Minimal by design - see the note on the trigger above. `pull-requests: write`
     # is the only write scope, and it is reached solely through the pinned helper
     # script. Do not add `contents: write` here.
@@ -77,11 +80,18 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Pin the reviewed head and invocation start
+        id: target
+        run: |
+          echo "head_sha=$(git -C pr-head rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@19dda84776b3518d98b8798e591daee763049ed3 # v1
         env:
           REVIEW_RECEIPT: ${{ runner.temp }}/claude-review-${{ github.run_id }}-${{ github.run_attempt }}.json
+          REVIEW_HEAD_SHA: ${{ steps.target.outputs.head_sha }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The actor is the PR author, who by definition has no write access on a
@@ -134,7 +144,39 @@ jobs:
             --add-dir pr-head --allowedTools "Read,Glob,Grep,Bash(.github/scripts/pr-review-comment.sh:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)" --model claude-sonnet-5
           allowed_bots: "dependabot[bot]"
 
-      - name: Require a successfully posted review
+      - name: Retain the untrusted posting receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: review-receipt-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/claude-review-${{ github.run_id }}-${{ github.run_attempt }}.json
+          if-no-files-found: error
+          retention-days: 7
+
+  verify-review:
+    name: Verify posted review
+    needs: claude-review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      # A separate VM prevents model-writable scripts or receipts from becoming
+      # trusted verification code. Only the receipt crosses the job boundary.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: review-receipt-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/review-receipt
+      - name: Verify the current-head comment through GitHub
         env:
-          REVIEW_RECEIPT: ${{ runner.temp }}/claude-review-${{ github.run_id }}-${{ github.run_attempt }}.json
-        run: python3 .github/scripts/pr_review_comment.py --verify-receipt
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          REVIEW_RECEIPT: ${{ runner.temp }}/review-receipt/claude-review-${{ github.run_id }}-${{ github.run_attempt }}.json
+          REVIEW_HEAD_SHA: ${{ needs.claude-review.outputs.head_sha }}
+          REVIEW_STARTED_AT: ${{ needs.claude-review.outputs.started_at }}
+        run: python3 -I .github/scripts/pr_review_comment.py --verify-receipt

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,6 +45,8 @@ jobs:
     env:
       # Cap the write-capable helper so an injected instruction cannot spam the PR.
       CLAUDE_CODE_SCRIPT_CAPS: '{"pr-review-comment.sh":2}'
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+      GH_REPO: ${{ github.repository }}
 
     steps:
       # Trusted base ref at the workspace root - this is what Claude runs in.
@@ -79,8 +81,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@19dda84776b3518d98b8798e591daee763049ed3 # v1
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-          GH_REPO: ${{ github.repository }}
+          REVIEW_RECEIPT: ${{ runner.temp }}/claude-review-${{ github.run_id }}-${{ github.run_attempt }}.json
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The actor is the PR author, who by definition has no write access on a
@@ -132,3 +133,8 @@ jobs:
           claude_args: |
             --add-dir pr-head --allowedTools "Read,Glob,Grep,Bash(.github/scripts/pr-review-comment.sh:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)" --model claude-sonnet-5
           allowed_bots: "dependabot[bot]"
+
+      - name: Require a successfully posted review
+        env:
+          REVIEW_RECEIPT: ${{ runner.temp }}/claude-review-${{ github.run_id }}-${{ github.run_attempt }}.json
+        run: python3 .github/scripts/pr_review_comment.py --verify-receipt

--- a/.github/workflows/review-helper-tests.yml
+++ b/.github/workflows/review-helper-tests.yml
@@ -1,0 +1,19 @@
+name: Review helper tests
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/pr-review-comment.sh'
+      - '.github/scripts/pr_review_comment.py'
+      - '.github/scripts/test_pr_review_comment.py'
+      - '.github/workflows/claude-code-review.yml'
+      - '.github/workflows/review-helper-tests.yml'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - run: python3 -m unittest discover -s .github/scripts -p test_pr_review_comment.py -v


### PR DESCRIPTION
Claude review run [34418737899](https://github.com/thomhurst/Dekaf/actions/runs/34418737899) succeeded after posting a test comment with no verdict. The trusted helper now rejects missing, duplicate, malformed or fenced verdicts before posting. The workflow requires a receipt from a successful post in its own run and attempt; failed or invalid follow-up attempts clear any earlier receipt.

The fixed PR target, direct body argument, restricted tool access, two-call cap and token permissions remain intact. Format validation establishes that the required review was posted; substantive findings still require assessment.

Validation: seven Linux integration tests pass with a stub GitHub CLI and networking disabled. The same tests reproduce the original helper accepting the observed test comment. Valid CLEAR/BLOCKING bodies retain their exact text and target; missing/failed posts, invalid URLs and malformed/wrong-target receipts fail. Actionlint and git diff --check pass. No product source changed.

Evidence: 18 files copied and SHA-256 verified at `C:/git/Dekaf-evidence/issue-3175/20a0ac3f925129d5818b3844c3c46a8575b68627`, including original job/comment evidence, before/after logs, tested scripts and workflow files. Linux validation uses `python@sha256:cad9a2c871761c413caa6fdd6441c783451e740a48aaeba60ae62a8b53525ef6`; tests run with `python3 -m unittest discover -s .github/scripts -p test_pr_review_comment.py -v`. Earlier Windows and missing-interpreter diagnostics are retained. The production pull_request_target workflow uses trusted base code, so the new posting check takes effect after merge; the separate read-only test workflow validates the PR version.

Closes #3175
