### PR TITLE
test(stress): add explicit hosted share lifecycle lane

### DIFF
--- a/.github/scripts/stress_timeout.py
+++ b/.github/scripts/stress_timeout.py
@@ -27,7 +27,7 @@ def budget(matrix, duration_minutes, warmup_seconds, adaptive_connections=False)
             segments += int(lane.get("run_adaptive", False) and not adaptive_connections)
             lane["producer_samples"] = segments
             validation = 0
-        elif str(lane.get("scenario", "")).startswith("consumer"):
+        elif str(lane.get("scenario", "")).startswith("consumer") or lane.get("scenario") == "hosted-share":
             segments = lane.get("paired_samples", 1) * (2 if lane.get("client") == "all" else 1)
             # The existing workflow field gates validation and its expected result count.
             lane["producer_samples"] = segments

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -94,6 +94,16 @@ class StressAbaComparisonTests(unittest.TestCase):
                 self.assertIn(item["status"], ("recorded", "n/a"), item["key"])
         self.assertIn(metric(comparison, "max")["status"], ("recorded", "n/a"))
 
+    def test_hosted_processing_latency_uses_existing_diagnostics_contract(self):
+        segment = result(scenario="hosted-share", diagnostics=True)
+        segment.pop("deliveredMessages")  # The headline is unique processing completions.
+        segment["idempotent"] = True
+        segment["consumedMessages"] = segment["throughput"]["totalMessages"]
+        self.assert_pass(compare(segment, segment, segment))
+        segment.pop("producerDeliveryDiagnostics")
+        with self.assertRaisesRegex(ValueError, "producerDeliveryDiagnostics"):
+            compare(segment, segment, segment)
+
     def test_maximum_latency_is_recorded_and_never_decides(self):
         for second_candidate in (False, True):
             for count in (10_000, 1_000_000):
@@ -813,10 +823,10 @@ class StressAbaWorkflowTests(unittest.TestCase):
             self.workflow,
         )
         self.assertIn(
-            "Exact-SHA A-B-A requires a duration-based producer lane or a consumer replay lane",
+            "Exact-SHA A-B-A requires a duration-based producer, consumer replay, or hosted-share lane",
             self.workflow,
         )
-        self.assertIn("consumer-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b) ;;", self.workflow)
+        self.assertIn("consumer-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b|hosted-share-1b) ;;", self.workflow)
 
     def test_matrix_forces_three_single_connection_dekaf_segments(self):
         self.assertIn('.baseline_sha = $baseline_sha', self.workflow)

--- a/.github/scripts/test_stress_timeout.py
+++ b/.github/scripts/test_stress_timeout.py
@@ -35,6 +35,7 @@ class StressTimeoutTests(unittest.TestCase):
         for scenario, client, paired, count in (
             ("consumer", "all", 2, 4), ("consumer-batch", "dekaf", 1, 1),
             ("consumer-raw", "dekaf", 1, 1), ("consumer-raw-batch", "dekaf", 1, 1),
+            ("hosted-share", "dekaf", 1, 1),
         ):
             with self.subTest(scenario=scenario):
                 lane = dict(scenario=scenario, client=client, paired_samples=paired, timeout_minutes=60)

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -1997,6 +1997,18 @@ class StressTrendTests(unittest.TestCase):
         options = re.findall(r"^\s+- (\S+)$", options_block, re.MULTILINE)
         self.assertEqual(options, lane_ids + ["all"])
 
+    def test_hosted_share_requires_explicit_selection_without_expanding_full_runs(self):
+        workflow = stress_workflow_text()
+        heredoc = re.search(r"cat > lanes\.json << 'EOF'\n(?P<body>.*?)\n\s*EOF\n", workflow, re.DOTALL)
+        lanes = json.loads(heredoc.group("body"))
+        regular = [lane for lane in lanes if not lane.get("manual_only", False)]
+        manual = [lane for lane in lanes if lane.get("manual_only", False)]
+        self.assertEqual(12, len(regular))
+        self.assertEqual(["hosted-share-1b"], [lane["lane"] for lane in manual])
+        self.assertEqual("dekaf", manual[0]["client"])
+        self.assertIn('select(($lane == "all" and .manual_only != true) or .lane == $lane)', workflow)
+        self.assertIn('consumer-raw-batch-1b|hosted-share-1b) ;;', workflow)
+
     def test_history_merge_uses_admin_token(self):
         workflow = stress_workflow_text()
         step = workflow[

--- a/.github/scripts/test_stress_warmup.py
+++ b/.github/scripts/test_stress_warmup.py
@@ -281,12 +281,12 @@ class StressWarmupTests(unittest.TestCase):
         self.assertIn('rsync -a --delete --exclude bin --exclude obj', workflow)
         self.assertIn('git merge-base --is-ancestor "$BASELINE_SHA" "$GITHUB_SHA"', workflow)
         self.assertIn('dotnet build-server shutdown', workflow)
-        self.assertIn("matrix.brokers == 1 && matrix.baseline_sha == '' && 'localhost:9092' || ''", workflow)
+        self.assertIn("matrix.brokers == 1 && matrix.baseline_sha == '' && matrix.scenario != 'hosted-share' && 'localhost:9092' || ''", workflow)
         self.assertIn('python3 .github/scripts/stress_warmup.py', workflow)
         self.assertIn("--require-startup-assessment", workflow)
         self.assertLess(workflow.index('Build Stress Tests (exact baseline)'), workflow.index('run_aba()'))
         self.assertNotIn("schedule:", workflow)
-        self.assertIn("consumer-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b) ;;", workflow)
+        self.assertIn("consumer-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b|hosted-share-1b) ;;", workflow)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -29,13 +29,14 @@ on:
           - consumer-batch-1b
           - consumer-raw-1b
           - consumer-raw-batch-1b
+          - hosted-share-1b
           - all
       duration_minutes:
         description: 'Test duration in minutes'
         required: false
         default: '15'
       producer_warmup_seconds:
-        description: 'Identical elapsed workload warmup for producers and consumer replay (minimum 20 seconds; no adaptive extension)'
+        description: 'Identical elapsed workload warmup for producers and consumer replay/hosted share (minimum 20 seconds; no adaptive extension)'
         required: false
         default: '180'
       message_size:
@@ -247,9 +248,9 @@ jobs:
             fi
             case "$lane" in
               producer-1b|producer-3b|producer-idempotent-1b|producer-idempotent-3b|producer-acks-all-1b|producer-acks-all-3b) ;;
