### PR TITLE
test(outbox): add maintained idle and active stress coverage

### DIFF
--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -7,6 +7,7 @@ from math import isfinite
 from pathlib import Path
 
 from stress_report import cpu_micros_per_message, effective_rate, median_interval_rate
+from stress_warmup import validate_outbox
 
 
 DEFAULT_TOLERANCE_PERCENT = 3.0
@@ -60,6 +61,10 @@ METRICS = (
 )
 
 LATENCY_KEYS = ("p50", "p95", "p99", "max")
+OUTBOX_METRICS = (
+    Metric("idleCpu", "Idle CPU", "ms/s", False),
+    Metric("idleAlloc", "Idle allocation", "B/s", False),
+)
 
 DEFAULT_STABILITY_FLOOR = 0.85
 
@@ -90,7 +95,8 @@ def _single_result(directory):
 
 
 def _identity(result):
-    return (
+    outbox = result.get("outbox") or {}
+    identity = (
         str(result.get("scenario", "")).casefold(),
         str(result.get("client", "")).casefold(),
         result.get("brokerCount"),
@@ -100,6 +106,11 @@ def _identity(result):
         result.get("idempotent"),
         result.get("roundTripSteadySeconds"),
     )
+    return identity + (
+        (outbox.get("idle") or {}).get("requestedSeconds"),
+        outbox.get("activeRequestedSeconds"),
+        (outbox.get("idleWarmup") or {}).get("requestedSeconds"),
+    ) if outbox else identity
 
 
 def _average_request_kib(result):
@@ -144,6 +155,7 @@ def _measurements(result, latency_required=True):
         "stability": result.get("steadyStatePeakRatio"),
         "averageRequest": _average_request_kib(result),
     }
