### PR TITLE
fix(share-consumer): publish replacement subscriptions

### DIFF
--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
@@ -51,8 +51,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
             if (_subscriptionSnapshot.Count == 0 || Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _disposed) != 0)
                 yield break;
             // Ensure we're part of the share group
-            await _coordinator.EnsureActiveGroupAsync(_subscriptionSnapshot, cancellationToken)
+            await _coordinator.EnsureActiveGroupAsync(cancellationToken)
                 .ConfigureAwait(false);
+            if (_subscriptionSnapshot.Count == 0)
+                yield break;
             _assignmentSnapshot = _coordinator.Assignment;
 
             var assignment = _assignmentSnapshot;

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -61,7 +61,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     [ThreadStatic]
     private static SerializationContext t_serializationContext;
 
-    private volatile StringSet _subscriptionSnapshot = new HashSet<string>();
+    private volatile HashSet<string> _subscriptionSnapshot = new();
     private volatile TopicPartitionSet _assignmentSnapshot = new HashSet<TopicPartition>();
 
     private readonly SemaphoreSlim _initLock = new(1, 1);
@@ -271,9 +271,12 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
 
     public IKafkaShareConsumer<TKey, TValue> Subscribe(params string[] topics)
     {
+        var subscription = new HashSet<string>(topics);
+        if (_subscriptionSnapshot.SetEquals(subscription))
+            return this;
         _recordBatchOwnerPools?.Clear();
-        _subscriptionSnapshot = new HashSet<string>(topics);
-        _coordinator.NotifyAssignmentChange();
+        _subscriptionSnapshot = subscription;
+        _coordinator.UpdateSubscription(subscription);
         return this;
     }
 
@@ -290,9 +293,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         _activeShareBatch?.Dispose();
         _activeShareBatch = null;
         _batchAcknowledgements?.Clear();
-        _subscriptionSnapshot = new HashSet<string>();
-        _coordinator.NotifyAssignmentChange();
+        var subscription = new HashSet<string>();
+        _subscriptionSnapshot = subscription;
         _recordBatchOwnerPools?.Clear();
+        _coordinator.UpdateSubscription(subscription);
         _sessionManager.ResetAll();
         ClearRenewedRecords();
         return this;
@@ -313,8 +317,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 yield break;
 
             // Ensure we're part of the share group
-            await _coordinator.EnsureActiveGroupAsync(_subscriptionSnapshot, cancellationToken)
+            await _coordinator.EnsureActiveGroupAsync(cancellationToken)
                 .ConfigureAwait(false);
+            if (_subscriptionSnapshot.Count == 0)
+                yield break;
             _assignmentSnapshot = _coordinator.Assignment;
 
             var assignment = _assignmentSnapshot;

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -9,10 +9,8 @@ using Dekaf.Protocol.Messages;
 using Dekaf.Retry;
 using Microsoft.Extensions.Logging;
 #if NETSTANDARD2_0
-using StringSet = System.Collections.Generic.IReadOnlyCollection<string>;
 using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
 #else
-using StringSet = System.Collections.Generic.IReadOnlySet<string>;
 using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
 #endif
 
@@ -50,8 +48,9 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     private readonly Func<int> _getCoordinationConnectionIndex;
 
     private volatile int _heartbeatIntervalMs;
-    private int _subscriptionChanged; // 0 = false, 1 = true; use Interlocked.Exchange for atomic snapshot
-    private volatile StringSet? _subscribedTopics;
+    private volatile HashSet<string>? _subscribedTopics;
+    private int _subscriptionVersion;
+    private int _acknowledgedSubscriptionVersion;
 
     internal static int GetCoordinationConnectionIndex(int connectionsPerBroker)
         => connectionsPerBroker - 1;
@@ -100,6 +99,15 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     internal void NotifyAssignmentChange()
         => Interlocked.Exchange(ref _assignmentChanged, null)?.TrySetResult(true);
 
