### PR TITLE
ci: select benchmarks for verified pending-fetch changes

### DIFF
--- a/.github/scripts/performance_gate.py
+++ b/.github/scripts/performance_gate.py
@@ -133,9 +133,9 @@ def _area_for(path):
     return match
 
 
-def select(changed_files):
+def select(changed_files, base=None, head=None):
     """Map changed product files to benchmark globs; order follows the first matching file."""
-    areas, filters, not_applicable, considered = [], [], {}, []
+    areas, filters, not_applicable, considered, scopes = [], [], {}, [], []
     for path in changed_files:
         path = path.replace('\\', '/')
         if path in BUILD_INPUTS:
@@ -144,6 +144,18 @@ def select(changed_files):
             continue
         else:
             match = _area_for(path)
+            if (base and head and path == 'src/Dekaf/Consumer/KafkaConsumer.cs'
+                    and _pending_fetch_only(base, head, path)):
+                match = (path, 'consumer', unit('ConsumerHotPathBenchmarks',
+                                              'ParsedRecordSlabLifecycleBenchmarks'), None)
+                scopes.append({'path': path, 'reason': 'Only PendingFetchData changed; consumer fetch '
+                               'scheduling and offset-store implementations are byte-for-byte unchanged.'})
+            elif (base and head and path == 'src/Dekaf/Protocol/Records/RecordBatch.cs'
+                  and _record_count_bound_only(base, head, path)):
+                match = (path, 'protocol', unit('ConsumerHotPathBenchmarks', 'ParsedRecordSlabLifecycleBenchmarks')
+                         + ['*.Unit.ProtocolBenchmarks.Read*RecordBatch*'], None)
+                scopes.append({'path': path, 'reason': 'Only the instance RecordCountUpperBound getter was added; '
+                               'retain read/lifecycle coverage. Unchanged write methods cannot call the new getter.'})
         if match is None:
             continue
         considered.append(path)
@@ -162,7 +174,47 @@ def select(changed_files):
         'filters': filters,
         'not_applicable': [{'area': area, 'reason': reason} for area, reason in not_applicable.items()],
         'considered_files': considered,
+        'scoped_files': scopes,
     }
+
+
+def _pending_fetch_only(base, head, path):
+    """Narrow only this known top-level type; unfamiliar formatting keeps the broad map."""
+    # This is a conservative boundary check for the maintained file, not a C# parser.
+    # Nested braces are indented. Every byte outside this class must remain unchanged.
+    pattern = re.compile(r'^internal sealed class PendingFetchData : IDisposable\n\{.*?^\}\n', re.M | re.S)
+    remaining = []
+    for revision in (base, head):
+        try:
+            source = subprocess.check_output(['git', 'show', f'{revision}:{path}'],
+                                             text=True, stderr=subprocess.DEVNULL)
+        except subprocess.CalledProcessError:
+            return False
+        matches = list(pattern.finditer(source))
+        if len(matches) != 1:
+            return False
+        match = matches[0]
+        remaining.append(source[:match.start()] + source[match.end():])
+    return remaining[0] == remaining[1]
+
+
+def _record_count_bound_only(base, head, path):
+    """Recognize only an added instance getter, with no field/layout or existing-code edits."""
+    diff = subprocess.check_output([
+        'git', 'diff', '--no-ext-diff', '--unified=0', f'{base}..{head}', '--', path,
+    ], text=True)
+    added = []
+    for line in diff.splitlines():
+        if line.startswith(('+++', '---')):
+            continue
+        if line.startswith('-'):
+            return False
+        if line.startswith('+') and line[1:].strip() and not line[1:].lstrip().startswith('//'):
+            added.append(line[1:])
+    return bool(re.fullmatch(
+        r'    internal int RecordCountUpperBound\n    \{\n'
+        r'(?:        \[MethodImpl\(MethodImplOptions\.AggressiveInlining\)\]\n)?'
+        r'        get => [^\n]+(?:\n            [^\n]+)*;\n    \}', '\n'.join(added)))
 
 
 def changed_files(base, head):
@@ -282,7 +334,7 @@ def main(argv=None):
             selection = {'applicable': True, 'areas': ['explicit'], 'filters': filters, 'not_applicable': [],
                          'considered_files': []}
         else:
-            selection = select(changed_files(args.base, args.head))
+            selection = select(changed_files(args.base, args.head), args.base, args.head)
         selection.update(base=args.base, head=args.head)
         args.output.write_text(json.dumps(selection, indent=2) + '\n', encoding='utf-8')
         print(json.dumps(selection, indent=2))

--- a/.github/scripts/test_performance_gate.py
+++ b/.github/scripts/test_performance_gate.py
@@ -41,6 +41,50 @@ class SelectionTests(unittest.TestCase):
                 self.assertIn(fixture, selection['filters'])
         self.assertIn('*.Unit.KeyOrderedDispatchBenchmarks.*', selection['filters'])
 
