### PR TITLE
ci: allow standard benchmark smoke builds to finish

### DIFF
--- a/.github/workflows/performance-harness-tests.yml
+++ b/.github/workflows/performance-harness-tests.yml
@@ -45,7 +45,7 @@ jobs:
           dotnet run --project Dekaf.Benchmarks.csproj -c Release --no-build -- \
             --filter '*.Unit.ValueTaskSourcePoolBenchmarks.RentReturnSameThread' '*.Unit.ConsumerHotPathBenchmarks.ConsumeBatch_String_Deserialize' \
             --warmupCount 3 --iterationCount 3 --iterationTime 100 --launchCount 1 --outliers DontRemove \
-            --exporters fulljson --artifacts "$results/timing" > "$results/timing.log" 2>&1
+            --exporters fulljson --buildTimeout 900 --artifacts "$results/timing" > "$results/timing.log" 2>&1
           python3 "$GITHUB_WORKSPACE/.github/scripts/performance_gate.py" validate --phase "$results/timing" \
             --expected 2 --iterations 3 --min-warmup 0 --merged "$results/same.json" --cases "$results/cases.json"
           jq -e 'length == 2 and any(.[]; any(.Metrics[]; .Descriptor.Id == "Allocated Memory" and .Value == 0)) and any(.[]; any(.Metrics[]; .Descriptor.Id == "Allocated Memory" and .Value > 0))' "$results/same.json"


### PR DESCRIPTION
The performance tooling smoke failed before sampling when BenchmarkDotNet killed its generated build at the default 120-second limit. The initial project build took 127 seconds on the same runner. Set `--buildTimeout 900`, matching the standard performance gate. The job retains its 15-minute limit.

Closes #3205.

Validation: 26 performance-gate tests passed on Linux; full-tree artifact policy and diff checks passed. [Original failure and uploaded build logs](https://github.com/thomhurst/Dekaf/actions/runs/34477165210/job/102870636472) establish the timeout. The updated GitHub job will exercise the standard benchmark build and export checks.