### PR TITLE
benchmarks: cover batch interceptor delivery

### DIFF
--- a/.github/scripts/performance_gate.py
+++ b/.github/scripts/performance_gate.py
@@ -47,10 +47,11 @@ AREAS = (
     # partition dispatcher has its own implementation; unknown files retain the
     # directory-wide fallback below.
     ('src/Dekaf/Consumer/KafkaConsumer.cs', 'consumer', unit(
-        'ConsumerHotPathBenchmarks', 'FetchResponseParsingBenchmarks', 'FetchRequestBuildBenchmarks',
+        'ConsumerHotPathBenchmarks', 'ConsumerBatchInterceptorBenchmarks', 'FetchResponseParsingBenchmarks', 'FetchRequestBuildBenchmarks',
         'OffsetStoreBenchmarks', 'ConsumeResultOffsetStoreBenchmarks'), None),
-    ('src/Dekaf/Consumer/IKafkaConsumer.cs', 'consumer', unit('ConsumerHotPathBenchmarks'), None),
-    ('src/Dekaf/Consumer/ConsumeBatch.cs', 'consumer', unit('ConsumerHotPathBenchmarks'), None),
+    ('src/Dekaf/Consumer/IKafkaConsumer.cs', 'consumer', unit('ConsumerHotPathBenchmarks', 'ConsumerBatchInterceptorBenchmarks'), None),
+    ('src/Dekaf/Consumer/IConsumerInterceptor.cs', 'consumer', unit('ConsumerHotPathBenchmarks', 'ConsumerBatchInterceptorBenchmarks'), None),
+    ('src/Dekaf/Consumer/ConsumeBatch.cs', 'consumer', unit('ConsumerHotPathBenchmarks', 'ConsumerBatchInterceptorBenchmarks'), None),
     ('src/Dekaf/Consumer/PartitionedProcessing.cs', 'consumer', unit(
         'PartitionedDispatchBenchmarks', 'KeyOrderedDispatchBenchmarks', 'PartitionedOffsetTrackingBenchmarks'), None),
     ('src/Dekaf/Consumer/CompletedOffsetRanges.cs', 'consumer', unit('PartitionedOffsetTrackingBenchmarks'), None),
@@ -71,7 +72,7 @@ AREAS = (
         'ValueTaskSourcePoolBenchmarks', 'ProduceResponseParsingBenchmarks', 'PartitionQueueAccountingBenchmarks',
         'WaveCoalesceProbeBenchmarks'), None),
     ('src/Dekaf/Consumer/', 'consumer', unit(
-        'ConsumerHotPathBenchmarks', 'FetchResponseParsingBenchmarks', 'FetchRequestBuildBenchmarks',
+        'ConsumerHotPathBenchmarks', 'ConsumerBatchInterceptorBenchmarks', 'FetchResponseParsingBenchmarks', 'FetchRequestBuildBenchmarks',
         'OffsetStoreBenchmarks', 'ConsumeResultOffsetStoreBenchmarks',
         'PartitionedDispatchBenchmarks', 'KeyOrderedDispatchBenchmarks'), None),
     ('src/Dekaf/ShareConsumer/', 'share-consumer', unit(

--- a/.github/scripts/test_performance_gate.py
+++ b/.github/scripts/test_performance_gate.py
@@ -110,10 +110,18 @@ class SelectionTests(unittest.TestCase):
 
     def test_kafka_consumer_retains_all_offset_store_api_coverage(self):
         selection = gate.select(['src/Dekaf/Consumer/KafkaConsumer.cs'])
-        self.assertEqual(gate.unit('ConsumerHotPathBenchmarks', 'FetchResponseParsingBenchmarks',
+        self.assertEqual(gate.unit('ConsumerHotPathBenchmarks', 'ConsumerBatchInterceptorBenchmarks', 'FetchResponseParsingBenchmarks',
                                    'FetchRequestBuildBenchmarks', 'OffsetStoreBenchmarks',
                                    'ConsumeResultOffsetStoreBenchmarks'), selection['filters'])
         self.assertNotIn('*.Unit.PartitionedDispatchBenchmarks.*', selection['filters'])
+
+    def test_batch_interceptor_paths_cover_configured_and_unconfigured_delivery(self):
+        for path in ('KafkaConsumer.cs', 'ConsumeBatch.cs', 'IKafkaConsumer.cs', 'IConsumerInterceptor.cs', 'UnknownConsumer.cs'):
+            selection = gate.select([f'src/Dekaf/Consumer/{path}'])
+            for fixture in gate.unit('ConsumerHotPathBenchmarks', 'ConsumerBatchInterceptorBenchmarks'):
+                self.assertIn(fixture, selection['filters'])
+            if path != 'UnknownConsumer.cs':
+                self.assertNotIn('*.Unit.PartitionedDispatchBenchmarks.*', selection['filters'])
 
     def test_partition_completion_retains_dispatch_and_tracking_coverage(self):
         selection = gate.select(['src/Dekaf/Consumer/PartitionedProcessing.cs',

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerBatchInterceptorBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerBatchInterceptorBenchmarks.cs
@@ -1,0 +1,107 @@
+using System.Buffers.Binary;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Benchmarks.Infrastructure;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Parsed batch delivery through the consumer's configured interceptor chain.</summary>
+[MemoryDiagnoser]
+public class ConsumerBatchInterceptorBenchmarks
+{
+    private const int MessageCount = 1000;
+    private const int ValueLength = 32;
+    private const string Topic = "batch-interceptors";
+    private Record[][] _records = null!;
+    private KafkaConsumer<Ignore, ReadOnlyMemory<byte>> _consumer = null!;
+    private Func<ConsumeResult<Ignore, ReadOnlyMemory<byte>>, ConsumeResult<Ignore, ReadOnlyMemory<byte>>>? _baselineOnConsume;
+
+    [Params(0, 1, 3)]
+    public int InterceptorCount { get; set; }
+
+    [Params(false, true)]
+    public bool ReplaceResult { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _records = [new Record[MessageCount]];
+        for (var index = 0; index < MessageCount; index++)
+        {
+            var value = new byte[ValueLength];
+            BinaryPrimitives.WriteInt32LittleEndian(value.AsSpan(ValueLength - sizeof(int)), index);
+            _records[0][index] = new Record { OffsetDelta = index, Value = value, IsKeyNull = true };
+        }
+        var interceptors = new CountingInterceptor[InterceptorCount];
+        for (var index = 0; index < interceptors.Length; index++)
+            interceptors[index] = new CountingInterceptor(ReplaceResult);
+        _consumer = new KafkaConsumer<Ignore, ReadOnlyMemory<byte>>(new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"], OffsetCommitMode = OffsetCommitMode.Manual,
+            Interceptors = interceptors, QueuedMinMessages = 1, MaxPollRecords = MessageCount
+        }, Serializers.Ignore, Serializers.RawBytes);
+        BufferedConsumerHarness.InitializeForBufferedFastPath(_consumer, Topic, 0);
+        _baselineOnConsume = BufferedConsumerHarness.BindBaselineBatchInterceptors(_consumer, InterceptorCount > 0);
+        var expectedLength = ValueLength - (ReplaceResult ? InterceptorCount : 0);
+        if (await EnumerateCore(validate: true) != MessageCount * expectedLength)
+            throw new InvalidOperationException("Every record must contain the result of the complete interceptor chain.");
+        foreach (var interceptor in interceptors)
+            if (interceptor.Calls != MessageCount)
+                throw new InvalidOperationException("Each interceptor must run once per delivered record.");
+    }
+
+    [Benchmark(OperationsPerInvoke = MessageCount)]
+    public ValueTask<int> Enumerate() => EnumerateCore(validate: false);
+
+    private async ValueTask<int> EnumerateCore(bool validate)
+    {
+        // Include one buffered fetch, the public batch iterator, delivery and disposal.
+        // Fetch-array and iterator allocations are amortized per batch, not per message.
+        BufferedConsumerHarness.ReseedPendingFetches(_consumer, Topic, 0, _records, 1, MessageCount);
+        var bytes = 0;
+        var index = 0;
+        await foreach (var batch in _consumer.ConsumeBatchAsync())
+        {
+            foreach (var record in batch)
+            {
+                var result = _baselineOnConsume is { } onConsume ? onConsume(record) : record;
+                if (validate)
+                {
+                    var removedBytes = ReplaceResult ? InterceptorCount : 0;
+                    if (index >= MessageCount || result.Offset != index ||
+                        !result.Value.Span.SequenceEqual(_records[0][index].Value.Span[removedBytes..]))
+                        throw new InvalidOperationException("Every record must retain its identity and fully transformed payload in order.");
+                    index++;
+                }
+                bytes += result.Value.Length;
+            }
+            break;
+        }
+        if (validate && index != MessageCount)
+            throw new InvalidOperationException("Every seeded record must be delivered exactly once.");
+        return bytes;
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        BufferedConsumerHarness.DrainPendingFetches(_consumer);
+        await _consumer.DisposeAsync();
+    }
+
+    private sealed class CountingInterceptor(bool replace) : IConsumerInterceptor<Ignore, ReadOnlyMemory<byte>>
+    {
+        public long Calls;
+        public ConsumeResult<Ignore, ReadOnlyMemory<byte>> OnConsume(ConsumeResult<Ignore, ReadOnlyMemory<byte>> result)
+        {
+            Calls++;
+            return replace
+                ? new(result.Topic, result.Partition, result.Offset, result.Key, result.Value[1..], result.Headers,
+                    result.Timestamp.ToUnixTimeMilliseconds(), result.TimestampType, result.LeaderEpoch)
+                : result;
+        }
+        public void OnCommit(IReadOnlyList<TopicPartitionOffset> offsets) { }
+    }
+}

--- a/tools/Dekaf.Benchmarks/Infrastructure/BufferedConsumerHarness.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/BufferedConsumerHarness.cs
@@ -24,6 +24,23 @@ namespace Dekaf.Benchmarks.Infrastructure;
 internal static class BufferedConsumerHarness
 {
     /// <summary>
+    /// Adapts revisions that omit batch callbacks by binding their existing interceptor
+    /// chain for the caller to execute. Native revisions return null. Call only in setup,
+    /// then validate per-record replacements and callback counts before measurement.
+    /// </summary>
+    public static Func<ConsumeResult<TKey, TValue>, ConsumeResult<TKey, TValue>>? BindBaselineBatchInterceptors<TKey, TValue>(
+        KafkaConsumer<TKey, TValue> consumer, bool hasInterceptors)
+    {
+        var consumerType = typeof(KafkaConsumer<TKey, TValue>);
+        if (!hasInterceptors || consumerType.GetField("_onBatchConsume", BindingFlags.Instance | BindingFlags.NonPublic) is not null)
+            return null;
+
+        var method = consumerType.GetMethod("ApplyOnConsumeInterceptorsSlow", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("The consumer interceptor chain was not found.");
+        return method.CreateDelegate<Func<ConsumeResult<TKey, TValue>, ConsumeResult<TKey, TValue>>>(consumer);
+    }
+
+    /// <summary>
     /// Marks the consumer initialized, assigns the partition, and acknowledges the manual
     /// assignment so the buffered fast path's currency check passes.
     /// </summary>


### PR DESCRIPTION
Adds six standard BenchmarkDotNet cases for public `ConsumeBatchAsync` delivery with zero, one or three interceptors, including replacement results, and maps the affected consumer paths to them. This is the missing baseline fixture for #3222 and #3198.

On revisions that omit batch callbacks, the fixture applies the existing consumer interceptor chain in the caller through the maintained buffered-consumer helper. Each record has a distinct payload and each replacement removes one byte. Setup verifies every delivered offset and transformed payload in order, plus byte totals and callback counts, detecting misplaced or discarded replacements and broken chaining. Native revisions execute callbacks through batch delivery. The measurement includes buffered fetch setup, traversal and disposal; allocations from the iterator and fetch array are per batch.

Validation: all six updated Dry cases pass on main; 41 selector tests passed for the unchanged mappings. Artifact policy passes. The same updated fixture is being synchronized and validated in #3222. Local Dry runs validate correctness only; this PR does not accept product performance. Raw validation is retained outside Git at `C:/git/Dekaf-evidence/pr-3223/b32d605cc7f20583b3653c736591263cdbcc9eb1`.
