### PR TITLE
perf(consumer): compact scalar lane dictionary storage

### DIFF
--- a/.github/scripts/performance_gate.py
+++ b/.github/scripts/performance_gate.py
@@ -41,9 +41,11 @@ COMMENT = re.compile(r'//[^\n]*|/\*.*?\*/', re.S)
 # finishes in roughly 25 minutes.
 SENTINELS = ('AccumulatorAppendBenchmarks', 'ConsumerHotPathBenchmarks',
              'FetchResponseParsingBenchmarks', 'ProduceResponseParsingBenchmarks')
+KEY_DISPATCH_BENCHMARKS = ('PartitionMessageKeyBenchmarks', 'BinaryKeyDispatchBenchmarks',
+                           'DistinctBinaryKeyDispatchBenchmarks', 'SharedSuffixBinaryKeyDispatchBenchmarks')
 COMPONENTS = {
-    'src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.cs': ('PartitionMessageKeyBenchmarks',),
-    'src/Dekaf/Consumer/PartitionMessageKey.cs': ('PartitionMessageKeyBenchmarks',),
+    'src/Dekaf/Consumer/KeyOrderedPartitionDispatcher': KEY_DISPATCH_BENCHMARKS,
+    'src/Dekaf/Consumer/PartitionMessageKey.cs': KEY_DISPATCH_BENCHMARKS,
     'src/Dekaf.Testing/': ('InMemoryMemberRegistrationBenchmarks', 'InMemoryDetailedClientQuotaBenchmarks',
                          'InMemoryDeliveryCallbackBenchmarks', 'InMemoryClassicGroupDescriptionBenchmarks'),
     'src/Dekaf/Admin/': ('AdminDetailedMutationBenchmarks', 'AdminMemberRemovalBenchmarks', 'AdminDetailedShareGroupOffsetBenchmarks',

--- a/.github/scripts/test_performance_gate.py
+++ b/.github/scripts/test_performance_gate.py
@@ -68,12 +68,18 @@ class SelectionTests(unittest.TestCase):
     def test_partition_message_key_selects_direct_fixture(self):
         path = 'src/Dekaf/Consumer/PartitionMessageKey.cs'
         selected = self.names(gate.select([path], root=REPO_ROOT))
-        self.assertIn('PartitionMessageKeyBenchmarks', selected)
+        for name in ('PartitionMessageKeyBenchmarks', 'BinaryKeyDispatchBenchmarks',
+                     'DistinctBinaryKeyDispatchBenchmarks', 'SharedSuffixBinaryKeyDispatchBenchmarks'):
+            self.assertIn(name, selected)
 
     def test_key_ordered_dispatcher_selects_message_key_fixture(self):
-        path = 'src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.cs'
-        selected = self.names(gate.select([path], root=REPO_ROOT))
-        self.assertIn('PartitionMessageKeyBenchmarks', selected)
+        for path in ('src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.cs',
+                     'src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.Storage.cs'):
+            with self.subTest(path=path):
+                selected = self.names(gate.select([path], root=REPO_ROOT))
+                for name in ('PartitionMessageKeyBenchmarks', 'BinaryKeyDispatchBenchmarks',
+                             'DistinctBinaryKeyDispatchBenchmarks', 'SharedSuffixBinaryKeyDispatchBenchmarks'):
+                    self.assertIn(name, selected)
 
     def test_detailed_mutation_paths_select_direct_fixture(self):
         for path in ('src/Dekaf/Admin/AdminClient.cs', 'src/Dekaf/Admin/AdminClient.DetailedTopicMutations.cs'):

--- a/src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.Storage.cs
+++ b/src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.Storage.cs
@@ -1,0 +1,76 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Dekaf.Consumer;
+
+internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
+{
+    // A dictionary entry aligns its lane reference after the key. Compact only when
+    // that alignment bucket shrinks; larger keys retain their existing representation.
+    // The size comparison folds away for reference keys before the binary type checks.
+    private static bool UseCompactKeys
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => ((Unsafe.SizeOf<PartitionMessageKey<TKey>.Uncached>() + IntPtr.Size - 1) & -IntPtr.Size)
+            < ((Unsafe.SizeOf<PartitionMessageKey<TKey>>() + IntPtr.Size - 1) & -IntPtr.Size)
+            && typeof(TKey) != typeof(byte[])
+            && typeof(TKey) != typeof(ReadOnlyMemory<byte>)
+            && typeof(TKey) != typeof(Memory<byte>)
+            && typeof(TKey) != typeof(ArraySegment<byte>);
+    }
+
+    // Only the constructor assigns _lanes, using the same predicate as every access.
+    // These exact casts avoid a wrapper allocation and per-record interface dispatch.
+    private Dictionary<PartitionMessageKey<TKey>.Uncached, KeyLane> CompactLanes =>
+        Unsafe.As<Dictionary<PartitionMessageKey<TKey>.Uncached, KeyLane>>(_lanes);
+
+    private Dictionary<PartitionMessageKey<TKey>, KeyLane> StandardLanes =>
+        Unsafe.As<Dictionary<PartitionMessageKey<TKey>, KeyLane>>(_lanes);
+
+    private int StorageCount => UseCompactKeys ? CompactLanes.Count : StandardLanes.Count;
+
+#if NETSTANDARD2_0
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryGetLane(PartitionMessageKey<TKey> key, out KeyLane lane) => UseCompactKeys
+        ? CompactLanes.TryGetValue(new(key), out lane!)
+        : StandardLanes.TryGetValue(key, out lane!);
+
+    private void AddLane(PartitionMessageKey<TKey> key, KeyLane lane)
+    {
+        if (UseCompactKeys) CompactLanes.Add(new(key), lane);
+        else StandardLanes.Add(key, lane);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool RemoveLane(PartitionMessageKey<TKey> key) => UseCompactKeys
+        ? CompactLanes.Remove(new(key)) : StandardLanes.Remove(key);
+#else
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ref KeyLane? GetLaneEntry(PartitionMessageKey<TKey> key)
+    {
+        if (UseCompactKeys)
+            return ref CollectionsMarshal.GetValueRefOrAddDefault(CompactLanes, new(key), out _);
+        return ref CollectionsMarshal.GetValueRefOrAddDefault(StandardLanes, key, out _);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool RemoveLane(PartitionMessageKey<TKey> key, out KeyLane? lane) => UseCompactKeys
+        ? CompactLanes.Remove(new(key), out lane) : StandardLanes.Remove(key, out lane);
+#endif
+
+    private void ReleaseLanes()
+    {
+        if (UseCompactKeys)
+        {
+            var lanes = CompactLanes;
+            foreach (var lane in lanes.Values) lane?.ReleaseKey();
+            lanes.Clear();
+        }
+        else
+        {
+            var lanes = StandardLanes;
+            foreach (var lane in lanes.Values) lane?.ReleaseKey();
+            lanes.Clear();
+        }
+    }
+}

--- a/src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.cs
+++ b/src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.cs
@@ -1,21 +1,20 @@
 using System.Buffers;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
-using System.Runtime.InteropServices;
 using Dekaf.Internal;
 
 namespace Dekaf.Consumer;
 
 // Only RunAsync owns queues, key membership and commit progress. Handler callbacks
 // publish completed workers to an intrusive stack and wake that single coordinator.
-internal sealed class KeyOrderedPartitionDispatcher<TKey, TValue>
+internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
 {
     private readonly PartitionProcessorContext<TKey, TValue> _context;
     private readonly Func<IReadOnlyList<ConsumeResult<TKey, TValue>>, CancellationToken, ValueTask> _processor;
     private PendingRecord[] _records;
     private readonly int _maxBufferedRecords;
-    private readonly Dictionary<PartitionMessageKey<TKey>, KeyLane> _lanes;
-    private readonly BinaryPartitionMessageKeyComparer<TKey>? _binaryKeyComparer;
+    private readonly object _lanes;
+    private readonly bool _hasBinaryKeyComparer;
     private readonly Stack<KeyLane> _freeLanes;
     private readonly Queue<KeyLane> _readyLanes;
     private readonly Stack<Worker> _freeWorkers;
@@ -64,15 +63,24 @@ internal sealed class KeyOrderedPartitionDispatcher<TKey, TValue>
         // A batch size is an upper bound. Divide reusable storage across workers so
         // multiplying the two user limits cannot allocate quadratic record storage.
         _batchSize = Math.Min(maxBatchSize, Math.Max(1, maxBufferedRecords / _maxWorkers));
-        IEqualityComparer<PartitionMessageKey<TKey>>? comparer = null;
-        if (_maxWorkers != 1 || _batchSize != 1)
+        if (UseCompactKeys)
         {
-            comparer = keyComparer is null
-                ? PartitionMessageKeyComparer<TKey>.Default
-                : new CustomPartitionMessageKeyComparer<TKey>(keyComparer);
+            var comparer = keyComparer is not null && (_maxWorkers != 1 || _batchSize != 1)
+                ? new CustomUncachedPartitionMessageKeyComparer<TKey>(keyComparer) : null;
+            _lanes = new Dictionary<PartitionMessageKey<TKey>.Uncached, KeyLane>(initialCapacity, comparer);
         }
-        _binaryKeyComparer = comparer as BinaryPartitionMessageKeyComparer<TKey>;
-        _lanes = new Dictionary<PartitionMessageKey<TKey>, KeyLane>(initialCapacity, comparer);
+        else
+        {
+            IEqualityComparer<PartitionMessageKey<TKey>>? comparer = null;
+            if (_maxWorkers != 1 || _batchSize != 1)
+            {
+                comparer = keyComparer is null
+                    ? PartitionMessageKeyComparer<TKey>.Default
+                    : new CustomPartitionMessageKeyComparer<TKey>(keyComparer);
+            }
+            _hasBinaryKeyComparer = comparer is BinaryPartitionMessageKeyComparer<TKey>;
+            _lanes = new Dictionary<PartitionMessageKey<TKey>, KeyLane>(initialCapacity, comparer);
+        }
         _freeLanes = new Stack<KeyLane>(initialCapacity);
         _readyLanes = new Queue<KeyLane>(initialCapacity);
         _freeWorkers = new Stack<Worker>(Math.Min(_maxWorkers, initialCapacity));
@@ -173,9 +181,7 @@ internal sealed class KeyOrderedPartitionDispatcher<TKey, TValue>
                 _records[index] = default;
             }
 
-            foreach (var lane in _lanes.Values)
-                lane?.ReleaseKey();
-            _lanes.Clear();
+            ReleaseLanes();
             if (_failure is not null)
             {
                 // A failed removal can displace another lane. No new dispatch starts
@@ -242,29 +248,31 @@ internal sealed class KeyOrderedPartitionDispatcher<TKey, TValue>
         var key = _maxWorkers == 1 && _batchSize == 1
             ? default
             : PartitionMessageKey<TKey>.From(record.Key, record.IsKeyNull);
-        if (_binaryKeyComparer is not null && key.HasValue)
-            key = key.WithBinaryHashCode(_binaryKeyComparer.GetHashCode(key));
+        var binaryKeyComparer = _hasBinaryKeyComparer
+            ? Unsafe.As<BinaryPartitionMessageKeyComparer<TKey>>(StandardLanes.Comparer) : null;
+        if (binaryKeyComparer is not null && key.HasValue)
+            key = key.WithBinaryHashCode(binaryKeyComparer.GetHashCode(key));
 #if NETSTANDARD2_0
-        if (!_lanes.TryGetValue(key, out var lane))
+        if (!TryGetLane(key, out var lane))
         {
             lane = _freeLanes.Count != 0 ? _freeLanes.Pop() : new KeyLane();
             lane.Key = key;
             lane.KeyStorage = record.RetainStorage();
             try
             {
-                _lanes.Add(key, lane);
+                AddLane(key, lane);
             }
             catch
             {
                 lane.ReleaseKey();
                 throw;
             }
-            Volatile.Write(ref _laneCount, _lanes.Count);
+            Volatile.Write(ref _laneCount, StorageCount);
         }
 #else
         // The coordinator owns membership. Publish the lane before retaining its
         // storage, so shutdown owns cleanup even if initialization fails.
-        ref var entry = ref CollectionsMarshal.GetValueRefOrAddDefault(_lanes, key, out _);
+        ref var entry = ref GetLaneEntry(key);
         var lane = entry;
         if (lane is null)
         {
@@ -272,7 +280,7 @@ internal sealed class KeyOrderedPartitionDispatcher<TKey, TValue>
             entry = lane;
             lane.Key = key;
             lane.KeyStorage = record.RetainStorage();
-            Volatile.Write(ref _laneCount, _lanes.Count);
+            Volatile.Write(ref _laneCount, StorageCount);
         }
 #endif
 
@@ -286,30 +294,31 @@ internal sealed class KeyOrderedPartitionDispatcher<TKey, TValue>
             lane.Scheduled = true;
             _readyLanes.Enqueue(lane);
         }
-        if (_binaryKeyComparer is { NeedsFullHashing: true })
-            StrengthenBinaryHashing();
+        if (binaryKeyComparer is { NeedsFullHashing: true })
+            StrengthenBinaryHashing(binaryKeyComparer);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void StrengthenBinaryHashing()
+    private void StrengthenBinaryHashing(BinaryPartitionMessageKeyComparer<TKey> comparer)
     {
         // Rebuild at most once per dispatcher after repeated expensive collisions.
         // Reuse dictionary capacity and rent temporary references; ordinary probes
         // neither allocate another table nor scan the active lanes.
-        var count = _lanes.Count;
+        var dictionary = StandardLanes;
+        var count = dictionary.Count;
         var lanes = ArrayPool<KeyLane>.Shared.Rent(count);
         try
         {
-            _lanes.Values.CopyTo(lanes, 0);
+            dictionary.Values.CopyTo(lanes, 0);
             try
             {
-                _lanes.Clear();
-                _binaryKeyComparer!.EnableFullHashing();
+                dictionary.Clear();
+                comparer.EnableFullHashing();
                 for (var index = 0; index < count; index++)
                 {
                     var lane = lanes[index];
-                    lane.Key = lane.Key.WithBinaryHashCode(_binaryKeyComparer.ComputeHashCode(lane.Key));
-                    _lanes.Add(lane.Key, lane);
+                    lane.Key = lane.Key.WithBinaryHashCode(comparer.ComputeHashCode(lane.Key));
+                    dictionary.Add(lane.Key, lane);
                 }
             }
             catch (Exception error)
@@ -443,10 +452,10 @@ internal sealed class KeyOrderedPartitionDispatcher<TKey, TValue>
             // A mutable user key can make its dictionary entry unreachable.
             // Keep the lane owned until shutdown instead of pooling an alias.
 #if NETSTANDARD2_0
-            if (!_lanes.TryGetValue(lane.Key, out var found) || !ReferenceEquals(found, lane) || !_lanes.Remove(lane.Key))
+            if (!TryGetLane(lane.Key, out var found) || !ReferenceEquals(found, lane) || !RemoveLane(lane.Key))
                 throw new InvalidOperationException("A partition key changed its hash code or equality while being processed.");
 #else
-            if (!_lanes.Remove(lane.Key, out var removed) || !ReferenceEquals(removed, lane))
+            if (!RemoveLane(lane.Key, out var removed) || !ReferenceEquals(removed, lane))
             {
                 // A mutated key may remove a different active lane. Keep its storage
                 // owned until every handler finishes, even though membership is gone.
@@ -459,7 +468,7 @@ internal sealed class KeyOrderedPartitionDispatcher<TKey, TValue>
             lane.Scheduled = false;
             lane.Tail = -1;
             _freeLanes.Push(lane);
-            Volatile.Write(ref _laneCount, _lanes.Count);
+            Volatile.Write(ref _laneCount, StorageCount);
         }
 
         if (frontierChanged)

--- a/src/Dekaf/Consumer/PartitionMessageKey.cs
+++ b/src/Dekaf/Consumer/PartitionMessageKey.cs
@@ -72,6 +72,28 @@ internal readonly struct PartitionMessageKey<TKey> : IEquatable<PartitionMessage
         => HasValue ? comparer.GetHashCode(_value!) : 0;
 
     internal bool HasSameKind(PartitionMessageKey<TKey> other) => _kind == other._kind;
+
+    // Scalar dictionary entries do not need the binary hash retained by a lane.
+    // Keep the kind independent of the value so wire null never aliases default(TKey).
+    internal readonly struct Uncached(PartitionMessageKey<TKey> key) : IEquatable<Uncached>
+    {
+        private readonly TKey? _value = key._value;
+        private readonly KeyKind _kind = key._kind;
+
+        public bool Equals(Uncached other) => _kind == other._kind
+            && (_kind != KeyKind.Value || EqualityComparer<TKey>.Default.Equals(_value!, other._value!));
+
+        public override bool Equals(object? obj) => obj is Uncached other && Equals(other);
+
+        public override int GetHashCode() => _kind == KeyKind.Value
+            ? EqualityComparer<TKey>.Default.GetHashCode(_value!) : 0;
+
+        internal bool Equals(Uncached other, IEqualityComparer<TKey> comparer) => _kind == other._kind
+            && (_kind != KeyKind.Value || comparer.Equals(_value!, other._value!));
+
+        internal int GetHashCode(IEqualityComparer<TKey> comparer) => _kind == KeyKind.Value
+            ? comparer.GetHashCode(_value!) : 0;
+    }
 }
 
 internal static class PartitionMessageKeyComparer<TKey>
@@ -179,4 +201,13 @@ internal sealed class CustomPartitionMessageKeyComparer<TKey>(IEqualityComparer<
     public bool Equals(PartitionMessageKey<TKey> x, PartitionMessageKey<TKey> y) => x.Equals(y, comparer);
 
     public int GetHashCode(PartitionMessageKey<TKey> obj) => obj.GetHashCode(comparer);
+}
+
+internal sealed class CustomUncachedPartitionMessageKeyComparer<TKey>(IEqualityComparer<TKey> comparer)
+    : IEqualityComparer<PartitionMessageKey<TKey>.Uncached>
+{
+    public bool Equals(PartitionMessageKey<TKey>.Uncached x, PartitionMessageKey<TKey>.Uncached y)
+        => x.Equals(y, comparer);
+
+    public int GetHashCode(PartitionMessageKey<TKey>.Uncached obj) => obj.GetHashCode(comparer);
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/KeyOrderedStorageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KeyOrderedStorageTests.cs
@@ -1,0 +1,70 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Dekaf.Consumer;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class KeyOrderedStorageTests
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task ScalarDictionaryKey_DoesNotPayForBinaryHashStorage(bool customComparer)
+    {
+        var dictionary = CreateDictionary<int>(customComparer ? EqualityComparer<int>.Default : null);
+        var keyType = dictionary.GetType().GenericTypeArguments[0];
+        var keySize = (int)typeof(KeyOrderedStorageTests)
+            .GetMethod(nameof(SizeOf), BindingFlags.NonPublic | BindingFlags.Static)!
+            .MakeGenericMethod(keyType).Invoke(null, null)!;
+
+        // Eight bytes fit the original 24-byte dictionary entry (hash, next, key, lane).
+        // A twelve-byte key enlarges every preallocated entry to 32 bytes on x64.
+        await Assert.That(keySize).IsEqualTo(8);
+    }
+
+    [Test]
+    public async Task BinaryDictionaryKey_RetainsFullCachedHashRepresentation()
+    {
+        await Assert.That(CreateDictionary<byte[]>().GetType().GenericTypeArguments[0])
+            .IsEqualTo(typeof(PartitionMessageKey<byte[]>));
+        await Assert.That(CreateDictionary<ReadOnlyMemory<byte>>().GetType().GenericTypeArguments[0])
+            .IsEqualTo(typeof(PartitionMessageKey<ReadOnlyMemory<byte>>));
+    }
+
+    private static int SizeOf<T>() => Unsafe.SizeOf<T>();
+
+    [Test]
+    public async Task CompactKeys_CustomComparerPreservesWireNullAndDefaultValue()
+    {
+        var comparer = new CustomUncachedPartitionMessageKeyComparer<int>(new ModuloTenComparer());
+        var wireNull = new PartitionMessageKey<int>.Uncached(PartitionMessageKey<int>.From(0, isKeyNull: true));
+        var zero = new PartitionMessageKey<int>.Uncached(PartitionMessageKey<int>.From(0));
+        var ten = new PartitionMessageKey<int>.Uncached(PartitionMessageKey<int>.From(10));
+        var keys = new Dictionary<PartitionMessageKey<int>.Uncached, string>(comparer)
+        {
+            [wireNull] = "wire-null",
+            [zero] = "value"
+        };
+        await Assert.That(keys.Count).IsEqualTo(2);
+        await Assert.That(keys[wireNull]).IsEqualTo("wire-null");
+        await Assert.That(keys[ten]).IsEqualTo("value");
+        await Assert.That(comparer.GetHashCode(zero)).IsEqualTo(comparer.GetHashCode(ten));
+    }
+
+    internal sealed class ModuloTenComparer : IEqualityComparer<int>
+    {
+        public bool Equals(int x, int y) => x % 10 == y % 10;
+        public int GetHashCode(int obj) => 0; // Also exercise collisions with the wire-null key.
+    }
+
+    private static object CreateDictionary<TKey>(IEqualityComparer<TKey>? comparer = null)
+    {
+        var lane = new PartitionLane<TKey, int>(new TopicPartition("topic", 0), 128,
+            static (_, _) => default, static _ => { }, static (_, error) => throw error);
+        var dispatcher = new KeyOrderedPartitionDispatcher<TKey, int>(
+            new PartitionProcessorContext<TKey, int>(lane), 16, 2, 128,
+            static (_, _) => default, comparer);
+        return typeof(KeyOrderedPartitionDispatcher<TKey, int>)
+            .GetField("_lanes", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(dispatcher)!;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedDispatchCoordinatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedDispatchCoordinatorTests.cs
@@ -9,6 +9,42 @@ namespace Dekaf.Tests.Unit.Consumer;
 public sealed class PartitionedDispatchCoordinatorTests
 {
     [Test]
+    public async Task CustomScalarComparer_SerializesEqualKeysWhileDifferentKeysProgress()
+    {
+        var lane = CreateLane(3);
+        await Assert.That(lane.TryEnqueueForTest(CreateRecord(0, keyOverride: 10))).IsTrue();
+        await Assert.That(lane.TryEnqueueForTest(CreateRecord(1, keyOverride: 20))).IsTrue();
+        await Assert.That(lane.TryEnqueueForTest(CreateRecord(2, keyOverride: 11))).IsTrue();
+        await lane.StopAsync(PartitionStopPolicy.Drain, Timeout.InfiniteTimeSpan);
+        var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var equalStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var differentStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var dispatcher = new KeyOrderedPartitionDispatcher<int, int>(
+            new PartitionProcessorContext<int, int>(lane), 1, 2, 3,
+            (records, _) =>
+            {
+                if (records[0].Offset == 0) return new ValueTask(releaseFirst.Task);
+                if (records[0].Offset == 1) equalStarted.TrySetResult();
+                else differentStarted.TrySetResult();
+                return default;
+            }, new KeyOrderedStorageTests.ModuloTenComparer());
+        var processing = dispatcher.RunAsync(timeout.Token).AsTask();
+        try
+        {
+            await differentStarted.Task.WaitAsync(timeout.Token);
+            await Assert.That(equalStarted.Task.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            releaseFirst.TrySetResult();
+            await processing.WaitAsync(timeout.Token);
+        }
+        await Assert.That(equalStarted.Task.IsCompletedSuccessfully).IsTrue();
+        await Assert.That(dispatcher.LaneCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task AutomaticCompletion_RetiresQueuedReservationsAndSkipsFutureStorage()
     {
         var lane = CreateLane(4);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/KeyOrderedDispatchBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/KeyOrderedDispatchBenchmarks.cs
@@ -12,9 +12,8 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [MemoryDiagnoser]
 public class KeyOrderedDispatchBenchmarks
 {
-    private const int RecordCount = 262144;
     private const int Capacity = 128;
-    private readonly long[] _lastByKey = new long[RecordCount];
+    private long[] _lastByKey = null!;
     private readonly HandlerGate _handlerGate = new();
     private Func<IReadOnlyList<ConsumeResult<int, int>>, CancellationToken, ValueTask> _handler = null!;
     private PartitionLane<int, int> _lane = null!;
@@ -29,9 +28,13 @@ public class KeyOrderedDispatchBenchmarks
     [Params(1, 16)]
     public int BatchSize { get; set; }
 
+    [Params(128, 262144)]
+    public int RecordCount { get; set; }
+
     [GlobalSetup]
     public async Task Setup()
     {
+        _lastByKey = new long[RecordCount];
         _handler = HandleBatch;
         await DispatchLifetime().ConfigureAwait(false);
     }


### PR DESCRIPTION
Scalar partition keys currently pay for the cached binary hash in every dictionary entry. This changes the lane dictionary to use an uncached key representation only when its aligned entry size is smaller. For `int` on x64, entries return from 32 to 24 bytes. Binary keys retain their complete cached 32-bit hash, content equality, collision escalation and retained-buffer ownership.

The dispatcher still allocates one dictionary. Concrete dictionary access avoids a wrapper allocation or interface dispatch; the storage predicate is aggressively inlined and folds away in inspected .NET 10 x64 enqueue/removal code. A compact custom-comparer adapter is allocated once per dispatcher when needed. Key conversion is a value-type copy per record. The built-in binary comparer is read from the dictionary when hashing binary keys, replacing a dispatcher reference field. No new per-record allocation or asynchronous operation is introduced. The 1,056-byte saving comprises preallocated dictionary storage and dispatcher storage, amortized over a dispatcher lifetime.

The steady-state `KeyOrderedDispatchBenchmarks` fixture now covers 128 and 262,144 records across three key patterns and two batch sizes (12 cases). Permanent component selection also includes repeated, distinct and shared-suffix binary dispatch fixtures for changes to the key or dispatcher, including its new partial file. No tolerance or PR-specific gate exception changes.

Validation on `8d3e8036732b005328636319c539b2f7e638a20e`, rebased onto `de392a56bcc460bbfa5dbc0dfdb315e21cb9691f`:

- Full Release build: zero warnings/errors, including the netstandard2.0 asset.
- 48 focused key/dispatcher unit cases passed on each of net8.0 and net10.0. Tests cover compact custom comparers, colliding hashes, equal-key serialization, different-key progress and wire-null/default-value separation. Two storage assertions failed before the product change; the binary representation control passed.
- 28 Kafka 4.3.1 integration cases passed for key comparers, dispatch and record lifetimes.
- 45 performance-selector tests and the repository artifact policy passed; final diff reviewed for correctness, reuse and hot-path costs.
- Before the unrelated share-subscription rebase, all 1,417 consumer cases passed on net8.0. The final net10.0 consumer run passed 1,416 and failed the existing 10 ms prefetch timeout assertion. Its cancellation-before-prefetch-start race is tracked in #3263; the failure is preserved, not hidden by a full-suite rerun. Earlier net10.0 consumer validation passed 1,417 before adding the inlining annotation.

Local performance is diagnostic, not acceptance. A Short/MemoryDiagnoser comparison against `8591f37dbc62ed08c302861e96408f12b7ddbd02`, using the same expanded fixture source, recovered exactly 1,056 B per dispatcher lifetime in all 12 scalar cases. Binary allocation reports stayed within 1 B/op of the control's rounded values. Scalar median differences ranged from -18.79% to +8.02%.

Several binary timings worsened substantially. One second baseline run of all 12 distinct-key cases did not explain several losses: for 1,024-byte keys and two handlers, byte-array medians were 232.76 / 335.77 / 232.26 ns and raw-memory medians were 236.64 / 374.39 / 240.38 ns (A1/B/A2). The 65,536-byte raw-memory/two-handler case was 285.47 / 423.30 / 247.27 ns. These results remain unresolved; no speedup, protected-metric tradeoff or merge acceptance is claimed. The hosted gate must supply the required A1/B/A2 result; any reproduced regression needs a product fix before merging. No further local benchmark retries or paid stress runs were dispatched. The parent #3048 remains open for collision escalation, synchronous rebuild costs and loaded acceptance.

Evidence is retained outside removable worktrees at `C:/git/Dekaf-evidence/issue-3258/scalar-storage/`: raw reports/logs in `baseline-bdn`, `baseline-suffix-bdn`, `candidate-bdn`, and `baseline-a2-bdn`; complete comparisons in `comparison.json` and `comparison-aba.json`; generated BenchmarkDotNet workers and source in the three baseline worker archives and `candidate-validation` (2,997 SHA-256-verified files). Red-test binaries/source, before/after native listings, the observed timeout failure and final rebased validation are also retained with file inventories. The measured source patch predates the unrelated share-subscription rebase; `final-8d3e80367` contains the final commit source and rebuilt test binaries.

Closes #3258


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved key-ordered dispatch storage efficiency by using compact representations where appropriate.
  - Preserved full binary-key handling and cached hash information for binary data.
  - Improved lane management during dispatch, removal, and shutdown.

- **Bug Fixes**
  - Ensured custom key comparers correctly distinguish wire-null and default-value keys.
  - Preserved ordering and serialization behavior when custom comparers treat keys as equivalent.

- **Testing**
  - Expanded coverage for scalar, binary, and custom-comparer key scenarios.
  - Added benchmark coverage for both small and large record volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->