### PR TITLE
fix(share-consumer): wake idle polls and recover missing leaders

### DIFF
--- a/.github/scripts/performance_gate.py
+++ b/.github/scripts/performance_gate.py
@@ -55,7 +55,7 @@ COMPONENTS = {
                             'ConsumerBatchInterceptorBenchmarks', 'ConsumerFollowerOffsetRetryBenchmarks'),
     'src/Dekaf/ShareConsumer/': ('ShareConsumerParsingBenchmarks', 'ShareConsumerBorrowedParsingBenchmarks', 'ShareFetchResponseDecodingBenchmarks',
                                  'ShareAcknowledgementTrackingBenchmarks',
-                                 'ShareConsumerPollBenchmarks', 'ShareConsumerUnsubscribeBenchmarks', 'ShareConsumerSparsePollBenchmarks', 'ShareBatchAcknowledgementBenchmarks', 'ShareBatchScalingBenchmarks',
+                                 'ShareConsumerPollBenchmarks', 'ShareConsumerIdleAssignmentBenchmarks', 'ShareConsumerMissingLeaderBenchmarks', 'ShareConsumerUnsubscribeBenchmarks', 'ShareConsumerSparsePollBenchmarks', 'ShareBatchAcknowledgementBenchmarks', 'ShareBatchScalingBenchmarks',
                                  'ShareBatchRenewalPollBenchmarks', 'ShareBatchPendingStateBenchmarks',
                                  'ShareBatchChunkedRenewalBenchmarks'),
     'src/Dekaf/Networking/': ('ResponseFrameReaderBenchmarks', 'PendingRequestTableBenchmarks',

--- a/.github/scripts/test_performance_gate.py
+++ b/.github/scripts/test_performance_gate.py
@@ -117,7 +117,7 @@ class SelectionTests(unittest.TestCase):
     def test_share_consumer_selects_polling_and_batch_fixtures(self):
         path = 'src/Dekaf/ShareConsumer/KafkaShareConsumer.cs'
         selected = self.names(gate.select([path], root=REPO_ROOT))
-        for fixture in ('ShareConsumerPollBenchmarks', 'ShareConsumerUnsubscribeBenchmarks', 'ShareConsumerSparsePollBenchmarks', 'ShareConsumerBorrowedParsingBenchmarks',
+        for fixture in ('ShareConsumerPollBenchmarks', 'ShareConsumerIdleAssignmentBenchmarks', 'ShareConsumerMissingLeaderBenchmarks', 'ShareConsumerUnsubscribeBenchmarks', 'ShareConsumerSparsePollBenchmarks', 'ShareConsumerBorrowedParsingBenchmarks',
                         'ShareBatchAcknowledgementBenchmarks', 'ShareBatchScalingBenchmarks',
                         'ShareBatchRenewalPollBenchmarks', 'ShareBatchPendingStateBenchmarks',
                         'ShareBatchChunkedRenewalBenchmarks'):

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
@@ -123,7 +123,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
             {
                 // No broker request provided long-poll back-pressure. Refresh missing
                 // leaders and use the configured retry delay only if none is available.
-                await PrepareRequestRetryAsync(0, cancellationToken, assignment).ConfigureAwait(false);
+                await PrepareMissingLeaderRetryAsync(assignment, cancellationToken).ConfigureAwait(false);
                 continue;
             }
 

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
@@ -48,7 +48,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            if (_subscriptionSnapshot.Count == 0)
+            if (_subscriptionSnapshot.Count == 0 || Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _disposed) != 0)
                 yield break;
             // Ensure we're part of the share group
             await _coordinator.EnsureActiveGroupAsync(_subscriptionSnapshot, cancellationToken)
@@ -59,10 +59,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
             acknowledgements.RemoveOutsideAssignment(assignment);
             if (assignment.Count == 0)
             {
-                // No partitions assigned (e.g. rebalance removed them while state is Stable).
-                // Delay to avoid a spin-loop — reuse FetchMaxWaitMs as the broker's natural
-                // back-pressure is absent when no fetch request is issued.
-                await Task.Delay(_options.FetchMaxWaitMs, cancellationToken).ConfigureAwait(false);
+                await WaitForAssignmentChangeAsync(assignment, cancellationToken).ConfigureAwait(false);
                 continue;
             }
 

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
@@ -119,6 +119,13 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
             }
 
             CompletePollFetch(fetchResults, pendingAcks, sentAcknowledgementPartitionCount);
+            if (fetchResults.Length == 0)
+            {
+                // No broker request provided long-poll back-pressure. Refresh missing
+                // leaders and use the configured retry delay only if none is available.
+                await PrepareRequestRetryAsync(0, cancellationToken, assignment).ConfigureAwait(false);
+                continue;
+            }
 
             foreach (var result in fetchResults)
             {

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Idle.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Idle.cs
@@ -1,4 +1,9 @@
 using Dekaf.Consumer;
+#if NETSTANDARD2_0
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
 
 namespace Dekaf.ShareConsumer;
 
@@ -13,11 +18,58 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
         var changed = _coordinator.GetAssignmentChangeTask();
         // Register first, then recheck every condition that can end this idle period.
         // Cancellation affects this wait only; a later poll can reuse the same signal.
-        if (Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _disposed) != 0 ||
-            subscription.Count == 0 || !ReferenceEquals(subscription, _subscriptionSnapshot) ||
-            _coordinator.State != CoordinatorState.Stable ||
-            !ReferenceEquals(observedAssignment, _coordinator.Assignment))
+        if (HasPollStateChanged(subscription, observedAssignment))
             return ValueTask.CompletedTask;
         return new ValueTask(changed.WaitAsync(cancellationToken));
     }
+
+    private async ValueTask PrepareMissingLeaderRetryAsync(
+        TopicPartitionSet observedAssignment,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var subscription = _subscriptionSnapshot;
+        var changed = _coordinator.GetAssignmentChangeTask();
+        if (HasPollStateChanged(subscription, observedAssignment))
+            return;
+
+        using var retryCancellation = cancellationToken.CanBeCanceled
+            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+            : new CancellationTokenSource();
+        var retry = PrepareRequestRetryAsync(0, retryCancellation.Token, observedAssignment);
+        if (retry.IsCompletedSuccessfully)
+        {
+            await retry.ConfigureAwait(false);
+            return;
+        }
+
+        var pending = retry.AsTask();
+        try
+        {
+            if (await Task.WhenAny(pending, changed).ConfigureAwait(false) != pending)
+                retryCancellation.Cancel();
+        }
+        finally
+        {
+            // Cancel and join the refresh/backoff before another poll or disposal
+            // can reuse its state. Caller cancellation and non-cancellation failures
+            // still propagate; only this recovery's state-change cancellation ends quietly.
+            try
+            {
+                await pending.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (
+                retryCancellation.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+            }
+        }
+    }
+
+    private bool HasPollStateChanged(
+        IReadOnlyCollection<string> observedSubscription,
+        IReadOnlyCollection<TopicPartition> observedAssignment)
+        => Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _disposed) != 0 ||
+           observedSubscription.Count == 0 || !ReferenceEquals(observedSubscription, _subscriptionSnapshot) ||
+           _coordinator.State != CoordinatorState.Stable ||
+           !ReferenceEquals(observedAssignment, _coordinator.Assignment);
 }

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Idle.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Idle.cs
@@ -1,0 +1,23 @@
+using Dekaf.Consumer;
+
+namespace Dekaf.ShareConsumer;
+
+internal sealed partial class KafkaShareConsumer<TKey, TValue>
+{
+    private ValueTask WaitForAssignmentChangeAsync(
+        IReadOnlyCollection<TopicPartition> observedAssignment,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var subscription = _subscriptionSnapshot;
+        var changed = _coordinator.GetAssignmentChangeTask();
+        // Register first, then recheck every condition that can end this idle period.
+        // Cancellation affects this wait only; a later poll can reuse the same signal.
+        if (Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _disposed) != 0 ||
+            subscription.Count == 0 || !ReferenceEquals(subscription, _subscriptionSnapshot) ||
+            _coordinator.State != CoordinatorState.Stable ||
+            !ReferenceEquals(observedAssignment, _coordinator.Assignment))
+            return ValueTask.CompletedTask;
+        return new ValueTask(changed.WaitAsync(cancellationToken));
+    }
+}

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -339,7 +339,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             {
                 // No broker request provided long-poll back-pressure. Refresh missing
                 // leaders and use the configured retry delay only if none is available.
-                await PrepareRequestRetryAsync(0, cancellationToken, assignment).ConfigureAwait(false);
+                await PrepareMissingLeaderRetryAsync(assignment, cancellationToken).ConfigureAwait(false);
                 continue;
             }
 

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -335,6 +335,13 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             }
 
             CompletePollFetch(fetchResults, pendingAcks, sentAcknowledgementPartitionCount);