+    def test_added_record_bound_retains_reads_but_does_not_select_unchanged_writes(self):
+        addition = ('+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs\n'
+                    '+    // Bound encoded records.\n+    internal int RecordCountUpperBound\n'
+                    '+    {\n+        get => _recordCount;\n+    }\n')
+        path = 'src/Dekaf/Protocol/Records/RecordBatch.cs'
+        with mock.patch.object(gate.subprocess, 'check_output', return_value=addition):
+            selection = gate.select([path], 'base', 'head')
+        self.assertIn('*.Unit.ProtocolBenchmarks.Read*RecordBatch*', selection['filters'])
+        self.assertIn('*.Unit.ParsedRecordSlabLifecycleBenchmarks.*', selection['filters'])
+        self.assertNotIn('*.Unit.ProtocolBenchmarks.*RecordBatch*', selection['filters'])
+        for diff in (addition + '-    WriteOld();\n+    WriteNew();\n',
+                     addition + '+    private int _newField;\n',
+                     addition.replace('get => _recordCount;', 'get;'),
+                     addition.replace('internal int', 'internal static int')):
+            with self.subTest(diff=diff), mock.patch.object(gate.subprocess, 'check_output', return_value=diff):
+                selection = gate.select([path], 'base', 'head')
+            self.assertIn('*.Unit.ProtocolBenchmarks.*RecordBatch*', selection['filters'])
+
+    def test_pending_fetch_only_changes_keep_actual_lifecycle_coverage(self):
+        source = ('using System;\ninternal sealed class PendingFetchData : IDisposable\n{\n'
+                  '    private int _count = 1;\n}\n'
+                  'public sealed class KafkaConsumer\n{\n    public void StoreOffset() { }\n}\n')
+        changed = source.replace('_count = 1', '_count = 2')
+        with mock.patch.object(gate.subprocess, 'check_output', side_effect=[source, changed]):
+            selection = gate.select(['src/Dekaf/Consumer/KafkaConsumer.cs'], 'base', 'head')
+        self.assertEqual(gate.unit('ConsumerHotPathBenchmarks', 'ParsedRecordSlabLifecycleBenchmarks'),
+                         selection['filters'])
+        self.assertEqual(1, len(selection['scoped_files']))
+
+        # Any change outside the known class, including a using, offset-store method,
+        # new top-level type or an unfamiliar declaration, retains the broad fallback.
+        for candidate in (changed.replace('StoreOffset()', 'StoreOffsets()'),
+                          changed.replace('using System;', 'using System.Text;'),
+                          changed + 'internal sealed class Other { }\n',
+                          changed.replace('internal sealed class PendingFetchData',
+                                          'internal partial class PendingFetchData')):
+            with self.subTest(candidate=candidate), mock.patch.object(
+                    gate.subprocess, 'check_output', side_effect=[source, candidate]):
+                selection = gate.select(['src/Dekaf/Consumer/KafkaConsumer.cs'], 'base', 'head')
+            self.assertIn('*.Unit.OffsetStoreBenchmarks.*', selection['filters'])
+            self.assertIn('*.Unit.ConsumeResultOffsetStoreBenchmarks.*', selection['filters'])
+            self.assertIn('*.Unit.FetchRequestBuildBenchmarks.*', selection['filters'])
+            self.assertEqual([], selection['scoped_files'])
+
     def test_kafka_consumer_retains_all_offset_store_api_coverage(self):
         selection = gate.select(['src/Dekaf/Consumer/KafkaConsumer.cs'])
         self.assertEqual(gate.unit('ConsumerHotPathBenchmarks', 'FetchResponseParsingBenchmarks',

--- a/.github/workflows/performance-gate.yml
+++ b/.github/workflows/performance-gate.yml
@@ -115,6 +115,7 @@ jobs:
             echo
             echo "Filters: $(jq -r '.filters | map("`" + . + "`") | join(" ")' "$GATE/selection.json")"
             jq -r '.not_applicable[] | "\n- " + .area + ": " + .reason' "$GATE/selection.json"
+            jq -r '.scoped_files[]? | "\n- " + .path + ": " + .reason' "$GATE/selection.json"
           } >> "$GITHUB_STEP_SUMMARY"
           if [[ "$applicable" != true ]]; then
             echo "No steady-state microbenchmark fixture maps to the changed paths; nothing was measured." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
#3083 still exceeds the 48-case gate because changes inside PendingFetchData select unrelated KafkaConsumer fetch-scheduling and offset-store methods. Its RecordBatch change only adds a computed instance getter, while the broad map also selects unchanged write methods.

Narrow those two verified scopes and record each reason in job output. Any change outside PendingFetchData, any existing RecordBatch code edit, field addition, auto-property, or unfamiliar shape retains the broader mapping. Keep consumer traversal, parsed-record lifecycle, dispatch, completion tracking and protocol-read coverage. The 48-case guard is unchanged.

The resulting selection is 37 baseline cases and 47 candidate cases, including #3083's ten added completion/epoch cases. All selected cases completed in standard BenchmarkDotNet Dry validation; all 314 Python tests pass on Linux, and the complete-tree artifact check passes. This fixes selection, not product acceptance: candidate-only fixtures still need compatible baseline coverage and the PR still needs its applicable performance evidence.

Closes #3187
