### PR TITLE
fix(share-consumer): preserve acknowledgement outcomes during hosted shutdown

### DIFF
--- a/src/Dekaf.Extensions.Hosting/KafkaShareConsumerService.cs
+++ b/src/Dekaf.Extensions.Hosting/KafkaShareConsumerService.cs
@@ -120,12 +120,13 @@ public abstract partial class KafkaShareConsumerService<TKey, TValue> : Backgrou
             ((AsyncAutoResetSignal)state!).Signal(), _operationCompleted);
         ShareConsumeResult<TKey, TValue>? current = null;
         var initialized = false;
+        Exception? executionFailure = null;
         try
         {
             if (_consumer is not IShareConsumerConfiguration { AcknowledgementMode: ShareAcknowledgementMode.Explicit })
                 throw new InvalidOperationException("Hosted share consumers require verified Explicit acknowledgement mode. Wrappers must implement IShareConsumerConfiguration.");
             if (_consumer is IHostedShareConsumer hostedConsumer)
-                hostedConsumer.ObserveAcknowledgements(ObserveAcknowledgements);
+                hostedConsumer.ObserveAcknowledgements(ObserveAcknowledgements, _shutdownCancellation.Token);
             if (_deadLetterOptions is not null)
             {
                 if (!_deadLetterOptions.AwaitDelivery)
@@ -226,12 +227,14 @@ public abstract partial class KafkaShareConsumerService<TKey, TValue> : Backgrou
         {
             if (_acknowledgementFailure is { } failure)
             {
+                executionFailure = failure;
                 await OnErrorAsync(failure, current, CancellationToken.None).ConfigureAwait(false);
                 ExceptionDispatchInfo.Capture(failure).Throw();
             }
         }
         catch (Exception exception)
         {
+            executionFailure = exception;
             await OnErrorAsync(exception, current, CancellationToken.None).ConfigureAwait(false);
             throw;
         }
@@ -259,6 +262,7 @@ public abstract partial class KafkaShareConsumerService<TKey, TValue> : Backgrou
                 }
                 catch (Exception exception)
                 {
+                    _acknowledgementFailure ??= exception;
                     LogFailure(exception, null);
                 }
                 try
@@ -281,6 +285,11 @@ public abstract partial class KafkaShareConsumerService<TKey, TValue> : Backgrou
                     LogFailure(exception, null);
                 }
             }
+            if (executionFailure is null && _acknowledgementFailure is { } finalAcknowledgementFailure)
+            {
+                await OnErrorAsync(finalAcknowledgementFailure, current, CancellationToken.None).ConfigureAwait(false);
+                ExceptionDispatchInfo.Capture(finalAcknowledgementFailure).Throw();
+            }
         }
     }
 
@@ -290,8 +299,6 @@ public abstract partial class KafkaShareConsumerService<TKey, TValue> : Backgrou
         {
             if (result.Exception is { } exception)
             {
-                if (exception is OperationCanceledException && _pollCancellation.IsCancellationRequested)
-                    continue;
                 _acknowledgementFailure ??= exception;
                 _pollCancellation.Cancel();
             }

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -82,7 +82,8 @@ public sealed partial class KafkaConnection :
     IKafkaConnectionStatusSource,
     IRetirableKafkaConnection,
     IKafkaPipelinedWriteCompletionConnection,
-    IKafkaRequestWriteObserverConnection
+    IKafkaRequestWriteObserverConnection,
+    IKafkaRequestCancellationConnection
 {
     private readonly string _host;
     private readonly int _port;
@@ -627,7 +628,13 @@ public sealed partial class KafkaConnection :
             cancellationToken,
             requestWriteStarted);
 
-    private async ValueTask<TResponse> SendAsyncCore<TRequest, TResponse>(
+    ValueTask<TResponse> IKafkaRequestCancellationConnection.SendWithResponseCancellationAsync<TRequest, TResponse>(
+        TRequest request, short apiVersion, KafkaRequestWriteContext context,
+        CancellationToken cancellationToken)
+        => SendAsyncCore<TRequest, TResponse, CancellationObservation>(request, apiVersion,
+            requireReady: true, new CancellationObservation(context), cancellationToken);
+
+    private ValueTask<TResponse> SendAsyncCore<TRequest, TResponse>(
         TRequest request,
         short apiVersion,
         bool requireReady,
@@ -635,6 +642,38 @@ public sealed partial class KafkaConnection :
         Action? requestWriteStarted = null)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
+        => SendAsyncCore<TRequest, TResponse, WriteObservation>(request, apiVersion,
+            requireReady, new WriteObservation(requestWriteStarted), cancellationToken);
+
+    // Both observation structs contain one reference, preserving the ordinary async state's
+    // existing callback slot. Constrained calls avoid boxing and per-request observer objects.
+    private interface IRequestObservation
+    {
+        Action? WriteStartedCallback { get; }
+        CancellationToken AfterWriteStarts(CancellationToken cancellationToken);
+    }
+
+    private readonly struct WriteObservation(Action? callback) : IRequestObservation
+    {
+        public Action? WriteStartedCallback => callback;
+        public CancellationToken AfterWriteStarts(CancellationToken cancellationToken) => cancellationToken;
+    }
+
+    private readonly struct CancellationObservation(KafkaRequestWriteContext context) : IRequestObservation
+    {
+        public Action? WriteStartedCallback => context.WriteStartedCallback;
+        public CancellationToken AfterWriteStarts(CancellationToken cancellationToken) => context.ResponseCancellationToken;
+    }
+
+    private async ValueTask<TResponse> SendAsyncCore<TRequest, TResponse, TObservation>(
+        TRequest request,
+        short apiVersion,
+        bool requireReady,
+        TObservation observation,
+        CancellationToken cancellationToken)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+        where TObservation : struct, IRequestObservation
     {
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(KafkaConnection));
@@ -688,16 +727,19 @@ public sealed partial class KafkaConnection :
             // Write phase
             LogSendingRequest(KafkaMessageMetadata<TRequest, TResponse>.ApiKey, correlationId, apiVersion, _host, _port);
 
-            await PreSerializeAndWriteAsync<TRequest, TResponse>(
+            await PreSerializeAndWriteCoreAsync<TRequest, TResponse, TObservation>(
                     request,
                     correlationId,
                     apiVersion,
                     headerVersion,
-                    cancellationToken,
-                    requestWriteStarted: requestWriteStarted)
+                    callerOwnsTimeout: false,
+                    observation,
+                    cancellationToken)
                 .ConfigureAwait(false);
 
             LogRequestSentWaitingForResponse(correlationId);
+
+            cancellationToken = observation.AfterWriteStarts(cancellationToken);
 
             // Response phase: await response with timeout and parse
             var response = await AwaitAndParseResponseAsync<TRequest, TResponse>(
@@ -1796,7 +1838,7 @@ public sealed partial class KafkaConnection :
     /// the pre-serialized bytes and flush. This minimizes lock hold time by keeping
     /// CPU-bound serialization out of the critical section.
     /// </summary>
-    private async ValueTask PreSerializeAndWriteAsync<TRequest, TResponse>(
+    private ValueTask PreSerializeAndWriteAsync<TRequest, TResponse>(
         TRequest request,
         int correlationId,
         short apiVersion,
@@ -1806,6 +1848,21 @@ public sealed partial class KafkaConnection :
         Action? requestWriteStarted = null)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
+        => PreSerializeAndWriteCoreAsync<TRequest, TResponse, WriteObservation>(request,
+            correlationId, apiVersion, headerVersion, callerOwnsTimeout,
+            new WriteObservation(requestWriteStarted), cancellationToken);
+
+    private async ValueTask PreSerializeAndWriteCoreAsync<TRequest, TResponse, TObservation>(
+        TRequest request,
+        int correlationId,
+        short apiVersion,
+        short headerVersion,
+        bool callerOwnsTimeout,
+        TObservation observation,
+        CancellationToken cancellationToken)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+        where TObservation : struct, IRequestObservation
     {
         if (!_isTls
             && _socket is not null
@@ -1841,12 +1898,12 @@ public sealed partial class KafkaConnection :
                 encodedRecords,
                 suffixOffset,
                 suffixLength,
-                requestWriteStarted);
+                observation.WriteStartedCallback);
             await AwaitBorrowedFrameWriteAsync(
                     segmentedWriteTask,
                     correlationId,
                     callerOwnsTimeout,
-                    cancellationToken)
+                    observation.AfterWriteStarts(cancellationToken))
                 .ConfigureAwait(false);
             return;
         }
@@ -1872,8 +1929,9 @@ public sealed partial class KafkaConnection :
             serializedArray,
             serializedLength,
             clearSerializedArray,
-            requestWriteStarted);
-        await AwaitFrameWriteAsync(writeTask, correlationId, callerOwnsTimeout, cancellationToken).ConfigureAwait(false);
+            observation.WriteStartedCallback);
+        await AwaitFrameWriteAsync(writeTask, correlationId, callerOwnsTimeout,
+            observation.AfterWriteStarts(cancellationToken)).ConfigureAwait(false);
     }
 
     internal bool TryPreSerializeSingleBatchProduceRequest(

--- a/src/Dekaf/Networking/KafkaRequestWriteContext.cs
+++ b/src/Dekaf/Networking/KafkaRequestWriteContext.cs
@@ -1,0 +1,29 @@
+namespace Dekaf.Networking;
+
+/// <summary>
+/// Reused by one serialized broker request stream to distinguish pre-write cancellation
+/// from an uncertain write and to keep observing a started request within a separate budget.
+/// </summary>
+internal sealed class KafkaRequestWriteContext
+{
+    internal KafkaRequestWriteContext(CancellationToken responseCancellationToken)
+    {
+        ResponseCancellationToken = responseCancellationToken;
+        WriteStartedCallback = MarkWriteStarted;
+    }
+
+    internal CancellationToken ResponseCancellationToken { get; }
+    internal Action WriteStartedCallback { get; }
+    internal bool WriteStarted { get; private set; }
+    internal void Reset() => WriteStarted = false;
+    internal void MarkWriteStarted() => WriteStarted = true;
+}
+
+internal interface IKafkaRequestCancellationConnection
+{
+    ValueTask<TResponse> SendWithResponseCancellationAsync<TRequest, TResponse>(
+        TRequest request, short apiVersion, KafkaRequestWriteContext context,
+        CancellationToken cancellationToken)
+        where TRequest : Protocol.IKafkaRequest<TResponse>
+        where TResponse : Protocol.IKafkaResponse;
+}

--- a/src/Dekaf/ShareConsumer/IShareConsumerConfiguration.cs
+++ b/src/Dekaf/ShareConsumer/IShareConsumerConfiguration.cs
@@ -21,4 +21,8 @@ internal interface IHostedShareConsumer
     // Hosted processing completes renewed work in place: terminal dispositions stop local
     // renewal replay while acknowledgement submission remains tracked independently.
     void ObserveAcknowledgements(ShareAcknowledgementCommitCallback observer);
+    // Poll cancellation stops pre-write work. Started requests remain observed within the
+    // host's shutdown budget, after which acknowledgement outcomes remain unconfirmed.
+    void ObserveAcknowledgements(ShareAcknowledgementCommitCallback observer,
+        CancellationToken requestCancellationToken);
 }

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Hosting.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Hosting.cs
@@ -1,3 +1,7 @@
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using System.Runtime.CompilerServices;
+
 namespace Dekaf.ShareConsumer;
 
 // Hosting capabilities are opt-in. Record payload capture reuses storage per poll round;
