### PR TITLE
fix(ci): partition oversized performance gates into validated batches

### DIFF
--- a/.github/benchmarks/README.md
+++ b/.github/benchmarks/README.md
@@ -5,8 +5,11 @@ See [standard tooling and evidence storage](STANDARD-TOOLS.md) and the repositor
 [performance requirements](../../AGENTS.md).
 
 The [automatic performance gate](../workflows/performance-gate.yml) selects maintained
-fixtures for changed product paths and runs A1/B/A2 sequentially on one hosted Ubuntu
-VM. It retains original exports and the reviewed screen in GitHub job output/artifacts.
+fixtures for changed product paths and divides validated expanded cases into batches
+of at most 48. Each batch runs A1/B/A2 sequentially on one hosted Ubuntu VM; the final
+check requires every batch. Up to four batches run, with two concurrent jobs. Missing
+fixtures and differing A/B case sets fail preparation before acceptance measurement.
+It retains original exports and the reviewed screen in GitHub job output/artifacts.
 For a targeted manual run, dispatch from main with `pr`, exact fresh-main `base_sha`,
 current PR `head_sha` and the affected standard-project `filters`. The workflow rejects
 stale pins and closed PRs. Fresh main, candidate ancestry, identical

--- a/.github/benchmarks/STANDARD-TOOLS.md
+++ b/.github/benchmarks/STANDARD-TOOLS.md
@@ -7,9 +7,11 @@ generated project templates or DLL-rebinding scripts. Do not extend or dispatch 
 legacy executable harnesses under `.github/benchmarks` or `tools/*Evidence`.
 
 The [performance gate](../workflows/performance-gate.yml) pins exact product revisions,
-selects fixtures from changed paths, builds and Dry-validates both, then runs A1/B/A2
-sequentially on one `ubuntu-latest` VM. Its thin shell/Python orchestration and jq
-comparison read original BenchmarkDotNet exports; they do not replace measurement.
+selects fixtures from changed paths, builds and Dry-validates both, then partitions
+identical expanded case sets into bounded batches. Each batch builds and validates
+both revisions again and runs A1/B/A2 sequentially on one `ubuntu-latest` VM. Its thin
+shell/Python orchestration and jq comparison read original BenchmarkDotNet exports;
+they do not replace measurement.
 If a fixture is missing on main, land compatible coverage in the benchmark project
 before comparison. Never compare different fixture work as equivalent performance.
 
@@ -19,7 +21,14 @@ iterations, one launch and `DontRemove` outliers identically in all phases. Veri
 least 20 seconds of actual workload warmup from full JSON. Increase declared warmup
 when needed for all phases; iteration counts alone do not prove steady state.
 The existing 5% protected-metric limits and 8 B/op micro allocation-noise floor remain.
-The gate's 48-case budget remains; select affected workloads before timing.
+Each batch retains the 48-case budget. At most four batches run, with two concurrent
+jobs; larger selections still require narrower affected-workload filters. Every
+selected case belongs to exactly one batch. BDN's original full names preserve each
+parameter combination, and every measured phase must match its planned case set.
+The final check requires all batches and combines verdicts, never metrics across VMs.
+Missing fixtures or differing A/B case sets stop preparation with named diagnostics;
+they cannot silently shrink the measured scope. Original discovery and batch artifacts
+are retained separately. Preparation failure is not a measured regression.
 
 Use original BenchmarkDotNet JSON/Markdown/CSV and logs as GitHub Actions artifacts.
 Put identities, absolute metrics, deltas, control drift, limitations and the verdict

--- a/.github/scripts/performance_gate.py
+++ b/.github/scripts/performance_gate.py
@@ -1,7 +1,8 @@
 """Select, validate and merge BenchmarkDotNet A1/B/A2 evidence for the automatic performance gate.
 
 The gate compares the maintained fixtures in tools/Dekaf.Benchmarks between a PR's merge base
-and its head on one hosted VM. Fixtures are selected from the changed product paths; every
+and its head, with each bounded A1/B/A2 batch on one hosted VM. Fixtures are selected from
+the changed product paths; every
 selected class uses BenchmarkDotNet's throughput strategy with [MemoryDiagnoser], so warmup
 elapsed time, sample counts and allocations are BenchmarkDotNet's own measurements.
 """
@@ -17,6 +18,7 @@ from pathlib import Path
 DEFAULT_ITERATIONS = 25
 DEFAULT_MIN_WARMUP_SECONDS = 20
 MAX_CASES = 48
+MAX_BATCHES = 4
 SOURCE_SUFFIXES = ('.cs', '.csproj', '.props', '.targets', '.proto')
 BUILD_INPUTS = ('Directory.Packages.props', 'Directory.Build.props', 'Directory.Build.targets', 'global.json')
 
@@ -252,6 +254,92 @@ def count_execution_cases(log):
     return int(totals[0])
 
 