-              consumer-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b) ;;
+              consumer-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b|hosted-share-1b) ;;
               *)
-                echo "::error::Exact-SHA A-B-A requires a duration-based producer lane or a consumer replay lane."
+                echo "::error::Exact-SHA A-B-A requires a duration-based producer, consumer replay, or hosted-share lane."
                 exit 1
                 ;;
             esac
@@ -271,7 +272,8 @@ jobs:
             {"lane": "consumer-1b", "scenario": "consumer", "client": "all", "brokers": 1, "timeout_minutes": 90, "name": "Consumer (Paired)"},
             {"lane": "consumer-batch-1b", "scenario": "consumer-batch", "client": "dekaf", "brokers": 1, "timeout_minutes": 60, "name": "Dekaf Consumer Batch"},
             {"lane": "consumer-raw-1b", "scenario": "consumer-raw", "client": "dekaf", "brokers": 1, "timeout_minutes": 60, "name": "Dekaf Consumer Raw"},
-            {"lane": "consumer-raw-batch-1b", "scenario": "consumer-raw-batch", "client": "dekaf", "brokers": 1, "timeout_minutes": 60, "name": "Dekaf Consumer Raw Batch"}
+            {"lane": "consumer-raw-batch-1b", "scenario": "consumer-raw-batch", "client": "dekaf", "brokers": 1, "timeout_minutes": 60, "name": "Dekaf Consumer Raw Batch"},
+            {"lane": "hosted-share-1b", "scenario": "hosted-share", "client": "dekaf", "brokers": 1, "manual_only": true, "timeout_minutes": 60, "name": "Dekaf Hosted Share (Live Producer and Two Workers)"}
           ]
           EOF
 