@@ -9,17 +13,56 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
     // without adding a timestamp field or another allocation to every delivered record.
     private Dictionary<TopicPartition, long>? _bufferedAcquisitionTimestamps;
     private bool _hostedProcessing;
+    private CancellationToken _hostedRequestCancellationToken;
+    private Dictionary<int, KafkaRequestWriteContext>? _hostedRequestContexts;
     long IHostedShareConsumer.AcquisitionStartedTimestamp => _acquisitionStartedTimestamp;
 
+    // Legacy hosts do not supply a separate shutdown budget. Keep their per-call cancellation.
     void IHostedShareConsumer.ObserveAcknowledgements(ShareAcknowledgementCommitCallback observer)
+        => ((IHostedShareConsumer)this).ObserveAcknowledgements(observer, default);
+
+    void IHostedShareConsumer.ObserveAcknowledgements(ShareAcknowledgementCommitCallback observer,
+        CancellationToken requestCancellationToken)
     {
         _hostedProcessing = true;
+        _hostedRequestCancellationToken = requestCancellationToken;
         var applicationCallback = _acknowledgementCommitCallback;
         _acknowledgementCommitCallback = results =>
         {
             observer(results);
             applicationCallback?.Invoke(results);
         };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private KafkaRequestWriteContext? GetHostedRequestContext(int brokerId)
+    {
+        if (!_hostedRequestCancellationToken.CanBeCanceled)
+            return null;
+        var contexts = _hostedRequestContexts ??= [];
+        if (!contexts.TryGetValue(brokerId, out var context))
+        {
+            context = new KafkaRequestWriteContext(_hostedRequestCancellationToken);
+            contexts.Add(brokerId, context);
+        }
+        return context;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ValueTask<TResponse> SendHostedRequestAsync<TRequest, TResponse>(
+        IKafkaConnection connection, TRequest request, short version,
+        KafkaRequestWriteContext? context, CancellationToken cancellationToken)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+    {
+        if (context is not null && connection is IKafkaRequestCancellationConnection controlled)
+            return controlled.SendWithResponseCancellationAsync<TRequest, TResponse>(
+                request, version, context, cancellationToken);
+
+        // Custom connections cannot prove their write boundary. Keep caller cancellation and
+        // treat a failure after handing them the request as potentially submitted.
+        context?.MarkWriteStarted();
+        return connection.SendAsync<TRequest, TResponse>(request, version, cancellationToken);
     }
 
     private Dictionary<TopicPartitionOffset, (int Start, int KeyLength, int ValueLength)>? _rawRecords;

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -337,6 +337,11 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
 
             CompletePollFetch(fetchResults, pendingAcks, sentAcknowledgementPartitionCount);
 
+            // A hosted stop observes every in-flight reply without delivering fetched
+            // records or replaying renewed work. Close releases remaining acquisitions.
+            if (_hostedProcessing && cancellationToken.IsCancellationRequested)
+                yield break;
+
             var recordCount = 0;
             List<ShareConsumeResult<TKey, TValue>>? fetchedRecords = _renewedRecords is null
                 ? null
@@ -594,6 +599,13 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 RequeueAcknowledgements(sentAcks);
                 if (acknowledgementError is not null)
                     AddAcknowledgementErrors(ref acknowledgementErrors, sentAcks, acknowledgementError);
+                else if (sentAcks is not null)
+                {
+                    // Cancellation before the write is not an acknowledgement outcome.
+                    // Retain these dispositions for final commit without reporting success.
+                    foreach (var partition in sentAcks.Keys)
+                        pendingAcks!.Remove(partition);
+                }
                 continue;
             }
 
@@ -731,6 +743,13 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         {
             ApplySuccessfulAcknowledgements(result.SuccessfulAcknowledgements);
             RequeueAcknowledgements(result.FailedAcknowledgements);
+            if (result.WasNotSent)
+            {
+                foreach (var partition in result.FailedAcknowledgements!.Keys)
+                    pendingAcks.Remove(partition);
+                firstError ??= new OperationCanceledException(cancellationToken);
+                continue;
+            }
             AddAcknowledgementErrors(ref acknowledgementErrors, result.Errors);
             if (result.Error is not null)
                 AddAcknowledgementErrors(ref acknowledgementErrors, result.FailedAcknowledgements, result.Error);
@@ -980,10 +999,12 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         Dictionary<TopicPartition, List<AcknowledgementBatchData>>? brokerAcks,
         CancellationToken cancellationToken)
     {
+        var requestContext = GetHostedRequestContext(brokerId);
         var isRenewAck = ContainsRenewAcknowledgement(brokerAcks);
 
         for (var attempt = 0; ; attempt++)
         {
+            requestContext?.Reset();
             try
             {
                 using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
@@ -1010,8 +1031,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     IsRenewAck = isRenewAck,
                     Topics = BuildShareFetchTopics(partitions, brokerAcks, version)
                 };
-                var response = (ShareFetchResponse)await connection
-                    .SendAsync<ShareFetchRequest, ShareFetchResponse>(request, version, cancellationToken)
+                var response = await SendHostedRequestAsync<ShareFetchRequest, ShareFetchResponse>(
+                        connection, request, version, requestContext, cancellationToken)
                     .ConfigureAwait(false);
                 var receivedTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
 
@@ -1038,6 +1059,11 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 {
                     ReceivedTimestamp = receivedTimestamp
                 };
+            }
+            catch (OperationCanceledException) when (requestContext is { WriteStarted: false }
+                && cancellationToken.IsCancellationRequested && !_hostedRequestCancellationToken.IsCancellationRequested)
+            {
+                return new ShareFetchBrokerResult(brokerId, 0, null, brokerAcks, null, null);
             }
             catch (Exception ex) when (ex is OperationCanceledException or BrokerVersionException)
             {
@@ -1149,6 +1175,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         CancellationToken cancellationToken,
         bool closeSession = false)
     {
+        var requestContext = GetHostedRequestContext(brokerId);
         Dictionary<TopicPartition, List<AcknowledgementBatchData>>? successfulAcknowledgements = null;
         Dictionary<TopicPartition, List<AcknowledgementBatchData>>? failedAcknowledgements = null;
         Dictionary<TopicPartition, Exception>? acknowledgementErrors = null;
@@ -1157,6 +1184,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
 
         for (var attempt = 0; ; attempt++)
         {
+            requestContext?.Reset();
             try
             {
                 var topics = BuildShareAcknowledgeTopics(pendingAcknowledgements);
@@ -1179,9 +1207,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     IsRenewAck = isRenewAck,
                     Topics = topics
                 };
-                var response = (ShareAcknowledgeResponse)await connection
-                    .SendAsync<ShareAcknowledgeRequest, ShareAcknowledgeResponse>(
-                        request, shareAckVersion, cancellationToken)
+                var response = await SendHostedRequestAsync<ShareAcknowledgeRequest, ShareAcknowledgeResponse>(
+                        connection, request, shareAckVersion, requestContext, cancellationToken)
                     .ConfigureAwait(false);
                 var receivedTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
 
@@ -1271,6 +1298,11 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             catch (BrokerVersionException)
             {
                 throw;
+            }
+            catch (OperationCanceledException) when (attempt == 0 && requestContext is { WriteStarted: false }
+                && cancellationToken.IsCancellationRequested && !_hostedRequestCancellationToken.IsCancellationRequested)
+            {
+                return AcknowledgeBrokerResult.NotSent(pendingAcknowledgements);
             }
             catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
             {
@@ -2447,7 +2479,17 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         Dictionary<TopicPartition, List<AcknowledgementBatchData>>? SuccessfulAcknowledgements,
         Dictionary<TopicPartition, List<AcknowledgementBatchData>>? FailedAcknowledgements,
         Exception? Error,
-        Dictionary<TopicPartition, Exception>? Errors);
+        Dictionary<TopicPartition, Exception>? Errors)
+    {
+        // Pending acknowledgements without a response or failure were never submitted.
+        // Reuse the existing representation without enlarging every broker result.
+        internal bool WasNotSent => FailedAcknowledgements is not null
+            && SuccessfulAcknowledgements is null && Error is null && Errors is null;
+
+        internal static AcknowledgeBrokerResult NotSent(
+            Dictionary<TopicPartition, List<AcknowledgementBatchData>> acknowledgements)
+            => new(null, acknowledgements, null, null);
+    }
 
     private readonly struct ShareFetchResponseScope(List<Task<ShareFetchBrokerResult>> tasks) : IDisposable
     {

--- a/tests/Dekaf.Tests.Integration/HostedShareConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/HostedShareConsumerTests.cs
@@ -30,9 +30,11 @@ public class HostedShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrati
         hostBuilder.Services.AddSingleton(state);
         hostBuilder.Services.AddDekaf(builder => builder
             .AddShareConsumerService<Worker, string, string>("first", c => c
-                .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId(group))
+                .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId(group)
+                .WithAcknowledgementCommitCallback(state.ObserveAcknowledgements))
             .AddShareConsumerService<Worker, string, string>("second", c => c
-                .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId(group)));
+                .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId(group)
+                .WithAcknowledgementCommitCallback(state.ObserveAcknowledgements)));
         using var host = hostBuilder.Build();
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         await host.StartAsync(timeout.Token);
@@ -57,6 +59,8 @@ public class HostedShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrati
         await Assert.That(workers.Sum(worker => worker.Processed)).IsGreaterThanOrEqualTo(20);
         await Assert.That(state.Values.Count).IsEqualTo(20);
         await Task.WhenAll(workers.Select(worker => worker.ExecuteTask!)).WaitAsync(timeout.Token);
+        await Assert.That(state.AcknowledgementFailures).IsEmpty();
+        await Assert.That(state.Acknowledged.Count).IsEqualTo(20);
 
         // A sentinel proves a replacement consumer has joined and fetched beyond accepted work.
         await producer.ProduceAsync(topic, "sentinel", "sentinel", timeout.Token);
@@ -67,10 +71,8 @@ public class HostedShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrati
         await foreach (var record in replacement.PollAsync(timeout.Token))
         {
             replacement.Acknowledge(record);
-            if (record.Value == "sentinel") break;
-            // A cancelled inline acknowledgement can be uncertain on shutdown. Duplicates are
-            // permitted, but only previously processed records may precede the sentinel.
-            await Assert.That(state.Values.ContainsKey(record.Value)).IsTrue();
+            await Assert.That(record.Value).IsEqualTo("sentinel");
+            break;
         }
         await replacement.CommitAsync(timeout.Token);
     }