+def check_listing(listing, filters, role):
+    """Validate every requested glob, not just the union (BDN silently ignores empty globs)."""
+    names = [line.strip() for line in listing.splitlines()
+             if line.strip().startswith('Dekaf.Benchmarks.')]
+    missing = []
+    for pattern in filters:
+        # BDN GlobFilter recognizes only * and ?, not fnmatch's [character classes].
+        regex = re.compile('^' + re.escape(pattern).replace(r'\*', '.*').replace(r'\?', '.') + '$', re.I)
+        if not any(regex.fullmatch(name) for name in names):
+            missing.append(pattern)
+    if missing:
+        raise ValueError(f'{role}: filters match no benchmark methods: {", ".join(missing)}. '
+                         'Land compatible fixtures on main before comparing, or correct the path map.')
+
+
+def plan_batches(baseline, candidate, max_cases=MAX_CASES):
+    """Partition original BDN full names; each batch will run its own same-VM A1/B/A2."""
+    if not 1 <= max_cases <= MAX_CASES:
+        raise ValueError(f'Batch size must be between 1 and {MAX_CASES}')
+    if not baseline or not candidate:
+        raise ValueError('Both revisions must have validated benchmark cases')
+    cases = []
+    for role, benchmarks in (('A', baseline), ('B', candidate)):
+        keys = [_case_key(item) for item in benchmarks]
+        if len(set(keys)) != len(keys):
+            raise ValueError(f'{role}: duplicate benchmark identities')
+        full_names = [item.get('FullName') for item in benchmarks]
+        if any(not isinstance(name, str) or not name.startswith('Dekaf.Benchmarks.')
+               or any(character in name for character in '*?\r\n') for name in full_names):
+            raise ValueError(f'{role}: missing or non-literal BenchmarkDotNet FullName; cannot safely partition filters')
+        if len({name.casefold() for name in full_names}) != len(full_names):
+            raise ValueError(f'{role}: ambiguous BenchmarkDotNet FullName filters')
+        cases.append(dict(zip(keys, full_names)))
+    if cases[0] != cases[1]:
+        baseline_only = sorted(set(cases[0]) - set(cases[1]))
+        candidate_only = sorted(set(cases[1]) - set(cases[0]))
+        renamed_filters = [f'{key}: A={cases[0][key]!r}, B={cases[1][key]!r}'
+                           for key in sorted(cases[0].keys() & cases[1].keys())
+                           if cases[0][key] != cases[1][key]]
+        raise ValueError('A/B benchmark cases differ. '
+                         f'Baseline only: {baseline_only}; candidate only: {candidate_only}. '
+                         f'FullName differences: {renamed_filters}. '
+                         'Land identical fixture coverage before comparison.')
+    if len(baseline) > max_cases * MAX_BATCHES:
+        raise ValueError(f'{len(baseline)} cases exceed {MAX_BATCHES} batches of {max_cases}; '
+                         'select affected workloads with narrower filters before timing')
+    ordered = sorted(cases[0])
+    batches = []
+    for start in range(0, len(ordered), max_cases):
+        keys = ordered[start:start + max_cases]
+        batches.append({'id': len(batches) + 1, 'cases': keys,
+                        'filters': [cases[0][key] for key in keys]})
+    return {'case_count': len(ordered), 'batches': batches}
+
+
+def check_case_set(benchmarks, expected):
+    actual = [_case_key(item) for item in benchmarks]
+    if len(actual) != len(set(actual)) or sorted(actual) != sorted(expected):
+        return [f'case set differs from plan; missing: {sorted(set(expected) - set(actual))}; '
+                f'unexpected: {sorted(set(actual) - set(expected))}']
+    return []
+
+
+def summarize_batches(plan, directory):
+    """Check complete coverage and combine verdicts only; never compare metrics across VMs."""
+    screens = []
+    for batch in plan['batches']:
+        path = Path(directory) / f'batch-{batch["id"]}' / 'comparison.json'
+        report = json.loads(path.read_text(encoding='utf-8'))
+        actual = [item['case'] for item in report['cases']]
+        if sorted(actual) != sorted(batch['cases']) or report['baseline_only'] or report['candidate_only']:
+            raise ValueError(f'Batch {batch["id"]}: comparison does not cover exactly the planned cases')
+        screen = report['screen']
+        if screen not in ('PASS', 'REGRESSION', 'INCONCLUSIVE'):
+            raise ValueError(f'Batch {batch["id"]}: unknown screen {screen}')
+        print(f'Batch {batch["id"]}: {len(actual)} cases, {screen}')
+        screens.append(screen)
+    if not screens:
+        raise ValueError('No measured batches')
+    if 'REGRESSION' in screens:
+        return 'REGRESSION'
+    if 'INCONCLUSIVE' in screens:
+        return 'INCONCLUSIVE'
+    return 'PASS'
+
+
 def _case_key(benchmark):
     parts = [benchmark.get(field) for field in ('Namespace', 'Type', 'Method', 'Parameters')]
     return ' '.join(str(part) for part in parts if part not in (None, ''))
@@ -319,8 +407,23 @@ def main(argv=None):
     selecting.add_argument('--filters', help='Explicit space-separated BDN globs that replace path selection')
     selecting.add_argument('--output', type=Path, required=True)
     counting = commands.add_parser('count', help='Count listed methods, or expanded cases from an execution log')
-    counting.add_argument('--max-cases', type=int, default=MAX_CASES)
+    count_budget = counting.add_mutually_exclusive_group()
+    count_budget.add_argument('--max-cases', type=int, default=MAX_CASES)
+    count_budget.add_argument('--discovery', action='store_true',
+                              help='Use the combined batch budget for Dry discovery, not measurement')
     counting.add_argument('--execution-log', type=Path, help='Use the BDN declared case total instead of stdin method names')
+    listing = commands.add_parser('check-list', help='Require each selected glob on one revision')
+    listing.add_argument('--listing', type=Path, required=True)
+    listing.add_argument('--selection', type=Path, required=True)
+    listing.add_argument('--role', required=True)
+    planning = commands.add_parser('plan', help='Partition identical Dry-validated cases into bounded A1/B/A2 jobs')
+    planning.add_argument('--baseline', type=Path, required=True)
+    planning.add_argument('--candidate', type=Path, required=True)
+    planning.add_argument('--output', type=Path, required=True)
+    planning.add_argument('--max-cases', type=int, default=MAX_CASES)
+    summarizing = commands.add_parser('summarize', help='Require every planned batch and report the combined screen')
+    summarizing.add_argument('--plan', type=Path, required=True)
+    summarizing.add_argument('--results', type=Path, required=True)
     validating = commands.add_parser('validate', help='Validate one phase and write its merged case array')
     validating.add_argument('--phase', type=Path, required=True)
     validating.add_argument('--expected', type=int)