+            if (fetchResults.Length == 0)
+            {
+                // No broker request provided long-poll back-pressure. Refresh missing
+                // leaders and use the configured retry delay only if none is available.
+                await PrepareRequestRetryAsync(0, cancellationToken, assignment).ConfigureAwait(false);
+                continue;
+            }
 
             // A hosted stop observes every in-flight reply without delivering fetched
             // records or replaying renewed work. Close releases remaining acquisitions.
@@ -1349,7 +1356,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         }
     }
 
-    private async ValueTask PrepareRequestRetryAsync(int zeroBasedAttempt, CancellationToken cancellationToken)
+    private async ValueTask PrepareRequestRetryAsync(
+        int zeroBasedAttempt,
+        CancellationToken cancellationToken,
+        TopicPartitionSet? assignmentAwaitingLeader = null)
     {
         try
         {
@@ -1368,6 +1378,14 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             // Same best-effort behavior for transient transport failures.
         }
 
+        if (assignmentAwaitingLeader is not null)
+        {
+            foreach (var partition in assignmentAwaitingLeader)
+            {
+                if (_metadataManager.Metadata.GetPartitionLeader(partition.Topic, partition.Partition) is not null)
+                    return;
+            }
+        }
         var delayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
             _options.RetryBackoffMs,
             _options.RetryBackoffMaxMs,

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -265,6 +265,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     public IKafkaShareConsumer<TKey, TValue> Subscribe(params string[] topics)
     {
         _subscriptionSnapshot = new HashSet<string>(topics);
+        _coordinator.NotifyAssignmentChange();
         return this;
     }
 
@@ -282,6 +283,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         _activeShareBatch = null;
         _batchAcknowledgements?.Clear();
         _subscriptionSnapshot = new HashSet<string>();
+        _coordinator.NotifyAssignmentChange();
         _sessionManager.ResetAll();
         ClearRenewedRecords();
         return this;
@@ -297,7 +299,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            if (_subscriptionSnapshot.Count == 0)
+            if (_subscriptionSnapshot.Count == 0 || Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _disposed) != 0)
                 yield break;
 
             // Ensure we're part of the share group
@@ -309,10 +311,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             RemoveRenewedRecordsOutsideAssignment(assignment);
             if (assignment.Count == 0)
             {
-                // No partitions assigned (e.g. rebalance removed them while state is Stable).
-                // Delay to avoid a spin-loop — reuse FetchMaxWaitMs as the broker's natural
-                // back-pressure is absent when no fetch request is issued.
-                await Task.Delay(_options.FetchMaxWaitMs, cancellationToken).ConfigureAwait(false);
+                await WaitForAssignmentChangeAsync(assignment, cancellationToken).ConfigureAwait(false);
                 continue;
             }
 
@@ -797,6 +796,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         await WaitForPendingReleaseAsync(cancellationToken).ConfigureAwait(false);
         if (Interlocked.Exchange(ref _closed, 1) != 0)
             return;
+        _coordinator.NotifyAssignmentChange();
 
         LogClosingShareConsumer();
         ClearRenewedRecords();
@@ -846,6 +846,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
+        _coordinator.NotifyAssignmentChange();
 
         ClearRenewedRecords();
 

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -46,6 +46,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     private long _lastSuccessfulHeartbeatTimestamp;
     private string? _lastHeartbeatFailure;
     private int _disposed;
+    private TaskCompletionSource<bool>? _assignmentChanged;
     private readonly Func<int> _getCoordinationConnectionIndex;
 
     private volatile int _heartbeatIntervalMs;
@@ -80,6 +81,25 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     public CoordinatorState State => _state;
     public TopicPartitionSet Assignment => _assignedPartitions;
 
+    // Allocate only when a poll actually waits without assignments. Subscribe to the
+    // signal before rechecking state so updates racing waiter registration cannot be lost.
+    internal Task GetAssignmentChangeTask()
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            return Task.CompletedTask;
+        var pending = Volatile.Read(ref _assignmentChanged);
+        if (pending is not null)
+            return pending.Task;
+        var created = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        pending = Interlocked.CompareExchange(ref _assignmentChanged, created, null) ?? created;
+        if (Volatile.Read(ref _disposed) != 0)
+            NotifyAssignmentChange();
+        return pending.Task;
+    }
+
+    internal void NotifyAssignmentChange()
+        => Interlocked.Exchange(ref _assignmentChanged, null)?.TrySetResult(true);
+
     internal ConsumerGroupStatus CaptureGroupStatus()
     {
         var assignment = _assignedPartitions;
@@ -107,6 +127,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     internal void RequestRejoin()
     {
         _state = CoordinatorState.Unjoined;
+        NotifyAssignmentChange();
     }
 
     /// <summary>
@@ -132,6 +153,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     {
         _coordinatorId = -1;
         _state = CoordinatorState.Unjoined;
+        NotifyAssignmentChange();
     }
 
     private static bool IsRetriableCoordinatorError(ErrorCode? errorCode) =>
@@ -299,6 +321,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
         _memberEpoch = 0;
         _assignedPartitions = [];
         _state = CoordinatorState.Unjoined;
+        NotifyAssignmentChange();
     }
 
     /// <summary>
@@ -441,6 +464,9 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     /// </summary>
     private void ProcessShareGroupAssignment(ShareGroupHeartbeatAssignment assignment)
     {
+        if (assignment.TopicPartitions.Count == 0 && _assignedPartitions.Count == 0)
+            return;
+
         var newAssignment = new HashSet<TopicPartition>();
 
         foreach (var tp in assignment.TopicPartitions)
@@ -460,12 +486,12 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
 
         var oldAssignment = _assignedPartitions;
 
-        if (newAssignment.Count != oldAssignment.Count || !newAssignment.SetEquals(oldAssignment))
-        {
-            LogAssignmentUpdate(newAssignment.Count);
-        }
+        if (newAssignment.Count == oldAssignment.Count && newAssignment.SetEquals(oldAssignment))
+            return;
 
+        LogAssignmentUpdate(newAssignment.Count);
         _assignedPartitions = newAssignment;
+        NotifyAssignmentChange();
     }
 
     /// <summary>
@@ -607,6 +633,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                             // see the Unjoined state and trigger a fresh join.
                             _memberEpoch = 0;
                             _state = CoordinatorState.Unjoined;
+                            NotifyAssignmentChange();
                             break;
 
                         case ErrorCode.UnknownMemberId:
@@ -742,6 +769,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
+        NotifyAssignmentChange();
         LogCoordinatorDisposing();
 
         await StopHeartbeatAsync().ConfigureAwait(false);

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -81,7 +81,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     public CoordinatorState State => _state;
     public TopicPartitionSet Assignment => _assignedPartitions;
 