@@ -201,6 +203,20 @@ public class HostedShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrati
     {
         public string Topic { get; } = topic;
         public readonly ConcurrentDictionary<string, byte> Values = new();
+        public readonly ConcurrentDictionary<TopicPartitionOffset, byte> Acknowledged = new();
+        public readonly ConcurrentQueue<Exception> AcknowledgementFailures = new();
+        public void ObserveAcknowledgements(ReadOnlySpan<ShareAcknowledgementCommitResult> results)
+        {
+            foreach (ref readonly var result in results)
+            {
+                if (result.Exception is { } failure)
+                    AcknowledgementFailures.Enqueue(failure);
+                else
+                    foreach (var offset in result.Offsets)
+                        Acknowledged.TryAdd(new TopicPartitionOffset(
+                            result.TopicPartition.Topic, result.TopicPartition.Partition, offset), 0);
+            }
+        }
         public readonly TaskCompletionSource FirstWorkerEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly TaskCompletionSource _bothWorkersEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private int _enteredWorkers;

--- a/tests/Dekaf.Tests.Unit/Hosting/KafkaShareConsumerServiceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Hosting/KafkaShareConsumerServiceTests.cs
@@ -288,6 +288,75 @@ public sealed class KafkaShareConsumerServiceTests
     }
 
     [Test]
