### PR TITLE
perf(share-consumer): count sparse acknowledgement prefixes

### DIFF
--- a/src/Dekaf/ShareConsumer/ShareAcknowledgedOffsets.cs
+++ b/src/Dekaf/ShareConsumer/ShareAcknowledgedOffsets.cs
@@ -22,9 +22,7 @@ public readonly struct ShareAcknowledgedOffsets
             if (firstGap >= 0)
             {
                 hasGaps = true;
-                for (var offset = firstGap; offset < types.Length; offset++)
-                    if (types[offset] == (byte)AcknowledgeType.Gap)
-                        count--;
+                count -= CountGaps(types.AsSpan(firstGap));
             }
             length = checked(length + count);
         }
@@ -42,9 +40,10 @@ public readonly struct ShareAcknowledgedOffsets
     /// Gets the acknowledged offset at the specified index.
     /// </summary>
     /// <remarks>
-    /// Each lookup scans acknowledgement batches from the beginning. With gaps, it also scans
-    /// their offset entries, taking O(n) time per lookup and O(n²) for a full indexed traversal.
-    /// Use <see cref="GetEnumerator"/> or <see cref="CopyTo"/> to traverse the entries once.
+    /// Sparse lookups count blocks of entries to skip acknowledged offsets without building an index.
+    /// Each lookup still takes O(n) time in the worst case, and a full indexed traversal takes O(n²).
+    /// Enumeration and <see cref="CopyTo"/> take O(n) time. Copies retain the same immutable batch data;
+    /// indexing adds no storage, cursor state or pool lifetime requirements.
     /// </remarks>
     public long this[int index]
     {
@@ -53,21 +52,13 @@ public readonly struct ShareAcknowledgedOffsets
             ArgumentOutOfRangeException.ThrowIfNegative(index);
             ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Length);
 
+            if (_hasGaps)
+                return GetSparseOffset(_batches!, index);
+
             var batches = _batches!;
             for (var batchIndex = 0; batchIndex < batches.Count; batchIndex++)
             {
                 var batch = batches[batchIndex];
-                if (_hasGaps)
-                {
-                    for (var offset = 0; offset < batch.AcknowledgeTypes.Length; offset++)
-                    {
-                        if (batch.AcknowledgeTypes[offset] == (byte)AcknowledgeType.Gap)
-                            continue;
-                        if (index-- == 0)
-                            return batch.FirstOffset + offset;
-                    }
-                    continue;
-                }
                 if (index < batch.AcknowledgeTypes.Length)
                     return batch.FirstOffset + index;
 
@@ -76,6 +67,51 @@ public readonly struct ShareAcknowledgedOffsets
 
             throw new InvalidOperationException("Offset index was not present in the acknowledgement batches.");
         }
+    }
+
+    // Pass fields so the JIT can keep the view in registers when inlining the indexer.
+    private static long GetSparseOffset(List<AcknowledgementBatchData> batches, int index)
+    {
+        for (var batchIndex = 0; batchIndex < batches.Count; batchIndex++)
+        {
+            var batch = batches[batchIndex];
+            var types = batch.AcknowledgeTypes;
+            var offset = 0;
+            // Keep short logical suffixes scalar so counting setup stays amortized over a prefix.
+            while (index >= 16 && offset < types.Length)
+            {
+                // At most index + 1 entries cannot pass the requested logical offset.
+                // A match inside this prefix therefore means every entry was acknowledged.
+                var prefixLength = Math.Min(index + 1, types.Length - offset);
+                var acknowledged = prefixLength - CountGaps(types.AsSpan(offset, prefixLength));
+                if (index < acknowledged)
+                    return batch.FirstOffset + offset + index;
+                index -= acknowledged;
+                offset += prefixLength;
+            }
+
+            for (; offset < types.Length; offset++)
+            {
+                if (types[offset] == (byte)AcknowledgeType.Gap)
+                    continue;
+                if (index-- == 0)
+                    return batch.FirstOffset + offset;
+            }
+        }
+
+        throw new InvalidOperationException("Offset index was not present in the acknowledgement batches.");
+    }
+
+    private static int CountGaps(ReadOnlySpan<byte> types)
+    {
+#if NET8_0_OR_GREATER
+        return types.Count((byte)AcknowledgeType.Gap);
+#else
+        var count = 0;
+        for (var index = 0; index < types.Length; index++)
+            count += types[index] == (byte)AcknowledgeType.Gap ? 1 : 0;
+        return count;
+#endif
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
@@ -286,6 +286,67 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
     }
 
     [Test]