-    // Allocate only when a poll actually waits without assignments. Subscribe to the
+    // Allocate only when a poll waits for assignment or leader recovery. Subscribe to the
     // signal before rechecking state so updates racing waiter registration cannot be lost.
     internal Task GetAssignmentChangeTask()
     {

--- a/tests/Dekaf.Tests.Integration/ShareConsumerIdleTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerIdleTests.cs
@@ -1,0 +1,50 @@
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("ShareConsumer")]
+[SupportsKafka(420)]
+[NotInParallel("ShareConsumerKafka42")]
+public sealed class ShareConsumerIdleTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task TopicRevocation_UnsubscribeWakesIdlePoll(bool batch)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        await using var consumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId($"share-idle-{Guid.NewGuid():N}")
+            .WithFetchMaxWaitMs(10_000)
+            .BuildAsync();
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).Build();
+        consumer.Subscribe(topic);
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(75));
+        await using var records = consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        await using var batches = consumer.PollBatchesAsync(cancellation.Token).GetAsyncEnumerator();
+        var pending = (batch ? batches.MoveNextAsync() : records.MoveNextAsync()).AsTask();
+        try
+        {
+            // Keep the first fetch active: cancelling a priming request would change
+            // the session epoch and would not isolate assignment waiting.
+            await WaitForConditionAsync(
+                () => consumer.Assignment.Count == 1 && consumer.AcquisitionLockTimeoutMs > 0,
+                TimeSpan.FromSeconds(30), description: "initial share assignment and successful fetch");
+            await admin.DeleteTopicsAsync([topic], cancellationToken: cancellation.Token);
+            await WaitForConditionAsync(() => consumer.Assignment.Count == 0,
+                TimeSpan.FromSeconds(30), description: "broker revokes the deleted topic");
+            await Assert.That(pending.IsCompleted).IsFalse();
+            consumer.Unsubscribe();
+            await Assert.That(await pending.WaitAsync(TimeSpan.FromSeconds(3))).IsFalse();
+            await consumer.CloseAsync(cancellation.Token);
+        }
+        finally
+        {
+            await cancellation.CancelAsync();
+            try { await pending; }
+            catch (OperationCanceledException) { }
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerIdleRecoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerIdleRecoveryTests.cs
@@ -1,0 +1,112 @@
+using System.Reflection;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public sealed partial class ShareConsumerRenewalTests
+{
+    [Test]
+    [Arguments(false, false, "unsubscribe")]
+    [Arguments(true, false, "unsubscribe")]
+    [Arguments(false, true, "unsubscribe")]
+    [Arguments(true, true, "unsubscribe")]
+    [Arguments(false, false, "close")]
+    [Arguments(true, false, "close")]
+    [Arguments(false, true, "close")]
+    [Arguments(true, true, "close")]
+    [Arguments(false, false, "dispose")]
+    [Arguments(true, false, "dispose")]
+    [Arguments(false, true, "dispose")]
+    [Arguments(true, true, "dispose")]
+    [Arguments(false, false, "reassign")]
+    [Arguments(true, false, "reassign")]
+    [Arguments(false, true, "reassign")]
+    [Arguments(true, true, "reassign")]
+    public async Task MissingLeader_StateChangeInterruptsRecovery(bool batch, bool delayedMetadata, string action)
+    {
+        var missing = new MetadataResponse
+        {
+            Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
+            Topics = [new TopicMetadata
+            {
+                ErrorCode = ErrorCode.None, Name = "topic", TopicId = TopicId,
+                Partitions =
+                [
+                    new PartitionMetadata
+                    {
+                        ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = -1,
+                        ReplicaNodes = [1], IsrNodes = [1]
+                    },
+                    new PartitionMetadata
+                    {
+                        ErrorCode = ErrorCode.None, PartitionIndex = 1, LeaderId = 1,
+                        ReplicaNodes = [1], IsrNodes = [1]
+                    }
+                ]
+            }]
+        };
+        var requested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stopped = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<MetadataResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var connection = new CapturingConnection(ApiKey.ShareFetch, maximumVersion: 2)
+        {
+            MetadataResponse = missing,
+            ShareFetchResponse = CreateFetchResponse(partition: 1, offset: 43),
+            OnSend = () => requested.TrySetResult(),
+            MetadataHandler = delayedMetadata ? async token =>
+            {
+                try { return await release.Task.WaitAsync(token); }
+                catch (OperationCanceledException)
+                {
+                    stopped.TrySetResult();
+                    throw;
+                }
+            } : null
+        };
+        await using var fixture = CreateFixture(connection, retryBackoffMs: 60_000);
+        fixture.MetadataManager.Metadata.Update(missing);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await using var records = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        await using var batches = fixture.Consumer.PollBatchesAsync(cancellation.Token).GetAsyncEnumerator();
+        var pending = (batch ? batches.MoveNextAsync() : records.MoveNextAsync()).AsTask();
+        try
+        {
+            await requested.Task.WaitAsync(TimeSpan.FromSeconds(3));
+            await Assert.That(pending.IsCompleted).IsFalse();
+            switch (action)
+            {
+                case "unsubscribe": fixture.Consumer.Unsubscribe(); break;
+                case "close": await fixture.Consumer.CloseAsync(); break;
+                case "dispose": await fixture.Consumer.DisposeAsync(); break;
+                case "reassign":
+                    typeof(ShareConsumerCoordinator)
+                        .GetMethod("ProcessShareGroupAssignment", BindingFlags.Instance | BindingFlags.NonPublic)!
+                        .Invoke(IdleCoordinator(fixture.Consumer), [new ShareGroupHeartbeatAssignment
+                        {
+                            TopicPartitions = [new ShareGroupHeartbeatTopicPartitions { TopicId = TopicId, Partitions = [1] }]
+                        }]);
+                    break;
+                default: throw new ArgumentOutOfRangeException(nameof(action));
+            }
+            await Assert.That(await pending.WaitAsync(TimeSpan.FromSeconds(3))).IsEqualTo(action == "reassign");
+            if (delayedMetadata)
+                await Assert.That(stopped.Task.IsCompletedSuccessfully).IsTrue();
+            if (action == "reassign")
+            {
+                if (batch) await Assert.That(batches.Current.Count).IsEqualTo(1);
+                else await Assert.That(records.Current.Offset).IsEqualTo(43L);
+            }
+        }
+        finally
+        {
+            await cancellation.CancelAsync();
+            release.TrySetResult(missing);
+            try { await pending; }
+            catch (OperationCanceledException) { }
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerIdleTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerIdleTests.cs
@@ -191,7 +191,7 @@ public sealed partial class ShareConsumerRenewalTests
         {
             ShareFetchResponse = CreateFetchResponse(partition: 0, offset: 42)
         };
-        await using var fixture = CreateFixture(connection);
+        await using var fixture = CreateFixture(connection, retryBackoffMs: 60_000);
         fixture.MetadataManager.Metadata.Update(new MetadataResponse
         {
             Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
@@ -218,6 +218,56 @@ public sealed partial class ShareConsumerRenewalTests
         {
             await Assert.That(await pending).IsTrue();
             await Assert.That(connection.SendCount).IsGreaterThanOrEqualTo(2);
+        }
+        finally
+        {
+            await cancellation.CancelAsync();
+            try { await pending; }
+            catch (OperationCanceledException) { }
+        }
+    }
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task MissingLeader_CancellationInterruptsUnavailableMetadataBackoff(bool batch)
+    {
+        var missing = new MetadataResponse
+        {
+            Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
+            Topics = [new TopicMetadata
+            {
+                ErrorCode = ErrorCode.None, Name = "topic", TopicId = TopicId,
+                Partitions = [new PartitionMetadata
+                {
+                    ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = -1,
+                    ReplicaNodes = [1], IsrNodes = [1]
+                }]
+            }]
+        };
+        var requested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var connection = new CapturingConnection(ApiKey.ShareFetch, maximumVersion: 2)
+        {
+            MetadataResponse = missing,
+            OnSend = () => requested.TrySetResult()
+        };
+        await using var fixture = CreateFixture(connection, retryBackoffMs: 60_000);
+        fixture.MetadataManager.Metadata.Update(missing);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await using var records = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        await using var batches = fixture.Consumer.PollBatchesAsync(cancellation.Token).GetAsyncEnumerator();
+        var pending = Task.Run(async () => batch
+            ? await batches.MoveNextAsync()
+            : await records.MoveNextAsync());
+        try
+        {
+            await requested.Task.WaitAsync(TimeSpan.FromSeconds(3));
+            await Assert.That(pending.IsCompleted).IsFalse();
+            await cancellation.CancelAsync();
+            await Assert.That(async () => await pending.WaitAsync(TimeSpan.FromSeconds(3)))
+                .Throws<OperationCanceledException>();
+            await Assert.That(connection.SendCount).IsEqualTo(1);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerIdleTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerIdleTests.cs
@@ -182,6 +182,50 @@ public sealed partial class ShareConsumerRenewalTests
         await Assert.That(wait.IsCompletedSuccessfully).IsTrue();
         await wait;
     }
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task MissingLeader_RefreshesMetadataBeforePollingAgain(bool batch)
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, maximumVersion: 2)
+        {
+            ShareFetchResponse = CreateFetchResponse(partition: 0, offset: 42)
+        };
+        await using var fixture = CreateFixture(connection);
+        fixture.MetadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
+            Topics = [new TopicMetadata
+            {
+                ErrorCode = ErrorCode.None, Name = "topic", TopicId = TopicId,
+                Partitions = [new PartitionMetadata
+                {
+                    ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = -1, ReplicaNodes = [1], IsrNodes = [1]
+                }]
+            }]
+        });
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        await using var records = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        await using var batches = fixture.Consumer.PollBatchesAsync(cancellation.Token).GetAsyncEnumerator();
+        // The old no-leader path never suspends. A separate worker lets the timeout
+        // bound that regression without blocking the test runner's calling thread.
+        var pending = Task.Run(async () => batch
+            ? await batches.MoveNextAsync()
+            : await records.MoveNextAsync());
+        try
+        {
+            await Assert.That(await pending).IsTrue();
+            await Assert.That(connection.SendCount).IsGreaterThanOrEqualTo(2);
+        }
+        finally
+        {
+            await cancellation.CancelAsync();
+            try { await pending; }
+            catch (OperationCanceledException) { }
+        }
+    }
     private static ShareConsumerCoordinator IdleCoordinator(KafkaShareConsumer<string, string> consumer)
         => (ShareConsumerCoordinator)typeof(KafkaShareConsumer<string, string>)
             .GetField("_coordinator", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(consumer)!;

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerIdleTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerIdleTests.cs
@@ -73,6 +73,115 @@ public sealed partial class ShareConsumerRenewalTests
         }
     }
 
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task NoAssignment_CancellationDoesNotCancelLaterPoll(bool batch)
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, maximumVersion: 2)
+        {
+            ShareFetchResponse = CreateFetchResponse(partition: 0, offset: 42)
+        };
+        await using var fixture = CreateFixture(connection, fetchMaxWaitMs: 60_000);
+        PrepareForPoll(fixture.Consumer);
+        var coordinator = IdleCoordinator(fixture.Consumer);
+        PublishAssignment(coordinator, assigned: false);
+        fixture.Consumer.Subscribe("topic");
+        using (var cancelled = new CancellationTokenSource())
+        {
+            await using var records = fixture.Consumer.PollAsync(cancelled.Token).GetAsyncEnumerator();
+            await using var batches = fixture.Consumer.PollBatchesAsync(cancelled.Token).GetAsyncEnumerator();
+            var pending = (batch ? batches.MoveNextAsync() : records.MoveNextAsync()).AsTask();
+            await Assert.That(pending.IsCompleted).IsFalse();
+            await cancelled.CancelAsync();
+            await Assert.That(async () => await pending).Throws<OperationCanceledException>();
+        }
+
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await using var nextRecords = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        await using var nextBatches = fixture.Consumer.PollBatchesAsync(cancellation.Token).GetAsyncEnumerator();
+        var next = (batch ? nextBatches.MoveNextAsync() : nextRecords.MoveNextAsync()).AsTask();
+        try
+        {
+            await Assert.That(next.IsCompleted).IsFalse();
+            PublishAssignment(coordinator, assigned: true);
+            await Assert.That(await next.WaitAsync(TimeSpan.FromSeconds(3))).IsTrue();
+        }
+        finally
+        {
+            await cancellation.CancelAsync();
+            try { await next; }
+            catch (OperationCanceledException) { }
+        }
+    }
+
+    [Test]
+    [Arguments(false, false)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(true, true)]
+    public async Task NoAssignment_CloseOrDisposeWakesPendingPoll(bool batch, bool dispose)
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, maximumVersion: 2);
+        await using var fixture = CreateFixture(connection, fetchMaxWaitMs: 60_000);
+        PrepareForPoll(fixture.Consumer);
+        PublishAssignment(IdleCoordinator(fixture.Consumer), assigned: false);
+        fixture.Consumer.Subscribe("topic");
+        using var cancellation = new CancellationTokenSource();
+        await using var records = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        await using var batches = fixture.Consumer.PollBatchesAsync(cancellation.Token).GetAsyncEnumerator();
+        var pending = (batch ? batches.MoveNextAsync() : records.MoveNextAsync()).AsTask();
+        try
+        {
+            await Assert.That(pending.IsCompleted).IsFalse();
+            if (dispose)
+                await fixture.Consumer.DisposeAsync();
+            else
+                await fixture.Consumer.CloseAsync();
+            await Assert.That(await pending.WaitAsync(TimeSpan.FromSeconds(3))).IsFalse();
+            await Assert.That(connection.SendCount).IsEqualTo(0);
+        }
+        finally
+        {
+            await cancellation.CancelAsync();
+            try { await pending; }
+            catch (OperationCanceledException) { }
+        }
+    }
+
+    [Test]
+    public async Task NoAssignment_UnchangedHeartbeatDoesNotWakeWaiter()
+    {
+        await using var fixture = CreateFixture(new CapturingConnection(ApiKey.ShareFetch, maximumVersion: 2));
+        PrepareForPoll(fixture.Consumer);
+        var coordinator = IdleCoordinator(fixture.Consumer);
+        PublishAssignment(coordinator, assigned: false);
+        var assignment = coordinator.Assignment;
+        var pending = coordinator.GetAssignmentChangeTask();
+        PublishAssignment(coordinator, assigned: false);
+        await Assert.That(pending.IsCompleted).IsFalse();
+        await Assert.That(coordinator.Assignment).IsSameReferenceAs(assignment);
+        await Assert.That(coordinator.GetAssignmentChangeTask()).IsSameReferenceAs(pending);
+        coordinator.RequestRejoin();
+        await pending.WaitAsync(TimeSpan.FromSeconds(3));
+        await Assert.That(coordinator.State).IsEqualTo(Dekaf.Consumer.CoordinatorState.Unjoined);
+    }
+
+    [Test]
+    public async Task NoAssignment_UpdateBeforeWaitRegistrationDoesNotLoseWakeup()
+    {
+        await using var fixture = CreateFixture(new CapturingConnection(ApiKey.ShareFetch, maximumVersion: 2));
+        PrepareForPoll(fixture.Consumer);
+        var coordinator = IdleCoordinator(fixture.Consumer);
+        PublishAssignment(coordinator, assigned: false);
+        fixture.Consumer.Subscribe("topic");
+        var observed = coordinator.Assignment;
+        PublishAssignment(coordinator, assigned: true);
+        var wait = (ValueTask)InvokePrivate(fixture.Consumer,
+            "WaitForAssignmentChangeAsync", observed, CancellationToken.None)!;
+        await Assert.That(wait.IsCompletedSuccessfully).IsTrue();
+        await wait;
+    }
     private static ShareConsumerCoordinator IdleCoordinator(KafkaShareConsumer<string, string> consumer)
         => (ShareConsumerCoordinator)typeof(KafkaShareConsumer<string, string>)
             .GetField("_coordinator", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(consumer)!;

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerIdleTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerIdleTests.cs
@@ -1,0 +1,89 @@
+using System.Reflection;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public sealed partial class ShareConsumerRenewalTests
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task NoAssignment_NewAssignmentWakesPollWithoutFetchDelay(bool batch)
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, maximumVersion: 2)
+        {
+            ShareFetchResponse = CreateFetchResponse(partition: 0, offset: 42)
+        };
+        await using var fixture = CreateFixture(connection, fetchMaxWaitMs: 60_000);
+        PrepareForPoll(fixture.Consumer);
+        var coordinator = IdleCoordinator(fixture.Consumer);
+        PublishAssignment(coordinator, assigned: false);
+        fixture.Consumer.Subscribe("topic");
+        using var cancellation = new CancellationTokenSource();
+        await using var records = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        await using var batches = fixture.Consumer.PollBatchesAsync(cancellation.Token).GetAsyncEnumerator();
+        var pending = (batch ? batches.MoveNextAsync() : records.MoveNextAsync()).AsTask();
+        try
+        {
+            await Assert.That(pending.IsCompleted).IsFalse();
+            await Assert.That(connection.SendCount).IsEqualTo(0);
+            PublishAssignment(coordinator, assigned: true);
+            await Assert.That(await pending.WaitAsync(TimeSpan.FromSeconds(3))).IsTrue();
+            if (batch)
+                await Assert.That(batches.Current.Count).IsEqualTo(1);
+            else
+                await Assert.That(records.Current.Offset).IsEqualTo(42L);
+        }
+        finally
+        {
+            await cancellation.CancelAsync();
+            try { await pending; }
+            catch (OperationCanceledException) { }
+        }
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task NoAssignment_UnsubscribeWakesPendingPoll(bool batch)
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, maximumVersion: 2);
+        await using var fixture = CreateFixture(connection, fetchMaxWaitMs: 60_000);
+        PrepareForPoll(fixture.Consumer);
+        PublishAssignment(IdleCoordinator(fixture.Consumer), assigned: false);
+        fixture.Consumer.Subscribe("topic");
+        using var cancellation = new CancellationTokenSource();
+        await using var records = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        await using var batches = fixture.Consumer.PollBatchesAsync(cancellation.Token).GetAsyncEnumerator();
+        var pending = (batch ? batches.MoveNextAsync() : records.MoveNextAsync()).AsTask();
+        try
+        {
+            await Assert.That(pending.IsCompleted).IsFalse();
+            fixture.Consumer.Unsubscribe();
+            await Assert.That(await pending.WaitAsync(TimeSpan.FromSeconds(3))).IsFalse();
+            await Assert.That(connection.SendCount).IsEqualTo(0);
+        }
+        finally
+        {
+            await cancellation.CancelAsync();
+            try { await pending; }
+            catch (OperationCanceledException) { }
+        }
+    }
+
+    private static ShareConsumerCoordinator IdleCoordinator(KafkaShareConsumer<string, string> consumer)
+        => (ShareConsumerCoordinator)typeof(KafkaShareConsumer<string, string>)
+            .GetField("_coordinator", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(consumer)!;
+
+    private static void PublishAssignment(ShareConsumerCoordinator coordinator, bool assigned)
+        => typeof(ShareConsumerCoordinator)
+            .GetMethod("ProcessShareGroupAssignment", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(coordinator, [new ShareGroupHeartbeatAssignment
+            {
+                TopicPartitions = assigned
+                    ? [new ShareGroupHeartbeatTopicPartitions { TopicId = TopicId, Partitions = [0] }]
+                    : []
+            }]);
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -1493,6 +1493,7 @@ public sealed partial class ShareConsumerRenewalTests
         internal ShareFetchRequest? ShareFetchRequest { get; private set; }
         internal ShareAcknowledgeRequest? ShareAcknowledgeRequest { get; private set; }
         internal MetadataResponse? MetadataResponse { get; init; }
+        internal Func<CancellationToken, ValueTask<MetadataResponse>>? MetadataHandler { get; init; }
         internal ShareFetchResponse? ShareFetchResponse { get; init; }
         internal Queue<ShareFetchResponse>? ShareFetchResponses { get; init; }
         internal ShareAcknowledgeResponse? ShareAcknowledgeResponse { get; init; }
@@ -1527,6 +1528,11 @@ public sealed partial class ShareConsumerRenewalTests
         {
             SendCount++;
             LastApiVersion = apiVersion;
+            if (request is MetadataRequest && MetadataHandler is not null)
+            {
+                OnSend?.Invoke();
+                return AwaitMetadataAsync<TResponse>(MetadataHandler(cancellationToken));
+            }
             if (request is ShareFetchRequest fetchRequest && ShareFetchHandler is not null)
             {
                 ShareFetchRequest = fetchRequest;
@@ -1614,6 +1620,10 @@ public sealed partial class ShareConsumerRenewalTests
         private static async ValueTask<TResponse> AwaitAcknowledgementAsync<TResponse>(ValueTask<ShareAcknowledgeResponse> response)
             where TResponse : IKafkaResponse
             => (TResponse)(IKafkaResponse)await response;
+
+        private static async ValueTask<TResponse> AwaitMetadataAsync<TResponse>(ValueTask<MetadataResponse> pending)
+            where TResponse : IKafkaResponse
+            => (TResponse)(IKafkaResponse)await pending;
 
         private ShareFetchResponse Capture(
             ShareFetchRequest request,

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -1086,7 +1086,8 @@ public sealed partial class ShareConsumerRenewalTests
         CapturingConnection? secondConnection = null,
         ShareAcknowledgementCommitCallback? acknowledgementCommitCallback = null,
         IDeserializer<string>? valueDeserializer = null,
-        Func<CancellationToken, ValueTask<IKafkaConnection>>? leaseHandler = null)
+        Func<CancellationToken, ValueTask<IKafkaConnection>>? leaseHandler = null,
+        int fetchMaxWaitMs = 200)
     {
         var options = new ShareConsumerOptions
         {
@@ -1094,6 +1095,7 @@ public sealed partial class ShareConsumerRenewalTests
             GroupId = "share-group",
             AcknowledgementMode = acknowledgementMode,
             MaxPollRecords = maxPollRecords,
+            FetchMaxWaitMs = fetchMaxWaitMs,
             AcknowledgementCommitCallback = acknowledgementCommitCallback
         };
         var pool = Substitute.For<IConnectionPool>();

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -1087,7 +1087,8 @@ public sealed partial class ShareConsumerRenewalTests
         ShareAcknowledgementCommitCallback? acknowledgementCommitCallback = null,
         IDeserializer<string>? valueDeserializer = null,
         Func<CancellationToken, ValueTask<IKafkaConnection>>? leaseHandler = null,
-        int fetchMaxWaitMs = 200)
+        int fetchMaxWaitMs = 200,
+        int retryBackoffMs = 100)
     {
         var options = new ShareConsumerOptions
         {
@@ -1096,6 +1097,8 @@ public sealed partial class ShareConsumerRenewalTests
             AcknowledgementMode = acknowledgementMode,
             MaxPollRecords = maxPollRecords,
             FetchMaxWaitMs = fetchMaxWaitMs,
+            RetryBackoffMs = retryBackoffMs,
+            RetryBackoffMaxMs = Math.Max(retryBackoffMs, 1000),
             AcknowledgementCommitCallback = acknowledgementCommitCallback
         };
         var pool = Substitute.For<IConnectionPool>();
@@ -1489,6 +1492,7 @@ public sealed partial class ShareConsumerRenewalTests
         internal short LastApiVersion { get; private set; }
         internal ShareFetchRequest? ShareFetchRequest { get; private set; }
         internal ShareAcknowledgeRequest? ShareAcknowledgeRequest { get; private set; }
+        internal MetadataResponse? MetadataResponse { get; init; }
         internal ShareFetchResponse? ShareFetchResponse { get; init; }
         internal Queue<ShareFetchResponse>? ShareFetchResponses { get; init; }
         internal ShareAcknowledgeResponse? ShareAcknowledgeResponse { get; init; }
@@ -1556,7 +1560,7 @@ public sealed partial class ShareConsumerRenewalTests
                         Responses = [],
                         NodeEndpoints = []
                     }),
-                MetadataRequest => new MetadataResponse
+                MetadataRequest => MetadataResponse ?? new MetadataResponse
                 {
                     Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
                     Topics =

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareBatchPendingStateBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareBatchPendingStateBenchmarks.cs
@@ -10,6 +10,9 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
 /// <summary>Checks pending state across retained renewed batches without changing their lifecycle.</summary>
 [MemoryDiagnoser]
+// This scalar read is smaller than the invocation overhead. Subtraction can clamp
+// valid control samples to zero; compare the same complete invocation on both revisions.
+[EvaluateOverhead(false)]
 public class ShareBatchPendingStateBenchmarks
 {
     private ShareBatchAcknowledgements<int, int> _tracker = null!;

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerIdleAssignmentBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerIdleAssignmentBenchmarks.cs
@@ -1,0 +1,73 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Models an assignment arriving after a cohort of consumers begins waiting, plus
+/// unchanged empty heartbeat assignments. The 1 ms broker wait keeps the old timer
+/// path measurable; it is not a proposal to change the production 200 ms default.
+/// One operation covers the full cohort, including assignment processing and delivery.
+/// </summary>
+[MemoryDiagnoser]
+public class ShareConsumerIdleAssignmentBenchmarks
+{
+    private ShareConsumerPollBenchmarks[] _consumers = null!;
+    private ValueTask<bool>[] _pending = null!;
+
+    [Params(1, 64)]
+    public int ConsumerCount { get; set; }
+
+    [Params(false, true)]
+    public bool Batch { get; set; }
+
+    [GlobalSetup]
+    public async ValueTask Setup()
+    {
+        _consumers = new ShareConsumerPollBenchmarks[ConsumerCount];
+        _pending = new ValueTask<bool>[ConsumerCount];
+        for (var index = 0; index < _consumers.Length; index++)
+        {
+            var consumer = new ShareConsumerPollBenchmarks
+            {
+                RecordCount = 1, BatchCount = 1, IdleFetchMaxWaitMs = 1
+            };
+            _consumers[index] = consumer;
+            await consumer.Setup();
+            consumer.PrepareIdlePolling(Batch);
+        }
+        if (await AssignmentArrival() != ConsumerCount)
+            throw new InvalidOperationException("Assignment arrival lost a consumer delivery.");
+        foreach (var consumer in _consumers)
+            consumer.PublishEmptyAssignment();
+    }
+
+    [Benchmark]
+    public async ValueTask<int> AssignmentArrival()
+    {
+        for (var index = 0; index < _consumers.Length; index++)
+            _pending[index] = _consumers[index].BeginIdleRound();
+        foreach (var consumer in _consumers)
+            consumer.PublishIdleAssignment();
+        var delivered = 0;
+        for (var index = 0; index < _pending.Length; index++)
+        {
+            if (await _pending[index])
+                delivered++;
+        }
+        return delivered;
+    }
+
+    [Benchmark]
+    public void UnchangedEmptyHeartbeat()
+    {
+        foreach (var consumer in _consumers)
+            consumer.PublishEmptyAssignment();
+    }
+
+    [GlobalCleanup]
+    public async ValueTask Cleanup()
+    {
+        foreach (var consumer in _consumers)
+            await consumer.Cleanup();
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerMissingLeaderBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerMissingLeaderBenchmarks.cs
@@ -3,9 +3,9 @@ using BenchmarkDotNet.Attributes;
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
 /// <summary>
-/// Measures one actual poll with an initially missing leader. The broker can supply
-/// current metadata immediately; an independent timer also publishes it so the old
-/// spinning poll completes. Both revisions join that timer before the next operation.
+/// Measures one actual poll with an initially missing leader. Metadata completes
+/// synchronously or after an independent timer, which also updates the cache so the
+/// old spinning poll completes. Both revisions join that timer before the next operation.
 /// Elapsed time therefore includes the fixture delay; this primarily exposes allocation
 /// cost while routing is unavailable, not real broker latency or loaded acceptance.
 /// </summary>
@@ -20,12 +20,15 @@ public class ShareConsumerMissingLeaderBenchmarks
     [Params(1, 10)]
     public int MetadataDelayMs { get; set; }
 
+    [Params(false, true)]
+    public bool AsynchronousMetadata { get; set; }
+
     [GlobalSetup]
     public async ValueTask Setup()
     {
         _poll = new ShareConsumerPollBenchmarks { RecordCount = 1, BatchCount = 1 };
         await _poll.Setup();
-        _poll.PrepareMissingLeaderPolling(Batch);
+        _poll.PrepareMissingLeaderPolling(Batch, AsynchronousMetadata);
         if (!await _poll.PollWithMissingLeader(MetadataDelayMs))
             throw new InvalidOperationException("Leader recovery lost the pending delivery.");
     }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerMissingLeaderBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerMissingLeaderBenchmarks.cs
@@ -5,7 +5,9 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 /// <summary>
 /// Measures one actual poll with an initially missing leader. Metadata completes
 /// synchronously or after an independent timer, which also updates the cache so the
-/// old spinning poll completes. Both revisions join that timer before the next operation.
+/// old spinning poll completes. The timer starts after the first routing enumeration
+/// observes the missing leader. Both revisions pay for that one fixture observer and
+/// join the timer before the next operation.
 /// Elapsed time therefore includes the fixture delay; this primarily exposes allocation
 /// cost while routing is unavailable, not real broker latency or loaded acceptance.
 /// </summary>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerMissingLeaderBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerMissingLeaderBenchmarks.cs
@@ -1,0 +1,38 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures one actual poll with an initially missing leader. The broker can supply
+/// current metadata immediately; an independent timer also publishes it so the old
+/// spinning poll completes. Both revisions join that timer before the next operation.
+/// Elapsed time therefore includes the fixture delay; this primarily exposes allocation
+/// cost while routing is unavailable, not real broker latency or loaded acceptance.
+/// </summary>
+[MemoryDiagnoser]
+public class ShareConsumerMissingLeaderBenchmarks
+{
+    private ShareConsumerPollBenchmarks _poll = null!;
+
+    [Params(false, true)]
+    public bool Batch { get; set; }
+
+    [Params(1, 10)]
+    public int MetadataDelayMs { get; set; }
+
+    [GlobalSetup]
+    public async ValueTask Setup()
+    {
+        _poll = new ShareConsumerPollBenchmarks { RecordCount = 1, BatchCount = 1 };
+        await _poll.Setup();
+        _poll.PrepareMissingLeaderPolling(Batch);
+        if (!await _poll.PollWithMissingLeader(MetadataDelayMs))
+            throw new InvalidOperationException("Leader recovery lost the pending delivery.");
+    }
+
+    [Benchmark]
+    public ValueTask<bool> RecoverLeader() => _poll.PollWithMissingLeader(MetadataDelayMs);
+
+    [GlobalCleanup]
+    public ValueTask Cleanup() => _poll.Cleanup();
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerPollBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerPollBenchmarks.cs
@@ -325,6 +325,7 @@ public class ShareConsumerPollBenchmarks
     private Timer? _metadataRestoreTimer;
     private TaskCompletionSource<bool>? _metadataRestored;
     private bool _asynchronousMetadata;
+    private MissingLeaderAssignment? _missingLeaderAssignment;
 
     internal void PrepareMissingLeaderPolling(bool batch, bool asynchronousMetadata = false)
     {
@@ -359,6 +360,16 @@ public class ShareConsumerPollBenchmarks
                 self._metadataRestored!.TrySetException(error);
             }
         }, this, Timeout.Infinite, Timeout.Infinite);
+        // The first assignment enumeration in these warmed polls is broker routing.
+        // Arm restoration only after routing has inspected the unavailable leader.
+        // Unlike arming after MoveNextAsync returns, this also lets the old synchronous
+        // spin finish. Subsequent enumerations use the ordinary HashSet enumerator.
+        _missingLeaderAssignment = new MissingLeaderAssignment(this) { new(Topic, 0) };
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+        var consumer = batch ? _borrowed : _compatibility;
+        var coordinator = typeof(KafkaShareConsumer<int, int>).GetField("_coordinator", flags)!.GetValue(consumer)!;
+        typeof(ShareConsumerCoordinator).GetField("_assignedPartitions", flags)!
+            .SetValue(coordinator, _missingLeaderAssignment);
     }
 
     internal async ValueTask<bool> PollWithMissingLeader(int metadataDelayMs)
@@ -368,21 +379,56 @@ public class ShareConsumerPollBenchmarks
         _metadataRestored = restored;
         if (_asynchronousMetadata)
             _connection.PendingMetadata = new TaskCompletionSource<MetadataResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
-        _metadataRestoreTimer!.Change(metadataDelayMs, Timeout.Infinite);
+        _missingLeaderAssignment!.Prepare(metadataDelayMs);
         try
         {
-            return await _idleMoveNext!();
+            var delivered = await _idleMoveNext!();
+            if (!_missingLeaderAssignment.ObservedMissingLeader)
+                throw new InvalidOperationException("Polling did not inspect the missing leader.");
+            return delivered;
         }
         finally
         {
             // Join the fixture's independent metadata publication before the next
             // operation, including when the client already refreshed it itself.
-            try { await restored.Task; }
+            try
+            {
+                if (_missingLeaderAssignment.ObservedMissingLeader)
+                    await restored.Task;
+            }
             finally
             {
                 _metadataRestored = null;
                 _connection.PendingMetadata = null;
             }
+        }
+    }
+
+    private sealed class MissingLeaderAssignment(ShareConsumerPollBenchmarks poll)
+        : HashSet<TopicPartition>, IEnumerable<TopicPartition>
+    {
+        private int _delayMs;
+        internal bool ObservedMissingLeader { get; private set; }
+
+        internal void Prepare(int delayMs)
+        {
+            _delayMs = delayMs;
+            ObservedMissingLeader = false;
+        }
+
+        IEnumerator<TopicPartition> IEnumerable<TopicPartition>.GetEnumerator()
+            => ObservedMissingLeader ? base.GetEnumerator() : ObserveRouting();
+
+        private IEnumerator<TopicPartition> ObserveRouting()
+        {
+            using var partitions = base.GetEnumerator();
+            while (partitions.MoveNext())
+                yield return partitions.Current;
+
+            if (poll._metadata.Metadata.GetPartitionLeader(Topic, 0) is not null)
+                throw new InvalidOperationException("Metadata was restored before missing-leader routing completed.");
+            ObservedMissingLeader = true;
+            poll._metadataRestoreTimer!.Change(_delayMs, Timeout.Infinite);
         }
     }
     private KafkaShareConsumer<int, int> CreateConsumer(Pool pool, int maxPollRecords = 0)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerPollBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerPollBenchmarks.cs
@@ -324,9 +324,11 @@ public class ShareConsumerPollBenchmarks
     private MetadataResponse? _missingLeader;
     private Timer? _metadataRestoreTimer;
     private TaskCompletionSource<bool>? _metadataRestored;
+    private bool _asynchronousMetadata;
 
-    internal void PrepareMissingLeaderPolling(bool batch)
+    internal void PrepareMissingLeaderPolling(bool batch, bool asynchronousMetadata = false)
     {
+        _asynchronousMetadata = asynchronousMetadata;
         PrepareIdlePolling(batch);
         PublishIdleAssignment();
         _missingLeader = new MetadataResponse
@@ -348,10 +350,12 @@ public class ShareConsumerPollBenchmarks
             try
             {
                 self._metadata.Metadata.Update(self._connection.MetadataResponse);
+                self._connection.PendingMetadata?.TrySetResult(self._connection.MetadataResponse);
                 self._metadataRestored!.TrySetResult(true);
             }
             catch (Exception error)
             {
+                self._connection.PendingMetadata?.TrySetException(error);
                 self._metadataRestored!.TrySetException(error);
             }
         }, this, Timeout.Infinite, Timeout.Infinite);
@@ -362,6 +366,8 @@ public class ShareConsumerPollBenchmarks
         _metadata.Metadata.Update(_missingLeader!);
         var restored = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         _metadataRestored = restored;
+        if (_asynchronousMetadata)
+            _connection.PendingMetadata = new TaskCompletionSource<MetadataResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
         _metadataRestoreTimer!.Change(metadataDelayMs, Timeout.Infinite);
         try
         {
@@ -371,8 +377,12 @@ public class ShareConsumerPollBenchmarks
         {
             // Join the fixture's independent metadata publication before the next
             // operation, including when the client already refreshed it itself.
-            await restored.Task;
-            _metadataRestored = null;
+            try { await restored.Task; }
+            finally
+            {
+                _metadataRestored = null;
+                _connection.PendingMetadata = null;
+            }
         }
     }
     private KafkaShareConsumer<int, int> CreateConsumer(Pool pool, int maxPollRecords = 0)
@@ -403,6 +413,7 @@ public class ShareConsumerPollBenchmarks
         private ManualResetValueTaskSourceCore<ShareFetchResponse> _completion;
         private bool _pending;
         internal MetadataResponse MetadataResponse { get; set; } = null!;
+        internal TaskCompletionSource<MetadataResponse>? PendingMetadata { get; set; }
         internal bool Asynchronous { get; set; } = asynchronous;
         internal int AcknowledgeRequests { get; private set; }
         internal long ReleasedOffsets { get; private set; }
@@ -425,6 +436,8 @@ public class ShareConsumerPollBenchmarks
         public ValueTask<TResponse> SendAsync<TRequest, TResponse>(TRequest request, short version, CancellationToken token = default)
             where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse
         {
+            if (request is MetadataRequest && PendingMetadata is { } metadata)
+                return AwaitMetadataAsync<TResponse>(metadata.Task, token);
             if (request is ShareAcknowledgeRequest acknowledge)
             {
                 AcknowledgeRequests++;
@@ -465,6 +478,11 @@ public class ShareConsumerPollBenchmarks
             };
             return ValueTask.FromResult((TResponse)response);
         }
+
+        private static async ValueTask<TResponse> AwaitMetadataAsync<TResponse>(
+            Task<MetadataResponse> pending, CancellationToken token)
+            where TResponse : IKafkaResponse
+            => (TResponse)(IKafkaResponse)await pending.WaitAsync(token);
 
         internal void CompletePendingFetch()
         {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerPollBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerPollBenchmarks.cs
@@ -41,6 +41,7 @@ public class ShareConsumerPollBenchmarks
     [Params(false, true)]
     public bool AsynchronousResponse { get; set; }
 
+    internal int IdleFetchMaxWaitMs { get; set; } = 200;
     internal bool RenewalMode { get; set; }
     internal int ReplayChunkSize { get; set; }
     internal ShareAcquisitionShape AcquisitionShape { get; set; }
@@ -290,11 +291,40 @@ public class ShareConsumerPollBenchmarks
         return _connection.ReleasedOffsets;
     }
 
+    private Action<ShareGroupHeartbeatAssignment>? _publishIdleAssignment;
+    private Func<ValueTask<bool>>? _idleMoveNext;
+    private static readonly ShareGroupHeartbeatAssignment EmptyAssignment = new() { TopicPartitions = [] };
+    private static readonly ShareGroupHeartbeatAssignment AssignedPartition = new()
+    {
+        TopicPartitions = [new ShareGroupHeartbeatTopicPartitions { TopicId = TopicId, Partitions = [0] }]
+    };
+
+    internal void PrepareIdlePolling(bool batch)
+    {
+        var consumer = batch ? _borrowed : _compatibility;
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+        var coordinator = typeof(KafkaShareConsumer<int, int>).GetField("_coordinator", flags)!.GetValue(consumer)!;
+        _publishIdleAssignment = typeof(ShareConsumerCoordinator)
+            .GetMethod("ProcessShareGroupAssignment", flags)!
+            .CreateDelegate<Action<ShareGroupHeartbeatAssignment>>(coordinator);
+        _idleMoveNext = batch ? _batches.MoveNextAsync : _records.MoveNextAsync;
+        PublishEmptyAssignment();
+    }
+
+    internal ValueTask<bool> BeginIdleRound()
+    {
+        PublishEmptyAssignment();
+        return _idleMoveNext!();
+    }
+
+    internal void PublishIdleAssignment() => _publishIdleAssignment!(AssignedPartition);
+    internal void PublishEmptyAssignment() => _publishIdleAssignment!(EmptyAssignment);
     private KafkaShareConsumer<int, int> CreateConsumer(Pool pool, int maxPollRecords = 0)
     {
         var consumer = new KafkaShareConsumer<int, int>(new ShareConsumerOptions
         {
             BootstrapServers = ["localhost:9092"], GroupId = "share-poll-benchmark",
+            FetchMaxWaitMs = IdleFetchMaxWaitMs,
             MaxPollRecords = maxPollRecords == 0 ? checked(RecordCount * BatchCount) : maxPollRecords,
             AcknowledgementMode = RenewalMode ? ShareAcknowledgementMode.Explicit : ShareAcknowledgementMode.Implicit
         }, Serializers.Int32, Serializers.Int32, pool, _metadata);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerPollBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerPollBenchmarks.cs
@@ -86,7 +86,7 @@ public class ShareConsumerPollBenchmarks
         _connection = new Connection(response, AsynchronousResponse);
         var pool = new Pool(_connection);
         _metadata = new MetadataManager(pool, ["localhost:9092"]);
-        _metadata.Metadata.Update(new MetadataResponse
+        _connection.MetadataResponse = new MetadataResponse
         {
             Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
             Topics = [new TopicMetadata
@@ -98,7 +98,8 @@ public class ShareConsumerPollBenchmarks
                     ReplicaNodes = [1], IsrNodes = [1]
                 }]
             }]
-        });
+        };
+        _metadata.Metadata.Update(_connection.MetadataResponse);
         _compatibility = CreateConsumer(pool);
         _borrowed = CreateConsumer(pool, ReplayChunkSize);
         _records = _compatibility.PollAsync().GetAsyncEnumerator();
