### PR TITLE
test(consumer): establish prefetch before timeout assertion

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -1031,12 +1031,21 @@ public sealed class ConsumeOneFastPathTests
     {
         await using var consumer = CreateInitializedConsumer(queuedMinMessages: 2, fetchMaxWaitMs: 1);
 
-        var result = await consumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(10), CancellationToken.None);
-
-        await Assert.That(result).IsNull();
+        // Establish the real prefetch lifetime before arming the short poll timeout.
+        // A poll canceled before ConsumeOneCoreAsync starts need not create a loop.
+        var startPrefetch = typeof(KafkaConsumer<string, string>)
+            .GetMethod("StartPrefetch", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("StartPrefetch method not found.");
+        startPrefetch.Invoke(consumer, null);
         var prefetchCts = GetPrefetchCts(consumer);
         await Assert.That(prefetchCts).IsNotNull();
         await Assert.That(prefetchCts!.IsCancellationRequested).IsFalse();
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+
+        await Assert.That(result).IsNull();
+        await Assert.That(GetPrefetchCts(consumer)).IsSameReferenceAs(prefetchCts);
+        await Assert.That(prefetchCts.IsCancellationRequested).IsFalse();
     }
 
     [Test]


### PR DESCRIPTION
The prefetch-lifetime test can time out before `ConsumeOneCoreAsync` starts prefetch, then incorrectly fail because no cancellation source exists. Start the real prefetch loop before arming the existing 10 ms poll timeout, capture its cancellation source, and verify the same source remains uncanceled afterward. The separate timeout-returns-null test remains in place.

This is a test-only synchronization fix. Setup invokes the actual private `StartPrefetch` method through the fixture's existing reflection approach; it does not substitute a fake lifetime or extend a deadline. Consumer behavior is unchanged.

Validation: all 50 `ConsumeOneFastPathTests` cases passed on net10.0 and net8.0 in Release. The repository artifact check and final diff review passed. The original intermittent failure is retained under the evidence linked in #3263; no repeated baseline run was used to manufacture a failure or green result.

Final source, loaded test binaries, reports and SHA-256 inventory are archived outside removable worktrees at `C:/git/Dekaf-evidence/issue-3263/prefetch-lifetime/`.

Closes #3263