+    measurements.update(validate_outbox(result))
     missing = [
         metric.label
         for metric in METRICS
@@ -357,6 +369,7 @@ def compare(
             if not isinstance(result.get(field), dict):
                 raise ValueError(f"Expected a {field} object")
         _validate_completed_messages(result)
+        validate_outbox(result)
 
     identities = {
         _identity(baseline_a_result),
@@ -399,7 +412,7 @@ def compare(
             floor_status=stability_status if metric.floor else None,
             candidate_b2=None if candidate_b2 is None else candidate_b2[metric.key],
         )
-        for metric in METRICS
+        for metric in METRICS + (OUTBOX_METRICS if candidate_result.get("outbox") is not None else ())
     ]
 
     def latency_count(item):

--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -25,6 +25,7 @@ SCENARIO_TITLES = {
     'consumer-batch': 'Consumer (Batch)',
     'consumer-raw': 'Consumer (Raw Bytes)',
     'consumer-raw-batch': 'Consumer (Raw Batch)',
+    'outbox': 'EF Outbox (Active Delivery)',
 }
 
 # Delivery-latency product bars: reported, never gating (see paired_latency_thresholds).

--- a/.github/scripts/stress_warmup.py
+++ b/.github/scripts/stress_warmup.py
@@ -107,7 +107,117 @@ def validate(result):
         raise ValueError("Measured runtime samples do not cover the complete window, including drain")
     # Preserve all measured samples, including both boundaries and drain.
     quiet([start] + [runtime(item.get("runtime")) for item in intervals] + [end], "Measurement")
+    validate_outbox(result)
     return requested
+
+
+OUTBOX_COUNTERS = ("acquisitions", "renewals", "probes", "reads", "marks", "metricQueries", "published", "errors")
+CUMULATIVE_RUNTIME_FIELDS = ("cpuSeconds", "allocatedBytes", "gen0Collections", "gen1Collections",
+                             "gen2Collections", "gcPauseMilliseconds")
+
+
+def _outbox_counts(value):
+    counts = object_value(value, "outbox operations")
+    for field in OUTBOX_COUNTERS:
+        value = number(counts.get(field), f"outbox {field}")
+        if not isinstance(value, int):
+            raise ValueError(f"Outbox {field} must be an integer")
+    return counts
+
+
+def _validate_idle(phase, label, warmup=False):
+    phase = object_value(phase, label)
+    requested = number(phase.get("requestedSeconds"), f"{label} requestedSeconds")
+    elapsed = number(phase.get("elapsedSeconds"), f"{label} elapsedSeconds")
+    if requested <= 0 or elapsed < requested or (warmup and requested < 20):
+        raise ValueError(f"{label} did not complete its declared duration")
+    samples = sample_list(phase.get("samples"), label)
+    times = [number(sample.get("elapsedSeconds"), f"{label} sample time") for sample in samples]
+    if len(times) < 2 or times[0] != 0 or times[-1] != elapsed or any(
+            right < left or right - left > MAX_SAMPLE_GAP_SECONDS for left, right in zip(times, times[1:])):
+        raise ValueError(f"{label} samples do not cover the complete window")
+    observations = [runtime(sample.get("runtime")) for sample in samples]
+    if observations[0] != runtime(phase.get("runtimeStart")) or observations[-1] != runtime(phase.get("runtimeEnd")):
+        raise ValueError(f"{label} runtime boundaries disagree with samples")
+    for previous, current in zip(observations, observations[1:]):
+        if any(current[field] < previous[field] for field in CUMULATIVE_RUNTIME_FIELDS):
+            raise ValueError(f"{label} runtime counters move backwards")
+    counts = [_outbox_counts(sample.get("operations")) for sample in samples]
+    for previous, current in zip(counts, counts[1:]):
+        if any(current[field] < previous[field] for field in OUTBOX_COUNTERS):
+            raise ValueError(f"{label} operation counters move backwards")
+    delta = _outbox_counts(phase.get("operations"))
+    if any(counts[-1][field] - counts[0][field] != delta[field] for field in OUTBOX_COUNTERS):
+        raise ValueError(f"{label} operation totals disagree with samples")
+    if delta["probes"] == 0 or any(sample["published"] or sample["errors"] for sample in counts):
+        raise ValueError(f"{label} must exercise an empty healthy relay")
+    tail = max(index for index, seconds in enumerate(times) if seconds <= elapsed - QUIET_WORKLOAD_SECONDS) if warmup else 0
+    quiet(observations[tail:], label)
+    return {"idleCpu": (observations[-1]["cpuSeconds"] - observations[0]["cpuSeconds"]) * 1000 / elapsed,
+            "idleAlloc": (observations[-1]["allocatedBytes"] - observations[0]["allocatedBytes"]) / elapsed}
+
+
+def validate_outbox(result):
+    """Require complete idle and active evidence; derive idle rates from retained boundaries."""
+    is_outbox = str(result.get("scenario", "")).casefold() == "outbox"
+    if not is_outbox:
+        if result.get("outbox") is not None:
+            raise ValueError("Outbox evidence requires the outbox scenario")
+        return {}
+    outbox = object_value(result.get("outbox"), "outbox")
+    object_value(result.get("latency"), "outbox latency")
+    if result.get("idempotent") is not True or result.get("brokerCount") != 1 or str(result.get("client", "")).casefold() != "dekaf":
+        raise ValueError("Outbox evidence requires one broker and the idempotent Dekaf publisher")
+    _validate_idle(outbox.get("idleWarmup"), "Outbox idle warmup", warmup=True)
+    rates = _validate_idle(outbox.get("idle"), "Outbox idle measurement")
+    throughput = object_value(result.get("throughput"), "throughput")
+    warmup = object_value(throughput.get("warmup"), "warmup")
+    if outbox["idleWarmup"]["requestedSeconds"] != number(warmup.get("requestedSeconds"), "active warmup duration"):
+        raise ValueError("Outbox idle and active warmups must declare the same duration")
+    active = number(outbox.get("activeRequestedSeconds"), "outbox activeRequestedSeconds")
+    duration = number(result.get("durationMinutes"), "durationMinutes") * 60
+    if active <= 0 or abs(outbox["idle"]["requestedSeconds"] + active - duration) > 0.001:
+        raise ValueError("Outbox phase durations must sum to the configured measured duration")
+    workload = number(outbox.get("activeWorkloadSeconds"), "outbox activeWorkloadSeconds")
+    if workload < active or number(throughput.get("elapsedSeconds"), "active elapsedSeconds") < workload:
+        raise ValueError("Outbox active phase did not complete its declared duration")
+    accepted = number(throughput.get("totalMessages"), "outbox completed messages")
+    if not isinstance(accepted, int):
+        raise ValueError("Outbox completed messages must be an integer")
+    operations = _outbox_counts(outbox.get("activeOperations"))
+    if accepted <= 0 or any(number(outbox.get(field), field) != accepted
+                            for field in ("committedMessages", "uniqueConsumedMessages")) or (
+            operations["published"] != accepted or operations["errors"] != 0
+            or number(result.get("consumedMessages"), "consumedMessages") != accepted):
+        raise ValueError("Outbox committed, marked and unique consumed counts must agree without errors")
+    duplicates = number(outbox.get("duplicatePublications"), "duplicatePublications")
+    if not isinstance(duplicates, int):
+        raise ValueError("Outbox duplicate publications must be an integer")
+    return rates
+
+
+def assess_idle_trends(result):
+    """Keep all idle observations, including spikes; use elapsed time instead of fake messages."""
+    samples = result["outbox"]["idle"]["samples"]
+    findings, metrics = [], {"intervals": len(samples) - 1}
+    if len(samples) - 1 < MIN_TREND_INTERVALS:
+        return {"findings": [f"idle requires at least {MIN_TREND_INTERVALS} intervals to assess trends"], "metrics": metrics}
+    third = len(samples) // 3
+    first, last = samples[:third], samples[-third:]
+    for field, label in (("cpuSeconds", "idle CPU per second"), ("allocatedBytes", "idle allocations per second")):
+        rates = [(part[-1]["runtime"][field] - part[0]["runtime"][field]) /
+                 (part[-1]["elapsedSeconds"] - part[0]["elapsedSeconds"]) for part in (first, last)]
+        drift = _percent_change(*rates)
+        metrics[f"{field}DriftPercent"] = drift
+        if drift is None or abs(drift) > TREND_TOLERANCE_PERCENT:
+            findings.append(f"{label} did not settle within the {TREND_TOLERANCE_PERCENT:g}% trend tolerance")
+    for field, label in (("heapBytes", "idle managed heap"), ("workingSetBytes", "idle working set")):
+        levels = [median(sample["runtime"][field] for sample in part) for part in (first, last)]
+        growth = _percent_change(*levels)
+        metrics[f"{field}GrowthPercent"] = growth
+        if growth is None or growth > MEMORY_GROWTH_PERCENT:
+            findings.append(f"{label} grew beyond the {MEMORY_GROWTH_PERCENT:g}% tolerance")
+    return {"findings": findings, "metrics": metrics}
 
 
 def _percent_change(first, last):
@@ -205,6 +315,8 @@ def _assess(label, result, errors, trends, durations):
         errors.append(f"{label}: {error}")
         return
     trends[label] = assess_trends(result)
+    if result.get("outbox") is not None:
+        trends[f"{label} idle"] = assess_idle_trends(result)
 
 
 def assess_results(results):

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -823,10 +823,10 @@ class StressAbaWorkflowTests(unittest.TestCase):
             self.workflow,
         )
         self.assertIn(
-            "Exact-SHA A-B-A requires a duration-based producer, consumer replay, or hosted-share lane",
+            "Exact-SHA A-B-A requires a duration-based producer, consumer replay, hosted-share, or outbox lane",
             self.workflow,
         )
-        self.assertIn("consumer-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b|hosted-share-1b) ;;", self.workflow)
+        self.assertIn("consumer-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b|hosted-share-1b|outbox-1b) ;;", self.workflow)
 
     def test_matrix_forces_three_single_connection_dekaf_segments(self):
         self.assertIn('.baseline_sha = $baseline_sha', self.workflow)

--- a/.github/scripts/test_stress_outbox.py
+++ b/.github/scripts/test_stress_outbox.py
@@ -1,0 +1,147 @@
+import copy
+import json
+import re
+import unittest
+from pathlib import Path
+
+from stress_aba import compare
+from stress_warmup import OUTBOX_COUNTERS, assess_results, validate_outbox
+from test_stress_aba import result as aggregate_result
+from test_stress_warmup import observation, result as runtime_result
+
+
+def idle_phase(seconds, cpu=0.001, allocation=100):
+    samples = []
+    for second in range(seconds + 1):
+        runtime = observation()
+        runtime.update(cpuSeconds=10 + second * cpu, allocatedBytes=1000 + second * allocation)
+        counts = dict.fromkeys(OUTBOX_COUNTERS, 0)
+        counts['probes'] = second * 8
+        samples.append(dict(elapsedSeconds=second, runtime=runtime, operations=counts))
+    return dict(requestedSeconds=seconds, elapsedSeconds=seconds,
+                runtimeStart=copy.deepcopy(samples[0]['runtime']), runtimeEnd=copy.deepcopy(samples[-1]['runtime']),
+                operations=copy.deepcopy(samples[-1]['operations']), samples=samples)
+
+
+def outbox_result():
+    result = aggregate_result(scenario='outbox')
+    result['idempotent'] = True
+    result['throughput'].update(runtime_result(intervals=180)['throughput'])
+    result['durationMinutes'] = 4
+    count = result['throughput']['totalMessages']
+    result['consumedMessages'] = count
+    result.pop('deliveredMessages')
+    operations = dict.fromkeys(OUTBOX_COUNTERS, 0)
+    operations.update(published=count, reads=100, marks=100, probes=200)
+    result['outbox'] = dict(idleWarmup=idle_phase(20), idle=idle_phase(60),
+                            activeRequestedSeconds=180, activeWorkloadSeconds=180,
+                            committedMessages=count, uniqueConsumedMessages=count,
+                            duplicatePublications=0, activeOperations=operations)
+    return result
+
+
+class StressOutboxTests(unittest.TestCase):
+    def test_complete_idle_and_active_evidence_passes_without_mutation(self):
+        result = outbox_result()
+        before = copy.deepcopy(result)
+        self.assertEqual('VALIDATED', assess_results({'B': result})['verdict'])
+        comparison = compare(result, result, result)
+        self.assertEqual('pass', comparison['verdict'])
+        self.assertEqual(2, len([item for item in comparison['metrics'] if item['key'].startswith('idle')]))
+        self.assertEqual(before, result)
+
+    def test_idle_spike_is_included_in_aggregate_regression(self):
+        baseline, candidate = outbox_result(), outbox_result()
+        idle = candidate['outbox']['idle']
+        # One spike in the middle; first/last trend windows still have equal rates.
+        for sample in idle['samples'][30:]:
+            sample['runtime']['cpuSeconds'] += 0.6
+        idle['runtimeEnd']['cpuSeconds'] += 0.6
+        idle['cpuMillisecondsPerSecond'] = 0  # Cached values cannot hide the spike.
+        self.assertEqual('VALIDATED', assess_results({'B': candidate})['verdict'])
+        comparison = compare(baseline, candidate, baseline)
+        metric = next(item for item in comparison['metrics'] if item['key'] == 'idleCpu')
+        self.assertEqual('regression', metric['status'])
+        self.assertAlmostEqual(11, metric['candidate'])
+
+    def test_idle_allocation_uses_the_same_adverse_tolerance(self):
+        baseline, candidate = outbox_result(), outbox_result()
+        candidate['outbox']['idle'] = idle_phase(60, allocation=104)
+        comparison = compare(baseline, candidate, baseline)
+        self.assertEqual('regression', next(item for item in comparison['metrics'] if item['key'] == 'idleAlloc')['status'])
+
+    def test_missing_or_inconsistent_evidence_is_rejected(self):
+        mutations = {
+            'missing outbox': lambda r: r.pop('outbox'),
+            'malformed outbox': lambda r: r.update(outbox=[1]),
+            'wrong scenario': lambda r: r.update(scenario='producer'),
+            'missing latency': lambda r: r.pop('latency'),
+            'non-idempotent publisher': lambda r: r.update(idempotent=False),
+            'missing idle': lambda r: r['outbox'].pop('idle'),
+            'short idle': lambda r: r['outbox']['idle'].update(requestedSeconds=61),
+            'drain replaces active work': lambda r: r['outbox'].update(activeWorkloadSeconds=1),
+            'long idle replaces active work': lambda r: r['outbox'].update(activeWorkloadSeconds=179),
+            'wrong total duration': lambda r: r.update(durationMinutes=5),
+            'nonfinite time': lambda r: r['outbox']['idle'].update(elapsedSeconds=float('nan')),
+            'missing sample': lambda r: r['outbox']['idle']['samples'].__delitem__(slice(10, 13)),
+            'thread pool change': lambda r: r['outbox']['idle']['samples'][30]['runtime'].update(threadPoolThreads=5),
+            'counter mismatch': lambda r: r['outbox']['idle']['operations'].update(probes=1),
+            'published while idle': lambda r: r['outbox']['idle']['samples'][30]['operations'].update(published=1),
+            'idle error': lambda r: r['outbox']['idle']['samples'][30]['operations'].update(errors=1),
+            'missing delivery': lambda r: r['outbox'].update(uniqueConsumedMessages=1),
+            'not marked': lambda r: r['outbox']['activeOperations'].update(published=1),
+            'active store error': lambda r: r['outbox']['activeOperations'].update(errors=1),
+            'missing consumed count': lambda r: r.pop('consumedMessages'),
+            'fractional duplicates': lambda r: r['outbox'].update(duplicatePublications=0.5),
+            'unequal warmups': lambda r: r['outbox']['idleWarmup'].update(requestedSeconds=19),
+        }
+        for label, mutate in mutations.items():
+            with self.subTest(label=label):
+                result = outbox_result()
+                mutate(result)
+                with self.assertRaises(ValueError):
+                    validate_outbox(result)
+                with self.assertRaises(ValueError):
+                    compare(outbox_result(), result, outbox_result())
+                self.assertEqual('INCONCLUSIVE', assess_results({'B': result})['verdict'])
+
+    def test_duplicate_publication_does_not_count_as_missing_unique_delivery(self):
+        result = outbox_result()
+        result['outbox']['duplicatePublications'] = 3
+        self.assertEqual('pass', compare(result, result, result)['verdict'])
+
+    def test_latency_sample_floor_remains_required(self):
+        result = outbox_result()
+        result['latency']['count'] = 9999
+        with self.assertRaisesRegex(ValueError, 'at least 10000'):
+            compare(result, result, result)
+
+    def test_idle_trends_and_minimum_coverage_are_gated(self):
+        result = outbox_result()
+        idle = result['outbox']['idle']
+        for sample in idle['samples'][40:]:
+            sample['runtime']['allocatedBytes'] += (sample['elapsedSeconds'] - 40) * 100
+        idle['runtimeEnd'] = copy.deepcopy(idle['samples'][-1]['runtime'])
+        report = assess_results({'B': result})
+        self.assertEqual('INCONCLUSIVE', report['verdict'])
+        self.assertTrue(any('idle allocations' in error for error in report['errors']))
+        result['outbox']['idle'] = idle_phase(15)
+        result['outbox']['activeRequestedSeconds'] = 225
+        result['outbox']['activeWorkloadSeconds'] = 225
+        result['throughput'].update(runtime_result(intervals=225)['throughput'])
+        report = assess_results({'B': result})
+        self.assertTrue(any('at least 30 intervals' in error for error in report['errors']))
+
+    def test_workflow_lane_is_manual_only_with_no_comparison_variants(self):
+        workflow = (Path(__file__).resolve().parents[1] / 'workflows/stress-tests.yml').read_text(encoding='utf-8')
+        lane = json.loads(re.search(r'\{"lane": "outbox-1b"[^\n]+\}', workflow).group())
+        self.assertTrue(lane['manual_only'])
+        self.assertEqual('dekaf', lane['client'])
+        self.assertEqual(1, lane['brokers'])
+        for key in ('run_3conn', 'run_adaptive', 'paired_samples'):
+            self.assertNotIn(key, lane)
+        self.assertIn('or .lane == $lane', workflow)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -2004,10 +2004,10 @@ class StressTrendTests(unittest.TestCase):
         regular = [lane for lane in lanes if not lane.get("manual_only", False)]
         manual = [lane for lane in lanes if lane.get("manual_only", False)]
         self.assertEqual(12, len(regular))
-        self.assertEqual(["hosted-share-1b"], [lane["lane"] for lane in manual])
+        self.assertEqual(["hosted-share-1b", "outbox-1b"], [lane["lane"] for lane in manual])
         self.assertEqual("dekaf", manual[0]["client"])
         self.assertIn('select(($lane == "all" and .manual_only != true) or .lane == $lane)', workflow)
-        self.assertIn('consumer-raw-batch-1b|hosted-share-1b) ;;', workflow)
+        self.assertIn('consumer-raw-batch-1b|hosted-share-1b|outbox-1b) ;;', workflow)
 
     def test_history_merge_uses_admin_token(self):
         workflow = stress_workflow_text()

--- a/.github/scripts/test_stress_warmup.py
+++ b/.github/scripts/test_stress_warmup.py
@@ -286,7 +286,7 @@ class StressWarmupTests(unittest.TestCase):
         self.assertIn("--require-startup-assessment", workflow)
         self.assertLess(workflow.index('Build Stress Tests (exact baseline)'), workflow.index('run_aba()'))
         self.assertNotIn("schedule:", workflow)
-        self.assertIn("consumer-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b|hosted-share-1b) ;;", workflow)
+        self.assertIn("consumer-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b|hosted-share-1b|outbox-1b) ;;", workflow)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -30,6 +30,7 @@ on:
           - consumer-raw-1b
           - consumer-raw-batch-1b
           - hosted-share-1b
+          - outbox-1b
           - all
       duration_minutes:
         description: 'Test duration in minutes'
@@ -263,9 +264,9 @@ jobs:
             fi
             case "$lane" in
               producer-1b|producer-3b|producer-idempotent-1b|producer-idempotent-3b|producer-acks-all-1b|producer-acks-all-3b) ;;
