### PR TITLE
benchmarks: cover consumer-group assignment decoding

### DIFF
--- a/.github/scripts/performance_gate.py
+++ b/.github/scripts/performance_gate.py
@@ -82,7 +82,8 @@ AREAS = (
         'CachingStringDeserializerBenchmarks', 'ConsumerHotPathBenchmarks'), None),
     ('src/Dekaf/Admin/', 'admin', unit(
         'ControlPlaneProtocolBenchmarks', 'AdminMultiGroupOffsetQueryBenchmarks', 'ListOffsetsProtocolBenchmarks',
-        'DescribeTransactionsProtocolBenchmarks', 'OffsetTopicIdProtocolBenchmarks'), None),
+        'DescribeTransactionsProtocolBenchmarks', 'OffsetTopicIdProtocolBenchmarks',
+        'ConsumerGroupAssignmentBenchmarks'), None),
     ('src/Dekaf/Metadata/', 'metadata', unit(
         'ControllerMetadataRefreshBenchmarks', 'TopicIdentityCheckBenchmarks', 'ProduceTopicCorrelationBenchmarks',
         'DnsPreferenceCacheBenchmarks'), None),

--- a/.github/scripts/test_performance_gate.py
+++ b/.github/scripts/test_performance_gate.py
@@ -33,6 +33,11 @@ def benchmark(method='Append', parameters='', mean=100.0, samples=25, allocated=
 
 
 class SelectionTests(unittest.TestCase):
+    def test_admin_changes_cover_consumer_assignment_decoding(self):
+        selection = gate.select(['src/Dekaf/Admin/AdminClient.cs'])
+        self.assertIn('*.Unit.ConsumerGroupAssignmentBenchmarks.*', selection['filters'])
+        self.assertIn('*.Unit.ControlPlaneProtocolBenchmarks.*', selection['filters'])
+
     def test_share_fetch_response_selects_its_actual_decoder(self):
         selection = gate.select(['src/Dekaf/Protocol/Messages/ShareFetchResponse.cs'])
         self.assertEqual(gate.unit('ShareFetchResponseDecodingBenchmarks'), selection['filters'])

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerGroupAssignmentBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerGroupAssignmentBenchmarks.cs
@@ -1,0 +1,54 @@
+using System.Buffers;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Admin;
+using Dekaf.Protocol;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Consumer assignment decoding, including frames with empty topic entries.</summary>
+[MemoryDiagnoser]
+public class ConsumerGroupAssignmentBenchmarks
+{
+    [Params(0, 1024)]
+    public int EmptyTopics { get; set; }
+
+    [Params(false, true)]
+    public bool IncludePartition { get; set; }
+
+    private byte[] _assignment = null!;
+    private Func<byte[]?, IReadOnlyList<TopicPartition>?> _parse = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt16(0);
+        writer.WriteInt32(EmptyTopics + (IncludePartition ? 1 : 0));
+        for (var i = 0; i < EmptyTopics; i++)
+        {
+            writer.WriteString("t");
+            writer.WriteInt32(0);
+        }
+        if (IncludePartition)
+        {
+            writer.WriteString("topic");
+            writer.WriteInt32(1);
+            writer.WriteInt32(2);
+        }
+        writer.WriteBytes([]);
+        _assignment = buffer.WrittenSpan.ToArray();
+        _parse = typeof(AdminClient).GetMethod("ParseMemberAssignment",
+            BindingFlags.NonPublic | BindingFlags.Static)!
+            .CreateDelegate<Func<byte[]?, IReadOnlyList<TopicPartition>?>>();
+
+        var result = Decode();
+        if (result is null || result.Count != (IncludePartition ? 1 : 0) ||
+            (IncludePartition && result[0] != new TopicPartition("topic", 2)))
+            throw new InvalidOperationException("Assignment decoding must preserve every assigned partition.");
+    }
+
+    [Benchmark]
+    public IReadOnlyList<TopicPartition>? Decode() => _parse(_assignment);
+}


### PR DESCRIPTION
Adds four consumer-group assignment cases to `tools/Dekaf.Benchmarks`: zero or 1024 empty topics, with or without an assigned partition. Admin changes select these cases alongside the existing protocol coverage. This provides identical fixtures on main for #3128's parser validation and allocation change.

Validation: 28 Linux performance-gate tests pass. All four standard BenchmarkDotNet Short cases complete on main and the fixed #3128 source, validating identical decoded partitions with `[MemoryDiagnoser]`. Short runs are diagnostic, not hosted performance acceptance. Raw exports and binaries are retained outside Git at `C:/git/Dekaf-evidence/issue-3211/c769ab5b6ec7b56d2545d8554953bc8037c4e594`; no generated files are committed.

Closes #3211.
