### PR TITLE
fix(ci): target consumer benchmarks and stabilize shutdown tests

### DIFF
--- a/.github/scripts/performance_gate.py
+++ b/.github/scripts/performance_gate.py
@@ -35,6 +35,22 @@ TRACE = unit('TraceContextInjectionBenchmarks', 'TraceContextExtractionBenchmark
 # [IterationSetup]/[IterationCleanup], fixed InvocationCount or ColdStart fixtures, because
 # those cannot reach the elapsed warmup floor with the shared BDN settings.
 AREAS = (
+    # KafkaConsumer owns both fetching and the offset-store API. The separate
+    # partition dispatcher has its own implementation; unknown files retain the
+    # directory-wide fallback below.
+    ('src/Dekaf/Consumer/KafkaConsumer.cs', 'consumer', unit(
+        'ConsumerHotPathBenchmarks', 'FetchResponseParsingBenchmarks', 'FetchRequestBuildBenchmarks',
+        'OffsetStoreBenchmarks', 'ConsumeResultOffsetStoreBenchmarks'), None),
+    ('src/Dekaf/Consumer/IKafkaConsumer.cs', 'consumer', unit('ConsumerHotPathBenchmarks'), None),
+    ('src/Dekaf/Consumer/ConsumeBatch.cs', 'consumer', unit('ConsumerHotPathBenchmarks'), None),
+    ('src/Dekaf/Consumer/PartitionedProcessing.cs', 'consumer', unit(
+        'PartitionedDispatchBenchmarks', 'KeyOrderedDispatchBenchmarks', 'PartitionedOffsetTrackingBenchmarks'), None),
+    ('src/Dekaf/Consumer/CompletedOffsetRanges.cs', 'consumer', unit('PartitionedOffsetTrackingBenchmarks'), None),
+    # Exercise real RecordBatch read/write and lazy slab lifetimes. CRC implementation
+    # and unrelated administrative protocol fixtures belong to the protocol fallback.
+    ('src/Dekaf/Protocol/Records/RecordBatch.cs', 'protocol',
+     unit('ConsumerHotPathBenchmarks', 'ParsedRecordSlabLifecycleBenchmarks')
+     + ['*.Unit.ProtocolBenchmarks.*RecordBatch*'], None),
     ('src/Dekaf/Producer/', 'producer', unit(
         'AccumulatorAppendBenchmarks', 'AccumulatorAdmissionAppendBenchmarks', 'ProducerFireHotPathBenchmarks',
         'PartitionerBenchmarks', 'InflightTrackingBenchmarks', 'BrokerUnackedByteBudgetBenchmarks',
@@ -42,7 +58,8 @@ AREAS = (
         'WaveCoalesceProbeBenchmarks'), None),
     ('src/Dekaf/Consumer/', 'consumer', unit(
         'ConsumerHotPathBenchmarks', 'FetchResponseParsingBenchmarks', 'FetchRequestBuildBenchmarks',
-        'OffsetStoreBenchmarks', 'PartitionedDispatchBenchmarks', 'KeyOrderedDispatchBenchmarks'), None),
+        'OffsetStoreBenchmarks', 'ConsumeResultOffsetStoreBenchmarks',
+        'PartitionedDispatchBenchmarks', 'KeyOrderedDispatchBenchmarks'), None),
     ('src/Dekaf/ShareConsumer/', 'share-consumer', unit(
         'ShareConsumerParsingBenchmarks', 'ShareAcknowledgementTrackingBenchmarks',
         'ShareConsumerPreparationReplayBenchmarks', 'ShareConsumerRenewalBenchmarks'), None),
@@ -144,7 +161,21 @@ def select(changed_files):
 
 def changed_files(base, head):
     output = subprocess.check_output(['git', 'diff', '--name-only', f'{base}..{head}'], text=True)
-    return [line.strip() for line in output.splitlines() if line.strip()]
+    return [path for path in output.splitlines() if path and not _friend_assembly_only(base, head, path)]
+
+
+def _friend_assembly_only(base, head, path):
+    """Ignore only standalone friend-assembly declarations, never build settings or references."""
+    if not path.startswith('src/') or not path.endswith('.csproj'):
+        return False
+    diff = subprocess.check_output([
+        'git', 'diff', '--no-ext-diff', '--unified=0', f'{base}..{head}', '--', path,
+    ], text=True)
+    changes = [line[1:].strip() for line in diff.splitlines()
+               if line.startswith(('+', '-')) and not line.startswith(('+++', '---'))]
+    return bool(changes) and all(re.fullmatch(
+        r'<InternalsVisibleTo Include="Dekaf\.(?:Tests(?:\.[A-Za-z0-9]+)*|Benchmarks|Profiling)"\s*/>',
+        line) for line in changes)
 
 
 def count_listed_cases(listing):

--- a/.github/scripts/test_performance_gate.py
+++ b/.github/scripts/test_performance_gate.py
@@ -33,6 +33,60 @@ def benchmark(method='Append', parameters='', mean=100.0, samples=25, allocated=
 
 
 class SelectionTests(unittest.TestCase):
+    def test_kafka_consumer_retains_all_offset_store_api_coverage(self):
+        selection = gate.select(['src/Dekaf/Consumer/KafkaConsumer.cs'])
+        self.assertEqual(gate.unit('ConsumerHotPathBenchmarks', 'FetchResponseParsingBenchmarks',
+                                   'FetchRequestBuildBenchmarks', 'OffsetStoreBenchmarks',
+                                   'ConsumeResultOffsetStoreBenchmarks'), selection['filters'])
+        self.assertNotIn('*.Unit.PartitionedDispatchBenchmarks.*', selection['filters'])
+
+    def test_partition_completion_retains_dispatch_and_tracking_coverage(self):
+        selection = gate.select(['src/Dekaf/Consumer/PartitionedProcessing.cs',
+                                 'src/Dekaf/Consumer/CompletedOffsetRanges.cs'])
+        self.assertEqual(gate.unit('PartitionedDispatchBenchmarks', 'KeyOrderedDispatchBenchmarks',
+                                   'PartitionedOffsetTrackingBenchmarks'), selection['filters'])
+
+    def test_record_batch_selects_real_read_write_and_lazy_lifecycle(self):
+        selection = gate.select(['src/Dekaf/Protocol/Records/RecordBatch.cs'])
+        self.assertIn('*.Unit.ProtocolBenchmarks.*RecordBatch*', selection['filters'])
+        self.assertIn('*.Unit.ParsedRecordSlabLifecycleBenchmarks.*', selection['filters'])
+        self.assertNotIn('*.Unit.Crc32CBenchmarks.*', selection['filters'])
+        fallback = gate.select(['src/Dekaf/Protocol/UnknownReader.cs'])
+        self.assertIn('*.Unit.Crc32CBenchmarks.*', fallback['filters'])
+        self.assertIn('*.Unit.KeyOrderedDispatchBenchmarks.*',
+                      gate.select(['src/Dekaf/Consumer/UnknownConsumer.cs'])['filters'])
+
+    def test_only_friend_assembly_edits_can_skip_the_build_input_screen(self):
+        original = Path.cwd()
+        with tempfile.TemporaryDirectory() as directory:
+            try:
+                os.chdir(directory)
+                def git(*args):
+                    return subprocess.check_output(['git', *args], stderr=subprocess.DEVNULL).decode().strip()
+                git('init', '-q')
+                git('config', 'user.email', 'gate@example.test')
+                git('config', 'user.name', 'Gate test')
+                project = Path('src/Dekaf/Dekaf.csproj')
+                project.parent.mkdir(parents=True)
+                before = '<Project>\n<ItemGroup>\n<InternalsVisibleTo Include="Dekaf.Tests.Unit" />\n</ItemGroup>\n</Project>\n'
+                project.write_text(before)
+                git('add', '.')
+                git('commit', '-qm', 'baseline')
+                baseline = git('rev-parse', 'HEAD')
+                for addition, expected in (
+                    ('<InternalsVisibleTo Include="Dekaf.Tests.Aot" />', []),
+                    ('<PackageReference Include="Another.Package" />', [project.as_posix()]),
+                    ('<InternalsVisibleTo Include="Dekaf.Tests.Aot" />\n<Optimize>false</Optimize>', [project.as_posix()]),
+                    ('<InternalsVisibleTo Include="Unknown.Assembly" />', [project.as_posix()]),
+                ):
+                    with self.subTest(addition=addition):
+                        project.write_text(before.replace('</ItemGroup>', addition + '\n</ItemGroup>'))
+                        git('add', '.')
+                        git('commit', '-qm', 'change')
+                        self.assertEqual(expected, gate.changed_files(baseline, 'HEAD'))
+            finally:
+                os.chdir(original)
+
     def test_longest_prefix_selects_the_area_not_the_core_set(self):
         selection = gate.select(['src/Dekaf/Producer/RecordAccumulator.cs'])
         self.assertEqual(['producer'], selection['areas'])
@@ -78,7 +132,8 @@ class SelectionTests(unittest.TestCase):
                 self.assertEqual(1, len(owners), f'{name} must be defined once under tools/Dekaf.Benchmarks/Benchmarks/Unit')
                 text = sources[owners[0]]
                 self.assertIn('MemoryDiagnoser', text, f'{name} needs [MemoryDiagnoser] for 0 B/op evidence')
-                self.assertIsNone(SINGLE_INVOCATION.search(text),
+                code = '\n'.join(line for line in text.splitlines() if not line.lstrip().startswith('//'))
+                self.assertIsNone(SINGLE_INVOCATION.search(code),
                                   f'{owners[0].name} uses a single-invocation fixture and cannot reach the warmup floor')
 
     def test_case_listing_counts_only_benchmark_lines(self):

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -12,6 +12,30 @@ namespace Dekaf.Tests.Unit.Consumer;
 public sealed class PartitionedConsumerRuntimeTests
 {
     [Test]
+    public async Task CommitTestConsumer_CancelledBeforeCompletedWait_DoesNotRecordCommit()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var consumer = new TestConsumer
+        {
+            CommitStarted = new TaskCompletionSource(),
+            ReleaseCommit = new TaskCompletionSource()
+        };
+        // Execute on the commit's stack: cancellation and release both happen
+        // after its initial token check but before it reaches WaitAsync.
+        var shutdown = consumer.CommitStarted.Task.ContinueWith(_ =>
+        {
+            cancellation.Cancel();
+            consumer.ReleaseCommit.SetResult();
+        }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+
+        await Assert.That(async () => await consumer.CommitAsync(
+            [new TopicPartitionOffset("topic", 0, 1)], cancellation.Token))
+            .Throws<OperationCanceledException>();
+        await shutdown;
+        await Assert.That(consumer.CommitCalls).IsEmpty();
+    }
+
+    [Test]
     public async Task StoreOffsets_LegacyConsumerFallback_AcceptsStructBackedList()
     {
         var implementation = new TestConsumer();
@@ -1430,6 +1454,11 @@ public sealed class PartitionedConsumerRuntimeTests
             CommitStarted?.TrySetResult();
             if (ReleaseCommit is not null)
                 await ReleaseCommit.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            // CommitStarted can let the test cancel and release before WaitAsync
+            // registers. A completed task bypasses WaitAsync's cancellation check;
+            // the fake must still observe cancellation before recording a commit.
+            cancellationToken.ThrowIfCancellationRequested();
 
             lock (_gate)
                 CommitCalls.Add(offsets.ToArray());


### PR DESCRIPTION
The performance gate selected unrelated consumer/protocol fixtures and treated test-only friend-assembly edits as product build changes. Specific implementation paths now select their maintained fixtures while unknown paths retain broad fallback coverage. KafkaConsumer keeps every offset-store overload covered; the nonexistent OffsetStore.cs mapping is removed. Only standalone known friend-assembly declarations can skip the build-input screen.

The failed .NET 8 shutdown test exposed a race in its fake commit: cancellation and release could both precede WaitAsync, whose completed-task fast path ignored cancellation. The fake now checks cancellation before recording completion. A synchronous continuation reproduces the original failure deterministically.

Validation: 309 Python tests pass under Ubuntu WSL; 71 focused runtime/backpressure tests pass on each of .NET 8 and .NET 10. All 16 offset-store BenchmarkDotNet Dry cases validate. Combined with retained Dry validation, the shared-path selections contain 40 cases for #3086 and 60 for #3083. These are correctness/coverage checks, not performance acceptance.

The 48-case budget and acceptance rules are unchanged. #3083 still needs a narrower affected-workload selection and coverage for its added fixtures before acceptance; removing offset-store coverage to fit the budget would be incorrect. This PR does not close that remaining scope.

Related: #3187. Squashed to one commit on main dccd99a62f3c4fd764240464e276c34b32fe7bd6. No generated evidence is committed.
