### PR TITLE
feat(share-consumer): report built-in client telemetry

### DIFF
--- a/docs/docs/consumer/share-consumers.md
+++ b/docs/docs/consumer/share-consumers.md
@@ -255,6 +255,16 @@ Common builder options beyond the connection/TLS/SASL settings shared with other
 | `WithSessionTimeoutMs` | 45000 | Coordinator removes the member without a heartbeat within this window |
 | `WithHeartbeatIntervalMs` | 3000 | Initial heartbeat interval (broker may adjust) |
 
+## Built-in client telemetry
+
+Share consumers publish the KIP-932 client metrics under `org.apache.kafka.consumer.share.` through [broker-side telemetry](../observability#broker-side-telemetry-kip-714). The broker selects metric prefixes. Recording starts when a supported broker subscribes to those metrics; application-only subscriptions leave the built-in recorder inactive.
+
+The built-in metrics cover poll intervals and idle ratio; coordinator heartbeat latency, activity and rebalances; fetch latency, throttling, request counts, serialized bytes and records; and acknowledgement sends and errors. Totals use monotonic OTLP sums with the broker's requested cumulative or delta temporality. Rates measure activity since the previous export of that rate, while averages and maxima retain their observation history. Record and byte averages divide by requests observed while record metrics were selected; fetch-only subscription periods do not dilute those averages. Age gauges report `-1` before the first observed poll or heartbeat. Metric points have no partition or group attributes; the broker associates the push with its assigned client instance identity.
+
+For streaming polling, a poll is one acquisition round. Time between rounds includes application processing; the idle ratio includes coordination, fetching and record preparation, excluding time spent in application code between yields. Record and byte totals count successfully deserialized acquired records, including the prepared portion of a partially consumed batch. A failed parsing window contributes no records or bytes; partial preparation results remain local until the partition parser succeeds. Bytes include the encoded record and its length prefix, excluding record-batch headers and unacquired offsets. Local renewal replay does not increment fetched totals. Acknowledgement totals count submitted records per request attempt, excluding gap placeholders; retry attempts and failed partitions contribute their own send/error counts.
+
+Measurements aggregate per request, partition parsing window or record batch. The recorder keeps a reusable sample per broker and creates exported metric objects only at telemetry collection. Existing classic polling allocations still apply; enabling telemetry does not make the classic API allocation-free.
+
 ## Application telemetry
 
 Share consumers can publish application counters and gauges through [broker-side telemetry](../observability#broker-side-telemetry-kip-714). Register metrics on the builder or on a running consumer:

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
@@ -5,6 +5,7 @@ using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
+using Dekaf.Telemetry;
 
 namespace Dekaf.ShareConsumer;
 
@@ -50,9 +51,17 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
         {
             if (_subscriptionSnapshot.Count == 0 || Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _disposed) != 0)
                 yield break;
-            // Ensure we're part of the share group
-            await _coordinator.EnsureActiveGroupAsync(cancellationToken)
-                .ConfigureAwait(false);
+            ShareMetrics?.PollStarted();
+            var coordinationStarted = ShareMetrics?.Timestamp(ShareConsumerTelemetryMetrics.Groups.Poll) ?? -1;
+            try
+            {
+                await _coordinator.EnsureActiveGroupAsync(cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                ShareMetrics?.PollWaitCompleted(coordinationStarted);
+            }
             if (_subscriptionSnapshot.Count == 0)
                 yield break;
             _assignmentSnapshot = _coordinator.Assignment;
@@ -61,7 +70,15 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
             acknowledgements.RemoveOutsideAssignment(assignment);
             if (assignment.Count == 0)
             {
-                await WaitForAssignmentChangeAsync(assignment, cancellationToken).ConfigureAwait(false);
+                var idleStarted = ShareMetrics?.Timestamp(ShareConsumerTelemetryMetrics.Groups.Poll) ?? -1;
+                try
+                {
+                    await WaitForAssignmentChangeAsync(assignment, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    ShareMetrics?.PollWaitCompleted(idleStarted);
+                }
                 continue;
             }
 
@@ -101,6 +118,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
                 continue;
             }
 
+            var fetchWaitStarted = ShareMetrics?.Timestamp(ShareConsumerTelemetryMetrics.Groups.Poll) ?? -1;
             var fetchTasks = StartPollFetch(assignment, cancellationToken,
                 out var pendingAcks, out var sentAcknowledgementPartitionCount);
             // Keep response frames valid while parsing producer batches. Parsed
@@ -119,18 +137,31 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
                 InvokeAcknowledgementCommitCallback(pendingAcks, ex);
                 throw;
             }
+            finally
+            {
+                ShareMetrics?.PollWaitCompleted(fetchWaitStarted);
+            }
 
             CompletePollFetch(fetchResults, pendingAcks, sentAcknowledgementPartitionCount);
             if (fetchResults.Length == 0)
             {
                 // No broker request provided long-poll back-pressure. Refresh missing
                 // leaders and use the configured retry delay only if none is available.
-                await PrepareMissingLeaderRetryAsync(assignment, cancellationToken).ConfigureAwait(false);
+                fetchWaitStarted = ShareMetrics?.Timestamp(ShareConsumerTelemetryMetrics.Groups.Poll) ?? -1;
+                try
+                {
+                    await PrepareMissingLeaderRetryAsync(assignment, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    ShareMetrics?.PollWaitCompleted(fetchWaitStarted);
+                }
                 continue;
             }
 
             foreach (var result in fetchResults)
             {
+                _activeTelemetryFetch = ShareMetrics?.GetFetchSample(result.BrokerId);
                 var response = result.Response;
                 if (response is null || response.ErrorCode != ErrorCode.None)
                     continue;
@@ -231,7 +262,13 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
         CancellationToken cancellationToken)
     {
         ShareBatchStorage<TKey, TValue>? storage = null;
-        var state = new BorrowedParserState { PreviousOffsetDelta = -1, AcquiredIndex = acquiredIndex };
+        var parsingStarted = ShareMetrics?.Timestamp(ShareConsumerTelemetryMetrics.Groups.Poll) ?? -1;
+        var telemetryFetch = _activeTelemetryFetch;
+        var state = new BorrowedParserState
+        {
+            PreviousOffsetDelta = -1, AcquiredIndex = acquiredIndex,
+            MeasureBytes = telemetryFetch is not null
+        };
         try
         {
             var data = source.GetUnparsedRecordData();
@@ -287,8 +324,13 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
                 {
                     Raw = pending.Raw, Key = pending.Key, Value = value, DeliveryCount = pending.DeliveryCount
                 };
+                if (telemetryFetch is not null)
+                    state.CompletedBytes += state.CurrentRecordBytes;
             }
-            return new ShareConsumeBatch<TKey, TValue>(storage);
+            var batch = new ShareConsumeBatch<TKey, TValue>(storage);
+            if (telemetryFetch is not null)
+                ShareMetrics!.Parsed(telemetryFetch, state.CompletedBytes, storage.Count);
+            return batch;
         }
         catch
         {
@@ -300,6 +342,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
         }
         finally
         {
+            ShareMetrics?.PollWaitCompleted(parsingStarted);
             if (state.Headers is not null)
                 ArrayPool<Header>.Shared.Return(state.Headers, clearArray: true);
         }
@@ -311,7 +354,19 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
         TopicPartition partition, RecordBatch source, ShareBatchStorage<TKey, TValue> storage,
         IReadOnlyList<ShareFetchAcquiredRecords> acquiredRecords, int capacity,
         CancellationToken cancellationToken, ref BorrowedParserState state,
+        out BorrowedRecordPreparation pending) =>
+        state.MeasureBytes
+            ? ParseBorrowedRecordsCore<RecordTelemetryEnabled>(partition, source, storage, acquiredRecords,
+                capacity, cancellationToken, ref state, out pending)
+            : ParseBorrowedRecordsCore<RecordTelemetryDisabled>(partition, source, storage, acquiredRecords,
+                capacity, cancellationToken, ref state, out pending);
+
+    private bool ParseBorrowedRecordsCore<TRecordTelemetry>(
+        TopicPartition partition, RecordBatch source, ShareBatchStorage<TKey, TValue> storage,
+        IReadOnlyList<ShareFetchAcquiredRecords> acquiredRecords, int capacity,
+        CancellationToken cancellationToken, ref BorrowedParserState state,
         out BorrowedRecordPreparation pending)
+        where TRecordTelemetry : struct
     {
         var data = source.GetUnparsedRecordData();
         while (state.ByteOffset < data.Length && storage.Count < capacity
@@ -321,7 +376,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
             ShareBatchRecordData raw;
             try
             {
+                var startOffset = state.ByteOffset;
                 raw = ReadBorrowedRecord(data, ref state.ByteOffset);
+                if (typeof(TRecordTelemetry) == typeof(RecordTelemetryEnabled))
+                    state.CurrentRecordBytes = state.ByteOffset - startOffset;
             }
             catch (Exception exception) when (RecordBatch.IsTruncatedRecordTail(
                 exception, data[state.ByteOffset..], state.ParsedCount, source.UnparsedLazyRecordCount))
@@ -391,6 +449,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
             {
                 Raw = raw, Key = key, Value = value, DeliveryCount = deliveryCount
             };
+            if (typeof(TRecordTelemetry) == typeof(RecordTelemetryEnabled))
+                state.CompletedBytes += state.CurrentRecordBytes;
         }
         pending = default;
         return false;
@@ -398,6 +458,9 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
 
     private struct BorrowedParserState
     {
+        internal bool MeasureBytes;
+        internal int CurrentRecordBytes;
+        internal long CompletedBytes;
         internal int ByteOffset;
         internal int ParsedCount;
         internal int AcquiredIndex;

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Telemetry.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Telemetry.cs
@@ -1,9 +1,15 @@
+using Dekaf.Protocol.Messages;
 using Dekaf.Telemetry;
 
 namespace Dekaf.ShareConsumer;
 
 internal sealed partial class KafkaShareConsumer<TKey, TValue>
 {
+    // Value-type specializations let the JIT remove disabled record accounting.
+    // Select once per parsing window; record loops do not read subscription state.
+    private readonly struct RecordTelemetryEnabled { }
+    private readonly struct RecordTelemetryDisabled { }
+
     /// <inheritdoc />
     public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
     {
@@ -16,5 +22,101 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
     {
         ThrowIfDisposed();
         _telemetryMetricCollector.UnregisterMetricFromSubscription(name);
+    }
+
+    // Count acknowledgement outcomes per request/partition. Gap entries are protocol
+    // placeholders, not acknowledged records. This scan runs only for subscribed metrics.
+    private void RecordAcknowledgementFailureMetrics(
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? acknowledgements)
+    {
+        var metrics = ShareMetrics;
+        if (acknowledgements is null || metrics is null
+            || !metrics.Enabled(ShareConsumerTelemetryMetrics.Groups.Acknowledgements))
+            return;
+
+        long count = 0;
+        foreach (var batches in acknowledgements.Values)
+        {
+            for (var index = 0; index < batches.Count; index++)
+            {
+                var batch = batches[index];
+                count += CountAcknowledgedRecords(batch.FirstOffset, batch.LastOffset, batch.AcknowledgeTypes);
+            }
+        }
+        metrics.AcknowledgementsFailed(count);
+    }
+
+    private void PrepareFetchTelemetry(int brokerId, ShareFetchRequest request)
+    {
+        var metrics = ShareMetrics;
+        if (metrics is null || !metrics.Enabled(ShareConsumerTelemetryMetrics.Groups.Fetch
+            | ShareConsumerTelemetryMetrics.Groups.Acknowledgements)) return;
+        if (!metrics.Enabled(ShareConsumerTelemetryMetrics.Groups.Acknowledgements))
+        {
+            metrics.StartFetch(brokerId, 0);
+            return;
+        }
+        long count = 0;
+        for (var topicIndex = 0; topicIndex < request.Topics.Count; topicIndex++)
+        {
+            var partitions = request.Topics[topicIndex].Partitions;
+            for (var partitionIndex = 0; partitionIndex < partitions.Count; partitionIndex++)
+            {
+                var batches = partitions[partitionIndex].AcknowledgementBatches;
+                if (batches is null) continue;
+                for (var index = 0; index < batches.Count; index++)
+                {
+                    var batch = batches[index];
+                    count += CountAcknowledgedRecords(batch.FirstOffset, batch.LastOffset, batch.AcknowledgeTypes);
+                }
+            }
+        }
+        metrics.StartFetch(brokerId, count);
+    }
+
+    private void PrepareAcknowledgementTelemetry(int brokerId, ShareAcknowledgeRequest request)
+    {
+        var metrics = ShareMetrics;
+        if (metrics is null || !metrics.Enabled(ShareConsumerTelemetryMetrics.Groups.Acknowledgements)) return;
+        long count = 0;
+        for (var topicIndex = 0; topicIndex < request.Topics.Count; topicIndex++)
+        {
+            var partitions = request.Topics[topicIndex].Partitions;
+            for (var partitionIndex = 0; partitionIndex < partitions.Count; partitionIndex++)
+            {
+                var batches = partitions[partitionIndex].AcknowledgementBatches;
+                for (var index = 0; index < batches.Count; index++)
+                {
+                    var batch = batches[index];
+                    count += CountAcknowledgedRecords(batch.FirstOffset, batch.LastOffset, batch.AcknowledgeTypes);
+                }
+            }
+        }
+        metrics.AcknowledgementRequestStarted(brokerId, count);
+    }
+
+    private static long CountAcknowledgedRecords(long firstOffset, long lastOffset, IReadOnlyList<byte> types)
+    {
+        if (types.Count == 1)
+            return types[0] == (byte)AcknowledgeType.Gap ? 0 : lastOffset - firstOffset + 1;
+        long count = types.Count;
+        if (types is byte[] array)
+        {
+            // The producer of these batches uses arrays. IndexOf skips contiguous
+            // non-gap regions with the runtime's span implementation.
+            ReadOnlySpan<byte> remaining = array;
+            int gap;
+            while ((gap = remaining.IndexOf((byte)AcknowledgeType.Gap)) >= 0)
+            {
+                count--;
+                remaining = remaining[(gap + 1)..];
+            }
+        }
+        else
+        {
+            for (var index = 0; index < types.Count; index++)
+                if (types[index] == (byte)AcknowledgeType.Gap) count--;
+        }
+        return count;
     }
 }

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -208,8 +208,12 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             options,
             _connectionPool,
             _metadataManager,
-            loggerFactory?.CreateLogger<ShareConsumerCoordinator>());
+            loggerFactory?.CreateLogger<ShareConsumerCoordinator>(),
+            telemetryMetrics: _telemetryMetricCollector.ShareConsumerMetrics);
     }
+
+    private ShareConsumerTelemetryMetrics? ShareMetrics => _telemetryMetricCollector.ShareConsumerMetrics;
+    private ShareConsumerTelemetryMetrics.FetchSample? _activeTelemetryFetch;
 
     public StringSet Subscription => _subscriptionSnapshot;
     public TopicPartitionSet Assignment => _assignmentSnapshot;
@@ -316,9 +320,17 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             if (_subscriptionSnapshot.Count == 0 || Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _disposed) != 0)
                 yield break;
 
-            // Ensure we're part of the share group
-            await _coordinator.EnsureActiveGroupAsync(cancellationToken)
-                .ConfigureAwait(false);
+            ShareMetrics?.PollStarted();
+            var coordinationStarted = ShareMetrics?.Timestamp(ShareConsumerTelemetryMetrics.Groups.Poll) ?? -1;
+            try
+            {
+                await _coordinator.EnsureActiveGroupAsync(cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                ShareMetrics?.PollWaitCompleted(coordinationStarted);
+            }
             if (_subscriptionSnapshot.Count == 0)
                 yield break;
             _assignmentSnapshot = _coordinator.Assignment;
@@ -327,10 +339,19 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             RemoveRenewedRecordsOutsideAssignment(assignment);
             if (assignment.Count == 0)
             {
-                await WaitForAssignmentChangeAsync(assignment, cancellationToken).ConfigureAwait(false);
+                var idleStarted = ShareMetrics?.Timestamp(ShareConsumerTelemetryMetrics.Groups.Poll) ?? -1;
+                try
+                {
+                    await WaitForAssignmentChangeAsync(assignment, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    ShareMetrics?.PollWaitCompleted(idleStarted);
+                }
                 continue;
             }
 
+            var fetchWaitStarted = ShareMetrics?.Timestamp(ShareConsumerTelemetryMetrics.Groups.Poll) ?? -1;
             var fetchTasks = StartPollFetch(assignment, cancellationToken,
                 out var pendingAcks, out var sentAcknowledgementPartitionCount);
             // Keep every response frame alive across parsing and yield boundaries.
@@ -349,13 +370,25 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 InvokeAcknowledgementCommitCallback(pendingAcks, ex);
                 throw;
             }
+            finally
+            {
+                ShareMetrics?.PollWaitCompleted(fetchWaitStarted);
+            }
 
             CompletePollFetch(fetchResults, pendingAcks, sentAcknowledgementPartitionCount);
             if (fetchResults.Length == 0)
             {
                 // No broker request provided long-poll back-pressure. Refresh missing
                 // leaders and use the configured retry delay only if none is available.
-                await PrepareMissingLeaderRetryAsync(assignment, cancellationToken).ConfigureAwait(false);
+                fetchWaitStarted = ShareMetrics?.Timestamp(ShareConsumerTelemetryMetrics.Groups.Poll) ?? -1;
+                try
+                {
+                    await PrepareMissingLeaderRetryAsync(assignment, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    ShareMetrics?.PollWaitCompleted(fetchWaitStarted);
+                }
                 continue;
             }
 
@@ -378,6 +411,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 // is per poll, not per message, and avoids buffering records when no renewal is active.
                 foreach (var fetchResult in fetchResults)
                 {
+                    _activeTelemetryFetch = ShareMetrics?.GetFetchSample(fetchResult.BrokerId);
                     var response = fetchResult.Response;
                     if (response is null || response.ErrorCode != ErrorCode.None)
                         continue;
@@ -406,71 +440,79 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                             var remainingRecordCount = _options.MaxPollRecords -
                                 (fetchedRecords?.Count ?? recordCount);
                             List<ShareConsumeResult<TKey, TValue>> parsed;
-                            if (!_hasDeserializerPreparers)
+                            var parsingStarted = ShareMetrics?.Timestamp(ShareConsumerTelemetryMetrics.Groups.Poll) ?? -1;
+                            try
                             {
-                                parsed = ParsePartitionRecords(
-                                    topicInfo,
-                                    partition,
-                                    remainingRecordCount);
-                            }
-                            else
-                            {
-                                parsed = [];
-                                var parserState = new DeserializerPreparationParserState();
-                                var hasRetainedKey = false;
-                                TKey? retainedKey = default;
-                                long? previousPreparationOffset = null;
-                                var previousPreparationComponent = default(SerializationComponent);
-                                var preparationAttempts = 0;
-                                var firstUndisclosedOwner = _polledBatchOwners.Count;
-                                try
+                                if (!_hasDeserializerPreparers)
                                 {
-                                    while (true)
+                                    parsed = ParsePartitionRecords(
+                                        topicInfo,
+                                        partition,
+                                        remainingRecordCount);
+                                }
+                                else
+                                {
+                                    parsed = [];
+                                    var parserState = new DeserializerPreparationParserState();
+                                    var hasRetainedKey = false;
+                                    TKey? retainedKey = default;
+                                    long? previousPreparationOffset = null;
+                                    var previousPreparationComponent = default(SerializationComponent);
+                                    var preparationAttempts = 0;
+                                    var firstUndisclosedOwner = _polledBatchOwners.Count;
+                                    try
                                     {
-                                        var pendingPreparation = ParsePartitionRecordsWithPreparation(
-                                            topicInfo,
-                                            partition,
-                                            remainingRecordCount,
-                                            parsed,
-                                            ref parserState,
-                                            hasRetainedKey,
-                                            retainedKey);
-                                        if (pendingPreparation is null)
-                                            break;
-
-                                        if (previousPreparationOffset == pendingPreparation.Offset &&
-                                            previousPreparationComponent == pendingPreparation.Component)
+                                        while (true)
                                         {
-                                            if (preparationAttempts >= MaxDeserializerPreparationAttempts)
+                                            var pendingPreparation = ParsePartitionRecordsWithPreparation(
+                                                topicInfo,
+                                                partition,
+                                                remainingRecordCount,
+                                                parsed,
+                                                ref parserState,
+                                                hasRetainedKey,
+                                                retainedKey);
+                                            if (pendingPreparation is null)
+                                                break;
+
+                                            if (previousPreparationOffset == pendingPreparation.Offset &&
+                                                previousPreparationComponent == pendingPreparation.Component)
                                             {
-                                                throw new InvalidOperationException(
-                                                    "Deserializer remained unprepared after PrepareAsync completed.");
+                                                if (preparationAttempts >= MaxDeserializerPreparationAttempts)
+                                                {
+                                                    throw new InvalidOperationException(
+                                                        "Deserializer remained unprepared after PrepareAsync completed.");
+                                                }
                                             }
-                                        }
-                                        else
-                                        {
-                                            previousPreparationOffset = pendingPreparation.Offset;
-                                            previousPreparationComponent = pendingPreparation.Component;
-                                            preparationAttempts = 0;
-                                        }
+                                            else
+                                            {
+                                                previousPreparationOffset = pendingPreparation.Offset;
+                                                previousPreparationComponent = pendingPreparation.Component;
+                                                preparationAttempts = 0;
+                                            }
 
-                                        preparationAttempts++;
-                                        await PrepareDeserializerAsync(pendingPreparation, cancellationToken)
-                                            .ConfigureAwait(false);
-                                        hasRetainedKey = pendingPreparation.HasRetainedKey;
-                                        retainedKey = pendingPreparation.RetainedKey;
+                                            preparationAttempts++;
+                                            await PrepareDeserializerAsync(pendingPreparation, cancellationToken)
+                                                .ConfigureAwait(false);
+                                            hasRetainedKey = pendingPreparation.HasRetainedKey;
+                                            retainedKey = pendingPreparation.RetainedKey;
+                                        }
+                                    }
+                                    catch
+                                    {
+                                        // No prepared results from this partition reached the caller.
+                                        ReleaseUndisclosedBatchOwners(firstUndisclosedOwner);
+                                        throw;
+                                    }
+                                    finally
+                                    {
+                                        parserState.DisposeCurrentBatch();
                                     }
                                 }
-                                catch
-                                {
-                                    // No prepared results from this partition reached the caller.
-                                    ReleaseUndisclosedBatchOwners(firstUndisclosedOwner);
-                                    throw;
-                                }
-                                finally
-                                {
-                                    parserState.DisposeCurrentBatch();
-                                }
+                            }
+                            finally
+                            {
+                                ShareMetrics?.PollWaitCompleted(parsingStarted);
                             }
 
                             // Preparation may have suspended while disposal or close began.
@@ -696,6 +738,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     acknowledgementFailures,
                     out var successfulAcknowledgements,
                     out var failedAcknowledgements);
+                RecordAcknowledgementFailureMetrics(failedAcknowledgements);
                 ApplySuccessfulAcknowledgements(successfulAcknowledgements, fetchResult.ReceivedTimestamp);
                 RequeueAcknowledgements(failedAcknowledgements);
                 AddAcknowledgementErrors(
@@ -1090,10 +1133,24 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     IsRenewAck = isRenewAck,
                     Topics = BuildShareFetchTopics(partitions, brokerAcks, version)
                 };
-                var response = await SendHostedRequestAsync<ShareFetchRequest, ShareFetchResponse>(
+                PrepareFetchTelemetry(brokerId, request);
+                ShareFetchResponse response;
+                try
+                {
+                    response = await SendHostedRequestAsync<ShareFetchRequest, ShareFetchResponse>(
                         connection, request, version, requestContext, cancellationToken)
                     .ConfigureAwait(false);
+                }
+                catch
+                {
+                    if (requestContext is null || requestContext.WriteStarted)
+                    {
+                        ShareMetrics?.FetchFailed(brokerId);
+                    }
+                    throw;
+                }
                 var receivedTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
+                ShareMetrics?.FetchCompleted(brokerId, response.ThrottleTimeMs, response.ErrorCode != ErrorCode.None);
 
                 if (attempt < RetryHelper.MaxRetries && response.ErrorCode.IsRetriable())
                 {
@@ -1195,6 +1252,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         List<TopicPartition> partitions,
         CancellationToken cancellationToken)
     {
+        var submitted = false;
         try
         {
             using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
@@ -1217,12 +1275,17 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 ShareAcquireMode = (sbyte)_options.ShareAcquireMode,
                 Topics = BuildShareFetchTopics(partitions, pendingAcks: null, version)
             };
+            ShareMetrics?.StartFetch(brokerId, 0, resetRecords: false);
+            submitted = true;
             var response = await connection.SendAsync<ShareFetchRequest, ShareFetchResponse>(
                 request, version, cancellationToken).ConfigureAwait(false);
+            ShareMetrics?.FetchCompleted(brokerId, response.ThrottleTimeMs);
+            submitted = false;
             response.Dispose();
         }
         catch
         {
+            if (submitted) ShareMetrics?.FetchFailed(brokerId);
             // Best-effort session close
         }
     }
@@ -1266,10 +1329,22 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     IsRenewAck = isRenewAck,
                     Topics = topics
                 };
-                var response = await SendHostedRequestAsync<ShareAcknowledgeRequest, ShareAcknowledgeResponse>(
+                PrepareAcknowledgementTelemetry(brokerId, request);
+                ShareAcknowledgeResponse response;
+                try
+                {
+                    response = await SendHostedRequestAsync<ShareAcknowledgeRequest, ShareAcknowledgeResponse>(
                         connection, request, shareAckVersion, requestContext, cancellationToken)
                     .ConfigureAwait(false);
+                }
+                catch
+                {
+                    if (requestContext is null || requestContext.WriteStarted)
+                        ShareMetrics?.AcknowledgementRequestCompleted(brokerId, failed: true);
+                    throw;
+                }
                 var receivedTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
+                ShareMetrics?.AcknowledgementRequestCompleted(brokerId, response.ErrorCode != ErrorCode.None);
 
                 if (response.ErrorCode != ErrorCode.None)
                 {
@@ -1312,6 +1387,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     acknowledgementFailures,
                     out var successfulThisAttempt,
                     out var failedThisAttempt);
+                RecordAcknowledgementFailureMetrics(failedThisAttempt);
                 RecordRenewalReceipt(successfulThisAttempt, receivedTimestamp);
                 MergeAcknowledgements(ref successfulAcknowledgements, successfulThisAttempt);
 
@@ -1490,7 +1566,9 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         var firstUndisclosedOwner = _polledBatchOwners.Count;
         try
         {
-            return ParsePartitionRecordsCore(topicInfo, partition, maxRecords);
+            return _activeTelemetryFetch is null
+                ? ParsePartitionRecordsCore<RecordTelemetryDisabled>(topicInfo, partition, maxRecords)
+                : ParsePartitionRecordsCore<RecordTelemetryEnabled>(topicInfo, partition, maxRecords);
         }
         catch
         {
@@ -1501,13 +1579,16 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         }
     }
 
-    private List<ShareConsumeResult<TKey, TValue>> ParsePartitionRecordsCore(
+    private List<ShareConsumeResult<TKey, TValue>> ParsePartitionRecordsCore<TRecordTelemetry>(
         TopicInfo topicInfo,
         ShareFetchResponsePartition partition,
         int maxRecords)
+        where TRecordTelemetry : struct
     {
         var results = new List<ShareConsumeResult<TKey, TValue>>();
 
+        var telemetryFetch = _activeTelemetryFetch;
+        long parsedBytes = 0;
         // A parser call covers one partition; reuse its owner pool across source batches.
         ShareRecordBatchOwner.Pool? ownerPool = null;
         var reader = new KafkaProtocolReader(partition.RecordBytes);
@@ -1610,6 +1691,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     if (owner is not null)
                         result.AttachBatchOwner(owner);
                     results.Add(result);
+                    if (typeof(TRecordTelemetry) == typeof(RecordTelemetryEnabled))
+                        parsedBytes += record.Length + Record.VarIntSize(record.Length);
                 }
             }
             finally
@@ -1621,6 +1704,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             }
         }
 
