### PR TITLE
benchmarks: cover follower offset recovery on both revisions

### DIFF
--- a/.github/scripts/performance_gate.py
+++ b/.github/scripts/performance_gate.py
@@ -47,7 +47,7 @@ AREAS = (
     # partition dispatcher has its own implementation; unknown files retain the
     # directory-wide fallback below.
     ('src/Dekaf/Consumer/KafkaConsumer.cs', 'consumer', unit(
-        'ConsumerHotPathBenchmarks', 'ConsumerBatchInterceptorBenchmarks', 'FetchResponseParsingBenchmarks', 'FetchRequestBuildBenchmarks',
+        'ConsumerHotPathBenchmarks', 'ConsumerBatchInterceptorBenchmarks', 'ConsumerFollowerOffsetRetryBenchmarks', 'FetchResponseParsingBenchmarks', 'FetchRequestBuildBenchmarks',
         'OffsetStoreBenchmarks', 'ConsumeResultOffsetStoreBenchmarks'), None),
     ('src/Dekaf/Consumer/IKafkaConsumer.cs', 'consumer', unit('ConsumerHotPathBenchmarks', 'ConsumerBatchInterceptorBenchmarks'), None),
     ('src/Dekaf/Consumer/IConsumerInterceptor.cs', 'consumer', unit('ConsumerHotPathBenchmarks', 'ConsumerBatchInterceptorBenchmarks'), None),
@@ -72,7 +72,7 @@ AREAS = (
         'ValueTaskSourcePoolBenchmarks', 'ProduceResponseParsingBenchmarks', 'PartitionQueueAccountingBenchmarks',
         'WaveCoalesceProbeBenchmarks'), None),
     ('src/Dekaf/Consumer/', 'consumer', unit(
-        'ConsumerHotPathBenchmarks', 'ConsumerBatchInterceptorBenchmarks', 'FetchResponseParsingBenchmarks', 'FetchRequestBuildBenchmarks',
+        'ConsumerHotPathBenchmarks', 'ConsumerBatchInterceptorBenchmarks', 'ConsumerFollowerOffsetRetryBenchmarks', 'FetchResponseParsingBenchmarks', 'FetchRequestBuildBenchmarks',
         'OffsetStoreBenchmarks', 'ConsumeResultOffsetStoreBenchmarks',
         'PartitionedDispatchBenchmarks', 'KeyOrderedDispatchBenchmarks'), None),
     ('src/Dekaf/ShareConsumer/', 'share-consumer', unit(
@@ -92,7 +92,7 @@ AREAS = (
         'DescribeTransactionsProtocolBenchmarks', 'OffsetTopicIdProtocolBenchmarks',
         'ConsumerGroupAssignmentBenchmarks'), None),
     ('src/Dekaf/Metadata/', 'metadata', unit(
-        'ControllerMetadataRefreshBenchmarks', 'TopicIdentityCheckBenchmarks', 'ProduceTopicCorrelationBenchmarks',
+        'ControllerMetadataRefreshBenchmarks', 'ConsumerFollowerOffsetRetryBenchmarks', 'TopicIdentityCheckBenchmarks', 'ProduceTopicCorrelationBenchmarks',
         'DnsPreferenceCacheBenchmarks'), None),
     ('src/Dekaf/Retry/', 'retry', unit(
         'ExponentialBackoffRetryPolicyBenchmarks', 'ProducerRetryWaitBenchmarks', 'TransactionRetryClockBenchmarks'), None),

--- a/.github/scripts/test_performance_gate.py
+++ b/.github/scripts/test_performance_gate.py
@@ -110,7 +110,7 @@ class SelectionTests(unittest.TestCase):
 
     def test_kafka_consumer_retains_all_offset_store_api_coverage(self):
         selection = gate.select(['src/Dekaf/Consumer/KafkaConsumer.cs'])
-        self.assertEqual(gate.unit('ConsumerHotPathBenchmarks', 'ConsumerBatchInterceptorBenchmarks', 'FetchResponseParsingBenchmarks',
+        self.assertEqual(gate.unit('ConsumerHotPathBenchmarks', 'ConsumerBatchInterceptorBenchmarks', 'ConsumerFollowerOffsetRetryBenchmarks', 'FetchResponseParsingBenchmarks',
                                    'FetchRequestBuildBenchmarks', 'OffsetStoreBenchmarks',
                                    'ConsumeResultOffsetStoreBenchmarks'), selection['filters'])
         self.assertNotIn('*.Unit.PartitionedDispatchBenchmarks.*', selection['filters'])
@@ -122,6 +122,11 @@ class SelectionTests(unittest.TestCase):
                 self.assertIn(fixture, selection['filters'])
             if path != 'UnknownConsumer.cs':
                 self.assertNotIn('*.Unit.PartitionedDispatchBenchmarks.*', selection['filters'])
+
+    def test_follower_recovery_covers_consumer_and_metadata_paths(self):
+        for path in ('src/Dekaf/Consumer/KafkaConsumer.cs', 'src/Dekaf/Consumer/Unknown.cs',
+                     'src/Dekaf/Metadata/ClusterMetadata.cs'):
+            self.assertIn('*.Unit.ConsumerFollowerOffsetRetryBenchmarks.*', gate.select([path])['filters'])
 
     def test_partition_completion_retains_dispatch_and_tracking_coverage(self):
         selection = gate.select(['src/Dekaf/Consumer/PartitionedProcessing.cs',

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerFollowerOffsetRetryBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerFollowerOffsetRetryBenchmarks.cs
@@ -1,0 +1,223 @@
+using System.Collections.Concurrent;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Benchmarks.Infrastructure;
+using Dekaf.Consumer;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Measures complete fetch-response handling with synchronous, pooled transport responses.</summary>
+[MemoryDiagnoser]
+public class ConsumerFollowerOffsetRetryBenchmarks
+{
+    private const string Topic = "replica-benchmark";
+    private static readonly TopicPartition Partition = new(Topic, 0);
+    private readonly List<TopicPartition> _partitions = [Partition];
+    private KafkaConsumer<byte[], byte[]> _consumer = null!;
+    private BenchmarkConnection _leader = null!;
+    private BenchmarkConnection _follower = null!;
+    private ConcurrentDictionary<TopicPartition, long> _positions = null!;
+    private Action<TopicPartition, long, bool> _setPosition = null!;
+    private Func<int, List<TopicPartition>, int, CancellationToken, ValueTask<List<PendingFetchData>?>> _fetch = null!;
+    private BufferedConsumerHarness.PrefetchResponseHandler _prefetch = null!;
+    private int _epoch;
+    private long _expectedFollowerPosition;
+
+    [Params(false, true)]
+    public bool Prefetch { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _leader = new BenchmarkConnection(1, "leader", 9092);
+        _follower = new BenchmarkConnection(2, "follower", 9093);
+        var pool = new BenchmarkPool(_leader, _follower);
+        var metadata = new MetadataManager(pool, ["localhost:9092"]);
+        metadata.SetApiVersion(ApiKey.Fetch, FetchRequest.LowestSupportedVersion, FetchRequest.HighestSupportedVersion);
+        metadata.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "leader", Port = 9092 },
+                new BrokerMetadata { NodeId = 2, Host = "follower", Port = 9093 }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = Topic,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0, LeaderId = 1, LeaderEpoch = 5,
+                            ReplicaNodes = [1, 2], IsrNodes = [1, 2]
+                        }
+                    ]
+                }
+            ]
+        });
+        _consumer = new KafkaConsumer<byte[], byte[]>(new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"], ClientRack = "rack-a",
+            EnableFetchSessions = false, AutoOffsetReset = AutoOffsetReset.Latest
+        }, Serializers.ByteArray, Serializers.ByteArray, pool, metadata);
+        _consumer.Assign(Partition);
+        var preservesFollowerPosition = BufferedConsumerHarness.BindFollowerFetchHandlers(
+            _consumer, out _fetch, out _prefetch, out _setPosition);
+        _positions = BufferedConsumerHarness.GetFetchPositions(_consumer);
+        _epoch = (int)BufferedConsumerHarness.GetPrivateField(_consumer, "_fetchBufferEpoch")!;
+        // Main resets follower errors to Latest; the fix preserves the requested offset.
+        // Validate each declared contract rather than learning expectations from output.
+        _expectedFollowerPosition = preservesFollowerPosition ? 42 : -1;
+        ValidateScenarios();
+    }
+
+    [Benchmark]
+    public long SuccessfulFetch() => Run(1, ErrorCode.None);
+
+    [Benchmark]
+    public long FollowerError() => Run(2, ErrorCode.OffsetOutOfRange);
+
+    // Measure two response handlers with the same explicit position restoration on
+    // both revisions. This isolates handler cost; it does not measure retry scheduling
+    // or baseline offset lookup after its known incorrect follower reset.
+    [Benchmark]
+    public long FollowerErrorThenLeaderSuccess()
+    {
+        Run(2, ErrorCode.OffsetOutOfRange);
+        _positions[Partition] = 42;
+        _setPosition(Partition, 42, false);
+        Fetch(1);
+        return _positions[Partition];
+    }
+
+    [Benchmark]
+    public long LeaderError() => Run(1, ErrorCode.OffsetOutOfRange);
+
+    [Benchmark]
+    public void ResponsePoolControl() => _leader.CreateResponse().ReturnToPool();
+
+    private long Run(int brokerId, ErrorCode error)
+    {
+        _positions[Partition] = 42;
+        _setPosition(Partition, 42, false);
+        _leader.Error = brokerId == 1 ? error : ErrorCode.None;
+        _follower.Error = brokerId == 2 ? error : ErrorCode.None;
+        Fetch(brokerId);
+        return _positions[Partition];
+    }
+
+    private void Fetch(int brokerId)
+    {
+        if (Prefetch)
+            _prefetch(brokerId, _partitions, 0, 1, 0, _epoch, default).GetAwaiter().GetResult();
+        else
+        {
+            var pending = _fetch(brokerId, _partitions, _epoch, default).GetAwaiter().GetResult();
+            if (pending is not null)
+                throw new InvalidOperationException("The empty-response fixture unexpectedly queued records.");
+        }
+    }
+
+    private void ValidateScenarios()
+    {
+        if (SuccessfulFetch() != 42 || _leader.SendCount != 1 || _follower.SendCount != 0)
+            throw new InvalidOperationException("SuccessfulFetch must request only the leader and preserve the position.");
+        if (FollowerError() != _expectedFollowerPosition || _leader.SendCount != 1 || _follower.SendCount != 1)
+            throw new InvalidOperationException("FollowerError must match the revision's declared position policy without an inline retry.");
+        if (FollowerErrorThenLeaderSuccess() != 42 || _leader.SendCount != 2 || _follower.SendCount != 2
+            || _leader.LastFetchOffset != 42 || _follower.LastFetchOffset != 42)
+            throw new InvalidOperationException("The controlled retry must request the leader at the explicitly restored position.");
+        if (LeaderError() != -1 || _leader.SendCount != 3 || _follower.SendCount != 2)
+            throw new InvalidOperationException("Only the leader error may reset the position to Latest.");
+        _leader.Error = ErrorCode.None;
+        _follower.Error = ErrorCode.None;
+    }
+
+    [GlobalCleanup]
+    public ValueTask Cleanup() => _consumer.DisposeAsync();
+
+    private sealed class BenchmarkConnection(int brokerId, string host, int port) : IKafkaConnection
+    {
+        private readonly FetchResponseTopic[] _topics = new FetchResponseTopic[1];
+        private readonly FetchResponsePartition[] _partitions = new FetchResponsePartition[1];
+        internal ErrorCode Error;
+        internal long SendCount;
+        internal long LastFetchOffset;
+        public int BrokerId => brokerId;
+        public string Host => host;
+        public int Port => port;
+        public bool IsConnected => true;
+
+        internal FetchResponse CreateResponse()
+        {
+            var partition = FetchResponsePartition.Rent();
+            partition.PartitionIndex = 0;
+            partition.ErrorCode = Error;
+            partition.HighWatermark = 42;
+            partition.LastStableOffset = 42;
+            partition.LogStartOffset = 0;
+            _partitions[0] = partition;
+            var topic = FetchResponseTopic.Rent();
+            topic.Topic = Topic;
+            topic.Partitions = _partitions;
+            _topics[0] = topic;
+            var response = FetchResponse.Rent();
+            response.Responses = _topics;
+            return response;
+        }
+
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse
+        {
+            if (request is not FetchRequest fetch)
+                throw new InvalidOperationException("The fixture supports only fetch requests.");
+            SendCount++;
+            LastFetchOffset = fetch.Topics[0].Partitions[0].FetchOffset;
+            return new((TResponse)(object)CreateResponse());
+        }
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => default;
+        public ValueTask DisposeAsync() => default;
+    }
+
+    private sealed class BenchmarkPool(BenchmarkConnection leader, BenchmarkConnection follower) : IConnectionPool
+    {
+        public ValueTask<IKafkaConnection> GetConnectionAsync(int brokerId, CancellationToken cancellationToken = default) => new(GetConnection(brokerId));
+        public ValueTask<IKafkaConnection> GetConnectionByIndexAsync(int brokerId, int index, CancellationToken cancellationToken = default) => new(GetConnection(brokerId));
+        public ValueTask<IKafkaConnection> GetConnectionAsync(string host, int port, CancellationToken cancellationToken = default)
+        {
+            if (host == leader.Host && port == leader.Port)
+                return new(leader);
+            if (host == follower.Host && port == follower.Port)
+                return new(follower);
+            throw new InvalidOperationException("Unexpected broker endpoint.");
+        }
+        private IKafkaConnection GetConnection(int brokerId) => brokerId switch
+        {
+            1 => leader,
+            2 => follower,
+            _ => throw new InvalidOperationException("Unexpected broker ID.")
+        };
+        public void RegisterBroker(int brokerId, string host, int port) { }
+        public ValueTask<int> ScaleConnectionGroupAsync(int brokerId, int newCount, CancellationToken cancellationToken = default) => new(1);
+        public ValueTask<IKafkaConnection?> ShrinkConnectionGroupAsync(int brokerId, int newCount, CancellationToken cancellationToken = default) => new((IKafkaConnection?)null);
+        public ValueTask RemoveConnectionAsync(int brokerId) => default;
+        public ValueTask CloseAllAsync() => default;
+        public ValueTask DisposeAsync() => default;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Infrastructure/BufferedConsumerHarness.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/BufferedConsumerHarness.cs
@@ -23,6 +23,28 @@ namespace Dekaf.Benchmarks.Infrastructure;
 /// </remarks>
 internal static class BufferedConsumerHarness
 {
+    public delegate ValueTask PrefetchResponseHandler(int brokerId, List<TopicPartition> partitions,
+        int startIndex, int count, int connectionIndex, int epoch, CancellationToken cancellationToken);
+
+    // Setup-only bindings for both follower-error handlers. The returned capability
+    // selects the declared correctness expectation, never the measured workload.
+    public static bool BindFollowerFetchHandlers<TKey, TValue>(KafkaConsumer<TKey, TValue> consumer,
+        out Func<int, List<TopicPartition>, int, CancellationToken, ValueTask<List<PendingFetchData>?>> fetch,
+        out PrefetchResponseHandler prefetch,
+        out Action<TopicPartition, long, bool> setPosition)
+    {
+        var consumerType = consumer.GetType();
+        MethodInfo RequireMethod(string name) => consumerType.GetMethod(name,
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"{name} method not found.");
+        fetch = RequireMethod("FetchFromBrokerAsync")
+            .CreateDelegate<Func<int, List<TopicPartition>, int, CancellationToken, ValueTask<List<PendingFetchData>?>>>(consumer);
+        prefetch = RequireMethod("PrefetchFromBrokerAsync").CreateDelegate<PrefetchResponseHandler>(consumer);
+        setPosition = RequireMethod("SetPosition").CreateDelegate<Action<TopicPartition, long, bool>>(consumer);
+        return consumerType.GetMethod("HandleFetchOffsetOutOfRangeAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic) is not null;
+    }
+
     /// <summary>
     /// Adapts revisions that omit batch callbacks by binding their existing interceptor
     /// chain for the caller to execute. Native revisions return null. Call only in setup,
@@ -130,11 +152,11 @@ internal static class BufferedConsumerHarness
         KafkaConsumer<TKey, TValue> consumer)
         => (Queue<PendingFetchData>)GetPrivateField(consumer, "_pendingFetches")!;
 
-    private static ConcurrentDictionary<TopicPartition, long> GetFetchPositions<TKey, TValue>(
+    public static ConcurrentDictionary<TopicPartition, long> GetFetchPositions<TKey, TValue>(
         KafkaConsumer<TKey, TValue> consumer)
         => (ConcurrentDictionary<TopicPartition, long>)GetPrivateField(consumer, "_fetchPositions")!;
 
-    private static object? GetPrivateField<TKey, TValue>(
+    public static object? GetPrivateField<TKey, TValue>(
         KafkaConsumer<TKey, TValue> consumer,
         string fieldName)
         => RequireField<TKey, TValue>(fieldName).GetValue(consumer);


### PR DESCRIPTION
Adds the standard-project fixture needed to compare #3086 against main. Ten BenchmarkDotNet cases cover normal fetch, follower and leader errors, a controlled two-response sequence, and pooled-response control through both fetch handlers. The existing BufferedConsumerHarness owns setup-only private bindings; path selection covers consumer and metadata changes.

The baseline incorrectly resets a follower error to Latest; the candidate preserves offset 42. Setup validates those declared contracts explicitly. The two-response case restores offset 42 on both revisions before the leader handler, so it measures identical handler work and does not claim to measure actual retry scheduling or the baseline's offset lookup. Loaded recovery evidence remains separate.

Validation: all ten Dry cases pass on baseline and #3086 with identical fixture/helper source; 42 selector tests pass; full-tree artifact policy passes. Original local exports and binaries are retained outside Git. No product performance PASS is claimed. This PR contains only fixture/helper source and selector changes.