### PR TITLE
perf(consumer): pool compact key lanes without a separate stack

### DIFF
--- a/.github/scripts/performance_gate.py
+++ b/.github/scripts/performance_gate.py
@@ -41,7 +41,7 @@ COMMENT = re.compile(r'//[^\n]*|/\*.*?\*/', re.S)
 # finishes in roughly 25 minutes.
 SENTINELS = ('AccumulatorAppendBenchmarks', 'ConsumerHotPathBenchmarks',
              'FetchResponseParsingBenchmarks', 'ProduceResponseParsingBenchmarks')
-KEY_DISPATCH_BENCHMARKS = ('PartitionMessageKeyBenchmarks', 'BinaryKeyDispatchBenchmarks',
+KEY_DISPATCH_BENCHMARKS = ('PartitionMessageKeyBenchmarks', 'CustomKeyOrderedDispatchBenchmarks', 'BinaryKeyDispatchBenchmarks',
                            'DistinctBinaryKeyDispatchBenchmarks', 'SharedSuffixBinaryKeyDispatchBenchmarks')
 COMPONENTS = {
     'src/Dekaf/Consumer/KeyOrderedPartitionDispatcher': KEY_DISPATCH_BENCHMARKS,

--- a/.github/scripts/test_performance_gate.py
+++ b/.github/scripts/test_performance_gate.py
@@ -68,7 +68,7 @@ class SelectionTests(unittest.TestCase):
     def test_partition_message_key_selects_direct_fixture(self):
         path = 'src/Dekaf/Consumer/PartitionMessageKey.cs'
         selected = self.names(gate.select([path], root=REPO_ROOT))
-        for name in ('PartitionMessageKeyBenchmarks', 'BinaryKeyDispatchBenchmarks',
+        for name in ('PartitionMessageKeyBenchmarks', 'CustomKeyOrderedDispatchBenchmarks', 'BinaryKeyDispatchBenchmarks',
                      'DistinctBinaryKeyDispatchBenchmarks', 'SharedSuffixBinaryKeyDispatchBenchmarks'):
             self.assertIn(name, selected)
 
@@ -77,7 +77,7 @@ class SelectionTests(unittest.TestCase):
                      'src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.Storage.cs'):
             with self.subTest(path=path):
                 selected = self.names(gate.select([path], root=REPO_ROOT))
-                for name in ('PartitionMessageKeyBenchmarks', 'BinaryKeyDispatchBenchmarks',
+                for name in ('PartitionMessageKeyBenchmarks', 'CustomKeyOrderedDispatchBenchmarks', 'BinaryKeyDispatchBenchmarks',
                              'DistinctBinaryKeyDispatchBenchmarks', 'SharedSuffixBinaryKeyDispatchBenchmarks'):
                     self.assertIn(name, selected)
 

--- a/src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.Storage.cs
+++ b/src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.Storage.cs
@@ -29,6 +29,52 @@ internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
 
     private int StorageCount => UseCompactKeys ? CompactLanes.Count : StandardLanes.Count;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private KeyLane RentLane()
+    {
+        if (UseCompactKeys)
+        {
+            var lane = Unsafe.As<KeyLane>(_freeLanes);
+            if (lane is null) return new KeyLane();
+            _freeLanes = lane.StorageOrNext;
+            lane.StorageOrNext = null;
+            return lane;
+        }
+        var lanes = Unsafe.As<Stack<KeyLane>>(_freeLanes!);
+        return lanes.Count != 0 ? lanes.Pop() : new KeyLane();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ReturnLane(KeyLane lane)
+    {
+        if (UseCompactKeys)
+        {
+            // Compact lanes enter this pool only after releasing key ownership.
+            lane.StorageOrNext = _freeLanes;
+            _freeLanes = lane;
+        }
+        else
+        {
+            Unsafe.As<Stack<KeyLane>>(_freeLanes!).Push(lane);
+        }
+    }
+
+    private void ReleaseFailureLaneKeys()
+    {
+        if (UseCompactKeys)
+        {
+            // A displaced compact lane retains storage in the completed worker,
+            // because its storage slot cannot also carry a free-pool link.
+            foreach (var worker in _freeWorkers)
+                worker.Lane?.ReleaseKey();
+        }
+        else
+        {
+            foreach (var lane in Unsafe.As<Stack<KeyLane>>(_freeLanes!))
+                lane.ReleaseKey();
+        }
+    }
+
 #if NETSTANDARD2_0
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryGetLane(PartitionMessageKey<TKey> key, out KeyLane lane) => UseCompactKeys

--- a/src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.cs
+++ b/src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.cs
@@ -15,7 +15,7 @@ internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
     private readonly int _maxBufferedRecords;
     private readonly object _lanes;
     private readonly bool _hasBinaryKeyComparer;
-    private readonly Stack<KeyLane> _freeLanes;
+    private object? _freeLanes;
     private readonly Queue<KeyLane> _readyLanes;
     private readonly Stack<Worker> _freeWorkers;
     private readonly int _maxWorkers;
@@ -80,8 +80,8 @@ internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
             }
             _hasBinaryKeyComparer = comparer is BinaryPartitionMessageKeyComparer<TKey>;
             _lanes = new Dictionary<PartitionMessageKey<TKey>, KeyLane>(initialCapacity, comparer);
+            _freeLanes = new Stack<KeyLane>(initialCapacity);
         }
-        _freeLanes = new Stack<KeyLane>(initialCapacity);
         _readyLanes = new Queue<KeyLane>(initialCapacity);
         _freeWorkers = new Stack<Worker>(Math.Min(_maxWorkers, initialCapacity));
         _automaticCompletion = automaticCompletion;
@@ -184,10 +184,9 @@ internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
             ReleaseLanes();
             if (_failure is not null)
             {
-                // A failed removal can displace another lane. No new dispatch starts
-                // after that failure, so the free stack also holds shutdown ownership.
-                foreach (var lane in _freeLanes)
-                    lane.ReleaseKey();
+                // Failed removal or rebuilding can displace lanes. Their retained
+                // keys remain owned until every in-flight worker has finished.
+                ReleaseFailureLaneKeys();
             }
             Volatile.Write(ref _laneCount, 0);
             registration.Dispose();
@@ -255,9 +254,9 @@ internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
 #if NETSTANDARD2_0
         if (!TryGetLane(key, out var lane))
         {
-            lane = _freeLanes.Count != 0 ? _freeLanes.Pop() : new KeyLane();
+            lane = RentLane();
             lane.Key = key;
-            lane.KeyStorage = record.RetainStorage();
+            lane.StorageOrNext = record.RetainStorage();
             try
             {
                 AddLane(key, lane);
@@ -276,10 +275,10 @@ internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
         var lane = entry;
         if (lane is null)
         {
-            lane = _freeLanes.Count != 0 ? _freeLanes.Pop() : new KeyLane();
+            lane = RentLane();
             entry = lane;
             lane.Key = key;
-            lane.KeyStorage = record.RetainStorage();
+            lane.StorageOrNext = record.RetainStorage();
             Volatile.Write(ref _laneCount, StorageCount);
         }
 #endif
@@ -327,7 +326,7 @@ internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
                 // must retain every key owner until all in-flight handlers complete,
                 // including lanes no longer reachable from the partially rebuilt table.
                 for (var index = 0; index < count; index++)
-                    _freeLanes.Push(lanes[index]);
+                    ReturnLane(lanes[index]);
                 if (error is ArgumentException)
                     throw new InvalidOperationException(
                         "A partition key changed its hash code or equality while being processed.", error);
@@ -460,14 +459,19 @@ internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
                 // A mutated key may remove a different active lane. Keep its storage
                 // owned until every handler finishes, even though membership is gone.
                 if (removed is not null)
-                    _freeLanes.Push(removed);
+                {
+                    if (UseCompactKeys)
+                        worker.Lane = removed;
+                    else
+                        ReturnLane(removed);
+                }
                 throw new InvalidOperationException("A partition key changed its hash code or equality while being processed.");
             }
 #endif
             lane.ReleaseKey();
             lane.Scheduled = false;
             lane.Tail = -1;
-            _freeLanes.Push(lane);
+            ReturnLane(lane);
             Volatile.Write(ref _laneCount, StorageCount);
         }
 
@@ -555,15 +559,17 @@ internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
     private sealed class KeyLane
     {
         internal PartitionMessageKey<TKey> Key;
-        internal PendingFetchData? KeyStorage;
+        // Active lanes retain PendingFetchData. A released compact lane reuses
+        // this reference for its free-pool link, without enlarging every lane.
+        internal object? StorageOrNext;
         internal int Head = -1;
         internal int Tail = -1;
         internal bool Scheduled;
 
         internal void ReleaseKey()
         {
-            KeyStorage?.ReleaseAfterProcessing();
-            KeyStorage = null;
+            Unsafe.As<PendingFetchData>(StorageOrNext)?.ReleaseAfterProcessing();
+            StorageOrNext = null;
             Key = default;
         }
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedDispatchCoordinatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedDispatchCoordinatorTests.cs
@@ -600,6 +600,113 @@ public sealed class PartitionedDispatchCoordinatorTests
     }
 
     [Test]
+    public async Task CustomScalarComparerMutation_ReleasesDisplacedLaneAndObservesWorkers()
+    {
+        var (lane, storage) = await CreateOwnedInt32LaneAsync(4);
+        var first = new ObservedCompletion();
+        var second = new ObservedCompletion();
+        var comparer = new MutatingInt32Comparer();
+        var handled = new List<long>();
+        var dispatcher = new KeyOrderedPartitionDispatcher<int, int>(
+            new PartitionProcessorContext<int, int>(lane), 1, 3, 4,
+            (records, _) =>
+            {
+                var offset = records[0].Offset;
+                handled.Add(offset);
+                if (offset == 0) return first.Task;
+                if (offset == 1) return second.Task;
+                if (offset == 2)
+                {
+                    comparer.AliasZeroToOne = true;
+                    first.Complete();
+                }
+                return default;
+            }, comparer, automaticCompletion: true);
+        var processing = dispatcher.RunAsync(CancellationToken.None).AsTask();
+        second.Complete();
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await processing.WaitAsync(TimeSpan.FromSeconds(2)));
+        await Assert.That(thrown!.Message).IsEqualTo("A partition key changed its hash code or equality while being processed.");
+        foreach (var memory in storage)
+            await Assert.That(memory.DisposeCount).IsEqualTo(1);
+        await Assert.That(handled).IsEquivalentTo(new long[] { 0, 1, 2 });
+        await Assert.That(first.Observed).IsEqualTo(1);
+        await Assert.That(second.Observed).IsEqualTo(1);
+        await Assert.That(dispatcher.LaneCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    [Timeout(30_000)]
+    public async Task CompactPool_ReusedLaneKeepsRecordStorage(
+        bool customComparer, CancellationToken cancellationToken)
+    {
+        var (lane, storage) = await CreateOwnedInt32LaneAsync(8);
+        var first = new ObservedCompletion();
+        var second = new ObservedCompletion();
+        var handled = new List<long>();
+        var dispatcher = new KeyOrderedPartitionDispatcher<int, int>(
+            new PartitionProcessorContext<int, int>(lane), 1, 2, 4,
+            (records, _) =>
+            {
+                var offset = records[0].Offset;
+                handled.Add(offset);
+                return offset switch { 0 => first.Task, 1 => second.Task, _ => default };
+            }, customComparer ? new MutatingInt32Comparer() : null, automaticCompletion: true);
+        var processing = dispatcher.RunAsync(cancellationToken).AsTask();
+        try
+        {
+            // Both workers are held while the complete pending window owns lanes.
+            // The remaining input must reuse those lanes as handlers finish.
+            await Assert.That(dispatcher.LaneCount).IsEqualTo(4);
+        }
+        finally
+        {
+            first.Complete();
+            second.Complete();
+            await processing.WaitAsync(cancellationToken);
+        }
+        await Assert.That(handled).IsEquivalentTo(new long[] { 0, 1, 2, 3, 4, 5, 6, 7 });
+        foreach (var memory in storage)
+            await Assert.That(memory.DisposeCount).IsEqualTo(1);
+        await Assert.That(first.Observed).IsEqualTo(1);
+        await Assert.That(second.Observed).IsEqualTo(1);
+        await Assert.That(dispatcher.LaneCount).IsEqualTo(0);
+    }
+
+    private static async Task<(PartitionLane<int, int> Lane, TrackedMemory[] Storage)> CreateOwnedInt32LaneAsync(int count)
+    {
+        var lane = CreateLane(count);
+        var storage = new TrackedMemory[count];
+        for (var offset = 0; offset < count; offset++)
+        {
+            var memory = storage[offset] = new TrackedMemory();
+            System.Buffers.Binary.BinaryPrimitives.WriteInt32BigEndian(memory.Bytes, offset);
+            var batch = new RecordBatch
+            {
+                BaseOffset = offset, LastOffsetDelta = 0,
+                Records = [new Record { Key = memory.Memory, Value = memory.Memory }]
+            };
+            using var pending = PendingFetchData.Create("dispatch", 0, [batch], memoryOwner: memory);
+            pending.EagerParseAll();
+            var records = new ConsumeBatch<int, int>(pending, Serializers.Int32, Serializers.Int32).GetEnumerator();
+            await Assert.That(records.MoveNext()).IsTrue();
+            await Assert.That(lane.TryEnqueueForTest(records.Current)).IsTrue();
+        }
+        await lane.StopAsync(PartitionStopPolicy.Drain, Timeout.InfiniteTimeSpan);
+        return (lane, storage);
+    }
+
+    private sealed class MutatingInt32Comparer : IEqualityComparer<int>
+    {
+        internal bool AliasZeroToOne { get; set; }
+        private int Canonical(int key) => AliasZeroToOne && key == 0 ? 1 : key;
+        public bool Equals(int x, int y) => Canonical(x) == Canonical(y);
+        public int GetHashCode(int key) => Canonical(key);
+    }
+
+    [Test]
     public async Task BinaryHashRebuildFailure_ObservesWorkersAndReleasesEveryOwner()
     {
         const int count = 9;

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/CustomKeyOrderedDispatchBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/CustomKeyOrderedDispatchBenchmarks.cs
@@ -1,0 +1,44 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Exercises the dispatcher custom-comparer adapter with the same keys, handler
+/// scheduling and lifetime lengths as the default scalar comparer fixture.
+/// </summary>
+[MemoryDiagnoser]
+public class CustomKeyOrderedDispatchBenchmarks
+{
+    private KeyOrderedDispatchBenchmarks _dispatch = null!;
+
+    [Params(KeyOrderedDispatchBenchmarks.KeyPattern.Repeated,
+        KeyOrderedDispatchBenchmarks.KeyPattern.Distinct,
+        KeyOrderedDispatchBenchmarks.KeyPattern.PendingPairs)]
+    public KeyOrderedDispatchBenchmarks.KeyPattern Pattern { get; set; }
+
+    [Params(1, 16)]
+    public int BatchSize { get; set; }
+
+    [Params(128, 262144)]
+    public int RecordCount { get; set; }
+
+    [GlobalSetup]
+    public Task Setup()
+    {
+        _dispatch = new KeyOrderedDispatchBenchmarks
+        {
+            Pattern = Pattern, BatchSize = BatchSize, RecordCount = RecordCount,
+            KeyComparer = new Int32Comparer()
+        };
+        return _dispatch.Setup();
+    }
+
+    [Benchmark]
+    public ValueTask<int> DispatchLifetime() => _dispatch.DispatchLifetime();
+
+    private sealed class Int32Comparer : IEqualityComparer<int>
+    {
+        public bool Equals(int x, int y) => x == y;
+        public int GetHashCode(int value) => value;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/KeyOrderedDispatchBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/KeyOrderedDispatchBenchmarks.cs
@@ -31,6 +31,8 @@ public class KeyOrderedDispatchBenchmarks
     [Params(128, 262144)]
     public int RecordCount { get; set; }
 
+    internal IEqualityComparer<int>? KeyComparer { get; set; }
+
     [GlobalSetup]
     public async Task Setup()
     {
@@ -57,7 +59,7 @@ public class KeyOrderedDispatchBenchmarks
             EnqueueNext();
         var dispatcher = new KeyOrderedPartitionDispatcher<int, int>(
             new PartitionProcessorContext<int, int>(_lane), BatchSize, 2, Capacity,
-            _handler, automaticCompletion: true);
+            _handler, keyComparer: KeyComparer, automaticCompletion: true);
 
         await dispatcher.RunAsync(deadline.Token).ConfigureAwait(false);
         if (_handled != RecordCount


### PR DESCRIPTION
**Do not merge: hosted performance gate REGRESSION, with no approved tradeoff.**

[Run 34634532334](https://github.com/thomhurst/Dekaf/actions/runs/34634532334) completed on `39337d474874c232dfcee3d0ae089ef77daf893c` against main `5ad345184d2a82dac4a700f80a4e5031cbbeeb5a`. Of 19 fixture classes / 133 compared cases, `PartitionedOffsetCompletionBenchmarks.Ordered(Records=64, OffsetStep=2)` fails. First A1/B/A2: 4.14/4.93/4.47 us (+19.1%/+10.4%); immediate automatic repeat: 4.62/5.13/4.29 us (+11.1%/+19.8%). All phases allocate 56 B/op. [Failed job table](https://github.com/thomhurst/Dekaf/actions/runs/34634532334/job/103380177780). Every other class passes, including the default/custom/binary dispatcher fixtures; there are no candidate-only or uncomparable cases.

The failing fixture directly exercises `PartitionLane<string, string>` in `PartitionedProcessing.cs`. Both files are byte-identical between the measured revisions, verified from Git objects. The product diff changes only the two `KeyOrderedPartitionDispatcher` files. This narrows source attribution but does not prove a harmless runner effect or waive the reproduced gate result. No product fix is established, no rerun is requested, and no gate rule or tolerance changes. A causal product fix or explicit maintainer disposition of this measured tradeoff is required.

All original gate exports/logs, first/repeat/final comparisons, failed job log and source hash evidence are retained outside worktrees at `D:/Dekaf-evidence/pr-3269-gate-34634532334`; the complete SHA-256 inventory is verified. Earlier local measurements and validation below remain diagnostic and do not override this hosted result.

Compact scalar-key dispatchers allocate a separate free-lane stack and backing array. This pools released lanes through their existing storage reference instead: active lanes retain `PendingFetchData`, and a compact lane reuses that reference as its free-list link only after releasing key ownership. Binary and other noncompact keys retain main's comparer lookup, stack representation, and object sizes.

Rent and return remain synchronous and constant time. The change adds no per-record allocation, async operation, interface dispatch, lock, thread hop, dispatcher field, or lane field. Inspected .NET 10 x64 dispatcher storage is 176 raw bytes on both revisions; lane storage is also identical for `int`, `byte[]`, `ReadOnlyMemory<byte>` and `string`. This removes the previous head's 8 B noncompact dispatcher increase and avoids adding a reference to every pending scalar lane.

A comparer mutation can displace an active lane before its handler completes. For compact keys, the completed worker retains that lane until all workers are observed; cleanup then releases its storage. This keeps retained payload ownership separate from free-list links. New tests cover displaced-lane cleanup plus a full pending window followed by lane reuse with retained payloads, for default and custom comparers.

`CustomKeyOrderedDispatchBenchmarks` reuses the existing dispatcher fixture with an explicit custom `IEqualityComparer<int>`. Its 12 steady-state `MemoryDiagnoser` cases cover repeated, distinct and pending-pair keys, batch sizes 1/16, and 128/262,144 records. Permanent component selection includes the fixture. No gate tolerance or PR-specific exception changes. The gate builds PR fixture source against both revisions when compatible, as verified locally here; candidate-only measurement is a fallback if the baseline cannot build that source.

Validation on `39337d474`, based on main `5ad345184d2a82dac4a700f80a4e5031cbbeeb5a`:

- Full Release build: zero warnings/errors, including netstandard2.0.
- 96 focused key, dispatcher, ownership and backpressure unit cases passed on each of net8.0 and net10.0 with normal test parallelism.
- 28 Kafka 4.3.1 key-comparer, dispatch and record-lifetime integration cases passed.
- 55 additional diagnostic cases passed with tiering disabled; inspected enqueue/removal bodies contain no calls to the pool helpers.
- The 45 performance-selector tests cover the unchanged selection/fixture source. The repository artifact policy and complete diff review passed.

The final 44-case local Short comparison saves exactly 1,080 B per dispatcher lifetime in all 24 default/custom scalar cases, at both record counts. All 20 binary/string cases show allocation parity at the report's precision, except one 1 B/op decrease. Both control invocations use main `5ad345184d2a82dac4a700f80a4e5031cbbeeb5a`: the previously archived 24-case scalar/custom run and a new 20-case binary run. All five fixture class sources match after line-ending normalization, with hashes retained.

Timing losses remain unresolved. Default scalar median differences range from -35.03% to +2.54%; custom-comparer differences range from -0.70% to +31.04%. The largest custom losses are repeated keys/batch 16/128 records (+31.04%) and repeated keys/batch 1/262,144 records (+25.96%). String control/two handlers is +16.53%; distinct byte-array/one handler is +15.62% for 1,024-byte keys and +15.96% for 65,536-byte keys. These are diagnostic local measurements, not accepted tradeoffs or speedups. **Do not merge until the revised head's hosted gate resolves the performance concerns.** No paid stress run was dispatched, and parent #3048 remains open for its remaining collision/rebuild work and loaded acceptance.

Final evidence is retained outside removable worktrees at `C:/git/Dekaf-evidence/pr-3269/storage-slot/`: raw reports/logs, `comparison.json`, fixture/source hashes, native listings, object-layout probe and results, final validation (1,976 SHA-256-verified files), and generated candidate workers. Main's binary control workers are retained in `C:/git/Dekaf-evidence/pr-3269/compact-pool-only/baseline-workers` (1,007 files); its scalar/custom control workers remain in `C:/git/Dekaf-evidence/pr-3264/direct-cache-pool/merged-main-workers` (1,009 files). Earlier rejected/intermediate variants and their measurements remain archived separately; they are not presented as final-head validation.

The earlier broad net8.0 consumer failure remains tracked in #3267. Its 32 simultaneous timeouts, original binaries, and isolated diagnostic limitation are retained at `C:/git/Dekaf-evidence/pr-3264/direct-cache-pool/`; passing focused checks on this revision do not explain or replace that failed run.

Follow-up to #3264. The final change retains main's comparer storage after its inspected original-head hosted scalar/binary/distinct-binary jobs passed; restoring a separate comparer reference would introduce an unapproved allocation increase. This PR does not close parent #3048.
