### PR TITLE
fix(hosting): start share acquisition clock at response receipt

### DIFF
--- a/docs/docs/hosted-services.md
+++ b/docs/docs/hosted-services.md
@@ -421,8 +421,11 @@ in the background.
 
 Renewal requires broker support for **ShareFetch/ShareAcknowledge v2**. On older brokers a required
 renewal fails, cancels processing, and leaves the record for redelivery. Long synchronous handlers
-must yield to permit renewal. The built-in consumer supplies a conservative fetch-start timestamp;
-if its known acquisition deadline has elapsed, the service refuses to process or accept that record.
+must yield to permit renewal. The built-in consumer timestamps each broker response when received,
+so fetch waiting does not consume a newly delivered record's local processing budget. Records retain
+that timestamp while waiting for other brokers, deserialization, or earlier handlers. If the local
+acquisition deadline has elapsed, the service refuses to process or accept that record. The broker
+remains authoritative: response transit time and process pauses can make a lock expire sooner.
 Renewal extends only the current record's lock. Other records acquired in the same batch may expire
 while a slow record is processed. Broker failures, lock expiry, and process pauses can all cause
 redelivery; make application effects idempotent. For tightly limited acquisition on v2 brokers,

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Hosting.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Hosting.cs
@@ -5,6 +5,9 @@ namespace Dekaf.ShareConsumer;
 internal sealed partial class KafkaShareConsumer<TKey, TValue>
 {
     private long _acquisitionStartedTimestamp;
+    // Only hosted renewal buffering needs this map. Reuse one timestamp per partition
+    // without adding a timestamp field or another allocation to every delivered record.
+    private Dictionary<TopicPartition, long>? _bufferedAcquisitionTimestamps;
     private bool _hostedProcessing;
     long IHostedShareConsumer.AcquisitionStartedTimestamp => _acquisitionStartedTimestamp;
 

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -310,7 +310,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 continue;
             }
 
-            _acquisitionStartedTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
+            _bufferedAcquisitionTimestamps?.Clear();
             _rawRecords?.Clear();
             // All readable slices belong to the new poll; overwrite payload bytes as needed.
             _rawBuffer?.ResetWrittenCount();
@@ -358,6 +358,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             List<ShareConsumeResult<TKey, TValue>>? fetchedRecords = _renewedRecords is null
                 ? null
                 : new List<ShareConsumeResult<TKey, TValue>>(_options.MaxPollRecords);
+            if (fetchedRecords is not null && _hostedProcessing)
+                _bufferedAcquisitionTimestamps ??= [];
             Exception? firstFetchError = null;
             Dictionary<TopicPartition, Exception>? acknowledgementErrors = null;
             if (pendingAcks is not null && sentAcknowledgementPartitionCount != pendingAcks.Count)
@@ -374,7 +376,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
 
             foreach (var fetchTask in fetchTasks)
             {
-                var (brokerId, version, response, sentAcks, error, acknowledgementError) = fetchTask.Result;
+                var fetchResult = await fetchTask.ConfigureAwait(false);
+                var (brokerId, version, response, sentAcks, error, acknowledgementError) = fetchResult;
 
                 if (error is not null)
                 {
@@ -432,7 +435,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                         acknowledgementFailures,
                         out var successfulAcknowledgements,
                         out var failedAcknowledgements);
-                    ApplySuccessfulAcknowledgements(successfulAcknowledgements);
+                    ApplySuccessfulAcknowledgements(successfulAcknowledgements, fetchResult.ReceivedTimestamp);
                     RequeueAcknowledgements(failedAcknowledgements);
                     AddAcknowledgementErrors(
                         ref acknowledgementErrors,
@@ -441,7 +444,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 }
                 else
                 {
-                    ApplySuccessfulAcknowledgements(sentAcks);
+                    ApplySuccessfulAcknowledgements(sentAcks, fetchResult.ReceivedTimestamp);
                 }
             }
 
@@ -454,7 +457,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             // is per poll, not per message, and avoids buffering records when no renewal is active.
             foreach (var fetchTask in fetchTasks)
             {
-                var (_, _, response, _, _, _) = fetchTask.Result;
+                var fetchResult = await fetchTask.ConfigureAwait(false);
+                var response = fetchResult.Response;
                 if (response is null || response.ErrorCode != ErrorCode.None)
                     continue;
 
@@ -543,6 +547,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                         }
 
                         var tp = new TopicPartition(topicInfo.Name, partition.PartitionIndex);
+                        if (fetchedRecords is not null && _hostedProcessing)
+                            _bufferedAcquisitionTimestamps![tp] = fetchResult.ReceivedTimestamp;
 
                         foreach (var result in parsed)
                         {
@@ -565,6 +571,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                             }
 
                             recordCount++;
