### PR TITLE
fix(stress): warm consumer replay before measurement

### DIFF
--- a/.github/scripts/stress_timeout.py
+++ b/.github/scripts/stress_timeout.py
@@ -1,4 +1,4 @@
-"""Budget selected producer samples, including warmup and bounded drains."""
+"""Budget selected stress samples, including workload warmup and bounded drains."""
 
 import argparse
 import json
@@ -7,7 +7,7 @@ import math
 
 def budget(matrix, duration_minutes, warmup_seconds, adaptive_connections=False):
     if not math.isfinite(duration_minutes) or duration_minutes <= 0 or warmup_seconds < 20:
-        raise ValueError("Duration must be positive and producer warmup must be at least 20 seconds")
+        raise ValueError("Duration must be positive and workload warmup must be at least 20 seconds")
     # Six warmup drains plus the measured drain, each with the existing 30s ceiling.
     drain_minutes = 7 * 30 / 60
     warmup_minutes = warmup_seconds / 60
@@ -27,6 +27,11 @@ def budget(matrix, duration_minutes, warmup_seconds, adaptive_connections=False)
             segments += int(lane.get("run_adaptive", False) and not adaptive_connections)
             lane["producer_samples"] = segments
             validation = 0
+        elif str(lane.get("scenario", "")).startswith("consumer"):
+            segments = lane.get("paired_samples", 1) * (2 if lane.get("client") == "all" else 1)
+            # The existing workflow field gates validation and its expected result count.
+            lane["producer_samples"] = segments
+            validation = 0
         else:
             continue
         required = math.ceil(
@@ -35,7 +40,7 @@ def budget(matrix, duration_minutes, warmup_seconds, adaptive_connections=False)
         )
         lane["timeout_minutes"] = max(lane["timeout_minutes"], required)
         if lane["timeout_minutes"] > 360:
-            raise ValueError("Requested producer run exceeds the 360-minute hosted job limit; reduce duration or warmup")
+            raise ValueError("Requested stress run exceeds the 360-minute hosted job limit; reduce duration or warmup")
     return matrix
 
 

