### PR TITLE
fix(consumer): apply interceptors to batch delivery

### DIFF
--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -239,6 +239,8 @@ namespace Dekaf.Consumer
         private readonly Action<PendingFetchData, long>? _rewindAfterDeliveryFailure;
         private readonly IConsumerRecordFilter? _recordFilter;
         private readonly Func<bool>? _tryRecordPollFast;
+        private readonly Func<ConsumeResult<TKey, TValue>, ConsumeResult<TKey, TValue>>? _onConsume;
+        private readonly bool _useFastPath;
         private readonly int _maxRecords;
         private long _count;
 
@@ -251,7 +253,8 @@ namespace Dekaf.Consumer
             Action<PendingFetchData, long>? rewindAfterDeliveryFailure = null,
             IConsumerRecordFilter? recordFilter = null,
             RecordHeaderRoutingPlan? recordHeaderRoutingPlan = null,
-            Func<bool>? tryRecordPollFast = null)
+            Func<bool>? tryRecordPollFast = null,
+            Func<ConsumeResult<TKey, TValue>, ConsumeResult<TKey, TValue>>? onConsume = null)
         {
             ArgumentOutOfRangeException.ThrowIfLessThan(maxRecords, 1);
             _pendingFetchData = pendingFetchData;
@@ -263,11 +266,13 @@ namespace Dekaf.Consumer
             _rewindAfterDeliveryFailure = rewindAfterDeliveryFailure;
             _recordFilter = recordFilter;
             _tryRecordPollFast = tryRecordPollFast;
+            _onConsume = onConsume;
             _recordHeaderRoutingPlan = recordHeaderRoutingPlan
                                        ?? RecordHeaderRoutingPlan.Create(
                                            keyDeserializer,
                                            valueDeserializer);
             _hasRecordHeaderDeserializers = _recordHeaderRoutingPlan is not null;
+            _useFastPath = recordFilter is null && !_hasRecordHeaderDeserializers && onConsume is null;
             _recordHeaderDeserializationHeaders =
                 _recordHeaderRoutingPlan?.NeedsMaterializedHeaders is true
                     ? new Headers(2)
@@ -400,7 +405,7 @@ namespace Dekaf.Consumer
                 if (!_canContinue)
                     return false;
 
-                return _batch._recordFilter is null && !_batch._hasRecordHeaderDeserializers
+                return _batch._useFastPath
                     ? MoveNextFast(pending)
                     : MoveNextFilteredOrRouted(pending);
             }
@@ -637,8 +642,19 @@ namespace Dekaf.Consumer
                         return false;
                     }
 
-                    if (!CompleteRecord(pending, offset, messageBytes, proveProcessed: false))
+                    if (_batch._onConsume is { } onConsume)
+                    {
+                        if (!CanDeliverRecord(pending))
+                            return false;
+                        var original = Current;
+                        Current = onConsume(original).WithBrokerIdentityFrom(in original);
+                        if (!CompleteRecord(pending, offset, messageBytes, proveProcessed: false))
+                            return false;
+                    }
+                    else if (!CompleteRecord(pending, offset, messageBytes, proveProcessed: false))
+                    {
                         return false;
+                    }
 
                     _hasYieldedResult = true;
                     _batch._count++;
@@ -653,6 +669,23 @@ namespace Dekaf.Consumer
                 int messageBytes,
                 bool proveProcessed)
             {
+                if (!CanDeliverRecord(pending))
+                    return false;
+
+                pending.TrackConsumed(offset, messageBytes);
+                if (proveProcessed && !_hasYieldedResult)
+                    pending.MarkYieldedProcessed();
+                _batch._storeOffsetOnDelivery?.Invoke(
+                    pending.TopicPartition,
+                    offset + 1,
+                    pending.LastYieldedLeaderEpoch);
+                _recordsExamined++;
+                return true;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private bool CanDeliverRecord(PendingFetchData pending)
+            {
                 var iterationStatus = _batch._iterationGuard.GetStatusAfterRead(
                     pending.TopicPartition,
                     ref _observedVersion);
@@ -664,14 +697,6 @@ namespace Dekaf.Consumer
                     return false;
                 }
 
-                pending.TrackConsumed(offset, messageBytes);
-                if (proveProcessed && !_hasYieldedResult)
-                    pending.MarkYieldedProcessed();
-                _batch._storeOffsetOnDelivery?.Invoke(
-                    pending.TopicPartition,
-                    offset + 1,
-                    pending.LastYieldedLeaderEpoch);
-                _recordsExamined++;
                 return true;
             }
 