+    [Arguments(false, true)]
+    [Arguments(true, false)]
+    [Arguments(true, true)]
+    public async Task Shutdown_FinalAcknowledgementFailureFaultsExecution(bool reportCallback, bool throwFromCommit)
+    {
+        var failure = new InvalidOperationException("Final acknowledgement failed.");
+        var consumer = new TestConsumer(Record(0))
+        {
+            FinalCommitFailure = failure,
+            ReportCommitFailure = reportCallback,
+            ThrowCommitFailure = throwFromCommit
+        };
+        await using var service = new TestService(consumer);
+        await Assert.That(async () => await RunAsync(service)).Throws<InvalidOperationException>();
+        await Assert.That(consumer.Events.Contains("close")).IsTrue();
+        await Assert.That(service.ExecuteTask!.Exception!.InnerException).IsSameReferenceAs(failure);
+    }
+
+    [Test]
+    public async Task Shutdown_RequestBudgetRemainsActiveUntilCallerDeadline()
+    {
+        var entered = Signal();
+        var consumer = new TestConsumer(Record(0));
+        await using var service = new TestService(consumer, async (_, token) =>
+        {
+            entered.SetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+        });
+        using var shutdown = new CancellationTokenSource();
+        await service.StartAsync(default);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var stop = service.StopAsync(shutdown.Token);
+        try
+        {
+            await Assert.That(consumer.RequestCancellationToken.CanBeCanceled).IsTrue();
+            await Assert.That(consumer.RequestCancellationToken.IsCancellationRequested).IsFalse();
+        }
+        finally
+        {
+            await shutdown.CancelAsync();
+        }
+        await stop.WaitAsync(TimeSpan.FromSeconds(10));
+        await service.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(10));
+        await Assert.That(consumer.RequestCancellationToken.IsCancellationRequested).IsTrue();
+        await Assert.That(consumer.Acknowledgements.Single().Type).IsEqualTo(AcknowledgeType.Release);
+    }
+
+    [Test]
+    public async Task Shutdown_UnconfirmedAcknowledgementCancellationRemainsFailure()
+    {
+        var entered = Signal();
+        var finish = Signal();
+        var consumer = new TestConsumer(Record(0));
+        await using var service = new TestService(consumer, async (_, token) =>
+        {
+            entered.SetResult();
+            await finish.Task.WaitAsync(token);
+        });
+        await service.StartAsync(default);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var stop = service.StopAsync(default);
+        consumer.ReportAcknowledgementFailure(new OperationCanceledException("Acknowledgement response unavailable."));
+        finish.TrySetResult();
+        await stop.WaitAsync(TimeSpan.FromSeconds(10));
+        await Assert.That(async () => await service.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(10)))
+            .Throws<OperationCanceledException>();
+    }
+
+    [Test]
     public async Task ShutdownBudget_CancelsCurrentWorkAndDoesNotRaceDisposal()
     {
         var entered = Signal();
@@ -508,6 +577,9 @@ public sealed class KafkaShareConsumerServiceTests
         public TaskCompletionSource? DisposalGate { get; init; }
         public ShareAcknowledgementMode AcknowledgementMode { get; init; } = ShareAcknowledgementMode.Explicit;
         public bool FailCommit { get; init; }
+        public Exception? FinalCommitFailure { get; init; }
+        public bool ReportCommitFailure { get; init; }
+        public bool ThrowCommitFailure { get; init; }
         public byte[]? RawValue { get; init; } = [1, 2, 3];
         public int Delivered { get; private set; }
         public StringSet Subscription { get; private set; } = new HashSet<string>();
@@ -518,7 +590,17 @@ public sealed class KafkaShareConsumerServiceTests
         public long AcquisitionStartedTimestamp => AcquisitionTimestamp ?? System.Diagnostics.Stopwatch.GetTimestamp();
         public Exception? InlineFailure { get; init; }
         private ShareAcknowledgementCommitCallback? _observer;
-        public void ObserveAcknowledgements(ShareAcknowledgementCommitCallback observer) => _observer = observer;
+        public CancellationToken RequestCancellationToken { get; private set; }
+        public void ObserveAcknowledgements(ShareAcknowledgementCommitCallback observer)
+            => ObserveAcknowledgements(observer, default);
+        public void ObserveAcknowledgements(ShareAcknowledgementCommitCallback observer,
+            CancellationToken requestCancellationToken)
+        {
+            _observer = observer;
+            RequestCancellationToken = requestCancellationToken;
+        }
+        internal void ReportAcknowledgementFailure(Exception exception)
+            => _observer?.Invoke([new ShareAcknowledgementCommitResult(new TopicPartition("orders", 0), default, exception)]);
         public ValueTask InitializeAsync(CancellationToken cancellationToken = default) { Events.Add("initialize"); return ValueTask.CompletedTask; }
         public IKafkaShareConsumer<string, string> Subscribe(params string[] topics) { Subscription = topics.ToHashSet(); Events.Add("subscribe"); return this; }
         public IKafkaShareConsumer<string, string> Unsubscribe() => this;
@@ -542,6 +624,11 @@ public sealed class KafkaShareConsumerServiceTests
         public ValueTask CommitAsync(CancellationToken cancellationToken = default)
         {
             Events.Add("commit");
+            if (FinalCommitFailure is { } failure)
+            {
+                if (ReportCommitFailure) ReportAcknowledgementFailure(failure);
+                if (ThrowCommitFailure) return ValueTask.FromException(failure);
+            }
             return FailCommit ? ValueTask.FromException(new InvalidOperationException("acknowledgement failed")) : ValueTask.CompletedTask;
         }
         public ValueTask CloseAsync(CancellationToken cancellationToken = default) { Events.Add("close"); return ValueTask.CompletedTask; }

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.RequestCancellation.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.RequestCancellation.cs
@@ -1,0 +1,100 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Networking;
+
+public sealed partial class KafkaConnectionTests
+{
+    [Test]
+    [Arguments("write lock")]
+    [Arguments("pending slot")]
+    [Arguments("broker throttle")]
+    [Timeout(10_000)]
+    public async Task ResponseObservation_PreWriteWaitPreservesCallerCancellation(
+        string wait, CancellationToken cancellationToken)
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var accept = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
+        await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
+        await connection.ConnectAsync(cancellationToken);
+        using var client = await accept;
+        using var caller = new CancellationTokenSource();
+        using var shutdown = new CancellationTokenSource();
+        var context = new KafkaRequestWriteContext(shutdown.Token);
+        SemaphoreSlim? held = null;
+        var heldCount = 0;
+        try
+        {
+            if (wait == "broker throttle")
+                GetPrivateField<BrokerThrottleState>(connection, "_brokerThrottleState").Observe(60_000);
+            else
+            {
+                held = GetPrivateField<SemaphoreSlim>(connection,
+                    wait == "write lock" ? "_writeLock" : "_pendingRequestSlots");
+                while (held.Wait(0, cancellationToken)) heldCount++;
+            }
+            var send = ((IKafkaRequestCancellationConnection)connection)
+                .SendWithResponseCancellationAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                    new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
+                    3, context, caller.Token).AsTask();
+            await Assert.That(send.IsCompleted).IsFalse();
+            await Assert.That(context.WriteStarted).IsFalse();
+            await caller.CancelAsync();
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await send);
+            await Assert.That(caller.IsCancellationRequested).IsTrue();
+            await Assert.That(context.WriteStarted).IsFalse();
+            await Assert.That(client.GetStream().DataAvailable).IsFalse();
+            await Assert.That(GetPrivateField<int>(connection, "_pendingRequestCount")).IsEqualTo(0);
+        }
+        finally
+        {
+            if (heldCount != 0) held!.Release(heldCount);
+        }
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    [Timeout(10_000)]
+    public async Task ResponseObservation_WrittenRequestUsesShutdownBudget(
+        bool deadlineExpires, CancellationToken cancellationToken)
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var accept = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
+        await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
+        await connection.ConnectAsync(cancellationToken);
+        using var client = await accept;
+        using var caller = new CancellationTokenSource();
+        using var shutdown = new CancellationTokenSource();
+        var context = new KafkaRequestWriteContext(shutdown.Token);
+        var send = ((IKafkaRequestCancellationConnection)connection)
+            .SendWithResponseCancellationAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
+                3, context, caller.Token).AsTask();
+        var request = await ReadRequestFrameAsync(client.GetStream(), cancellationToken);
+        await caller.CancelAsync();
+        await Assert.That(context.WriteStarted).IsTrue();
+        await Assert.That(send.IsCompleted).IsFalse();
+        if (deadlineExpires)
+        {
+            await shutdown.CancelAsync();
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(async () => await send);
+            await Assert.That(exception!.CancellationToken).IsEqualTo(shutdown.Token);
+        }
+        else
+        {
+            var correlationId = BinaryPrimitives.ReadInt32BigEndian(request.AsSpan(4, 4));
+            await client.GetStream().WriteAsync(BuildApiVersionsV3ResponseFrame(correlationId), cancellationToken);
+            await Assert.That((await send).ErrorCode).IsEqualTo(ErrorCode.None);
+        }
+        await Assert.That(GetPrivateField<int>(connection, "_pendingRequestCount")).IsEqualTo(0);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -22,7 +22,7 @@ namespace Dekaf.Tests.Unit.Networking;
 /// Tests for KafkaConnection, particularly the IsConnected fix
 /// that ensures disposed connections report as disconnected.
 /// </summary>