+        if (typeof(TRecordTelemetry) == typeof(RecordTelemetryEnabled))
+            ShareMetrics!.Parsed(telemetryFetch!, parsedBytes, results.Count);
         return results;
     }
 
@@ -1635,176 +1720,227 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         bool hasRetainedKey,
         TKey? retainedKey)
     {
-        ShareRecordBatchOwner.Pool? ownerPool = null;
-        while (results.Count < maxRecords)
+        var telemetryFetch = _activeTelemetryFetch;
+        var initialCount = results.Count;
+        try
         {
-            if (parserState.CurrentBatch is null)
+            var pending = telemetryFetch is null
+                ? ParsePartitionRecordsWithPreparationCore<RecordTelemetryDisabled>(
+                    topicInfo, partition, maxRecords, results, ref parserState, hasRetainedKey, retainedKey)
+                : ParsePartitionRecordsWithPreparationCore<RecordTelemetryEnabled>(
+                    topicInfo, partition, maxRecords, results, ref parserState, hasRetainedKey, retainedKey);
+            if (telemetryFetch is not null)
             {
-                if (parserState.NextBatchByteOffset >= partition.RecordBytes.Length)
-                    break;
-
-                var reader = new KafkaProtocolReader(
-                    partition.RecordBytes[parserState.NextBatchByteOffset..]);
-                try
+                telemetryFetch.PendingRecords += results.Count - initialCount;
+                if (pending is null)
                 {
-                    parserState.CurrentBatch = RecordBatch.ReadForShareConsumer(ref reader, _compressionCodecs,
-                        _recordBuffers ??= new ShareRecordBufferPool(_options.FetchMaxBytes));
+                    // A preparation suspension keeps the sample local. A later exception
+                    // discards the entire undisclosed partition, including earlier windows.
+                    ShareMetrics!.Parsed(telemetryFetch, telemetryFetch.PendingBytes, telemetryFetch.PendingRecords);
+                    telemetryFetch.ResetPending();
                 }
-                catch (InsufficientDataException)
-                {
-                    break; // Partial batch
-                }
-
-                parserState.NextBatchByteOffset += checked((int)reader.Consumed);
-                parserState.CurrentBatch.ConfigureHeaderRouting(_recordHeaderRoutingPlan);
-                parserState.RecordIndex = 0;
             }
+            return pending;
+        }
+        catch
+        {
+            telemetryFetch?.ResetPending();
+            throw;
+        }
+    }
 
