### PR TITLE
fix(ci): count expanded BenchmarkDotNet cases

### DIFF
--- a/.github/scripts/performance_gate.py
+++ b/.github/scripts/performance_gate.py
@@ -8,6 +8,7 @@ elapsed time, sample counts and allocations are BenchmarkDotNet's own measuremen
 import argparse
 import json
 import math
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -144,8 +145,16 @@ def changed_files(base, head):
 
 
 def count_listed_cases(listing):
-    """Count BenchmarkDotNet `--list flat` lines (one per case, ignoring blank/log lines)."""
+    """Count listed methods; BDN --list flat does not expand parameter combinations."""
     return sum(1 for line in listing.splitlines() if line.strip().startswith('Dekaf.Benchmarks.'))
+
+
+def count_execution_cases(log):
+    """Read BDN's declared expanded total, including cases that later fail execution."""
+    totals = re.findall(r'^// \*+ Found (\d+) benchmark\(s\) in total \*+\s*$', log, re.MULTILINE)
+    if len(totals) != 1:
+        raise ValueError('Expected exactly one BenchmarkDotNet expanded case total in the execution log')
+    return int(totals[0])
 
 
 def _case_key(benchmark):
@@ -214,8 +223,9 @@ def main(argv=None):
     selecting.add_argument('--head', required=True)
     selecting.add_argument('--filters', help='Explicit space-separated BDN globs that replace path selection')
     selecting.add_argument('--output', type=Path, required=True)
-    counting = commands.add_parser('count', help='Count cases from a BDN --list flat listing on stdin')
+    counting = commands.add_parser('count', help='Count listed methods, or expanded cases from an execution log')
     counting.add_argument('--max-cases', type=int, default=MAX_CASES)
+    counting.add_argument('--execution-log', type=Path, help='Use the BDN declared case total instead of stdin method names')
     validating = commands.add_parser('validate', help='Validate one phase and write its merged case array')
     validating.add_argument('--phase', type=Path, required=True)
     validating.add_argument('--expected', type=int)
@@ -238,7 +248,12 @@ def main(argv=None):
         print(json.dumps(selection, indent=2))
         return 0
     if args.command == 'count':
-        count = count_listed_cases(sys.stdin.read())
+        try:
+            count = (count_execution_cases(args.execution_log.read_text(encoding='utf-8-sig'))
+                     if args.execution_log else count_listed_cases(sys.stdin.read()))
+        except ValueError as error:
+            print(str(error), file=sys.stderr)
+            return 1
         if count == 0:
             print('The selected filters match no benchmark cases', file=sys.stderr)
             return 1

--- a/.github/scripts/test_performance_gate.py
+++ b/.github/scripts/test_performance_gate.py
@@ -81,6 +81,28 @@ class SelectionTests(unittest.TestCase):
         listing = '// Validating benchmarks\nDekaf.Benchmarks.Benchmarks.Unit.A.M\n\nDekaf.Benchmarks.Benchmarks.Unit.A.N(X: 1)\n'
         self.assertEqual(2, gate.count_listed_cases(listing))
 
+    def test_execution_total_includes_parameterized_and_failed_cases(self):
+        log = ('// ***** Found 31 benchmark(s) in total *****\n'
+               '// Found 4 benchmarks:\n// Found 27 benchmarks:\n'
+               '// Benchmark process exited with code 1\n')
+        self.assertEqual(31, gate.count_execution_cases(log))
+        fatal, _ = gate.validate_phase([benchmark()], gate.count_execution_cases(log), None, 0)
+        self.assertIn('expected 31 cases, found 1', fatal)
+
+    def test_execution_count_rejects_missing_or_ambiguous_totals(self):
+        line = '// ***** Found 31 benchmark(s) in total *****\n'
+        for log in ('// Found 31 benchmarks:\n', line + line):
+            with self.subTest(log=log), self.assertRaises(ValueError):
+                gate.count_execution_cases(log)
+
+    def test_execution_count_enforces_expanded_case_budget(self):
+        with tempfile.TemporaryDirectory() as directory:
+            log = Path(directory) / 'dry.log'
+            log.write_text(f'// ***** Found {gate.MAX_CASES + 1} benchmark(s) in total *****\n', encoding='utf-8')
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(1, gate.main(['count', '--execution-log', str(log)]))
+                self.assertEqual(0, gate.main(['count', '--execution-log', str(log), '--max-cases', str(gate.MAX_CASES + 1)]))
+
     def test_count_command_rejects_empty_and_oversized_selections(self):
         with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
             with mock.patch('sys.stdin', io.StringIO('')):

