### PR TITLE
test: wait for broker telemetry subscription readiness

### DIFF
--- a/tests/Dekaf.Tests.Integration/ClientTelemetryReceiverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ClientTelemetryReceiverIntegrationTests.cs
@@ -12,6 +12,33 @@ namespace Dekaf.Tests.Integration;
 public sealed class ClientTelemetryReceiverIntegrationTests(TelemetryReceiverKafkaContainer kafka)
 {
     [Test]
+    [Timeout(90_000)]
+    public async Task SubscriptionProbe_DistinguishesUnconfiguredAndReadyClients(CancellationToken cancellationToken)
+    {
+        const string metricName = "com.example.telemetry.readiness";
+        var clientId = $"telemetry-readiness-{Guid.NewGuid():N}";
+        var unconfigured = await kafka.ReadSubscriptionAsync(clientId, cancellationToken);
+        await Assert.That(unconfigured.ErrorCode).IsEqualTo(Protocol.ErrorCode.None);
+        await Assert.That(unconfigured.RequestedMetrics.Count).IsEqualTo(0);
+        await Assert.That(unconfigured.PushIntervalMs).IsGreaterThan(30_000);
+
+        await using var admin = kafka.CreateAdminClient();
+        await admin.IncrementalAlterConfigsAsync(new Dictionary<ConfigResource, IReadOnlyList<ConfigAlter>>
+        {
+            [new ConfigResource { Type = ConfigResourceType.ClientMetrics, Name = clientId }] =
+            [
+                ConfigAlter.Set("metrics", metricName),
+                ConfigAlter.Set("interval.ms", "500"),
+                ConfigAlter.Set("match", $"client_id={clientId}")
+            ]
+        }, cancellationToken: cancellationToken);
+
+        var ready = await kafka.WaitForSubscriptionAsync(clientId, [metricName], 500, cancellationToken);
+        await Assert.That(ready.RequestedMetrics).Contains(metricName);
+        await Assert.That(ready.PushIntervalMs).IsEqualTo(500);
+    }
+
+    [Test]
     [Arguments(42.0)]
     [Arguments(84.0)]
     [Timeout(90_000)]
@@ -31,6 +58,8 @@ public sealed class ClientTelemetryReceiverIntegrationTests(TelemetryReceiverKaf
                 ConfigAlter.Set("match", $"client_id={clientId}")
             ]
         }, cancellationToken: cancellationToken);
+
+        await kafka.WaitForSubscriptionAsync(clientId, [applicationName, builtinName], 1000, cancellationToken);
 
         var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(kafka.BootstrapServers)
@@ -89,6 +118,8 @@ public sealed class ClientTelemetryReceiverIntegrationTests(TelemetryReceiverKaf
                 ConfigAlter.Set("match", $"client_id={clientId}")
             ]
         }, cancellationToken: cancellationToken);
+
+        await kafka.WaitForSubscriptionAsync(clientId, [applicationName], 1000, cancellationToken);
 
         var consumer = await Kafka.CreateShareConsumer<string, string>()
             .WithBootstrapServers(kafka.BootstrapServers)

--- a/tests/Dekaf.Tests.Integration/TelemetryReceiverKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/TelemetryReceiverKafkaContainer.cs
@@ -1,4 +1,7 @@
 using System.Text;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Images;
 using Testcontainers.Kafka;