+                            _acquisitionStartedTimestamp = fetchResult.ReceivedTimestamp;
                             yield return result;
                         }
                     }
@@ -580,6 +587,15 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     _options.MaxPollRecords - recordCount - bufferedRecordCount);
                 foreach (var renewedRecord in renewedRecords)
                 {
+                    if (_hostedProcessing)
+                    {
+                        // A previous handler can finish another record from this replay snapshot.
+                        if (_renewedRecords is null || !_renewedRecords.TryGetValue(
+                                new RenewedRecordKey(renewedRecord.Topic, renewedRecord.Partition, renewedRecord.Offset),
+                                out var state) || !state.Active)
+                            continue;
+                        _acquisitionStartedTimestamp = state.ReceiptTimestamp;
+                    }
                     Interlocked.Increment(ref _renewedRecordReplayCount);
                     recordCount++;
                     yield return renewedRecord;
@@ -600,6 +616,9 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     }
 
                     recordCount++;
+                    if (_hostedProcessing)
+                        _acquisitionStartedTimestamp = _bufferedAcquisitionTimestamps![
+                            new TopicPartition(fetchedRecord.Topic, fetchedRecord.Partition)];
                     yield return fetchedRecord;
                 }
             }
@@ -819,6 +838,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
 
         _rawRecords = null;
         _rawBuffer = null;
+        _bufferedAcquisitionTimestamps = null;
         _initLock.Dispose();
     }
 
@@ -942,6 +962,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 var response = (ShareFetchResponse)await connection
                     .SendAsync<ShareFetchRequest, ShareFetchResponse>(request, version, cancellationToken)
                     .ConfigureAwait(false);
+                var receivedTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
 
                 if (attempt < RetryHelper.MaxRetries && response.ErrorCode.IsRetriable())
                 {
@@ -961,7 +982,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     continue;
                 }
 