--- a/src/Dekaf/Consumer/IConsumerInterceptor.cs
+++ b/src/Dekaf/Consumer/IConsumerInterceptor.cs
@@ -28,6 +28,8 @@ public interface IConsumerInterceptor<TKey, TValue>
     /// <para>This method is called on the consumer's hot path. Implementations should
     /// be lightweight and avoid blocking operations.</para>
     /// <para>If an interceptor throws, the original result is used and the exception is logged.</para>
+    /// <para>Batch delivery preserves the original topic, partition, offset and leader epoch
+    /// so replacement results cannot change partitioned routing or committed broker progress.</para>
     /// </remarks>
     ConsumeResult<TKey, TValue> OnConsume(ConsumeResult<TKey, TValue> result);
 

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -111,6 +111,7 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// Each batch contains all records from a single partition fetch response.
     /// Records within a batch are iterated synchronously (no async overhead per message).
     /// Position tracking is deferred to batch completion.
+    /// Configured OnConsume interceptors run in registration order before each record is delivered.
     /// When partition EOF reporting is enabled, EOF is surfaced as a zero-record batch whose
     /// <see cref="ConsumeBatch{TKey,TValue}.IsPartitionEof"/> property is <see langword="true"/>.
     /// </summary>
@@ -562,6 +563,32 @@ public readonly struct ConsumeResult<TKey, TValue>
     }
 
     internal void ReleaseStorage() => _headerOwner?.ReleaseAfterProcessing();
+
+    // Partitioned completion uses the delivered record's broker identity. Interceptors
+    // may replace payload metadata, but cannot redirect routing or committed progress.
+    internal ConsumeResult<TKey, TValue> WithBrokerIdentityFrom(in ConsumeResult<TKey, TValue> original)
+        => new(this, in original);
+
+    private ConsumeResult(in ConsumeResult<TKey, TValue> replacement, in ConsumeResult<TKey, TValue> original)
+    {
+        this = replacement;
+        Topic = original.Topic;
+        Partition = original.Partition;
+        Offset = original.Offset;
+        LeaderEpoch = original.LeaderEpoch;
+        IsPartitionEof = original.IsPartitionEof;
+    }
+
+    // A replacement may still borrow the original key/value memory. Preserve the
+    // fetch owner so partitioned handlers can retain that storage while queued.
+    internal ConsumeResult<TKey, TValue> WithStorageOwnerFrom(in ConsumeResult<TKey, TValue> original)
+        => _headerOwner is null && original._headerOwner is { } owner ? new(this, owner) : this;
+
+    private ConsumeResult(in ConsumeResult<TKey, TValue> replacement, PendingFetchData owner)
+    {
+        this = replacement;
+        _headerOwner = owner;
+    }
 
     /// <summary>
     /// Creates a new ConsumeResult with eager deserialization.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1493,6 +1493,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     // Interceptors - stored as typed array for zero-allocation iteration
     private readonly IConsumerInterceptor<TKey, TValue>[]? _interceptors;
+    private readonly Func<ConsumeResult<TKey, TValue>, ConsumeResult<TKey, TValue>>? _onBatchConsume;
 
     // Incremental fetch responses can omit unchanged empty partitions; EOF mode needs those
     // empty partition responses to emit partition EOF events.
@@ -1881,6 +1882,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 interceptors[i] = (IConsumerInterceptor<TKey, TValue>)options.Interceptors[i];
             }
             _interceptors = interceptors;
+            _onBatchConsume = ApplyOnConsumeInterceptorsSlow;
         }
 
         _connectionPool = infrastructure.Pool;
@@ -3573,6 +3575,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 long? batchProcessingStarted = _adaptiveFetchSizer is not null
                     ? Stopwatch.GetTimestamp() : null;
 