@@ -295,7 +297,7 @@ jobs:
             def drop_3conn: .run_3conn = false | .artifact_suffix = "";
             def drop_adaptive: .run_adaptive = false;
             {include: [ .[]
-              | select($lane == "all" or .lane == $lane)
+              | select(($lane == "all" and .manual_only != true) or .lane == $lane)
               | segments as $full_segments
               | ((.timeout_minutes / $full_segments) | ceil) as $segment_budget
               | if $client != "" and .client == "all" then
@@ -363,7 +365,7 @@ jobs:
       # two-core consumer runner, creating permanent throughput steps unrelated to
       # either Kafka client. Pin consumer jobs to stable Server GC topology so paired
       # comparisons measure client work; producer jobs retain the runtime default.
-      DOTNET_GCDynamicAdaptationMode: ${{ startsWith(matrix.scenario, 'consumer') && '0' || '1' }}
+      DOTNET_GCDynamicAdaptationMode: ${{ (startsWith(matrix.scenario, 'consumer') || matrix.scenario == 'hosted-share') && '0' || '1' }}
       # Broker log dirs live on tmpfs so disk I/O never caps ingestion. Sized above the
       # worst-case retention overshoot (see KafkaEnvironment.RetentionConfig for the
       # math); a fill halts the broker, so the disk monitor below samples usage during
@@ -454,7 +456,7 @@ jobs:
         run: dotnet build-server shutdown
 
       - name: Start Kafka
-        if: matrix.brokers == 1 && matrix.baseline_sha == ''
+        if: matrix.brokers == 1 && matrix.baseline_sha == '' && matrix.scenario != 'hosted-share'
         run: |
           # Broker pinned to its own cores (client under test gets the rest) and log
           # dir on tmpfs so neither broker CPU starvation nor disk I/O caps ingestion.
@@ -508,7 +510,7 @@ jobs:
         env:
           # A-B-A gets fresh Testcontainers brokers for every process, including 1-broker
           # lanes; retained topics, JVM state and broker caches cannot leak across phases.
-          KAFKA_BOOTSTRAP_SERVERS: ${{ matrix.brokers == 1 && matrix.baseline_sha == '' && 'localhost:9092' || '' }}
+          KAFKA_BOOTSTRAP_SERVERS: ${{ matrix.brokers == 1 && matrix.baseline_sha == '' && matrix.scenario != 'hosted-share' && 'localhost:9092' || '' }}
           # Multi-broker runs start brokers via Testcontainers from inside the client
           # process; these apply the same core pinning and tmpfs as the docker run above.
           STRESS_BROKER_CPUSET: ${{ env.BROKER_CPUS }}
@@ -720,7 +722,7 @@ jobs:
       # such check and would otherwise report near-zero throughput as a valid result;
       # this step also gives a clearer verdict than the client's exception trace.
       - name: Verify Broker Survived
-        if: matrix.brokers == 1 && matrix.baseline_sha == ''
+        if: matrix.brokers == 1 && matrix.baseline_sha == '' && matrix.scenario != 'hosted-share'
         run: |
           status=$(docker inspect -f '{{.State.Status}}' kafka 2>/dev/null || echo "missing")
           if [ "$status" != "running" ]; then
@@ -793,7 +795,7 @@ jobs:
           retention-days: 90
 
       - name: Stop Kafka
-        if: always() && matrix.brokers == 1 && matrix.baseline_sha == ''
+        if: always() && matrix.brokers == 1 && matrix.baseline_sha == '' && matrix.scenario != 'hosted-share'
         run: docker rm -f kafka || true
 
   # Collect all results and generate summary

--- a/tools/Dekaf.StressTests.Tests/HostedShareWorkloadTests.cs
+++ b/tools/Dekaf.StressTests.Tests/HostedShareWorkloadTests.cs
@@ -1,0 +1,140 @@
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Text.Json;
+using Dekaf.StressTests.Diagnostics;
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Scenarios;
+
+namespace Dekaf.StressTests.Tests;
+
+public class HostedShareWorkloadTests
+{
+    [Test]
+    [Arguments(0L)]
+    [Arguments(4500L)]
+    public async Task WorkerWithoutMeasuredProgress_FailsEvenAfterWarmup(long warmupProcessed)
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        {
+            HostedShareStressTest.ValidateWorkerProgress(warmupProcessed, warmupProcessed);
+            return Task.CompletedTask;
+        });
+    }
+
+    [Test]
+    public void WorkerWithMeasuredProgress_Passes()
+    {
+        HostedShareStressTest.ValidateWorkerProgress(4500, 4501);
+    }
+
+    [Test]
+    public async Task MissingRecord_BlocksSlotReuseEvenWhenLaterRecordsComplete()
+    {
+        var state = new HostedShareWorkloadState("topic", 16);
+        var tracker = new ThroughputTracker();
+        state.BeginCycle(tracker);
+        for (var sequence = 0; sequence < HostedShareWorkloadState.WindowSize; sequence++)
+        {
+            state.RecordProduced();
+            if (sequence != 0) state.Process(Payload(sequence));
+        }
+        await Assert.That(state.CanProduce).IsFalse();
+        state.Process(Payload(0));
+        await Assert.That(state.CanProduce).IsTrue();
+        await Assert.That(state.Completed).IsEqualTo((long)HostedShareWorkloadState.WindowSize);
+        await Assert.That(tracker.MessageCount).IsEqualTo(state.Completed);
+    }
+
+    [Test]
+    public async Task ConcurrentRedelivery_CountsOnlyOneCompletion()
+    {
+        var state = new HostedShareWorkloadState("topic", 16);
+        var tracker = new ThroughputTracker();
+        state.BeginCycle(tracker);
+        state.RecordProduced();
+        var payload = Payload(0);
+        await Task.WhenAll(Task.Run(() => state.Process(payload)), Task.Run(() => state.Process(payload)));
+        await Assert.That(state.Completed).IsEqualTo(1L);
+        await Assert.That(state.Duplicates).IsEqualTo(1L);
+        await Assert.That(tracker.MessageCount).IsEqualTo(1L);
+        await Assert.That(state.Latency.GetSnapshot().Count).IsEqualTo(1L);
+    }
+
+    [Test]
+    public async Task OldDuplicate_AfterSlotReuse_DoesNotCompleteNewWork()
+    {
+        var state = new HostedShareWorkloadState("topic", 16);
+        state.BeginCycle(new ThroughputTracker());
+        state.Process(Payload(0));
+        state.Process(Payload(HostedShareWorkloadState.WindowSize));
+        await Assert.That(state.Process(Payload(0))).IsFalse();
+        await Assert.That(state.Completed).IsEqualTo(2L);
+    }
+
+    [Test]
+    public async Task SkippedGeneration_FailsInsteadOfHidingMissingRecord()
+    {
+        var state = new HostedShareWorkloadState("topic", 16);
+        state.BeginCycle(new ThroughputTracker());
+        await Assert.ThrowsAsync<InvalidOperationException>(() => Task.Run(() => state.Process(Payload(HostedShareWorkloadState.WindowSize))));
+    }
+
+    [Test]
+    public async Task UndrainedCycle_CannotResetMeasuredCounters()
+    {
+        var state = new HostedShareWorkloadState("topic", 16);
+        state.BeginCycle(new ThroughputTracker());
+        state.RecordProduced();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => Task.Run(() => state.BeginCycle(new ThroughputTracker())));
+    }
+
+    [Test]
+    public async Task BackgroundFailure_RemainsVisibleAcrossCycleBoundary()
+    {
+        var state = new HostedShareWorkloadState("topic", 16);
+        state.RecordFailure(new IOException("acknowledgement failed"));
+        await Assert.ThrowsAsync<IOException>(() => Task.Run(() => state.BeginCycle(new ThroughputTracker())));
+    }
+
+    [Test]
+    public async Task Result_RetainsProducerDiagnosticsWithProcessingLatency()
+    {
+        using var watchdog = new ProgressWatchdog(Path.GetTempPath());
+        var options = new StressTestOptions
+        {
+            BootstrapServers = "localhost:1", Topic = "topic", DurationMinutes = 1,
+            MessageSizeBytes = 16, EnableProducerDeliveryDiagnostics = true,
+            ProgressWatchdog = watchdog
+        };
+        var builder = Kafka.CreateProducer<string, byte[]>().WithBootstrapServers(options.BootstrapServers);
+        StressTestHelpers.ConfigureProducerDeliveryDiagnostics(builder, options);
+        await using var producer = builder.Build();
+        var throughput = new ThroughputTracker();
+        var latency = new LatencyTracker();
+        using var gc = new GcStats();
+        throughput.Start();
+        throughput.RecordMessage(16);
+        latency.RecordTicks(100);
+        throughput.Stop();
+        gc.Capture();
+        var run = new ProducerWorkloadResult(1, throughput.GetSnapshot(), gc.ToSnapshot());
+
+        var result = new HostedShareStressTest().CreateResult(options, DateTime.UtcNow, run, throughput, latency, producer);
+        using var json = JsonDocument.Parse(result.ToJson());
+
+        await Assert.That(json.RootElement.GetProperty("producerDeliveryDiagnostics").ValueKind).IsEqualTo(JsonValueKind.Object);
+        await Assert.That(json.RootElement.GetProperty("producerDeliveryDiagnostics").GetProperty("diagnosticsEnabled").GetBoolean()).IsTrue();
+        await Assert.That(json.RootElement.GetProperty("latency").GetProperty("count").GetInt64()).IsEqualTo(1L);
+        await Assert.That(json.RootElement.GetProperty("idempotent").GetBoolean()).IsTrue();
+        await Assert.That(json.RootElement.GetProperty("consumedMessages").GetInt64()).IsEqualTo(1L);
+        await Assert.That(json.RootElement.TryGetProperty("deliveredMessages", out _)).IsFalse();
+    }
+
+    private static byte[] Payload(long sequence)
+    {
+        var payload = new byte[16];
+        BinaryPrimitives.WriteInt64LittleEndian(payload, sequence);
+        BinaryPrimitives.WriteInt64LittleEndian(payload.AsSpan(8), Stopwatch.GetTimestamp());
+        return payload;
+    }
+}