@@ -44,24 +47,91 @@ public sealed class TelemetryReceiverKafkaContainer : KafkaContainerDefault
     {
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeout.CancelAfter(TimeSpan.FromSeconds(30));
-        while (true)
+        var completedPolls = 0;
+        var lastPayloadCount = 0;
+        var lastClientPayloadCount = 0;
+        try
         {
-            var text = await _http.GetStringAsync("payloads", timeout.Token);
-            foreach (var line in text.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            while (true)
             {
-                var fields = line.Split('\t');
-                if (fields.Length != 5)
-                    throw new InvalidDataException("Malformed telemetry receiver output.");
-                if (DecodeText(fields[2]) != clientId)
-                    continue;
-                var payload = new ReceivedTelemetry(Guid.Parse(fields[0]), bool.Parse(fields[1]),
-                    DecodeText(fields[3]), Convert.FromBase64String(fields[4]));
-                if (matches(payload))
-                    return payload;
+                var text = await _http.GetStringAsync("payloads", timeout.Token);
+                completedPolls++;
+                var lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+                lastPayloadCount = lines.Length;
+                lastClientPayloadCount = 0;
+                foreach (var line in lines)
+                {
+                    var fields = line.Split('\t');
+                    if (fields.Length != 5)
+                        throw new InvalidDataException("Malformed telemetry receiver output.");
+                    if (DecodeText(fields[2]) != clientId)
+                        continue;
+                    lastClientPayloadCount++;
+                    var payload = new ReceivedTelemetry(Guid.Parse(fields[0]), bool.Parse(fields[1]),
+                        DecodeText(fields[3]), Convert.FromBase64String(fields[4]));
+                    if (matches(payload))
+                        return payload;
+                }
+                await Task.Delay(100, timeout.Token);
             }
-            await Task.Delay(100, timeout.Token);
+        }
+        catch (OperationCanceledException exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException($"No matching telemetry payload for {clientId} within 30 seconds. " +
+                $"Completed HTTP polls: {completedPolls}; last response payloads: {lastPayloadCount}; " +
+                $"payloads for this client: {lastClientPayloadCount}.", exception);
         }
     }
+
+    internal async Task<GetTelemetrySubscriptionsResponse> ReadSubscriptionAsync(
+        string clientId, CancellationToken cancellationToken)
+    {
+        await using var connection = CreateSubscriptionConnection(clientId);
+        await connection.ConnectAsync(cancellationToken);
+        return await ReadFreshSubscriptionAsync(connection, cancellationToken);
+    }
+
+    internal async Task<GetTelemetrySubscriptionsResponse> WaitForSubscriptionAsync(
+        string clientId, IReadOnlyList<string> metrics, int expectedPushIntervalMs, CancellationToken cancellationToken)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(30));
+        await using var connection = CreateSubscriptionConnection(clientId);
+        GetTelemetrySubscriptionsResponse? last = null;
+        try
+        {
+            await connection.ConnectAsync(timeout.Token);
+            while (true)
+            {
+                last = await ReadFreshSubscriptionAsync(connection, timeout.Token);
+                if (last.ErrorCode != ErrorCode.None)
+                    throw new InvalidOperationException($"Telemetry subscription probe failed: {last.ErrorCode}.");
+                if (last.PushIntervalMs == expectedPushIntervalMs && metrics.All(metric => last.RequestedMetrics.Contains(metric)))
+                    return last;
+                await Task.Delay(100, timeout.Token);
+            }
+        }
+        catch (OperationCanceledException exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException($"Telemetry subscription for {clientId} was not ready within 30 seconds. " +
+                $"Expected interval: {expectedPushIntervalMs}; last interval: {last?.PushIntervalMs}; requested metrics: " +
+                $"{string.Join(",", last?.RequestedMetrics ?? [])}.", exception);
+        }
+    }
+
+    private KafkaConnection CreateSubscriptionConnection(string clientId)
+    {
+        var endpoint = BootstrapServerList.Parse(BootstrapServers);
+        return new KafkaConnection(0, endpoint.Host, endpoint.Port, clientId,
+            new ConnectionOptions { RequestTimeout = TimeSpan.FromSeconds(10) });
+    }
+
+    // A config write can be acknowledged before the broker applies its subscription.
+    // Fresh instance IDs avoid retaining an earlier empty five-minute subscription.
+    private static ValueTask<GetTelemetrySubscriptionsResponse> ReadFreshSubscriptionAsync(
+        KafkaConnection connection, CancellationToken cancellationToken) =>
+        connection.SendAsync<GetTelemetrySubscriptionsRequest, GetTelemetrySubscriptionsResponse>(
+            new GetTelemetrySubscriptionsRequest { ClientInstanceId = Guid.Empty }, 0, cancellationToken);
 
     private static string DecodeText(string value) => Encoding.UTF8.GetString(Convert.FromBase64String(value));
 


### PR DESCRIPTION
Telemetry tests can bootstrap while a newly written ClientMetrics config is still being applied. Kafka then selects an empty subscription with a five-minute push interval, which exceeds the test's 30-second payload wait.

Wait for GetTelemetrySubscriptions to select the expected metrics and one-second interval before building each tested client. Fresh probe instance IDs avoid retaining an earlier empty subscription. Payload timeout errors now include completed HTTP polls and counts of received/client-matching payloads.

Validation: five Kafka telemetry receiver tests pass on the final rebased head, including a deterministic check of the unconfigured interval and subsequent ready subscription. The original [CI failure](https://github.com/thomhurst/Dekaf/actions/runs/34488331482/job/102911683638) lacked subscription diagnostics, so it cannot be uniquely attributed; this removes the demonstrated startup race without extending the payload deadline. Kafka's [subscription selection](https://github.com/apache/kafka/blob/4.3.1/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java) uses the [five-minute default](https://github.com/apache/kafka/blob/4.3.1/server/src/main/java/org/apache/kafka/server/metrics/ClientMetricsConfigs.java) when no configured subscription matches.

Raw validation and binaries are retained outside Git at `C:/git/Dekaf-evidence/issue-3214/5baf3d9e7f7f4976da8b7dc46d2f662047cd7fc0`. No product source, reports or logs are committed.

Closes #3214.


The readiness helper accepts the expected push interval explicitly and reports expected/observed intervals on timeout. The direct probe uses 500 ms; both payload tests retain 1000 ms. All five Kafka tests pass on the final head.