+                // User callbacks can seek or revoke this fetch during synchronous batch
+                // iteration. Retain once across the yield, including its final cleanup.
+                using var interceptorRetention = _onBatchConsume is null
+                    ? (PendingFetchData.RetentionLease?)null
+                    : pending.RetainForIteration();
                 try
                 {
                     // Eagerly parse all records upfront for cache-friendly access
@@ -3593,7 +3600,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         _rewindBatchAfterDeliveryFailure,
                         _options.RecordFilter,
                         _recordHeaderRoutingPlan,
-                        _tryRecordPollFast);
+                        _tryRecordPollFast,
+                        _onBatchConsume);
                     batchYielded = true;
                     yield return batch;
                     // Resumption = the caller requested the next batch, proving this one was
@@ -11106,7 +11114,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             try
             {
-                result = interceptor.OnConsume(result);
+                var replacement = interceptor.OnConsume(result);
+                result = replacement.WithStorageOwnerFrom(in result);
             }
             catch (Exception ex)
             {

--- a/tests/Dekaf.Tests.Integration/BatchConsumerInterceptorTests.cs
+++ b/tests/Dekaf.Tests.Integration/BatchConsumerInterceptorTests.cs
@@ -1,0 +1,150 @@
+using System.Collections.Concurrent;
+using System.Text;
+using Dekaf.Consumer;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("ConsumerGroup")]
+public sealed class BatchConsumerInterceptorTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    [Arguments("batch", 1)]
+    [Arguments("batch", 1000)]
+    [Arguments("partitioned", 1)]
+    [Arguments("partitioned", 1000)]
+    [Arguments("partitioned-batches", 1)]
+    [Arguments("partitioned-batches", 1000)]
+    [Arguments("raw", 1)]
+    [Arguments("raw", 1000)]
+    public async Task Delivery_AppliesOrderedInterceptorsExceptRaw(string delivery, int queuedMinMessages)
+    {
+        const int count = 4;
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).BuildAsync();
+        for (var index = 0; index < count; index++)
+            await producer.ProduceAsync(topic, "key", $"value-{index}");
+
+        var calls = new ConcurrentQueue<string>();
+        var groupId = $"batch-interceptors-{Guid.NewGuid():N}";
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithQueuedMinMessages(queuedMinMessages)
+            .AddInterceptor(new CallbackInterceptor(result =>
+            {
+                calls.Enqueue($"first:{result.Value}");
+                return new ConsumeResult<string, string>("replacement-topic", 99, 99,
+                    result.Key, $"changed-{result.Offset}", result.Headers, result.Timestamp.ToUnixTimeMilliseconds(),
+                    result.TimestampType, 99);
+            }))
+            .AddInterceptor(new CallbackInterceptor(result =>
+            {
+                calls.Enqueue($"throw:{result.Value}");
+                throw new InvalidOperationException("Expected interceptor failure");
+            }))
+            .AddInterceptor(new CallbackInterceptor(result =>
+            {
+                calls.Enqueue($"last:{result.Value}");
+                return result;
+            }))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+        consumer.Subscribe(topic);
+
+        using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        using var stop = CancellationTokenSource.CreateLinkedTokenSource(deadline.Token);
+        var received = new ConcurrentQueue<string>();
+        var delivered = new ConcurrentQueue<ConsumeResult<string, string>>();
+        var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        ValueTask Handle(ConsumeResult<string, string> record)
+        {
+            delivered.Enqueue(record);
+            received.Enqueue(record.Value);
+            if (received.Count == count)
+                done.TrySetResult();
+            return ValueTask.CompletedTask;
+        }
+
+        if (delivery == "raw")
+        {
+            await foreach (var batch in consumer.ConsumeRawBatchAsync(deadline.Token))
+            {
+                foreach (var record in batch)
+                    received.Enqueue(Encoding.UTF8.GetString(record.Value.Span));
+                if (received.Count == count)
+                    break;
+            }
+        }
+        else if (delivery == "batch")
+        {
+            await foreach (var batch in consumer.ConsumeBatchAsync(deadline.Token))
+            {
+                foreach (var record in batch)
+                    await Handle(record);
+                if (received.Count == count)
+                    break;
+            }
+        }
+        else
+        {
+            var options = new PartitionedProcessingOptions
+            {
+                Ordering = PartitionedProcessingOrder.Key,
+                MaxConcurrentHandlersPerPartition = 2,
+                MaxBufferedRecordsPerPartition = 8,
+                MaxHandlerBatchSize = 4,
+                CommitPolicy = PartitionCommitPolicy.CommitCompletedOnRevoke,
+                StopPolicy = PartitionStopPolicy.Drain
+            };
+            var run = delivery == "partitioned"
+                ? consumer.RunPartitionedAsync((_, record, _) => Handle(record), options, stop.Token).AsTask()
+                : consumer.RunPartitionedBatchesAsync(async (_, records, _) =>
+                {
+                    for (var index = 0; index < records.Count; index++)
+                        await Handle(records[index]);
+                }, options, stop.Token).AsTask();
+            try
+            {
+                await Task.WhenAny(done.Task, run).WaitAsync(deadline.Token);
+                if (run.IsCompleted)
+                    await run;
+                await done.Task.WaitAsync(deadline.Token);
+            }
+            finally
+            {
+                await stop.CancelAsync();
+                try { await run.WaitAsync(TimeSpan.FromSeconds(15)); }
+                catch (OperationCanceledException) when (stop.IsCancellationRequested) { }
+            }
+        }
+
+        await Assert.That(received.ToArray()).IsEquivalentTo(
+            Enumerable.Range(0, count).Select(index => delivery == "raw" ? $"value-{index}" : $"changed-{index}"));
+        var expectedCalls = delivery == "raw" ? [] : Enumerable.Range(0, count)
+            .SelectMany(index => new[] { $"first:value-{index}", $"throw:changed-{index}", $"last:changed-{index}" }).ToArray();
+        await Assert.That(calls.SequenceEqual(expectedCalls)).IsTrue();
+        foreach (var record in delivered)
+        {
+            await Assert.That(record.Topic).IsEqualTo(topic);
+            await Assert.That(record.Partition).IsEqualTo(0);
+            await Assert.That(record.Value).IsEqualTo($"changed-{record.Offset}");
+            await Assert.That(record.LeaderEpoch).IsNotEqualTo(99);
+        }
+        if (delivery is "partitioned" or "partitioned-batches")
+        {
+            await using var admin = KafkaContainer.CreateAdminClient();
+            var committed = await admin.ListConsumerGroupOffsetsAsync(groupId);
+            await Assert.That(committed[new TopicPartition(topic, 0)]).IsEqualTo((long)count);
+        }
+    }
+
+    private sealed class CallbackInterceptor(Func<ConsumeResult<string, string>, ConsumeResult<string, string>> callback)
+        : IConsumerInterceptor<string, string>
+    {
+        public ConsumeResult<string, string> OnConsume(ConsumeResult<string, string> result) => callback(result);
+        public void OnCommit(IReadOnlyList<TopicPartitionOffset> offsets) { }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
@@ -8,6 +8,74 @@ namespace Dekaf.Tests.Unit.Consumer;
 public class ConsumeBatchTests
 {
     [Test]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    public async Task Interceptor_DeliveryGuardHonorsUserCallbacks(bool duringDeserialization, bool paused)
+    {
+        var stoppedStatus = paused ? BatchIterationStatus.Paused : BatchIterationStatus.Stopped;
+        using var pending = CreatePendingFetchData("test-topic", 0, 7, 1);
+        var epoch = new BatchIterationEpoch();
+        var status = BatchIterationStatus.Continue;
+        var calls = 0;
+        var stored = 0;
+        void Stop()
+        {
+            status = stoppedStatus;
+            epoch.Invalidate();
+        }
+        var batch = new ConsumeBatch<string, string>(pending, Serializers.String,
+            duringDeserialization ? new CallbackDeserializer(Stop) : Serializers.String,
+            new BatchIterationGuard(epoch, epoch.Version, _ => status),
+            storeOffsetOnDelivery: (_, _, _) => stored++,
+            onConsume: result =>
+            {
+                calls++;
+                Stop();
+                return result;
+            });
+        using var records = batch.GetEnumerator();
+        await Assert.That(records.MoveNext()).IsFalse();
+        await Assert.That(calls).IsEqualTo(duringDeserialization ? 0 : 1);
+        await Assert.That(stored).IsEqualTo(0);
+        await Assert.That(batch.Count).IsEqualTo(0);
+        await Assert.That(pending.MoveNext()).IsEqualTo(stoppedStatus == BatchIterationStatus.Paused);
+    }
+
+    [Test]
+    public async Task Interceptor_OnlySeesUnfilteredRecordsAndPreservesDeliveredOffsets()
+    {
+        using var pending = CreatePendingFetchData("test-topic", 0, 0, 3);
+        var calls = new List<long>();
+        var stored = new List<long>();
+        var batch = new ConsumeBatch<string, string>(pending, Serializers.String, Serializers.String,
+            storeOffsetOnDelivery: (_, offset, _) => stored.Add(offset), recordFilter: new OddOffsetFilter(),
+            onConsume: result =>
+            {
+                calls.Add(result.Offset);
+                return new ConsumeResult<string, string>("replacement-topic", 99, 99, result.Key,
+                    "replacement", result.Headers, 0, result.TimestampType, 99);
+            });
+        var results = batch.ToList();
+        await Assert.That(results.Count).IsEqualTo(1);
+        await Assert.That(results[0].Value).IsEqualTo("replacement");
+        await Assert.That(results[0].Topic).IsEqualTo("test-topic");
+        await Assert.That(results[0].Partition).IsEqualTo(0);
+        await Assert.That(results[0].Offset).IsEqualTo(1);
+        await Assert.That(results[0].LeaderEpoch).IsNull();
+        await Assert.That(results[0].IsPartitionEof).IsFalse();
+        await Assert.That(calls.SequenceEqual([1L])).IsTrue();
+        // Replacement metadata must not change the broker progress tracked for this fetch.
+        await Assert.That(stored.SequenceEqual([1L, 2L, 3L])).IsTrue();
+    }
+
+    private sealed class OddOffsetFilter : IConsumerRecordFilter
+    {
+        public bool ShouldDeserialize(scoped in ConsumerRecordFilterContext context) => context.Offset % 2 != 0;
+    }
+
+    [Test]
     public async Task ConsumeBatch_EnumeratesAllRecords()
     {
         // Arrange

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedRecordLifetimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedRecordLifetimeTests.cs
@@ -11,6 +11,77 @@ namespace Dekaf.Tests.Unit.Consumer;
 public sealed class PartitionedRecordLifetimeTests
 {
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task InterceptorBatch_RetainsStorageUntilRevocationGuard(bool disposeDuringDeserialization)
+    {
+        var memory = new ReusedMemory();
+        var pending = CreatePending(memory);
+        var disposedInsideCallback = -1;
+        var calls = 0;
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer = null!;
+        void Revoke()
+        {
+            consumer.Unassign();
+            disposedInsideCallback = memory.DisposeCount;
+        }
+        consumer = new KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                QueuedMinMessages = 1,
+                Interceptors = [new CallbackRawInterceptor(() => { calls++; Revoke(); })]
+            }, Serializers.RawBytes,
+            disposeDuringDeserialization ? new CallbackRawDeserializer(Revoke) : Serializers.RawBytes);
+        await using var ownedConsumer = consumer;
+        var consumerType = consumer.GetType();
+        System.Reflection.FieldInfo Field(string name) => consumerType.GetField(name,
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"{name} field not found.");
+        Field("_initialized").SetValue(consumer, true);
+        consumer.Assign(pending.TopicPartition);
+        Field("_lastManualAssignmentEnsureVersion").SetValue(consumer, Field("_assignmentEnsureVersion").GetValue(consumer));
+        ((System.Collections.Concurrent.ConcurrentDictionary<TopicPartition, long>)Field("_fetchPositions").GetValue(consumer)!)
+            [pending.TopicPartition] = 0;
+        ((Queue<PendingFetchData>)Field("_pendingFetches").GetValue(consumer)!).Enqueue(pending);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await using (var batches = consumer.ConsumeBatchAsync(timeout.Token).GetAsyncEnumerator())
+        {
+            await Assert.That(await batches.MoveNextAsync()).IsTrue();
+            using var records = batches.Current.GetEnumerator();
+            await Assert.That(records.MoveNext()).IsFalse();
+            await Assert.That(calls).IsEqualTo(disposeDuringDeserialization ? 0 : 1);
+            await Assert.That(disposedInsideCallback).IsEqualTo(0);
+            await Assert.That(memory.DisposeCount).IsEqualTo(0);
+        }
+        await Assert.That(memory.DisposeCount).IsEqualTo(1);
+    }
+
+    private sealed class CallbackRawInterceptor(Action callback)
+        : IConsumerInterceptor<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>
+    {
+        public ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> OnConsume(
+            ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> result)
+        {
+            callback();
+            return result;
+        }
+
+        public void OnCommit(IReadOnlyList<TopicPartitionOffset> offsets) { }
+    }
+
+    private sealed class CallbackRawDeserializer(Action callback) : IDeserializer<ReadOnlyMemory<byte>>
+    {
+        public ReadOnlyMemory<byte> Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            callback();
+            return data;
+        }
+    }
+
+    [Test]
     public async Task FullOrCompletedQueue_DoesNotRetainRejectedRecords()
     {
         var acceptedMemory = new ReusedMemory();
@@ -57,12 +128,16 @@ public sealed class PartitionedRecordLifetimeTests
     }
 
     [Test]
-    [Arguments(PartitionedProcessingOrder.Partition, PartitionBackpressureMode.AwaitCapacity)]
-    [Arguments(PartitionedProcessingOrder.Partition, PartitionBackpressureMode.PauseResume)]
-    [Arguments(PartitionedProcessingOrder.Key, PartitionBackpressureMode.AwaitCapacity)]
-    [Arguments(PartitionedProcessingOrder.Key, PartitionBackpressureMode.PauseResume)]
+    [Arguments(PartitionedProcessingOrder.Partition, PartitionBackpressureMode.AwaitCapacity, false)]
+    [Arguments(PartitionedProcessingOrder.Partition, PartitionBackpressureMode.PauseResume, false)]
+    [Arguments(PartitionedProcessingOrder.Key, PartitionBackpressureMode.AwaitCapacity, false)]
+    [Arguments(PartitionedProcessingOrder.Key, PartitionBackpressureMode.PauseResume, false)]
+    [Arguments(PartitionedProcessingOrder.Partition, PartitionBackpressureMode.AwaitCapacity, true)]
+    [Arguments(PartitionedProcessingOrder.Partition, PartitionBackpressureMode.PauseResume, true)]
+    [Arguments(PartitionedProcessingOrder.Key, PartitionBackpressureMode.AwaitCapacity, true)]
+    [Arguments(PartitionedProcessingOrder.Key, PartitionBackpressureMode.PauseResume, true)]
     public async Task RawRecords_RemainValidAfterFetchAdvances(
-        PartitionedProcessingOrder ordering, PartitionBackpressureMode backpressure)
+        PartitionedProcessingOrder ordering, PartitionBackpressureMode backpressure, bool replaceResult)
     {
         using var timeout = new CancellationTokenSource();
         var handlerStarted = NewSignal();
@@ -70,10 +145,21 @@ public sealed class PartitionedRecordLifetimeTests
         var releaseHandler = NewSignal();
         var memory = new ReusedMemory();
         var pending = CreatePending(memory);
+        await using var interceptorConsumer = new KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                Interceptors = replaceResult ? [new BorrowingReplacementInterceptor()] : null
+            }, Serializers.RawBytes, Serializers.RawBytes);
+        var onConsume = (Func<ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>,
+            ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>>?)typeof(KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>)
+            .GetField("_onBatchConsume", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(interceptorConsumer);
         var consumer = Substitute.For<IKafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>>();
         consumer.Partitions.Assignment.Returns(new HashSet<TopicPartition> { new("lifetime", 0) });
         consumer.ConsumeBatchAsync(Arg.Any<CancellationToken>()).Returns(call =>
-            Fetch(pending, handlerStarted, fetchAdvanced, call.Arg<CancellationToken>()));
+            Fetch(pending, handlerStarted, fetchAdvanced, call.Arg<CancellationToken>(), onConsume: onConsume));
 
         // Start the operation budget after pooled storage and proxy setup.
         timeout.CancelAfter(TimeSpan.FromSeconds(10));