+    public async Task ShareConsumer_SparseCommitOffsetsRemainValidAfterAnotherCommit()
+    {
+        const int messageCount = 64;
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        ShareAcknowledgementCommitResult[]? outcomes = null;
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .BuildAsync();
+        await using var consumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId($"share-sparse-offsets-{Guid.NewGuid():N}")
+            .WithAcknowledgementMode(ShareAcknowledgementMode.Explicit)
+            .WithMaxPollRecords(messageCount)
+            .WithAcknowledgementCommitCallback(results => outcomes = results.ToArray())
+            .BuildAsync();
+        consumer.Subscribe(topic);
+        await ShareConsumerTestHelper.PrimeShareConsumerAsync(consumer);
+        await ShareConsumerTestHelper.ProduceAsync(producer, topic, messageCount);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var received = new List<ShareConsumeResult<string, string>>(messageCount);
+        await foreach (var record in consumer.PollAsync(timeout.Token))
+        {
+            received.Add(record);
+            if (received.Count == messageCount)
+                break;
+        }
+        await Assert.That(received.Count).IsEqualTo(messageCount);
+        received.Sort(static (left, right) => left.Offset.CompareTo(right.Offset));
+
+        // Alternating dispositions create real gaps inside the broker acknowledgement vector.
+        for (var index = 0; index < messageCount; index += 2)
+            consumer.Acknowledge(received[index], AcknowledgeType.Accept);
+        await consumer.CommitAsync(timeout.Token);
+        await Assert.That(outcomes).HasSingleItem();
+        var firstOutcome = outcomes![0];
+        var firstOffsets = firstOutcome.Offsets;
+        await Assert.That(firstOutcome.Succeeded).IsTrue();
+        await Assert.That(firstOffsets.Length).IsEqualTo(messageCount / 2);
+
+        outcomes = null;
+        for (var index = 1; index < messageCount; index += 2)
+            consumer.Acknowledge(received[index], AcknowledgeType.Accept);
+        await consumer.CommitAsync(timeout.Token);
+        await Assert.That(outcomes).HasSingleItem();
+        var secondOutcome = outcomes![0];
+        await Assert.That(secondOutcome.Succeeded).IsTrue();
+        await Assert.That(secondOutcome.Offsets.Length).IsEqualTo(messageCount / 2);
+
+        // Both retained struct copies and property access must survive return of the callback array.
+        var copied = new long[firstOffsets.Length];
+        firstOffsets.CopyTo(copied);
+        for (var index = 0; index < copied.Length; index++)
+        {
+            await Assert.That(copied[index]).IsEqualTo(received[index * 2].Offset);
+            await Assert.That(firstOutcome.Offsets[index]).IsEqualTo(copied[index]);
+            await Assert.That(secondOutcome.Offsets[index]).IsEqualTo(received[index * 2 + 1].Offset);
+        }
+    }
+
+    [Test]
     public async Task ShareConsumer_ExplicitAcknowledgement_DoesNotAutoAcceptPolledRecord()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareAcknowledgedOffsetsTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareAcknowledgedOffsetsTests.cs
@@ -5,6 +5,125 @@ namespace Dekaf.Tests.Unit.ShareConsumer;
 public sealed class ShareAcknowledgedOffsetsTests
 {
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task OffsetView_FirstAccessDoesNotAllocate(bool sparse)
+    {
+        var types = new byte[64];
+        long expectedSum = 0;
+        for (var index = 0; index < types.Length; index++)
+        {
+            types[index] = sparse && index % 2 != 0 ? (byte)0 : (byte)1;
+            if (types[index] != 0)
+                expectedSum += 10 + index;
+        }
+        List<AcknowledgementBatchData> batches = [new(10, 73, types)];
+        var destination = new long[64];
+
+        // Construct this view inside the measured region, without warming an index or cursor.
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        var offsets = new ShareAcknowledgedOffsets(batches);
+        long sum = 0;
+        for (var index = 0; index < offsets.Length; index++)
+            sum += offsets[index];
+        foreach (var offset in offsets)
+            sum += offset;
+        offsets.CopyTo(destination);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
+        await Assert.That(sum).IsEqualTo(expectedSum * 2);
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(7)]
+    [Arguments(8)]
+    [Arguments(9)]
+    [Arguments(15)]
+    [Arguments(16)]
+    [Arguments(17)]
+    [Arguments(31)]
+    [Arguments(32)]
+    [Arguments(33)]
+    [Arguments(63)]
+    [Arguments(64)]
+    [Arguments(65)]
+    [Arguments(127)]
+    [Arguments(128)]
+    [Arguments(129)]
+    [Arguments(255)]
+    [Arguments(256)]
+    [Arguments(257)]
+    [Arguments(511)]
+    [Arguments(512)]
+    [Arguments(513)]
+    [Arguments(1024)]
+    [Arguments(1025)]
+    public async Task OffsetView_PreservesSparseAccessOrdersAndCopiedViews(int length)
+    {
+        // Include unknown dispositions and signed-byte boundaries: only Gap is excluded.
+        byte[] dispositions = [1, 2, 3, 127, 128, 255];
+        var random = new Random(3261 + length);
+        foreach (var gapPercent in new[] { 0, 1, 50, 99, 100 })
+        {
+            var batches = new List<AcknowledgementBatchData>();
+            var expected = new List<long>();
+            for (var batchIndex = 0; batchIndex < 4; batchIndex++)
+            {
+                var types = new byte[length];
+                var firstOffset = 10L + batchIndex * (length + 13L);
+                for (var index = 0; index < types.Length; index++)
+                {
+                    types[index] = random.Next(100) < gapPercent
+                        ? (byte)0
+                        : dispositions[random.Next(dispositions.Length)];
+                    if (types[index] != 0)
+                        expected.Add(firstOffset + index);
+                }
+                batches.Add(new AcknowledgementBatchData(firstOffset, firstOffset + length - 1, types));
+                // Empty and gap-only batches must not change logical indices in subsequent batches.
+                batches.Add(new AcknowledgementBatchData(firstOffset + length, firstOffset + length - 1, []));
+                batches.Add(new AcknowledgementBatchData(firstOffset + length, firstOffset + length + 2, [0, 0, 0]));
+            }
+
+            var offsets = new ShareAcknowledgedOffsets(batches);
+            var retainedCopy = offsets;
+            var result = new ShareAcknowledgementCommitResult(default, offsets, null);
+            await Assert.That(offsets.Length).IsEqualTo(expected.Count);
+
+            var ascending = new long[expected.Count];
+            var descending = new long[expected.Count];
+            var shuffled = new long[expected.Count];
+            var order = Enumerable.Range(0, expected.Count).ToArray();
+            random.Shuffle(order);
+            for (var index = 0; index < expected.Count; index++)
+            {
+                ascending[index] = offsets[index];
+                var reverseIndex = expected.Count - index - 1;
+                descending[reverseIndex] = retainedCopy[reverseIndex];
+                shuffled[order[index]] = result.Offsets[order[index]];
+            }
+            await Assert.That(ascending.SequenceEqual(expected)).IsTrue();
+            await Assert.That(descending.SequenceEqual(expected)).IsTrue();
+            await Assert.That(shuffled.SequenceEqual(expected)).IsTrue();
+
+            var copied = new long[expected.Count + 1];
+            copied[^1] = -1;
+            retainedCopy.CopyTo(copied);
+            await Assert.That(copied.Take(expected.Count).SequenceEqual(expected)).IsTrue();
+            await Assert.That(copied[^1]).IsEqualTo(-1);
+            var enumerated = new List<long>();
+            foreach (var offset in result.Offsets)
+                enumerated.Add(offset);
+            await Assert.That(enumerated.SequenceEqual(expected)).IsTrue();
+            await Assert.That(() => offsets[-1]).Throws<ArgumentOutOfRangeException>();
+            await Assert.That(() => offsets[expected.Count]).Throws<ArgumentOutOfRangeException>();
+        }
+    }
+
+    [Test]
     public async Task OffsetView_SkipsGapsAcrossEveryAccessPath()
     {
         var offsets = new ShareAcknowledgedOffsets(

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgedOffsetsBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgedOffsetsBenchmarks.cs
@@ -11,22 +11,37 @@ public class ShareAcknowledgedOffsetsBenchmarks
 
     [Params(64, 1024)] public int RecordCount { get; set; }
     [Params(false, true)] public bool Sparse { get; set; }
+    [Params(1, 4)] public int BatchCount { get; set; }
 
     [GlobalSetup]
     public void Setup()
     {
-        var types = new byte[RecordCount];
-        for (var index = 0; index < types.Length; index++)
-            types[index] = Sparse && index % 2 != 0 ? (byte)AcknowledgeType.Gap : (byte)AcknowledgeType.Accept;
-        _batches = [new AcknowledgementBatchData(0, RecordCount - 1, types)];
+        _batches = CreateBatches(RecordCount, Sparse, BatchCount);
         var offsets = new ShareAcknowledgedOffsets(_batches);
         if (offsets.Length != (Sparse ? (RecordCount + 1) / 2 : RecordCount))
             throw new InvalidOperationException("The callback included an unacknowledged offset.");
-        var expectedSum = Sparse
-            ? (long)offsets.Length * (offsets.Length - 1)
-            : (long)RecordCount * (RecordCount - 1) / 2;
+        long expectedSum = 0;
+        foreach (var batch in _batches)
+            for (var index = 0; index < batch.AcknowledgeTypes.Length; index++)
+                if (batch.AcknowledgeTypes[index] != (byte)AcknowledgeType.Gap)
+                    expectedSum += batch.FirstOffset + index;
         if (CreateAndEnumerate() != expectedSum || CreateAndIndex() != expectedSum)
             throw new InvalidOperationException("Indexed and enumerated offsets must cover the same acknowledged records.");
+    }
+
+    internal static List<AcknowledgementBatchData> CreateBatches(int recordCount, bool sparse, int batchCount)
+    {
+        var batches = new List<AcknowledgementBatchData>(batchCount);
+        var recordsPerBatch = recordCount / batchCount;
+        for (var batchIndex = 0; batchIndex < batchCount; batchIndex++)
+        {
+            var types = new byte[recordsPerBatch];
+            for (var index = 0; index < types.Length; index++)
+                types[index] = sparse && index % 2 != 0 ? (byte)AcknowledgeType.Gap : (byte)AcknowledgeType.Accept;
+            var firstOffset = batchIndex * (recordsPerBatch + 10L);
+            batches.Add(new AcknowledgementBatchData(firstOffset, firstOffset + recordsPerBatch - 1, types));
+        }
+        return batches;
     }
 
     [Benchmark]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgedOffsetsLookupBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgedOffsetsLookupBenchmarks.cs
@@ -1,0 +1,36 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Includes view construction in every operation, even for a single indexed lookup.</summary>
+[MemoryDiagnoser]
+public class ShareAcknowledgedOffsetsLookupBenchmarks
+{
+    private List<AcknowledgementBatchData> _batches = null!;
+
+    [Params(64, 1024)] public int RecordCount { get; set; }
+    [Params(false, true)] public bool Sparse { get; set; }
+    [Params(1, 4)] public int BatchCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _batches = ShareAcknowledgedOffsetsBenchmarks.CreateBatches(RecordCount, Sparse, BatchCount);
+        var expectedCount = Sparse ? RecordCount / 2 : RecordCount;
+        var lastBatch = _batches[^1];
+        var expectedLast = lastBatch.LastOffset - (Sparse ? 1 : 0);
+        if (CreateAndCount() != expectedCount || CreateAndLookupLast() != expectedLast)
+            throw new InvalidOperationException("Construction and lookup must preserve acknowledged offsets.");
+    }
+
+    [Benchmark]
+    public int CreateAndCount() => new ShareAcknowledgedOffsets(_batches).Length;
+
+    [Benchmark]
+    public long CreateAndLookupLast()
+    {
+        var offsets = new ShareAcknowledgedOffsets(_batches);
+        return offsets[offsets.Length - 1];
+    }
+}


### PR DESCRIPTION
**Do not merge: full gate REGRESSION.** Run [34639318789](https://github.com/thomhurst/Dekaf/actions/runs/34639318789) completed: 21 classes / 201 compared cases. Twenty classes pass; warm prepared parsing at 64 records / zero headers reproduces a time regression against both controls (repeat +61.8%/+62.9%, unchanged 5,752 B/op). Both changed offset classes still pass all 32 cases at 0 B/op. No tradeoff approved, causal fix established, or rerun requested. Full artifacts and source attribution are retained at `C:/git/Dekaf-evidence/pr-3273/gate-34639318789`. A validated fresh-main rebase is archived but not pushed; it does not resolve this failure. See the final gate disposition comment.

Hosted validation of both changed classes passes all 32 compared cases with 0 B/op in A1/B/A2. Full sparse indexing at 1,024 entries improves approximately sixfold, while all dense cases pass unchanged tolerances. [Traversal table](https://github.com/thomhurst/Dekaf/actions/runs/34639318789/job/103395220890), [construction/lookup table](https://github.com/thomhurst/Dekaf/actions/runs/34639318789/job/103395221023). These exact-head results resolve the local dense-timing concerns described below; the full gate is now blocked by the reproduced parsing regression described above.

Sparse acknowledgement indexing repeatedly scans each earlier disposition. Count bounded prefixes with the framework's accelerated byte-count implementation, then finish the short logical suffix with a scalar scan. View construction also counts gaps this way. The .NET Standard build retains a scalar count implementation.

This materially reduces the existing cost without adding an index allocation: local full traversal of 1,024 alternating-gap entries falls from 87.76/99.62 microseconds to 14.63/14.85 microseconds for one/four batches. It is a constant-factor improvement, not an asymptotic change: each sparse lookup remains O(n), full indexed traversal O(n²), and enumeration/CopyTo O(n). Public remarks document those limits. Copies share the existing immutable batch data; there is no cursor, cache, additional field, pool lifetime or retained response ownership change.

Costs remain per view construction and per explicit index lookup, with prefix counting amortized across the entries it skips. No new per-message produce/consume work, allocation, lock or async state is introduced. Passing fields into a static sparse helper preserves register allocation when the dense indexer is inlined.

The two maintained MemoryDiagnoser classes each expand to 16 cases: 64/1,024 entries, dense/alternating gaps, one/four batches, construction, single last lookup, enumeration and full indexing. Every measured operation constructs a fresh view; GlobalSetup only supplies existing protocol vectors and validates results. Both expanded fixtures were also measured against main locally. All 32 baseline and candidate cases report 0 B/op.

Performance acceptance is blocked by the reproduced hosted parsing regression described above. Local Windows Short runs are diagnostic: some dense cases exceed tolerance, including final dense 1,024-entry single-batch indexing and four-batch enumeration, and several tiny lookup cases drift. These are retained, not accepted as tradeoffs or rerun for green. A separate two-case JIT diagnosis established and removed stack materialization caused by an earlier instance helper; the final static helper restores register fields. The changed offset fixtures pass hosted controls; the whole PR remains blocked by the parsing case. No performance-gate rule or tolerance changes.

Validation: full Release solution build passes with zero warnings/errors; all 350 share-consumer unit cases pass on each of .NET 10 and .NET 8. The 31 offset-view cases cover default/empty views, bounds, 25 boundary lengths, five gap densities, multiple batches, unknown disposition bytes, forward/reverse/shuffled access, retained copies and 0 B first access. Two Kafka 4.3.1 integration cases pass, including actual alternating acknowledgements and retained offsets after another commit. Earlier forced no-AVX2 and no-hardware-intrinsic runs passed the 29-case offset suite. All 45 performance-selector tests and repository artifact policy pass. Final diff reviewed for reuse, clarity and efficiency.

Evidence is outside removable worktrees at `C:/git/Dekaf-evidence/issue-3261`: complete source ZIPs, original BenchmarkDotNet exports/logs, actual generated worker binaries, disassembly and test reports. The measured candidate snapshot is `c30acf58a64d3a70bdf6a7b484ed205091c9ad77` over `5ad345184d2a82dac4a700f80a4e5031cbbeeb5a`; final head `9938a613d5da076e13ebfeb316e590bd71b7d498` rebases the same product/fixture sources onto `c77800beb673e7080e61245695eb1da1865e3168`, adding the integration test and simplifying equivalent unit-test input selection. `candidate-v3-short-retained` contains 1,008 SHA-256-verified source/binary files; `integration-v3-retained` contains 348. Earlier V1/V2 results and binaries remain retained. `dense-v1-disasm` is explicitly invalid as candidate evidence because a timestamp-preserving source restore left baseline binaries loaded; its limitation and actual baseline hashes are recorded, and the verified replacement has its own directory.

`final-validation-retained` contains 1,290 source/binary/report files verified against originals. Both complete final/main source ZIPs were verified against fresh `git archive` output before publishing.

This changes offset-view access, not batching, network loops, scheduling, lifecycle or stress defaults. Parent #3103 and #3032 retain their original allocation and loaded-acceptance requirements; sibling #3260 owns parsing/preparation regressions.

Closes #3261

