### PR TITLE
perf(outbox): avoid duplicate change detection during saves

### DIFF
--- a/src/Dekaf.Outbox.EntityFrameworkCore/OutboxCommitObserver.cs
+++ b/src/Dekaf.Outbox.EntityFrameworkCore/OutboxCommitObserver.cs
@@ -2,7 +2,10 @@ using System.Data.Common;
 using System.Runtime.CompilerServices;
 using System.Transactions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Dekaf.Outbox.EntityFrameworkCore;
@@ -11,9 +14,10 @@ namespace Dekaf.Outbox.EntityFrameworkCore;
 // contexts). Weak keys prevent disposed contexts or externally owned transactions being retained.
 internal sealed class OutboxCommitObserver
 {
+    private static readonly object CommittedRows = new();
     private readonly IOutboxNotifier _notifier;
     private readonly ConditionalWeakTable<DbContext, PendingSave> _saves = new();
-    private readonly ConditionalWeakTable<DbTransaction, PendingSave> _transactions = new();
+    private readonly ConditionalWeakTable<DbTransaction, object> _transactions = new();
     private readonly ConditionalWeakTable<Transaction, AmbientCommit> _ambientTransactions = new();
     private readonly ConditionalWeakTable<Transaction, AmbientCommit>.CreateValueCallback _createAmbientCommit;
 
@@ -32,25 +36,46 @@ internal sealed class OutboxCommitObserver
     {
         if (context is null)
             return;
-        var pending = _saves.GetOrCreateValue(context);
-        pending.HasRows = false;
-        foreach (var entry in context.ChangeTracker.Entries<OutboxMessage>())
-        {
-            if (entry.State != EntityState.Added)
-                continue;
-            pending.HasRows = true;
-            break;
-        }
+        var pending = _saves.GetValue(context, static context => new PendingSave(context));
+        pending.Stop(context);
+        pending.Refresh();
+        pending.Start(context);
     }
+
+    // Inspect only EF's Added state map. Do not invoke DetectChanges here: EF runs
+    // its normal pass after all SavingChanges interceptors. PendingSave observes
+    // that pass so navigation-discovered inserts are included before SQL is sent.
+#pragma warning disable EF1001
+    private static bool HasAddedOutboxRows(IStateManager stateManager)
+    {
+        if (stateManager.ChangedCount == 0)
+            return false;
+        var entries = stateManager.GetEntriesForState(added: true);
+        if (entries is Dictionary<object, InternalEntityEntry>.ValueCollection added)
+        {
+            foreach (var entry in added)
+                if (entry.Entity is OutboxMessage)
+                    return true;
+            return false;
+        }
+        foreach (var entry in entries)
+            if (entry.Entity is OutboxMessage)
+                return true;
+        return false;
+    }
+#pragma warning restore EF1001
 
     private void Saved(DbContext? context)
     {
-        if (context is null || !_saves.TryGetValue(context, out var pending) || !pending.HasRows)
+        if (context is null || !_saves.TryGetValue(context, out var pending))
+            return;
+        pending.Stop(context);
+        if (!pending.HasRows)
             return;
         pending.HasRows = false;
         if (context.Database.CurrentTransaction is { } transaction)
         {
-            _transactions.GetOrCreateValue(transaction.GetDbTransaction()).HasRows = true;
+            _transactions.GetValue(transaction.GetDbTransaction(), static _ => CommittedRows);
         }
         else if ((context.Database.GetEnlistedTransaction() ?? Transaction.Current) is { } ambient)
         {
@@ -72,22 +97,41 @@ internal sealed class OutboxCommitObserver
     private void Failed(DbContext? context)
     {
         if (context is not null && _saves.TryGetValue(context, out var pending))
+        {
+            pending.Stop(context);
             pending.HasRows = false;
+        }
     }
 
     private void Committed(DbTransaction transaction)
     {
-        if (!_transactions.TryGetValue(transaction, out var pending))
-            return;
-        _transactions.Remove(transaction);
-        if (pending.HasRows)
+        if (_transactions.Remove(transaction))
             _notifier.NotifyCommitted();
     }
 
+    // The context-keyed weak table permits its value to cache a context-scoped service
+    // without retaining an otherwise unreachable context. Pooled leases reuse it.
+#pragma warning disable EF1001
     private sealed class PendingSave
     {
+        private readonly IStateManager _stateManager;
+        private readonly EventHandler<DetectedChangesEventArgs> _detected;
         public bool HasRows;
+
+        public PendingSave(DbContext context)
+        {
+            _stateManager = context.GetService<IStateManager>();
+            _detected = OnDetected;
+        }
+
+        public void Refresh() => HasRows = HasAddedOutboxRows(_stateManager);
+
+        public void Start(DbContext context) => context.ChangeTracker.DetectedAllChanges += _detected;
+        public void Stop(DbContext context) => context.ChangeTracker.DetectedAllChanges -= _detected;
+
+        private void OnDetected(object? sender, DetectedChangesEventArgs args) => Refresh();
     }
+#pragma warning restore EF1001
 
     private sealed class AmbientCommit
     {

--- a/tests/Dekaf.Tests.Unit/Outbox/OutboxCommitNotificationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Outbox/OutboxCommitNotificationTests.cs
@@ -1,14 +1,122 @@
+using System.Data.Common;
 using System.Transactions;
 using Dekaf.Outbox;
 using Dekaf.Outbox.EntityFrameworkCore;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Dekaf.Tests.Unit.Outbox;
 
 public sealed class OutboxCommitNotificationTests
 {
+    [Test]
+    [Arguments(false, false)]
+    [Arguments(false, true)]
+    [Arguments(true, false)]
+    [Arguments(true, true)]
+    public async Task Saving_DetectsChangesOnlyOnce_WithOrWithoutOutboxRows(bool asynchronous, bool outboxRow)
+    {
+        using var database = new Database();
+        await using var context = database.CreateContext();
+        for (var index = 1; index <= 1024; index++)
+            context.Attach(new BusinessRow { Id = index });
+        if (outboxRow)
+            context.Set<OutboxMessage>().Add(Row());
+        var detectionPasses = 0;
+        context.ChangeTracker.DetectedAllChanges += (_, _) => detectionPasses++;
+
+        await SaveAsync(context, asynchronous);
+
+        await Assert.That(detectionPasses).IsEqualTo(1);
+        await Assert.That(database.Notifier.Count).IsEqualTo(outboxRow ? 1 : 0);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task DirectAdd_NotifiesWithoutAcceptingTrackedChanges(bool asynchronous)
+    {
+        using var database = new Database();
+        await using var context = database.CreateContext();
+        var row = Row();
+        context.Set<OutboxMessage>().Add(row);
+        if (asynchronous)
+            await context.SaveChangesAsync(acceptAllChangesOnSuccess: false);
+        else
+            context.SaveChanges(acceptAllChangesOnSuccess: false);
+
+        await Assert.That(database.Notifier.Count).IsEqualTo(1);
+        await Assert.That(context.Entry(row).State).IsEqualTo(EntityState.Added);
+        await Assert.That(await context.Set<OutboxMessage>().CountAsync()).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task NavigationDiscoveredInsert_NotifiesAfterCommit(bool asynchronous)
+    {
+        using var database = new Database();
+        await using var context = database.CreateContext();
+        var business = new BusinessRow { Id = 1 };
+        context.Add(business);
+        await SaveAsync(context, asynchronous);
+        await Assert.That(database.Notifier.Count).IsEqualTo(0);
+
+        // Adding to the CLR collection only becomes a tracked insert during EF's
+        // change detection, after the SavingChanges interceptor has run.
+        business.OutboxMessages.Add(Row());
+        await SaveAsync(context, asynchronous);
+
+        await Assert.That(database.Notifier.Count).IsEqualTo(1);
+        await Assert.That(await context.Set<OutboxMessage>().CountAsync()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task UnchangedOutboxRows_DoNotNotifyForUnrelatedInserts()
+    {
+        using var database = new Database();
+        await using var context = database.CreateContext();
+        for (var index = 0; index < 1024; index++)
+            context.Attach(Row(index + 1));
+        context.Add(new BusinessRow { Id = 1 });
+
+        await context.SaveChangesAsync();
+
+        await Assert.That(database.Notifier.Count).IsEqualTo(0);
+        await Assert.That(await context.Set<BusinessRow>().CountAsync()).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task PooledContext_ReattachesNotificationsForEachLease(bool asynchronous)
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        var notifier = new CountingNotifier();
+        var services = new ServiceCollection();
+        services.AddPooledDbContextFactory<Context>(options =>
+            options.UseSqlite(connection).UseDekafOutboxNotifications(notifier), poolSize: 1);
+        await using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IDbContextFactory<Context>>();
+        var previousLease = 0;
+        for (var iteration = 1; iteration <= 3; iteration++)
+        {
+            await using var context = await factory.CreateDbContextAsync();
+            if (iteration == 1)
+                await context.Database.EnsureCreatedAsync();
+            await Assert.That(context.ContextId.Lease).IsGreaterThan(previousLease);
+            previousLease = context.ContextId.Lease;
+            await SaveAsync(context, asynchronous);
+            await Assert.That(notifier.Count).IsEqualTo(iteration - 1);
+            context.AddOutboxMessage(Row());
+            await SaveAsync(context, asynchronous);
+            await Assert.That(notifier.Count).IsEqualTo(iteration);
+        }
+    }
+
     [Test]
     [Arguments(false)]
     [Arguments(true)]
@@ -127,6 +235,58 @@ public sealed class OutboxCommitNotificationTests
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task CancellationAfterCommandInspection_DoesNotNotifyOnLaterEmptySave(bool asynchronous)
+    {
+        var cancel = new CancelFirstSaveCommand();
+        using var database = new Database(cancel);
+        await using var context = database.CreateContext();
+        context.AddOutboxMessage(Row());
+        await Assert.That(async () => await SaveAsync(context, asynchronous)).Throws<OperationCanceledException>();
+        await Assert.That(database.Notifier.Count).IsEqualTo(0);
+        context.ChangeTracker.Clear();
+        await SaveAsync(context, asynchronous);
+        await Assert.That(database.Notifier.Count).IsEqualTo(0);
+        context.AddOutboxMessage(Row());
+        await SaveAsync(context, asynchronous);
+        await Assert.That(database.Notifier.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task SavedChangesHandler_CanSaveAgainWithoutLosingCommitNotification(bool asynchronous)
+    {
+        using var database = new Database();
+        await using var context = database.CreateContext();
+        var nested = false;
+        context.SavedChanges += (_, _) =>
+        {
+            if (nested) return;
+            nested = true;
+            context.SaveChanges();
+        };
+        context.AddOutboxMessage(Row());
+        await SaveAsync(context, asynchronous);
+        await Assert.That(database.Notifier.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task DisabledAutomaticDetection_PreservesExplicitlyAddedNotification(bool asynchronous)
+    {
+        using var database = new Database();
+        await using var context = database.CreateContext();
+        context.ChangeTracker.AutoDetectChangesEnabled = false;
+        context.Set<OutboxMessage>().Add(Row());
+        await SaveAsync(context, asynchronous);
+        await Assert.That(database.Notifier.Count).IsEqualTo(1);
+        await Assert.That(context.ChangeTracker.AutoDetectChangesEnabled).IsFalse();
+    }
+
+    [Test]
     public async Task SharedOptions_KeepPendingSavesIndependentAcrossContexts()
     {
         using var database = new Database();
@@ -147,9 +307,9 @@ public sealed class OutboxCommitNotificationTests
         return Task.CompletedTask;
     }
 
-    private static OutboxMessage Row() => new()
+    private static OutboxMessage Row(long id = 0) => new()
     {
-        MessageId = Guid.NewGuid(), Topic = "outbox-notification", Bucket = 0,
+        Id = id, MessageId = Guid.NewGuid(), Topic = "outbox-notification", Bucket = 0,
         Value = [1], CreatedAtUtc = DateTimeOffset.UnixEpoch
     };
 
@@ -159,11 +319,11 @@ public sealed class OutboxCommitNotificationTests
         private readonly DbContextOptions<Context> _options;
         public CountingNotifier Notifier { get; } = new();
 
-        public Database()
+        public Database(params IInterceptor[] interceptors)
         {
             _connection.Open();
             _options = new DbContextOptionsBuilder<Context>().UseSqlite(_connection)
-                .UseDekafOutboxNotifications(Notifier).Options;
+                .UseDekafOutboxNotifications(Notifier).AddInterceptors(interceptors).Options;
             using var context = CreateContext();
             context.Database.EnsureCreated();
         }
@@ -174,7 +334,39 @@ public sealed class OutboxCommitNotificationTests
 
     private sealed class Context(DbContextOptions<Context> options) : DbContext(options)
     {
-        protected override void OnModelCreating(ModelBuilder modelBuilder) => modelBuilder.UseDekafOutbox();
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.UseDekafOutbox();
+            modelBuilder.Entity<BusinessRow>().HasKey(row => row.Id);
+            modelBuilder.Entity<BusinessRow>().HasMany(row => row.OutboxMessages)
+                .WithOne().HasForeignKey("BusinessId");
+        }
+    }
+
+    private sealed class BusinessRow
+    {
+        public int Id { get; set; }
+        public List<OutboxMessage> OutboxMessages { get; } = [];
+    }
+
+    private sealed class CancelFirstSaveCommand : DbCommandInterceptor
+    {
+        private bool _cancel = true;
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(DbCommand command,
+            CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            if (_cancel && eventData.CommandSource == CommandSource.SaveChanges)
+            {
+                _cancel = false;
+                throw new OperationCanceledException("Cancel after the notification observer inspects the write.");
+            }
+            return result;
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(DbCommand command,
+            CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default) => new(ReaderExecuting(command, eventData, result));
     }
 
     private sealed class CountingNotifier : IOutboxNotifier


### PR DESCRIPTION
Outbox notification interception currently invokes EF change detection before EF's normal SaveChanges pass, scanning and allocating for unchanged business entities twice. This change inspects only the Added state map and observes EF's existing detection-completed event, preserving navigation-discovered inserts and notification ordering before user SavedChanges handlers. A context-scoped cached state manager avoids repeated service resolution, and transaction tracking reuses an immutable marker.

Validation: all 113 outbox tests pass on net10.0 and net8.0, including new single-detection, navigation discovery, pooled context, disabled detection, cancellation and reentrant save coverage. The product builds for both frameworks without warnings. EF's internal state-map access is deliberately narrow and covered against EF 8 and 10; unfamiliar collection shapes retain an enumeration fallback.

All 16 cases in the maintained OutboxSaveChangesBenchmarks validate in local BenchmarkDotNet Short runs. Against the local current-main control, unchanged saves improve approximately 21–25% at zero business rows and 59–61% at 1024 rows; allocations decrease from 152 to 144 B and from 409960 to 204968 B respectively. These are diagnostic results, not hosted performance acceptance. Fresh exact-head CI and A1/B/A2 remain required. EF/SQLite allocations are per-save costs, not Kafka per-message allocation evidence.

Related: #3232. This fixes duplicate change detection; it does not claim the original notification feature has achieved parity with its pre-feature baseline or resolve its previously recorded loaded idle-CPU regression. Evidence stays outside Git under C:/git/Dekaf-evidence/issue-3232; hosted job output/artifacts will supply acceptance. Only product code and correctness tests are committed.