-            var batch = parserState.CurrentBatch;
-            var records = batch.Records;
-            while (parserState.RecordIndex < records.Count && results.Count < maxRecords)
+    private PendingDeserializerPreparation? ParsePartitionRecordsWithPreparationCore<TRecordTelemetry>(
+        TopicInfo topicInfo,
+        ShareFetchResponsePartition partition,
+        int maxRecords,
+        List<ShareConsumeResult<TKey, TValue>> results,
+        ref DeserializerPreparationParserState parserState,
+        bool hasRetainedKey,
+        TKey? retainedKey)
+        where TRecordTelemetry : struct
+    {
+        var telemetryFetch = _activeTelemetryFetch;
+        long parsedBytes = 0;
+        try
+        {
+            ShareRecordBatchOwner.Pool? ownerPool = null;
+            while (results.Count < maxRecords)
             {
-                var record = records[parserState.RecordIndex];
-                var offset = batch.BaseOffset + record.OffsetDelta;
-
-                var deliveryCount = FindDeliveryCount(
-                    partition.AcquiredRecords,
-                    offset,
-                    ref parserState.AcquiredRecordIndex);
-                if (deliveryCount < 0)
+                if (parserState.CurrentBatch is null)
                 {
-                    parserState.RecordIndex++;
-                    continue;
+                    if (parserState.NextBatchByteOffset >= partition.RecordBytes.Length)
+                        break;
+
+                    var reader = new KafkaProtocolReader(
+                        partition.RecordBytes[parserState.NextBatchByteOffset..]);
+                    try
+                    {
+                        parserState.CurrentBatch = RecordBatch.ReadForShareConsumer(ref reader, _compressionCodecs,
+                            _recordBuffers ??= new ShareRecordBufferPool(_options.FetchMaxBytes));
+                    }
+                    catch (InsufficientDataException)
+                    {
+                        break; // Partial batch
+                    }
+
+                    parserState.NextBatchByteOffset += checked((int)reader.Consumed);
+                    parserState.CurrentBatch.ConfigureHeaderRouting(_recordHeaderRoutingPlan);
+                    parserState.RecordIndex = 0;
                 }
 
-                t_serializationContext.Topic = topicInfo.Name;
-                t_serializationContext.Component = SerializationComponent.Key;
-                t_serializationContext.KeyData = ReadOnlyMemory<byte>.Empty;
-                t_serializationContext.IsNull = record.IsKeyNull;
-                var headerRouting = record.CreateHeaderRoutingLookup(
-                    _recordHeaderRoutingPlan);
-                var materializedHeaders = _recordHeaderDeserializationHeaders;
-                if (materializedHeaders is not null)
-                    headerRouting.CopyTo(materializedHeaders);
-                t_serializationContext.Headers = headerRouting.KeyRequiresMaterializedHeaders
-                    ? materializedHeaders
-                    : null;
-                TKey? key = default;
-                if (!record.IsKeyNull)
+                var batch = parserState.CurrentBatch;
+                var records = batch.Records;
+                while (parserState.RecordIndex < records.Count && results.Count < maxRecords)
                 {
-                    if (hasRetainedKey)
+                    var record = records[parserState.RecordIndex];
+                    var offset = batch.BaseOffset + record.OffsetDelta;
+
+                    var deliveryCount = FindDeliveryCount(
+                        partition.AcquiredRecords,
+                        offset,
+                        ref parserState.AcquiredRecordIndex);
+                    if (deliveryCount < 0)
                     {
-                        key = retainedKey;
+                        parserState.RecordIndex++;
+                        continue;
                     }
-                    else if (_keyDeserializerPreparer is { } keyPreparer)
+
+                    t_serializationContext.Topic = topicInfo.Name;
+                    t_serializationContext.Component = SerializationComponent.Key;
+                    t_serializationContext.KeyData = ReadOnlyMemory<byte>.Empty;
+                    t_serializationContext.IsNull = record.IsKeyNull;
+                    var headerRouting = record.CreateHeaderRoutingLookup(
+                        _recordHeaderRoutingPlan);
+                    var materializedHeaders = _recordHeaderDeserializationHeaders;
+                    if (materializedHeaders is not null)
+                        headerRouting.CopyTo(materializedHeaders);
+                    t_serializationContext.Headers = headerRouting.KeyRequiresMaterializedHeaders
+                        ? materializedHeaders
+                        : null;
+                    TKey? key = default;
+                    if (!record.IsKeyNull)
                     {
-                        if (!TryDeserializePrepared(
-                                keyPreparer,
+                        if (hasRetainedKey)
+                        {
+                            key = retainedKey;
+                        }
+                        else if (_keyDeserializerPreparer is { } keyPreparer)
+                        {
+                            if (!TryDeserializePrepared(
+                                    keyPreparer,
+                                    record.Key,
+                                    t_serializationContext,
+                                    in headerRouting,
+                                    out key))
+                            {
+                                return CreatePendingPreparation(
+                                    SerializationComponent.Key,
+                                    topicInfo.Name,
+                                    offset,
+                                    record,
+                                    retainedKey: default,
+                                    hasRetainedKey: false);
+                            }
+                        }
+                        else
+                        {
+                            key = RecordHeaderDeserializer.Deserialize(
+                                _keyDeserializer,
                                 record.Key,
                                 t_serializationContext,
+                                in headerRouting);
+                        }
+                    }
+
+                    t_serializationContext.Component = SerializationComponent.Value;
+                    t_serializationContext.KeyData = SerializationContext.NormalizeKeyData(
+                        record.Key,
+                        record.IsKeyNull);
+                    t_serializationContext.IsNull = record.IsValueNull;
+                    t_serializationContext.Headers = headerRouting.ValueRequiresMaterializedHeaders
+                        ? materializedHeaders
+                        : null;
+                    TValue value;
+                    if (record.IsValueNull)
+                    {
+                        value = default!;
+                    }
+                    else if (_valueDeserializerPreparer is { } valuePreparer)
+                    {
+                        if (!TryDeserializePrepared(
+                                valuePreparer,
+                                record.Value,
+                                t_serializationContext,
                                 in headerRouting,
-                                out key))
+                                out value))
                         {
                             return CreatePendingPreparation(
-                                SerializationComponent.Key,
+                                SerializationComponent.Value,
                                 topicInfo.Name,
                                 offset,
                                 record,
-                                retainedKey: default,
-                                hasRetainedKey: false);
+                                key,
+                                hasRetainedKey: !record.IsKeyNull);
                         }
                     }
                     else
                     {
-                        key = RecordHeaderDeserializer.Deserialize(
-                            _keyDeserializer,
-                            record.Key,
+                        value = RecordHeaderDeserializer.Deserialize(
+                            _valueDeserializer,
+                            record.Value,
                             t_serializationContext,
                             in headerRouting);
                     }
-                }
 
-                t_serializationContext.Component = SerializationComponent.Value;
-                t_serializationContext.KeyData = SerializationContext.NormalizeKeyData(
-                    record.Key,
-                    record.IsKeyNull);
-                t_serializationContext.IsNull = record.IsValueNull;
-                t_serializationContext.Headers = headerRouting.ValueRequiresMaterializedHeaders
-                    ? materializedHeaders
-                    : null;
-                TValue value;
-                if (record.IsValueNull)
-                {
-                    value = default!;
-                }
-                else if (_valueDeserializerPreparer is { } valuePreparer)
-                {
-                    if (!TryDeserializePrepared(
-                            valuePreparer,
-                            record.Value,
-                            t_serializationContext,
-                            in headerRouting,
-                            out value))
+                    var headers = Array.Empty<Header>();
+                    if (record.Headers is not null && record.HeaderCount > 0)
                     {
-                        return CreatePendingPreparation(
-                            SerializationComponent.Value,
-                            topicInfo.Name,
-                            offset,
-                            record,
-                            key,
-                            hasRetainedKey: !record.IsKeyNull);
+                        headers = new Header[record.HeaderCount];
+                        Array.Copy(record.Headers, headers, record.HeaderCount);
                     }
-                }
-                else
-                {
-                    value = RecordHeaderDeserializer.Deserialize(
-                        _valueDeserializer,
-                        record.Value,
-                        t_serializationContext,
-                        in headerRouting);
+
+                    if (_rawRecords is not null)
+                    {
+                        CaptureRawRecord(new TopicPartitionOffset(topicInfo.Name, partition.PartitionIndex, offset),
+                            record.IsKeyNull ? (ReadOnlyMemory<byte>?)null : record.Key,
+                            record.IsValueNull ? (ReadOnlyMemory<byte>?)null : record.Value);
+                    }
+
+                    if (!_inputIsolatedDeserializers || headers.Length != 0)
+                        parserState.CurrentOwner ??= RetainParsedBatch(
+                            ownerPool ??= GetRecordBatchOwnerPool(new TopicPartition(topicInfo.Name, partition.PartitionIndex)), batch);
+                    var result = new ShareConsumeResult<TKey, TValue>
+                    {
+                        Topic = topicInfo.Name,
+                        Partition = partition.PartitionIndex,
+                        Offset = offset,
+                        Key = key,
+                        Value = value,
+                        Headers = headers,
+                        TimestampMs = batch.BaseTimestamp + record.TimestampDelta,
+                        DeliveryCount = deliveryCount
+                    };
+                    if (parserState.CurrentOwner is { } owner)
+                        result.AttachBatchOwner(owner);
+                    results.Add(result);
+                    if (typeof(TRecordTelemetry) == typeof(RecordTelemetryEnabled))
+                        parsedBytes += record.Length + Record.VarIntSize(record.Length);
+                    parserState.RecordIndex++;
+                    hasRetainedKey = false;
+                    retainedKey = default;
                 }
 
-                var headers = Array.Empty<Header>();
-                if (record.Headers is not null && record.HeaderCount > 0)
-                {
-                    headers = new Header[record.HeaderCount];
-                    Array.Copy(record.Headers, headers, record.HeaderCount);
-                }
-
-                if (_rawRecords is not null)
-                {
-                    CaptureRawRecord(new TopicPartitionOffset(topicInfo.Name, partition.PartitionIndex, offset),
-                        record.IsKeyNull ? (ReadOnlyMemory<byte>?)null : record.Key,
-                        record.IsValueNull ? (ReadOnlyMemory<byte>?)null : record.Value);
-                }
-
-                if (!_inputIsolatedDeserializers || headers.Length != 0)
-                    parserState.CurrentOwner ??= RetainParsedBatch(
-                        ownerPool ??= GetRecordBatchOwnerPool(new TopicPartition(topicInfo.Name, partition.PartitionIndex)), batch);
-                var result = new ShareConsumeResult<TKey, TValue>
-                {
-                    Topic = topicInfo.Name,
-                    Partition = partition.PartitionIndex,
-                    Offset = offset,
-                    Key = key,
-                    Value = value,
-                    Headers = headers,
-                    TimestampMs = batch.BaseTimestamp + record.TimestampDelta,
-                    DeliveryCount = deliveryCount
-                };
-                if (parserState.CurrentOwner is { } owner)
-                    result.AttachBatchOwner(owner);
-                results.Add(result);
-                parserState.RecordIndex++;
-                hasRetainedKey = false;
-                retainedKey = default;
+                if (parserState.RecordIndex >= records.Count)
+                    parserState.DisposeCurrentBatch();
             }
 
-            if (parserState.RecordIndex >= records.Count)
-                parserState.DisposeCurrentBatch();
+            return null;
         }
-
-        return null;
+        finally
+        {
+            if (typeof(TRecordTelemetry) == typeof(RecordTelemetryEnabled))
+                telemetryFetch!.PendingBytes += parsedBytes;
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -7,6 +7,7 @@ using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Retry;
+using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
 #if NETSTANDARD2_0
 using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
@@ -58,13 +59,17 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     internal static int GetWaitForAssignmentDelayMs(int heartbeatIntervalMs)
         => Math.Max(heartbeatIntervalMs, 1);
 
+    private readonly ShareConsumerTelemetryMetrics? _telemetryMetrics;
+
     public ShareConsumerCoordinator(
         ShareConsumerOptions options,
         IConnectionPool connectionPool,
         MetadataManager metadataManager,
         ILogger? logger = null,
-        Func<int>? getConnectionCount = null)
+        Func<int>? getConnectionCount = null,
+        ShareConsumerTelemetryMetrics? telemetryMetrics = null)
     {
+        _telemetryMetrics = telemetryMetrics;
         _options = options;
         _connectionPool = connectionPool;
         _metadataManager = metadataManager;
@@ -375,8 +380,10 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                 ApiKey.ShareGroupHeartbeat,
                 ShareGroupHeartbeatRequest.LowestSupportedVersion,
                 ShareGroupHeartbeatRequest.HighestSupportedVersion);
+            var heartbeatStarted = _telemetryMetrics?.HeartbeatStarted() ?? -1;
             response = await connection.SendAsync<ShareGroupHeartbeatRequest, ShareGroupHeartbeatResponse>(
                 request, version, cancellationToken).ConfigureAwait(false);
+            _telemetryMetrics?.HeartbeatCompleted(heartbeatStarted);
         }
         catch (Exception ex) when (
             ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
@@ -501,7 +508,15 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
         var oldAssignment = _assignedPartitions;
 
         if (newAssignment.Count == oldAssignment.Count && newAssignment.SetEquals(oldAssignment))
+        {
+            // A rejoin can complete with the existing assignment. Repeated assignment
+            // payloads while stable are not new rebalances and do not notify waiters.
+            if (_state == CoordinatorState.Joining && newAssignment.Count > 0)
+                _telemetryMetrics?.Rebalanced();
             return;
+        }
+
+        _telemetryMetrics?.Rebalanced();
 
         LogAssignmentUpdate(newAssignment.Count);
         _assignedPartitions = newAssignment;
@@ -722,8 +737,10 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                 ShareGroupHeartbeatRequest.LowestSupportedVersion,
                 ShareGroupHeartbeatRequest.HighestSupportedVersion);
 
+            var heartbeatStarted = _telemetryMetrics?.HeartbeatStarted() ?? -1;
             var response = await connection.SendAsync<ShareGroupHeartbeatRequest, ShareGroupHeartbeatResponse>(
                 request, version, cancellationToken).ConfigureAwait(false);
