### PR TITLE
perf(share-consumer): isolate contiguous parsing fallback

### DIFF
--- a/src/Dekaf/Protocol/KafkaProtocolReader.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolReader.cs
@@ -855,6 +855,25 @@ public ref struct KafkaProtocolReader
         return buffer;
     }
 
+    // Record and header readers construct contiguous-memory readers. Keep their
+    // slicing path small enough to inline without expanding the general reader.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ReadOnlyMemory<byte> ReadContiguousMemorySlice(int count)
+    {
+        if (!_isContiguous || !_hasMemory)
+            return ReadMemorySliceFallback(count);
+        if (count == 0)
+            return ReadOnlyMemory<byte>.Empty;
+
+        ValidateReadableLength(count);
+        var result = _memory.Slice(_position, count);
+        _position += count;
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private ReadOnlyMemory<byte> ReadMemorySliceFallback(int count) => ReadMemorySlice(count);
+
     /// <summary>
     /// Reads a slice like <see cref="ReadMemorySlice(int)"/>, but fails with
     /// <see cref="InsufficientDataException"/> when the slice would extend past

--- a/src/Dekaf/ShareConsumer/ShareBatchRecordReader.cs
+++ b/src/Dekaf/ShareConsumer/ShareBatchRecordReader.cs
@@ -19,7 +19,7 @@ internal static class ShareBatchRecordReader
         // tail; an invalid field inside a complete body is protocol corruption.
         if (length > reader.Remaining)
             throw new InsufficientDataException();
-        var body = reader.ReadMemorySlice(length);
+        var body = reader.ReadContiguousMemorySlice(length);
         var bodyReader = new KafkaProtocolReader(body);
         try
         {
@@ -27,9 +27,9 @@ internal static class ShareBatchRecordReader
             var timestampDelta = bodyReader.ReadVarLong();
             var offsetDelta = bodyReader.ReadVarInt();
             var keyLength = bodyReader.ReadVarInt();
-            var key = keyLength < 0 ? ReadOnlyMemory<byte>.Empty : bodyReader.ReadMemorySlice(keyLength);
+            var key = keyLength < 0 ? ReadOnlyMemory<byte>.Empty : bodyReader.ReadContiguousMemorySlice(keyLength);
             var valueLength = bodyReader.ReadVarInt();
-            var value = valueLength < 0 ? ReadOnlyMemory<byte>.Empty : bodyReader.ReadMemorySlice(valueLength);
+            var value = valueLength < 0 ? ReadOnlyMemory<byte>.Empty : bodyReader.ReadContiguousMemorySlice(valueLength);
             var headerCount = bodyReader.ReadVarInt();
             if (headerCount < 0 || headerCount > Record.MaxReasonableHeaderCount
                 || headerCount > bodyReader.Remaining / 2)

--- a/src/Dekaf/ShareConsumer/ShareConsumeBatch.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumeBatch.cs
@@ -46,9 +46,9 @@ public readonly struct ShareBatchHeaders
             if (_remaining == 0)
                 return false;
             var reader = new KafkaProtocolReader(_bytes[_position..]);
-            var key = reader.ReadMemorySlice(reader.ReadVarInt());
+            var key = reader.ReadContiguousMemorySlice(reader.ReadVarInt());
             var valueLength = reader.ReadVarInt();
-            var value = valueLength < 0 ? ReadOnlyMemory<byte>.Empty : reader.ReadMemorySlice(valueLength);
+            var value = valueLength < 0 ? ReadOnlyMemory<byte>.Empty : reader.ReadContiguousMemorySlice(valueLength);
             Current = new ShareBatchHeader(key, value, valueLength < 0);
             _position += checked((int)reader.Consumed);
             _remaining--;

--- a/tests/Dekaf.Tests.Unit/Protocol/KafkaProtocolReaderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/KafkaProtocolReaderTests.cs
@@ -6,6 +6,69 @@ namespace Dekaf.Tests.Unit.Protocol;
 public class KafkaProtocolReaderTests
 {
     [Test]
+    [Arguments(-1)]
+    [Arguments(5)]
+    public async Task ReadContiguousMemorySlice_InvalidLength_PreservesCursor(int length)
+    {
+        var reader = new KafkaProtocolReader(new byte[] { 1, 2, 3, 4, 5 });
+        _ = reader.ReadInt8();
+        var rejected = false;
+        try
+        {
+            _ = reader.ReadContiguousMemorySlice(length);
+        }
+        catch (MalformedProtocolDataException)
+        {
+            rejected = true;
+        }
+        var consumed = reader.Consumed;
+        var next = reader.ReadInt8();
+
+        await Assert.That(rejected).IsTrue();
+        await Assert.That(consumed).IsEqualTo(1);
+        await Assert.That(next).IsEqualTo((sbyte)2);
+    }
+
+    [Test]
+    [Arguments(0, false)]
+    [Arguments(1, false)]
+    [Arguments(2, false)]
+    [Arguments(3, false)]
+    [Arguments(4, false)]
+    [Arguments(0, true)]
+    [Arguments(1, true)]
+    [Arguments(2, true)]
+    [Arguments(3, true)]
+    [Arguments(4, true)]
+    public async Task ReadMemorySlice_PreservesBorrowingAndCursor(int inputKind, bool contiguous)
+    {
+        byte[] data = [1, 2, 3, 4, 5];
+        var reader = inputKind switch
+        {
+            0 => new KafkaProtocolReader(data.AsMemory()),
+            1 => new KafkaProtocolReader(data.AsSpan()),
+            2 => new KafkaProtocolReader(new ReadOnlySequence<byte>(data)),
+            3 => new KafkaProtocolReader(SequenceTestHelpers.CreateMultiSegmentSequence(data, splitAt: 2)),
+            _ => new KafkaProtocolReader(SequenceTestHelpers.CreateMultiSegmentSequence(data, splitAt: 4))
+        };
+        _ = reader.ReadInt8();
+        var empty = contiguous ? reader.ReadContiguousMemorySlice(0) : reader.ReadMemorySlice(0);
+        var afterEmpty = reader.Consumed;
+        var slice = contiguous ? reader.ReadContiguousMemorySlice(3) : reader.ReadMemorySlice(3);
+        var afterSlice = reader.Consumed;
+        var remainingByte = reader.ReadInt8();
+        data[1] = 9;
+
+        await Assert.That(empty.IsEmpty).IsTrue();
+        await Assert.That(afterEmpty).IsEqualTo(1);
+        await Assert.That(afterSlice).IsEqualTo(4);
+        await Assert.That(remainingByte).IsEqualTo((sbyte)5);
+        await Assert.That(slice.Length).IsEqualTo(3);
+        await Assert.That(slice.Span[0]).IsEqualTo((byte)(inputKind is 0 or 2 or 4 ? 9 : 2));
+        await Assert.That(slice.Span[2]).IsEqualTo((byte)4);
+    }
+
+    [Test]
     public async Task ReadInt16_ReadsBigEndian()
     {
         var data = new byte[] { 0x01, 0x02 };

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareBatchHeaderTraversalBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareBatchHeaderTraversalBenchmarks.cs
@@ -1,0 +1,50 @@
+using System.Buffers;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Protocol;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Measures validated borrowed header traversal without string materialization.</summary>
+[MemoryDiagnoser]
+public class ShareBatchHeaderTraversalBenchmarks
+{
+    private ShareBatchHeaders _headers;
+
+    [Params(0, 2, 16)]
+    public int HeaderCount { get; set; }
+
+    [Params(4, 256)]
+    public int KeyLength { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        var key = new string('h', KeyLength);
+        for (var index = 0; index < HeaderCount; index++)
+        {
+            var header = new Header(key, index % 2 == 0 ? new byte[] { 37 } : null);
+            HeaderProtocol.Write(in header, ref writer);
+        }
+        _headers = new ShareBatchHeaders(buffer.WrittenMemory, HeaderCount);
+        var expected = HeaderCount * KeyLength + (HeaderCount + 1) / 2 * 37;
+        if (Traverse() != expected)
+            throw new InvalidOperationException("Header traversal changed bytes, count or null values.");
+    }
+
+    [Benchmark]
+    public int Traverse()
+    {
+        var checksum = 0;
+        foreach (var header in _headers)
+        {
+            checksum += header.KeyUtf8.Length;
+            if (!header.IsValueNull)
+                checksum += header.Value.Span[0];
+        }
+        return checksum;
+    }
+}


### PR DESCRIPTION
Borrowed record and header readers now use a small internal contiguous-memory slicing path. A private `NoInlining` fallback preserves the general reader's span and sequence behavior while keeping that code out of the inline path. Bounds, cursor advancement, borrowed memory, and null handling retain their existing contracts.

Refs #3260.

**Do not merge: historical parsing/preparation acceptance and fresh-main validation remain unresolved. No performance tradeoff is approved.** This candidate enables hosted comparison of the implementation; #3260 remains open for its full scope, including compatibility multi-batch preparation.

Hosted validation is now available for this exact head: [performance gate 34630276250](https://github.com/thomhurst/Dekaf/actions/runs/34630276250) compares baseline `7745de98dcc7b84f356472925ae89bf42a8dac17`, candidate `c28b3cf0cc3eb8e5bbaa9471f31095512f4fd07f`, then the same baseline on each class's VM. All 178 compared cases across 22 classes PASS; none are candidate-only or NOT COMPARED.

The [borrowed-parser job](https://github.com/thomhurst/Dekaf/actions/runs/34630276250/job/103365291184) directly covers the three local 1,024-record losses: cold/no headers is 76.88 / 79.24 / 81.29 microseconds A1/B/A2; warm/two headers is 88.62 / 80.17 / 87.33; cold/two headers is 110.90 / 107.39 / 111.57. Allocation is equal in all 12 parser cases (128 B for synchronous/warm, 792 B for cold preparation). These hosted results do not reproduce the local deltas. They are not claimed as timing wins.

The synchronous 1,024-record/two-header case is +10.5% versus A1 and +9.8% versus A2, which the unchanged gate classifies as PASS with a one-sided note. Header traversal's empty-header case initially exceeded tolerance but did not reproduce in the gate's built-in immediate repeat (+1.1%/+1.2%); all six final header cases allocate zero bytes. All six multi-batch cases also pass with allocation parity.

All original exports, logs, comparison tables and automatic-repeat reports from the 22 class artifacts are retained with a SHA-256 inventory at `D:/Dekaf-evidence/pr-3266-gate-34630276250`. No workflow rerun was requested. This establishes the current candidate-versus-7745 screen, not a comparison against the original pre-ownership controls from #3158/#3248. #3260's broader historical acceptance remains unresolved; a fresh-main rebase and subsequent review/CI cycle are still required before any merge.

Work is constant per slice: up to three slices per record and two per header. The change introduces no per-record/header allocation, asynchronous boundary, lock, or tracking collection. The new six-case `MemoryDiagnoser` fixture covers empty/nonempty headers and short/long keys. Existing borrowed parsing fixtures still exercise synchronous, warm, and original `Task.Yield` cold preparation.

Validation:
- Full Release build: zero warnings/errors.
- Protocol tests: 1,405 on net10.0; 1,399 on net8.0. Share-consumer tests: 535 on each runtime.
- Kafka 4.3.1: all 13 batch/lifetime and sustained ownership tests pass.
- All 45 performance-selector tests, artifact policy, and diff checks pass. Bounds tests also verify invalid lengths fail without advancing the cursor.
- Eighteen local baseline/candidate cases completed with identical fixtures, ten warmup iterations, five measured 500 ms iterations, and outlier removal disabled. Reported nonempty-header code size fell from 3,969�4,027 B to 1,486�1,528 B. Timing remained mixed: at 1,024 records, cold/header-free parsing was +26.75%, warm/two-header parsing +49.59%, and cold/two-header parsing +14.48%. Those losses are unresolved; smaller timings elsewhere are not claimed as wins. Synchronous/warm parsing retained 128 B per batch, and header traversal allocated zero bytes. Exact cold-path allocation deltas remain in the raw comparison.

The local comparison used base `de392a56bcc460bbfa5dbc0dfdb315e21cb9691f` and candidate source retained in `03c176259` before rebasing onto fresh main `7745de98dcc7b84f356472925ae89bf42a8dac17`. Directly changed product files and the fixture are identical after rebasing; main's telemetry changes require fresh hosted validation.

The earlier [#3158 cold-preparation loss](https://github.com/thomhurst/Dekaf/actions/runs/34607767112) and [#3248 parsing/preparation losses](https://github.com/thomhurst/Dekaf/actions/runs/34593080468) remain acceptance requirements. Loaded validation remains subject to #3248/#3245 and the full #3103/#3032 contracts. No paid stress run was dispatched for this candidate.

Exact source snapshots, actual test binaries and generated benchmark workers, disassembly, original logs/reports, comparisons, and verified SHA-256 inventories are retained outside removable worktrees at `D:/Dekaf-evidence/issue-3260`. `isolated-fallback/` contains this implementation experiment; `final-validation/` contains rebased validation. Earlier rejected experiments and the unsuitable single-CPU warmup diagnostic remain separately retained, without being presented as acceptance evidence.
