### PR TITLE
fix(ci): serialize performance-gate CLI initialization

### DIFF
--- a/.github/scripts/test_performance_gate.py
+++ b/.github/scripts/test_performance_gate.py
@@ -1,8 +1,12 @@
 import contextlib
 import io
 import json
+import os
 import re
+import shutil
+import subprocess
 import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -12,6 +16,12 @@ import performance_gate as gate
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / '.github' / 'workflows' / 'performance-gate.yml'
+BASH = shutil.which('bash')
+if os.name == 'nt':
+    # Windows' system32/bash.exe launches WSL, not a shell for Windows paths.
+    git = shutil.which('git')
+    git_bash = Path(git).parent.parent / 'bin/bash.exe' if git else None
+    BASH = str(git_bash) if git_bash and git_bash.is_file() else None
 
 
 def benchmark(method='Append', parameters='', median=100.0, samples=15, allocated=0, type_name='AppendBenchmarks'):
@@ -311,6 +321,96 @@ class CommandTests(unittest.TestCase):
 
 
 class WorkflowTests(unittest.TestCase):
+    @unittest.skipUnless(BASH, 'workflow execution requires bash')
+    def test_initialization_finishes_before_parallel_builds(self):
+        result, events, _ = self.run_build_step()
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertEqual(['prepare-A', 'prepare-B'], events[:2])
+        self.assertIn('build-B-background', events)
+        self.assertIn('build-A-foreground', events)
+
+    @unittest.skipUnless(BASH, 'workflow execution requires bash')
+    def test_preparation_failure_stops_before_builds(self):
+        for role in ('A', 'B'):
+            with self.subTest(role=role):
+                result, events, _ = self.run_build_step(fail_prepare=role)
+                self.assertNotEqual(0, result.returncode)
+                self.assertFalse(any(event.startswith('build-') for event in events), events)
+
+    @unittest.skipUnless(BASH, 'workflow execution requires bash')
+    def test_baseline_fallback_prepares_again_and_observes_candidate_failure(self):
+        for fail_candidate in (False, True):
+            with self.subTest(fail_candidate=fail_candidate):
+                result, events, fallback = self.run_build_step(fallback=True, fail_candidate=fail_candidate)
+                self.assertEqual(2, events.count('prepare-A'), events)
+                self.assertEqual(2, events.count('build-A-foreground'), events)
+                self.assertTrue(fallback)
+                self.assertEqual(not fail_candidate, result.returncode == 0, result.stdout + result.stderr)
+                if fail_candidate:
+                    self.assertIn('The candidate fixtures failed to build', result.stdout)
+
+    def run_build_step(self, *, fail_prepare='', fallback=False, fail_candidate=False):
+        workflow = WORKFLOW.read_text(encoding='utf-8')
+        start = re.search(r'^          (?:prepare|build)\(\) \{', workflow, re.MULTILINE).start()
+        end = workflow.index('\n      - name: Measure A1', start)
+        commands = textwrap.dedent(workflow[start:end])
+        # Model a first-use CLI that rejects initialization in a background job.
+        # BASH_SUBSHELL distinguishes the concurrent build from foreground setup
+        # deterministically, without sleeps or depending on scheduler timing.
+        stub = r'''
+            dotnet() {
+              local role=${PWD##*/gate-}
+              role=${role%%/*}
+              case "$1" in
+                new)
+                  if (( BASH_SUBSHELL > 1 )); then
+                    echo 'Concurrent CLI first-use initialization' >&2
+                    return 71
+                  fi
+                  echo "prepare-$role" >> "$EVENTS"
+                  [[ "$FAIL_PREPARE" != "$role" ]] || return 61
+                  touch GateBenchmarkExecution.sln
+                  ;;
+                sln) ;;
+                build)
+                  local execution=foreground
+                  if (( BASH_SUBSHELL > 1 )); then execution=background; fi
+                  echo "build-$role-$execution" >> "$EVENTS"
+                  [[ -f GateBenchmarkExecution.sln ]] || return 62
+                  if [[ "$role" == B && "$FAIL_CANDIDATE" == 1 ]]; then return 63; fi
+                  if [[ "$role" == A && "$FALLBACK" == 1 && ! -f "$RUNNER_TEMP/attempted-A" ]]; then
+                    touch "$RUNNER_TEMP/attempted-A"
+                    return 64
+                  fi
+                  ;;
+                run) echo Dekaf.Benchmarks.Benchmarks.Unit.ExampleBenchmarks.Example ;;
+                build-server) ;;
+                *) return 65 ;;
+              esac
+            }
+            git() {
+              if [[ "$1" == clean ]]; then
+                rm -f tools/Dekaf.Benchmarks/GateBenchmarkExecution.sln
+              fi
+            }
+        '''
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for role in ('A', 'B'):
+                (root / f'gate-{role}/tools/Dekaf.Benchmarks').mkdir(parents=True)
+            (root / 'results').mkdir()
+            events = root / 'events'
+            events.touch()
+            script = root / 'build.sh'
+            script.write_text('set -euo pipefail\n' + textwrap.dedent(stub) + commands, encoding='utf-8')
+            environment = dict(os.environ, RUNNER_TEMP=root.as_posix(), GATE=(root / 'results').as_posix(),
+                               GITHUB_STEP_SUMMARY=(root / 'summary').as_posix(), EVENTS=events.as_posix(),
+                               FAIL_PREPARE=fail_prepare, FALLBACK=str(int(fallback)),
+                               FAIL_CANDIDATE=str(int(fail_candidate)), HEAD_SHA='candidate', FILTER='*')
+            result = subprocess.run([BASH, script.as_posix()], cwd=root, env=environment,
+                                    text=True, capture_output=True, timeout=30)
+            return result, events.read_text().splitlines(), (root / 'results/baseline-fixtures').exists()
+
     def test_gate_workflow_runs_one_same_vm_job_per_class_and_repeats_regressions(self):
         workflow = WORKFLOW.read_text(encoding='utf-8')
         measure = workflow.split('\n  measure:\n', 1)[1].split('\n  gate:\n', 1)[0]