+            _telemetryMetrics?.HeartbeatCompleted(heartbeatStarted);
 
             if (response.ErrorCode != ErrorCode.None)
             {

--- a/src/Dekaf/Telemetry/ClientTelemetryManager.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryManager.cs
@@ -115,6 +115,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
                 return;
             }
 
+            _metricCollector?.ShareConsumerMetrics?.Subscribe(subscription.RequestedMetrics);
             Volatile.Write(ref _subscription, subscription);
             var loopCts = new CancellationTokenSource();
             _loopCts = loopCts;
@@ -192,6 +193,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
                 }
             }
 
+            _metricCollector?.ShareConsumerMetrics?.Disable();
             _loopCts?.Dispose();
             _loopCts = null;
             _loopTask = null;
@@ -248,6 +250,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
 
                     if (refreshed is not null)
                     {
+                        _metricCollector?.ShareConsumerMetrics?.Subscribe(refreshed.RequestedMetrics);
                         Volatile.Write(ref _subscription, refreshed);
                     }
                 }
@@ -529,6 +532,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
 
     private void Disable()
     {
+        _metricCollector?.ShareConsumerMetrics?.Disable();
         if (Interlocked.Exchange(ref _disabled, 1) == 0)
         {
             _loopCts?.Cancel();

--- a/src/Dekaf/Telemetry/ClientTelemetryMetricCollector.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryMetricCollector.cs
@@ -70,8 +70,12 @@ internal sealed class ClientTelemetryMetricCollector
     private long _connectionCreationTotal;
     private long _connectionCreationDelta;
 
+    internal ShareConsumerTelemetryMetrics? ShareConsumerMetrics { get; }
+
     public ClientTelemetryMetricCollector(ClientTelemetryClientRole role)
     {
+        ShareConsumerMetrics = role == ClientTelemetryClientRole.ShareConsumer
+            ? new ShareConsumerTelemetryMetrics() : null;
         (_connectionCreationTotalName,
             _nodeRequestLatencyAvgName,
             _nodeRequestLatencyMaxName,
@@ -267,6 +271,7 @@ internal sealed class ClientTelemetryMetricCollector
             }
         }
 
+        ShareConsumerMetrics?.Collect(subscription, metrics);
         AddApplicationMetrics(subscription, requestedMetrics, metrics);
 
         return metrics.Count == 0

--- a/src/Dekaf/Telemetry/ShareConsumerTelemetryMetrics.cs
+++ b/src/Dekaf/Telemetry/ShareConsumerTelemetryMetrics.cs
@@ -1,0 +1,409 @@
+using System.Diagnostics;
+using System.Collections.Concurrent;
+
+namespace Dekaf.Telemetry;
+
+/// <summary>Request/window aggregates for the KIP-932 standard client metrics.</summary>
+internal sealed class ShareConsumerTelemetryMetrics
+{
+    private const string Prefix = "org.apache.kafka.consumer.share.";
+    private const string FetchPrefix = Prefix + "fetch.manager.";
+    private const string CoordinatorPrefix = Prefix + "coordinator.";
+    private static readonly string[] Names =
+    [
+        Prefix + "last.poll.seconds.ago", Prefix + "time.between.poll.avg",
+        Prefix + "time.between.poll.max", Prefix + "poll.idle.ratio.avg",
+        CoordinatorPrefix + "heartbeat.response.time.max", CoordinatorPrefix + "heartbeat.rate",
+        CoordinatorPrefix + "heartbeat.total", CoordinatorPrefix + "last.heartbeat.seconds.ago",
+        CoordinatorPrefix + "rebalance.total", CoordinatorPrefix + "rebalance.rate.per.hour",
+        FetchPrefix + "fetch.size.avg", FetchPrefix + "fetch.size.max",
+        FetchPrefix + "bytes.consumed.rate", FetchPrefix + "bytes.consumed.total",
+        FetchPrefix + "records.per.request.avg", FetchPrefix + "records.per.request.max",
+        FetchPrefix + "records.consumed.rate", FetchPrefix + "records.consumed.total",
+        FetchPrefix + "acknowledgements.send.rate", FetchPrefix + "acknowledgements.send.total",
+        FetchPrefix + "acknowledgements.error.rate", FetchPrefix + "acknowledgements.error.total",
+        FetchPrefix + "fetch.latency.avg", FetchPrefix + "fetch.latency.max",
+        FetchPrefix + "fetch.rate", FetchPrefix + "fetch.total",
+        FetchPrefix + "fetch.throttle.time.avg", FetchPrefix + "fetch.throttle.time.max"
+    ];
+    // Declaration order matches Names and the per-metric collection cursors.
+    private enum Metric
+    {
+        LastPollSecondsAgo,
+        TimeBetweenPollAverage,
+        TimeBetweenPollMax,
+        PollIdleRatioAverage,
+        HeartbeatResponseTimeMax,
+        HeartbeatRate,
+        HeartbeatTotal,
+        LastHeartbeatSecondsAgo,
+        RebalanceTotal,
+        RebalanceRatePerHour,
+        FetchSizeAverage,
+        FetchSizeMax,
+        BytesConsumedRate,
+        BytesConsumedTotal,
+        RecordsPerRequestAverage,
+        RecordsPerRequestMax,
+        RecordsConsumedRate,
+        RecordsConsumedTotal,
+        AcknowledgementsSendRate,
+        AcknowledgementsSendTotal,
+        AcknowledgementsErrorRate,
+        AcknowledgementsErrorTotal,
+        FetchLatencyAverage,
+        FetchLatencyMax,
+        FetchRate,
+        FetchTotal,
+        FetchThrottleTimeAverage,
+        FetchThrottleTimeMax,
+    }
+
+    private readonly Func<long> _clock;
+    private readonly long _frequency;
+    private readonly ConcurrentDictionary<int, FetchSample> _fetchSamples = new();
+    private readonly Measurement _pollInterval = new();
+    private readonly Measurement _pollIdleRatio = new();
+    private readonly Measurement _heartbeatLatency = new();
+    private readonly Measurement _fetchLatency = new();
+    private readonly Measurement _fetchThrottle = new();
+    private readonly bool[] _requestedRates = new bool[Names.Length];
+    private readonly long[] _previousValues = new long[Names.Length];
+    private readonly long[] _previousTimes = new long[Names.Length];
+    private long _heartbeats, _rebalances, _fetches, _bytes, _records, _sentAcks, _failedAcks;
+    private long _maxFetchBytes, _maxFetchRecords;
+    private long _recordFetches;
+    private long _lastPoll = -1, _lastHeartbeat = -1;
+    private long _pollIdleTicks;
+    private int _enabled;
+    private int _recordEpoch;
+    private int _fetchEpoch;
+    private int _acknowledgementEpoch;
+
+    [Flags]
+    internal enum Groups { None = 0, Poll = 1, Heartbeat = 2, Rebalance = 4, Fetch = 8, Records = 16, Acknowledgements = 32 }
+
+    internal ShareConsumerTelemetryMetrics(Func<long>? timestampClock = null, long timestampFrequency = 0)
+    {
+        _clock = timestampClock ?? Stopwatch.GetTimestamp;
+        _frequency = timestampFrequency > 0 ? timestampFrequency : Stopwatch.Frequency;
+        var created = _clock();
+        for (var index = 0; index < _previousTimes.Length; index++)
+            _previousTimes[index] = created;
+    }
+
+    internal bool Enabled(Groups group) => ((Groups)Volatile.Read(ref _enabled) & group) != 0;
+    internal long Timestamp(Groups group) => Enabled(group) ? _clock() : -1;
+
+    internal void Subscribe(IReadOnlyList<string> prefixes)
+    {
+        var groups = Groups.None;
+        var now = _clock();
+        for (var index = 0; index < Names.Length; index++)
+        {
+            var requested = Requested(Names[index], prefixes);
+            var metric = (Metric)index;
+            if (IsRate(metric))
+            {
+                if (requested && !_requestedRates[index])
+                {
+                    _previousTimes[index] = now;
+                    _previousValues[index] = GetTotal(metric);
+                }
+                _requestedRates[index] = requested;
+            }
+            if (!requested) continue;
+            groups |= index switch
+            {
+                < 4 => Groups.Poll,
+                < 8 => Groups.Heartbeat,
+                < 10 => Groups.Rebalance,
+                < 18 => Groups.Records | Groups.Fetch,
+                < 22 => Groups.Acknowledgements,
+                _ => Groups.Fetch
+            };
+        }
+        if (Enabled(Groups.Fetch) != ((groups & Groups.Fetch) != 0))
+            Interlocked.Increment(ref _fetchEpoch);
+        if (Enabled(Groups.Acknowledgements) != ((groups & Groups.Acknowledgements) != 0))
+            Interlocked.Increment(ref _acknowledgementEpoch);
+        if (Enabled(Groups.Records) != ((groups & Groups.Records) != 0))
+            Interlocked.Increment(ref _recordEpoch);
+        if (Enabled(Groups.Poll) != ((groups & Groups.Poll) != 0))
+        {
+            Volatile.Write(ref _lastPoll, -1);
+            Interlocked.Exchange(ref _pollIdleTicks, 0);
+        }
+        Volatile.Write(ref _enabled, (int)groups);
+    }
+
+    internal void Disable() => Volatile.Write(ref _enabled, 0);
+
+    internal void PollStarted()
+    {
+        if (!Enabled(Groups.Poll)) return;
+        var now = _clock();
+        var previous = Interlocked.Exchange(ref _lastPoll, now);
+        var idle = Interlocked.Exchange(ref _pollIdleTicks, 0);
+        if (previous < 0) return;
+        var elapsed = Math.Max(0, now - previous);
+        _pollInterval.Record(elapsed);
+        if (elapsed > 0)
+            _pollIdleRatio.Record((long)(Math.Min(1d, idle / (double)elapsed) * 1_000_000));
+    }
+
+    internal void PollWaitCompleted(long started)
+    {
+        if (started >= 0 && Enabled(Groups.Poll))
+            Interlocked.Add(ref _pollIdleTicks, Math.Max(0, _clock() - started));
+    }
+
+    internal long HeartbeatStarted()
+    {
+        if (!Enabled(Groups.Heartbeat)) return -1;
+        var now = _clock();
+        Volatile.Write(ref _lastHeartbeat, now);
+        Interlocked.Increment(ref _heartbeats);
+        return now;
+    }
+
+    internal void HeartbeatCompleted(long started)
+    {
+        if (started >= 0 && Enabled(Groups.Heartbeat))
+            _heartbeatLatency.Record(Math.Max(0, _clock() - started));
+    }
+
+    internal void Rebalanced()
+    {
+        if (Enabled(Groups.Rebalance)) Interlocked.Increment(ref _rebalances);
+    }
+
+    internal void FetchStarted(int brokerId) => StartFetch(brokerId, 0);
+
+    internal void StartFetch(int brokerId, long acknowledgements, bool resetRecords = true)
+    {
+        if (!Enabled(Groups.Fetch | Groups.Acknowledgements)) return;
+        var sample = _fetchSamples.GetOrAdd(brokerId, static _ => new FetchSample());
+        if (resetRecords)
+        {
+            sample.Reset();
+            sample.RecordEpoch = Enabled(Groups.Records) ? Volatile.Read(ref _recordEpoch) : -1;
+        }
+        sample.FetchEpoch = Volatile.Read(ref _fetchEpoch);
+        sample.FetchAcknowledgementEpoch = Volatile.Read(ref _acknowledgementEpoch);
+        sample.Started = Enabled(Groups.Fetch) ? _clock() : -1;
+        sample.FetchAcknowledgements = acknowledgements;
+    }
+
+    internal void FetchFailed(int brokerId)
+    {
+        if (!Enabled(Groups.Fetch | Groups.Acknowledgements)) return;
+        if (!_fetchSamples.TryGetValue(brokerId, out var sample)) return;
+        if (sample.Started >= 0 && Enabled(Groups.Fetch) && sample.FetchEpoch == Volatile.Read(ref _fetchEpoch))
+            RecordFetch(sample);
+        if (sample.FetchAcknowledgementEpoch == Volatile.Read(ref _acknowledgementEpoch))
+        {
+            AcknowledgementsSent(sample.FetchAcknowledgements);
+            AcknowledgementsFailed(sample.FetchAcknowledgements);
+        }
+    }
+
+    internal void FetchCompleted(int brokerId, int throttleMs, bool acknowledgementsFailed = false)
+    {
+        if (!Enabled(Groups.Fetch | Groups.Acknowledgements)) return;
+        if (!_fetchSamples.TryGetValue(brokerId, out var sample)) return;
+        if (sample.Started >= 0 && Enabled(Groups.Fetch) && sample.FetchEpoch == Volatile.Read(ref _fetchEpoch))
+        {
+            RecordFetch(sample);
+            _fetchLatency.Record(Math.Max(0, _clock() - sample.Started));
+            if (throttleMs >= 0) _fetchThrottle.Record(throttleMs);
+        }
+        if (sample.FetchAcknowledgementEpoch == Volatile.Read(ref _acknowledgementEpoch))
+        {
+            AcknowledgementsSent(sample.FetchAcknowledgements);
+            if (acknowledgementsFailed) AcknowledgementsFailed(sample.FetchAcknowledgements);
+        }
+    }
+
+    private void RecordFetch(FetchSample sample)
+    {
+        Interlocked.Increment(ref _fetches);
+        // Record totals only include requests observed under the record subscription.
+        // Fetch-only intervals must not dilute their lifetime per-request averages.
+        if (Enabled(Groups.Records) && sample.RecordEpoch == Volatile.Read(ref _recordEpoch))
+            Interlocked.Increment(ref _recordFetches);
+    }
+
+    internal void AcknowledgementRequestStarted(int brokerId, long count)
+    {
+        if (!Enabled(Groups.Acknowledgements)) return;
+        var sample = _fetchSamples.GetOrAdd(brokerId, static _ => new FetchSample());
+        sample.StandaloneAcknowledgementEpoch = Volatile.Read(ref _acknowledgementEpoch);
+        sample.StandaloneAcknowledgements = count;
+    }
+
+    internal void AcknowledgementRequestCompleted(int brokerId, bool failed)
+    {
+        if (!Enabled(Groups.Acknowledgements) || !_fetchSamples.TryGetValue(brokerId, out var sample)
+            || sample.StandaloneAcknowledgementEpoch != Volatile.Read(ref _acknowledgementEpoch)) return;
+        AcknowledgementsSent(sample.StandaloneAcknowledgements);
+        if (failed) AcknowledgementsFailed(sample.StandaloneAcknowledgements);
+    }
+
+    internal FetchSample? GetFetchSample(int brokerId) =>
+        Enabled(Groups.Records) && _fetchSamples.TryGetValue(brokerId, out var sample)
+        && sample.RecordEpoch == Volatile.Read(ref _recordEpoch) ? sample : null;
+
+    internal void Parsed(FetchSample sample, long bytes, int records)
+    {
+        if (!Enabled(Groups.Records) || sample.RecordEpoch != Volatile.Read(ref _recordEpoch)) return;
+        sample.Bytes += bytes;
+        sample.Records += records;
+        Interlocked.Add(ref _bytes, bytes);
+        Interlocked.Add(ref _records, records);
+        AtomicMax(ref _maxFetchBytes, sample.Bytes);
+        AtomicMax(ref _maxFetchRecords, sample.Records);
+    }
+
+    internal void AcknowledgementsSent(long count)
+    {
+        if (Enabled(Groups.Acknowledgements)) Interlocked.Add(ref _sentAcks, count);
+    }
+
+    internal void AcknowledgementsFailed(long count)
+    {
+        if (Enabled(Groups.Acknowledgements)) Interlocked.Add(ref _failedAcks, count);
+    }
+
+    internal void Collect(ClientTelemetrySubscription subscription, List<ClientTelemetryMetric> metrics)
+    {
+        var now = _clock();
+        var poll = _pollInterval.Read();
+        var idle = _pollIdleRatio.Read();
+        var heartbeat = _heartbeatLatency.Read();
+        var fetch = _fetchLatency.Read();
+        var throttle = _fetchThrottle.Read();
+        var recordFetches = Volatile.Read(ref _recordFetches);
+        for (var index = 0; index < Names.Length; index++)
+        {
+            if (!Requested(Names[index], subscription.RequestedMetrics)) continue;
+            var metric = (Metric)index;
+            var kind = IsCounter(metric) ? ClientTelemetryMetricKind.Counter : ClientTelemetryMetricKind.Gauge;
+            var total = GetTotal(metric);
+            double value = metric switch
+            {
+                Metric.LastPollSecondsAgo => SecondsSince(Volatile.Read(ref _lastPoll), now),
+                Metric.TimeBetweenPollAverage => Milliseconds(poll.Average),
+                Metric.TimeBetweenPollMax => Milliseconds(poll.Max),
+                Metric.PollIdleRatioAverage => idle.Average / 1_000_000d,
+                Metric.HeartbeatResponseTimeMax => Milliseconds(heartbeat.Max),
+                Metric.LastHeartbeatSecondsAgo => SecondsSince(Volatile.Read(ref _lastHeartbeat), now),
+                Metric.FetchSizeAverage => recordFetches == 0 ? 0 : Volatile.Read(ref _bytes) / (double)recordFetches,
+                Metric.FetchSizeMax => Volatile.Read(ref _maxFetchBytes),
+                Metric.RecordsPerRequestAverage => recordFetches == 0 ? 0 : Volatile.Read(ref _records) / (double)recordFetches,
+                Metric.RecordsPerRequestMax => Volatile.Read(ref _maxFetchRecords),
+                Metric.FetchLatencyAverage => Milliseconds(fetch.Average),
+                Metric.FetchLatencyMax => Milliseconds(fetch.Max),
+                Metric.FetchThrottleTimeAverage => throttle.Average,
+                Metric.FetchThrottleTimeMax => throttle.Max,
+                _ => total
+            };
+            if (IsRate(metric))
+            {
+                var elapsed = (now - _previousTimes[index]) / (double)_frequency;
+                value = elapsed > 0 ? Math.Max(0, total - _previousValues[index]) / elapsed : 0;
+                if (metric == Metric.RebalanceRatePerHour) value *= 3600;
+                _previousTimes[index] = now;
+                _previousValues[index] = total;
+            }
+            else if (kind == ClientTelemetryMetricKind.Counter && subscription.DeltaTemporality)
+            {
+                value = Math.Max(0, total - _previousValues[index]);
+                _previousValues[index] = total;
+            }
+            metrics.Add(new ClientTelemetryMetric(Names[index], kind, value, []));
+        }
+    }
+
+    private long GetTotal(Metric metric) => metric switch
+    {
+        Metric.HeartbeatRate or Metric.HeartbeatTotal => Volatile.Read(ref _heartbeats),
+        Metric.RebalanceTotal or Metric.RebalanceRatePerHour => Volatile.Read(ref _rebalances),
+        Metric.BytesConsumedRate or Metric.BytesConsumedTotal => Volatile.Read(ref _bytes),
+        Metric.RecordsConsumedRate or Metric.RecordsConsumedTotal => Volatile.Read(ref _records),
+        Metric.AcknowledgementsSendRate or Metric.AcknowledgementsSendTotal => Volatile.Read(ref _sentAcks),
+        Metric.AcknowledgementsErrorRate or Metric.AcknowledgementsErrorTotal => Volatile.Read(ref _failedAcks),
+        Metric.FetchRate or Metric.FetchTotal => Volatile.Read(ref _fetches),
+        _ => 0
+    };
+
+    private static bool IsCounter(Metric metric) => metric is
+        Metric.HeartbeatTotal or Metric.RebalanceTotal or Metric.BytesConsumedTotal or Metric.RecordsConsumedTotal
+        or Metric.AcknowledgementsSendTotal or Metric.AcknowledgementsErrorTotal or Metric.FetchTotal;
+
+    private static bool IsRate(Metric metric) => metric is
+        Metric.HeartbeatRate or Metric.RebalanceRatePerHour or Metric.BytesConsumedRate or Metric.RecordsConsumedRate
+        or Metric.AcknowledgementsSendRate or Metric.AcknowledgementsErrorRate or Metric.FetchRate;
+
+    private double Milliseconds(double ticks) => ticks * 1000d / _frequency;
+    private double SecondsSince(long previous, long now) => previous < 0 ? -1 : Math.Max(0, now - previous) / (double)_frequency;
+    private static bool Requested(string name, IReadOnlyList<string> prefixes)
+    {
+        for (var index = 0; index < prefixes.Count; index++)
+            if (name.StartsWith(prefixes[index], StringComparison.Ordinal)) return true;
+        return false;
+    }
+
+    private static void AtomicMax(ref long target, long value)
+    {
+        var current = Volatile.Read(ref target);
+        while (value > current)
+        {
+            var previous = Interlocked.CompareExchange(ref target, value, current);
+            if (previous == current) return;
+            current = previous;
+        }
+    }
+
+    // Polling and acknowledgement submission are serialized per broker by the
+    // share consumer. Reuse their request state without growing async state machines.
+    internal sealed class FetchSample
+    {
+        internal int RecordEpoch = -1;
+        internal int FetchEpoch = -1;
+        internal int FetchAcknowledgementEpoch = -1;
+        internal int StandaloneAcknowledgementEpoch = -1;
+        internal long Started = -1;
+        internal long FetchAcknowledgements;
+        internal long StandaloneAcknowledgements;
+        internal long Bytes;
+        internal long Records;
+        // One prepared partition is active per broker sample. Retain partial accounting
+        // here across preparation awaits without enlarging each poll's async state.
+        internal long PendingBytes;
+        internal int PendingRecords;
+        internal void Reset()
+        {
+            Bytes = 0;
+            Records = 0;
+            ResetPending();
+        }
+        internal void ResetPending() { PendingBytes = 0; PendingRecords = 0; }
+    }
+
+    private sealed class Measurement
+    {
+        private long _count, _total, _max;
+        internal void Record(long value)
+        {
+            Interlocked.Add(ref _total, value);
+            AtomicMax(ref _max, value);
+            Interlocked.Increment(ref _count);
+        }
+        internal (double Average, long Max) Read()
+        {
+            var count = Volatile.Read(ref _count);
+            return (count == 0 ? 0 : Volatile.Read(ref _total) / (double)count, Volatile.Read(ref _max));
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ClientTelemetryReceiverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ClientTelemetryReceiverIntegrationTests.cs
@@ -156,6 +156,83 @@ public sealed class ClientTelemetryReceiverIntegrationTests(TelemetryReceiverKaf
         }
     }
 
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    [Timeout(90_000)]
+    public async Task ShareConsumer_BrokerReceivesBuiltInsDuringFetchAndAcknowledgement(
+        bool batchApi, CancellationToken cancellationToken)
+    {
+        const string applicationName = "com.example.telemetry.share.processing";
+        const string recordsName = "org.apache.kafka.consumer.share.fetch.manager.records.consumed.total";
+        const string acknowledgementsName = "org.apache.kafka.consumer.share.fetch.manager.acknowledgements.send.total";
+        var clientId = $"share-builtins-{Guid.NewGuid():N}";
+        var group = $"share-builtins-group-{Guid.NewGuid():N}";
+        var topic = await kafka.CreateTestTopicAsync(partitions: 1);
+        await using var admin = kafka.CreateAdminClient();
+        await admin.IncrementalAlterConfigsAsync(new Dictionary<ConfigResource, IReadOnlyList<ConfigAlter>>
+        {
+            [new ConfigResource { Type = ConfigResourceType.ClientMetrics, Name = clientId }] =
+            [
+                ConfigAlter.Set("metrics", $"{applicationName},{recordsName},{acknowledgementsName}"),
+                ConfigAlter.Set("interval.ms", "1000"),
+                ConfigAlter.Set("match", $"client_id={clientId}")
+            ],
+            [new ConfigResource { Type = ConfigResourceType.Group, Name = group }] =
+                [ConfigAlter.Set("share.auto.offset.reset", "earliest")]
+        }, cancellationToken: cancellationToken);
+        await kafka.WaitForSubscriptionAsync(clientId,
+            [applicationName, recordsName, acknowledgementsName], 1000, cancellationToken);
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers).BuildAsync(cancellationToken);
+        await ShareConsumerTestHelper.ProduceAsync(producer, topic, count: 2);
+        await using var consumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers).WithClientId(clientId).WithGroupId(group)
+            .WithAcknowledgementMode(ShareAcknowledgementMode.Explicit)
+            .RegisterMetricForSubscription(new ApplicationTelemetryMetric(applicationName,
+                ApplicationTelemetryMetricKind.Gauge, () => 42))
+            .BuildAsync(cancellationToken);
+        consumer.Subscribe(topic);
+        var values = new HashSet<string?>();
+        if (batchApi)
+        {
+            await foreach (var batch in consumer.PollBatchesAsync(cancellationToken))
+            {
+                foreach (var record in batch)
+                {
+                    values.Add(record.Value);
+                    batch.Acknowledge(record);
+                }
+                await consumer.CommitAsync(cancellationToken);
+                if (values.Count == 2) break;
+            }
+        }
+        else
+        {
+            await foreach (var record in consumer.PollAsync(cancellationToken))
+            {
+                values.Add(record.Value);
+                consumer.Acknowledge(record);
+                if (values.Count == 2) break;
+            }
+            await consumer.CommitAsync(cancellationToken);
+        }
+        string?[] expected = ["value-0", "value-1"];
+        await Assert.That(values).IsEquivalentTo(expected);
+        var identity = ((IKafkaClientInstanceIdentity)consumer).ClientInstanceId;
+        foreach (var name in new[] { recordsName, acknowledgementsName })
+        {
+            var received = await kafka.WaitForPayloadAsync(clientId, payload =>
+                !payload.IsTerminating && Decode(payload).Any(metric => metric.Name == name
+                    && metric.Sum.DataPoints.Single().AsDouble > 0), cancellationToken);
+            await Assert.That(received.ClientInstanceId).IsEqualTo(identity!.Value);
+            var decoded = Decode(received);
+            await Assert.That(decoded.Single(metric => metric.Name == applicationName)
+                .Gauge.DataPoints.Single().AsDouble).IsEqualTo(42d);
+            await Assert.That(decoded.Single(metric => metric.Name == name).Sum.IsMonotonic).IsTrue();
+        }
+    }
+
     private static Metric[] Decode(ReceivedTelemetry payload) => MetricsData.Parser.ParseFrom(payload.Data)
         .ResourceMetrics.SelectMany(resource => resource.ScopeMetrics)
         .SelectMany(scope => scope.Metrics).ToArray();

--- a/tests/Dekaf.Tests.Integration/ExactlyOnceCrashAtomicityTests.cs
+++ b/tests/Dekaf.Tests.Integration/ExactlyOnceCrashAtomicityTests.cs
@@ -1,3 +1,4 @@
+using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.Protocol.Messages;
@@ -22,6 +23,19 @@ public sealed class ExactlyOnceCrashAtomicityTests(KafkaTestContainer kafka) : T
     {
         var inputTopic = await KafkaContainer.CreateTestTopicAsync();
         var outputTopic = await KafkaContainer.CreateTestTopicAsync();
+        // The shared broker deletes logs after 30 seconds. Crash/recovery and
+        // coordinator startup can exceed that, so preserve both sides of the
+        // atomicity assertion for longer than this test's maximum lifetime.
+        await using (var admin = KafkaContainer.CreateAdminClient())
+        {
+            await admin.IncrementalAlterConfigsAsync(
+                new Dictionary<ConfigResource, IReadOnlyList<ConfigAlter>>
+                {
+                    [ConfigResource.Topic(inputTopic)] = [ConfigAlter.Set("retention.ms", "600000")],
+                    [ConfigResource.Topic(outputTopic)] = [ConfigAlter.Set("retention.ms", "600000")]
+                },
+                cancellationToken: cancellationToken);
+        }
         var runId = Guid.NewGuid().ToString("N");
         var consumerGroupId = $"eos-crash-group-{runId}";
         var transactionId = $"eos-crash-txn-{runId}";
@@ -171,6 +185,14 @@ public sealed class ExactlyOnceCrashAtomicityTests(KafkaTestContainer kafka) : T
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync(cancellationToken);
 
+        var watermarks = await consumer.QueryWatermarkOffsetsAsync(
+            new TopicPartition(outputTopic, 0), cancellationToken: cancellationToken);
+        if (watermarks.Low != 0)
+        {
+            throw new InvalidOperationException(
+                $"EOS output was truncated before validation: topic={outputTopic}, " +
+                $"log start={watermarks.Low}, log end={watermarks.High}.");
+        }
         consumer.Subscribe(outputTopic);
         var messages = new List<ConsumeResult<string, string>>();
 

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.Shutdown.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.Shutdown.cs
@@ -119,6 +119,7 @@ public sealed partial class ShareConsumerRenewalTests
         await using var fixture = CreateFixture(connection, leaseHandler: waitForLease
             ? async token => { await WaitBeforeWrite(token); return connection; }
             : null);
+        var metrics = EnableShareTelemetry(fixture.Consumer);
         ((IHostedShareConsumer)fixture.Consumer).ObserveAcknowledgements(results =>
         {
             foreach (ref readonly var result in results)
@@ -141,6 +142,9 @@ public sealed partial class ShareConsumerRenewalTests
                 await Assert.That(await pendingPoll!.WaitAsync(TimeSpan.FromSeconds(10))).IsFalse();
             await Assert.That(callbacks).IsEmpty();
             await Assert.That(connection.SendCount).IsEqualTo(0);
+            await Assert.That(ShareMetricValue(metrics, "fetch.total")).IsEqualTo(0d);
+            await Assert.That(ShareMetricValue(metrics, "acknowledgements.send.total")).IsEqualTo(0d);
+            await Assert.That(ShareMetricValue(metrics, "acknowledgements.error.total")).IsEqualTo(0d);
             await Assert.That(GetSessionEpoch(fixture.Consumer, 1)).IsEqualTo(0);
             await Assert.That(HasPendingAcknowledgements(fixture.Consumer)).IsTrue();
         }

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.Telemetry.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.Telemetry.cs
@@ -1,0 +1,328 @@
+using System.Buffers;
+using Dekaf.Protocol.Records;
+using System.Reflection;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.ShareConsumer;
+using Dekaf.Telemetry;
+using Dekaf.Consumer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public sealed partial class ShareConsumerRenewalTests
+{
+    private const string ShareMetricPrefix = "org.apache.kafka.consumer.share.fetch.manager.";
+
+    [Test]
+    [Arguments(false, 0)]
+    [Arguments(true, 0)]
+    [Arguments(false, 1)]
+    [Arguments(true, 1)]
+    [Arguments(false, 2)]
+    [Arguments(true, 2)]
+    public async Task Telemetry_FailedParsing_DiscardsUndisclosedRecords(bool batchApi, int preparationMode)
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = CreateFetchResponse(0, 42, recordCount: 2)
+        };
+        var deserializer = preparationMode == 0
+            ? new TelemetryFailingDeserializer()
+            : new TelemetryFailingPreparer(preparationMode == 2);
+        await using var fixture = CreateFixture(connection, valueDeserializer: deserializer);
+        var metrics = EnableShareTelemetry(fixture.Consumer);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        if (batchApi)
+        {
+            await using var poll = fixture.Consumer.PollBatchesAsync().GetAsyncEnumerator();
+            await Assert.That(async () => await poll.MoveNextAsync()).Throws<InvalidOperationException>();
+        }
+        else
+        {
+            await using var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator();
+            await Assert.That(async () => await poll.MoveNextAsync()).Throws<InvalidOperationException>();
+        }
+
+        await Assert.That(deserializer.Calls).IsGreaterThanOrEqualTo(1);
+        await Assert.That(ShareMetricValue(metrics, "records.consumed.total")).IsEqualTo(0d);
+        await Assert.That(ShareMetricValue(metrics, "bytes.consumed.total")).IsEqualTo(0d);
+        await Assert.That(ShareMetricValue(metrics, "records.per.request.max")).IsEqualTo(0d);
+
+        deserializer.Fail = false;
+        if (batchApi)
+        {
+            await using var poll = fixture.Consumer.PollBatchesAsync().GetAsyncEnumerator();
+            await Assert.That(await poll.MoveNextAsync()).IsTrue();
+        }
+        else
+        {
+            await using var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator();
+            await Assert.That(await poll.MoveNextAsync()).IsTrue();
+        }
+        await Assert.That(ShareMetricValue(metrics, "records.consumed.total")).IsEqualTo(2d);
+        await Assert.That(ShareMetricValue(metrics, "bytes.consumed.total")).IsEqualTo(32d);
+    }
+
+    [Test]
+    [Arguments(CoordinatorState.Stable, 0d)]
+    [Arguments(CoordinatorState.Joining, 1d)]
+    public async Task Telemetry_IdenticalAssignment_CountsOnlyCompletedRejoin(CoordinatorState state, double expected)
+    {
+        await using var fixture = CreateFixture(new CapturingConnection(ApiKey.ShareFetch, 2));
+        var metrics = EnableShareTelemetry(fixture.Consumer);
+        PrepareForPoll(fixture.Consumer);
+        var coordinator = IdleCoordinator(fixture.Consumer);
+        var assignment = coordinator.Assignment;
+        typeof(ShareConsumerCoordinator).GetField("_state", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(coordinator, state);
+        PublishAssignment(coordinator, assigned: true);
+        await Assert.That(ReferenceEquals(coordinator.Assignment, assignment)).IsTrue();
+        var snapshot = new List<ClientTelemetryMetric>();
+        metrics.Collect(new ClientTelemetrySubscription(Guid.Empty, 1, 0, 60000, 4096, false,
+            ["org.apache.kafka.consumer.share.coordinator."]), snapshot);
+        await Assert.That(snapshot.Single(metric => metric.Name.EndsWith("rebalance.total", StringComparison.Ordinal)).Value)
+            .IsEqualTo(expected);
+    }
+
+    private class TelemetryFailingDeserializer : IDeserializer<string>
+    {
+        public int Calls { get; private set; }
+        public bool Fail { get; set; } = true;
+
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            if (++Calls == 2 && Fail)
+                throw new InvalidOperationException("Second record failed.");
+            return Serializers.String.Deserialize(data, context);
+        }
+    }
+
+    private sealed class TelemetryFailingPreparer(bool failPreparation)
+        : TelemetryFailingDeserializer, IAsyncDeserializerPreparer<string>
+    {
+        public bool TryDeserialize(ReadOnlyMemory<byte> data, SerializationContext context, out string value)
+        {
+            if (Fail && failPreparation && Calls == 1)
+            {
+                value = string.Empty;
+                return false;
+            }
+            value = Deserialize(data, context);
+            return true;
+        }
+
+        public ValueTask PrepareAsync(ReadOnlyMemory<byte> data, SerializationContext context, CancellationToken cancellationToken)
+            => ValueTask.FromException(new InvalidOperationException("Second record preparation failed."));
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Telemetry_AcknowledgementOutcome_ExcludesGaps(bool failed)
+    {
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2)
+        {
+            ShareAcknowledgeResponse = new ShareAcknowledgeResponse
+            {
+                ErrorCode = failed ? ErrorCode.InvalidRequest : ErrorCode.None,
+                Responses = [], NodeEndpoints = []
+            }
+        };
+        await using var fixture = CreateFixture(connection);
+        var metrics = EnableShareTelemetry(fixture.Consumer);
+        var acknowledgements = new Dictionary<TopicPartition, List<AcknowledgementBatchData>>
+        {
+            [new TopicPartition("topic", 0)] =
+            [new AcknowledgementBatchData(42, 44, [(byte)AcknowledgeType.Accept, (byte)AcknowledgeType.Gap, (byte)AcknowledgeType.Release])]
+        };
+        await InvokeShareAcknowledgeAsync(fixture.Consumer, acknowledgements);
+        await Assert.That(ShareMetricValue(metrics, "acknowledgements.send.total")).IsEqualTo(2d);
+        await Assert.That(ShareMetricValue(metrics, "acknowledgements.error.total")).IsEqualTo(failed ? 2d : 0d);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Telemetry_PartialConsumption_CountsParsedRecordsOnce(bool batchApi)
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = CreateFetchResponse(0, 42, recordCount: 3)
+        };
+        await using var fixture = CreateFixture(connection);
+        var metrics = EnableShareTelemetry(fixture.Consumer);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        if (batchApi)
+        {
+            await using var enumerator = fixture.Consumer.PollBatchesAsync().GetAsyncEnumerator();
+            await Assert.That(await enumerator.MoveNextAsync()).IsTrue();
+            var records = enumerator.Current.GetEnumerator();
+            await Assert.That(records.MoveNext()).IsTrue();
+        }
+        else
+        {
+            await using var enumerator = fixture.Consumer.PollAsync().GetAsyncEnumerator();
+            await Assert.That(await enumerator.MoveNextAsync()).IsTrue();
+        }
+        await Assert.That(ShareMetricValue(metrics, "fetch.total")).IsEqualTo(1d);
+        await Assert.That(ShareMetricValue(metrics, "records.consumed.total")).IsEqualTo(3d);
+        await Assert.That(ShareMetricValue(metrics, "bytes.consumed.total")).IsGreaterThan(0d);
+        await Assert.That(ShareMetricValue(metrics, "records.per.request.max")).IsEqualTo(3d);
+    }
+
+    [Test]
+    public async Task Telemetry_FetchRetry_CountsEachSubmittedAttemptAndItsAcknowledgementFailure()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponses = new Queue<ShareFetchResponse>([
+                new ShareFetchResponse { ErrorCode = ErrorCode.RequestTimedOut, Responses = [], NodeEndpoints = [] },
+                new ShareFetchResponse { ErrorCode = ErrorCode.None, Responses = [], NodeEndpoints = [] }
+            ])
+        };
+        await using var fixture = CreateFixture(connection);
+        var metrics = EnableShareTelemetry(fixture.Consumer);
+        await InvokeShareFetchAsync(fixture.Consumer, RenewalAcknowledgements());
+        await Assert.That(ShareMetricValue(metrics, "fetch.total")).IsEqualTo(2d);
+        await Assert.That(ShareMetricValue(metrics, "acknowledgements.send.total")).IsEqualTo(2d);
+        await Assert.That(ShareMetricValue(metrics, "acknowledgements.error.total")).IsEqualTo(1d);
+        await Assert.That(ShareMetricValue(metrics, "records.consumed.total")).IsEqualTo(0d);
+    }
+
+    [Test]
+    public async Task Telemetry_RenewalReplay_DoesNotCountFetchedRecordsAgain()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = new ShareFetchResponse
+            {
+                ErrorCode = ErrorCode.None, AcquisitionLockTimeoutMs = 30000,
+                Responses = [], NodeEndpoints = []
+            }
+        };
+        await using var fixture = CreateFixture(connection);
+        var metrics = EnableShareTelemetry(fixture.Consumer);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        var original = CreateRecord();
+        fixture.Consumer.Acknowledge(original, AcknowledgeType.Renew);
+        await using var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator();
+        await Assert.That(await poll.MoveNextAsync()).IsTrue();
+        await Assert.That(ReferenceEquals(poll.Current, original)).IsTrue();
+        await Assert.That(ShareMetricValue(metrics, "records.consumed.total")).IsEqualTo(0d);
+        await Assert.That(ShareMetricValue(metrics, "bytes.consumed.total")).IsEqualTo(0d);
+        await Assert.That(ShareMetricValue(metrics, "acknowledgements.send.total")).IsEqualTo(1d);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Telemetry_FetchTotals_ExcludeUnacquiredRecordsAndCompactedGaps(bool batchApi)
+    {
+        var bytes = new ArrayBufferWriter<byte>();
+        using (var batch = new RecordBatch
+        {
+            BaseOffset = 42, LastOffsetDelta = 5,
+            Records = [
+                new Record { OffsetDelta = 0, IsKeyNull = true, Value = "v"u8.ToArray() },
+                new Record { OffsetDelta = 2, IsKeyNull = true, Value = "v"u8.ToArray() },
+                new Record { OffsetDelta = 5, IsKeyNull = true, Value = "v"u8.ToArray() }
+            ]
+        }) batch.Write(bytes);
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = new ShareFetchResponse
+            {
+                ErrorCode = ErrorCode.None, NodeEndpoints = [],
+                Responses = [new ShareFetchResponseTopic
+                {
+                    TopicId = TopicId,
+                    Partitions = [new ShareFetchResponsePartition
+                    {
+                        PartitionIndex = 0, CurrentLeader = new ShareFetchLeaderIdAndEpoch(), RecordBytes = bytes.WrittenMemory,
+                        AcquiredRecords = [new ShareFetchAcquiredRecords { FirstOffset = 42, LastOffset = 45, DeliveryCount = 1 }]
+                    }]
+                }]
+            }
+        };
+        await using var fixture = CreateFixture(connection);
+        var metrics = EnableShareTelemetry(fixture.Consumer);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        if (batchApi)
+        {
+            await using var poll = fixture.Consumer.PollBatchesAsync().GetAsyncEnumerator();
+            await Assert.That(await poll.MoveNextAsync()).IsTrue();
+            await Assert.That(poll.Current.Count).IsEqualTo(2);
+        }
+        else
+        {
+            await using var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator();
+            await Assert.That(await poll.MoveNextAsync()).IsTrue();
+        }
+        await Assert.That(ShareMetricValue(metrics, "records.consumed.total")).IsEqualTo(2d);
+        await Assert.That(ShareMetricValue(metrics, "bytes.consumed.total")).IsEqualTo(16d);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Telemetry_ColdPreparationCountsRecordsOnlyAfterSuccessfulDeserialization(bool batchApi)
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = CreateFetchResponse(0, 42, recordCount: 2)
+        };
+        var preparer = new PausedDeserializerPreparer();
+        await using var fixture = CreateFixture(connection, valueDeserializer: preparer);
+        var metrics = EnableShareTelemetry(fixture.Consumer);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        try
+        {
+            if (batchApi)
+            {
+                await using var poll = fixture.Consumer.PollBatchesAsync().GetAsyncEnumerator();
+                var pending = poll.MoveNextAsync();
+                await preparer.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+                await Assert.That(ShareMetricValue(metrics, "records.consumed.total")).IsEqualTo(0d);
+                preparer.Release.TrySetResult();
+                await Assert.That(await pending).IsTrue();
+            }
+            else
+            {
+                await using var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator();
+                var pending = poll.MoveNextAsync();
+                await preparer.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+                await Assert.That(ShareMetricValue(metrics, "records.consumed.total")).IsEqualTo(0d);
+                preparer.Release.TrySetResult();
+                await Assert.That(await pending).IsTrue();
+            }
+            await Assert.That(ShareMetricValue(metrics, "records.consumed.total")).IsEqualTo(2d);
+            await Assert.That(ShareMetricValue(metrics, "bytes.consumed.total")).IsEqualTo(32d);
+        }
+        finally
+        {
+            preparer.Release.TrySetResult();
+        }
+    }
+
+    private static ShareConsumerTelemetryMetrics EnableShareTelemetry(KafkaShareConsumer<string, string> consumer)
+    {
+        var collector = (ClientTelemetryMetricCollector)typeof(KafkaShareConsumer<string, string>)
+            .GetField("_telemetryMetricCollector", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(consumer)!;
+        var metrics = collector.ShareConsumerMetrics!;
+        metrics.Subscribe(["org.apache.kafka.consumer.share."]);
+        return metrics;
+    }
+
+    private static double ShareMetricValue(ShareConsumerTelemetryMetrics metrics, string suffix)
+    {
+        var snapshot = new List<ClientTelemetryMetric>();
+        metrics.Collect(new ClientTelemetrySubscription(Guid.Empty, 1, 0, 60000, 4096, false, [ShareMetricPrefix]), snapshot);
+        return snapshot.Single(metric => metric.Name == ShareMetricPrefix + suffix).Value;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -602,6 +602,7 @@ public sealed partial class ShareConsumerRenewalTests
             ])
         };
         await using var fixture = CreateFixture(connection);