-                return new ShareFetchBrokerResult(brokerId, version, response, brokerAcks, null, null);
+                return new ShareFetchBrokerResult(brokerId, version, response, brokerAcks, null, null)
+                {
+                    ReceivedTimestamp = receivedTimestamp
+                };
             }
             catch (Exception ex) when (ex is OperationCanceledException or BrokerVersionException)
             {
@@ -1105,6 +1129,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     .SendAsync<ShareAcknowledgeRequest, ShareAcknowledgeResponse>(
                         request, shareAckVersion, cancellationToken)
                     .ConfigureAwait(false);
+                var receivedTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
 
                 if (response.ErrorCode != ErrorCode.None)
                 {
@@ -1132,6 +1157,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     pendingAcknowledgements);
                 if (acknowledgementFailures is null)
                 {
+                    RecordRenewalReceipt(pendingAcknowledgements, receivedTimestamp);
                     MergeAcknowledgements(ref successfulAcknowledgements, pendingAcknowledgements);
                     return new AcknowledgeBrokerResult(
                         successfulAcknowledgements,
@@ -1145,6 +1171,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     acknowledgementFailures,
                     out var successfulThisAttempt,
                     out var failedThisAttempt);
+                RecordRenewalReceipt(successfulThisAttempt, receivedTimestamp);
                 MergeAcknowledgements(ref successfulAcknowledgements, successfulThisAttempt);
 
                 SplitRetriableAcknowledgements(
@@ -2074,7 +2101,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     }
 
     private void ApplySuccessfulAcknowledgements(
-        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? acknowledgements)
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? acknowledgements,
+        long receivedTimestamp = 0)
     {
         if (_renewedRecords is null || acknowledgements is null)
             return;
@@ -2093,7 +2121,11 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     if (type == AcknowledgeType.Renew)
                     {
                         if (_renewedRecords.TryGetValue(key, out var state))
+                        {
+                            if (receivedTimestamp != 0)
+                                state.ReceiptTimestamp = receivedTimestamp;
                             state.Active = true;
+                        }
                     }
                     else
                     {
@@ -2105,6 +2137,23 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
 
         if (_renewedRecords.Count == 0)
             _renewedRecords = null;
+    }
+
+    private void RecordRenewalReceipt(
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? acknowledgements, long receivedTimestamp)
+    {
+        if (!_hostedProcessing || _renewedRecords is null || acknowledgements is null)
+            return;
+
+        // Broker tasks only read the dictionary and update their own records. Activation and
+        // dictionary mutation remain after Task.WhenAll. Retried partitions keep distinct times.
+        foreach (var (partition, batches) in acknowledgements)
+            foreach (var batch in batches)
+                for (var index = 0; index < batch.AcknowledgeTypes.Length; index++)
+                    if (batch.AcknowledgeTypes[index] == (byte)AcknowledgeType.Renew
+                        && _renewedRecords.TryGetValue(new RenewedRecordKey(
+                            partition.Topic, partition.Partition, batch.FirstOffset + index), out var state))
+                        state.ReceiptTimestamp = -receivedTimestamp;
     }
 
     private List<ShareConsumeResult<TKey, TValue>> GetActiveRenewedRecords(
@@ -2293,7 +2342,14 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     private sealed class RenewedRecordState(ShareConsumeResult<TKey, TValue> record)
     {
         internal ShareConsumeResult<TKey, TValue> Record { get; set; } = record;
-        internal bool Active { get; set; }
+        // The sign stores pending/active state in the timestamp, replacing the bool and its
+        // padding instead of adding another per-record field. Zero means no confirmed renewal.
+        internal long ReceiptTimestamp { get; set; }
+        internal bool Active
+        {
+            get => ReceiptTimestamp > 0;
+            set => ReceiptTimestamp = value ? Math.Max(1, Math.Abs(ReceiptTimestamp)) : 0;
+        }
     }
 
     private sealed class AcknowledgementFailures(
@@ -2337,7 +2393,12 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         ShareFetchResponse? Response,
         Dictionary<TopicPartition, List<AcknowledgementBatchData>>? SentAcknowledgements,
         Exception? Error,
-        Exception? AcknowledgementError);
+        Exception? AcknowledgementError)
+    {
+        // Capture before awaiting other brokers or preparing deserializers. Every record in
+        // this response shares the same local receipt time, including records buffered for yield.
+        public long ReceivedTimestamp { get; init; }
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ThrowIfNotInitialized()

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -130,6 +130,52 @@ public sealed class ShareConsumerRenewalTests
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Poll_AcquisitionTimestamp_UsesEachBrokerResponseAndSurvivesBuffering(bool bufferRecords)
+    {
+        var received = new long[2];
+        var first = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = CreateFetchResponse(partition: 0, offset: 42, recordCount: 2),
+            OnSend = () => received[0] = System.Diagnostics.Stopwatch.GetTimestamp()
+        };
+        var second = new CapturingConnection(ApiKey.ShareFetch, 2, brokerId: 2)
+        {
+            ShareFetchResponse = CreateFetchResponse(partition: 1, offset: 100),
+            OnSend = () => received[1] = System.Diagnostics.Stopwatch.GetTimestamp()
+        };
+        await using var fixture = CreateFixture(first, secondConnection: second);
+        var hosted = (IHostedShareConsumer)fixture.Consumer;
+        hosted.ObserveAcknowledgements(static _ => { });
+        PrepareForPoll(fixture.Consumer, new TopicPartition("topic", 0), new TopicPartition("topic", 1));
+        fixture.Consumer.Subscribe("topic");
+        if (bufferRecords)
+        {
+            fixture.Consumer.Acknowledge(CreateRecord(), AcknowledgeType.Renew);
+            FlushPendingAcknowledgements(fixture.Consumer);
+            ApplySuccessfulAcknowledgements(fixture.Consumer, RenewalAcknowledgements());
+        }
+
+        await using var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator();
+        var timestamps = new Dictionary<int, long>();
+        for (var index = 0; index < 3; index++)
+        {
+            await Assert.That(await poll.MoveNextAsync()).IsTrue();
+            var timestamp = hosted.AcquisitionStartedTimestamp;
+            var responseBoundary = received[poll.Current.Partition];
+            await Assert.That(timestamp).IsGreaterThanOrEqualTo(responseBoundary);
+            var lastResponseBoundary = Math.Max(received[0], received[1]);
+            if (responseBoundary < lastResponseBoundary)
+                await Assert.That(timestamp).IsLessThan(lastResponseBoundary);
+            if (timestamps.TryGetValue(poll.Current.Partition, out var earlierRecordTimestamp))
+                await Assert.That(timestamp).IsEqualTo(earlierRecordTimestamp);
+            timestamps[poll.Current.Partition] = timestamp;
+        }
+        await Assert.That(timestamps.Count).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task Poll_RenewalSuccess_ReplaysRecordAndPublishesLockTimeout()
     {
         var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
@@ -144,10 +190,13 @@ public sealed class ShareConsumerRenewalTests
         };
         await using var fixture = CreateFixture(connection);
         var record = CreateRecord();
+        var hosted = (IHostedShareConsumer)fixture.Consumer;
+        hosted.ObserveAcknowledgements(static _ => { });
         PrepareForPoll(fixture.Consumer);
         fixture.Consumer.Subscribe("topic");
         fixture.Consumer.Acknowledge(record, AcknowledgeType.Renew);
 
+        var beforePoll = System.Diagnostics.Stopwatch.GetTimestamp();
         await using var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator();
         var moved = await poll.MoveNextAsync();
 
@@ -155,6 +204,7 @@ public sealed class ShareConsumerRenewalTests
         await Assert.That(ReferenceEquals(poll.Current, record)).IsTrue();
         await Assert.That(fixture.Consumer.AcquisitionLockTimeoutMs).IsEqualTo(30_000);
         await Assert.That(fixture.Consumer.RenewedRecordReplayCount).IsEqualTo(1);
+        await Assert.That(hosted.AcquisitionStartedTimestamp).IsGreaterThanOrEqualTo(beforePoll);
     }
 
     [Test]
@@ -178,6 +228,70 @@ public sealed class ShareConsumerRenewalTests
         await Assert.That(poll.Current.Offset).IsEqualTo(100);
         var assignment = new HashSet<TopicPartition> { new("topic", 0) };
         await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment)).HasSingleItem();
