### PR TITLE
test(producer): wait for append completion before sealing tracing batch

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -777,6 +777,11 @@ public class KafkaProducerFastPathTests
         var topicPartition = new TopicPartition(Topic, 0);
         await Assert.That(() => HasCurrentOrSealedBatch(producer.RecordAccumulator, topicPartition))
             .Eventually(found => found.IsTrue(), TimeSpan.FromSeconds(5));
+        // Publishing CurrentBatch precedes the worker's append. Completing it here
+        // requires the same ownership fence as other asynchronous append tests.
+        await TestWait.UntilAsync(
+            () => GetSlowPathAppendCount(producer.RecordAccumulator, topicPartition) == 0,
+            TimeSpan.FromSeconds(5));
         var readyBatch = CompleteCurrentBatch(producer.RecordAccumulator, topicPartition);
         readyBatch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow);
         _ = await produceTask;


### PR DESCRIPTION
The async serializer tracing test can see a newly published batch while its append worker is still filling it, then prematurely complete an empty batch. Wait for the existing slow-path ownership counter to reach zero before sealing. Caller-owned header assertions remain intact.

Validation: all 26 KafkaProducerFastPathTests pass on .NET 10 and .NET 8. Product source is unchanged. Fixes the race seen in [#3082 CI](https://github.com/thomhurst/Dekaf/actions/runs/34476027216/job/102866894434).

Closes #3201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved asynchronous producer test synchronization to ensure background processing completes before batch finalization.
  - Increased test reliability by reducing the risk of timing-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->