--- a/.github/workflows/performance-gate.yml
+++ b/.github/workflows/performance-gate.yml
@@ -144,13 +144,18 @@ jobs:
           git fetch --no-tags --depth 1 origin "$BASE_SHA" "$HEAD_SHA"
           git worktree add --detach "$RUNNER_TEMP/gate-A" "$BASE_SHA"
           git worktree add --detach "$RUNNER_TEMP/gate-B" "$HEAD_SHA"
-          build() {
+          prepare() {
             (
               cd "$RUNNER_TEMP/gate-$1/tools/Dekaf.Benchmarks"
               rm -f GateBenchmarkExecution.sln
               # BDN looks for a solution to locate the project for its generated worker (PR #3180).
               dotnet new sln --name GateBenchmarkExecution --format sln > "$GATE/solution-$1.log" 2>&1
               dotnet sln GateBenchmarkExecution.sln add Dekaf.Benchmarks.csproj >> "$GATE/solution-$1.log" 2>&1
+            )
+          }
+          build() {
+            (
+              cd "$RUNNER_TEMP/gate-$1/tools/Dekaf.Benchmarks"
               dotnet build Dekaf.Benchmarks.csproj -c Release --disable-build-servers > "$GATE/build-$1.log" 2>&1
             )
           }
@@ -160,6 +165,11 @@ jobs:
           # no baseline benchmark at all, so only the candidate is measured and reported.
           rm -rf "$RUNNER_TEMP/gate-A/tools/Dekaf.Benchmarks"
           cp -R "$RUNNER_TEMP/gate-B/tools/Dekaf.Benchmarks" "$RUNNER_TEMP/gate-A/tools/Dekaf.Benchmarks"
+          # Complete each SDK's CLI first-use migration before any background build.
+          # dotnet --info does not initialize it; concurrent dotnet new commands can
+          # race while creating the shared NuGet-Migrations mutex on fresh Linux VMs.
+          prepare A
+          prepare B
           build B &
           candidate_build=$!
           if build A; then
@@ -168,6 +178,7 @@ jobs:
             echo '::notice::The PR fixtures do not build against the baseline; the baseline measures its own fixtures. Cases from fixture files that differ are reported, not compared.'
             mv "$GATE/build-A.log" "$GATE/build-A-candidate-fixtures.log"
             (cd "$RUNNER_TEMP/gate-A" && git checkout -- tools/Dekaf.Benchmarks && git clean -fdxq tools/Dekaf.Benchmarks)
+            prepare A
             build A
             touch "$GATE/baseline-fixtures"
             echo 'Baseline built its own fixture source (the candidate fixtures need newer APIs); cases whose fixture file differs are reported, not compared.' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The performance gate can fail before measuring anything when baseline and candidate dotnet new commands enter first-use initialization concurrently. PR #3129 hit the NuGet-Migrations/EEXIST startup failure on two successive heads.

Prepare both SDKs and benchmark solutions serially before launching parallel builds. Recreate the solution during baseline-fixture fallback. Benchmark execution, selection, tolerances, and verdicts are unchanged.

Closes #3236

Validation: 33 performance-tooling tests pass with Git Bash on Windows after rebasing onto main 16991110b (including #3129). Deterministic workflow execution tests reject background first-use initialization, verify preparation failures stop before builds, exercise baseline fallback, and confirm candidate build failures remain failures. Four checks fail against the previous workflow. Current head 2e3dad3 completes all applicable CI checks and has a current-head CLEAR review, Greptile 5/5, and no unresolved review threads. Archive hashes were verified before merge.
Current source archive, raw tooling test output, and verified SHA-256 inventory: C:/git/Dekaf-evidence/pr-3237/2e3dad36ba34ccff931452f239a9220d9c922e86. Earlier before/after evidence remains in this PR's 8c6aed4584b192fc322a2c3c9e60eddc3aa2f72d archive.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance-gate build reliability by ensuring SDK setup completes before parallel builds begin.
  * Added safer handling for baseline fallback builds and preparation failures.
  * Added cross-platform Bash discovery, including Windows Git Bash support.

* **Tests**
  * Expanded workflow coverage for initialization order, preparation failures, fallback retries, and candidate build failures.
  * Added automated shell-based validation for workflow execution and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