+    }
+
+    [Test]
+    public async Task Commit_RenewalRetry_PreservesEachSuccessfulResponseTimeForReplay()
+    {
+        var received = new List<long>();
+        CapturingConnection connection = null!;
+        connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2, supportShareFetch: true)
+        {
+            ShareAcknowledgeResponses = new Queue<ShareAcknowledgeResponse>(
+            [
+                CreateAcknowledgeResponse((0, ErrorCode.None), (1, ErrorCode.NotLeaderOrFollower)),
+                CreateAcknowledgeResponse((1, ErrorCode.None))
+            ]),
+            OnSend = () =>
+            {
+                if (connection.ShareAcknowledgeRequests.Count > received.Count)
+                    received.Add(System.Diagnostics.Stopwatch.GetTimestamp());
+            }
+        };
+        await using var fixture = CreateFixture(connection);
+        var hosted = (IHostedShareConsumer)fixture.Consumer;
+        hosted.ObserveAcknowledgements(static _ => { });
+        PrepareForPoll(fixture.Consumer, new TopicPartition("topic", 0), new TopicPartition("topic", 1));
+        fixture.Consumer.Subscribe("topic");
+        fixture.Consumer.Acknowledge(CreateRecord(partition: 0, offset: 40), AcknowledgeType.Renew);
+        fixture.Consumer.Acknowledge(CreateRecord(partition: 1, offset: 41), AcknowledgeType.Renew);
+
+        await fixture.Consumer.CommitAsync();
+        var beforeReplay = System.Diagnostics.Stopwatch.GetTimestamp();
+        await Assert.That(received.Count).IsEqualTo(2);
+        await using var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator();
+        for (var index = 0; index < 2; index++)
+        {
+            await Assert.That(await poll.MoveNextAsync()).IsTrue();
+            var partition = poll.Current.Partition;
+            await Assert.That(hosted.AcquisitionStartedTimestamp).IsGreaterThanOrEqualTo(received[partition]);
+            await Assert.That(hosted.AcquisitionStartedTimestamp).IsLessThanOrEqualTo(beforeReplay);
+            if (partition == 0)
+                await Assert.That(hosted.AcquisitionStartedTimestamp).IsLessThan(received[1]);
+        }
+    }
+
+    [Test]
+    public async Task Poll_TerminalDispositionSkipsRemainingRenewedSnapshot()
+    {
+        await using var fixture = CreateFixture(new CapturingConnection(ApiKey.ShareFetch, 2));
+        var hosted = (IHostedShareConsumer)fixture.Consumer;
+        hosted.ObserveAcknowledgements(static _ => { });
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        var first = CreateRecord(offset: 42);
+        var second = CreateRecord(offset: 43);
+        fixture.Consumer.Acknowledge(first, AcknowledgeType.Renew);
+        fixture.Consumer.Acknowledge(second, AcknowledgeType.Renew);
+        using var cancellation = new CancellationTokenSource();
+        await using var poll = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        await Assert.That(await poll.MoveNextAsync()).IsTrue();
+
+        fixture.Consumer.Acknowledge(first, AcknowledgeType.Accept);
+        fixture.Consumer.Acknowledge(second, AcknowledgeType.Accept);
+        await cancellation.CancelAsync();
+
+        await Assert.That(await poll.MoveNextAsync()).IsFalse();
     }
 
     [Test]