@@ -329,7 +432,30 @@ def main(argv=None):
     validating.add_argument('--min-warmup', type=float, default=DEFAULT_MIN_WARMUP_SECONDS)
     validating.add_argument('--merged', type=Path)
     validating.add_argument('--cases', type=Path)
+    validating.add_argument('--expected-cases', type=Path, help='Require these exact case identities, not just a count')
     args = parser.parse_args(argv)
+
+    if args.command in ('check-list', 'plan', 'summarize'):
+        try:
+            if args.command == 'check-list':
+                selection = json.loads(args.selection.read_text(encoding='utf-8'))
+                check_listing(args.listing.read_text(encoding='utf-8-sig'), selection['filters'], args.role)
+            elif args.command == 'plan':
+                plan = plan_batches(load_reports(args.baseline), load_reports(args.candidate), args.max_cases)
+                args.output.write_text(json.dumps(plan, indent=2) + '\n', encoding='utf-8')
+                print(f'{plan["case_count"]} cases in {len(plan["batches"])} same-VM A1/B/A2 batch(es)')
+            else:
+                plan = json.loads(args.plan.read_text(encoding='utf-8'))
+                screen = summarize_batches(plan, args.results)
+                print(f'Micro screen: {screen}. Loaded pipeline evidence remains a separate requirement.')
+                if screen == 'REGRESSION':
+                    return 1
+                if screen == 'INCONCLUSIVE':
+                    print('::warning::Micro screen INCONCLUSIVE; review the named cases in the batch job summaries.')
+        except (ValueError, OSError, KeyError) as error:
+            print(f'::error::{error}', file=sys.stderr)
+            return 1
+        return 0
 
     if args.command == 'select':
         if args.filters and args.filters.strip():
@@ -352,8 +478,9 @@ def main(argv=None):
         if count == 0:
             print('The selected filters match no benchmark cases', file=sys.stderr)
             return 1