--- a/.github/scripts/stress_warmup.py
+++ b/.github/scripts/stress_warmup.py
@@ -1,6 +1,6 @@
 """Validate runtime coverage and assess steady-state trends for stress comparison segments.
 
-Coverage checks confirm that every phase retained its warmup (duration-based producers), its
+Coverage checks confirm that every phase retained its warmup (duration-based producers and consumer replay), its
 runtime observations at both measurement boundaries and one-second interval samples across
 the whole measured window. The trend assessment then compares the first and last third of
 the measured intervals: throughput, CPU per completed message, allocations per message and
@@ -64,11 +64,6 @@ def quiet(samples, label):
             raise ValueError(f"{label}: thread-pool size changes; steady state is not established")
 
 
-def _requires_warmup(result):
-    scenario = str(result.get("scenario") or "producer").casefold()
-    return not scenario.startswith("consumer")
-
-
 def _validate_warmup(warmup):
     requested = number(warmup.get("requestedSeconds"), "warmup requestedSeconds")
     workload = number(warmup.get("workloadSeconds"), "warmup workloadSeconds")
@@ -98,13 +93,9 @@ def _validate_warmup(warmup):
 
 
 def validate(result):
-    """Validate runtime coverage. Returns the declared warmup seconds (None for consumer replay)."""
+    """Validate runtime coverage and return the declared workload warmup seconds."""
     throughput = object_value(result.get("throughput"), "throughput")
-    warmup = throughput.get("warmup")
-    if warmup is None and not _requires_warmup(result):
-        requested = None
-    else:
-        requested = _validate_warmup(object_value(warmup, "warmup"))
+    requested = _validate_warmup(object_value(throughput.get("warmup"), "warmup"))
 
     start = runtime(throughput.get("runtimeStart"))
     end = runtime(throughput.get("runtimeEnd"))

--- a/.github/scripts/test_stress_timeout.py
+++ b/.github/scripts/test_stress_timeout.py
@@ -26,10 +26,23 @@ class StressTimeoutTests(unittest.TestCase):
         self.assertEqual(52, actual["timeout_minutes"])
 
     def test_other_scenarios_keep_their_own_budget(self):
-        for scenario in ("consumer", "producer-transactional", "producer-roundtrip-steady"):
+        for scenario in ("producer-transactional", "producer-roundtrip-steady"):
             lane = dict(scenario=scenario, timeout_minutes=90)
             expected = lane.copy()
             self.assertEqual(expected, budget({"include": [lane]}, 30, 180)["include"][0])
+
+    def test_consumer_samples_include_declared_warmup(self):
+        for scenario, client, paired, count in (
+            ("consumer", "all", 2, 4), ("consumer-batch", "dekaf", 1, 1),
+            ("consumer-raw", "dekaf", 1, 1), ("consumer-raw-batch", "dekaf", 1, 1),
+        ):
+            with self.subTest(scenario=scenario):
+                lane = dict(scenario=scenario, client=client, paired_samples=paired, timeout_minutes=60)
+                actual = budget({"include": [lane]}, 15, 3600)["include"][0]
+                self.assertGreaterEqual(actual["timeout_minutes"], count * 78.5 + 15)
+                self.assertEqual(count, actual["producer_samples"])
+        with self.assertRaisesRegex(ValueError, "360-minute"):
+            budget({"include": [dict(scenario="consumer", client="all", timeout_minutes=90)]}, 15, 999999)
 
     def test_regular_producer_cannot_exceed_hosted_limit(self):
         lane = dict(scenario="producer", client="all", paired_samples=2, timeout_minutes=180)

--- a/.github/scripts/test_stress_warmup.py
+++ b/.github/scripts/test_stress_warmup.py
@@ -37,9 +37,7 @@ def result(scenario=None, intervals=INTERVALS):
 
 
 def consumer_result():
-    data = result(scenario="consumer")
-    del data["throughput"]["warmup"]
-    return data
+    return result(scenario="consumer")
 
 
 def write(root, *results, name="stress-test-results.json"):
@@ -124,9 +122,9 @@ class StressWarmupTests(unittest.TestCase):
             sample["runtime"]["allocatedBytes"] = 1000 + index * 100 + (index // 20) * 500
         self.assertEqual([], assess_trends(candidate)["findings"])
 
-    def test_consumer_replay_segments_need_no_producer_warmup(self):
+    def test_consumer_replay_segments_validate_workload_warmup(self):
         candidate = consumer_result()
-        self.assertIsNone(validate(candidate))
+        self.assertEqual(20, validate(candidate))
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             write(root, candidate)
@@ -134,8 +132,9 @@ class StressWarmupTests(unittest.TestCase):
             self.assertEqual(0, code)
             self.assertEqual("VALIDATED", report["verdict"])
 
-    def test_producer_segments_without_warmup_are_rejected(self):
-        for scenario in (None, "producer", "producer-idempotent"):
+    def test_segments_without_warmup_are_rejected(self):
+        for scenario in (None, "producer", "producer-idempotent", "consumer", "consumer-batch",
+                         "consumer-raw", "consumer-raw-batch"):
             with self.subTest(scenario=scenario):
                 candidate = result(scenario=scenario)
                 del candidate["throughput"]["warmup"]

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -35,7 +35,7 @@ on:
         required: false
         default: '15'
       producer_warmup_seconds:
-        description: 'Identical elapsed workload warmup for duration-based producers (minimum 20 seconds; no adaptive extension)'
+        description: 'Identical elapsed workload warmup for producers and consumer replay (minimum 20 seconds; no adaptive extension)'
         required: false
         default: '180'
       message_size:
@@ -78,7 +78,7 @@ on:
         type: boolean
         default: false
       baseline_sha:
-        description: 'Duration-based producer lanes only: exact SHA for baseline → candidate → baseline; triples duration and blocks on regression/noisy controls'
+        description: 'Duration-based producer and consumer replay lanes: exact SHA for baseline → candidate → baseline; triples duration and blocks on regression/noisy controls'
         required: false
         default: ''
       aba_second_candidate:
@@ -741,7 +741,7 @@ jobs:
             aba-results/baseline-a tools/Dekaf.StressTests/results aba-results/baseline-a2 "${extra[@]}" \
             --output aba-results/warmup-validation.json --summary "$GITHUB_STEP_SUMMARY"
 
-      - name: Validate regular producer warmup and runtime coverage
+      - name: Validate regular workload warmup and runtime coverage
         if: always() && matrix.baseline_sha == '' && matrix.producer_samples > 0
         run: |
           python3 .github/scripts/stress_warmup.py tools/Dekaf.StressTests/results \

--- a/tests/Dekaf.Tests.Unit/StressTests/ConsumerWarmupTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConsumerWarmupTests.cs
@@ -1,0 +1,45 @@
+using Dekaf.StressTests.Diagnostics;
+using Dekaf.StressTests.Scenarios;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class ConsumerWarmupTests
+{
+    [Test]
+    [Arguments(false, false)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    public async Task IncompleteFailedOrCancelledReplay_DoesNotStartMeasurement(bool fail, bool cancel)
+    {
+        var directory = Path.Join(Path.GetTempPath(), "dekaf-consumer-warmup-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            using var watchdog = new ProgressWatchdog(directory);
+            var options = new StressTestOptions
+            {
+                BootstrapServers = "unused:9092", Topic = "test", DurationMinutes = 1,
+                MessageSizeBytes = 1000, ProducerWarmupSeconds = 20, ProgressWatchdog = watchdog
+            };
+            var cycles = 0;
+            using var cancellation = new CancellationTokenSource();
+            async Task RunAsync() => await StressTestHelpers.RunConsumerAsync(options,
+                new ConsumerBatchStressTest(), (throughput, _) =>
+                {
+                    cycles++;
+                    throughput.RecordMessage(1000);
+                    if (cancel) cancellation.Cancel();
+                    return fail ? Task.FromException(new InvalidOperationException("replay failed")) : Task.CompletedTask;
+                }, connectionsPerBroker: 3, cancellationToken: cancellation.Token);
+            if (cancel)
+                await Assert.That(RunAsync).Throws<OperationCanceledException>();
+            else
+                await Assert.That(RunAsync).Throws<InvalidOperationException>();
+            await Assert.That(cycles).IsEqualTo(1);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -1097,7 +1097,7 @@ public static class Program
 
             Options:
               --duration <minutes>    Test duration in minutes (default: 15)
-              --producer-warmup-seconds <n>  Duration-based producer workload warmup (default: {ProducerWarmup.DefaultSeconds}; minimum: {ProducerWarmup.MinimumSeconds})
+              --producer-warmup-seconds <n>  Producer and consumer replay workload warmup (default: {ProducerWarmup.DefaultSeconds}; minimum: {ProducerWarmup.MinimumSeconds})
               --message-size <bytes>  Message size in bytes (default: 1000)
               --scenario <name>       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip-steady, consumer, consumer-batch, consumer-raw, consumer-raw-batch, soak, all (default: all; all excludes soak)
               --client <name>         Run specific client: dekaf, confluent, all (default: all)

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
@@ -11,9 +11,6 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
 
     public async Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
     {
-        var throughput = new ThroughputTracker();
-        var startedAt = DateTime.UtcNow;
-
         var consumerConfig = new ConfluentKafka.ConsumerConfig
         {
             BootstrapServers = options.BootstrapServers,
@@ -57,90 +54,37 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
 
         Console.WriteLine($"  Consuming pre-seeded topic in a loop ({endOffsets.Sum():N0} messages per pass)");
 
-        // GC baseline before consumer measurement
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
-
-        using var gcStats = new GcStats();
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
-
-        Console.WriteLine($"  Running Confluent consumer stress test for {options.DurationMinutes} minutes...");
-        Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
-        StressTestHelpers.LogResourceUsage("Initial");
-
-        throughput.Start();
-        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
-        var progress = new PeriodicProgressReporter(throughput);
-
-        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
-        var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
-
-        try
-        {
-            while (!cts.Token.IsCancellationRequested)
+        return await StressTestHelpers.RunConsumerAsync(options, this,
+            (throughput, token) =>
             {
-                try
+                var progress = new PeriodicProgressReporter(throughput);
+                while (!token.IsCancellationRequested)
                 {
-                    var result = consumer.Consume(TimeSpan.FromMilliseconds(100));
-                    if (result is null)
+                    try
                     {
-                        continue;
-                    }
-
-                    throughput.RecordMessage(result.Message.Value?.Length ?? 0);
-                    progress.RecordMessage();
-
-                    if (replay.RecordConsumed(result.Partition.Value, result.Offset.Value))
-                    {
-                        foreach (var tp in partitions)
+                        var result = consumer.Consume(TimeSpan.FromMilliseconds(100));
+                        if (result is null)
                         {
-                            consumer.Seek(new ConfluentKafka.TopicPartitionOffset(tp, ConfluentKafka.Offset.Beginning));
+                            continue;
+                        }
+
+                        throughput.RecordMessage(result.Message.Value?.Length ?? 0);
+                        progress.RecordMessage();
+
+                        if (replay.RecordConsumed(result.Partition.Value, result.Offset.Value))
+                        {
+                            foreach (var tp in partitions)
+                            {
+                                consumer.Seek(new ConfluentKafka.TopicPartitionOffset(tp, ConfluentKafka.Offset.Beginning));
+                            }
                         }
                     }
+                    catch (ConfluentKafka.ConsumeException ex)
+                    {
+                        throughput.RecordError(ex, "Confluent consume loop");
+                    }
                 }
-                catch (ConfluentKafka.ConsumeException ex)
-                {
-                    throughput.RecordError(ex, "Confluent consume loop");
-                }
-            }
-        }
-        catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
-        {
-            // Expected — duration timer expired
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"  Consumer error: {ex}");
-            throughput.RecordError(ex, "Confluent consume loop");
-        }
-
-        throughput.Stop();
-        gcStats.Capture();
-
-        try { await samplerTask.ConfigureAwait(false); } catch { }
-        try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
-
-        var completedAt = DateTime.UtcNow;
-        Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
-        StressTestHelpers.LogResourceUsage("Final");
-
-        return new StressTestResult
-        {
-            Scenario = Name,
-            Client = Client,
-            DurationMinutes = options.DurationMinutes,
-            BrokerCount = options.BrokerCount,
-            MessageSizeBytes = options.MessageSizeBytes,
-            ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
-            ConsumerConnectionsPerBroker = 1,
-            StartedAtUtc = startedAt,
-            CompletedAtUtc = completedAt,
-            Throughput = throughput.GetSnapshot(),
-            Latency = null,
-            GcStats = gcStats.ToSnapshot(),
-            CpuTimeSeconds = throughput.CpuTimeSeconds
-        };
+                return Task.CompletedTask;
+            }, connectionsPerBroker: 1, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
@@ -16,9 +16,6 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
 
     public async Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
     {
-        var throughput = new ThroughputTracker();
-        var startedAt = DateTime.UtcNow;
-
         // The topic is pre-seeded by Program.SeedConsumerTopicAsync. The consumer re-reads
         // that fixed data set in a loop (seek to beginning when all partitions are drained).
         // A live feeder would compete with the consumer for CPU and cap throughput at the
@@ -46,92 +43,27 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
 
         Console.WriteLine($"  Consuming pre-seeded topic in a loop ({endOffsets.Sum():N0} messages per pass)");
 
-        // GC baseline before consumer measurement
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
-
-        using var gcStats = new GcStats();
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
-        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic, enabled: options.EnableConsumerFetchDiagnostics);
-        consumerDiagnostics.Start(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
-
-        Console.WriteLine($"  Running Dekaf consumer-batch stress test for {options.DurationMinutes} minutes...");
-        Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
-        StressTestHelpers.LogResourceUsage("Initial");
-
-        throughput.Start();
-        using var watchdog = options.ProgressWatchdog.Track(
-            throughput,
-            Client,
-            Name,
-            captureConsumerDiagnostics: () => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
-        var progress = new PeriodicProgressReporter(throughput);
-
-        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
-        var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
-        var consumerDiagnosticsTask = consumerDiagnostics.RunSamplerAsync(
-            () => StressTestHelpers.CaptureConsumerDiagnostics(consumer),
-            cts.Token);
-
-        try
-        {
-            await foreach (var batch in consumer.ConsumeBatchAsync(cts.Token).ConfigureAwait(false))
+        return await StressTestHelpers.RunConsumerAsync(options, this,
+            async (throughput, token) =>
             {
-                var lastOffset = -1L;
-                foreach (var record in batch)
+                var progress = new PeriodicProgressReporter(throughput);
+                await foreach (var batch in consumer.ConsumeBatchAsync(token).ConfigureAwait(false))
                 {
-                    throughput.RecordMessage(record.Value?.Length ?? 0);
-                    progress.RecordMessage();
-                    lastOffset = record.Offset;
+                    var lastOffset = -1L;
+                    foreach (var record in batch)
+                    {
+                        throughput.RecordMessage(record.Value?.Length ?? 0);
+                        progress.RecordMessage();
+                        lastOffset = record.Offset;
+                    }
+
+                    // Offsets are monotonic within a batch, so the last one decides drain state
+                    if (lastOffset >= 0 && replay.RecordConsumed(batch.Partition, lastOffset))
+                    {
+                        consumer.Positions.SeekToBeginning(partitions);
+                    }
                 }
-
-                // Offsets are monotonic within a batch, so the last one decides drain state
-                if (lastOffset >= 0 && replay.RecordConsumed(batch.Partition, lastOffset))
-                {
-                    consumer.Positions.SeekToBeginning(partitions);
-                }
-            }
-        }
-        catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
-        {
-            // Expected — duration timer expired
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"  Consumer error: {ex}");
-            throughput.RecordError(ex, "ConsumeBatch loop");
-        }
-
-        throughput.Stop();
-        gcStats.Capture();
-
-        try { await samplerTask.ConfigureAwait(false); } catch { }
-        try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
-        try { await consumerDiagnosticsTask.ConfigureAwait(false); } catch { }
-        consumerDiagnostics.TryTakeSample(() => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
-
-        var completedAt = DateTime.UtcNow;
-        Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
-        StressTestHelpers.LogResourceUsage("Final");
-
-        return new StressTestResult
-        {
-            Scenario = Name,
-            Client = Client,
-            DurationMinutes = options.DurationMinutes,
-            BrokerCount = options.BrokerCount,
-            MessageSizeBytes = options.MessageSizeBytes,
-            ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
-            ConsumerConnectionsPerBroker = StressTestOptions.HighThroughputConsumerConnectionsPerBroker,
-            StartedAtUtc = startedAt,
-            CompletedAtUtc = completedAt,
-            Throughput = throughput.GetSnapshot(),
-            Latency = null,
-            GcStats = gcStats.ToSnapshot(),
-            CpuTimeSeconds = throughput.CpuTimeSeconds,
-            ConsumerFetchDiagnostics = consumerDiagnostics.GetSnapshot()
-        };
+            }, connectionsPerBroker: StressTestOptions.HighThroughputConsumerConnectionsPerBroker,
+            captureConsumerDiagnostics: () => StressTestHelpers.CaptureConsumerDiagnostics(consumer), cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
@@ -16,9 +16,6 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
 
     public async Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
     {
-        var throughput = new ThroughputTracker();
-        var startedAt = DateTime.UtcNow;
-
         // The topic is pre-seeded by Program.SeedConsumerTopicAsync. The consumer re-reads
         // that fixed data set in a loop (seek to beginning when all partitions are drained).
         // A live feeder would compete with the consumer for CPU and cap throughput at the
@@ -44,92 +41,27 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
 
         Console.WriteLine($"  Consuming pre-seeded topic in a loop ({endOffsets.Sum():N0} messages per pass)");
 
-        // GC baseline before consumer measurement
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
-
-        using var gcStats = new GcStats();
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
-        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic, enabled: options.EnableConsumerFetchDiagnostics);
-        consumerDiagnostics.Start(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
-
-        Console.WriteLine($"  Running Dekaf consumer-raw-batch stress test for {options.DurationMinutes} minutes...");
-        Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
-        StressTestHelpers.LogResourceUsage("Initial");
-
-        throughput.Start();
-        using var watchdog = options.ProgressWatchdog.Track(
-            throughput,
-            Client,
-            Name,
-            captureConsumerDiagnostics: () => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
-        var progress = new PeriodicProgressReporter(throughput);
-
-        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
-        var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
-        var consumerDiagnosticsTask = consumerDiagnostics.RunSamplerAsync(
-            () => StressTestHelpers.CaptureConsumerDiagnostics(consumer),
-            cts.Token);
-
-        try
-        {
-            await foreach (var batch in consumer.ConsumeRawBatchAsync(cts.Token).ConfigureAwait(false))
+        return await StressTestHelpers.RunConsumerAsync(options, this,
+            async (throughput, token) =>
             {
-                var lastOffset = -1L;
-                foreach (var record in batch)
+                var progress = new PeriodicProgressReporter(throughput);
+                await foreach (var batch in consumer.ConsumeRawBatchAsync(token).ConfigureAwait(false))
                 {
-                    throughput.RecordMessage(record.Value.Length);
-                    progress.RecordMessage();
-                    lastOffset = record.Offset;
+                    var lastOffset = -1L;
+                    foreach (var record in batch)
+                    {
+                        throughput.RecordMessage(record.Value.Length);
+                        progress.RecordMessage();
+                        lastOffset = record.Offset;
+                    }
+
+                    // Offsets are monotonic within a batch, so the last one decides drain state
+                    if (lastOffset >= 0 && replay.RecordConsumed(batch.Partition, lastOffset))
+                    {
+                        consumer.Positions.SeekToBeginning(partitions);
+                    }
                 }
-
-                // Offsets are monotonic within a batch, so the last one decides drain state
-                if (lastOffset >= 0 && replay.RecordConsumed(batch.Partition, lastOffset))
-                {
-                    consumer.Positions.SeekToBeginning(partitions);
-                }
-            }
-        }
-        catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
-        {
-            // Expected — duration timer expired
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"  Consumer error: {ex}");
-            throughput.RecordError(ex, "ConsumeRawBatch loop");
-        }
-
-        throughput.Stop();
-        gcStats.Capture();
-
-        try { await samplerTask.ConfigureAwait(false); } catch { }
-        try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
-        try { await consumerDiagnosticsTask.ConfigureAwait(false); } catch { }
-        consumerDiagnostics.TryTakeSample(() => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
-
-        var completedAt = DateTime.UtcNow;
-        Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
-        StressTestHelpers.LogResourceUsage("Final");
-
-        return new StressTestResult
-        {
-            Scenario = Name,
-            Client = Client,
-            DurationMinutes = options.DurationMinutes,
-            BrokerCount = options.BrokerCount,
-            MessageSizeBytes = options.MessageSizeBytes,
-            ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
-            ConsumerConnectionsPerBroker = StressTestOptions.HighThroughputConsumerConnectionsPerBroker,
-            StartedAtUtc = startedAt,
-            CompletedAtUtc = completedAt,
-            Throughput = throughput.GetSnapshot(),
-            Latency = null,
-            GcStats = gcStats.ToSnapshot(),
-            CpuTimeSeconds = throughput.CpuTimeSeconds,
-            ConsumerFetchDiagnostics = consumerDiagnostics.GetSnapshot()
-        };
+            }, connectionsPerBroker: StressTestOptions.HighThroughputConsumerConnectionsPerBroker,
+            captureConsumerDiagnostics: () => StressTestHelpers.CaptureConsumerDiagnostics(consumer), cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
@@ -18,9 +18,6 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
 
     public async Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
     {
-        var throughput = new ThroughputTracker();
-        var startedAt = DateTime.UtcNow;
-
         // The topic is pre-seeded by Program.SeedConsumerTopicAsync. The consumer re-reads
         // that fixed data set in a loop (seek to beginning when all partitions are drained).
         // A live feeder would compete with the consumer for CPU and cap throughput at the
@@ -46,86 +43,21 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
 
         Console.WriteLine($"  Consuming pre-seeded topic in a loop ({endOffsets.Sum():N0} messages per pass)");
 
-        // GC baseline before consumer measurement
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
-
-        using var gcStats = new GcStats();
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
-        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic, enabled: options.EnableConsumerFetchDiagnostics);
-        consumerDiagnostics.Start(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
-
-        Console.WriteLine($"  Running Dekaf consumer-raw stress test for {options.DurationMinutes} minutes...");
-        Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
-        StressTestHelpers.LogResourceUsage("Initial");
-
-        throughput.Start();
-        using var watchdog = options.ProgressWatchdog.Track(
-            throughput,
-            Client,
-            Name,
-            captureConsumerDiagnostics: () => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
-        var progress = new PeriodicProgressReporter(throughput);
-
-        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
-        var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
-        var consumerDiagnosticsTask = consumerDiagnostics.RunSamplerAsync(
-            () => StressTestHelpers.CaptureConsumerDiagnostics(consumer),
-            cts.Token);
-
-        try
-        {
-            await foreach (var record in consumer.ConsumeAsync(cts.Token).ConfigureAwait(false))
+        return await StressTestHelpers.RunConsumerAsync(options, this,
+            async (throughput, token) =>
             {
-                throughput.RecordMessage(record.Value.Length);
-                progress.RecordMessage();
-
-                if (replay.RecordConsumed(record.Partition, record.Offset))
+                var progress = new PeriodicProgressReporter(throughput);
+                await foreach (var record in consumer.ConsumeAsync(token).ConfigureAwait(false))
                 {
-                    consumer.Positions.SeekToBeginning(partitions);
+                    throughput.RecordMessage(record.Value.Length);
+                    progress.RecordMessage();
+
+                    if (replay.RecordConsumed(record.Partition, record.Offset))
+                    {
+                        consumer.Positions.SeekToBeginning(partitions);
+                    }
                 }
-            }
-        }
-        catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
-        {
-            // Expected — duration timer expired
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"  Consumer error: {ex}");
-            throughput.RecordError(ex, "ConsumeRaw loop");
-        }
-
-        throughput.Stop();
-        gcStats.Capture();
-
-        try { await samplerTask.ConfigureAwait(false); } catch { }
-        try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
-        try { await consumerDiagnosticsTask.ConfigureAwait(false); } catch { }
-        consumerDiagnostics.TryTakeSample(() => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
-
-        var completedAt = DateTime.UtcNow;
-        Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
-        StressTestHelpers.LogResourceUsage("Final");
-
-        return new StressTestResult
-        {
-            Scenario = Name,
-            Client = Client,
-            DurationMinutes = options.DurationMinutes,
-            BrokerCount = options.BrokerCount,
-            MessageSizeBytes = options.MessageSizeBytes,
-            ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
-            ConsumerConnectionsPerBroker = StressTestOptions.HighThroughputConsumerConnectionsPerBroker,
-            StartedAtUtc = startedAt,
-            CompletedAtUtc = completedAt,
-            Throughput = throughput.GetSnapshot(),
-            Latency = null,
-            GcStats = gcStats.ToSnapshot(),
-            CpuTimeSeconds = throughput.CpuTimeSeconds,
-            ConsumerFetchDiagnostics = consumerDiagnostics.GetSnapshot()
-        };
+            }, connectionsPerBroker: StressTestOptions.HighThroughputConsumerConnectionsPerBroker,
+            captureConsumerDiagnostics: () => StressTestHelpers.CaptureConsumerDiagnostics(consumer), cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
@@ -11,9 +11,6 @@ internal sealed class ConsumerStressTest : IStressTestScenario
 
     public async Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
     {
-        var throughput = new ThroughputTracker();
-        var startedAt = DateTime.UtcNow;
-
         // The topic is pre-seeded by Program.SeedConsumerTopicAsync. The consumer re-reads
         // that fixed data set in a loop (seek to beginning when all partitions are drained).
         // A live feeder would compete with the consumer for CPU and cap throughput at the
@@ -42,90 +39,21 @@ internal sealed class ConsumerStressTest : IStressTestScenario
 
         Console.WriteLine($"  Consuming pre-seeded topic in a loop ({endOffsets.Sum():N0} messages per pass)");
 
-        // GC baseline before consumer measurement
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
-
-        using var gcStats = new GcStats();
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
-        // Dekaf-only diagnostics (per-fetch MeterListener + 1-minute snapshot sampler) are
-        // opt-in via --consumer-fetch-diagnostics: enabled they slightly inflate Dekaf's own
-        // CPU/msg and alloc/msg vs Confluent, so measurement runs keep them off and debug
-        // runs turn them on when fetch-path visibility is needed to diagnose a regression.
-        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic, enabled: options.EnableConsumerFetchDiagnostics);
-        consumerDiagnostics.Start(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
-
-        Console.WriteLine($"  Running Dekaf consumer stress test for {options.DurationMinutes} minutes...");
-        Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
-        StressTestHelpers.LogResourceUsage("Initial");
-
-        throughput.Start();
-        using var watchdog = options.ProgressWatchdog.Track(
-            throughput,
-            Client,
-            Name,
-            captureConsumerDiagnostics: () => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
-        var progress = new PeriodicProgressReporter(throughput);
-
-        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
-        var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
-        var consumerDiagnosticsTask = consumerDiagnostics.RunSamplerAsync(
-            () => StressTestHelpers.CaptureConsumerDiagnostics(consumer),
-            cts.Token);
-
-        try
-        {
-            await foreach (var record in consumer.ConsumeAsync(cts.Token).ConfigureAwait(false))
+        return await StressTestHelpers.RunConsumerAsync(options, this,
+            async (throughput, token) =>
             {
-                throughput.RecordMessage(record.Value?.Length ?? 0);
-                progress.RecordMessage();
-
-                if (replay.RecordConsumed(record.Partition, record.Offset))
+                var progress = new PeriodicProgressReporter(throughput);
+                await foreach (var record in consumer.ConsumeAsync(token).ConfigureAwait(false))
                 {
-                    consumer.Positions.SeekToBeginning(partitions);
+                    throughput.RecordMessage(record.Value?.Length ?? 0);
+                    progress.RecordMessage();
+
+                    if (replay.RecordConsumed(record.Partition, record.Offset))
+                    {
+                        consumer.Positions.SeekToBeginning(partitions);
+                    }
                 }
-            }
-        }
-        catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
-        {
-            // Expected — duration timer expired
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"  Consumer error: {ex}");
-            throughput.RecordError(ex, "Consume loop");
-        }
-
-        throughput.Stop();
-        gcStats.Capture();
-
-        try { await samplerTask.ConfigureAwait(false); } catch { }
-        try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
-        try { await consumerDiagnosticsTask.ConfigureAwait(false); } catch { }
-        consumerDiagnostics.TryTakeSample(() => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
-
-        var completedAt = DateTime.UtcNow;
-        Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
-        StressTestHelpers.LogResourceUsage("Final");
-
-        return new StressTestResult
-        {
-            Scenario = Name,
-            Client = Client,
-            DurationMinutes = options.DurationMinutes,
-            BrokerCount = options.BrokerCount,
-            MessageSizeBytes = options.MessageSizeBytes,
-            ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
-            ConsumerConnectionsPerBroker = StressTestOptions.HighThroughputConsumerConnectionsPerBroker,
-            StartedAtUtc = startedAt,
-            CompletedAtUtc = completedAt,
-            Throughput = throughput.GetSnapshot(),
-            Latency = null,
-            GcStats = gcStats.ToSnapshot(),
-            CpuTimeSeconds = throughput.CpuTimeSeconds,
-            ConsumerFetchDiagnostics = consumerDiagnostics.GetSnapshot()
-        };
+            }, connectionsPerBroker: StressTestOptions.HighThroughputConsumerConnectionsPerBroker,
+            captureConsumerDiagnostics: () => StressTestHelpers.CaptureConsumerDiagnostics(consumer), cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ProducerWorkload.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerWorkload.cs
@@ -206,7 +206,7 @@ internal static class ProducerWorkload
 
     // Timer callbacks can arrive slightly before their nominal duration. Recheck an
     // elapsed monotonic clock instead of counting an early timer as full workload warmup.
-    private static async Task StopIngressAsync(CancellationTokenSource ingress, TimeSpan duration, TimeProvider timeProvider)
+    internal static async Task StopIngressAsync(CancellationTokenSource ingress, TimeSpan duration, TimeProvider timeProvider)
     {
         var started = timeProvider.GetTimestamp();
         try

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -5,11 +5,106 @@ using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Reporting;
 
 namespace Dekaf.StressTests.Scenarios;
 
 internal static class StressTestHelpers
 {
+    // Run the same consumer, replay loop and observers in warmup and measurement.
+    // ProducerWarmup's existing six-cycle scheduler records completed workload and
+    // runtime samples; each consumer iterator unwinds before the next cycle begins.
+    internal static async Task<StressTestResult> RunConsumerAsync(
+        StressTestOptions options, IStressTestScenario scenario,
+        Func<ThroughputTracker, CancellationToken, Task> consume,
+        int connectionsPerBroker,
+        Func<ConsumerDiagnosticSnapshot?>? captureConsumerDiagnostics = null,
+        CancellationToken cancellationToken = default)
+    {
+        var throughput = new ThroughputTracker();
+        Console.WriteLine($"  Warming up {scenario.Client} {scenario.Name}: {options.ProducerWarmupSeconds}s of replay workload...");
+        throughput.Warmup = await ProducerWarmup.RunAsync(options.ProducerWarmupSeconds,
+            async (duration, cycleThroughput, token) =>
+            {
+                var cycle = await RunCycleAsync(duration, cycleThroughput, token).ConfigureAwait(false);
+                return new ProducerWorkloadResult(cycle.WorkloadSeconds, cycle.Result.Throughput, cycle.Result.GcStats);
+            }, cancellationToken).ConfigureAwait(false);
+        return (await RunCycleAsync(TimeSpan.FromMinutes(options.DurationMinutes), throughput, cancellationToken).ConfigureAwait(false)).Result;
+
+        async Task<(StressTestResult Result, double WorkloadSeconds)> RunCycleAsync(
+            TimeSpan duration, ThroughputTracker tracker, CancellationToken token)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            using var gcStats = new GcStats();
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            using var diagnostics = captureConsumerDiagnostics is null ? null
+                : new ConsumerFetchDiagnosticsTracker(options.Topic, enabled: options.EnableConsumerFetchDiagnostics);
+            if (captureConsumerDiagnostics?.Invoke() is { } initial)
+                diagnostics?.Start(initial);
+
+            var startedAt = DateTime.UtcNow;
+            if (tracker.Warmup is not null)
+                Console.WriteLine($"  Running {scenario.Client} {scenario.Name} stress test for {options.DurationMinutes} minutes...");
+            LogResourceUsage("Initial");
+            tracker.Start();
+            var stop = ProducerWorkload.StopIngressAsync(cts, duration, TimeProvider.System);
+            using var watchdog = options.ProgressWatchdog.Track(tracker, scenario.Client, scenario.Name,
+                captureConsumerDiagnostics: captureConsumerDiagnostics);
+            var sampler = RunSamplerAsync(tracker, cts.Token);
+            var resources = RunResourceMonitorAsync(cts.Token);
+            var diagnosticSampler = diagnostics?.RunSamplerAsync(captureConsumerDiagnostics!, cts.Token) ?? Task.CompletedTask;
+            double workloadSeconds;
+            try
+            {
+                await consume(tracker, cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cts.IsCancellationRequested && !token.IsCancellationRequested)
+            {
+                // The declared workload duration ended; the iterator has unwound.
+            }
+            catch (Exception error) when (!token.IsCancellationRequested)
+            {
+                // Retain the replay failure even if an observer also fails during cleanup.
+                Console.Error.WriteLine($"  {scenario.Client} {scenario.Name} error: {error}");
+                tracker.RecordError(error, $"{scenario.Name} loop");
+            }
+            finally
+            {
+                workloadSeconds = tracker.Elapsed.TotalSeconds;
+                cts.Cancel();
+                await stop.ConfigureAwait(false);
+                try { await Task.WhenAll(sampler, resources, diagnosticSampler).ConfigureAwait(false); }
+                catch (OperationCanceledException) when (cts.IsCancellationRequested) { }
+                tracker.Stop();
+                gcStats.Capture();
+            }
+            token.ThrowIfCancellationRequested();
+            if (captureConsumerDiagnostics is not null)
+                diagnostics?.TryTakeSample(captureConsumerDiagnostics);
+            Console.WriteLine($"  Completed: {tracker.MessageCount:N0} messages, {tracker.GetAverageMessagesPerSecond():N0} msg/sec");
+            LogResourceUsage("Final");
+            return (new StressTestResult
+            {
+                Scenario = scenario.Name,
+                Client = scenario.Client,
+                DurationMinutes = options.DurationMinutes,
+                BrokerCount = options.BrokerCount,
+                MessageSizeBytes = options.MessageSizeBytes,
+                ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
+                ConsumerConnectionsPerBroker = connectionsPerBroker,
+                StartedAtUtc = startedAt,
+                CompletedAtUtc = DateTime.UtcNow,
+                Throughput = tracker.GetSnapshot(),
+                Latency = null,
+                GcStats = gcStats.ToSnapshot(),
+                CpuTimeSeconds = tracker.CpuTimeSeconds,
+                ConsumerFetchDiagnostics = diagnostics?.GetSnapshot()
+            }, workloadSeconds);
+        }
+    }
+
     /// <summary>
     /// Pins the configured connection count for like-for-like comparison with Confluent
     /// unless the run asked to measure Dekaf's default adaptive scaling.


### PR DESCRIPTION
Consumer replay previously entered its measured window immediately, and the validator exempted it from elapsed workload warmup. This change runs the existing replay loop through the existing six-cycle warmup scheduler before measurement, keeping the consumer and replay state alive and using separate throughput counters for each phase. It covers all four Dekaf replay lanes and the paired Confluent consumer without adding another timing engine or project.

The validator now requires retained consumer warmup, rejects early/failed cycles, and preserves the existing steady-state checks. Workflow timeout budgeting includes consumer warmup. The existing `producer_warmup_seconds` input remains compatible and now documents its consumer scope.

Validation: 234 Python stress-tooling tests; 25 focused net10.0 warmup/workload tests; standard Kafka replay smoke runs with 20-second warmup and one-minute measurement. The stress test suite is net10.0-only; net8.0 excludes it. Local smoke validates execution and separation of warmup counts, not product performance acceptance. The batch smoke correctly reports INCONCLUSIVE for thread-pool movement during warmup. No protected-metric tolerances are changed.

Tooling only: no `src/` changes, custom harness, or generated evidence committed. Local reports, logs, binaries and inputs are retained outside the repository under `C:/git/Dekaf-evidence/consumer-warmup`. Related: #3222.