@@ -1221,7 +1335,7 @@ public sealed class ShareConsumerRenewalTests
     private static void ApplySuccessfulAcknowledgements(
         KafkaShareConsumer<string, string> consumer,
         Dictionary<TopicPartition, List<AcknowledgementBatchData>> acknowledgements)
-        => InvokePrivate(consumer, "ApplySuccessfulAcknowledgements", acknowledgements);
+        => InvokePrivate(consumer, "ApplySuccessfulAcknowledgements", acknowledgements, System.Diagnostics.Stopwatch.GetTimestamp());
 
     private static List<ShareConsumeResult<string, string>> GetActiveRenewedRecords(
         KafkaShareConsumer<string, string> consumer,
@@ -1337,7 +1451,8 @@ public sealed class ShareConsumerRenewalTests
     private sealed class CapturingConnection(
         ApiKey apiKey,
         short maximumVersion,
-        int brokerId = 1) :
+        int brokerId = 1,
+        bool supportShareFetch = false) :
         IKafkaConnection,
         IKafkaCapabilityProvider
     {
@@ -1352,6 +1467,7 @@ public sealed class ShareConsumerRenewalTests
                 ApiKeys =
                 [
                     new ApiVersion(apiKey, 0, maximumVersion),
+                    .. supportShareFetch ? new[] { new ApiVersion(ApiKey.ShareFetch, 0, 2) } : [],
                     new ApiVersion(
                         ApiKey.Metadata,
                         MetadataRequest.LowestSupportedVersion,

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerRenewalBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerRenewalBenchmarks.cs
@@ -9,6 +9,10 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 5)]
 public class ShareConsumerRenewalBenchmarks
 {
+    [Params(false, true)]
+    public bool Hosted { get; set; }
+
+    private Action<string, int, long> _removeRenewedRecord = null!;
     private readonly KafkaShareConsumer<string, string> _consumer = new(
         new ShareConsumerOptions
         {
@@ -29,9 +33,30 @@ public class ShareConsumerRenewalBenchmarks
     };
 
     [GlobalSetup]
-    public void Setup() => _consumer.Acknowledge(_record, AcknowledgeType.Renew);
+    public void Setup()
+    {
+        if (Hosted)
+            ((IHostedShareConsumer)_consumer).ObserveAcknowledgements(static _ => { });
+        _consumer.Acknowledge(_record, AcknowledgeType.Renew);
+        // Keep the dictionary allocated while cycling one record's renewal state.
+        _consumer.Acknowledge(new ShareConsumeResult<string, string>
+        {
+            Topic = _record.Topic, Partition = _record.Partition, Offset = 43, Value = "sentinel", DeliveryCount = 1
+        }, AcknowledgeType.Renew);
+        _removeRenewedRecord = typeof(KafkaShareConsumer<string, string>)
+            .GetMethod("RemoveRenewedRecord", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .CreateDelegate<Action<string, int, long>>(_consumer);
+    }
 
     [Benchmark]
     public void AcknowledgeExistingRenewal()
         => _consumer.Acknowledge(_record, AcknowledgeType.Renew);
+
+    // Includes the existing per-renewed-record state allocation; dictionary capacity is steady-state.
+    [Benchmark]
+    public void CreateRenewalState()
+    {
+        _removeRenewedRecord(_record.Topic, _record.Partition, _record.Offset);
+        _consumer.Acknowledge(_record, AcknowledgeType.Renew);
+    }
 }


### PR DESCRIPTION
Hosted share consumers previously started their acquisition clock before waiting for ShareFetch, so a slow fetch could exhaust the local processing budget before a handler ran. Capture each successful broker response's receipt timestamp and preserve it across direct delivery, buffered delivery and renewed-record replay.

Successful renewals keep their own receipt time, including when other partitions retry. Replay skips records that an earlier handler has already terminally acknowledged. The existing renewal-state object stores its timestamp and activation state in one field; local BenchmarkDotNet diagnostics confirm the existing 32 B state allocation remains unchanged on x64, with 0 B for repeated renewal acknowledgements.

Validation: 78 focused share-renewal/hosting unit tests pass on each of net8.0 and net10.0, and all six hosted-share Kafka integration cases pass. Regression coverage includes replay with no newly fetched records, partial renewal retries, terminal disposition during replay, separate broker responses and buffering. Local benchmark diagnostics are not performance acceptance; the current-head hosted gate and applicable loaded evidence remain required.

Follow-up to #3224 addressing the acquisition-timing review.

The existing ShareConsumerRenewalBenchmarks fixture now covers hosted/non-hosted repeated acknowledgement and renewal-state creation (four cases). It is byte-identical to the locally measured fixture and builds through the standard benchmark project; the automatic gate selects it from this PR.