--- a/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
+++ b/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dekaf\Dekaf.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Extensions.Hosting\Dekaf.Extensions.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Lz4\Dekaf.Compression.Lz4.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Snappy\Dekaf.Compression.Snappy.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Zstd\Dekaf.Compression.Zstd.csproj" />

--- a/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
@@ -182,8 +182,10 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
         _network = network;
     }
 
-    public static async Task<KafkaEnvironment> CreateAsync(int brokerCount = 1)
+    public static async Task<KafkaEnvironment> CreateAsync(int brokerCount = 1, bool enableShareGroups = false)
     {
+        if (enableShareGroups && brokerCount != 1)
+            throw new ArgumentException("The hosted-share lane requires one broker.", nameof(brokerCount));
         var externalBootstrap = Environment.GetEnvironmentVariable("KAFKA_BOOTSTRAP_SERVERS");
         if (!string.IsNullOrEmpty(externalBootstrap))
         {
@@ -196,10 +198,10 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
             return await CreateMultiBrokerAsync(brokerCount).ConfigureAwait(false);
         }
 
-        return await CreateSingleBrokerAsync().ConfigureAwait(false);
+        return await CreateSingleBrokerAsync(enableShareGroups).ConfigureAwait(false);
     }
 
-    private static async Task<KafkaEnvironment> CreateSingleBrokerAsync()
+    private static async Task<KafkaEnvironment> CreateSingleBrokerAsync(bool enableShareGroups)
     {
         Console.WriteLine("Starting Kafka container via Testcontainers...");
         var builder = new KafkaBuilder(KafkaImage);
@@ -207,7 +209,7 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
         {
             ConsensusProtocol.KRaft => builder.WithKRaft(),
             ConsensusProtocol.ZooKeeper => builder,
-            _ => throw new ArgumentOutOfRangeException(nameof(SingleBrokerConsensusProtocol)),
+            _ => throw new InvalidOperationException("Unsupported single-broker consensus protocol."),
         };
 
         builder = builder
@@ -219,6 +221,16 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
             // Explicit log dir so the optional tmpfs mount target always matches
             .WithEnvironment("KAFKA_LOG_DIRS", KafkaLogDir)
             .WithEnvironment("KAFKA_HEAP_OPTS", BrokerHeapOpts);
+
+        if (enableShareGroups)
+        {
+            builder = builder
+                .WithEnvironment("KAFKA_GROUP_SHARE_ENABLE", "true")
+                .WithEnvironment("KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS", "classic,consumer,share")
+                .WithEnvironment("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR", "1")
+                .WithEnvironment("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR", "1")
+                .WithEnvironment("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_NUM_PARTITIONS", "3");
+        }
 
         foreach (var (key, value) in RetentionConfig)
         {

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -19,7 +19,7 @@ namespace Dekaf.StressTests;
 /// Options:
 ///   --duration &lt;minutes&gt;    Test duration in minutes (default: 15)
 ///   --message-size &lt;bytes&gt;  Message size in bytes (default: 1000)
-///   --scenario &lt;name&gt;       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip-steady, consumer, consumer-batch, consumer-raw, consumer-raw-batch, all (default: all)
+///   --scenario &lt;name&gt;       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip-steady, consumer, consumer-batch, consumer-raw, consumer-raw-batch, hosted-share, all (default: all)
 ///   --client &lt;name&gt;         Run specific client: dekaf, confluent, all (default: all)
 ///   --output &lt;path&gt;         Output directory for results (default: ./results)
 ///   --brokers &lt;count&gt;      Number of Kafka brokers (default: 1, use 3 for multi-broker)
@@ -149,7 +149,7 @@ public static class Program
         Directory.CreateDirectory(options.OutputPath);
         using var progressWatchdog = new ProgressWatchdog(options.OutputPath);
 
-        await using var kafka = await KafkaEnvironment.CreateAsync(options.Brokers).ConfigureAwait(false);
+        await using var kafka = await KafkaEnvironment.CreateAsync(options.Brokers, enableShareGroups: options.Scenario == "hosted-share").ConfigureAwait(false);
         var scenarios = GetScenarios(options);
 
         var producerTopic = $"stress-producer-{Guid.NewGuid():N}";
@@ -428,7 +428,8 @@ public static class Program
 
     private static bool UsesProducerTopic(string scenarioName) =>
         scenarioName.StartsWith("producer", StringComparison.OrdinalIgnoreCase) ||
-        scenarioName.Equals("soak", StringComparison.OrdinalIgnoreCase);
+        scenarioName.Equals("soak", StringComparison.OrdinalIgnoreCase) ||
+        scenarioName.Equals("hosted-share", StringComparison.OrdinalIgnoreCase);
 
     private static bool IsRoundTripScenario(string scenarioName) =>
         scenarioName.StartsWith("producer-roundtrip", StringComparison.OrdinalIgnoreCase);
@@ -802,7 +803,7 @@ public static class Program
     {
         var scenarios = CreateAllScenarios()
             .Where(s => options.Scenario == "all"
-                ? !s.Name.Equals("soak", StringComparison.OrdinalIgnoreCase)
+                ? !s.Name.Equals("soak", StringComparison.OrdinalIgnoreCase) && !s.Name.Equals("hosted-share", StringComparison.OrdinalIgnoreCase)
                 : s.Name.Equals(options.Scenario, StringComparison.OrdinalIgnoreCase))
             .Where(s => options.Client == "all" || s.Client.Equals(options.Client, StringComparison.OrdinalIgnoreCase))
             .ToList();
@@ -837,7 +838,8 @@ public static class Program
             new ConsumerRawStressTest(),
             new ConsumerRawBatchStressTest(),
             new ConfluentConsumerStressTest(),
-            new SoakStressTest()
+            new SoakStressTest(),
+            new HostedShareStressTest()
         ];
 
     private static List<IStressTestScenario> ApplyClientOrder(List<IStressTestScenario> scenarios, string requestedClient)

--- a/tools/Dekaf.StressTests/README.md
+++ b/tools/Dekaf.StressTests/README.md
@@ -1,0 +1,15 @@
+# Stress runner
+
+`hosted-share` is an explicit manual scenario. It runs an idempotent live producer and two instances of the same hosted share service under distinct DI keys in one Kafka share group. The `hosted-share-1b` workflow lane is excluded from both `lane=all` and `full_run=true`; the existing full matrix remains 12 jobs.
+
+```powershell
+dotnet run -c Release --project tools/Dekaf.StressTests -- --scenario hosted-share --client dekaf --duration 5 --producer-warmup-seconds 180
+```
+
+The scenario requires Kafka with share groups enabled. Its single-broker Testcontainers environment configures the share coordinator automatically. When using `KAFKA_BOOTSTRAP_SERVERS`, configure the external broker yourself. The scenario requires one broker, one producer connection, no compression, and messages of at least 16 bytes. It changes only its unique group's `share.auto.offset.reset` to `earliest`.
+
+The feeder reuses its serialized payload and permits at most 16,384 outstanding sequence slots. A missing record prevents that slot's reuse. Both workers complete records synchronously with `ValueTask`, and the harness counts each sequence once across redelivery and worker races. Persistent failure state reports polling, processing, acknowledgement and producer-delivery failures. Every phase stops ingress, flushes the producer and waits up to 30 seconds for every produced record to finish processing. Shutdown stops both services, observes their execution tasks and awaits asynchronous disposal.
+
+Warmup runs the same workload and observers through the existing six-cycle scheduler. The measured phase records unique processing throughput, admission-to-processing latency for every unique record, process CPU, process allocations, runtime observations and throughput stability. Producer request diagnostics reset at each phase and are retained in the result for the existing A/B/A diagnostics contract; workflow runs enable full producer delivery diagnostics. CPU and allocation figures include the live producer, both consumers, serialization and measurement overhead. These figures cannot be compared to the pre-seeded consumer replay lanes. A processing completion is not a broker-confirmed acknowledgement; final service shutdown submits acknowledgements, and any callback failure invalidates the run. Shutdown is validated outside the measured phase.
+
+Use `baseline_sha` for acceptance. The workflow overlays the candidate stress harness onto both product revisions, then runs baseline, candidate and baseline on one VM. Existing warmup, stability and performance gates apply unchanged. Every product revision must support the hosted-share APIs and pass this workload. A baseline that fails cannot supply a valid comparison. This fast-handler lane exercises normal polling, acknowledgement and shutdown under sustained load; delayed-handler renewal and fault routing retain their dedicated unit/integration coverage.

--- a/tools/Dekaf.StressTests/Scenarios/HostedShareStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/HostedShareStressTest.cs
@@ -1,0 +1,280 @@
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using Dekaf.Admin;
+using Dekaf.Extensions.DependencyInjection;
+using Dekaf.Extensions.Hosting;
+using Dekaf.Producer;
+using Dekaf.ShareConsumer;
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Reporting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Dekaf.StressTests.Scenarios;
+
+/// <summary>
+/// Measures a bounded live producer and two keyed hosted share consumers together.
+/// Share groups cannot seek a fixed replay corpus. CPU and allocations therefore include
+/// the feeder, serialization and both workers; latency ends at successful processing.
+/// </summary>
+internal sealed class HostedShareStressTest : IStressTestScenario
+{
+    public string Name => "hosted-share";
+    public string Client => "Dekaf";
+
+    public async Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.MessageSizeBytes, 16);
+        if (options.BrokerCount != 1 || options.ConnectionsPerBroker != 1 || options.Compression != "none")
+            throw new ArgumentException("Hosted-share requires one broker, one producer connection and no compression.");
+        var group = $"stress-hosted-share-{Guid.NewGuid():N}";
+        await using (var admin = Kafka.CreateAdminClient().WithBootstrapServers(options.BootstrapServers).Build())
+        {
+            await admin.IncrementalAlterConfigsAsync(new Dictionary<ConfigResource, IReadOnlyList<ConfigAlter>>
+            {
+                [new ConfigResource { Type = ConfigResourceType.Group, Name = group }] =
+                    [ConfigAlter.Set("share.auto.offset.reset", "earliest")]
+            }, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        var state = new HostedShareWorkloadState(options.Topic, options.MessageSizeBytes);
+        var builder = Host.CreateApplicationBuilder();
+        builder.Logging.ClearProviders();
+        builder.Services.AddSingleton(state);
+        builder.Services.AddDekaf(dekaf => dekaf
+            .AddShareConsumerService<Worker, string, byte[]>("first", Configure)
+            .AddShareConsumerService<Worker, string, byte[]>("second", Configure));
+        using var host = builder.Build();
+        var producerBuilder = Kafka.CreateProducer<string, byte[]>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
+            .WithBootstrapServers(options.BootstrapServers)
+            .WithIdempotence(true).WithAcks(Acks.All)
+            .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
+            .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs)).WithBatchSize(options.BatchSize)
+            .WithConnectionsPerBroker(1).WithoutAdaptiveConnections();
+        StressTestHelpers.ConfigureProducerDeliveryDiagnostics(producerBuilder, options);
+        await using var producer = await producerBuilder.BuildAsync(cancellationToken).ConfigureAwait(false);
+        var workers = host.Services.GetServices<IHostedService>().OfType<Worker>().ToArray();
+        if (workers.Length != 2 || ReferenceEquals(workers[0].Consumer, workers[1].Consumer))
+            throw new InvalidOperationException("The two keyed registrations did not create independent workers.");
+
+        var measured = new ThroughputTracker();
+        try
+        {
+            await host.StartAsync(cancellationToken).ConfigureAwait(false);
+            Console.WriteLine($"  Warming up hosted-share: {options.ProducerWarmupSeconds}s, two keyed workers, {HostedShareWorkloadState.WindowSize} outstanding records maximum.");
+            measured.Warmup = await ProducerWarmup.RunAsync(options.ProducerWarmupSeconds,
+                RunCycleAsync, cancellationToken).ConfigureAwait(false);
+            var warmupProcessed = new[] { workers[0].Processed, workers[1].Processed };
+            var started = DateTime.UtcNow;
+            var run = await RunCycleAsync(TimeSpan.FromMinutes(options.DurationMinutes), measured, cancellationToken).ConfigureAwait(false);
+            using var shutdown = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            shutdown.CancelAfter(StressTestHelpers.OperationTimeout);
+            await host.StopAsync(shutdown.Token).ConfigureAwait(false);
+            for (var i = 0; i < workers.Length; i++)
+            {
+                var worker = workers[i];
+                if (worker.ExecuteTask is { } execution) await execution.WaitAsync(shutdown.Token).ConfigureAwait(false);
+                ValidateWorkerProgress(warmupProcessed[i], worker.Processed);
+            }
+            state.ThrowIfFailed();
+            Console.WriteLine($"  Hosted workers stopped after processing {state.Completed:N0} unique records; duplicates={state.Duplicates:N0}.");
+            return CreateResult(options, started, run, measured, state.Latency, producer);
+        }
+        finally
+        {
+            using var shutdown = new CancellationTokenSource(StressTestHelpers.OperationTimeout);
+            try { await host.StopAsync(shutdown.Token).ConfigureAwait(false); }
+            finally
+            {
+                // Observe every cleanup even if another worker faults during disposal.
+                await Task.WhenAll(workers.Select(worker => worker.DisposeAsync().AsTask())).ConfigureAwait(false);
+            }
+        }
+
+        void Configure(ShareConsumerBuilder<string, byte[]> consumer) => consumer
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
+            .WithBootstrapServers(options.BootstrapServers).WithGroupId(group)
+            .WithAcknowledgementCommitCallback(state.ObserveAcknowledgements);
+
+        async Task<ProducerWorkloadResult> RunCycleAsync(TimeSpan duration, ThroughputTracker tracker, CancellationToken token)
+        {
+            state.BeginCycle(tracker);
+            StressTestHelpers.ResetProducerDeliveryDiagnostics(producer);
+            var payload = new byte[options.MessageSizeBytes];
+            if (tracker.Warmup is not null)
+                Console.WriteLine($"  Running {Client} {Name} stress test for {options.DurationMinutes} minutes...");
+            using var deliveryErrors = new DekafDeliveryErrorListener(tracker, options.Topic);
+            using var gc = new GcStats();
+            using var ingress = CancellationTokenSource.CreateLinkedTokenSource(token);
+            using var sampling = new CancellationTokenSource();
+            tracker.Start();
+            var stop = ProducerWorkload.StopIngressAsync(ingress, duration, TimeProvider.System);
+            using var watchdog = options.ProgressWatchdog.Track(tracker, Client, Name);
+            var sampler = StressTestHelpers.RunSamplerAsync(tracker, sampling.Token);
+            var resources = StressTestHelpers.RunResourceMonitorAsync(sampling.Token);
+            double workloadSeconds;
+            try
+            {
+                while (!ingress.IsCancellationRequested)
+                {
+                    state.ThrowIfFailed();
+                    if (!state.CanProduce)
+                    {
+                        await Task.Delay(1, token).ConfigureAwait(false);
+                        continue;
+                    }
+                    var sequence = state.Produced;
+                    BinaryPrimitives.WriteInt64LittleEndian(payload, sequence);
+                    BinaryPrimitives.WriteInt64LittleEndian(payload.AsSpan(8), Stopwatch.GetTimestamp());
+                    // FireAsync copies the reusable payload before completing. This path has
+                    // no cancellation overload; the outstanding window bounds admission.
+                    await producer.FireAsync(options.Topic, StressTestHelpers.GetKey(sequence), payload).ConfigureAwait(false);
+                    state.RecordProduced();
+                }
+                workloadSeconds = tracker.Elapsed.TotalSeconds;
+                using var drain = CancellationTokenSource.CreateLinkedTokenSource(token);
+                drain.CancelAfter(StressTestHelpers.OperationTimeout);
+                await producer.FlushAsync(drain.Token).ConfigureAwait(false);
+                // Process publishes shared completion before the worker updates its own count.
+                // Drain both counters so a late warmup increment cannot pass measured validation.
+                while (state.Completed != state.Produced || workers[0].Processed + workers[1].Processed != state.Produced)
+                {
+                    state.ThrowIfFailed();
+                    await Task.Delay(1, drain.Token).ConfigureAwait(false);
+                }
+                state.ThrowIfFailed();
+            }
+            catch (OperationCanceledException exception) when (!token.IsCancellationRequested)
+            {
+                throw new TimeoutException($"Hosted-share drain incomplete: produced={state.Produced}, completed={state.Completed}, duplicates={state.Duplicates}, workers={string.Join(",", workers.Select(worker => $"{worker.Processed}:{worker.ExecuteTask?.Status}"))}.", exception);
+            }
+            finally
+            {
+                ingress.Cancel();
+                sampling.Cancel();
+                await stop.ConfigureAwait(false);
+                await Task.WhenAll(sampler, resources).ConfigureAwait(false);
+                tracker.Stop();
+                gc.Capture();
+            }
+            token.ThrowIfCancellationRequested();
+            return new ProducerWorkloadResult(workloadSeconds, tracker.GetSnapshot(), gc.ToSnapshot());
+        }
+    }
+
+    internal static void ValidateWorkerProgress(long warmupProcessed, long totalProcessed)
+    {
+        if (totalProcessed <= warmupProcessed)
+            throw new InvalidOperationException("A keyed worker processed no records in the measured phase.");
+    }
+
+    internal StressTestResult CreateResult(StressTestOptions options, DateTime started,
+        ProducerWorkloadResult run, ThroughputTracker measured, LatencyTracker latency,
+        IKafkaProducer<string, byte[]> producer) => new()
+    {
+        Scenario = Name, Client = Client, DurationMinutes = options.DurationMinutes,
+        MessageSizeBytes = options.MessageSizeBytes, BrokerCount = options.BrokerCount,
+        StartedAtUtc = started, CompletedAtUtc = DateTime.UtcNow,
+        Throughput = run.Throughput, GcStats = run.Gc, Latency = latency.GetSnapshot(),
+        CpuTimeSeconds = measured.CpuTimeSeconds, ConsumedMessages = measured.MessageCount,
+        Idempotent = true,
+        ProducerDeliveryDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options)
+            ?? throw new InvalidOperationException("Hosted-share results require producer delivery diagnostics.")
+    };
+
+    private sealed class Worker(IKafkaShareConsumer<string, byte[]> consumer, HostedShareWorkloadState state)
+        : KafkaShareConsumerService<string, byte[]>(consumer,
+            StressClientLogging.LoggerFactory.CreateLogger("HostedShareStress"))
+    {
+        public IKafkaShareConsumer<string, byte[]> Consumer { get; } = consumer;
+        private long _processed;
+        public long Processed => Volatile.Read(ref _processed);
+        protected override IEnumerable<string> Topics => [state.Topic];
+        protected override ValueTask ProcessAsync(ShareConsumeResult<string, byte[]> result, CancellationToken cancellationToken)
+        {
+            if (state.Process(result.Value)) Volatile.Write(ref _processed, _processed + 1);
+            return ValueTask.CompletedTask;
+        }
+        protected override ValueTask OnErrorAsync(Exception exception, ShareConsumeResult<string, byte[]>? result, CancellationToken cancellationToken)
+        {
+            state.RecordFailure(exception);
+            return ValueTask.CompletedTask;
+        }
+    }
+}
+
+/// <summary>Fixed memory, exact per-slot generations, and unique completion counts across both workers.</summary>
+internal sealed class HostedShareWorkloadState
+{
+    internal const int WindowSize = 16_384;
+    private readonly long[] _completedSequences = new long[WindowSize];
+    private readonly int _messageSize;
+    private ThroughputTracker? _throughput;
+    private Exception? _failure;
+    private long _completed;
+    private long _duplicates;
+    public string Topic { get; }
+    public long Produced { get; private set; }
+    public long Completed => Interlocked.Read(ref _completed);
+    public long Duplicates => Interlocked.Read(ref _duplicates);
+    public LatencyTracker Latency { get; } = new();
+    public bool CanProduce => Produced - Completed < WindowSize
+        && Volatile.Read(ref _completedSequences[Produced % WindowSize]) == Produced - WindowSize;
+
+    public HostedShareWorkloadState(string topic, int messageSize)
+    {
+        Topic = topic;
+        _messageSize = messageSize;
+        for (var i = 0; i < WindowSize; i++) _completedSequences[i] = i - WindowSize;
+    }
+
+    public void BeginCycle(ThroughputTracker throughput)
+    {
+        if (Completed != Produced) throw new InvalidOperationException("Previous hosted-share cycle has not drained.");
+        ThrowIfFailed();
+        Latency.Reset();
+        _throughput = throughput;
+    }
+
+    public void RecordProduced() => Produced++;
+
+    public bool Process(byte[]? payload)
+    {
+        if (payload is null || payload.Length != _messageSize || payload.Length < 16)
+            throw new InvalidOperationException("Hosted-share payload size does not match the workload.");
+        var sequence = BinaryPrimitives.ReadInt64LittleEndian(payload);
+        if (sequence < 0) throw new InvalidOperationException("Hosted-share sequence is negative.");
+        var timestamp = BinaryPrimitives.ReadInt64LittleEndian(payload.AsSpan(8));
+        var ticks = Stopwatch.GetTimestamp() - timestamp;
+        if (timestamp <= 0 || ticks < 0) throw new InvalidOperationException("Hosted-share timestamp is invalid.");
+        ref var slot = ref _completedSequences[sequence % WindowSize];
+        var previous = Interlocked.CompareExchange(ref slot, sequence, sequence - WindowSize);
+        if (previous >= sequence)
+        {
+            Interlocked.Increment(ref _duplicates);
+            return false;
+        }
+        if (previous != sequence - WindowSize)
+            throw new InvalidOperationException("Hosted-share sequence skipped an unfinished slot generation.");
+        Latency.RecordTicks(ticks);
+        _throughput!.RecordMessage(payload.Length);
+        Interlocked.Increment(ref _completed);
+        return true;
+    }
+
+    public void ObserveAcknowledgements(ReadOnlySpan<ShareAcknowledgementCommitResult> results)
+    {
+        foreach (var result in results)
+            if (result.Exception is { } failure) RecordFailure(failure);
+    }
+
+    public void RecordFailure(Exception exception) => Interlocked.CompareExchange(ref _failure, exception, null);
+    public void ThrowIfFailed()
+    {
+        if (Volatile.Read(ref _failure) is { } failure) ExceptionDispatchInfo.Capture(failure).Throw();
+        if (_throughput?.DeliveryErrorCount > 0) throw new InvalidOperationException("The hosted-share feeder reported a delivery failure.");
+    }
+}