+    // Subscription snapshots are immutable after publication. The consumer compares
+    // contents on Subscribe, keeping this work out of the stable per-poll path.
+    internal void UpdateSubscription(HashSet<string> topics)
+    {
+        _subscribedTopics = topics;
+        Interlocked.Increment(ref _subscriptionVersion);
+        NotifyAssignmentChange();
+    }
+
     internal ConsumerGroupStatus CaptureGroupStatus()
     {
         var assignment = _assignedPartitions;
@@ -134,7 +142,6 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     /// Ensures the share consumer has joined the group.
     /// </summary>
     public async ValueTask EnsureActiveGroupAsync(
-        StringSet topics,
         CancellationToken cancellationToken)
     {
         if (Volatile.Read(ref _disposed) != 0)
@@ -143,7 +150,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
         if (_state == CoordinatorState.Stable)
             return;
 
-        await EnsureActiveGroupCoreAsync(topics, cancellationToken).ConfigureAwait(false);
+        await EnsureActiveGroupCoreAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -328,30 +335,35 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     /// Sends a ShareGroupHeartbeat request and processes the response.
     /// </summary>
     private async ValueTask<bool> SendShareGroupHeartbeatAsync(
-        bool isInitial,
         CancellationToken cancellationToken)
     {
         using var connectionLease = await LeaseHeartbeatConnectionAsync(cancellationToken)
             .ConfigureAwait(false);
         var connection = connectionLease.Connection;
 
+        var memberEpoch = _memberEpoch;
+        // Capture the version before the immutable snapshot. Replacements during this
+        // request remain pending, and failures never acknowledge their version.
+        var subscriptionVersion = Volatile.Read(ref _subscriptionVersion);
+        var subscription = _subscribedTopics;
+        // Unsubscribe may race coordinator discovery or an in-flight join. Kafka rejects
+        // an empty epoch-zero subscription, so let the polling loop observe unsubscribe.
+        if (memberEpoch == 0 && subscription is not { Count: > 0 })
+            return false;
+
         // Share groups always use client-generated UUID v4 member IDs.
         // Generate once when _memberId is null; subsequent heartbeats reuse the stored ID.
         _memberId ??= Guid.NewGuid().ToString();
 
-        var memberEpoch = isInitial ? 0 : _memberEpoch;
-
-        // Atomically snapshot and clear the subscription-changed flag.
-        // Always send topics on initial join — required by the protocol.
-        var subscriptionChanged = Interlocked.Exchange(ref _subscriptionChanged, 0) == 1;
-        var subscribedTopics = (isInitial || subscriptionChanged) ? _subscribedTopics?.ToList() : null;
+        var subscribedTopics = (memberEpoch == 0 || subscriptionVersion != Volatile.Read(ref _acknowledgedSubscriptionVersion))
+            ? subscription?.ToList() : null;
 
         var request = new ShareGroupHeartbeatRequest
         {
             GroupId = _options.GroupId,
             MemberId = _memberId,
             MemberEpoch = memberEpoch,
-            RackId = isInitial ? _options.RackId : null,
+            RackId = memberEpoch == 0 ? _options.RackId : null,
             SubscribedTopicNames = subscribedTopics
         };
 
@@ -385,6 +397,8 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                 throw;
             }
         }
+
+        Volatile.Write(ref _acknowledgedSubscriptionVersion, subscriptionVersion);
 
         Volatile.Write(ref _lastSuccessfulHeartbeatTimestamp, Stopwatch.GetTimestamp());
         Volatile.Write(ref _lastHeartbeatFailure, null);
@@ -498,12 +512,8 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     /// Ensures the share consumer has joined the group using the ShareGroupHeartbeat API.
     /// </summary>
     private async ValueTask EnsureActiveGroupCoreAsync(
-        StringSet topics,
         CancellationToken cancellationToken)
     {
-        _subscribedTopics = topics;
-        Interlocked.Exchange(ref _subscriptionChanged, 1);
-
         await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
@@ -520,6 +530,9 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
 
             while (_state != CoordinatorState.Stable)
             {
+                if (_subscribedTopics is not { Count: > 0 } && _memberEpoch <= 0)
+                    return;
+
                 if (Stopwatch.GetElapsedTime(startedAt) > timeout)
                 {
                     throw new KafkaTimeoutException(
@@ -539,9 +552,20 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                     _state = CoordinatorState.Joining;
                     LogCoordinatorStateTransition(CoordinatorState.Joining);
 
-                    var gotAssignment = await SendShareGroupHeartbeatAsync(
-                        isInitial: _memberEpoch <= 0,
-                        cancellationToken).ConfigureAwait(false);
+                    var gotAssignment = await SendShareGroupHeartbeatAsync(cancellationToken).ConfigureAwait(false);
+
+                    if (_subscribedTopics is not { Count: > 0 })
+                    {
+                        // A join accepted before unsubscribe must publish the empty snapshot
+                        // before activation finishes. Failed publication uses the join retries.
+                        if (_memberEpoch > 0 && Volatile.Read(ref _subscriptionVersion) ==
+                            Volatile.Read(ref _acknowledgedSubscriptionVersion))
+                        {
+                            _state = CoordinatorState.Stable;
+                            break;
+                        }
+                        continue;
+                    }
 
                     if (gotAssignment && _assignedPartitions.Count > 0)
                     {
@@ -612,8 +636,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
             {
                 await Task.Delay(_heartbeatIntervalMs, cancellationToken).ConfigureAwait(false);
 
-                await SendShareGroupHeartbeatAsync(
-                    isInitial: false, cancellationToken).ConfigureAwait(false);
+                await SendShareGroupHeartbeatAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/tests/Dekaf.Tests.Integration/ShareConsumerSubscriptionTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerSubscriptionTests.cs
@@ -1,0 +1,58 @@
+using Dekaf.Admin;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("ShareConsumer")]
+[SupportsKafka(420)]
+[NotInParallel("ShareConsumerKafka42")]
+public sealed class ShareConsumerSubscriptionTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task JoinedConsumer_ReplacementTopicBecomesConsumable(bool batch)
+    {
+        var first = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        var second = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        var group = $"share-subscription-{Guid.NewGuid():N}";
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).Build();
+        await admin.IncrementalAlterConfigsAsync(new Dictionary<ConfigResource, IReadOnlyList<ConfigAlter>>
+        {
+            [new ConfigResource { Type = ConfigResourceType.Group, Name = group }] =
+                [ConfigAlter.Set("share.auto.offset.reset", "earliest")]
+        });
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).BuildAsync();
+        await ShareConsumerTestHelper.ProduceAsync(producer, first, count: 1);
+        await ShareConsumerTestHelper.ProduceAsync(producer, second, count: 1);
+        await using var consumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId(group)
+            .WithAcknowledgementMode(ShareAcknowledgementMode.Explicit).BuildAsync();
+        consumer.Subscribe(first);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(45));
+        await using var records = consumer.PollAsync(timeout.Token).GetAsyncEnumerator();
+        await using var batches = consumer.PollBatchesAsync(timeout.Token).GetAsyncEnumerator();
+        foreach (var topic in new[] { first, second })
+        {
+            consumer.Subscribe(topic);
+            if (batch)
+            {
+                await Assert.That(await batches.MoveNextAsync()).IsTrue();
+                await Assert.That(batches.Current.TopicPartition.Topic).IsEqualTo(topic);
+                foreach (var record in batches.Current)
+                    batches.Current.Acknowledge(record);
+            }
+            else
+            {
+                await Assert.That(await records.MoveNextAsync()).IsTrue();
+                await Assert.That(records.Current.Topic).IsEqualTo(topic);
+                consumer.Acknowledge(records.Current);
+            }
+            await consumer.CommitAsync(timeout.Token);
+        }
+        await Assert.That(consumer.Assignment.All(partition => partition.Topic == second)).IsTrue();
+        await consumer.CloseAsync(timeout.Token);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
@@ -28,12 +28,13 @@ public sealed class ShareConsumerConnectionOwnershipTests
         typeof(ShareConsumerCoordinator).GetField(
             "_coordinatorId",
             BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(coordinator, 1);
+        coordinator.UpdateSubscription(["topic"]);
         var method = typeof(ShareConsumerCoordinator).GetMethod(
             "SendShareGroupHeartbeatAsync",
             BindingFlags.Instance | BindingFlags.NonPublic)!;
         var heartbeat = (ValueTask<bool>)method.Invoke(
             coordinator,
-            [false, CancellationToken.None])!;
+            [CancellationToken.None])!;
 
         await Assert.ThrowsAsync<IOException>(async () => await heartbeat);
 
@@ -62,12 +63,13 @@ public sealed class ShareConsumerConnectionOwnershipTests
         typeof(ShareConsumerCoordinator).GetField(
             "_coordinatorId",
             BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(coordinator, 1);
+        coordinator.UpdateSubscription(["topic"]);
         var method = typeof(ShareConsumerCoordinator).GetMethod(
             "SendShareGroupHeartbeatAsync",
             BindingFlags.Instance | BindingFlags.NonPublic)!;
         var heartbeat = (ValueTask<bool>)method.Invoke(
             coordinator,
-            [false, CancellationToken.None])!;
+            [CancellationToken.None])!;
 
         await Assert.ThrowsAsync<BrokerVersionException>(async () => await heartbeat);
 

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerSubscriptionTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerSubscriptionTests.cs
@@ -1,0 +1,277 @@
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public sealed class ShareConsumerSubscriptionTests
+{
+    private static readonly string[] FirstTopics = ["first"];
+    private static readonly string[] SecondTopics = ["second"];
+    [Test]
+    public async Task StableConsumer_ReplacementSubscriptionIsSentOnce()
+    {
+        await using var fixture = new Fixture();
+        fixture.Consumer.Subscribe("first");
+        await fixture.Heartbeat();
+        fixture.Consumer.Subscribe("second");
+        await fixture.Heartbeat();
+        await Assert.That(fixture.Requests[^1].SubscribedTopicNames).IsEquivalentTo(SecondTopics);
+        await fixture.Heartbeat();
+        await Assert.That(fixture.Requests[^1].SubscribedTopicNames).IsNull();
+    }
+
+    [Test]
+    public async Task IdenticalSubscription_DoesNotRepublishOrWakeAssignmentWaiters()
+    {
+        await using var fixture = new Fixture();
+        fixture.Consumer.Subscribe("first", "second");
+        await fixture.Heartbeat();
+        var changed = fixture.Coordinator.GetAssignmentChangeTask();
+        fixture.Consumer.Subscribe("second", "first", "first");
+        await fixture.Heartbeat();
+        await Assert.That(fixture.Requests[^1].SubscribedTopicNames).IsNull();
+        await Assert.That(changed.IsCompleted).IsFalse();
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task FailedHeartbeat_RetriesReplacementSubscription(bool cancelled)
+    {
+        await using var fixture = new Fixture();
+        fixture.Consumer.Subscribe("first");
+        await fixture.Heartbeat();
+        fixture.Consumer.Subscribe("second");
+        fixture.Response = _ => ValueTask.FromException<ShareGroupHeartbeatResponse>(
+            cancelled ? new OperationCanceledException() : new IOException("send failed"));
+        try { await fixture.Heartbeat(); }
+        catch (Exception ex) when (ex is IOException or OperationCanceledException) { }
+        fixture.Response = _ => new(Fixture.Success());
+        await fixture.Heartbeat();
+        await Assert.That(fixture.Requests[^1].SubscribedTopicNames).IsEquivalentTo(SecondTopics);
+    }
+
+    [Test]
+    public async Task ReplacementDuringHeartbeat_RemainsPendingAfterOlderResponse()
+    {
+        await using var fixture = new Fixture();
+        fixture.Consumer.Subscribe("first");
+        var response = new TaskCompletionSource<ShareGroupHeartbeatResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.Response = _ => new(response.Task);
+        var heartbeat = fixture.Heartbeat();
+        fixture.Consumer.Subscribe("second");
+        response.SetResult(Fixture.Success());
+        await heartbeat;
+        fixture.Response = _ => new(Fixture.Success());
+        await fixture.Heartbeat();
+        await Assert.That(fixture.Requests[^1].SubscribedTopicNames).IsEquivalentTo(SecondTopics);
+    }
+
+    [Test]
+    public async Task Unsubscribe_PublishesEmptySubscription_AndAllowsResubscribe()
+    {
+        await using var fixture = new Fixture();
+        fixture.Consumer.Subscribe("first");
+        await fixture.Heartbeat();
+        fixture.Consumer.Unsubscribe();
+        await fixture.Heartbeat();
+        await Assert.That(fixture.Requests[^1].SubscribedTopicNames).IsNotNull();
+        await Assert.That(fixture.Requests[^1].SubscribedTopicNames!.Count).IsEqualTo(0);
+        fixture.Consumer.Subscribe("first");
+        await fixture.Heartbeat();
+        await Assert.That(fixture.Requests[^1].SubscribedTopicNames).IsEquivalentTo(FirstTopics);
+    }
+
+    [Test]
+    public async Task BrokerRejectedSubscription_IsRetried()
+    {
+        await using var fixture = new Fixture();
+        fixture.Consumer.Subscribe("first");
+        await fixture.Heartbeat();
+        fixture.Consumer.Subscribe("second");
+        fixture.Response = _ => new(new ShareGroupHeartbeatResponse { ErrorCode = ErrorCode.CoordinatorLoadInProgress });
+        await Assert.ThrowsAsync<GroupException>(async () => await fixture.Heartbeat());
+        fixture.Response = _ => new(Fixture.Success());
+        await fixture.Heartbeat();
+        await Assert.That(fixture.Requests[^1].SubscribedTopicNames).IsEquivalentTo(SecondTopics);
+    }
+
+    [Test]
+    public async Task EpochZeroHeartbeat_ResendsPreviouslyAcknowledgedSubscription()
+    {
+        await using var fixture = new Fixture();
+        fixture.Consumer.Subscribe("first");
+        await fixture.Heartbeat();
+        fixture.ResetMemberEpoch();
+        await fixture.Heartbeat();
+        await Assert.That(fixture.Requests[^1].SubscribedTopicNames).IsEquivalentTo(FirstTopics);
+    }
+
+    [Test]
+    public async Task UnsubscribeBeforeInitialHeartbeat_DoesNotSendInvalidEmptyJoin()
+    {
+        await using var fixture = new Fixture();
+        fixture.Consumer.Subscribe("first");
+        fixture.Consumer.Unsubscribe();
+        fixture.ResetMemberEpoch();
+        await Assert.That(await fixture.Heartbeat()).IsFalse();
+        await Assert.That(fixture.Requests.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task UnsubscribeDuringActivation_DoesNotFetch(bool batch)
+    {
+        await using var fixture = new Fixture();
+        fixture.Consumer.Subscribe("first");
+        fixture.PrepareJoin();
+        var joined = new TaskCompletionSource<ShareGroupHeartbeatResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.Response = request => request.MemberEpoch == 0 ? new(joined.Task) : new(Fixture.Success());
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await using var records = fixture.Consumer.PollAsync(timeout.Token).GetAsyncEnumerator();
+        await using var batches = fixture.Consumer.PollBatchesAsync(timeout.Token).GetAsyncEnumerator();
+        var pending = (batch ? batches.MoveNextAsync() : records.MoveNextAsync()).AsTask();
+        await Assert.That(pending.IsCompleted).IsFalse();
+        fixture.Consumer.Unsubscribe();
+        joined.SetResult(Fixture.Success());
+        await Assert.That(await pending.WaitAsync(TimeSpan.FromSeconds(3))).IsFalse();
+        await Assert.That(fixture.FetchRequests).IsEqualTo(0);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task UnsubscribeDuringJoin_PublishesEmptySubscription(bool failFirstPublication)
+    {
+        await using var fixture = new Fixture();
+        fixture.Consumer.Subscribe("first");
+        fixture.PrepareJoin();
+        var joined = new TaskCompletionSource<ShareGroupHeartbeatResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var published = new TaskCompletionSource<ShareGroupHeartbeatRequest>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var failed = false;
+        fixture.Response = request =>
+        {
+            if (request.MemberEpoch == 0) return new(joined.Task);
+            if (request.SubscribedTopicNames is { Count: 0 })
+            {
+                if (failFirstPublication && !failed)
+                {
+                    failed = true;
+                    return ValueTask.FromException<ShareGroupHeartbeatResponse>(new KafkaException(ErrorCode.NetworkException, "publication failed"));
+                }
+                published.TrySetResult(request);
+            }
+            return new(Fixture.Success());
+        };
+        var activation = fixture.Coordinator.EnsureActiveGroupAsync(CancellationToken.None);
+        await Assert.That(activation.IsCompleted).IsFalse();
+        fixture.Consumer.Unsubscribe();
+        joined.SetResult(Fixture.Success());
+        await activation;
+        await Assert.That(published.Task.IsCompletedSuccessfully).IsTrue();
+        var request = await published.Task.WaitAsync(TimeSpan.FromSeconds(3));
+        await Assert.That(request.MemberEpoch).IsEqualTo(1);
+        await Assert.That(request.SubscribedTopicNames!.Count).IsEqualTo(0);
+        await Assert.That(failed).IsEqualTo(failFirstPublication);
+    }
+
+    private sealed class Fixture : IAsyncDisposable
+    {
+        private static readonly MethodInfo SendHeartbeat = typeof(ShareConsumerCoordinator).GetMethod(
+            "SendShareGroupHeartbeatAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        private readonly MetadataManager _metadata;
+        public KafkaShareConsumer<string, string> Consumer { get; }
+        public ShareConsumerCoordinator Coordinator { get; }
+        public List<ShareGroupHeartbeatRequest> Requests { get; } = [];
+        public int FetchRequests { get; private set; }
+        public Func<ShareGroupHeartbeatRequest, ValueTask<ShareGroupHeartbeatResponse>> Response { get; set; }
+            = _ => new(Success());
+
+        public Fixture()
+        {
+            var options = new ShareConsumerOptions { BootstrapServers = ["localhost:9092"], GroupId = "subscription", ConnectionsPerBroker = 1, HeartbeatIntervalMs = 10 };
+            var connection = Substitute.For<IKafkaConnection>();
+            connection.SendAsync<ShareGroupHeartbeatRequest, ShareGroupHeartbeatResponse>(
+                Arg.Any<ShareGroupHeartbeatRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+                .Returns(call =>
+                {
+                    var request = call.Arg<ShareGroupHeartbeatRequest>();
+                    Requests.Add(request);
+                    return Response(request);
+                });
+            connection.SendAsync<ShareFetchRequest, ShareFetchResponse>(
+                Arg.Any<ShareFetchRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    FetchRequests++;
+                    return new ShareFetchResponse { ErrorCode = ErrorCode.None, Responses = [], NodeEndpoints = [] };
+                });
+            connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+                .Returns(new FindCoordinatorResponse
+                {
+                    Coordinators = [new Coordinator
+                    {
+                        Key = options.GroupId, NodeId = 1, Host = "localhost", Port = 9092
+                    }]
+                });
+            var pool = Substitute.For<IConnectionPool>();
+            pool.GetConnectionAsync(1, Arg.Any<CancellationToken>()).Returns(connection);
+            pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>()).Returns(connection);
+            _metadata = new MetadataManager(pool, options.BootstrapServers);
+            _metadata.SetApiVersion(ApiKey.ShareGroupHeartbeat, 0, 1);
+            _metadata.SetApiVersion(ApiKey.ShareFetch, 1, 2);
+            _metadata.SetApiVersion(ApiKey.FindCoordinator,
+                FindCoordinatorRequest.LowestSupportedVersion, FindCoordinatorRequest.HighestSupportedVersion);
+            _metadata.Metadata.Update(new MetadataResponse
+            {
+                Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
+                Topics = [new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None, Name = "first", TopicId = Guid.NewGuid(),
+                    Partitions = [new PartitionMetadata
+                    {
+                        ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = 1,
+                        ReplicaNodes = [1], IsrNodes = [1]
+                    }]
+                }]
+            });
+            Consumer = new KafkaShareConsumer<string, string>(options, Substitute.For<IDeserializer<string>>(),
+                Substitute.For<IDeserializer<string>>(), pool, _metadata);
+            Coordinator = (ShareConsumerCoordinator)typeof(KafkaShareConsumer<string, string>).GetField(
+                "_coordinator", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(Consumer)!;
+            Set("_coordinatorId", 1);
+            Set("_state", CoordinatorState.Stable);
+            Set("_memberEpoch", 1);
+        }
+
+        private void Set(string name, object value) => typeof(ShareConsumerCoordinator)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(Coordinator, value);
+        public void PrepareJoin()
+        {
+            Set("_state", CoordinatorState.Unjoined);
+            Set("_memberEpoch", 0);
+            Set("_assignedPartitions", new HashSet<TopicPartition> { new("first", 0) });
+            typeof(KafkaShareConsumer<string, string>).GetField("_initialized", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(Consumer, true);
+        }
+        public void ResetMemberEpoch() => Set("_memberEpoch", 0);
+        public ValueTask<bool> Heartbeat() => (ValueTask<bool>)SendHeartbeat.Invoke(Coordinator, [CancellationToken.None])!;
+        public static ShareGroupHeartbeatResponse Success() => new() { ErrorCode = ErrorCode.None, MemberEpoch = 1 };
+        public async ValueTask DisposeAsync()
+        {
+            Set("_memberId", null!);
+            await Consumer.DisposeAsync();
+            await _metadata.DisposeAsync();
+        }
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerPollBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerPollBenchmarks.cs
@@ -301,6 +301,33 @@ public class ShareConsumerPollBenchmarks
         TopicPartitions = [new ShareGroupHeartbeatTopicPartitions { TopicId = TopicId, Partitions = [0] }]
     };
 
+    private Func<bool, CancellationToken, ValueTask<bool>>? _sendLegacyHeartbeat;
+    private Func<CancellationToken, ValueTask<bool>>? _sendHeartbeat;
+
+    internal void PrepareSubscriptionHeartbeats()
+    {
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+        var coordinator = typeof(KafkaShareConsumer<int, int>).GetField("_coordinator", flags)!.GetValue(_compatibility)!;
+        typeof(ShareConsumerCoordinator).GetField("_coordinatorId", flags)!.SetValue(coordinator, 1);
+        var method = typeof(ShareConsumerCoordinator).GetMethod("SendShareGroupHeartbeatAsync", flags)!;
+        // Keep the same fixture compatible with the baseline's redundant initial-join argument.
+        if (method.GetParameters().Length == 1)
+            _sendHeartbeat = method.CreateDelegate<Func<CancellationToken, ValueTask<bool>>>(coordinator);
+        else
+            _sendLegacyHeartbeat = method.CreateDelegate<Func<bool, CancellationToken, ValueTask<bool>>>(coordinator);
+    }
+
+    internal ValueTask<bool> SendSubscriptionHeartbeat()
+    {
+        var pending = _sendHeartbeat is { } send
+            ? send(CancellationToken.None) : _sendLegacyHeartbeat!(false, CancellationToken.None);
+        _connection.CompleteHeartbeat();
+        return pending;
+    }
+
+    internal void RepeatSubscription(bool batch)
+        => (batch ? _borrowed : _compatibility).Subscribe(Topic);
+
     internal void PrepareIdlePolling(bool batch)
     {
         var consumer = batch ? _borrowed : _compatibility;
@@ -454,10 +481,13 @@ public class ShareConsumerPollBenchmarks
     }
 
     private sealed class Connection(ShareFetchResponse fetch, bool asynchronous)
-        : IKafkaConnection, IKafkaCapabilityProvider, IValueTaskSource<ShareFetchResponse>
+        : IKafkaConnection, IKafkaCapabilityProvider, IValueTaskSource<ShareFetchResponse>, IValueTaskSource<ShareGroupHeartbeatResponse>
     {
         private ManualResetValueTaskSourceCore<ShareFetchResponse> _completion;
         private bool _pending;
+        private ManualResetValueTaskSourceCore<ShareGroupHeartbeatResponse> _heartbeatCompletion;
+        private bool _heartbeatPending;
+        private readonly ShareGroupHeartbeatResponse _heartbeat = new() { ErrorCode = ErrorCode.None, MemberEpoch = 1 };
         internal MetadataResponse MetadataResponse { get; set; } = null!;
         internal TaskCompletionSource<MetadataResponse>? PendingMetadata { get; set; }
         internal bool Asynchronous { get; set; } = asynchronous;
@@ -475,7 +505,7 @@ public class ShareConsumerPollBenchmarks
         public KafkaConnectionCapabilities Capabilities { get; } = KafkaConnectionCapabilities.Create(new ApiVersionsResponse
         {
             ErrorCode = ErrorCode.None,
-            ApiKeys = [new ApiVersion(ApiKey.ShareFetch, 1, 2), new ApiVersion(ApiKey.ShareAcknowledge, 1, 2),
+            ApiKeys = [new ApiVersion(ApiKey.ShareGroupHeartbeat, 0, 1), new ApiVersion(ApiKey.ShareFetch, 1, 2), new ApiVersion(ApiKey.ShareAcknowledge, 1, 2),
                 new ApiVersion(ApiKey.Metadata, MetadataRequest.LowestSupportedVersion, MetadataRequest.HighestSupportedVersion)]
         });
 
@@ -507,6 +537,14 @@ public class ShareConsumerPollBenchmarks
                         ReleasedOffsets += acquired.LastOffset - acquired.FirstOffset + 1;
                 }
             }
+            if (Asynchronous && request is ShareGroupHeartbeatRequest)
+            {
+                if (_heartbeatPending)
+                    throw new InvalidOperationException("The fixture allows one pending heartbeat at a time.");
+                _heartbeatCompletion.Reset();
+                _heartbeatPending = true;
+                return new ValueTask<TResponse>((IValueTaskSource<TResponse>)(object)this, _heartbeatCompletion.Version);
+            }
             if (Asynchronous && request is ShareFetchRequest)
             {
                 if (_pending)
@@ -517,6 +555,7 @@ public class ShareConsumerPollBenchmarks
             }
             IKafkaResponse response = request switch
             {
+                ShareGroupHeartbeatRequest => _heartbeat,
                 ShareFetchRequest => fetch,
                 ShareAcknowledgeRequest => _acknowledge,
                 MetadataRequest => MetadataResponse,
@@ -537,6 +576,18 @@ public class ShareConsumerPollBenchmarks
             _pending = false;
             _completion.SetResult(fetch);
         }
+
+        internal void CompleteHeartbeat()
+        {
+            if (!_heartbeatPending) return;
+            _heartbeatPending = false;
+            _heartbeatCompletion.SetResult(_heartbeat);
+        }
+
+        ShareGroupHeartbeatResponse IValueTaskSource<ShareGroupHeartbeatResponse>.GetResult(short token) => _heartbeatCompletion.GetResult(token);
+        ValueTaskSourceStatus IValueTaskSource<ShareGroupHeartbeatResponse>.GetStatus(short token) => _heartbeatCompletion.GetStatus(token);
+        void IValueTaskSource<ShareGroupHeartbeatResponse>.OnCompleted(Action<object?> continuation, object? state,
+            short token, ValueTaskSourceOnCompletedFlags flags) => _heartbeatCompletion.OnCompleted(continuation, state, token, flags);
 
         ShareFetchResponse IValueTaskSource<ShareFetchResponse>.GetResult(short token) => _completion.GetResult(token);
         ValueTaskSourceStatus IValueTaskSource<ShareFetchResponse>.GetStatus(short token) => _completion.GetStatus(token);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerSubscriptionBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerSubscriptionBenchmarks.cs
@@ -1,0 +1,34 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Measures stable polling and repeated equivalent subscriptions through the public API.</summary>
+[MemoryDiagnoser]
+public class ShareConsumerSubscriptionBenchmarks
+{
+    private ShareConsumerPollBenchmarks _consumer = null!;
+
+    [Params(1, 1024)] public int RecordCount { get; set; }
+    [Params(false, true)] public bool Batch { get; set; }
+
+    [GlobalSetup]
+    public async ValueTask Setup()
+    {
+        _consumer = new ShareConsumerPollBenchmarks { RecordCount = RecordCount };
+        await _consumer.Setup();
+    }
+
+    [Benchmark]
+    public ValueTask<long> StablePoll()
+        => Batch ? _consumer.PollBorrowedBatch() : _consumer.PollCompatibilityBatch();
+
+    [Benchmark]
+    public ValueTask<long> EquivalentSubscriptionAndPoll()
+    {
+        _consumer.RepeatSubscription(Batch);
+        return StablePoll();
+    }
+
+    [GlobalCleanup]
+    public ValueTask Cleanup() => _consumer.Cleanup();
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerSubscriptionHeartbeatBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerSubscriptionHeartbeatBenchmarks.cs
@@ -1,0 +1,27 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Includes real heartbeat handling and deterministic response suspension, excluding broker latency.</summary>
+[MemoryDiagnoser]
+public class ShareConsumerSubscriptionHeartbeatBenchmarks
+{
+    private ShareConsumerPollBenchmarks _consumer = null!;
+
+    [Params(false, true)] public bool AsynchronousResponse { get; set; }
+
+    [GlobalSetup]
+    public async ValueTask Setup()
+    {
+        _consumer = new ShareConsumerPollBenchmarks { RecordCount = 1, AsynchronousResponse = AsynchronousResponse };
+        await _consumer.Setup();
+        _consumer.PrepareSubscriptionHeartbeats();
+        await _consumer.SendSubscriptionHeartbeat();
+    }
+
+    [Benchmark]
+    public ValueTask<bool> UnchangedHeartbeat() => _consumer.SendSubscriptionHeartbeat();
+
+    [GlobalCleanup]
+    public ValueTask Cleanup() => _consumer.Cleanup();
+}


### PR DESCRIPTION
Joined share consumers now publish replacement topics on the next ShareGroupHeartbeat. Subscription versions remain pending until a successful response, preserving updates across failed/cancelled sends and replacements during an in-flight heartbeat. Equivalent subscriptions retain the existing snapshot and avoid assignment wakeups.

If unsubscribe races an accepted join, activation publishes the empty subscription through its existing retry loop before returning. Both classic and batch polling recheck subscription after activation, preventing a stale assignment from starting another fetch. Empty epoch-zero joins remain suppressed. The rebase preserves owner-pool cleanup from #3158, with cleanup preceding the unsubscribe wakeup.

Costs are per subscription change, heartbeat or poll batch: one additional coordinator integer, version reads/writes per heartbeat, a topic list per publication/join, and one subscription-count check after each poll activation. No new per-record work or allocation is introduced.

Validation at 2a58488744b3d9c73dd0c8640cee9cfdb6fbd68e, based on 322449fb085f753a8b300de5526a532d231693ee:
- Release build: zero warnings/errors. All 504 share-consumer unit cases pass on each of net10.0 and net8.0.
- Four deterministic review regressions failed before the fixes. Coverage includes both poll APIs and a failed first empty-subscription publication, proving publication succeeds before activation returns.
- Kafka 4.3.1: ten tests pass: subscription replacement (2), idle unsubscribe (2), close (4), and retained-payload ownership under sustained multi-partition fetches (2).
- Ten steady-state ShortRun cases use identical fixture files against fresh main. Every case has exactly zero allocation delta. Unchanged heartbeats remain 56 B synchronously and 240 B with deterministic response suspension. Both runs retain generated BenchmarkDotNet workers with --keepFiles.
- Local timing is diagnostic only. Median deltas range from -37.04% to +18.41%; the positive outlier is classic equivalent-subscription polling at one record. No timing win or accepted tradeoff is claimed. The hosted A1/B/A2 gate remains required.
- Performance-selector tests (45), artifact policy and diff checks pass. Full-diff review for correctness, reuse and hot-path costs is complete.

Loaded acceptance remains pending #3248 and the combined lifecycle validation tracked by #3245. #3158 merged separately, but its repeated hosted cold-preparation regression remains unresolved under #3103. No paid stress run was dispatched against these unresolved prerequisites. The maintained hosted-share-1b lane must pass at exact fresh-main/candidate SHAs before merge.

Evidence is retained outside disposable worktrees at D:/Dekaf-evidence/pr-3256/rebase-3158. final-tests contains exact source and 1629 hash-verified test binary/report entries; final-idle-report.html and the raw integration logs preserve both integration commands. baseline-binaries and candidate-binaries each retain exact source and 1005 hash-verified entries, including the actual generated BenchmarkDotNet workers. Raw logs/exports, fixture hashes, comparison.json, validation-inputs.txt, original failing tests and the intermediate failed retry experiment are retained. The directory SHA-256 inventory is verified. Earlier implementation evidence remains in D:/Dekaf-evidence/issue-3255; this fresh-main comparison supersedes those earlier measurements for the current head.

Closes #3255