-        if count > args.max_cases:
-            print(f'{count} cases exceed the {args.max_cases}-case budget '
+        max_cases = MAX_CASES * MAX_BATCHES if args.discovery else args.max_cases
+        if count > max_cases:
+            print(f'{count} cases exceed the {max_cases}-case budget '
                   f'(about {estimate_minutes(count)} minutes); dispatch with narrower filters', file=sys.stderr)
             return 1
         print(count)
@@ -361,6 +488,8 @@ def main(argv=None):
     benchmarks = load_reports(args.phase)
     fatal, warnings = validate_phase(
         benchmarks, args.expected, None if args.dry else args.iterations, 0 if args.dry else args.min_warmup)
+    if args.expected_cases:
+        fatal.extend(check_case_set(benchmarks, json.loads(args.expected_cases.read_text(encoding='utf-8'))))
     for warning in warnings:
         print(f'::warning::{args.phase.name}: {warning}')
     for issue in fatal:

--- a/.github/scripts/test_performance_gate.py
+++ b/.github/scripts/test_performance_gate.py
@@ -28,6 +28,8 @@ def benchmark(method='Append', parameters='', mean=100.0, samples=25, allocated=
                      for _ in range(samples)]
     metrics = [] if allocated is None else [{'Descriptor': {'Id': 'Allocated Memory'}, 'Value': allocated}]
     return {'Namespace': 'Dekaf.Benchmarks.Benchmarks.Unit', 'Type': 'AppendBenchmarks', 'Method': method,
+            'FullName': f'Dekaf.Benchmarks.Benchmarks.Unit.AppendBenchmarks.{method}'
+                        + (f'({parameters.replace("=", ": ")})' if parameters else ''),
             'Parameters': parameters, 'Statistics': {'Mean': mean, 'StandardDeviation': 1.0, 'N': samples},
             'Metrics': metrics, 'Measurements': measurements}
 
@@ -227,6 +229,21 @@ class SelectionTests(unittest.TestCase):
                 self.assertEqual(1, gate.main(['count', '--execution-log', str(log)]))
                 self.assertEqual(0, gate.main(['count', '--execution-log', str(log), '--max-cases', str(gate.MAX_CASES + 1)]))
 
+    def test_discovery_count_derives_budget_from_both_batch_limits(self):
+        with tempfile.TemporaryDirectory() as directory:
+            log = Path(directory) / 'dry.log'
+            # Changing either limit must affect discovery without another workflow edit.
+            for per_batch, batches in ((3, 2), (4, 2), (4, 3)):
+                with self.subTest(per_batch=per_batch, batches=batches), \
+                        mock.patch.object(gate, 'MAX_CASES', per_batch), \
+                        mock.patch.object(gate, 'MAX_BATCHES', batches):
+                    for count in (per_batch + 1, per_batch * batches, per_batch * batches + 1):
+                        log.write_text(f'// ***** Found {count} benchmark(s) in total *****\n')
+                        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                            self.assertEqual(int(count > per_batch * batches),
+                                             gate.main(['count', '--execution-log', str(log), '--discovery']))
+                            self.assertEqual(1, gate.main(['count', '--execution-log', str(log)]))
+
     def test_count_command_rejects_empty_and_oversized_selections(self):
         with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
             with mock.patch('sys.stdin', io.StringIO('')):
@@ -238,7 +255,127 @@ class SelectionTests(unittest.TestCase):
                 self.assertEqual(0, gate.main(['count', '--max-cases', str(gate.MAX_CASES + 1)]))
 
 
+class PlanningTests(unittest.TestCase):
+    def test_every_requested_glob_must_match_on_each_revision(self):
+        listing = 'Dekaf.Benchmarks.Benchmarks.Unit.A.Read\n'
+        gate.check_listing(listing, ['*.Unit.A.*'], 'A')
+        with self.assertRaisesRegex(ValueError, r'A:.*Missing'):
+            gate.check_listing(listing, ['*.Unit.A.*', '*.Unit.Missing.*'], 'A')
+        with self.assertRaisesRegex(ValueError, r'B:.*compatible fixtures'):
+            gate.check_listing('', ['*.Unit.A.*'], 'B')
+
+    def test_listing_uses_bdn_globs_not_shell_character_classes(self):
+        listing = 'Dekaf.Benchmarks.Benchmarks.Unit.A.Read[Int32]\n'
+        gate.check_listing(listing, ['*.unit.a.read[Int32]'], 'A')
+        with self.assertRaises(ValueError):
+            gate.check_listing(listing, ['*.Unit.A.Read[I]*'], 'A')
+
+    def test_expanded_179_case_selection_is_partitioned_without_loss_or_overlap(self):
+        cases = [benchmark('Read', f'Size={size}') for size in range(179)]
+        plan = gate.plan_batches(cases, list(reversed(cases)))
+        self.assertEqual(179, plan['case_count'])
+        self.assertEqual([48, 48, 48, 35], [len(batch['cases']) for batch in plan['batches']])
+        self.assertEqual(sorted(gate._case_key(item) for item in cases),
+                         [key for batch in plan['batches'] for key in batch['cases']])
+        self.assertEqual({item['FullName'] for item in cases},
+                         {name for batch in plan['batches'] for name in batch['filters']})
+        self.assertEqual(plan, gate.plan_batches(list(reversed(cases)), cases))
+
+    def test_plan_rejects_missing_or_different_cases_even_when_counts_match(self):
+        for baseline, candidate in (([], []), ([benchmark()], [benchmark('Other')]),
+                                     ([benchmark(parameters='Size=1')], [benchmark(parameters='Size=2')]),
+                                     ([benchmark()], [benchmark(), benchmark()])):
+            with self.subTest(baseline=baseline, candidate=candidate), self.assertRaises(ValueError):
+                gate.plan_batches(baseline, candidate)
+
+    def test_filter_identity_must_be_literal_and_unambiguous(self):
+        for name in (None, '', 'SomethingElse.Read', 'Dekaf.Benchmarks.A.Read(X: *)',
+                     'Dekaf.Benchmarks.A.Read(X: ?)', 'Dekaf.Benchmarks.A.Read\n--job Dry'):
+            item = benchmark() | {'FullName': name}
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                gate.plan_batches([item], [item])
+        cases = [benchmark('Read'), benchmark('read')]
+        with self.assertRaisesRegex(ValueError, 'ambiguous'):
+            gate.plan_batches(cases, cases)
+        with self.assertRaisesRegex(ValueError, 'FullName'):
+            gate.plan_batches([benchmark()], [benchmark() | {'FullName': 'Dekaf.Benchmarks.Other.Read'}])
+
+    def test_total_work_and_batch_size_remain_bounded(self):
+        cases = [benchmark(f'Method{i}') for i in range(gate.MAX_CASES * gate.MAX_BATCHES + 1)]
+        with self.assertRaisesRegex(ValueError, 'narrower filters'):
+            gate.plan_batches(cases, cases)
+        for size in (0, -1, gate.MAX_CASES + 1):
+            with self.subTest(size=size), self.assertRaises(ValueError):
+                gate.plan_batches([benchmark()], [benchmark()], size)
+
+    def test_changed_full_name_diagnostic_identifies_both_filters(self):
+        baseline = benchmark()
+        candidate = baseline | {'FullName': baseline['FullName'].replace('.Append', '.append')}
+        with self.assertRaises(ValueError) as failure:
+            gate.plan_batches([baseline], [candidate])
+        diagnostic = str(failure.exception)
+        self.assertIn(gate._case_key(baseline), diagnostic)
+        self.assertIn(f'A={baseline["FullName"]!r}', diagnostic)
+        self.assertIn(f'B={candidate["FullName"]!r}', diagnostic)
+
+    def test_summary_requires_every_planned_case_and_preserves_verdicts(self):
+        plan = gate.plan_batches([benchmark(), benchmark('Read')], [benchmark(), benchmark('Read')], 1)
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for batch in plan['batches']:
+                target = root / f'batch-{batch["id"]}' / 'comparison.json'
+                target.parent.mkdir()
+                target.write_text(json.dumps({'screen': 'PASS', 'baseline_only': [], 'candidate_only': [],
+                                              'cases': [{'case': key} for key in batch['cases']]}))
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual('PASS', gate.summarize_batches(plan, root))
+                target = root / 'batch-2' / 'comparison.json'
+                original = json.loads(target.read_text())
+                for screen in ('INCONCLUSIVE', 'REGRESSION'):
+                    target.write_text(json.dumps(original | {'screen': screen}))
+                    self.assertEqual(screen, gate.summarize_batches(plan, root))
+                for changes in ({'cases': []}, {'cases': [{'case': 'unexpected'}]},
+                                {'cases': original['cases'] * 2}, {'candidate_only': ['new']},
+                                {'baseline_only': ['old']}, {'screen': 'UNKNOWN'}):
+                    target.write_text(json.dumps(original | changes))
+                    with self.subTest(changes=changes), self.assertRaises(ValueError):
+                        gate.summarize_batches(plan, root)
+                target.unlink()
+                with self.assertRaises(FileNotFoundError):
+                    gate.summarize_batches(plan, root)
+
+    def test_plan_command_uses_original_exports(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for role in ('A', 'B'):
+                (root / role).mkdir()
+                (root / role / 'original-report-full.json').write_text(json.dumps(
+                    {'Benchmarks': [benchmark('Read', 'Size=128'), benchmark('Read', 'Size=512')]}))
+            output = root / 'plan.json'
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(0, gate.main(['plan', '--baseline', str(root / 'A'),
+                                               '--candidate', str(root / 'B'), '--output', str(output),
+                                               '--max-cases', '1']))
+            plan = json.loads(output.read_text())
+            self.assertEqual(2, len(plan['batches']))
+            self.assertEqual('Dekaf.Benchmarks.Benchmarks.Unit.AppendBenchmarks.Read(Size: 128)',
+                             plan['batches'][0]['filters'][0])
+
+
 class ValidationTests(unittest.TestCase):
+    def test_exact_case_validation_catches_same_count_substitutions(self):
+        expected = [gate._case_key(benchmark('Read', 'Size=128'))]
+        self.assertEqual([], gate.check_case_set([benchmark('Read', 'Size=128')], expected))
+        self.assertTrue(gate.check_case_set([benchmark('Read', 'Size=512')], expected))
+        self.assertTrue(gate.check_case_set([benchmark('Other', 'Size=128')], expected))
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / 'case-report-full.json').write_text(json.dumps({'Benchmarks': [benchmark('Other')]}))
+            (root / 'expected.json').write_text(json.dumps(expected))
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(1, gate.main(['validate', '--phase', str(root), '--expected', '1',
+                                               '--expected-cases', str(root / 'expected.json')]))
+
     def test_complete_phase_has_no_findings(self):
         fatal, warnings = gate.validate_phase([benchmark(), benchmark('Drain')], 2, 25, 20)
         self.assertEqual(([], []), (fatal, warnings))
@@ -326,12 +463,25 @@ gh() { printf '%s' "$TEST_PR_JSON"; }
 
     def test_gate_workflow_measures_a1_b_a2_on_one_hosted_vm_with_the_shared_screen(self):
         workflow = WORKFLOW.read_text(encoding='utf-8')
+        measurement_job = workflow.split('\n  measure:\n', 1)[1].split('\n  gate:\n', 1)[0]
         self.assertIn('pull_request:', workflow)
         self.assertIn('runs-on: ubuntu-latest', workflow)
-        self.assertIn('for phase in A1 B A2', workflow)
+        self.assertIn('for phase in A1 B A2', measurement_job)
+        self.assertIn('runs-on: ubuntu-latest', measurement_job)
+        self.assertIn('fail-fast: false', measurement_job)
+        self.assertIn('max-parallel: 2', measurement_job)
+        self.assertIn("if: needs.plan.result == 'success' && needs.plan.outputs.applicable == 'true' "
+                      "&& needs.plan.outputs.matrix != ''", measurement_job)
+        self.assertIn('--execution-log "$GATE/dry-$role.log" --discovery', workflow)
+        self.assertNotIn('--max-cases 192', workflow)
+        self.assertIn('--expected-cases "$GATE/expected-cases.json"', measurement_job)
+        self.assertIn('needs: [plan, measure]', workflow)
+        self.assertIn('defaults:\n  run:\n    shell: bash', workflow)
+        self.assertIn('performance_gate.py summarize --plan plan/plan.json', workflow)
+        self.assertIn('"$MEASURE_RESULT" != success', workflow)
         for setting in ('--warmupCount 50', '--iterationCount 25', '--iterationTime 1000', '--launchCount 1',
                         '--outliers DontRemove', '--exporters fulljson'):
-            self.assertIn(setting, workflow, setting)
+            self.assertIn(setting, measurement_job, setting)
         self.assertIn('performance_gate.py select', workflow)
         self.assertIn('performance_gate.py validate', workflow)
         self.assertIn('--argjson alloc_floor 8', workflow)

--- a/.github/workflows/performance-gate.yml
+++ b/.github/workflows/performance-gate.yml
@@ -34,6 +34,9 @@ on:
 permissions:
   contents: read
   pull-requests: read
+defaults:
+  run:
+    shell: bash
 concurrency:
   group: performance-gate-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
@@ -49,11 +52,17 @@ env:
   TOLERANCE: '5'
   MIN_WARMUP: '20'
 jobs:
-  gate:
-    name: Micro A1/B/A2 screen
+  plan:
+    name: Validate and plan benchmark cases
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 330
+    timeout-minutes: 60
+    outputs:
+      base: ${{ steps.pins.outputs.base }}
+      head: ${{ steps.pins.outputs.head }}
+      tooling: ${{ steps.pins.outputs.tooling }}
+      applicable: ${{ steps.select.outputs.applicable }}
+      matrix: ${{ steps.plan.outputs.matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -87,6 +96,7 @@ jobs:
           for sha in "$base" "$head"; do [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; done
           echo "base=$base" >> "$GITHUB_OUTPUT"
           echo "head=$head" >> "$GITHUB_OUTPUT"
+          echo "tooling=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           jq -n --arg base "$base" --arg head "$head" --arg main "$(git rev-parse origin/main)" \
             --arg workflow "$GITHUB_SHA" --arg run "$GITHUB_RUN_ID" \
             '{baseline_sha: $base, candidate_sha: $head, main_at_start: $main, workflow_sha: $workflow, run_id: $run}' \
@@ -139,6 +149,18 @@ jobs:
             echo "::warning::The PR changes tools/Dekaf.Benchmarks; each revision measured its own fixture source. Review the fixture diff before trusting the comparison."
             { echo; echo "Fixture source differs between A and B:"; echo '```'; cat "$GATE/fixture-diff.txt"; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
           fi
+      - name: Require every selected fixture on both revisions
+        if: steps.select.outputs.applicable == 'true'
+        run: |
+          mapfile -t filters < <(jq -r '.filters[]' "$GATE/selection.json")
+          for role in A B; do
+            (
+              cd "$RUNNER_TEMP/gate-$role/tools/Dekaf.Benchmarks"
+              dotnet run --project Dekaf.Benchmarks.csproj -c Release --no-build -- --list flat --filter "${filters[@]}" > "$GATE/list-$role.txt" 2>&1
+            )
+            python3 .github/scripts/performance_gate.py check-list --listing "$GATE/list-$role.txt" \
+              --selection "$GATE/selection.json" --role "$role"
+          done
       - name: Validate the selected cases on both revisions
         id: dry
         if: steps.select.outputs.applicable == 'true'
@@ -147,24 +169,109 @@ jobs:
           for role in A B; do
             (
               cd "$RUNNER_TEMP/gate-$role/tools/Dekaf.Benchmarks"
-              dotnet run --project Dekaf.Benchmarks.csproj -c Release --no-build -- --list flat --filter "${filters[@]}" > "$GATE/list-$role.txt" 2>&1
-              count=$(python3 "$GITHUB_WORKSPACE/.github/scripts/performance_gate.py" count < "$GATE/list-$role.txt")
               dotnet run --project Dekaf.Benchmarks.csproj -c Release --no-build -- --job Dry --filter "${filters[@]}" --exporters fulljson --buildTimeout 900 --artifacts "$GATE/dry-$role" > "$GATE/dry-$role.log" 2>&1
               # --list flat counts methods; execution expands their parameter combinations.
-              count=$(python3 "$GITHUB_WORKSPACE/.github/scripts/performance_gate.py" count --execution-log "$GATE/dry-$role.log")
+              # Discovery may cover four batches; each measured job still has at most 48 cases.
+              count=$(python3 "$GITHUB_WORKSPACE/.github/scripts/performance_gate.py" count --execution-log "$GATE/dry-$role.log" --discovery)
               echo "$count" > "$GATE/count-$role.txt"
               python3 "$GITHUB_WORKSPACE/.github/scripts/performance_gate.py" validate --dry --phase "$GATE/dry-$role" --expected "$count"
             )
           done
           dotnet build-server shutdown
-          {
-            echo
-            echo "Cases: A $(cat "$GATE/count-A.txt") · B $(cat "$GATE/count-B.txt") · estimated $(python3 -c "import sys; sys.path.insert(0, '.github/scripts'); import performance_gate as g; print(g.estimate_minutes($(cat "$GATE/count-B.txt")))") minutes for A1/B/A2"
-          } >> "$GITHUB_STEP_SUMMARY"
-      - name: Measure A1, B and A2 sequentially on this VM
+      - name: Plan bounded same-VM comparisons
+        id: plan
         if: steps.select.outputs.applicable == 'true'
         run: |
-          mapfile -t filters < <(jq -r '.filters[]' "$GATE/selection.json")
+          python3 .github/scripts/performance_gate.py plan --baseline "$GATE/dry-A" --candidate "$GATE/dry-B" \
+            --output "$GATE/plan.json" | tee -a "$GITHUB_STEP_SUMMARY"
+          matrix=$(jq -c '{include: [.batches[] | {id}]}' "$GATE/plan.json")
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo 'Every selected case is retained. Each batch measures A1, B and A2 on its own Ubuntu VM; metrics are never compared between batches.' >> "$GITHUB_STEP_SUMMARY"
+      - name: Show preparation failure details
+        if: failure()
+        run: |
+          echo '::error::Benchmark preparation failed before acceptance measurement. See the named fixture/build error and retained logs.'
+          for log in "$GATE"/build-*.log "$GATE"/dry-*.log; do
+            if [[ -f "$log" ]]; then echo "::group::$(basename "$log")"; tail -n 60 "$log"; echo '::endgroup::'; fi
+          done
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        if: always()
+        with:
+          name: performance-gate-plan-${{ github.run_id }}
+          path: gate/
+          include-hidden-files: true
+          retention-days: 90
+
+  measure:
+    name: A1/B/A2 batch ${{ matrix.id }}
+    needs: plan
+    if: needs.plan.result == 'success' && needs.plan.outputs.applicable == 'true' && needs.plan.outputs.matrix != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    env:
+      GATE: ${{ github.workspace }}/gate/batch-${{ matrix.id }}
+      BASE_SHA: ${{ needs.plan.outputs.base }}
+      HEAD_SHA: ${{ needs.plan.outputs.head }}
+      BATCH_ID: ${{ matrix.id }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.plan.outputs.tooling }}
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68
+        with:
+          global-json-file: global.json
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: performance-gate-plan-${{ github.run_id }}
+          path: plan/
+      - name: Prepare pinned revisions on this VM
+        run: |
+          mkdir -p "$GATE"
+          jq --argjson id "$BATCH_ID" '.batches[] | select(.id == $id)' plan/plan.json > "$GATE/batch.json"
+          jq '.cases' "$GATE/batch.json" > "$GATE/expected-cases.json"
+          cp plan/provenance.json plan/fixture-diff.txt "$GATE/"
+          dotnet --info > "$GATE/runtime.txt"
+          lscpu > "$GATE/cpu.txt"
+          cp /etc/os-release "$GATE/os-release.txt"
+          echo "Batch $BATCH_ID · Baseline A: $BASE_SHA · Candidate B: $HEAD_SHA" >> "$GITHUB_STEP_SUMMARY"
+          echo "Runner: $RUNNER_NAME · Image: $ImageOS $ImageVersion" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -s "$GATE/fixture-diff.txt" ]]; then
+            echo '::warning::Fixture source differs; review the retained fixture diff before trusting this comparison.'
+            cat "$GATE/fixture-diff.txt" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          for role in A B; do
+            sha="$BASE_SHA"; if [[ "$role" == B ]]; then sha="$HEAD_SHA"; fi
+            git fetch --no-tags origin "$sha"
+            git worktree add --detach "$RUNNER_TEMP/gate-$role" "$sha"
+            (
+              cd "$RUNNER_TEMP/gate-$role/tools/Dekaf.Benchmarks"
+              dotnet new sln --name GateBenchmarkExecution --format sln > "$GATE/solution-$role.log" 2>&1
+              dotnet sln GateBenchmarkExecution.sln add Dekaf.Benchmarks.csproj >> "$GATE/solution-$role.log" 2>&1
+              dotnet build Dekaf.Benchmarks.csproj -c Release --disable-build-servers > "$GATE/build-$role.log" 2>&1
+            )
+          done
+      - name: Validate exact batch filters on this VM
+        run: |
+          mapfile -t filters < <(jq -r '.filters[]' "$GATE/batch.json")
+          for role in A B; do
+            (
+              cd "$RUNNER_TEMP/gate-$role/tools/Dekaf.Benchmarks"
+              dotnet run --project Dekaf.Benchmarks.csproj -c Release --no-build -- --job Dry --filter "${filters[@]}" \
+                --exporters fulljson --buildTimeout 900 --artifacts "$GATE/dry-$role" > "$GATE/dry-$role.log" 2>&1
+            )
+            count=$(python3 .github/scripts/performance_gate.py count --execution-log "$GATE/dry-$role.log")
+            python3 .github/scripts/performance_gate.py validate --dry --phase "$GATE/dry-$role" --expected "$count" \
+              --expected-cases "$GATE/expected-cases.json"
+          done
+          dotnet build-server shutdown
+      - name: Measure A1, B and A2 sequentially on this VM
+        run: |
+          mapfile -t filters < <(jq -r '.filters[]' "$GATE/batch.json")
           for phase in A1 B A2; do
             role=A; if [[ "$phase" == B ]]; then role=B; fi
             (
@@ -173,11 +280,10 @@ jobs:
                 --warmupCount 50 --iterationCount 25 --iterationTime 1000 --launchCount 1 --outliers DontRemove \
                 --exporters fulljson --buildTimeout 900 --artifacts "$GATE/$phase" > "$GATE/$phase.log" 2>&1
             )
-            python3 .github/scripts/performance_gate.py validate --phase "$GATE/$phase" --expected "$(cat "$GATE/count-$role.txt")" \
+            python3 .github/scripts/performance_gate.py validate --phase "$GATE/$phase" --expected-cases "$GATE/expected-cases.json" \
               --iterations 25 --min-warmup "$MIN_WARMUP" --merged "$GATE/$phase.json" --cases "$GATE/$phase-cases.json"
           done
       - name: Screen the candidate against both controls
-        if: steps.select.outputs.applicable == 'true'
         run: |
           compare=(jq -nr --slurpfile a1 "$GATE/A1.json" --slurpfile b "$GATE/B.json" --slurpfile a2 "$GATE/A2.json"
                    --argjson tolerance "$TOLERANCE" --argjson alloc_floor 8 --argjson min_warmup 20
@@ -194,11 +300,59 @@ jobs:
       - name: Record final main
         if: always()
         run: git ls-remote origin refs/heads/main > "$GATE/main-at-end.txt" || true
+      - name: Show failed batch logs
+        if: failure()
+        run: |
+          for log in "$GATE"/build-*.log "$GATE"/dry-*.log "$GATE"/A1.log "$GATE"/B.log "$GATE"/A2.log; do
+            if [[ -f "$log" ]]; then echo "::group::$(basename "$log")"; tail -n 60 "$log"; echo '::endgroup::'; fi
+          done
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
-          name: performance-gate-${{ github.event.pull_request.number || github.ref_name }}-${{ github.run_id }}
+          name: performance-gate-batches-${{ github.run_id }}-${{ matrix.id }}
           path: gate/
           include-hidden-files: true
           overwrite: true
           retention-days: 90
+
+  gate:
+    name: Micro A1/B/A2 screen
+    needs: [plan, measure]
+    if: always() && (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ needs.plan.outputs.tooling || github.sha }}
+      - name: Require successful preparation
+        env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+        run: |
+          if [[ "$PLAN_RESULT" != success ]]; then
+            echo '::error::Benchmark preparation failed. No complete performance verdict is available; inspect Validate and plan benchmark cases.'
+            exit 1
+          fi
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: performance-gate-plan-${{ github.run_id }}
+          path: plan/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        if: needs.plan.outputs.applicable == 'true'
+        with:
+          pattern: performance-gate-batches-${{ github.run_id }}-*
+          path: results/
+          merge-multiple: true
+      - name: Require every planned comparison
+        env:
+          APPLICABLE: ${{ needs.plan.outputs.applicable }}
+          MEASURE_RESULT: ${{ needs.measure.result }}
+        run: |
+          if [[ "$APPLICABLE" != true ]]; then
+            echo 'No steady-state fixture maps to these changes; nothing was measured. Review the preparation summary for missing coverage.' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          python3 .github/scripts/performance_gate.py summarize --plan plan/plan.json --results results/ | tee -a "$GITHUB_STEP_SUMMARY"
+          if [[ "$MEASURE_RESULT" != success ]]; then
+            echo '::error::At least one batch failed or was cancelled. Partial results cannot establish whole-screen acceptance.'
+            exit 1
+          fi

--- a/.github/workflows/performance-harness-tests.yml
+++ b/.github/workflows/performance-harness-tests.yml
@@ -15,10 +15,13 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+defaults:
+  run:
+    shell: bash
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68
@@ -50,6 +53,31 @@ jobs:
             --expected 2 --iterations 3 --min-warmup 0 --merged "$results/same.json" --cases "$results/cases.json"
           jq -e 'length == 2 and any(.[]; any(.Metrics[]; .Descriptor.Id == "Allocated Memory" and .Value == 0)) and any(.[]; any(.Metrics[]; .Descriptor.Id == "Allocated Memory" and .Value > 0))' "$results/same.json"
           echo 'Standard BenchmarkDotNet project/export correctness smoke passed; this short run is not performance acceptance.' >> "$GITHUB_STEP_SUMMARY"
+      - name: Verify planned filters preserve expanded parameter cases
+        working-directory: tools/Dekaf.Benchmarks
+        env:
+          MSBUILDDISABLENODEREUSE: '1'
+          DOTNET_CLI_USE_MSBUILD_SERVER: '0'
+        run: |
+          results="$GITHUB_WORKSPACE/.artifacts/bdn-smoke/planning"
+          mkdir -p "$results"
+          gate="$GITHUB_WORKSPACE/.github/scripts/performance_gate.py"
+          # Dry exports are discovery/correctness evidence only. Two values of one method
+          # prove that FullName filters preserve parameters rather than rerunning the class.
+          dotnet run --project Dekaf.Benchmarks.csproj -c Release --no-build -- --job Dry \
+            --filter '*.Unit.Crc32CBenchmarks.Software(Size: 128)' '*.Unit.Crc32CBenchmarks.Software(Size: 512)' \
+            --exporters fulljson --buildTimeout 900 --artifacts "$results/discovery" > "$results/discovery.log" 2>&1
+          python3 "$gate" validate --dry --phase "$results/discovery" --expected 2
+          python3 "$gate" plan --baseline "$results/discovery" --candidate "$results/discovery" \
+            --max-cases 1 --output "$results/plan.json"
+          for batch in 1 2; do
+            mapfile -t filters < <(jq -r --argjson id "$batch" '.batches[] | select(.id == $id) | .filters[]' "$results/plan.json")
+            jq --argjson id "$batch" '.batches[] | select(.id == $id) | .cases' "$results/plan.json" > "$results/expected-$batch.json"
+            dotnet run --project Dekaf.Benchmarks.csproj -c Release --no-build -- --job Dry --filter "${filters[@]}" \
+              --exporters fulljson --buildTimeout 900 --artifacts "$results/batch-$batch" > "$results/batch-$batch.log" 2>&1
+            python3 "$gate" validate --dry --phase "$results/batch-$batch" --expected 1 --expected-cases "$results/expected-$batch.json"
+          done
+          echo 'Original parameterized BDN exports round-trip through the batch plan without lost or duplicated cases. This is tooling validation, not performance acceptance.' >> "$GITHUB_STEP_SUMMARY"
       - name: Verify comparison decisions against original exports
         run: |
           results="$GITHUB_WORKSPACE/.artifacts/bdn-smoke"


### PR DESCRIPTION
Automatic performance gates stop before measurement when parameter expansion exceeds the 48-case budget: recent jobs selected 58, 78, 85 and 179 cases. This change plans up to four batches of at most 48 validated cases, with two concurrent jobs. Every selected case is retained, and each batch builds both pinned revisions and runs A1/B/A2 sequentially on one Ubuntu VM. The existing final check requires every batch and combines verdicts, never metrics across runners.

Preparation now names every filter missing from either revision and rejects different baseline/candidate case sets. Each Dry and measured batch must match its exact planned identities, preventing a successful comparison of silently reduced or substituted coverage. Failed preparation and batch logs are surfaced in job output; explicit Bash enables pipeline failure propagation. Original exports remain artifacts. Measurement settings, tolerances, regression decisions and loaded-evidence requirements are unchanged.

Measurement jobs explicitly require successful preparation and a nonempty matrix. Discovery derives its limit from the shared batch constants, and FullName mismatches identify the case and both revision-specific filters.

Validation: all 39 performance-tooling tests pass on Linux, six artifact-policy tests pass, the complete committed tree passes artifact policy, both workflows pass actionlint, and the standard benchmark project builds without warnings. GitHub's expression library validates the actual measurement condition across 24 preparation states. Real BenchmarkDotNet Dry exports for two parameter values round-trip through two one-case plans; each generated filter executes exactly its expected case. Replaying the original 179-case discovery export produces 48/48/48/35 batches without loss. CI repeats the parameterized filter smoke test. These are tooling correctness checks, not product performance acceptance.

Cost is explicitly bounded at 192 cases across four jobs; each job keeps the existing 48-case and 330-minute limits. Preparation adds a build/Dry pass before the per-VM validation. This fixes scheduling and coverage validation; missing baseline fixtures, product regressions and loaded-coverage gaps still require their own fixes.