@@ -257,6 +258,7 @@ public class ShareConsumerPollBenchmarks
     [GlobalCleanup]
     public async ValueTask Cleanup()
     {
+        _metadataRestoreTimer?.Dispose();
         _connection.Asynchronous = false;
         await _records.DisposeAsync();
         await _batches.DisposeAsync();
@@ -319,6 +321,60 @@ public class ShareConsumerPollBenchmarks
 
     internal void PublishIdleAssignment() => _publishIdleAssignment!(AssignedPartition);
     internal void PublishEmptyAssignment() => _publishIdleAssignment!(EmptyAssignment);
+    private MetadataResponse? _missingLeader;
+    private Timer? _metadataRestoreTimer;
+    private TaskCompletionSource<bool>? _metadataRestored;
+
+    internal void PrepareMissingLeaderPolling(bool batch)
+    {
+        PrepareIdlePolling(batch);
+        PublishIdleAssignment();
+        _missingLeader = new MetadataResponse
+        {
+            Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
+            Topics = [new TopicMetadata
+            {
+                ErrorCode = ErrorCode.None, Name = Topic, TopicId = TopicId,
+                Partitions = [new PartitionMetadata
+                {
+                    ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = -1,
+                    ReplicaNodes = [1], IsrNodes = [1]
+                }]
+            }]
+        };
+        _metadataRestoreTimer = new Timer(static state =>
+        {
+            var self = (ShareConsumerPollBenchmarks)state!;
+            try
+            {
+                self._metadata.Metadata.Update(self._connection.MetadataResponse);
+                self._metadataRestored!.TrySetResult(true);
+            }
+            catch (Exception error)
+            {
+                self._metadataRestored!.TrySetException(error);
+            }
+        }, this, Timeout.Infinite, Timeout.Infinite);
+    }
+
+    internal async ValueTask<bool> PollWithMissingLeader(int metadataDelayMs)
+    {
+        _metadata.Metadata.Update(_missingLeader!);
+        var restored = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _metadataRestored = restored;
+        _metadataRestoreTimer!.Change(metadataDelayMs, Timeout.Infinite);
+        try
+        {
+            return await _idleMoveNext!();
+        }
+        finally
+        {
+            // Join the fixture's independent metadata publication before the next
+            // operation, including when the client already refreshed it itself.
+            await restored.Task;
+            _metadataRestored = null;
+        }
+    }
     private KafkaShareConsumer<int, int> CreateConsumer(Pool pool, int maxPollRecords = 0)
     {
         var consumer = new KafkaShareConsumer<int, int>(new ShareConsumerOptions
@@ -346,6 +402,7 @@ public class ShareConsumerPollBenchmarks
     {
         private ManualResetValueTaskSourceCore<ShareFetchResponse> _completion;
         private bool _pending;
+        internal MetadataResponse MetadataResponse { get; set; } = null!;
         internal bool Asynchronous { get; set; } = asynchronous;
         internal int AcknowledgeRequests { get; private set; }
         internal long ReleasedOffsets { get; private set; }
@@ -361,7 +418,8 @@ public class ShareConsumerPollBenchmarks
         public KafkaConnectionCapabilities Capabilities { get; } = KafkaConnectionCapabilities.Create(new ApiVersionsResponse
         {
             ErrorCode = ErrorCode.None,
-            ApiKeys = [new ApiVersion(ApiKey.ShareFetch, 1, 2), new ApiVersion(ApiKey.ShareAcknowledge, 1, 2)]
+            ApiKeys = [new ApiVersion(ApiKey.ShareFetch, 1, 2), new ApiVersion(ApiKey.ShareAcknowledge, 1, 2),
+                new ApiVersion(ApiKey.Metadata, MetadataRequest.LowestSupportedVersion, MetadataRequest.HighestSupportedVersion)]
         });
 
         public ValueTask<TResponse> SendAsync<TRequest, TResponse>(TRequest request, short version, CancellationToken token = default)
@@ -402,6 +460,7 @@ public class ShareConsumerPollBenchmarks
             {
                 ShareFetchRequest => fetch,
                 ShareAcknowledgeRequest => _acknowledge,
+                MetadataRequest => MetadataResponse,
                 _ => throw new NotSupportedException(typeof(TRequest).Name)
             };
             return ValueTask.FromResult((TResponse)response);


### PR DESCRIPTION
A share consumer whose assignment is revoked currently wakes on a `FetchMaxWaitMs` timer. Both polling APIs now wait on a cancellable assignment-change signal. When every assigned partition lacks a leader, polling refreshes metadata and uses the configured retry backoff only while leaders remain unavailable. Assignment changes, unsubscribe, close, and disposal interrupt both the metadata request and backoff; the interrupted operation is cancelled and joined before polling continues.

Refs #3247

**Do not merge yet:** hosted performance and loaded acceptance remain outstanding. The hosted-share lane uses classic polling and depends on the acquisition fixes in #3248 and #3158. Shutdown fix #3246 is included. No performance tradeoff has been accepted.

Registration precedes state checks to prevent lost wakeups. Individual cancellation does not cancel the shared assignment signal, and completed signals are removed. Unchanged assignments preserve snapshot identity; unchanged empty heartbeat assignments allocate no new `HashSet`. Initial group-join heartbeats retain broker cadence. `FetchMaxWaitMs` remains 200 ms and `FetchMinBytes` remains 1: mixed-broker diagnostics below argue against raising the default.

Costs are per poll, assignment change, or metadata-recovery attempt. There is no added per-message allocation, task, or asynchronous state machine. Ordinary polling adds lifecycle checks and a result-length check. Leader recovery allocates its cancellation source and, when asynchronous, a task race; the shared signal remains reusable after successful recovery. Cancellation joins the in-flight request/backoff and preserves caller cancellation and non-cancellation failures.

Validation:

- Product revision `71304ad9498f9d1b6d1da41384b6b42199a09e61` (followed only by the pending-state fixture adjustment): all library target frameworks build with zero warnings/errors; 560 related unit tests pass on each of net10.0 and net8.0. Sixteen new deterministic cases cover both polling APIs, delayed metadata or retry backoff, and reassignment/unsubscribe/close/disposal. All sixteen first failed against the previous product in red-test commit `76859e75d2df00045d7a84ee82a59f7b21e55a2e`.
- Both real-broker idle/revocation integration cases pass on net10.0 / Kafka 4.3.1 and net8.0 / Kafka 4.2.1 at `71304ad94`.
- 41 performance-selector tests and repository artifact policy pass. Final review covers reuse, cancellation ownership, and hot-path costs.
- Steady-state `[MemoryDiagnoser]` coverage includes eight assignment/empty-heartbeat cases and eight missing-leader cases, including asynchronous metadata. All 22 Short cases complete against baseline `bb46ba2d2fbb00f60e9b85d1ddda14964cf213fe` and candidate `412c5c342` with identical fixture source. Every candidate median is positive; unchanged empty heartbeats and all pending-state cases allocate 0 B. Missing-leader allocations fall from 40.7–123.7 MiB to approximately 9.7–13.7 KiB per recovery. Both revisions join the fixture timer, so elapsed times include Windows timer resolution. Concurrent independent Windows workloads make local timings unsuitable for acceptance.
- The previous hosted [pending-state job](https://github.com/thomhurst/Dekaf/actions/runs/34592242642/job/103240119513) failed with **invalid measurement**, not REGRESSION: three control medians were zero after invocation-overhead subtraction. Its [raw artifact](https://github.com/thomhurst/Dekaf/actions/runs/34592242642/artifacts/10260287607) is retained. Commit `412c5c342` disables overhead subtraction for this scalar-read fixture, measuring the same complete invocation on both revisions. Sampling remains steady-state; no tolerance or gate comparison rule changes.

Twenty fresh-process Linux broker observations compare `bb46ba2d2` and `77aa643fd`, with DLL hashes and informational revisions checked before each case. They use Kafka 4.3.1, .NET 10.0.11, separate client/broker CPU sets, and ten-second observation windows. These are diagnostics, not A1/B/A2 acceptance, and predate the lifecycle-recovery fix above.

- With 64 unassigned consumers, CPU falls from 310.064 to 118.492 ms, allocations from 735,664 to 148,704 B, and completed thread-pool work from 4,184 to 982 per window. Both issue zero fetches and 128 heartbeats; retained heap growth is approximately 38.8 MB on each revision.
- Empty and acquired-record workloads issue approximately five fetches per consumer per second at 200 ms; no immediate-empty spin was observed with valid leaders. Normal empty independent-consumer heap growth is 38.6/39.3 MB on Linux. The much larger gap in an earlier Windows pair was not reproduced in this experiment; its cause is not established.
- Existing shared infrastructure sharply lowers retained memory, but its default one connection per broker serializes fetches across the cohort and takes approximately thirteen seconds to close. Independent consumers default to two connections per broker. This deployment-shape comparison does not establish a universal recommendation or equal-provisioning performance win.
- Low-rate and mixed-broker cases each deliver 39 records. Mixed-broker p99 estimates rise from 150.6/154.1 ms at 200 ms waits to 487.3/692.5 ms at 1,000 ms waits (baseline/candidate). The small samples cannot establish precise tail-latency acceptance; they support preserving the current default.
- The acquired-record 200 ms sample has higher candidate CPU (198.767/261.981 ms). Its three-second warmup avoids acquisition-lock expiry, but the CPU difference remains unattributed. Earlier Windows CPU/heap gaps and one explicitly contaminated sample remain in the evidence; no Pareto PASS is claimed.

Durable local evidence is outside removable worktrees: `C:/git/Dekaf-evidence/pr-3249/recovery-wakeup-red`, `recovery-wakeup-final`, `recovery-benchmarks`, and `gate-34592242642`; the complete resource matrix, exact harness source, immutable binaries, environment and per-case manifests/logs are under `C:/git/Dekaf-evidence/issue-3247/idle-broker-harness/linux-pinned`. Source snapshots, test binaries/reports, and generated benchmark workers are retained with SHA-256 inventories. Earlier `77aa643fd` microbenchmark diagnostics and all earlier resource observations remain under `C:/git/Dekaf-evidence/issue-3247`.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Share consumer polling now responds promptly to assignment changes, unsubscribe, close, disposal, and cancellation.
  - Improved recovery when partition leaders are temporarily unavailable.
  - Polling exits correctly when the consumer is closed or disposed.
  - Avoids unnecessary waiting when assignments change or leader information is restored.

- **Performance**
  - Added benchmarks covering idle assignments, missing leaders, and unsubscribe behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Benchmark review follow-up at `1407ff936`: the missing-leader fixture now arms its restoration timer only after the warmed poll's first routing enumeration has inspected the unavailable leader. Every operation asserts that observation. This also works against the baseline's synchronous spin; simply arming the timer after `MoveNextAsync` returns would deadlock that baseline. Both revisions use the same one-time fixture observer per recovery; subsequent enumerations use the normal HashSet enumerator. No product code, performance tolerance or gate selection changed.

All eight corrected missing-leader cases pass Dry against baseline `bb46ba2d2` and candidate; all eight candidate Short cases pass. The earlier missing-leader measurements above did not assert branch entry on every operation and should not support an acceptance decision. The six pending-state cases also pass Short with `EvaluateOverhead=False`, positive measurements and zero allocated bytes. `BenchmarkDotNet.Attributes.EvaluateOverheadAttribute` is present in the installed 0.15.8 package and compiles successfully. All 41 selector tests and the artifact policy pass. These fixture-only changes need no new broker or stress run; the PR's existing loaded and performance blockers remain.

New evidence: `C:/git/Dekaf-evidence/pr-3249/benchmark-order/`. BenchmarkDotNet removed the generated workers after the first successful runs; those reports and host binaries remain, but their exact generated workers are unavailable. I repeated the same validation with `--keepFiles` to retain executable evidence, not to obtain a different verdict. Replacement runs again pass all 14 candidate Short cases and eight baseline Dry cases. Their reports are in `candidate-retained` and `baseline-retained`; full host/worker trees are in `candidate-retained-binaries` and `baseline-retained-binaries`, with SHA-256 inventories compared against the originals. Both source snapshots and identical fixture overlays are retained. No local timing gain or hosted acceptance is claimed.
