### PR TITLE
chore(deps): update Confluent packages together to 2.15.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,10 +15,10 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
     <PackageVersion Include="Confluent.Kafka" Version="2.15.1" />
-    <PackageVersion Include="Confluent.SchemaRegistry" Version="2.15.0" />
-    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.15.0" />
-    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.15.0" />
-    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.15.0" />
+    <PackageVersion Include="Confluent.SchemaRegistry" Version="2.15.1" />
+    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.15.1" />
+    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.15.1" />
+    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.15.1" />
     <PackageVersion Include="Dekaf" Version="$(DekafPackageVersion)" />
     <PackageVersion Include="Dekaf.Abstractions" Version="$(DekafPackageVersion)" />
     <PackageVersion Include="GitVersion.MsBuild" Version="6.8.2" />

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
+      "description": "Confluent packages depend on matching client versions; update the release train together",
+      "matchPackageNames": [
+        "/^Confluent\\./"
+      ],
+      "groupName": "Confluent .NET packages"
+    },
+    {
       "description": "EF 8.x train pinned for the net8.0 TFM (Directory.Packages.props conditioned entry); 9+/10+ do not support net8.0",
       "matchPackageNames": [
         "/^Microsoft\\.EntityFrameworkCore\\./"


### PR DESCRIPTION
Update Confluent SchemaRegistry and the Avro, JSON and Protobuf serializers to 2.15.1, matching the Kafka client already on main. Updating these packages separately causes NU1605 downgrades because the serializers require SchemaRegistry 2.15.1. Group future Confluent updates in Renovate.

This includes the package changes proposed in #3199 and #3200. Validation: Release integration-project build and eight Confluent interoperability tests pass. The vulnerability audit covers 44 projects and three tool manifests with zero blocking findings or audit problems; existing suppressions are unchanged. Renovate configuration validation passed for the unchanged grouping rule.

One commit, rebased onto latest main. Raw validation output is retained outside Git under C:/git/Dekaf-evidence/pr-3196/715a74b9b0086ac93e6e9c222da18f374efd8c0b/. Current-head CI and review must finish before merge.