### PR DESCRIPTION
Add a manual-only hosted-share-1b stress lane for #3210: one idempotent live producer and two independently keyed hosted share workers, bounded by 16,384 outstanding sequence slots. Track unique completions, duplicates, processing latency, CPU/message, allocations/message, stability and producer diagnostics. The lane uses the existing six-cycle warmup and exact-SHA A/B/A comparator. It is excluded from lane=all and full_run=true; the existing 12-job matrix and thresholds remain unchanged.

Both workers must complete unique records during the measured phase. Each cycle drains shared and worker counters before the next phase, preventing a late warmup increment from satisfying measured acceptance. Worker counter publication uses Volatile; snapshot allocation and validation are per phase. Handler counting remains synchronous without per-record allocation. CPU and allocation results include the feeder and both workers.

Refs #3210, #3158, #3116. This PR does not close #3210.

Validation on fa40ca443b21091b9ac6526275348df2feb4bcf7, one commit on main c113d02159c1734fdd2e5c0968cccffbc0af16c2: all 49 stress-runner tests and 236 stress-tooling tests pass; artifact policy and whitespace checks pass. Reviewed for reuse, correctness and efficiency. Source archive, test log, loaded binaries and reports are retained at C:/git/Dekaf-evidence/pr-3243/fa40ca443b21091b9ac6526275348df2feb4bcf7 with 276 file hashes verified against their originals. Subsequent CI/review is required.

