### PR TITLE
benchmarks: land compatible binary-key dispatch fixtures

### DIFF
--- a/.github/scripts/performance_gate.py
+++ b/.github/scripts/performance_gate.py
@@ -51,6 +51,12 @@ AREAS = (
     ('src/Dekaf/Protocol/Records/RecordBatch.cs', 'protocol',
      unit('ConsumerHotPathBenchmarks', 'ParsedRecordSlabLifecycleBenchmarks')
      + ['*.Unit.ProtocolBenchmarks.*RecordBatch*'], None),
+    ('src/Dekaf/Consumer/PartitionMessageKey.cs', 'consumer', unit(
+        'BinaryKeyDispatchBenchmarks', 'DistinctBinaryKeyDispatchBenchmarks',
+        'SharedSuffixBinaryKeyDispatchBenchmarks'), None),
+    ('src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.cs', 'consumer', unit(
+        'KeyOrderedDispatchBenchmarks', 'BinaryKeyDispatchBenchmarks',
+        'DistinctBinaryKeyDispatchBenchmarks', 'SharedSuffixBinaryKeyDispatchBenchmarks'), None),
     ('src/Dekaf/Producer/', 'producer', unit(
         'AccumulatorAppendBenchmarks', 'AccumulatorAdmissionAppendBenchmarks', 'ProducerFireHotPathBenchmarks',
         'PartitionerBenchmarks', 'InflightTrackingBenchmarks', 'BrokerUnackedByteBudgetBenchmarks',

--- a/.github/scripts/test_performance_gate.py
+++ b/.github/scripts/test_performance_gate.py
@@ -33,6 +33,14 @@ def benchmark(method='Append', parameters='', mean=100.0, samples=25, allocated=
 
 
 class SelectionTests(unittest.TestCase):
+    def test_binary_key_paths_retain_distinct_and_collision_workloads(self):
+        for path in ('PartitionMessageKey.cs', 'KeyOrderedPartitionDispatcher.cs'):
+            selection = gate.select([f'src/Dekaf/Consumer/{path}'])
+            for fixture in gate.unit('BinaryKeyDispatchBenchmarks', 'DistinctBinaryKeyDispatchBenchmarks',
+                                     'SharedSuffixBinaryKeyDispatchBenchmarks'):
+                self.assertIn(fixture, selection['filters'])
+        self.assertIn('*.Unit.KeyOrderedDispatchBenchmarks.*', selection['filters'])
+
     def test_kafka_consumer_retains_all_offset_store_api_coverage(self):
         selection = gate.select(['src/Dekaf/Consumer/KafkaConsumer.cs'])
         self.assertEqual(gate.unit('ConsumerHotPathBenchmarks', 'FetchResponseParsingBenchmarks',

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BinaryKeyDispatchBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BinaryKeyDispatchBenchmarks.cs
@@ -1,0 +1,155 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Consumer;
+using Dekaf.Protocol;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+public class BinaryKeyDispatchBenchmarks
+{
+    private const int RecordCount = 1024;
+    private ConsumeResult<byte[], string>[] _binary = null!;
+    private ConsumeResult<ReadOnlyMemory<byte>, string>[] _memory = null!;
+    private ConsumeResult<string, string>[] _strings = null!;
+
+    // One handler measures the sequential shortcut; two exercise keyed dispatch.
+    [Params(1, 2)]
+    public int MaxConcurrentHandlers { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _binary = CreateRecords(Serializers.ByteArray);
+        _memory = CreateRecords(Serializers.RawBytes);
+        _strings = CreateRecords(Serializers.String);
+    }
+
+    [Benchmark(OperationsPerInvoke = RecordCount)]
+    public Task ByteArray() => DispatchAsync(_binary, MaxConcurrentHandlers);
+
+    [Benchmark(OperationsPerInvoke = RecordCount)]
+    public Task RawMemory() => DispatchAsync(_memory, MaxConcurrentHandlers);
+
+    [Benchmark(OperationsPerInvoke = RecordCount)]
+    public Task StringControl() => DispatchAsync(_strings, MaxConcurrentHandlers);
+
+    private static ConsumeResult<TKey, string>[] CreateRecords<TKey>(IDeserializer<TKey> deserializer)
+    {
+        var result = new ConsumeResult<TKey, string>[RecordCount];
+        for (var i = 0; i < result.Length; i++)
+        {
+            // Distinct deserializer inputs reproduce separately fetched copies of one wire key.
+            result[i] = new ConsumeResult<TKey, string>("topic", 0, i,
+                "same-key"u8.ToArray(), false, default, false, null, 0,
+                TimestampType.CreateTime, null, deserializer, Serializers.String);
+        }
+        return result;
+    }
+
+    internal static async Task DispatchAsync<TKey>(ConsumeResult<TKey, string>[] records, int maxConcurrentHandlers,
+        bool holdAllWorkers = false)
+    {
+        var lane = new PartitionLane<TKey, string>(new TopicPartition("topic", 0), records.Length,
+            static (_, _) => ValueTask.CompletedTask, static _ => { }, static (_, error) => throw error);
+        var context = new PartitionProcessorContext<TKey, string>(lane);
+        var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var dispatcher = new KeyOrderedPartitionDispatcher<TKey, string>(context, 1, maxConcurrentHandlers, records.Length,
+            async (batch, _) =>
+            {
+                if (batch[0].Offset == 0 || (holdAllWorkers && batch[0].Offset < maxConcurrentHandlers))
+                    await releaseFirst.Task.ConfigureAwait(false);
+                context.MarkProcessed(batch[0]);
+            });
+        for (var i = 0; i < records.Length; i++)
+            lane.TryEnqueue(records[i]);
+        await lane.StopAsync(PartitionStopPolicy.Drain, Timeout.InfiniteTimeSpan).ConfigureAwait(false);
+        var running = dispatcher.RunAsync(CancellationToken.None);
+        var bufferedKeys = dispatcher.LaneCount;
+        releaseFirst.SetResult();
+        await running.ConfigureAwait(false);
+        if (holdAllWorkers && bufferedKeys != records.Length)
+            throw new InvalidOperationException("The shared-suffix fixture did not fill the keyed buffer.");
+        if (lane.GetCommitOffset()?.Offset != records.Length)
+            throw new InvalidOperationException("The dispatcher did not complete every input record.");
+    }
+}
+
+/// <summary>
+/// Keeps lane cardinality identical before/after content equality, exposing the cost
+/// of hashing large keys without the repeated-key workload's lane-coalescing benefit.
+/// </summary>
+[MemoryDiagnoser]
+public class DistinctBinaryKeyDispatchBenchmarks
+{
+    private const int RecordCount = 128;
+    private ConsumeResult<byte[], string>[] _binary = null!;
+    private ConsumeResult<ReadOnlyMemory<byte>, string>[] _memory = null!;
+
+    [Params(8, 1024, 65536)]
+    public int KeySize { get; set; }
+
+    [Params(1, 2)]
+    public int MaxConcurrentHandlers { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _binary = CreateRecords(Serializers.ByteArray);
+        _memory = CreateRecords(Serializers.RawBytes);
+    }
+
+    [Benchmark(OperationsPerInvoke = RecordCount)]
+    public Task ByteArray() => BinaryKeyDispatchBenchmarks.DispatchAsync(_binary, MaxConcurrentHandlers);
+
+    [Benchmark(OperationsPerInvoke = RecordCount)]
+    public Task RawMemory() => BinaryKeyDispatchBenchmarks.DispatchAsync(_memory, MaxConcurrentHandlers);
+
+    private ConsumeResult<TKey, string>[] CreateRecords<TKey>(IDeserializer<TKey> deserializer)
+    {
+        var result = new ConsumeResult<TKey, string>[RecordCount];
+        for (var index = 0; index < result.Length; index++)
+        {
+            var key = new byte[KeySize];
+            key.AsSpan().Fill(0x61);
+            System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(key.AsSpan(KeySize - sizeof(int)), index);
+            result[index] = new ConsumeResult<TKey, string>("topic", 0, index,
+                key, false, default, false, null, 0,
+                TimestampType.CreateTime, null, deserializer, Serializers.String);
+        }
+        return result;
+    }
+}
+
+/// <summary>
+/// Exercises a full buffer of distinct large keys with a common prefix and suffix.
+/// Their discriminator lies outside the former four-region sampling scheme.
+/// </summary>
+[MemoryDiagnoser]
+public class SharedSuffixBinaryKeyDispatchBenchmarks
+{
+    private const int RecordCount = 256;
+    private ConsumeResult<ReadOnlyMemory<byte>, string>[] _records = null!;
+
+    [Params(1024, 65536)]
+    public int KeySize { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _records = new ConsumeResult<ReadOnlyMemory<byte>, string>[RecordCount];
+        for (var index = 0; index < _records.Length; index++)
+        {
+            var key = new byte[KeySize];
+            key.AsSpan().Fill(0x61);
+            System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(key.AsSpan(KeySize - 32), index);
+            _records[index] = new ConsumeResult<ReadOnlyMemory<byte>, string>("topic", 0, index,
+                key, false, default, false, null, 0, TimestampType.CreateTime, null,
+                Serializers.RawBytes, Serializers.String);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = RecordCount)]
+    public Task RawMemory() => BinaryKeyDispatchBenchmarks.DispatchAsync(_records,
+        maxConcurrentHandlers: 2, holdAllWorkers: true);
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionedDispatchBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionedDispatchBenchmarks.cs
@@ -45,7 +45,15 @@ public class PartitionedDispatchBenchmarks
         Delegate handler = batches
             ? (PartitionBatchProcessor<int, int>)HandleBatch
             : (PartitionRecordProcessor<int, int>)HandleRecord;
-        _processor = (PartitionProcessor<int, int>)factory.Invoke(null, [handler, options])!;
+        // Older revisions have no optional key comparer. Resolve this only during setup
+        // so both revisions execute the same processor workload when compared.
+        object?[] arguments = factory.GetParameters().Length switch
+        {
+            2 => [handler, options],
+            3 => [handler, options, null],
+            _ => throw new InvalidOperationException("Unexpected partition processor factory signature.")
+        };
+        _processor = (PartitionProcessor<int, int>)factory.Invoke(null, arguments)!;
         await Dispatch();
     }
 


### PR DESCRIPTION
The binary-key workloads added by #3082 are missing from main, preventing identical-fixture before/after comparisons. Add those fixtures to the existing benchmark project and map the key implementation paths. Partition dispatch setup supports both processor factory signatures, with reflection outside timing.

Coverage includes repeated keys, 8-byte/1-KiB/64-KiB distinct keys, and a full buffer of 256 keys sharing the sampled prefix/suffix. The fixtures verify completion, and the collision case verifies all 256 lanes remain buffered.

Validation: all 32 binary-key and partition-dispatch cases complete with BenchmarkDotNet Dry against main product code; the same fixture source has also passed candidate validation on #3082. All 24 gate tests pass on Linux. No product source changes or performance acceptance; #3082 still needs its budget, collision-performance and loaded-evidence blockers resolved.

Closes #3193