-              consumer-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b|hosted-share-1b) ;;
+              consumer-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b|hosted-share-1b|outbox-1b) ;;
               *)
-                echo "::error::Exact-SHA A-B-A requires a duration-based producer, consumer replay, or hosted-share lane."
+                echo "::error::Exact-SHA A-B-A requires a duration-based producer, consumer replay, hosted-share, or outbox lane."
                 exit 1
                 ;;
             esac
@@ -288,7 +289,8 @@ jobs:
             {"lane": "consumer-batch-1b", "scenario": "consumer-batch", "client": "dekaf", "brokers": 1, "timeout_minutes": 60, "name": "Dekaf Consumer Batch"},
             {"lane": "consumer-raw-1b", "scenario": "consumer-raw", "client": "dekaf", "brokers": 1, "timeout_minutes": 60, "name": "Dekaf Consumer Raw"},
             {"lane": "consumer-raw-batch-1b", "scenario": "consumer-raw-batch", "client": "dekaf", "brokers": 1, "timeout_minutes": 60, "name": "Dekaf Consumer Raw Batch"},
-            {"lane": "hosted-share-1b", "scenario": "hosted-share", "client": "dekaf", "brokers": 1, "manual_only": true, "timeout_minutes": 60, "name": "Dekaf Hosted Share (Live Producer and Two Workers)"}
+            {"lane": "hosted-share-1b", "scenario": "hosted-share", "client": "dekaf", "brokers": 1, "manual_only": true, "timeout_minutes": 60, "name": "Dekaf Hosted Share (Live Producer and Two Workers)"},
+            {"lane": "outbox-1b", "scenario": "outbox", "client": "dekaf", "brokers": 1, "manual_only": true, "timeout_minutes": 120, "name": "Dekaf EF Outbox (Idle and Active)"}
           ]
           EOF
 

--- a/tools/Dekaf.StressTests.Tests/OutboxPhaseTimingTests.cs
+++ b/tools/Dekaf.StressTests.Tests/OutboxPhaseTimingTests.cs
@@ -1,0 +1,23 @@
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Scenarios;
+
+namespace Dekaf.StressTests.Tests;
+
+public class OutboxPhaseTimingTests
+{
+    [Test]
+    [Arguments(15.0, 45.0, true)]
+    [Arguments(20.0, 40.0, false)]
+    [Arguments(5.0, 55.0, false)]
+    [Arguments(double.NaN, 45.0, false)]
+    [Arguments(15.0, double.PositiveInfinity, false)]
+    public async Task EachPhaseMustCompleteItsOwnDeclaredDuration(double idleElapsed, double activeElapsed, bool expected)
+    {
+        var operations = new OutboxOperationCounts(0, 0, 1, 0, 0, 0, 0, 0);
+        var idle = new OutboxIdleSnapshot(15, idleElapsed, new RuntimeObservation(), new RuntimeObservation(), operations, []);
+        var snapshot = new OutboxWorkloadSnapshot(idle, idle, 45, activeElapsed, 1, 1, 0, operations);
+        await Assert.That(snapshot.HasCompleteDuration(1, activeElapsed)).IsEqualTo(expected);
+        await Assert.That(snapshot.HasCompleteDuration(2, activeElapsed)).IsFalse();
+        await Assert.That((snapshot with { ActiveWorkloadSeconds = 1 }).HasCompleteDuration(1, 60)).IsFalse();
+    }
+}