@@ -337,12 +423,13 @@ public sealed class PartitionedRecordLifetimeTests
 
     private static async IAsyncEnumerable<ConsumeBatch<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>> Fetch(
         PendingFetchData pending, TaskCompletionSource handlerStarted, TaskCompletionSource fetchAdvanced,
-        [EnumeratorCancellation] CancellationToken cancellationToken, bool keepOpen = false)
+        [EnumeratorCancellation] CancellationToken cancellationToken, bool keepOpen = false,
+        Func<ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>, ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>>? onConsume = null)
     {
         using (pending)
         {
             yield return new ConsumeBatch<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
-                pending, Serializers.RawBytes, Serializers.RawBytes);
+                pending, Serializers.RawBytes, Serializers.RawBytes, onConsume: onConsume);
             await handlerStarted.Task.WaitAsync(cancellationToken);
         }
         fetchAdvanced.TrySetResult();
@@ -445,6 +532,16 @@ public sealed class PartitionedRecordLifetimeTests
     }
 
     private static TaskCompletionSource NewSignal() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private sealed class BorrowingReplacementInterceptor : IConsumerInterceptor<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>
+    {
+        public ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> OnConsume(
+            ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> result)
+            => new(result.Topic, result.Partition, result.Offset, result.Key, result.Value, result.Headers,
+                result.Timestamp.ToUnixTimeMilliseconds(), result.TimestampType, result.LeaderEpoch);
+
+        public void OnCommit(IReadOnlyList<TopicPartitionOffset> offsets) { }
+    }
 
     // Public so NSubstitute can construct the generic consumer proxy for this test key.
     public readonly struct BorrowedKey(ReadOnlyMemory<byte> bytes, TaskCompletionSource sameKeyFound) : IEquatable<BorrowedKey>