--- a/.github/workflows/performance-gate.yml
+++ b/.github/workflows/performance-gate.yml
@@ -110,7 +110,13 @@ jobs:
           for role in A B; do
             sha="${{ steps.pins.outputs.base }}"; if [[ "$role" == B ]]; then sha="${{ steps.pins.outputs.head }}"; fi
             git worktree add --detach "$RUNNER_TEMP/gate-$role" "$sha"
-            (cd "$RUNNER_TEMP/gate-$role" && dotnet build tools/Dekaf.Benchmarks -c Release --disable-build-servers > "$GATE/build-$role.log" 2>&1)
+            (
+              cd "$RUNNER_TEMP/gate-$role/tools/Dekaf.Benchmarks"
+              # Scope BDN project discovery so the bespoke harness's namesake is not ambiguous.
+              dotnet new sln --name GateBenchmarkExecution --format sln > "$GATE/solution-$role.log" 2>&1
+              dotnet sln GateBenchmarkExecution.sln add Dekaf.Benchmarks.csproj >> "$GATE/solution-$role.log" 2>&1
+              dotnet build Dekaf.Benchmarks.csproj -c Release --disable-build-servers > "$GATE/build-$role.log" 2>&1
+            )
           done
           git diff --stat "${{ steps.pins.outputs.base }}" "${{ steps.pins.outputs.head }}" -- tools/Dekaf.Benchmarks > "$GATE/fixture-diff.txt" || true
           if [[ -s "$GATE/fixture-diff.txt" ]]; then
@@ -124,11 +130,13 @@ jobs:
           mapfile -t filters < <(jq -r '.filters[]' "$GATE/selection.json")
           for role in A B; do
             (
-              cd "$RUNNER_TEMP/gate-$role"
-              dotnet run --project tools/Dekaf.Benchmarks -c Release --no-build -- --list flat --filter "${filters[@]}" > "$GATE/list-$role.txt" 2>&1
+              cd "$RUNNER_TEMP/gate-$role/tools/Dekaf.Benchmarks"
+              dotnet run --project Dekaf.Benchmarks.csproj -c Release --no-build -- --list flat --filter "${filters[@]}" > "$GATE/list-$role.txt" 2>&1
               count=$(python3 "$GITHUB_WORKSPACE/.github/scripts/performance_gate.py" count < "$GATE/list-$role.txt")
+              dotnet run --project Dekaf.Benchmarks.csproj -c Release --no-build -- --job Dry --filter "${filters[@]}" --exporters fulljson --buildTimeout 900 --artifacts "$GATE/dry-$role" > "$GATE/dry-$role.log" 2>&1
+              # --list flat counts methods; execution expands their parameter combinations.
+              count=$(python3 "$GITHUB_WORKSPACE/.github/scripts/performance_gate.py" count --execution-log "$GATE/dry-$role.log")
               echo "$count" > "$GATE/count-$role.txt"
-              dotnet run --project tools/Dekaf.Benchmarks -c Release --no-build -- --job Dry --filter "${filters[@]}" --exporters fulljson --buildTimeout 900 --artifacts "$GATE/dry-$role" > "$GATE/dry-$role.log" 2>&1
               python3 "$GITHUB_WORKSPACE/.github/scripts/performance_gate.py" validate --dry --phase "$GATE/dry-$role" --expected "$count"
             )
           done
@@ -144,8 +152,8 @@ jobs:
           for phase in A1 B A2; do
             role=A; if [[ "$phase" == B ]]; then role=B; fi
             (
-              cd "$RUNNER_TEMP/gate-$role"
-              dotnet run --project tools/Dekaf.Benchmarks -c Release --no-build -- --filter "${filters[@]}" \
+              cd "$RUNNER_TEMP/gate-$role/tools/Dekaf.Benchmarks"
+              dotnet run --project Dekaf.Benchmarks.csproj -c Release --no-build -- --filter "${filters[@]}" \
                 --warmupCount 50 --iterationCount 25 --iterationTime 1000 --launchCount 1 --outliers DontRemove \
                 --exporters fulljson --buildTimeout 900 --artifacts "$GATE/$phase" > "$GATE/$phase.log" 2>&1
             )


### PR DESCRIPTION
The automatic performance gate rejected successful Dry runs because BenchmarkDotNet's `--list flat` counts methods, while parameters expand into additional cases. In run 34450471271, all 31 cases ran but validation expected 16.

Read the expanded total declared by the Dry execution, enforce the existing case budget, and validate every resulting case. Missing or ambiguous totals still fail. Also scope BenchmarkDotNet project discovery with a local solution and project-directory execution, avoiding the same-named bespoke project.

Validation: 18 harness tests pass; actionlint passes. Reanalysis of the retained Ubuntu Dry output counts and validates all 31 cases. The earlier failed-build artifact remains rejected. No product code or acceptance thresholds change.

Closes #3179