+        var metrics = EnableShareTelemetry(fixture.Consumer);
         PrepareForPoll(fixture.Consumer);
         fixture.Consumer.Acknowledge(CreateRecord(partition: 0, offset: 40), AcknowledgeType.Accept);
         fixture.Consumer.Acknowledge(CreateRecord(partition: 1, offset: 41), AcknowledgeType.Renew);
@@ -615,6 +616,8 @@ public sealed partial class ShareConsumerRenewalTests
             .ToArray();
         await Assert.That(retryPartitions).IsEquivalentTo([1]);
         await Assert.That(HasPendingAcknowledgements(fixture.Consumer)).IsFalse();
+        await Assert.That(ShareMetricValue(metrics, "acknowledgements.send.total")).IsEqualTo(3d);
+        await Assert.That(ShareMetricValue(metrics, "acknowledgements.error.total")).IsEqualTo(1d);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.ShareConsumer.cs
+++ b/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.ShareConsumer.cs
@@ -193,6 +193,31 @@ public sealed partial class ClientTelemetryManagerTests
         await Assert.That(calls).IsEqualTo(0);
     }
 
+    [Test]
+    public async Task ShareConsumer_SubscriptionRefreshDeactivatesUnrequestedBuiltIns()
+    {
+        const string prefix = "org.apache.kafka.consumer.share.";
+        const string applicationName = "com.example.share.refresh";
+        await using var context = new TelemetryTestContext(shareConsumerOptions: ShareOptions(
+            new ApplicationTelemetryMetric(applicationName, ApplicationTelemetryMetricKind.Gauge, () => 42)));
+        var identity = Guid.NewGuid();
+        context.Connection.Enqueue(Subscription(identity, 1, 10, telemetryMaxBytes: 8192, requestedMetrics: [prefix]));
+        context.Connection.Enqueue(new PushTelemetryResponse { ErrorCode = ErrorCode.UnknownSubscriptionId });
+        context.Connection.Enqueue(Subscription(identity, 2, 10, requestedMetrics: [applicationName]));
+        context.Connection.Enqueue(new PushTelemetryResponse { ErrorCode = ErrorCode.None });
+        await context.Manager.StartAsync();
+        var pushes = await context.Connection.WaitForRequestsAsync<PushTelemetryRequest>(2, TimeSpan.FromSeconds(2));
+        await Assert.That(DecodeShareMetrics(pushes[0]).Length).IsEqualTo(28);
+        var refreshed = DecodeShareMetrics(pushes[1]);
+        await Assert.That(refreshed).HasSingleItem();
+        await Assert.That(refreshed[0].Name).IsEqualTo(applicationName);
+        var collector = (ClientTelemetryMetricCollector)typeof(KafkaShareConsumer<string, string>)
+            .GetField("_telemetryMetricCollector", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(context.ShareConsumer)!;
+        await Assert.That(collector.ShareConsumerMetrics!.Enabled(ShareConsumerTelemetryMetrics.Groups.Records)).IsFalse();
+        await Assert.That(collector.ShareConsumerMetrics.Enabled(ShareConsumerTelemetryMetrics.Groups.Heartbeat)).IsFalse();
+    }
+
     private static ShareConsumerOptions ShareOptions(params ApplicationTelemetryMetric[] metrics) => new()
     {
         BootstrapServers = ["localhost:9092"], GroupId = "share-telemetry", ApplicationMetrics = metrics

--- a/tests/Dekaf.Tests.Unit/Telemetry/ShareConsumerTelemetryMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Telemetry/ShareConsumerTelemetryMetricsTests.cs
@@ -1,0 +1,287 @@
+using Dekaf.Telemetry;
+
+namespace Dekaf.Tests.Unit.Telemetry;
+
+public sealed class ShareConsumerTelemetryMetricsTests
+{
+    private const string Prefix = "org.apache.kafka.consumer.share.";
+    private const string Fetch = Prefix + "fetch.manager.";
+    private const string Coordinator = Prefix + "coordinator.";
+
+    [Test]
+    public async Task FetchWindows_AccumulateOnceAcrossPartitions_IncludeEmptyRequests()
+    {
+        var clock = new Clock();
+        var metrics = new ShareConsumerTelemetryMetrics(clock.Read, 1000);
+        metrics.Subscribe([Fetch]);
+        metrics.FetchStarted(1);
+        clock.Advance(20);
+        metrics.FetchCompleted(1, 7);
+        var sample = metrics.GetFetchSample(1)!;
+        metrics.Parsed(sample, 80, 2);
+        metrics.Parsed(sample, 160, 4);
+        metrics.FetchStarted(2);
+        clock.Advance(40);
+        metrics.FetchCompleted(2, 3);
+        clock.Advance(940);
+        var snapshot = Collect(metrics);
+        await Assert.That(Value(snapshot, Fetch + "fetch.total")).IsEqualTo(2d);
+        await Assert.That(Value(snapshot, Fetch + "bytes.consumed.total")).IsEqualTo(240d);
+        await Assert.That(Value(snapshot, Fetch + "records.consumed.total")).IsEqualTo(6d);
+        await Assert.That(Value(snapshot, Fetch + "fetch.size.avg")).IsEqualTo(120d);
+        await Assert.That(Value(snapshot, Fetch + "fetch.size.max")).IsEqualTo(240d);
+        await Assert.That(Value(snapshot, Fetch + "records.per.request.avg")).IsEqualTo(3d);
+        await Assert.That(Value(snapshot, Fetch + "records.per.request.max")).IsEqualTo(6d);
+        await Assert.That(Value(snapshot, Fetch + "fetch.latency.avg")).IsEqualTo(30d);
+        await Assert.That(Value(snapshot, Fetch + "fetch.latency.max")).IsEqualTo(40d);
+        await Assert.That(Value(snapshot, Fetch + "fetch.throttle.time.avg")).IsEqualTo(5d);
+        await Assert.That(Value(snapshot, Fetch + "fetch.throttle.time.max")).IsEqualTo(7d);
+        await Assert.That(Value(snapshot, Fetch + "fetch.rate")).IsEqualTo(2d);
+        await Assert.That(Value(snapshot, Fetch + "records.consumed.rate")).IsEqualTo(6d);
+        await Assert.That(Value(snapshot, Fetch + "bytes.consumed.rate")).IsEqualTo(240d);
+    }
+
+    [Test]
+    public async Task PollAndCoordinator_UseElapsedTime_ExcludeApplicationTimeFromIdle()
+    {
+        var clock = new Clock();
+        var metrics = new ShareConsumerTelemetryMetrics(clock.Read, 1000);
+        metrics.Subscribe([Prefix]);
+        metrics.PollStarted();
+        var waiting = metrics.Timestamp(ShareConsumerTelemetryMetrics.Groups.Poll);
+        var heartbeat = metrics.HeartbeatStarted();
+        clock.Advance(20);
+        metrics.HeartbeatCompleted(heartbeat);
+        metrics.Rebalanced();
+        clock.Advance(80);
+        metrics.PollWaitCompleted(waiting);
+        clock.Advance(300);
+        metrics.PollStarted();
+        clock.Advance(600);
+        var snapshot = Collect(metrics);
+        await Assert.That(snapshot.Count).IsEqualTo(28);
+        await Assert.That(snapshot.All(metric => metric.Attributes.Count == 0)).IsTrue();
+        await Assert.That(Value(snapshot, Prefix + "last.poll.seconds.ago")).IsEqualTo(.6d);
+        await Assert.That(Value(snapshot, Prefix + "time.between.poll.avg")).IsEqualTo(400d);
+        await Assert.That(Value(snapshot, Prefix + "time.between.poll.max")).IsEqualTo(400d);
+        await Assert.That(Value(snapshot, Prefix + "poll.idle.ratio.avg")).IsEqualTo(.25d);
+        await Assert.That(Value(snapshot, Coordinator + "heartbeat.response.time.max")).IsEqualTo(20d);
+        await Assert.That(Value(snapshot, Coordinator + "heartbeat.total")).IsEqualTo(1d);
+        await Assert.That(Value(snapshot, Coordinator + "heartbeat.rate")).IsEqualTo(1d);
+        await Assert.That(Value(snapshot, Coordinator + "last.heartbeat.seconds.ago")).IsEqualTo(1d);
+        await Assert.That(Value(snapshot, Coordinator + "rebalance.total")).IsEqualTo(1d);
+        await Assert.That(Value(snapshot, Coordinator + "rebalance.rate.per.hour")).IsEqualTo(3600d);
+    }
+
+    [Test]
+    public async Task SubscriptionRefresh_DisablesUnrequestedGroups_AndDisableStopsRecording()
+    {
+        var metrics = new ShareConsumerTelemetryMetrics();
+        metrics.FetchStarted(1);
+        await Assert.That(metrics.GetFetchSample(1)).IsNull();
+        metrics.Subscribe([Coordinator]);
+        await Assert.That(metrics.Enabled(ShareConsumerTelemetryMetrics.Groups.Heartbeat)).IsTrue();
+        await Assert.That(metrics.Enabled(ShareConsumerTelemetryMetrics.Groups.Records)).IsFalse();
+        metrics.HeartbeatStarted();
+        metrics.Subscribe(["com.example."]);
+        metrics.HeartbeatStarted();
+        metrics.Subscribe([Fetch]);
+        metrics.AcknowledgementsSent(3);
+        metrics.Disable();
+        metrics.AcknowledgementsSent(5);
+        var snapshot = Collect(metrics);
+        await Assert.That(Value(snapshot, Coordinator + "heartbeat.total")).IsEqualTo(1d);
+        await Assert.That(Value(snapshot, Fetch + "acknowledgements.send.total")).IsEqualTo(3d);
+        var filtered = Collect(metrics, prefixes: [Coordinator + "heartbeat.total"]);
+        await Assert.That(filtered.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task AcknowledgementRetries_CountersAndRatesHaveIndependentCollectionState(bool delta)
+    {
+        var clock = new Clock();
+        var metrics = new ShareConsumerTelemetryMetrics(clock.Read, 1000);
+        metrics.Subscribe([Fetch]);
+        metrics.AcknowledgementsSent(10);
+        metrics.AcknowledgementsFailed(4);
+        clock.Advance(1000);
+        var first = Collect(metrics, delta);
+        metrics.AcknowledgementsSent(4);
+        clock.Advance(2000);
+        var second = Collect(metrics, delta);
+        await Assert.That(Value(first, Fetch + "acknowledgements.send.total")).IsEqualTo(10d);
+        await Assert.That(Value(first, Fetch + "acknowledgements.error.total")).IsEqualTo(4d);
+        await Assert.That(Value(first, Fetch + "acknowledgements.send.rate")).IsEqualTo(10d);
+        await Assert.That(Value(first, Fetch + "acknowledgements.error.rate")).IsEqualTo(4d);
+        await Assert.That(Value(second, Fetch + "acknowledgements.send.total")).IsEqualTo(delta ? 4d : 14d);
+        await Assert.That(Value(second, Fetch + "acknowledgements.error.total")).IsEqualTo(delta ? 0d : 4d);
+        await Assert.That(Value(second, Fetch + "acknowledgements.send.rate")).IsEqualTo(2d);
+        await Assert.That(Value(second, Fetch + "acknowledgements.error.rate")).IsEqualTo(0d);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task BuiltInPayload_EncodesMonotonicCountersAndGauges(bool delta)
+    {
+        var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.ShareConsumer);
+        collector.ShareConsumerMetrics!.Subscribe([Prefix]);
+        collector.ShareConsumerMetrics.AcknowledgementsSent(3);
+        collector.RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+            "com.example.share.depth", ApplicationTelemetryMetricKind.Gauge, () => 42,
+            new Dictionary<string, string> { ["tenant"] = "north" }));
+        var subscription = new ClientTelemetrySubscription(Guid.NewGuid(), 1, 0, 1000, 8192, delta,
+            [Fetch + "acknowledgements.send.total", Prefix + "last.poll.seconds.ago", "com.example.share."]);
+        var provider = new ClientTelemetryPayloadProvider();
+        var payload = provider.Collect(subscription, collector.Collect(subscription), false);
+        var decoded = Dekaf.Tests.Integration.Telemetry.MetricsData.Parser.ParseFrom(payload.ToArray())
+            .ResourceMetrics.SelectMany(resource => resource.ScopeMetrics).SelectMany(scope => scope.Metrics).ToArray();
+        await Assert.That(decoded.Length).IsEqualTo(3);
+        var counter = decoded.Single(metric => metric.Name == Fetch + "acknowledgements.send.total");
+        await Assert.That(counter.Sum.IsMonotonic).IsTrue();
+        await Assert.That((int)counter.Sum.AggregationTemporality).IsEqualTo(delta ? 1 : 2);
+        await Assert.That(counter.Sum.DataPoints.Single().AsDouble).IsEqualTo(3d);
+        await Assert.That(counter.Sum.DataPoints.Single().Attributes.Count).IsEqualTo(0);
+        var gauge = decoded.Single(metric => metric.Name == Prefix + "last.poll.seconds.ago");
+        await Assert.That(gauge.Gauge.DataPoints.Count).IsEqualTo(1);
+        await Assert.That(gauge.Gauge.DataPoints.Single().AsDouble).IsEqualTo(-1d);
+        var application = decoded.Single(metric => metric.Name == "com.example.share.depth");
+        await Assert.That(application.Gauge.DataPoints.Single().AsDouble).IsEqualTo(42d);
+        await Assert.That(application.Gauge.DataPoints.Single().Attributes.Single().Value.StringValue).IsEqualTo("north");
+    }
+
+    [Test]
+    public async Task RateSubscription_StartsAtSubscriptionRatherThanClientCreation()
+    {
+        var clock = new Clock();
+        var metrics = new ShareConsumerTelemetryMetrics(clock.Read, 1000);
+        clock.Advance(10000);
+        metrics.Subscribe([Coordinator]);
+        metrics.HeartbeatStarted();
+        clock.Advance(1000);
+        await Assert.That(Value(Collect(metrics), Coordinator + "heartbeat.rate")).IsEqualTo(1d);
+        metrics.Subscribe([Coordinator + "heartbeat.total"]);
+        metrics.HeartbeatStarted();
+        clock.Advance(10000);
+        metrics.Subscribe([Coordinator]);
+        metrics.HeartbeatStarted();
+        clock.Advance(1000);
+        var snapshot = Collect(metrics);
+        await Assert.That(Value(snapshot, Coordinator + "heartbeat.rate")).IsEqualTo(1d);
+        await Assert.That(Value(snapshot, Coordinator + "heartbeat.total")).IsEqualTo(3d);
+    }
+
+    [Test]
+    public async Task SubscriptionRefresh_PreservesPendingAcknowledgements_WhenRecordMetricsChange()
+    {
+        var metrics = new ShareConsumerTelemetryMetrics();
+        metrics.Subscribe([Prefix]);
+        metrics.StartFetch(1, 2);
+        metrics.AcknowledgementRequestStarted(1, 3);
+        metrics.Subscribe([Fetch + "acknowledgements."]);
+        metrics.FetchCompleted(1, 0);
+        metrics.AcknowledgementRequestCompleted(1, true);
+        var snapshot = Collect(metrics);
+        await Assert.That(Value(snapshot, Fetch + "acknowledgements.send.total")).IsEqualTo(5d);
+        await Assert.That(Value(snapshot, Fetch + "acknowledgements.error.total")).IsEqualTo(3d);
+        metrics.Subscribe([Prefix]);
+        await Assert.That(metrics.GetFetchSample(1)).IsNull();
+    }
+
+    [Test]
+    public async Task SubscriptionRefresh_DoesNotReuseRequestState_FromAnInactiveSubscription()
+    {
+        var metrics = new ShareConsumerTelemetryMetrics();
+        metrics.Subscribe([Prefix]);
+        metrics.StartFetch(1, 2);
+        metrics.FetchCompleted(1, 0);
+        metrics.Subscribe(["com.example."]);
+        metrics.StartFetch(1, 7);
+        metrics.Subscribe([Prefix]);
+        metrics.FetchCompleted(1, 0);
+        var snapshot = Collect(metrics);
+        await Assert.That(Value(snapshot, Fetch + "fetch.total")).IsEqualTo(1d);
+        await Assert.That(Value(snapshot, Fetch + "acknowledgements.send.total")).IsEqualTo(2d);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task SubscriptionRefresh_RecordAveragesExcludeFetchOnlyIntervals(bool failFetch)
+    {
+        var metrics = new ShareConsumerTelemetryMetrics();
+        metrics.Subscribe([Prefix]);
+        metrics.FetchStarted(1);
+        metrics.FetchCompleted(1, 0);
+        metrics.Parsed(metrics.GetFetchSample(1)!, 100, 4);
+
+        metrics.Subscribe([Fetch + "fetch.total"]);
+        metrics.FetchStarted(1);
+        if (failFetch)
+            metrics.FetchFailed(1);
+        else
+            metrics.FetchCompleted(1, 0);
+
+        // A request submitted without record accounting must also be excluded if
+        // its response arrives after the record metrics are selected again.
+        metrics.FetchStarted(1);
+        metrics.Subscribe([Prefix]);
+        metrics.FetchCompleted(1, 0);
+        metrics.FetchStarted(1);
+        metrics.FetchCompleted(1, 0);
+        metrics.Parsed(metrics.GetFetchSample(1)!, 300, 8);
+        // An empty/failed request submitted with record accounting is a real
+        // zero-record sample, so it must remain in the average's denominator.
+        metrics.FetchStarted(1);
+        if (failFetch)
+            metrics.FetchFailed(1);
+        else
+            metrics.FetchCompleted(1, 0);
+
+        var snapshot = Collect(metrics);
+        await Assert.That(Value(snapshot, Fetch + "fetch.total")).IsEqualTo(5d);
+        await Assert.That(Value(snapshot, Fetch + "fetch.size.avg")).IsEqualTo(400d / 3);
+        await Assert.That(Value(snapshot, Fetch + "records.per.request.avg")).IsEqualTo(4d);
+        await Assert.That(Value(snapshot, Fetch + "bytes.consumed.total")).IsEqualTo(400d);
+        await Assert.That(Value(snapshot, Fetch + "records.consumed.total")).IsEqualTo(12d);
+    }
+
+    [Test]
+    public async Task PollSubscriptionRefresh_DiscardsTheInterruptedRoundBeforeMeasuringNewIntervals()
+    {
+        var clock = new Clock();
+        var metrics = new ShareConsumerTelemetryMetrics(clock.Read, 1000);
+        metrics.Subscribe([Prefix]);
+        metrics.PollStarted();
+        var waiting = metrics.Timestamp(ShareConsumerTelemetryMetrics.Groups.Poll);
+        clock.Advance(100);
+        metrics.Subscribe(["com.example."]);
+        clock.Advance(100);
+        metrics.Subscribe([Prefix]);
+        clock.Advance(100);
+        metrics.PollWaitCompleted(waiting);
+        metrics.PollStarted();
+        clock.Advance(100);
+        metrics.PollStarted();
+        await Assert.That(Value(Collect(metrics), Prefix + "poll.idle.ratio.avg")).IsEqualTo(0d);
+    }
+
+    private static List<ClientTelemetryMetric> Collect(ShareConsumerTelemetryMetrics metrics,
+        bool delta = false, string[]? prefixes = null)
+    {
+        var subscription = new ClientTelemetrySubscription(Guid.Empty, 1, 0, 1000, 4096, delta, prefixes ?? [Prefix]);
+        var snapshot = new List<ClientTelemetryMetric>();
+        metrics.Collect(subscription, snapshot);
+        return snapshot;
+    }
+
+    private static double Value(List<ClientTelemetryMetric> metrics, string name) => metrics.Single(metric => metric.Name == name).Value;
+    private sealed class Clock
+    {
+        private long _now;
+        internal long Read() => _now;
+        internal void Advance(long milliseconds) => _now += milliseconds;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerTelemetryParsingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerTelemetryParsingBenchmarks.cs
@@ -1,0 +1,84 @@
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Measures parsing with and without a broker subscription to share-consumer metrics.</summary>
+[MemoryDiagnoser]
+public class ShareConsumerTelemetryParsingBenchmarks
+{
+    private static readonly string[] MetricPrefixes = ["org.apache.kafka.consumer.share."];
+    private ShareConsumerParsingBenchmarks _parsing = null!;
+    private Action _resetSynchronous = static () => { };
+    private Action _resetPrepared = static () => { };
+
+    [Params(64, 1024)]
+    public int RecordCount { get; set; }
+
+    [Params(false, true)]
+    public bool Subscribed { get; set; }
+
+    [GlobalSetup]
+    public async ValueTask Setup()
+    {
+        _parsing = new ShareConsumerParsingBenchmarks { RecordCount = RecordCount, HeaderCount = 0 };
+        await _parsing.Setup();
+        if (!Subscribed) return;
+
+        // Bind only during setup so this fixture also builds against the pre-feature
+        // baseline, which has no built-in recorder. Timed methods use the same parsers.
+        foreach (var name in new[] { "_synchronousConsumer", "_preparedConsumer" })
+        {
+            var consumer = typeof(ShareConsumerParsingBenchmarks)
+                .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(_parsing)!;
+            var collector = consumer.GetType().GetField("_telemetryMetricCollector",
+                BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(consumer)!;
+            var metrics = collector.GetType().GetProperty("ShareConsumerMetrics",
+                BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(collector);
+            if (metrics is null) continue;
+            metrics.GetType().GetMethod("Subscribe", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(metrics, [MetricPrefixes]);
+            metrics.GetType().GetMethod("FetchStarted", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(metrics, [1]);
+            var sample = metrics.GetType().GetMethod("GetFetchSample", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(metrics, [1]);
+            consumer.GetType().GetField("_activeTelemetryFetch", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(consumer, sample);
+            var reset = sample!.GetType().GetMethod("Reset", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .CreateDelegate<Action>(sample);
+            if (name == "_synchronousConsumer") _resetSynchronous = reset;
+            else _resetPrepared = reset;
+        }
+    }
+
+    [Benchmark]
+    public long ParseSynchronousBatch()
+    {
+        _resetSynchronous();
+        return _parsing.ParseSynchronousBatch();
+    }
+
+    [Benchmark]
+    public long ParseWarmPreparedBatch()
+    {
+        _resetPrepared();
+        return _parsing.ParseWarmPreparedBatch();
+    }
+
+    [Benchmark]
+    public ValueTask<long> ParseBorrowedSynchronousBatch()
+    {
+        _resetSynchronous();
+        return _parsing.ParseBorrowedSynchronousBatch();
+    }
+
+    [Benchmark]
+    public ValueTask<long> ParseBorrowedWarmPreparedBatch()
+    {
+        _resetPrepared();
+        return _parsing.ParseBorrowedWarmPreparedBatch();
+    }
+
+    [GlobalCleanup]
+    public ValueTask Cleanup() => _parsing.Cleanup();
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerTelemetryPollBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerTelemetryPollBenchmarks.cs
@@ -1,0 +1,53 @@
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Exercises subscribed request, acknowledgement and poll metrics through both polling APIs.</summary>
+[MemoryDiagnoser]
+public class ShareConsumerTelemetryPollBenchmarks
+{
+    private static readonly string[] MetricPrefixes = ["org.apache.kafka.consumer.share."];
+    private ShareConsumerPollBenchmarks _poll = null!;
+
+    [Params(1, 1024)]
+    public int RecordCount { get; set; }
+
+    [Params(false, true)]
+    public bool Subscribed { get; set; }
+
+    [Params(false, true)]
+    public bool AsynchronousResponse { get; set; }
+
+    [GlobalSetup]
+    public async ValueTask Setup()
+    {
+        _poll = new ShareConsumerPollBenchmarks
+        {
+            RecordCount = RecordCount, BatchCount = 1, AsynchronousResponse = AsynchronousResponse
+        };
+        await _poll.Setup();
+        if (!Subscribed) return;
+        foreach (var name in new[] { "_compatibility", "_borrowed" })
+        {
+            var consumer = typeof(ShareConsumerPollBenchmarks)
+                .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(_poll)!;
+            var collector = consumer.GetType().GetField("_telemetryMetricCollector",
+                BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(consumer)!;
+            var metrics = collector.GetType().GetProperty("ShareConsumerMetrics",
+                BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(collector);
+            // The pre-feature baseline has no built-in share recorder.
+            metrics?.GetType().GetMethod("Subscribe", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(metrics, [MetricPrefixes]);
+        }
+    }
+
+    [Benchmark]
+    public ValueTask<long> PollClassic() => _poll.PollCompatibilityBatch();
+
+    [Benchmark]
+    public ValueTask<long> PollBorrowed() => _poll.PollBorrowedBatch();
+
+    [GlobalCleanup]
+    public ValueTask Cleanup() => _poll.Cleanup();
+}


### PR DESCRIPTION
Share consumers currently export application registrations without the built-in KIP-932 client metrics. This adds all 28 broker-selected share-consumer metrics through the existing collector and OTLP provider, including subscription refresh, delta/cumulative counters, request outcomes, poll timing and documented parsing semantics.

Record accounting now commits only after a parsing window succeeds. Classic preparation keeps partial counts in its reusable broker sample across preparation awaits; a failed window contributes no exported records or bytes. Successful rejoining with the existing assignment increments the rebalance counter, while repeated assignment payloads in the stable state retain the notification fast path and do not count another rebalance.

Disabled record telemetry selects a value-type parser specialization once per parsing window. Enabled telemetry adds local byte arithmetic per successfully deserialized acquired record; atomic aggregation occurs per completed partition/window or request. Two pending-counter fields are amortized per reusable broker sample, avoiding growth of each poll's async state. Acknowledgement counting occurs per submitted request, including retries and excluding gaps. Export objects are allocated at collection. Record averages use an independent observed-request count, so fetch-only subscription periods cannot dilute them. Existing classic polling allocations remain tracked by #3032; this PR does not claim that API is allocation-free.

The EOS crash tests preserve their input/output topics for ten minutes. The shared broker's 30-second retention could delete output before a minute-long crash/recovery scenario inspected it. An output watermark check now identifies truncation explicitly. Original atomicity assertions and timeouts remain intact.

Current head `9132f2aca` is one commit on main `de392a56bcc460bbfa5dbc0dfdb315e21cb9691f`. Both polling APIs preserve main's coordinator-owned subscription snapshots and post-await unsubscribe checks inside the existing telemetry timing boundary. No record-parser or fixture changes were made for this rebase.

Current validation: full Release build with zero warnings/errors; all 377 share-consumer/telemetry unit cases pass on each of net10.0 and net8.0; 45 performance-selector tests, artifact policy and diff checks pass. All 14 Kafka 4.3.1 replacement-subscription, telemetry receiver and EOS crash-atomicity integration cases pass on net10.0. The range diff was reviewed to preserve both subscription behavior and all previously addressed telemetry findings. Current source, binaries and test reports are retained with SHA-256 inventories at `C:/git/Dekaf-evidence/pr-3252/rebase-de392a56b`.

Previous validation for `f718b8b497dbe6ee2aaca9a6da027844120906c3`, on main `322449fb085f753a8b300de5526a532d231693ee`:

- Full Release build: zero warnings/errors. All 364 share-consumer/telemetry unit cases pass on each of net10.0 and net8.0. All 12 Kafka 4.3.1 EOS/telemetry receiver integration cases pass on net10.0. Documentation build, 45 performance selector cases, artifact policy and diff checks pass. Final changes reviewed for correctness, reuse and hot-path cost.
- Seven new cases fail before the fixes and pass afterward: failed synchronous, warm-prepared and cold-preparation paths through both polling APIs, plus an unchanged-assignment rejoin. An eighth stable-assignment control passes before and after. The failed-parse cases verify zero exported totals followed by exactly two records on successful reacquisition.
- Final .NET 10 x64 FullOpts disassembly contains separate enabled/disabled bodies for all three parsing cores. The record-loop policy tests are constant-folded; the disabled bodies do not perform dynamic telemetry checks. The diagnostic run passes 168 existing cases with serial test execution and tiering disabled; those settings are not applied to the benchmark comparison.
- Both 16-case steady-state fixtures complete `--job Short --keepFiles`, comparing unchanged fixture source at control `c2ee2813d09e144e8cc9d49c476262d8621d4d8f` with the final product source. Allocation matches within 0.001 B/op in 26/32 cases. Five parsing controls report 9–20 B/op more than the candidate, without an attributed allocation saving. Classic/subscribed/asynchronous/1,024-record polling reports 94,308 versus 94,288 B/op (+20 B/poll, 0.0212%). That difference remains unexplained.
- Local timing is mixed: classic/unsubscribed/asynchronous/1,024-record polling measures 157.283 versus 121.142 microseconds (+29.8%); borrowed/subscribed/synchronous measures 75.358 versus 57.056 microseconds (+32.1%); borrowed/subscribed/asynchronous measures 68.702 versus 57.325 microseconds (+19.8%). These one-control local measurements are diagnostic, not acceptance or an approved tradeoff. No local speedup is claimed and no run was repeated to obtain green.

**Performance and loaded acceptance remain pending.** No throughput, latency, CPU, allocation or stability tradeoff is approved. Fresh current-head hosted performance results and subsequent bot review are required. The applicable loaded lane is `hosted-share-1b`, with acceptance baseline `de392a56bcc460bbfa5dbc0dfdb315e21cb9691f`; no new paid run has been dispatched. That lane does not configure broker telemetry subscriptions, so enabled telemetry also needs a deliberately configured experiment.

Raw reports, original generated benchmark workers, red/final test binaries, final native disassembly and source snapshots are retained outside removable worktrees at `C:/git/Dekaf-evidence/pr-3252/rebase-322449fb0`. The red archive contains 662 SHA-256-verified files, the control worker archive 1,007, and candidate test/documentation validation 1,847. Pre-commit binaries carry the earlier informational version; the archived validation patch and final commit's delta from `c2ee2813d` have identical SHA-256 `3afa7c273df5847bf77425a7d2dfb68a75fd270a9ab2be865163890d04f84154`, identifying the exact tested source. The final worker inventory and full comparison are retained alongside them. No evidence files are committed.

Historical evidence remains under `D:/Dekaf-evidence/pr-3252/351ea70795d36e1ddc9bed7d1a9a504d7cfa5a17` and `D:/Dekaf-evidence/pr-3252/review-20260911-1417`. This includes the original subscription-average red tests, the unexplained earlier +24.012 B/poll result, and the controlled retention experiment: five EOS cases failed with a 45-second inspection delay and truncated output, then passed with topic retention fixed. The diagnostic delay is absent from final source. The [failed faults job](https://github.com/thomhurst/Dekaf/actions/runs/34606923595/job/103290543814) was not rerun.

Closes #3098