**Loaded acceptance remains blocked; do not merge based only on CI.** #3244 now tracks confirmed truncation in classic PollAsync, and #3245 tracks shutdown acknowledgement/session handling. Both are native sub-issues and blockers of #3210. #3158 must also provide accepted response/payload ownership and performance evidence. No diagnostic overlay or higher poll limit is committed here, and no paid run has been dispatched.

A bounded Kafka 4.3.1 diagnostic on this driver with #3158 product 82a2b642 overlaid reproduces the original default-limit stall: 9,000/16,384 unique completions, zero duplicates, both workers alive at 4,500 each. Eighteen responses grant 16,235 acquired records but classic parsing yields only 9,000; individual grants of 924–1,030 are truncated to 500. The recorded ranges do not account for the other 149 produced records. Raising MaxPollRecords to 16,384 only as a diagnostic eliminates sampled truncation and permits full draining, confirming that configuration is an intervention rather than a product fix.

The subsequent phase-logging diagnostic drains 9,738,726 unique records (7,588,154 during measurement), zero duplicates, and both workers finish. Final acknowledgement validation still fails with a retained OperationCanceledException from an in-flight ShareFetch canceled during stop; final ShareAcknowledge calls also report InvalidShareSessionEpoch. No error was suppressed, and this is not a loaded PASS. Exact composed source, commands, 106 SHA-256-verified binary files per driver, raw logs and counts are retained at C:/git/Dekaf-evidence/pr-3243/classic-poll-cap-diagnostic-fa40ca443 and classic-poll-cap-phase-fa40ca443. Full attribution and limitations: https://github.com/thomhurst/Dekaf/pull/3243#issuecomment-5630475859.

The #3116 acquired-batch correction covers PollBatchesAsync; this lane uses classic PollAsync. Resolve #3244 and #3245, then validate this lane with an appropriate exact-SHA baseline experiment. Earlier diagnostics remain attributed to their measured revisions and are not acceptance for this head.

Earlier source/test evidence remains under C:/git/Dekaf-evidence/pr-3243/5601e65705e65d539fb8c0a46191f0a018f2ef64 and bb678a3fc7602c18c497105ab34b915e618ac175. The counted diagnostic's exact source, driver, product binaries and failure logs remain in ownership-probe-counts-retained with a verified inventory. The first main-failure archive retains unchanged main product binaries, but its driver was rebuilt afterward; that first failure does not have an exact retained loaded driver. No earlier result is claimed for this new head.

