### PR TITLE
benchmarks: cover ShareFetch response decoding

### DIFF
--- a/.github/scripts/performance_gate.py
+++ b/.github/scripts/performance_gate.py
@@ -35,6 +35,8 @@ TRACE = unit('TraceContextInjectionBenchmarks', 'TraceContextExtractionBenchmark
 # [IterationSetup]/[IterationCleanup], fixed InvocationCount or ColdStart fixtures, because
 # those cannot reach the elapsed warmup floor with the shared BDN settings.
 AREAS = (
+    ('src/Dekaf/Protocol/Messages/ShareFetchResponse.cs', 'share-consumer',
+     unit('ShareFetchResponseDecodingBenchmarks'), None),
     # KafkaConsumer owns both fetching and the offset-store API. The separate
     # partition dispatcher has its own implementation; unknown files retain the
     # directory-wide fallback below.

--- a/.github/scripts/test_performance_gate.py
+++ b/.github/scripts/test_performance_gate.py
@@ -33,6 +33,14 @@ def benchmark(method='Append', parameters='', mean=100.0, samples=25, allocated=
 
 
 class SelectionTests(unittest.TestCase):
+    def test_share_fetch_response_selects_its_actual_decoder(self):
+        selection = gate.select(['src/Dekaf/Protocol/Messages/ShareFetchResponse.cs'])
+        self.assertEqual(gate.unit('ShareFetchResponseDecodingBenchmarks'), selection['filters'])
+        self.assertIn('*.Unit.PipelinedResponseAllocationBenchmarks.*',
+                      gate.select(['src/Dekaf/Networking/KafkaConnection.cs'])['filters'])
+        self.assertIn('*.Unit.Crc32CBenchmarks.*',
+                      gate.select(['src/Dekaf/Protocol/UnknownResponse.cs'])['filters'])
+
     def test_binary_key_paths_retain_distinct_and_collision_workloads(self):
         for path in ('PartitionMessageKey.cs', 'KeyOrderedPartitionDispatcher.cs'):
             selection = gate.select([f'src/Dekaf/Consumer/{path}'])

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareFetchResponseDecodingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareFetchResponseDecodingBenchmarks.cs
@@ -1,0 +1,136 @@
+using System.Buffers;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// One ShareFetch v1 response: optional managed pool rent/copy, actual connection
+/// decoding, metadata consumption and response release. Payload bytes stay opaque;
+/// record-batch parsing, network I/O and per-message delivery are outside this boundary.
+/// Allocations are per response, not per record. No payload view is read after decoding:
+/// older products already return pooled storage before handing the response back.
+/// </summary>
+[MemoryDiagnoser]
+public class ShareFetchResponseDecodingBenchmarks
+{
+    private static readonly Guid TopicId = Guid.Parse("01234567-89ab-cdef-0123-456789abcdef");
+    private byte[] _encoded = null!;
+    private ResponseBufferPool _pool = null!;
+    private Func<PooledResponseBuffer, short, bool, IResponseMemoryReservation?, ShareFetchResponse> _parse = null!;
+    private Action<ShareFetchResponse> _release = null!;
+
+    [Params(false, true)]
+    public bool Pooled { get; set; }
+
+    [Params(0, 65536)]
+    public int PayloadBytes { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var payload = new byte[PayloadBytes];
+        payload.AsSpan().Fill(0x5a);
+        _encoded = Encode(payload).WrittenSpan.ToArray();
+        _pool = new ResponseBufferPool(1024 * 1024, managedArraysPerBucket: 1);
+        _parse = typeof(KafkaConnection)
+            .GetMethod("ParsePipelinedResponse", BindingFlags.NonPublic | BindingFlags.Static)!
+            .MakeGenericMethod(typeof(ShareFetchRequest), typeof(ShareFetchResponse))
+            .CreateDelegate<Func<PooledResponseBuffer, short, bool, IResponseMemoryReservation?, ShareFetchResponse>>();
+        // Older decoders release the frame before returning; newer responses own it.
+        // Both revisions measure decode/consume/release, with reflection confined to setup.
+        _release = typeof(ShareFetchResponse).GetMethod("Dispose", Type.EmptyTypes)?
+            .CreateDelegate<Action<ShareFetchResponse>>() ?? (static _ => { });
+
+        var response = _parse(new PooledResponseBuffer(_encoded, _encoded.Length, false), 1, false, null);
+        try
+        {
+            Validate(response);
+            if (!response.Responses[0].Partitions[0].RecordBytes.Span.SequenceEqual(payload))
+                throw new InvalidOperationException("ShareFetch payload changed.");
+        }
+        finally
+        {
+            _release(response);
+        }
+        // Validate both the selected storage path and its cleanup before timing.
+        DecodeAndRelease();
+    }
+
+    [Benchmark]
+    public int DecodeAndRelease()
+    {
+        var bytes = _encoded;
+        if (Pooled)
+        {
+            bytes = _pool.Pool.Rent(_encoded.Length);
+            _encoded.CopyTo(bytes, 0);
+        }
+        var response = _parse(new PooledResponseBuffer(bytes, _encoded.Length, Pooled, pool: _pool), 1, false, null);
+        try
+        {
+            return Validate(response);
+        }
+        finally
+        {
+            _release(response);
+        }
+    }
+
+    private int Validate(ShareFetchResponse response)
+    {
+        if (response.ErrorCode != ErrorCode.None || response.AcquisitionLockTimeoutMs != 30000
+            || response.Responses.Count != 1 || response.NodeEndpoints.Count != 0)
+            throw new InvalidOperationException("ShareFetch response metadata changed.");
+        var topic = response.Responses[0];
+        if (topic.TopicId != TopicId || topic.Partitions.Count != 1)
+            throw new InvalidOperationException("ShareFetch topic metadata changed.");
+        var partition = topic.Partitions[0];
+        if (partition.PartitionIndex != 0 || partition.ErrorCode != ErrorCode.None
+            || partition.RecordBytes.Length != PayloadBytes || partition.AcquiredRecords.Count != (PayloadBytes == 0 ? 0 : 1)
+            || PayloadBytes != 0 && (partition.AcquiredRecords[0].FirstOffset != 0
+                                    || partition.AcquiredRecords[0].LastOffset != 0
+                                    || partition.AcquiredRecords[0].DeliveryCount != 1))
+            throw new InvalidOperationException("ShareFetch partition metadata changed.");
+        return partition.RecordBytes.Length;
+    }
+
+    private static ArrayBufferWriter<byte> Encode(ReadOnlySpan<byte> records)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0); // throttle
+        writer.WriteInt16(0); // top-level error
+        writer.WriteCompactString(null);
+        writer.WriteInt32(30000); // acquisition lock timeout
+        writer.WriteUnsignedVarInt(2); // one topic
+        writer.WriteUuid(TopicId);
+        writer.WriteUnsignedVarInt(2); // one partition
+        writer.WriteInt32(0);
+        writer.WriteInt16(0);
+        writer.WriteCompactString(null);
+        writer.WriteInt16(0); // acknowledgement error
+        writer.WriteCompactString(null);
+        writer.WriteInt32(1); // leader ID
+        writer.WriteInt32(1); // leader epoch
+        writer.WriteUnsignedVarInt(0); // leader tags
+        writer.WriteUnsignedVarInt(records.Length + 1);
+        writer.WriteRawBytes(records);
+        writer.WriteUnsignedVarInt(records.IsEmpty ? 1 : 2);
+        if (!records.IsEmpty)
+        {
+            writer.WriteInt64(0);
+            writer.WriteInt64(0);
+            writer.WriteInt16(1); // delivery count
+            writer.WriteUnsignedVarInt(0); // acquired range tags
+        }
+        writer.WriteUnsignedVarInt(0); // partition tags
+        writer.WriteUnsignedVarInt(0); // topic tags
+        writer.WriteUnsignedVarInt(1); // no node endpoints
+        writer.WriteUnsignedVarInt(0); // response tags
+        return buffer;
+    }
+}


### PR DESCRIPTION
Add four steady-state BenchmarkDotNet cases for actual ShareFetch v1 connection decoding with pooled/unpooled managed frames and empty/nonempty payloads. Map ShareFetchResponse.cs to this fixture; general networking and unknown-protocol coverage stays selected for those paths.

Closes #3207.

The measured boundary includes pool rent/copy where applicable, decode, metadata consumption and response cleanup. It excludes record parsing and delivery. Older products release pooled payloads inside decoding, so the fixture never dereferences those returned payload views. Setup validates payload bytes using owned, unpooled input.

Validation: all four Dry cases passed on main and #3158 with the same fixture implementation; 27 Linux selection/validation tests passed. Full-tree artifact policy and final diff checks passed. Raw local exports and validated binaries are retained outside Git at C:\git\Dekaf-evidence\pr-3208\eff787c7cf09f0c3bb0f7c0d1d8a450d0be24c23. These are fixture correctness checks, not performance acceptance. GitHub job output/artifacts provide subsequent CI results.

The pre-existing pooled payload lifetime defect is tracked by #3158; its correctness/performance acceptance is separate from this fixture PR.


Native-buffer review coverage is delivered separately in #3209. This PR merged at eff787c7cf09f0c3bb0f7c0d1d8a450d0be24c23 and contains the four managed/unpooled cases.