--- a/tools/Dekaf.StressTests.Tests/OutboxWorkloadStateTests.cs
+++ b/tools/Dekaf.StressTests.Tests/OutboxWorkloadStateTests.cs
@@ -1,0 +1,95 @@
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Scenarios;
+using Dekaf.Outbox;
+
+namespace Dekaf.StressTests.Tests;
+
+public class OutboxWorkloadStateTests
+{
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task ShutdownCancellationCannotHideAnUnrelatedPublisherFailure(bool initialize)
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var state = new OutboxWorkloadState(24, 1, 42);
+        await using var publisher = new ObservedOutboxPublisher(new FailedPublisher(), state);
+        if (initialize)
+            await Assert.That(async () => await publisher.InitializeAsync(cancellation.Token)).Throws<InvalidOperationException>();
+        else
+            await Assert.That(async () => await publisher.PublishAsync([], "message-id", cancellation.Token)).Throws<InvalidOperationException>();
+        await Assert.That(() => state.ThrowIfFailed()).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task DeliveryCanRaceSaveCompletionButThePhaseMustDrainBoth()
+    {
+        var state = new OutboxWorkloadState(24, 1, 42);
+        var throughput = new ThroughputTracker();
+        state.BeginCycle(throughput);
+        await Assert.That(state.TryReserve(out var sequence)).IsTrue();
+        await Assert.That(state.Process(state.CreatePayload(sequence), 0, 0)).IsTrue();
+        await Assert.That(() => state.BeginCycle(new ThroughputTracker())).Throws<InvalidOperationException>();
+        state.RecordCommitted(1);
+        state.BeginCycle(new ThroughputTracker());
+        await Assert.That(throughput.MessageCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task DuplicatePublicationDoesNotCountAsAnotherUniqueCompletion()
+    {
+        var state = new OutboxWorkloadState(24, 1, 42);
+        var throughput = new ThroughputTracker();
+        state.BeginCycle(throughput);
+        state.TryReserve(out var sequence);
+        var payload = state.CreatePayload(sequence);
+        state.RecordCommitted(1);
+        await Assert.That(state.Process(payload, 0, 0)).IsTrue();
+        await Assert.That(state.Process(payload, 0, 1)).IsFalse();
+        await Assert.That(state.Duplicates).IsEqualTo(1);
+        await Assert.That(throughput.MessageCount).IsEqualTo(1);
+        await Assert.That(state.HasReadThrough([2])).IsTrue();
+    }
+
+    [Test]
+    public async Task MissingOldestIdentityPreventsSlotReuseEvenWhenOtherRecordsComplete()
+    {
+        var state = new OutboxWorkloadState(24, 1, 42);
+        state.BeginCycle(new ThroughputTracker());
+        for (var i = 0; i < OutboxWorkloadState.WindowSize; i++)
+            await Assert.That(state.TryReserve(out _)).IsTrue();
+        state.RecordCommitted(OutboxWorkloadState.WindowSize);
+        for (var i = 1; i < OutboxWorkloadState.WindowSize; i++)
+            state.Process(state.CreatePayload(i), 0, i - 1);
+        await Assert.That(state.TryReserve(out _)).IsFalse();
+        state.Process(state.CreatePayload(0), 0, OutboxWorkloadState.WindowSize - 1);
+        await Assert.That(state.TryReserve(out var next)).IsTrue();
+        await Assert.That(next).IsEqualTo(OutboxWorkloadState.WindowSize);
+    }
+
+    [Test]
+    public async Task ForeignUnreservedAndSkippedKafkaRecordsAreRejected()
+    {
+        var state = new OutboxWorkloadState(24, 1, 42);
+        state.BeginCycle(new ThroughputTracker());
+        await Assert.That(() => state.Process(state.CreatePayload(0), 0, 0)).Throws<InvalidOperationException>();
+        state.TryReserve(out _);
+        var foreign = new OutboxWorkloadState(24, 1, 43).CreatePayload(0);
+        await Assert.That(() => state.Process(foreign, 0, 0)).Throws<InvalidOperationException>();
+        await Assert.That(() => state.Process(state.CreatePayload(0), 0, 1)).Throws<InvalidOperationException>();
+        await Assert.That(state.Process(state.CreatePayload(0), 0, 0)).IsTrue();
+    }
+
+    private sealed class FailedPublisher : IOutboxPublisher
+    {
+        public ValueTask InitializeAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromException(new InvalidOperationException("Initialization failed during shutdown."));
+
+        public ValueTask<OutboxPublishResult> PublishAsync(IReadOnlyList<OutboxMessage> messages,
+            string messageIdHeaderName, CancellationToken cancellationToken = default) =>
+            ValueTask.FromException<OutboxPublishResult>(new InvalidOperationException("Publication failed during shutdown."));
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
+++ b/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dekaf\Dekaf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Extensions.Hosting\Dekaf.Extensions.Hosting.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Outbox.EntityFrameworkCore\Dekaf.Outbox.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Lz4\Dekaf.Compression.Lz4.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Snappy\Dekaf.Compression.Snappy.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Zstd\Dekaf.Compression.Zstd.csproj" />
@@ -30,6 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
     <PackageReference Include="SSH.NET" PrivateAssets="All" />
     <PackageReference Include="Testcontainers" />
     <PackageReference Include="Testcontainers.Kafka" />

--- a/tools/Dekaf.StressTests/Outbox.md
+++ b/tools/Dekaf.StressTests/Outbox.md
@@ -1,0 +1,21 @@
+# EF outbox stress workload
+
+`outbox` is a manual Dekaf-only scenario using an isolated SQLite WAL database, the real EF Core outbox store and relay, an idempotent Kafka publisher, and a verifying Kafka consumer. The `outbox-1b` workflow lane is excluded from `lane=all` and `full_run=true`.
+
+```powershell
+dotnet run -c Release --project tools/Dekaf.StressTests -- --scenario outbox --client dekaf --brokers 1 --duration 5 --producer-warmup-seconds 180 --message-size 1000 --producer-delivery-diagnostics --output ./outbox-results
+```
+
+The duration is **total measured time**: 25% idle and 75% active. Five minutes means 75 measured idle seconds and 225 seconds of active admission, followed by complete drain. Each phase must finish its own duration; extra idle time or drain cannot replace active admission. Each phase also has a separate warmup of `producer_warmup_seconds`; active warmup retains the existing six drain/reuse cycles. Setup, warmups and final drain add to wall time.
+
+Idle runs the real empty relay with no writer or Kafka reader. Boundary and approximately one-second observations retain CPU, managed allocations, heap, working set, collections, GC pauses, thread-pool activity and store counters. CPU is milliseconds per elapsed second; allocation is bytes per elapsed second. No synthetic messages enter either denominator. All samples, including CPU spikes, remain in JSON. Aggregate idle costs use the complete boundary deltas.
+
+The writer commits batches of at most 32 records. Relay defaults remain eight buckets, 500 records per batch, one-second polling, 30-second leases and ten-second renewal. At most 4,096 sequence slots can be outstanding; admission stops when the next reusable slot is still missing. Payloads contain run identity, logical sequence and enqueue timestamp. The reader requires consecutive Kafka offsets within each partition and one unique completion per committed logical record. Logical records can arrive out of order across relay buckets. Repeated logical records at new Kafka offsets are counted separately as legitimate at-least-once duplicate publications. They do not inflate throughput or latency samples.
+
+A transaction inserts a poison record and rolls back before active work. The database must then be empty; publishing the poison record fails the identity oracle. Every warmup cycle and measured active phase drains committed rows, successful store marks, producer delivery and Kafka end offsets. Store and publisher exceptions remain sticky failures even if the relay normally retries. The result returns only after reader and relay shutdown is observed. Success deletes only that invocation's database; failure retains it in the result directory.
+
+Active metrics cover the complete writer/store/relay/publisher/reader process, including drain. These are end-to-end outbox costs. Payload creation, EF tracking and persistence allocate per message; observation adds work per store operation or runtime sample. Both product revisions receive the identical maintained harness. Producer diagnostics are mandatory. Existing latency sample floors, active steady-state checks and comparison tolerances remain unchanged.
+
+For acceptance, dispatch one lane with `baseline_sha` set to fresh main contained in the candidate. The workflow overlays the candidate harness onto both revisions, performs one-minute correctness preflights, then measures baseline, candidate and baseline on one VM. Five-minute samples with 180-second warmups budget approximately 47 minutes across preflights and measurements, plus setup and drains. Idle coverage and steady-state CPU, allocation and memory trends are checked independently. The comparator adds idle CPU and allocation rows using the existing adverse and control-drift policy. Missing, contradictory or unsettled evidence is `INCONCLUSIVE`. Discarding a spike cannot hide an aggregate loss.
+
+Root SDK/package inputs and baseline ancestry retain the existing workflow guards. Historical revisions with incompatible root inputs need a separately reviewed experiment. This infrastructure does not resolve the notification allocation overhead or historical idle CPU regression tracked by #3232.

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -19,7 +19,7 @@ namespace Dekaf.StressTests;
 /// Options:
 ///   --duration &lt;minutes&gt;    Test duration in minutes (default: 15)
 ///   --message-size &lt;bytes&gt;  Message size in bytes (default: 1000)
-///   --scenario &lt;name&gt;       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip-steady, consumer, consumer-batch, consumer-raw, consumer-raw-batch, hosted-share, all (default: all)
+///   --scenario &lt;name&gt;       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip-steady, consumer, consumer-batch, consumer-raw, consumer-raw-batch, hosted-share, outbox, all (default: all)
 ///   --client &lt;name&gt;         Run specific client: dekaf, confluent, all (default: all)
 ///   --output &lt;path&gt;         Output directory for results (default: ./results)
 ///   --brokers &lt;count&gt;      Number of Kafka brokers (default: 1, use 3 for multi-broker)
@@ -221,6 +221,7 @@ public static class Program
 
         StressTestOptions BuildTestOptions(IStressTestScenario scenario, int connectionsPerBroker, string topic) => new()
         {
+            OutputDirectory = options.OutputPath,
             BootstrapServers = kafka.BootstrapServers,
             Topic = topic,
             DurationMinutes = options.DurationMinutes,
@@ -429,6 +430,7 @@ public static class Program
     private static bool UsesProducerTopic(string scenarioName) =>
         scenarioName.StartsWith("producer", StringComparison.OrdinalIgnoreCase) ||
         scenarioName.Equals("soak", StringComparison.OrdinalIgnoreCase) ||
+        scenarioName.Equals("outbox", StringComparison.OrdinalIgnoreCase) ||
         scenarioName.Equals("hosted-share", StringComparison.OrdinalIgnoreCase);
 
     private static bool IsRoundTripScenario(string scenarioName) =>
@@ -526,7 +528,7 @@ public static class Program
             }
 
             if (StressRunCompletionPolicy.EndedEarly(
-                    result.Throughput.ElapsedSeconds,
+                    result.Throughput.ElapsedSeconds + (result.Outbox?.Idle.ElapsedSeconds ?? 0),
                     result.DurationMinutes,
                     isSelfBounded: result.RoundTripSteadySeconds is not null))
             {
@@ -534,6 +536,13 @@ public static class Program
                 reasons.Add(
                     $"run ended early ({result.Throughput.ElapsedSeconds:N0}s of {expectedSeconds:N0}s)");
             }
+
+            if (result.Outbox is { } outbox
+                && (!outbox.HasCompleteDuration(result.DurationMinutes, result.Throughput.ElapsedSeconds)
+                    || outbox.CommittedMessages != accepted || outbox.UniqueConsumedMessages != accepted
+                    || outbox.ActiveOperations.Published != accepted || outbox.ActiveOperations.Errors != 0
+                    || outbox.Idle.Operations.Published != 0 || outbox.Idle.Operations.Errors != 0))
+                reasons.Add("outbox phases or committed publication/drain counts are incomplete");
 
             var maxStall = MaxConsecutiveZeroSamples(result.Throughput.MessagesPerSecondSamples);
             if (maxStall >= StallThresholdSamples)
@@ -803,7 +812,9 @@ public static class Program
     {
         var scenarios = CreateAllScenarios()
             .Where(s => options.Scenario == "all"
-                ? !s.Name.Equals("soak", StringComparison.OrdinalIgnoreCase) && !s.Name.Equals("hosted-share", StringComparison.OrdinalIgnoreCase)
+                ? !s.Name.Equals("soak", StringComparison.OrdinalIgnoreCase)
+                    && !s.Name.Equals("hosted-share", StringComparison.OrdinalIgnoreCase)
+                    && !s.Name.Equals("outbox", StringComparison.OrdinalIgnoreCase)
                 : s.Name.Equals(options.Scenario, StringComparison.OrdinalIgnoreCase))
             .Where(s => options.Client == "all" || s.Client.Equals(options.Client, StringComparison.OrdinalIgnoreCase))
             .ToList();
@@ -839,7 +850,8 @@ public static class Program
             new ConsumerRawBatchStressTest(),
             new ConfluentConsumerStressTest(),
             new SoakStressTest(),
-            new HostedShareStressTest()
+            new HostedShareStressTest(),
+            new OutboxStressTest()
         ];
 
     private static List<IStressTestScenario> ApplyClientOrder(List<IStressTestScenario> scenarios, string requestedClient)
@@ -1101,7 +1113,7 @@ public static class Program
               --duration <minutes>    Test duration in minutes (default: 15)
               --producer-warmup-seconds <n>  Producer and consumer replay workload warmup (default: {ProducerWarmup.DefaultSeconds}; minimum: {ProducerWarmup.MinimumSeconds})
               --message-size <bytes>  Message size in bytes (default: 1000)
-              --scenario <name>       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip-steady, consumer, consumer-batch, consumer-raw, consumer-raw-batch, soak, all (default: all; all excludes soak)
+              --scenario <name>       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip-steady, consumer, consumer-batch, consumer-raw, consumer-raw-batch, hosted-share, outbox, soak, all (default: all; all excludes hosted-share, outbox and soak)
               --client <name>         Run specific client: dekaf, confluent, all (default: all)
               --output <path>         Output directory for results (default: ./results)
               --partitions <count>    Number of topic partitions (default: 6)

--- a/tools/Dekaf.StressTests/README.md
+++ b/tools/Dekaf.StressTests/README.md
@@ -1,5 +1,7 @@
 # Stress runner
 
+For the manual EF outbox workload, see [idle and active outbox coverage](Outbox.md).
+
 `hosted-share` is an explicit manual scenario. It runs an idempotent live producer and two instances of the same hosted share service under distinct DI keys in one Kafka share group. The `hosted-share-1b` workflow lane is excluded from both `lane=all` and `full_run=true`; the existing full matrix remains 12 jobs.
 
 ```powershell

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -30,6 +30,19 @@ internal static class MarkdownReporter
             var label = FormatGroupTitle(FormatScenarioLabel(group.Key.Scenario), group.Key.BrokerCount);
 
             GenerateThroughputTable(sb, title, groupResults);
+            foreach (var result in groupResults)
+            {
+                if (result.Outbox is not { } outbox)
+                    continue;
+                sb.AppendLine($"### EF Outbox Idle - {result.Client}");
+                sb.AppendLine();
+                sb.AppendLine("| Elapsed | CPU (ms/s) | Allocation (B/s) | Empty probes | Published | Errors |");
+                sb.AppendLine("|---------|------------|------------------|--------------|-----------|--------|");
+                sb.AppendLine($"| {outbox.Idle.ElapsedSeconds:F2}s | {outbox.Idle.CpuMillisecondsPerSecond:F3} | {outbox.Idle.AllocatedBytesPerSecond:F1} | {outbox.Idle.Operations.Probes} | {outbox.Idle.Operations.Published} | {outbox.Idle.Operations.Errors} |");
+                sb.AppendLine();
+                sb.AppendLine($"Active phase committed and consumed {outbox.UniqueConsumedMessages:N0} unique records; {outbox.DuplicatePublications:N0} additional at-least-once publications. Idle samples and runtime boundaries are retained in JSON.");
+                sb.AppendLine();
+            }
             GenerateConnectionScaleTimeline(sb, groupResults, label);
             GenerateProducerRequestDiagnostics(sb, groupResults, label);
             GenerateProducerBudgetTimeline(sb, groupResults, label);
@@ -725,6 +738,7 @@ internal static class MarkdownReporter
         "consumer-batch" => "Consumer (Batch) Throughput",
         "consumer-raw" => "Consumer (Raw Bytes) Throughput",
         "consumer-raw-batch" => "Consumer (Raw Batch) Throughput",
+        "outbox" => "EF Outbox Active Delivery Throughput",
         "soak" => "Mixed Produce/Consume Soak",
         _ => $"{scenario} Throughput"
     };
@@ -742,6 +756,7 @@ internal static class MarkdownReporter
         "consumer-batch" => "Consumer (Batch)",
         "consumer-raw" => "Consumer (Raw Bytes)",
         "consumer-raw-batch" => "Consumer (Raw Batch)",
+        "outbox" => "EF Outbox (Active Delivery)",
         "soak" => "Mixed Soak",
         _ => scenario
     };

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -35,6 +35,7 @@ internal sealed class StressTestResult
     public RoundTripValidationSnapshot? RoundTripValidation { get; init; }
     public RoundTripPhaseSnapshot? RoundTripPhases { get; init; }
     public int? RoundTripSteadySeconds { get; init; }
+    public OutboxWorkloadSnapshot? Outbox { get; init; }
 
     /// <summary>
     /// Whether the scenario's producer ran with idempotence enabled. Must mirror the

--- a/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
+++ b/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
@@ -17,6 +17,7 @@ internal sealed class StressTestOptions
 
     public required string BootstrapServers { get; init; }
     public required string Topic { get; init; }
+    public string OutputDirectory { get; init; } = ".";
     public required int DurationMinutes { get; init; }
     public required int MessageSizeBytes { get; init; }
     public int ProducerWarmupSeconds { get; init; } = ProducerWarmup.DefaultSeconds;

--- a/tools/Dekaf.StressTests/Scenarios/ObservedOutboxStore.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ObservedOutboxStore.cs
@@ -1,0 +1,113 @@
+using Dekaf.Outbox;
+using Dekaf.Outbox.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dekaf.StressTests.Scenarios;
+
+/// <summary>Counts store operations without replacing database work or optional store capabilities.</summary>
+internal sealed class ObservedOutboxStore<TContext>(EfCoreOutboxStore<TContext> inner, OutboxWorkloadState state)
+    : IOutboxStore, IOutboxLeaseRenewalStore, IOutboxMetricsStore where TContext : DbContext
+{
+    private long _acquisitions;
+    private long _renewals;
+    private long _probes;
+    private long _reads;
+    private long _marks;
+    private long _metricQueries;
+    private long _published;
+    private long _errors;
+
+    public long Published => Interlocked.Read(ref _published);
+
+    public OutboxOperationCounts Snapshot() => new(
+        Interlocked.Read(ref _acquisitions), Interlocked.Read(ref _renewals), Interlocked.Read(ref _probes),
+        Interlocked.Read(ref _reads), Interlocked.Read(ref _marks), Interlocked.Read(ref _metricQueries),
+        Interlocked.Read(ref _published), Interlocked.Read(ref _errors));
+
+    public async ValueTask<IReadOnlyList<int>> AcquireBucketLeasesAsync(OutboxLeaseRequest request, CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref _acquisitions);
+        try { return await inner.AcquireBucketLeasesAsync(request, cancellationToken).ConfigureAwait(false); }
+        catch (Exception error) when (error is not OperationCanceledException || !cancellationToken.IsCancellationRequested) { RecordFailure(error); throw; }
+    }
+
+    public async ValueTask<bool> RenewBucketLeasesAsync(OutboxLeaseRequest request, IReadOnlyList<int> buckets, CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref _renewals);
+        try { return await inner.RenewBucketLeasesAsync(request, buckets, cancellationToken).ConfigureAwait(false); }
+        catch (Exception error) when (error is not OperationCanceledException || !cancellationToken.IsCancellationRequested) { RecordFailure(error); throw; }
+    }
+
+    public async ValueTask<IReadOnlyList<int>> GetBucketsWithPendingAsync(IReadOnlyList<int> buckets, CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref _probes);
+        try { return await inner.GetBucketsWithPendingAsync(buckets, cancellationToken).ConfigureAwait(false); }
+        catch (Exception error) when (error is not OperationCanceledException || !cancellationToken.IsCancellationRequested) { RecordFailure(error); throw; }
+    }
+
+    public async ValueTask<IReadOnlyList<OutboxMessage>> GetNextBatchAsync(int bucket, int maxCount, CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref _reads);
+        try { return await inner.GetNextBatchAsync(bucket, maxCount, cancellationToken).ConfigureAwait(false); }
+        catch (Exception error) when (error is not OperationCanceledException || !cancellationToken.IsCancellationRequested) { RecordFailure(error); throw; }
+    }
+
+    public async ValueTask MarkPublishedAsync(int bucket, IReadOnlyList<OutboxMessage> publishedMessages, CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref _marks);
+        try
+        {
+            await inner.MarkPublishedAsync(bucket, publishedMessages, cancellationToken).ConfigureAwait(false);
+            Interlocked.Add(ref _published, publishedMessages.Count);
+        }
+        catch (Exception error) when (error is not OperationCanceledException || !cancellationToken.IsCancellationRequested) { RecordFailure(error); throw; }
+    }
+
+    public async ValueTask<OutboxPendingMetrics?> GetPendingMetricsAsync(CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref _metricQueries);
+        try { return await inner.GetPendingMetricsAsync(cancellationToken).ConfigureAwait(false); }
+        catch (Exception error) when (error is not OperationCanceledException || !cancellationToken.IsCancellationRequested) { RecordFailure(error); throw; }
+    }
+
+    private void RecordFailure(Exception error)
+    {
+        Interlocked.Increment(ref _errors);
+        state.RecordFailure(error);
+    }
+}
+
+internal sealed record OutboxOperationCounts(long Acquisitions, long Renewals, long Probes,
+    long Reads, long Marks, long MetricQueries, long Published, long Errors)
+{
+    public OutboxOperationCounts Since(OutboxOperationCounts start) => new(
+        Acquisitions - start.Acquisitions, Renewals - start.Renewals, Probes - start.Probes,
+        Reads - start.Reads, Marks - start.Marks, MetricQueries - start.MetricQueries,
+        Published - start.Published, Errors - start.Errors);
+}
+
+internal sealed class ObservedOutboxPublisher(IOutboxPublisher inner, OutboxWorkloadState state) : IOutboxPublisher
+{
+    public async ValueTask InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        try { await inner.InitializeAsync(cancellationToken).ConfigureAwait(false); }
+        catch (Exception error) when (error is not OperationCanceledException || !cancellationToken.IsCancellationRequested) { state.RecordFailure(error); throw; }
+    }
+
+    public async ValueTask<OutboxPublishResult> PublishAsync(IReadOnlyList<OutboxMessage> messages, string messageIdHeaderName,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var result = await inner.PublishAsync(messages, messageIdHeaderName, cancellationToken).ConfigureAwait(false);
+            if (result.FirstError is { } error)
+                state.RecordFailure(error);
+            else if (result.AckedCount != messages.Count)
+                state.RecordFailure(new InvalidOperationException("The outbox publisher returned an incomplete prefix without an error."));
+            return result;
+        }
+        catch (Exception error) when (error is not OperationCanceledException || !cancellationToken.IsCancellationRequested) { state.RecordFailure(error); throw; }
+    }
+
+    public ValueTask DisposeAsync() => inner.DisposeAsync();
+}

--- a/tools/Dekaf.StressTests/Scenarios/OutboxIdlePhase.cs
+++ b/tools/Dekaf.StressTests/Scenarios/OutboxIdlePhase.cs
@@ -1,0 +1,62 @@
+using System.Diagnostics;
+using Dekaf.StressTests.Metrics;
+
+namespace Dekaf.StressTests.Scenarios;
+
+/// <summary>Real idle time, with no invented message completions or throughput denominator.</summary>
+internal static class OutboxIdlePhase
+{
+    public static async Task<OutboxIdleSnapshot> RunAsync(TimeSpan duration, Func<OutboxOperationCounts> readOperations,
+        OutboxWorkloadState state, CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(duration, TimeSpan.Zero);
+        var samples = new List<OutboxIdleSample>((int)Math.Ceiling(duration.TotalSeconds) + 2);
+        var operationsStart = readOperations();
+        var runtimeStart = RuntimeObservation.Capture();
+        var started = Stopwatch.GetTimestamp();
+        samples.Add(new OutboxIdleSample(0, runtimeStart, operationsStart));
+        while (true)
+        {
+            var remaining = duration - Stopwatch.GetElapsedTime(started);
+            if (remaining <= TimeSpan.Zero)
+                break;
+            await Task.Delay(remaining < TimeSpan.FromSeconds(1) ? remaining : TimeSpan.FromSeconds(1), cancellationToken).ConfigureAwait(false);
+            state.ThrowIfFailed();
+            if (state.Reserved != 0 || state.Completed != 0)
+                throw new InvalidOperationException("The idle outbox phase contains message activity.");
+            samples.Add(new OutboxIdleSample(Stopwatch.GetElapsedTime(started).TotalSeconds, RuntimeObservation.Capture(), readOperations()));
+        }
+        var elapsed = Stopwatch.GetElapsedTime(started).TotalSeconds;
+        var end = RuntimeObservation.Capture();
+        var operations = readOperations();
+        samples.Add(new OutboxIdleSample(elapsed, end, operations));
+        var delta = operations.Since(operationsStart);
+        if (delta.Probes == 0 || delta.Published != 0 || delta.Errors != 0)
+            throw new InvalidOperationException("The idle phase did not exercise a healthy empty relay.");
+        return new OutboxIdleSnapshot(duration.TotalSeconds, elapsed, runtimeStart, end, delta, samples);
+    }
+}
+
+internal sealed record OutboxIdleSample(double ElapsedSeconds, RuntimeObservation Runtime, OutboxOperationCounts Operations);
+
+internal sealed record OutboxIdleSnapshot(double RequestedSeconds, double ElapsedSeconds,
+    RuntimeObservation RuntimeStart, RuntimeObservation RuntimeEnd, OutboxOperationCounts Operations,
+    IReadOnlyList<OutboxIdleSample> Samples)
+{
+    public double CpuMillisecondsPerSecond => (RuntimeEnd.CpuSeconds - RuntimeStart.CpuSeconds) * 1000 / ElapsedSeconds;
+    public double AllocatedBytesPerSecond => (RuntimeEnd.AllocatedBytes - RuntimeStart.AllocatedBytes) / ElapsedSeconds;
+}
+
+internal sealed record OutboxWorkloadSnapshot(OutboxIdleSnapshot IdleWarmup, OutboxIdleSnapshot Idle,
+    double ActiveRequestedSeconds, double ActiveWorkloadSeconds, long CommittedMessages, long UniqueConsumedMessages,
+    long DuplicatePublications, OutboxOperationCounts ActiveOperations)
+{
+    public bool HasCompleteDuration(int configuredMinutes, double activeElapsedSeconds) =>
+        double.IsFinite(Idle.RequestedSeconds) && double.IsFinite(Idle.ElapsedSeconds)
+        && double.IsFinite(ActiveRequestedSeconds) && double.IsFinite(activeElapsedSeconds)
+        && double.IsFinite(ActiveWorkloadSeconds) && ActiveWorkloadSeconds >= ActiveRequestedSeconds
+        && activeElapsedSeconds >= ActiveWorkloadSeconds
+        && Idle.RequestedSeconds > 0 && ActiveRequestedSeconds > 0
+        && Math.Abs(Idle.RequestedSeconds + ActiveRequestedSeconds - configuredMinutes * 60) < 0.001
+        && Idle.ElapsedSeconds >= Idle.RequestedSeconds && activeElapsedSeconds >= ActiveRequestedSeconds;
+}

--- a/tools/Dekaf.StressTests/Scenarios/OutboxStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/OutboxStressTest.cs
@@ -1,0 +1,262 @@
+using Dekaf.Consumer;
+using Dekaf.Outbox;
+using Dekaf.Outbox.EntityFrameworkCore;
+using Dekaf.Serialization;
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Reporting;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Dekaf.StressTests.Scenarios;
+
+/// <summary>Measures an empty relay, then committed EF writes through real Kafka delivery.</summary>
+internal sealed class OutboxStressTest : IStressTestScenario
+{
+    internal const int WriteBatchSize = 32;
+    internal const double IdleFraction = 0.25;
+    public string Name => "outbox";
+    public string Client => "Dekaf";
+
+    public async Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.MessageSizeBytes, 24);
+        if (options.BrokerCount != 1 || options.ConnectionsPerBroker != 1 || options.Compression != "none" || options.AdaptiveConnections)
+            throw new ArgumentException("The outbox workload requires one broker, one connection and no compression.", nameof(options));
+        if (!options.EnableProducerDeliveryDiagnostics)
+            throw new ArgumentException("The outbox workload requires --producer-delivery-diagnostics.", nameof(options));
+        var directory = Path.GetFullPath(options.OutputDirectory);
+        Directory.CreateDirectory(directory);
+        var database = Path.Combine(directory, $"outbox-{Guid.NewGuid():N}.db");
+        var success = false;
+        try
+        {
+            var result = await RunDatabaseAsync(options, database, cancellationToken).ConfigureAwait(false);
+            success = true;
+            return result;
+        }
+        finally
+        {
+            if (success)
+            {
+                // Only this invocation's database files; pooled connections are disabled.
+                foreach (var suffix in new[] { "", "-wal", "-shm" })
+                    File.Delete(database + suffix);
+            }
+            else
+                Console.Error.WriteLine($"Outbox failure database retained at {database}.");
+        }
+    }
+
+    private async Task<StressTestResult> RunDatabaseAsync(StressTestOptions options, string database, CancellationToken cancellationToken)
+    {
+        var started = DateTime.UtcNow;
+        var state = new OutboxWorkloadState(options.MessageSizeBytes, options.Partitions, Random.Shared.NextInt64(1, long.MaxValue));
+        var producerBuilder = OutboxServiceCollectionExtensions.CreateRelayProducerBuilder(builder => builder
+            .WithBootstrapServers(options.BootstrapServers)
+            .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
+            .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs)).WithBatchSize(options.BatchSize)
+            .WithConnectionsPerBroker(1).WithoutAdaptiveConnections(), StressClientLogging.LoggerFactory);
+        StressTestHelpers.ConfigureProducerDeliveryDiagnostics(producerBuilder, options);
+        var producer = await producerBuilder.BuildAsync(cancellationToken).ConfigureAwait(false);
+        await using var publisher = new ObservedOutboxPublisher(new DekafOutboxPublisher(producer), state);
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IOutboxPublisher>(publisher);
+        services.AddDekafEntityFrameworkCoreOutboxStore<OutboxContext>((_, builder) => builder.UseSqlite(
+            new SqliteConnectionStringBuilder { DataSource = database, Pooling = false, DefaultTimeout = 30 }.ToString()));
+        services.AddSingleton<IOutboxStore>(provider => new ObservedOutboxStore<OutboxContext>(
+            new EfCoreOutboxStore<OutboxContext>(provider.GetRequiredService<IDbContextFactory<OutboxContext>>()), state));
+        services.AddDekafOutboxRelay(new OutboxRelayOptions());
+        await using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IDbContextFactory<OutboxContext>>();
+        var store = (ObservedOutboxStore<OutboxContext>)provider.GetRequiredService<IOutboxStore>();
+        var relay = provider.GetServices<IHostedService>().OfType<OutboxRelayService>().Single();
+        await using (var context = await factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false))
+        {
+            await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+            await context.Database.ExecuteSqlRawAsync("PRAGMA journal_mode=WAL;", cancellationToken).ConfigureAwait(false);
+        }
+        await relay.StartAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            Console.WriteLine($"  Outbox idle warmup: {options.ProducerWarmupSeconds}s; no writer or Kafka reader is active.");
+            var idleWarmup = await OutboxIdlePhase.RunAsync(TimeSpan.FromSeconds(options.ProducerWarmupSeconds),
+                store.Snapshot, state, cancellationToken).ConfigureAwait(false);
+            var idleDuration = TimeSpan.FromMinutes(options.DurationMinutes * IdleFraction);
+            var activeDuration = TimeSpan.FromMinutes(options.DurationMinutes * (1 - IdleFraction));
+            Console.WriteLine($"  Outbox idle measurement: {idleDuration.TotalSeconds}s.");
+            var idle = await OutboxIdlePhase.RunAsync(idleDuration, store.Snapshot, state, cancellationToken).ConfigureAwait(false);
+            await VerifyRollbackAsync(factory, options, state, cancellationToken).ConfigureAwait(false);
+
+            await using var consumer = new KafkaConsumer<string, byte[]>(new ConsumerOptions
+            {
+                BootstrapServers = options.BootstrapServers.Split(','),
+                AutoOffsetReset = AutoOffsetReset.None,
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                EnableAutoOffsetStore = false,
+                ConnectionsPerBroker = 1,
+                MaxConnectionsPerBroker = 1,
+                EnableAdaptiveConnections = false
+            }, Serializers.String, Serializers.ByteArray);
+            await consumer.InitializeAsync(cancellationToken).ConfigureAwait(false);
+            var assignments = new TopicPartitionOffset[options.Partitions];
+            for (var p = 0; p < assignments.Length; p++)
+                assignments[p] = new TopicPartitionOffset(options.Topic, p, 0);
+            consumer.IncrementalAssign(assignments);
+            using var readerLifetime = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var reader = ReadAsync(consumer, state, readerLifetime.Token);
+            try
+            {
+                var keys = new string[OutboxRelayOptions.DefaultBucketCount];
+                for (var i = 0; i < keys.Length; i++)
+                    keys[i] = $"outbox-key-{i}";
+                var measured = new ThroughputTracker();
+                Console.WriteLine($"  Warming up Dekaf outbox: {options.ProducerWarmupSeconds}s of committed writes and complete drain.");
+                measured.Warmup = await ProducerWarmup.RunAsync(options.ProducerWarmupSeconds,
+                    RunCycleAsync, cancellationToken).ConfigureAwait(false);
+                var committedStart = state.Committed;
+                var completedStart = state.Completed;
+                var duplicatesStart = state.Duplicates;
+                var operationsStart = store.Snapshot();
+                Console.WriteLine($"  Running Dekaf outbox stress test: {activeDuration.TotalSeconds}s active after {idleDuration.TotalSeconds}s measured idle.");
+                var run = await RunCycleAsync(activeDuration, measured, cancellationToken).ConfigureAwait(false);
+                state.ThrowIfFailed();
+                return new StressTestResult
+                {
+                    Scenario = Name, Client = Client, DurationMinutes = options.DurationMinutes,
+                    MessageSizeBytes = options.MessageSizeBytes, BrokerCount = options.BrokerCount,
+                    StartedAtUtc = started, CompletedAtUtc = DateTime.UtcNow,
+                    Throughput = run.Throughput, GcStats = run.Gc, Latency = state.Latency.GetSnapshot(),
+                    CpuTimeSeconds = measured.CpuTimeSeconds, ConsumedMessages = state.Completed - completedStart,
+                    Idempotent = true,
+                    ProducerDeliveryDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options)
+                        ?? throw new InvalidOperationException("The outbox workload requires producer delivery diagnostics."),
+                    Outbox = new OutboxWorkloadSnapshot(idleWarmup, idle, activeDuration.TotalSeconds,
+                        run.WorkloadSeconds,
+                        state.Committed - committedStart, state.Completed - completedStart,
+                        state.Duplicates - duplicatesStart, store.Snapshot().Since(operationsStart))
+                };
+
+                async Task<ProducerWorkloadResult> RunCycleAsync(TimeSpan duration, ThroughputTracker tracker, CancellationToken token)
+                {
+                    state.BeginCycle(tracker);
+                    StressTestHelpers.ResetProducerDeliveryDiagnostics(producer);
+                    using var gc = new GcStats();
+                    using var ingress = CancellationTokenSource.CreateLinkedTokenSource(token);
+                    using var sampling = new CancellationTokenSource();
+                    tracker.Start();
+                    var stop = ProducerWorkload.StopIngressAsync(ingress, duration, TimeProvider.System);
+                    using var watchdog = options.ProgressWatchdog.Track(tracker, Client, Name);
+                    var sampler = StressTestHelpers.RunSamplerAsync(tracker, sampling.Token);
+                    var resources = StressTestHelpers.RunResourceMonitorAsync(sampling.Token);
+                    double workloadSeconds;
+                    try
+                    {
+                        while (!ingress.IsCancellationRequested)
+                        {
+                            state.ThrowIfFailed();
+                            if (!state.TryReserve(out var sequence))
+                            {
+                                await Task.Delay(1, token).ConfigureAwait(false);
+                                continue;
+                            }
+                            await using var context = await factory.CreateDbContextAsync(token).ConfigureAwait(false);
+                            var count = 0;
+                            do
+                            {
+                                var key = (int)(sequence % keys.Length);
+                                context.AddOutboxMessage(options.Topic, keys[key], state.CreatePayload(sequence),
+                                    Serializers.String, Serializers.ByteArray, partition: key % options.Partitions);
+                                count++;
+                            } while (count < WriteBatchSize && state.TryReserve(out sequence));
+                            await context.SaveChangesAsync(token).ConfigureAwait(false);
+                            state.RecordCommitted(count);
+                        }
+                        workloadSeconds = tracker.Elapsed.TotalSeconds;
+                        using var drain = CancellationTokenSource.CreateLinkedTokenSource(token);
+                        drain.CancelAfter(StressTestHelpers.OperationTimeout);
+                        while (state.Completed != state.Committed || store.Published != state.Committed
+                            || await PendingCountAsync(factory, drain.Token).ConfigureAwait(false) != 0)
+                        {
+                            state.ThrowIfFailed();
+                            await Task.Delay(1, drain.Token).ConfigureAwait(false);
+                        }
+                        await producer.FlushAsync(drain.Token).ConfigureAwait(false);
+                        var ends = await StressTestHelpers.QueryEndOffsetsAsync(consumer, options.Topic, options.Partitions, drain.Token).ConfigureAwait(false);
+                        while (!state.HasReadThrough(ends))
+                        {
+                            state.ThrowIfFailed();
+                            await Task.Delay(1, drain.Token).ConfigureAwait(false);
+                        }
+                        if (ends.Sum() != state.Completed + state.Duplicates)
+                            throw new InvalidOperationException("Kafka offsets do not match unique and duplicate outbox deliveries.");
+                        state.ThrowIfFailed();
+                    }
+                    finally
+                    {
+                        ingress.Cancel();
+                        sampling.Cancel();
+                        await stop.ConfigureAwait(false);
+                        await Task.WhenAll(sampler, resources).ConfigureAwait(false);
+                        tracker.Stop();
+                        gc.Capture();
+                    }
+                    token.ThrowIfCancellationRequested();
+                    return new ProducerWorkloadResult(workloadSeconds, tracker.GetSnapshot(), gc.ToSnapshot());
+                }
+            }
+            finally
+            {
+                readerLifetime.Cancel();
+                await reader.ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            using var shutdown = new CancellationTokenSource(StressTestHelpers.OperationTimeout);
+            await relay.StopAsync(shutdown.Token).ConfigureAwait(false);
+            if (relay.ExecuteTask is { } execution)
+                await execution.WaitAsync(shutdown.Token).ConfigureAwait(false);
+            state.ThrowIfFailed();
+        }
+    }
+
+    private static async Task ReadAsync(KafkaConsumer<string, byte[]> consumer, OutboxWorkloadState state, CancellationToken token)
+    {
+        try
+        {
+            await foreach (var record in consumer.ConsumeAsync(token).ConfigureAwait(false))
+                state.Process(record.Value, record.Partition, record.Offset);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested) { }
+        catch (Exception error) { state.RecordFailure(error); }
+    }
+
+    private static async Task VerifyRollbackAsync(IDbContextFactory<OutboxContext> factory, StressTestOptions options,
+        OutboxWorkloadState state, CancellationToken cancellationToken)
+    {
+        await using (var context = await factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false))
+        {
+            await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+            context.AddOutboxMessage(options.Topic, "rolled-back", state.CreatePayload(-1), Serializers.String, Serializers.ByteArray);
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+        }
+        if (await PendingCountAsync(factory, cancellationToken).ConfigureAwait(false) != 0)
+            throw new InvalidOperationException("The rolled-back outbox row remains in the database.");
+    }
+
+    private static async Task<long> PendingCountAsync(IDbContextFactory<OutboxContext> factory, CancellationToken token)
+    {
+        await using var context = await factory.CreateDbContextAsync(token).ConfigureAwait(false);
+        return await context.Set<OutboxMessage>().LongCountAsync(token).ConfigureAwait(false);
+    }
+
+    public sealed class OutboxContext(DbContextOptions<OutboxContext> options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder) => modelBuilder.UseDekafOutbox();
+    }
+}

--- a/tools/Dekaf.StressTests/Scenarios/OutboxWorkloadState.cs
+++ b/tools/Dekaf.StressTests/Scenarios/OutboxWorkloadState.cs
@@ -1,0 +1,125 @@
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using Dekaf.StressTests.Metrics;
+
+namespace Dekaf.StressTests.Scenarios;
+
+/// <summary>Bounded message identities shared by one database writer and one Kafka reader.</summary>
+internal sealed class OutboxWorkloadState
+{
+    internal const int WindowSize = 4096;
+    private readonly long[] _completedSequences = new long[WindowSize];
+    private readonly long[] _readOffsets;
+    private readonly int _messageSize;
+    private readonly long _runIdentity;
+    private ThroughputTracker? _throughput;
+    private Exception? _failure;
+    private long _reserved;
+    private long _committed;
+    private long _completed;
+    private long _duplicates;
+
+    public long Reserved => Volatile.Read(ref _reserved);
+    public long Committed => Volatile.Read(ref _committed);
+    public long Completed => Volatile.Read(ref _completed);
+    public long Duplicates => Volatile.Read(ref _duplicates);
+    public LatencyTracker Latency { get; } = new();
+
+    public OutboxWorkloadState(int messageSize, int partitions, long runIdentity)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(messageSize, 24);
+        ArgumentOutOfRangeException.ThrowIfLessThan(partitions, 1);
+        _messageSize = messageSize;
+        _runIdentity = runIdentity;
+        _readOffsets = new long[partitions];
+        for (var i = 0; i < WindowSize; i++)
+            _completedSequences[i] = i - WindowSize;
+    }
+
+    public void BeginCycle(ThroughputTracker throughput)
+    {
+        ThrowIfFailed();
+        if (Reserved != Committed || Completed != Committed)
+            throw new InvalidOperationException("The previous outbox phase has not fully drained.");
+        Latency.Reset();
+        _throughput = throughput;
+    }
+
+    // Reservation precedes SaveChanges: a post-commit notification can deliver the row
+    // before SaveChanges returns to the writer. Failed saves fail the entire workload.
+    public bool TryReserve(out long sequence)
+    {
+        sequence = _reserved;
+        if (sequence - Completed >= WindowSize
+            || Volatile.Read(ref _completedSequences[sequence % WindowSize]) != sequence - WindowSize)
+            return false;
+        Volatile.Write(ref _reserved, sequence + 1);
+        return true;
+    }
+
+    public void RecordCommitted(int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(count, 1);
+        var committed = _committed + count;
+        if (committed > Reserved)
+            throw new InvalidOperationException("Committed rows exceed reserved message identities.");
+        Volatile.Write(ref _committed, committed);
+    }
+
+    public byte[] CreatePayload(long sequence)
+    {
+        var payload = new byte[_messageSize];
+        BinaryPrimitives.WriteInt64LittleEndian(payload, sequence);
+        BinaryPrimitives.WriteInt64LittleEndian(payload.AsSpan(8), Stopwatch.GetTimestamp());
+        BinaryPrimitives.WriteInt64LittleEndian(payload.AsSpan(16), _runIdentity);
+        return payload;
+    }
+
+    public bool Process(byte[]? payload, int partition, long offset)
+    {
+        if (payload is null || payload.Length != _messageSize
+            || BinaryPrimitives.ReadInt64LittleEndian(payload.AsSpan(16)) != _runIdentity)
+            throw new InvalidOperationException("The outbox record does not belong to this workload.");
+        var sequence = BinaryPrimitives.ReadInt64LittleEndian(payload);
+        var timestamp = BinaryPrimitives.ReadInt64LittleEndian(payload.AsSpan(8));
+        var elapsed = Stopwatch.GetTimestamp() - timestamp;
+        if (sequence < 0 || sequence >= Reserved || timestamp <= 0 || elapsed < 0)
+            throw new InvalidOperationException("The outbox record has an invalid identity or timestamp.");
+        if ((uint)partition >= (uint)_readOffsets.Length || offset != _readOffsets[partition])
+            throw new InvalidOperationException("The Kafka reader skipped or repeated a partition offset.");
+        Volatile.Write(ref _readOffsets[partition], offset + 1);
+
+        ref var slot = ref _completedSequences[sequence % WindowSize];
+        var previous = Interlocked.CompareExchange(ref slot, sequence, sequence - WindowSize);
+        if (previous >= sequence)
+        {
+            Interlocked.Increment(ref _duplicates);
+            return false;
+        }
+        if (previous != sequence - WindowSize)
+            throw new InvalidOperationException("An outbox identity skipped an unfinished slot generation.");
+        Latency.RecordTicks(elapsed);
+        _throughput!.RecordMessage(payload.Length);
+        Interlocked.Increment(ref _completed);
+        return true;
+    }
+
+    public bool HasReadThrough(long[] endOffsets)
+    {
+        if (endOffsets.Length != _readOffsets.Length)
+            throw new ArgumentException("Partition counts do not match.", nameof(endOffsets));
+        for (var i = 0; i < endOffsets.Length; i++)
+            if (Volatile.Read(ref _readOffsets[i]) < endOffsets[i])
+                return false;
+        return true;
+    }
+
+    public void RecordFailure(Exception exception) => Interlocked.CompareExchange(ref _failure, exception, null);
+
+    public void ThrowIfFailed()
+    {
+        if (Volatile.Read(ref _failure) is { } failure)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+}


### PR DESCRIPTION
The maintained stress runner had no workload that exercised the EF outbox store, relay and real Kafka publication, leaving #3232 without supported loaded evidence. Add the manual-only `outbox-1b` lane with an isolated SQLite WAL database and broker-visible delivery verification.

The measured duration is split into 25% genuine idle time and 75% active admission, followed by full drain. Each phase has its own declared warmup; active warmup retains six drain/reuse cycles. Idle measurements retain process CPU, allocations/second, runtime samples and store counters without inventing message completions. Active measurements use the existing throughput, latency, CPU/message, allocation/message and stability machinery.

The oracle bounds outstanding identities to 4,096, checks Kafka partition offsets, distinguishes unique committed delivery from at-least-once duplicate publication, verifies rollback poison never appears, and drains both database marks and broker end offsets before shutdown. Store/publisher failures remain observable, including failures racing cancellation.

Idle coverage and trends are validated independently. The A-B-A comparison adds idle CPU and allocation rows using existing tolerances; retained CPU spikes remain in aggregate costs. Existing lane defaults, the 12-job full matrix, exact-SHA ancestry and root build-input guards remain unchanged. See `tools/Dekaf.StressTests/Outbox.md` for phase boundaries, ordering scope and experiment budget.

No product source changes. Harness payload creation, EF tracking and persistence allocate per message; observation costs occur per store operation or runtime sample. Both revisions receive identical harness sources. This infrastructure does not resolve the 112 B/save notification overhead or historical idle CPU regression in parent #3232.

Validation:
- Final head: 60 stress-harness tests and 244 Python stress tests pass; repository artifact policy reports zero violations.
- Full Release solution build passed without warnings before rebasing the unrelated #3256 share-subscription merge; the final stress/harness build passes after rebase.
- Real local Kafka run: 155,919 committed and unique consumed messages, zero duplicates/errors, complete database/broker drain and clean shutdown. It measured 30.018 seconds idle and 90.018 seconds active admission, with 20-second warmups and the fixed-32-worker experiment settings.
- That local run is **INCONCLUSIVE for steady state**: idle warmup still changed observed thread-pool size (4 to 7). The validator rejects it. It is correctness evidence, not loaded acceptance, and no tolerance or sample was removed.
- Local measurement used source commit `57554a878` over `8591f37db`; subsequent changes preserve unrelated failures during cancellation, add two tests, preserve other scenarios' identity shape and rebase onto main. Hosted validation will exercise the final head.

Evidence is retained outside removable worktrees at `C:/git/Dekaf-evidence/issue-3262`: raw local JSON/logs and assessment, `local-v2-retained` (496 SHA-256-verified files including measured binaries and changed sources), `final-retained` (475 verified output files), complete source ZIPs and test logs. `source-final.zip` SHA-256: `6A6E5604F20F41500A9F4C917D7A276A65CFB4C3D77AF4B0A43014E70F0FE589`. No generated evidence is committed.

Hosted acceptance is pending. Planned single dispatch: `outbox-1b`, `dispatch_shape=cheap`, `duration_minutes=5`, `producer_warmup_seconds=180`, `fixed_worker_threads=32`, `message_size=1000`, profiling off, `baseline_sha=de392a56bcc460bbfa5dbc0dfdb315e21cb9691f`. Exact-SHA mode replaces cheap sampling with A1/B/A2. Each measured sample has 75 idle and 225 active seconds; both warmups plus two correctness preflights budget approximately 47 minutes before setup/drains. Results apply to this explicit worker-pool configuration. Record the run and verdict here before merge or another paid dispatch.

Closes #3262