### PR DESCRIPTION
Applies configured consumer interceptors to typed batch delivery and partitioned handlers, in registration order, with the existing non-fatal exception handling. Raw batches remain unintercepted. Batch delivery preserves the broker topic, partition, offset and leader epoch when an interceptor replaces a result, protecting routing and committed progress.

The consumer caches its callback once and retains fetch storage once across each yielded batch. Replacement results preserve borrowed storage ownership for queued partitioned handlers; the no-interceptor record fast path remains synchronous.

Validation: 42 focused unit tests pass on each of net10.0 and net8.0; eight Kafka integration cases pass, including broker commit offsets after metadata replacement. The broker-identity regression was reproduced before the fix. Six standard BenchmarkDotNet Dry cases pass on both main and this candidate with identical fixtures. Forty performance-tooling tests and artifact policy pass. Raw local validation is retained outside Git at `C:/git/Dekaf-evidence/pr-3222/d38c9c21fc4c5878ce016854efe99afeb86c5696/dry`.

The latest update synchronizes #3223's fixture and setup helper: unique payloads validate every record and each replacement in order; private delegate binding lives in the existing BufferedConsumerHarness. All six updated Dry cases pass on both revisions, and 41 selector tests pass. The callback guarantee is documented on `ConsumeBatchAsync`; selector exclusions are checked per specific path. Updated raw validation is retained at `C:/git/Dekaf-evidence/pr-3222/297cd08dde53147450ebbc848d88d59563bcc7c8`.

Performance acceptance remains pending. #3223 has landed the compatible fixture. This single commit is rebased onto main db15903f0; the automatic gate now covers the batch-interceptor cases. Loaded consumer evidence is also required. Source patch-id: `5db3b650130155ba87f2879c7baac1ae1054b4ef`. Local validation is not a performance PASS.

Closes #3198