-public sealed class KafkaConnectionTests
+public sealed partial class KafkaConnectionTests
 {
     [Test]
     public async Task IsConnected_BeforeConnect_ReturnsFalse()

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.Shutdown.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.Shutdown.cs
@@ -1,0 +1,388 @@
+using System.Reflection;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public sealed partial class ShareConsumerRenewalTests
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task HostedStop_UnsentBrokerDoesNotDiscardAnotherBrokersReply(bool commit)
+    {
+        using var caller = new CancellationTokenSource();
+        using var shutdown = new CancellationTokenSource();
+        var firstWaiting = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondSent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callbacks = new List<(int Partition, long[] Offsets, Exception? Error)>();
+        var first = new CapturingConnection(ApiKey.ShareAcknowledge, 2, supportShareFetch: true)
+        {
+            BeforeWrite = async token =>
+            {
+                firstWaiting.TrySetResult();
+                await release.Task.WaitAsync(token);
+            }
+        };
+        var second = new CapturingConnection(ApiKey.ShareAcknowledge, 2, brokerId: 2, supportShareFetch: true)
+        {
+            ShareFetchHandler = async (_, token) =>
+            {
+                secondSent.TrySetResult();
+                await release.Task.WaitAsync(token);
+                return CreateFetchResponse(1, 100);
+            },
+            ShareAcknowledgeHandler = async (_, token) =>
+            {
+                secondSent.TrySetResult();
+                await release.Task.WaitAsync(token);
+                return CreateAcknowledgeResponse((1, ErrorCode.None));
+            }
+        };
+        await using var fixture = CreateFixture(first, secondConnection: second);
+        ((IHostedShareConsumer)fixture.Consumer).ObserveAcknowledgements(results =>
+        {
+            foreach (ref readonly var result in results)
+                callbacks.Add((result.TopicPartition.Partition, CopyOffsets(result.Offsets), result.Exception));
+        }, shutdown.Token);
+        PrepareForPoll(fixture.Consumer, new TopicPartition("topic", 0), new TopicPartition("topic", 1));
+        fixture.Consumer.Subscribe("topic");
+        fixture.Consumer.Acknowledge(CreateRecord(0, 42), AcknowledgeType.Release);
+        fixture.Consumer.Acknowledge(CreateRecord(1, 43), AcknowledgeType.Accept);
+        await using var poll = fixture.Consumer.PollAsync(caller.Token).GetAsyncEnumerator();
+        var pendingPoll = commit ? null : poll.MoveNextAsync().AsTask();
+        var request = commit ? fixture.Consumer.CommitAsync(caller.Token).AsTask() : pendingPoll!;
+        try
+        {
+            await Task.WhenAll(firstWaiting.Task, secondSent.Task).WaitAsync(TimeSpan.FromSeconds(10));
+            await caller.CancelAsync();
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+        if (commit)
+            await Assert.That(async () => await request.WaitAsync(TimeSpan.FromSeconds(10)))
+                .Throws<OperationCanceledException>();
+        else
+            await Assert.That(await pendingPoll!.WaitAsync(TimeSpan.FromSeconds(10))).IsFalse();
+        await Assert.That(callbacks.Count).IsEqualTo(1);
+        await Assert.That(callbacks[0].Partition).IsEqualTo(1);
+        await Assert.That(callbacks[0].Offsets).IsEquivalentTo(new long[] { 43 });
+        await Assert.That(callbacks[0].Error).IsNull();
+        await Assert.That(GetSessionEpoch(fixture.Consumer, 1)).IsEqualTo(0);
+        await Assert.That(GetSessionEpoch(fixture.Consumer, 2)).IsEqualTo(1);
+        await fixture.Consumer.CommitAsync(shutdown.Token);
+        await Assert.That(callbacks.Count).IsEqualTo(2);
+        await Assert.That(callbacks[1].Partition).IsEqualTo(0);
+        await Assert.That(callbacks[1].Offsets).IsEquivalentTo(new long[] { 42 });
+        await Assert.That(callbacks[1].Error).IsNull();
+        await Assert.That(HasPendingAcknowledgements(fixture.Consumer)).IsFalse();
+    }
+
+    [Test]
+    [Arguments(AcknowledgeType.Accept, false, false)]
+    [Arguments(AcknowledgeType.Accept, true, false)]
+    [Arguments(AcknowledgeType.Release, false, false)]
+    [Arguments(AcknowledgeType.Release, true, false)]
+    [Arguments(AcknowledgeType.Reject, false, false)]
+    [Arguments(AcknowledgeType.Reject, true, false)]
+    [Arguments(AcknowledgeType.Renew, false, false)]
+    [Arguments(AcknowledgeType.Renew, true, false)]
+    [Arguments(AcknowledgeType.Accept, false, true)]
+    [Arguments(AcknowledgeType.Accept, true, true)]
+    [Arguments(AcknowledgeType.Release, false, true)]
+    [Arguments(AcknowledgeType.Release, true, true)]
+    [Arguments(AcknowledgeType.Reject, false, true)]
+    [Arguments(AcknowledgeType.Reject, true, true)]
+    [Arguments(AcknowledgeType.Renew, false, true)]
+    [Arguments(AcknowledgeType.Renew, true, true)]
+    public async Task HostedStop_BeforeWriteRetainsAcknowledgementsForFinalCommit(
+        AcknowledgeType disposition, bool waitForLease, bool commit)
+    {
+        using var pollCancellation = new CancellationTokenSource();
+        using var shutdownCancellation = new CancellationTokenSource();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callbacks = new List<Exception?>();
+        async ValueTask WaitBeforeWrite(CancellationToken token)
+        {
+            entered.TrySetResult();
+            await release.Task.WaitAsync(token);
+        }
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2, supportShareFetch: true)
+        {
+            BeforeWrite = waitForLease ? null : WaitBeforeWrite
+        };
+        await using var fixture = CreateFixture(connection, leaseHandler: waitForLease
+            ? async token => { await WaitBeforeWrite(token); return connection; }
+            : null);
+        ((IHostedShareConsumer)fixture.Consumer).ObserveAcknowledgements(results =>
+        {
+            foreach (ref readonly var result in results)
+                callbacks.Add(result.Exception);
+        }, shutdownCancellation.Token);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        fixture.Consumer.Acknowledge(CreateRecord(), disposition);
+        await using var poll = fixture.Consumer.PollAsync(pollCancellation.Token).GetAsyncEnumerator();
+        var pendingPoll = commit ? null : poll.MoveNextAsync().AsTask();
+        var request = commit ? fixture.Consumer.CommitAsync(pollCancellation.Token).AsTask() : pendingPoll!;
+        try
+        {
+            await entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await pollCancellation.CancelAsync();
+            if (commit)
+                await Assert.That(async () => await request.WaitAsync(TimeSpan.FromSeconds(10)))
+                    .Throws<OperationCanceledException>();
+            else
+                await Assert.That(await pendingPoll!.WaitAsync(TimeSpan.FromSeconds(10))).IsFalse();
+            await Assert.That(callbacks).IsEmpty();
+            await Assert.That(connection.SendCount).IsEqualTo(0);
+            await Assert.That(GetSessionEpoch(fixture.Consumer, 1)).IsEqualTo(0);
+            await Assert.That(HasPendingAcknowledgements(fixture.Consumer)).IsTrue();
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+        await fixture.Consumer.CommitAsync(shutdownCancellation.Token);
+        await Assert.That(callbacks.Count).IsEqualTo(1);
+        await Assert.That(callbacks[0]).IsNull();
+        await Assert.That(connection.ShareAcknowledgeRequest!.Topics[0].Partitions[0]
+            .AcknowledgementBatches[0].AcknowledgeTypes[0]).IsEqualTo((byte)disposition);
+        await Assert.That(HasPendingAcknowledgements(fixture.Consumer)).IsFalse();
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task LegacyHostedObserver_PreservesInflightRequestCancellation(bool fetch)
+    {
+        using var cancellation = new CancellationTokenSource();
+        var sent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2, supportShareFetch: true)
+        {
+            ShareFetchHandler = async (_, token) =>
+            {
+                sent.TrySetResult();
+                await release.Task.WaitAsync(token);
+                return CreateFetchResponse(0, 100);
+            },
+            ShareAcknowledgeHandler = async (_, token) =>
+            {
+                sent.TrySetResult();
+                await release.Task.WaitAsync(token);
+                return CreateAcknowledgeResponse((0, ErrorCode.None));
+            }
+        };
+        await using var fixture = CreateFixture(connection);
+        ((IHostedShareConsumer)fixture.Consumer).ObserveAcknowledgements(static _ => { });
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        fixture.Consumer.Acknowledge(CreateRecord(), AcknowledgeType.Accept);
+        await using var poll = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        var request = fetch ? poll.MoveNextAsync().AsTask() : fixture.Consumer.CommitAsync(cancellation.Token).AsTask();
+        try
+        {
+            await sent.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await cancellation.CancelAsync();
+            await Assert.That(async () => await request.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Throws<OperationCanceledException>();
+        }
+        finally
+        {
+            release.TrySetResult();
+            try { await request; } catch (OperationCanceledException) { }
+            FlushPendingAcknowledgements(fixture.Consumer);
+        }
+    }
+
+    [Test]
+    [Arguments(AcknowledgeType.Accept, false)]
+    [Arguments(AcknowledgeType.Accept, true)]
+    [Arguments(AcknowledgeType.Renew, false)]
+    [Arguments(AcknowledgeType.Renew, true)]
+    public async Task HostedCommit_UsesShutdownBudgetForInflightAcknowledgements(
+        AcknowledgeType disposition, bool shutdownDeadlineExpires)
+    {
+        using var processingCancellation = new CancellationTokenSource();
+        using var shutdownCancellation = new CancellationTokenSource();
+        var sent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completeResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callbacks = new List<Exception?>();
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2, supportShareFetch: true)
+        {
+            ShareAcknowledgeHandler = async (_, token) =>
+            {
+                token.ThrowIfCancellationRequested();
+                sent.TrySetResult();
+                await completeResponse.Task.WaitAsync(token);
+                return CreateAcknowledgeResponse((0, ErrorCode.None));
+            }
+        };
+        await using var fixture = CreateFixture(connection);
+        ((IHostedShareConsumer)fixture.Consumer).ObserveAcknowledgements(results =>
+        {
+            foreach (ref readonly var result in results)
+                callbacks.Add(result.Exception);
+        }, shutdownCancellation.Token);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Acknowledge(CreateRecord(), disposition);
+        var commit = fixture.Consumer.CommitAsync(processingCancellation.Token).AsTask();
+        try
+        {
+            await sent.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await processingCancellation.CancelAsync();
+            await Assert.That(commit.IsCompleted).IsFalse();
+            if (shutdownDeadlineExpires)
+                await shutdownCancellation.CancelAsync();
+        }
+        finally
+        {
+            completeResponse.TrySetResult();
+        }
+
+        if (shutdownDeadlineExpires)
+            await Assert.That(async () => await commit.WaitAsync(TimeSpan.FromSeconds(10)))
+                .Throws<OperationCanceledException>();
+        else
+            await commit.WaitAsync(TimeSpan.FromSeconds(10));
+        await Assert.That(callbacks.Count).IsEqualTo(1);
+        await Assert.That(callbacks[0] is OperationCanceledException).IsEqualTo(shutdownDeadlineExpires);
+        await Assert.That(HasPendingAcknowledgements(fixture.Consumer)).IsEqualTo(shutdownDeadlineExpires);
+        await Assert.That(connection.ShareAcknowledgeRequest!.Topics[0].Partitions[0]
+            .AcknowledgementBatches[0].AcknowledgeTypes[0]).IsEqualTo((byte)disposition);
+        FlushPendingAcknowledgements(fixture.Consumer);
+    }
+
+    [Test]
+    public async Task HostedStop_ShutdownDeadlineKeepsCancelledAcknowledgementsUnconfirmed()
+    {
+        using var pollCancellation = new CancellationTokenSource();
+        using var shutdownCancellation = new CancellationTokenSource();
+        var sent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callbacks = new List<Exception?>();
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2, supportShareFetch: true)
+        {
+            ShareFetchHandler = async (request, token) =>
+            {
+                if (request.ShareSessionEpoch == ShareSessionManager.CloseEpoch)
+                    return new ShareFetchResponse { ErrorCode = ErrorCode.None, Responses = [], NodeEndpoints = [] };
+                sent.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("The request must end at the shutdown deadline.");
+            }
+        };
+        await using var fixture = CreateFixture(connection);
+        ((IHostedShareConsumer)fixture.Consumer).ObserveAcknowledgements(results =>
+        {
+            foreach (ref readonly var result in results)
+                callbacks.Add(result.Exception);
+        }, shutdownCancellation.Token);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        fixture.Consumer.Acknowledge(CreateRecord(), AcknowledgeType.Reject);
+        await using var poll = fixture.Consumer.PollAsync(pollCancellation.Token).GetAsyncEnumerator();
+        var pendingPoll = poll.MoveNextAsync().AsTask();
+        try
+        {
+            await sent.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await pollCancellation.CancelAsync();
+            await Assert.That(pendingPoll.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            await shutdownCancellation.CancelAsync();
+        }
+
+        await Assert.That(async () => await pendingPoll.WaitAsync(TimeSpan.FromSeconds(10)))
+            .Throws<OperationCanceledException>();
+        // Without a response, neither the session epoch nor acknowledgement success is known.
+        await Assert.That(GetSessionEpoch(fixture.Consumer, 1)).IsEqualTo(0);
+        await Assert.That(callbacks.Count).IsEqualTo(1);
+        await Assert.That(callbacks[0]).IsTypeOf<TaskCanceledException>();
+        await Assert.That(HasPendingAcknowledgements(fixture.Consumer)).IsTrue();
+        var pending = FlushPendingAcknowledgements(fixture.Consumer);
+        await Assert.That(pending[new TopicPartition("topic", 0)][0].AcknowledgeTypes[0])
+            .IsEqualTo((byte)AcknowledgeType.Reject);
+    }
+
+    [Test]
+    [Arguments(AcknowledgeType.Accept, false)]
+    [Arguments(AcknowledgeType.Accept, true)]
+    [Arguments(AcknowledgeType.Release, false)]
+    [Arguments(AcknowledgeType.Release, true)]
+    [Arguments(AcknowledgeType.Reject, false)]
+    [Arguments(AcknowledgeType.Reject, true)]
+    [Arguments(AcknowledgeType.Renew, false)]
+    [Arguments(AcknowledgeType.Renew, true)]
+    public async Task HostedStop_ObservesInflightAcknowledgementsBeforeFinalCommit(
+        AcknowledgeType disposition, bool appliedBeforeStop)
+    {
+        using var pollCancellation = new CancellationTokenSource();
+        using var shutdownCancellation = new CancellationTokenSource();
+        var sent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completeResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var brokerEpoch = 1;
+        var callbacks = new List<(long[] Offsets, Exception? Error)>();
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2, supportShareFetch: true)
+        {
+            ShareFetchHandler = async (request, token) =>
+            {
+                if (request.ShareSessionEpoch != brokerEpoch)
+                    throw new InvalidOperationException("Unexpected broker session epoch.");
+                if (appliedBeforeStop)
+                    brokerEpoch++;
+                sent.TrySetResult();
+                await completeResponse.Task.WaitAsync(token);
+                if (!appliedBeforeStop)
+                    brokerEpoch++;
+                return CreateFetchResponse(partition: 0, offset: 100);
+            }
+        };
+        await using var fixture = CreateFixture(connection);
+        ((IHostedShareConsumer)fixture.Consumer).ObserveAcknowledgements(results =>
+        {
+            foreach (ref readonly var result in results)
+                callbacks.Add((CopyOffsets(result.Offsets), result.Exception));
+        }, shutdownCancellation.Token);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        var sessions = (ShareSessionManager)typeof(KafkaShareConsumer<string, string>)
+            .GetField("_sessionManager", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(fixture.Consumer)!;
+        sessions.IncrementEpoch(1);
+        fixture.Consumer.Acknowledge(CreateRecord(offset: 42), disposition);
+        await using var poll = fixture.Consumer.PollAsync(pollCancellation.Token).GetAsyncEnumerator();
+        var pendingPoll = poll.MoveNextAsync().AsTask();
+        try
+        {
+            await sent.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await pollCancellation.CancelAsync();
+        }
+        finally
+        {
+            completeResponse.TrySetResult();
+        }
+
+        // Stopping the next poll must not discard an already-sent acknowledgement response.
+        await Assert.That(await pendingPoll.WaitAsync(TimeSpan.FromSeconds(10))).IsFalse();
+        await Assert.That(callbacks.Count).IsEqualTo(1);
+        await Assert.That(callbacks[0].Error).IsNull();
+        await Assert.That(callbacks[0].Offsets).IsEquivalentTo(new long[] { 42 });
+        await Assert.That(GetSessionEpoch(fixture.Consumer, 1)).IsEqualTo(brokerEpoch);
+        await Assert.That(HasPendingAcknowledgements(fixture.Consumer)).IsFalse();
+        await Assert.That(connection.ShareFetchRequest!.Topics[0].Partitions[0]
+            .AcknowledgementBatches![0].AcknowledgeTypes[0]).IsEqualTo((byte)disposition);
+
+        fixture.Consumer.Acknowledge(CreateRecord(offset: 43), AcknowledgeType.Accept);
+        await fixture.Consumer.CommitAsync();
+        await Assert.That(connection.ShareAcknowledgeRequest!.ShareSessionEpoch).IsEqualTo(brokerEpoch);
+        await Assert.That(connection.ShareAcknowledgeRequest.Topics[0].Partitions[0]
+            .AcknowledgementBatches[0].FirstOffset).IsEqualTo(43);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -1085,7 +1085,8 @@ public sealed partial class ShareConsumerRenewalTests
         int maxPollRecords = 500,
         CapturingConnection? secondConnection = null,
         ShareAcknowledgementCommitCallback? acknowledgementCommitCallback = null,
-        IDeserializer<string>? valueDeserializer = null)
+        IDeserializer<string>? valueDeserializer = null,
+        Func<CancellationToken, ValueTask<IKafkaConnection>>? leaseHandler = null)
     {
         var options = new ShareConsumerOptions
         {
@@ -1097,6 +1098,9 @@ public sealed partial class ShareConsumerRenewalTests
         };
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionAsync(1, Arg.Any<CancellationToken>()).Returns(connection);
+        if (leaseHandler is not null)
+            pool.GetConnectionAsync(1, Arg.Any<CancellationToken>())
+                .Returns(call => leaseHandler(call.Arg<CancellationToken>()));
         if (secondConnection is not null)
             pool.GetConnectionAsync(2, Arg.Any<CancellationToken>()).Returns(secondConnection);
         var metadataManager = new MetadataManager(pool, options.BootstrapServers);
@@ -1457,7 +1461,8 @@ public sealed partial class ShareConsumerRenewalTests
         bool includeShareAcknowledge = false,
         bool supportShareFetch = false) :
         IKafkaConnection,
-        IKafkaCapabilityProvider
+        IKafkaCapabilityProvider,
+        IKafkaRequestCancellationConnection
     {
         public int BrokerId => brokerId;
         public string Host => "localhost";
@@ -1490,6 +1495,22 @@ public sealed partial class ShareConsumerRenewalTests
         internal Exception? ShareFetchException { get; init; }
         internal Action? OnSend { get; init; }
         internal TaskCompletionSource<ShareAcknowledgeResponse>? DelayedFinalAcknowledgement { get; init; }
+        internal Func<CancellationToken, ValueTask>? BeforeWrite { get; init; }
+        internal Func<ShareFetchRequest, CancellationToken, ValueTask<ShareFetchResponse>>? ShareFetchHandler { get; init; }
+        internal Func<ShareAcknowledgeRequest, CancellationToken, ValueTask<ShareAcknowledgeResponse>>? ShareAcknowledgeHandler { get; init; }
+
+        public async ValueTask<TResponse> SendWithResponseCancellationAsync<TRequest, TResponse>(
+            TRequest request, short apiVersion, KafkaRequestWriteContext context,
+            CancellationToken cancellationToken)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            if (BeforeWrite is not null)
+                await BeforeWrite(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            context.MarkWriteStarted();
+            return await SendAsync<TRequest, TResponse>(request, apiVersion, context.ResponseCancellationToken);
+        }
 
         public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
             TRequest request,
@@ -1500,6 +1521,19 @@ public sealed partial class ShareConsumerRenewalTests
         {
             SendCount++;
             LastApiVersion = apiVersion;
+            if (request is ShareFetchRequest fetchRequest && ShareFetchHandler is not null)
+            {
+                ShareFetchRequest = fetchRequest;
+                OnSend?.Invoke();
+                return AwaitFetchAsync<TResponse>(ShareFetchHandler(fetchRequest, cancellationToken));
+            }
+            if (request is ShareAcknowledgeRequest acknowledgeRequest && ShareAcknowledgeHandler is not null)
+            {
+                ShareAcknowledgeRequest = acknowledgeRequest;
+                ShareAcknowledgeRequests.Add(acknowledgeRequest);
+                OnSend?.Invoke();
+                return AwaitAcknowledgementAsync<TResponse>(ShareAcknowledgeHandler(acknowledgeRequest, cancellationToken));
+            }
             IKafkaResponse response = request switch
             {
                 ShareFetchRequest fetch => Capture(
@@ -1566,6 +1600,14 @@ public sealed partial class ShareConsumerRenewalTests
             static async Task<TResponse> AwaitResponseAsync(Task<ShareAcknowledgeResponse> pending)
                 => (TResponse)(IKafkaResponse)await pending;
         }
+
+        private static async ValueTask<TResponse> AwaitFetchAsync<TResponse>(ValueTask<ShareFetchResponse> response)
+            where TResponse : IKafkaResponse
+            => (TResponse)(IKafkaResponse)await response;
+
+        private static async ValueTask<TResponse> AwaitAcknowledgementAsync<TResponse>(ValueTask<ShareAcknowledgeResponse> response)
+            where TResponse : IKafkaResponse
+            => (TResponse)(IKafkaResponse)await response;
 
         private ShareFetchResponse Capture(
             ShareFetchRequest request,

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/HostedShareRequestBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/HostedShareRequestBenchmarks.cs
@@ -1,0 +1,187 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Steady-state share request construction, lease use and reply bookkeeping.</summary>
+[MemoryDiagnoser]
+public class HostedShareRequestBenchmarks
+{
+    [Params(false, true)]
+    public bool Hosted { get; set; }
+
+    [Params(1, 16)]
+    public int PartitionCount { get; set; }
+
+    private KafkaShareConsumer<string, string> _consumer = null!;
+    private MetadataManager _metadata = null!;
+    private readonly CancellationTokenSource _shutdown = new();
+    private readonly List<TopicPartition> _partitions = [];
+    private readonly Dictionary<TopicPartition, List<AcknowledgementBatchData>> _acknowledgements = [];
+    private readonly List<ShareConsumeResult<string, string>> _records = [];
+    private Func<int, List<TopicPartition>, Dictionary<TopicPartition, List<AcknowledgementBatchData>>,
+        CancellationToken, Task> _fetch = null!;
+    private Func<int, Dictionary<TopicPartition, List<AcknowledgementBatchData>>, bool,
+        CancellationToken, Task> _acknowledge = null!;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        var topicId = Guid.NewGuid();
+        var metadataPartitions = new PartitionMetadata[PartitionCount];
+        var fetchPartitions = new ShareFetchResponsePartition[PartitionCount];
+        var acknowledgePartitions = new ShareAcknowledgeResponsePartition[PartitionCount];
+        for (var index = 0; index < PartitionCount; index++)
+        {
+            var partition = new TopicPartition("topic", index);
+            _partitions.Add(partition);
+            _records.Add(new ShareConsumeResult<string, string>
+            {
+                Topic = "topic", Partition = index, Offset = 42, Value = "value", DeliveryCount = 1
+            });
+            _acknowledgements.Add(partition,
+                [new AcknowledgementBatchData(42, 42, [(byte)AcknowledgeType.Accept])]);
+            metadataPartitions[index] = new PartitionMetadata
+            {
+                ErrorCode = ErrorCode.None, PartitionIndex = index, LeaderId = 1, ReplicaNodes = [1], IsrNodes = [1]
+            };
+            fetchPartitions[index] = new ShareFetchResponsePartition
+            {
+                PartitionIndex = index, CurrentLeader = new(), AcquiredRecords = []
+            };
+            acknowledgePartitions[index] = new ShareAcknowledgeResponsePartition
+            {
+                PartitionIndex = index, CurrentLeader = new()
+            };
+        }
+        var metadata = new MetadataResponse
+        {
+            Brokers = [new() { NodeId = 1, Host = "localhost", Port = 9092 }],
+            Topics = [new() { ErrorCode = ErrorCode.None, Name = "topic", TopicId = topicId, Partitions = metadataPartitions }]
+        };
+        var connection = new Connection(
+            new() { ErrorCode = ErrorCode.None, Responses = [new() { TopicId = topicId, Partitions = fetchPartitions }], NodeEndpoints = [] },
+            new() { Responses = [new() { TopicId = topicId, Partitions = acknowledgePartitions }], NodeEndpoints = [] });
+        var pool = new Pool(connection);
+        _metadata = new MetadataManager(pool, ["localhost:9092"]);
+        _metadata.Metadata.Update(metadata);
+        _metadata.SetApiVersion(ApiKey.ShareFetch, 2, 2);
+        _metadata.SetApiVersion(ApiKey.ShareAcknowledge, 2, 2);
+        _consumer = new KafkaShareConsumer<string, string>(
+            new() { BootstrapServers = ["localhost:9092"], GroupId = "benchmark", AcknowledgementMode = ShareAcknowledgementMode.Explicit },
+            Serializers.String, Serializers.String, pool, _metadata);
+        if (Hosted)
+        {
+            ShareAcknowledgementCommitCallback observer = static _ => { };
+            var hostedOverload = typeof(IHostedShareConsumer).GetMethod("ObserveAcknowledgements",
+                [typeof(ShareAcknowledgementCommitCallback), typeof(CancellationToken)]);
+            if (hostedOverload is null)
+                ((IHostedShareConsumer)_consumer).ObserveAcknowledgements(observer);
+            else
+                hostedOverload.Invoke(_consumer, [observer, _shutdown.Token]);
+        }
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+        typeof(KafkaShareConsumer<string, string>).GetField("_initialized", flags)!.SetValue(_consumer, true);
+        var coordinator = typeof(KafkaShareConsumer<string, string>).GetField("_coordinator", flags)!.GetValue(_consumer)!;
+        typeof(ShareConsumerCoordinator).GetField("_memberId", flags)!.SetValue(coordinator, "benchmark-member");
+        _fetch = typeof(KafkaShareConsumer<string, string>).GetMethod("SendShareFetchForPartitionsAsync", flags)!
+            .CreateDelegate<Func<int, List<TopicPartition>, Dictionary<TopicPartition, List<AcknowledgementBatchData>>, CancellationToken, Task>>(_consumer);
+        // Older products have four parameters; batch-session cleanup adds an optional fifth.
+        // Bind the same direct-call adapter on both revisions outside measurement.
+        var acknowledge = typeof(KafkaShareConsumer<string, string>).GetMethod("SendAcknowledgeAsync", flags)!;
+        var broker = Expression.Parameter(typeof(int));
+        var acknowledgements = Expression.Parameter(typeof(Dictionary<TopicPartition, List<AcknowledgementBatchData>>));
+        var retry = Expression.Parameter(typeof(bool));
+        var cancellation = Expression.Parameter(typeof(CancellationToken));
+        Expression[] arguments = [broker, acknowledgements, retry, cancellation];
+        if (acknowledge.GetParameters().Length == 5)
+            arguments = [.. arguments, Expression.Constant(false)];
+        _acknowledge = Expression.Lambda<Func<int, Dictionary<TopicPartition, List<AcknowledgementBatchData>>, bool, CancellationToken, Task>>(
+            Expression.Call(Expression.Constant(_consumer), acknowledge, arguments),
+            broker, acknowledgements, retry, cancellation).Compile();
+        await ShareFetch();
+        await ShareAcknowledge();
+        var sessions = (ShareSessionManager)typeof(KafkaShareConsumer<string, string>)
+            .GetField("_sessionManager", flags)!.GetValue(_consumer)!;
+        if (connection.RequestCount != 2 || sessions.GetSessionEpoch(1) != 1)
+            throw new InvalidOperationException("Both request paths must complete successful broker bookkeeping.");
+        await Commit();
+        if (connection.RequestCount != 3 || sessions.GetSessionEpoch(1) != 2)
+            throw new InvalidOperationException("Commit must submit its tracked acknowledgement outcomes.");
+    }
+
+    // Costs are per request with PartitionCount acknowledgement batches. Cached replies exclude
+    // network I/O, parsing, delivery and shutdown; setup binds delegates outside measurement.
+    [Benchmark]
+    public Task ShareFetch() => _fetch(1, _partitions, _acknowledgements, CancellationToken.None);
+
+    [Benchmark]
+    public Task ShareAcknowledge() => _acknowledge(1, _acknowledgements, false, CancellationToken.None);
+
+    [Benchmark]
+    public ValueTask Commit()
+    {
+        for (var index = 0; index < _records.Count; index++)
+            _consumer.Acknowledge(_records[index], AcknowledgeType.Accept);
+        return _consumer.CommitAsync();
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _consumer.DisposeAsync();
+        await _metadata.DisposeAsync();
+        _shutdown.Dispose();
+    }
+
+    private sealed class Connection(ShareFetchResponse fetch, ShareAcknowledgeResponse acknowledge) : IKafkaConnection
+    {
+        internal int RequestCount { get; private set; }
+        public int BrokerId => 1;
+        public string Host => "localhost";
+        public int Port => 9092;
+        public bool IsConnected => true;
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(TRequest request, short version, CancellationToken token = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse
+        {
+            RequestCount++;
+            IKafkaResponse response = request switch
+            {
+                ShareFetchRequest => fetch,
+                ShareAcknowledgeRequest => acknowledge,
+                _ => throw new NotSupportedException(typeof(TRequest).Name)
+            };
+            return ValueTask.FromResult((TResponse)response);
+        }
+        public ValueTask ConnectAsync(CancellationToken token = default) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(TRequest request, short version, CancellationToken token = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(TRequest request, short version, CancellationToken token = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request, short version, CancellationToken token = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request, short version, CancellationToken token = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
+    }
+
+    private sealed class Pool(Connection connection) : IConnectionPool
+    {
+        public ValueTask<IKafkaConnection> GetConnectionAsync(int brokerId, CancellationToken token = default) => ValueTask.FromResult<IKafkaConnection>(connection);
+        public ValueTask<IKafkaConnection> GetConnectionAsync(string host, int port, CancellationToken token = default) => ValueTask.FromResult<IKafkaConnection>(connection);
+        public ValueTask<IKafkaConnection> GetConnectionByIndexAsync(int brokerId, int index, CancellationToken token = default) => ValueTask.FromResult<IKafkaConnection>(connection);
+        public void RegisterBroker(int id, string host, int port) { }
+        public ValueTask<int> ScaleConnectionGroupAsync(int id, int count, CancellationToken token = default) => ValueTask.FromResult(1);
+        public ValueTask<IKafkaConnection?> ShrinkConnectionGroupAsync(int id, int count, CancellationToken token = default) => ValueTask.FromResult<IKafkaConnection?>(null);
+        public ValueTask RemoveConnectionAsync(int id) => ValueTask.CompletedTask;
+        public ValueTask CloseAllAsync() => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PipelinedResponseAllocationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PipelinedResponseAllocationBenchmarks.cs
@@ -2,6 +2,8 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
+using System.Linq.Expressions;
+using System.Reflection;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
 using Dekaf.Networking;
@@ -24,6 +26,7 @@ public class PipelinedResponseAllocationBenchmarks
     private KafkaConnection _connection = null!;
     private CancellationTokenSource _serverCancellation = null!;
     private Task _serverTask = null!;
+    private Func<ApiVersionsRequest, short, CancellationToken, ValueTask<ApiVersionsResponse>> _sendObserved = null!;
 
     [GlobalSetup]
     public async Task Setup()
@@ -38,6 +41,43 @@ public class PipelinedResponseAllocationBenchmarks
         _serverCancellation = new CancellationTokenSource();
         _serverTask = RunServerAsync(_serverClient.GetStream(), _serverCancellation.Token);
         await connectTask.ConfigureAwait(false);
+        _sendObserved = CreateObservedSender();
+    }
+
+    private Func<ApiVersionsRequest, short, CancellationToken, ValueTask<ApiVersionsResponse>> CreateObservedSender()
+    {
+        // Bind outside measurement so the same fixture source builds against the baseline,
+        // whose ordinary SendAsync has one cancellation token for the whole request.
+        var assembly = typeof(KafkaConnection).Assembly;
+        var capability = assembly.GetType("Dekaf.Networking.IKafkaRequestCancellationConnection");
+        var contextType = assembly.GetType("Dekaf.Networking.KafkaRequestWriteContext");
+        if (capability is null || contextType is null)
+            return _connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>;
+        var context = Activator.CreateInstance(contextType, BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null, args: [_serverCancellation.Token], culture: null)!;
+        var method = capability.GetMethod("SendWithResponseCancellationAsync")!
+            .MakeGenericMethod(typeof(ApiVersionsRequest), typeof(ApiVersionsResponse));
+        var request = Expression.Parameter(typeof(ApiVersionsRequest));
+        var version = Expression.Parameter(typeof(short));
+        var token = Expression.Parameter(typeof(CancellationToken));
+        return Expression.Lambda<Func<ApiVersionsRequest, short, CancellationToken, ValueTask<ApiVersionsResponse>>>(
+            Expression.Call(Expression.Convert(Expression.Constant(_connection), capability), method,
+                request, version, Expression.Constant(context, contextType), token),
+            request, version, token).Compile();
+    }
+
+    [Benchmark]
+    public async ValueTask<ErrorCode> OrdinaryRequest()
+    {
+        var response = await _connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(CreateRequest(), 3);
+        return response.ErrorCode;
+    }
+
+    [Benchmark]
+    public async ValueTask<ErrorCode> ObservedRequest()
+    {
+        var response = await _sendObserved(CreateRequest(), 3, CancellationToken.None);
+        return response.ErrorCode;
     }
 
     [Benchmark(Baseline = true)]


### PR DESCRIPTION
Hosted share shutdown now preserves caller cancellation while requests wait for a connection, broker throttle, pending-request slot or write lock. Once writing starts, the existing shutdown budget governs write completion and response observation, so final commit/close uses observed acknowledgement outcomes and session epochs. Requests cancelled before writing retain their explicit dispositions for final commit without reporting an acknowledgement outcome. Actual failures and expired response budgets remain visible.

Refs #3245

Legacy hosting assemblies that call the one-argument observer retain per-call cancellation. Custom connections without the internal write-boundary capability also retain caller cancellation. Final cleanup acknowledgement failures now fault the hosted execution task after cleanup, including failures delivered only through the acknowledgement callback. An earlier execution failure remains the primary failure.

The rebase preserves main's response ownership scopes, shared fetch/acknowledgement bookkeeping, batch acknowledgement tracking and delayed-release tests. The hosted stop check runs after all broker bookkeeping and before classic record delivery or renewal replay. The external merge at beb85e47c was inspected; its test-conflict resolution is preserved.

Costs are amortized per broker/request/poll: one reusable context and cached callback per hosted broker, a dictionary lookup per request, and a stop check per poll. The ordinary and observed transport paths use constrained generic structs containing one reference, preserving the existing async-state callback slot without boxing or a per-request observer allocation. No new per-message allocation, state machine, synchronization or thread-pool hop is introduced. Cleanup failure tracking is per hosted execution.

Validation on main b11b207bf95af9be0e766c39d81e2f8aebc92b0b:

- All 784 related share, hosting, networking, throttle, transaction, watermark and streams-group unit cases pass on each of net10.0 and net8.0. New regressions cover all four explicit dispositions, broker application before/after stop, legacy callers, pre-write lease/transport waits, mixed-broker outcomes, response-budget expiry and final cleanup failures. Five legacy/final-cleanup cases and eight pre-write CommitAsync cases have retained failing controls.
- All nine hosted/close integration cases pass on net10.0 with Kafka 4.3.1. The drained workload requires 20 confirmed acknowledgements, zero acknowledgement failures, and no redelivery before its sentinel.
- All 12 steady-state HostedShareRequestBenchmarks Short cases complete, covering hosted/ordinary ShareFetch, ShareAcknowledge and public CommitAsync with 1/16 partitions. The setup adapter binds the four- or five-parameter method outside measurement. Four real-network PipelinedResponseAllocationBenchmarks Short cases also complete on the identical product source; ordinary and observed requests each report 1,016 B/op. The share fixture uses cached responses and a custom-connection fallback; the separate network fixture exercises the new transport capability. The initial rebased share setup failure and its exact worker are retained, not counted as completed measurements.
- All 40 selector tests pass. Repository artifact policy reports zero violations and whitespace checks pass. Final changes reviewed for reuse, correctness and hot-path costs.

**Do not merge: automatic performance checks and loaded acceptance remain required.** Earlier local request timings showed losses; later candidate/control measurements varied substantially, including unchanged network controls. These are diagnostic measurements, not a protected-metric PASS. No tolerance, selector exception or CI rerun was used. Focused A1/B/A2 run https://github.com/thomhurst/Dekaf/actions/runs/34583803717 compares baseline beb85e47c4412322b3a25d2e3a1087a0f210d110 with candidate 261618470caccad7b34834853ab0164c7e6f50a8, filter *.Unit.HostedShareRequestBenchmarks.*. All 12 cases PASS, with identical allocations across A1/B/A2. Control drift and one-sided differences remain notes under the unchanged screen; both products contain the same main changes. The later test-only review fix leaves all measured product and fixture sources identical to 261618470. The automatic gate also covers the changed real-network fixture.

The hosted-share-1b lane is now on main; the previous no-lane statement was stale. No paid stress run was dispatched because main still contains the classic MaxPollRecords truncation demonstrated in #3244, and the ownership prerequisite #3158 remains unmerged with performance blockers. #3244 was closed without an associated commit; closure does not remove the reproducible source-level prerequisite. The classic overflow correction is now proposed in #3248, which includes the #3158 ownership foundation. The requested exact-SHA loaded run remains outstanding and must exercise the combined lifecycle fixes. Existing cancellation and InvalidShareSessionEpoch failures are not suppressed, and a diagnostic higher MaxPollRecords limit will not be presented as acceptance.

Current head bdae70d6a2e73b4f99e424a5fceba38f0f611af6 is one commit on b11b207bf. Its source, loaded unit binaries/reports and verified inventory (1,297 files) are retained at D:\Dekaf-evidence\issue-3245-20260911\bdae70d6a2e73b4f99e424a5fceba38f0f611af6. The deadline test now asserts the unchanged consumer epoch, failure callback and retained disposition; it no longer repeats an input flag as an assertion. Fake request handlers invoke OnSend consistently. Product and benchmark sources are identical to 261618470. Its earlier archive retains the nine Kafka integration results, generated benchmark workers and 2,648 verified files; the four network measurements and integration binaries identify 36e76100d, whose product source is also identical. Raw logs, source archives and revision provenance remain under D:/Dekaf-evidence/issue-3245-20260911 through the compatible C:/git/Dekaf-evidence/issue-3245 junction. Earlier failures, controls, source patches and experiment provenance remain in sibling directories. No generated evidence is committed. Fresh CI and subsequent review are required.







