### PR TITLE
fix(benchmarks): allow absent completion reservations

### DIFF
--- a/.github/benchmarks/dispatch-aba/DispatchBenchmarks.cs
+++ b/.github/benchmarks/dispatch-aba/DispatchBenchmarks.cs
@@ -22,7 +22,7 @@ public class KeyOrderedDispatchBenchmarks
     private PartitionProcessor<int, int> _processor = null!;
     private PartitionLane<int, int> _lane = null!;
 #if COMPLETION_BATCHES
-    private OffsetCompletionBatch _completionBatch = null!;
+    private OffsetCompletionBatch? _completionBatch;
 #endif
     private bool _storageWarmed;
     private int _written;


### PR DESCRIPTION
PR #3083's micro and shutdown comparison jobs fail to compile because CreateCompletionBatch now returns a nullable reservation. Match that contract in the maintained fixture's field; existing enqueue and completion APIs already accept null.

Both archived exact products from run 34409075242 build successfully with this fixture (0 warnings/errors), and both pass the repeated-key batch smoke. Local smoke validates fixture correctness only; this change does not claim performance acceptance.

Closes #3181
