### PR TITLE
fix(share-consumer): count telemetry after request write starts

### DIFF
--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Hosting.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Hosting.cs
@@ -55,9 +55,30 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
-        if (context is not null && connection is IKafkaRequestCancellationConnection controlled)
-            return controlled.SendWithResponseCancellationAsync<TRequest, TResponse>(
-                request, version, context, cancellationToken);
+        if (context is not null && context.ResponseCancellationToken.CanBeCanceled)
+        {
+            if (connection is IKafkaRequestCancellationConnection controlled)
+                return controlled.SendWithResponseCancellationAsync<TRequest, TResponse>(
+                    request, version, context, cancellationToken);
+
+            // Custom connections without response-cancellation support use the caller's token.
+            context.MarkWriteStarted();
+            return connection.SendAsync<TRequest, TResponse>(request, version, cancellationToken);
+        }
+
+        return SendObservedRequestAsync<TRequest, TResponse>(connection, request, version, context, cancellationToken);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ValueTask<TResponse> SendObservedRequestAsync<TRequest, TResponse>(
+        IKafkaConnection connection, TRequest request, short version,
+        KafkaRequestWriteContext? context, CancellationToken cancellationToken)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+    {
+        if (context is not null && connection is IKafkaRequestWriteObserverConnection observed)
+            return observed.SendWithWriteObservationAsync<TRequest, TResponse>(
+                request, version, context.WriteStartedCallback, cancellationToken);
 
         // Custom connections cannot prove their write boundary. Keep caller cancellation and
         // treat a failure after handing them the request as potentially submitted.

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Telemetry.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Telemetry.cs
@@ -1,3 +1,4 @@
+using Dekaf.Networking;
 using Dekaf.Protocol.Messages;
 using Dekaf.Telemetry;
 
@@ -46,15 +47,22 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
         metrics.AcknowledgementsFailed(count);
     }
 
-    private void PrepareFetchTelemetry(int brokerId, ShareFetchRequest request)
+    private KafkaRequestWriteContext? PrepareFetchTelemetry(
+        int brokerId, ShareFetchRequest request, KafkaRequestWriteContext? context)
     {
         var metrics = ShareMetrics;
         if (metrics is null || !metrics.Enabled(ShareConsumerTelemetryMetrics.Groups.Fetch
-            | ShareConsumerTelemetryMetrics.Groups.Acknowledgements)) return;
+            | ShareConsumerTelemetryMetrics.Groups.Acknowledgements))
+            return _hostedRequestCancellationToken.CanBeCanceled ? context : null;
+        if (context is null)
+        {
+            context = metrics.GetRequestWriteContext(brokerId);
+            context.Reset();
+        }
         if (!metrics.Enabled(ShareConsumerTelemetryMetrics.Groups.Acknowledgements))
         {
             metrics.StartFetch(brokerId, 0);
-            return;
+            return context;
         }
         long count = 0;
         for (var topicIndex = 0; topicIndex < request.Topics.Count; topicIndex++)
@@ -72,12 +80,20 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
             }
         }
         metrics.StartFetch(brokerId, count);
+        return context;
     }
 
-    private void PrepareAcknowledgementTelemetry(int brokerId, ShareAcknowledgeRequest request)
+    private KafkaRequestWriteContext? PrepareAcknowledgementTelemetry(
+        int brokerId, ShareAcknowledgeRequest request, KafkaRequestWriteContext? context)
     {
         var metrics = ShareMetrics;
-        if (metrics is null || !metrics.Enabled(ShareConsumerTelemetryMetrics.Groups.Acknowledgements)) return;
+        if (metrics is null || !metrics.Enabled(ShareConsumerTelemetryMetrics.Groups.Acknowledgements))
+            return _hostedRequestCancellationToken.CanBeCanceled ? context : null;
+        if (context is null)
+        {
+            context = metrics.GetRequestWriteContext(brokerId);
+            context.Reset();
+        }
         long count = 0;
         for (var topicIndex = 0; topicIndex < request.Topics.Count; topicIndex++)
         {
@@ -93,6 +109,17 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
             }
         }
         metrics.AcknowledgementRequestStarted(brokerId, count);
+        return context;
+    }
+
+    private KafkaRequestWriteContext? PrepareSessionCloseTelemetry(int brokerId)
+    {
+        var metrics = ShareMetrics;
+        if (metrics is null || !metrics.Enabled(ShareConsumerTelemetryMetrics.Groups.Fetch)) return null;
+        var context = metrics.GetRequestWriteContext(brokerId);
+        context.Reset();
+        metrics.StartFetch(brokerId, 0, resetRecords: false);
+        return context;
     }
 
     private static long CountAcknowledgedRecords(long firstOffset, long lastOffset, IReadOnlyList<byte> types)

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -1133,7 +1133,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     IsRenewAck = isRenewAck,
                     Topics = BuildShareFetchTopics(partitions, brokerAcks, version)
                 };
-                PrepareFetchTelemetry(brokerId, request);
+                requestContext = PrepareFetchTelemetry(brokerId, request, requestContext);
                 ShareFetchResponse response;
                 try
                 {
@@ -1176,7 +1176,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     ReceivedTimestamp = receivedTimestamp
                 };
             }
-            catch (OperationCanceledException) when (requestContext is { WriteStarted: false }
+            catch (OperationCanceledException) when (_hostedRequestCancellationToken.CanBeCanceled
+                && requestContext is { WriteStarted: false }
                 && cancellationToken.IsCancellationRequested && !_hostedRequestCancellationToken.IsCancellationRequested)
             {
                 return new ShareFetchBrokerResult(brokerId, 0, null, brokerAcks, null, null);
@@ -1252,7 +1253,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         List<TopicPartition> partitions,
         CancellationToken cancellationToken)
     {
-        var submitted = false;
+        var telemetryPrepared = false;
         try
         {
             using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
@@ -1275,17 +1276,20 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 ShareAcquireMode = (sbyte)_options.ShareAcquireMode,
                 Topics = BuildShareFetchTopics(partitions, pendingAcks: null, version)
             };
-            ShareMetrics?.StartFetch(brokerId, 0, resetRecords: false);
-            submitted = true;
-            var response = await connection.SendAsync<ShareFetchRequest, ShareFetchResponse>(
-                request, version, cancellationToken).ConfigureAwait(false);
-            ShareMetrics?.FetchCompleted(brokerId, response.ThrottleTimeMs);
-            submitted = false;
+            var requestContext = PrepareSessionCloseTelemetry(brokerId);
+            telemetryPrepared = requestContext is not null;
+            var response = await SendObservedRequestAsync<ShareFetchRequest, ShareFetchResponse>(
+                connection, request, version, requestContext, cancellationToken).ConfigureAwait(false);
+            if (telemetryPrepared) ShareMetrics?.FetchCompleted(brokerId, response.ThrottleTimeMs);
+            telemetryPrepared = false;
             response.Dispose();
         }
         catch
         {
-            if (submitted) ShareMetrics?.FetchFailed(brokerId);
+            // The broker stream is serialized. Recover its cached marker only on failure;
+            // no extra context reference needs to survive the response await.
+            if (telemetryPrepared && ShareMetrics is { } metrics && metrics.RequestWriteStarted(brokerId))
+                metrics.FetchFailed(brokerId);
             // Best-effort session close
         }
     }
@@ -1329,7 +1333,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     IsRenewAck = isRenewAck,
                     Topics = topics
                 };
-                PrepareAcknowledgementTelemetry(brokerId, request);
+                requestContext = PrepareAcknowledgementTelemetry(brokerId, request, requestContext);
                 ShareAcknowledgeResponse response;
                 try
                 {
@@ -1434,7 +1438,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
             {
                 throw;
             }
-            catch (OperationCanceledException) when (attempt == 0 && requestContext is { WriteStarted: false }
+            catch (OperationCanceledException) when (attempt == 0 && _hostedRequestCancellationToken.CanBeCanceled
+                && requestContext is { WriteStarted: false }
                 && cancellationToken.IsCancellationRequested && !_hostedRequestCancellationToken.IsCancellationRequested)
             {
                 return AcknowledgeBrokerResult.NotSent(pendingAcknowledgements);

--- a/src/Dekaf/Telemetry/ShareConsumerTelemetryMetrics.cs
+++ b/src/Dekaf/Telemetry/ShareConsumerTelemetryMetrics.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Collections.Concurrent;
+using Dekaf.Networking;
 
 namespace Dekaf.Telemetry;
 
@@ -179,6 +180,17 @@ internal sealed class ShareConsumerTelemetryMetrics
     }
 
     internal void FetchStarted(int brokerId) => StartFetch(brokerId, 0);
+
+    internal KafkaRequestWriteContext GetRequestWriteContext(int brokerId)
+    {
+        // Broker requests are serialized, but leases for different brokers may complete together.
+        // Reuse the concurrent sample map and allocate the callback once per observed broker.
+        var sample = _fetchSamples.GetOrAdd(brokerId, static _ => new FetchSample());
+        return sample.WriteContext ??= new KafkaRequestWriteContext(default);
+    }
+
+    internal bool RequestWriteStarted(int brokerId) =>
+        _fetchSamples.TryGetValue(brokerId, out var sample) && sample.WriteContext is { WriteStarted: true };
 
     internal void StartFetch(int brokerId, long acknowledgements, bool resetRecords = true)
     {
@@ -369,6 +381,7 @@ internal sealed class ShareConsumerTelemetryMetrics
     // share consumer. Reuse their request state without growing async state machines.
     internal sealed class FetchSample
     {
+        internal KafkaRequestWriteContext? WriteContext;
         internal int RecordEpoch = -1;
         internal int FetchEpoch = -1;
         internal int FetchAcknowledgementEpoch = -1;

--- a/tests/Dekaf.Tests.Integration/ClientTelemetryReceiverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ClientTelemetryReceiverIntegrationTests.cs
@@ -166,6 +166,8 @@ public sealed class ClientTelemetryReceiverIntegrationTests(TelemetryReceiverKaf
         const string applicationName = "com.example.telemetry.share.processing";
         const string recordsName = "org.apache.kafka.consumer.share.fetch.manager.records.consumed.total";
         const string acknowledgementsName = "org.apache.kafka.consumer.share.fetch.manager.acknowledgements.send.total";
+        const string acknowledgementErrorsName = "org.apache.kafka.consumer.share.fetch.manager.acknowledgements.error.total";
+        const string fetchesName = "org.apache.kafka.consumer.share.fetch.manager.fetch.total";
         var clientId = $"share-builtins-{Guid.NewGuid():N}";
         var group = $"share-builtins-group-{Guid.NewGuid():N}";
         var topic = await kafka.CreateTestTopicAsync(partitions: 1);
@@ -174,7 +176,7 @@ public sealed class ClientTelemetryReceiverIntegrationTests(TelemetryReceiverKaf
         {
             [new ConfigResource { Type = ConfigResourceType.ClientMetrics, Name = clientId }] =
             [
-                ConfigAlter.Set("metrics", $"{applicationName},{recordsName},{acknowledgementsName}"),
+                ConfigAlter.Set("metrics", $"{applicationName},{recordsName},{acknowledgementsName},{acknowledgementErrorsName},{fetchesName}"),
                 ConfigAlter.Set("interval.ms", "1000"),
                 ConfigAlter.Set("match", $"client_id={clientId}")
             ],
@@ -182,15 +184,16 @@ public sealed class ClientTelemetryReceiverIntegrationTests(TelemetryReceiverKaf
                 [ConfigAlter.Set("share.auto.offset.reset", "earliest")]
         }, cancellationToken: cancellationToken);
         await kafka.WaitForSubscriptionAsync(clientId,
-            [applicationName, recordsName, acknowledgementsName], 1000, cancellationToken);
+            [applicationName, recordsName, acknowledgementsName, acknowledgementErrorsName, fetchesName], 1000, cancellationToken);
         await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(kafka.BootstrapServers).BuildAsync(cancellationToken);
         await ShareConsumerTestHelper.ProduceAsync(producer, topic, count: 2);
+        var applicationValue = 42;
         await using var consumer = await Kafka.CreateShareConsumer<string, string>()
             .WithBootstrapServers(kafka.BootstrapServers).WithClientId(clientId).WithGroupId(group)
             .WithAcknowledgementMode(ShareAcknowledgementMode.Explicit)
             .RegisterMetricForSubscription(new ApplicationTelemetryMetric(applicationName,
-                ApplicationTelemetryMetricKind.Gauge, () => 42))
+                ApplicationTelemetryMetricKind.Gauge, () => Volatile.Read(ref applicationValue)))
             .BuildAsync(cancellationToken);
         consumer.Subscribe(topic);
         var values = new HashSet<string?>();
@@ -231,7 +234,37 @@ public sealed class ClientTelemetryReceiverIntegrationTests(TelemetryReceiverKaf
                 .Gauge.DataPoints.Single().AsDouble).IsEqualTo(42d);
             await Assert.That(decoded.Single(metric => metric.Name == name).Sum.IsMonotonic).IsTrue();
         }
+        // Built-ins are collected before application gauges. The first marker may race with
+        // an earlier collection; observing the second proves a complete subsequent export.
+        // Polling has stopped, so all pre-close fetch deltas must now be at the receiver.
+        foreach (var marker in new[] { 43, 44 })
+        {
+            Volatile.Write(ref applicationValue, marker);
+            await kafka.WaitForPayloadAsync(clientId, payload => !payload.IsTerminating
+                && Decode(payload).Any(metric => metric.Name == applicationName
+                    && metric.Gauge.DataPoints.Single().AsDouble == marker), cancellationToken);
+        }
+        var beforeClose = await kafka.ReadPayloadsAsync(clientId, cancellationToken);
+        var fetchesBeforeClose = ExportedTotal(beforeClose, fetchesName);
+        await Assert.That(fetchesBeforeClose).IsGreaterThan(0d);
+        await consumer.DisposeAsync();
+        var terminating = await kafka.WaitForPayloadAsync(clientId,
+            payload => payload.IsTerminating && Decode(payload).Any(metric => metric.Name == fetchesName), cancellationToken);
+        await Assert.That(terminating.ClientInstanceId).IsEqualTo(identity!.Value);
+        var finalPayloads = await kafka.ReadPayloadsAsync(clientId, cancellationToken);
+        // Sum every delta: a periodic push may export the close fetch before termination.
+        // This single-broker consumer sends exactly one session-close fetch.
+        await Assert.That(ExportedTotal(finalPayloads, fetchesName))
+            .IsEqualTo(fetchesBeforeClose + 1d);
+        await Assert.That(ExportedTotal(finalPayloads, acknowledgementsName))
+            .IsEqualTo(2d);
+        await Assert.That(ExportedTotal(finalPayloads, acknowledgementErrorsName))
+            .IsEqualTo(0d);
     }
+
+    private static double ExportedTotal(IReadOnlyList<ReceivedTelemetry> payloads, string name) => payloads
+        .SelectMany(Decode).Where(metric => metric.Name == name)
+        .Sum(metric => metric.Sum.DataPoints.Single().AsDouble);
 
     private static Metric[] Decode(ReceivedTelemetry payload) => MetricsData.Parser.ParseFrom(payload.Data)
         .ResourceMetrics.SelectMany(resource => resource.ScopeMetrics)

--- a/tests/Dekaf.Tests.Integration/TelemetryReceiverKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/TelemetryReceiverKafkaContainer.cs
@@ -83,6 +83,23 @@ public sealed class TelemetryReceiverKafkaContainer : KafkaContainerDefault
         }
     }
 
+    internal async Task<IReadOnlyList<ReceivedTelemetry>> ReadPayloadsAsync(
+        string clientId, CancellationToken cancellationToken)
+    {
+        var text = await _http.GetStringAsync("payloads", cancellationToken);
+        var payloads = new List<ReceivedTelemetry>();
+        foreach (var line in text.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var fields = line.Split('\t');
+            if (fields.Length != 5)
+                throw new InvalidDataException("Malformed telemetry receiver output.");
+            if (DecodeText(fields[2]) == clientId)
+                payloads.Add(new ReceivedTelemetry(Guid.Parse(fields[0]), bool.Parse(fields[1]),
+                    DecodeText(fields[3]), Convert.FromBase64String(fields[4])));
+        }
+        return payloads;
+    }
+
     internal async Task<GetTelemetrySubscriptionsResponse> ReadSubscriptionAsync(
         string clientId, CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.TelemetryWrite.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.TelemetryWrite.cs
@@ -1,0 +1,181 @@
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public sealed partial class ShareConsumerRenewalTests
+{
+    [Test]
+    [Arguments(TelemetryRequestKind.Fetch, false, false)]
+    [Arguments(TelemetryRequestKind.Fetch, true, false)]
+    [Arguments(TelemetryRequestKind.InlineAcknowledgements, false, false)]
+    [Arguments(TelemetryRequestKind.InlineAcknowledgements, true, false)]
+    [Arguments(TelemetryRequestKind.StandaloneAcknowledgements, false, false)]
+    [Arguments(TelemetryRequestKind.StandaloneAcknowledgements, true, false)]
+    [Arguments(TelemetryRequestKind.SessionClose, false, false)]
+    [Arguments(TelemetryRequestKind.SessionClose, true, false)]
+    [Arguments(TelemetryRequestKind.Fetch, false, true)]
+    [Arguments(TelemetryRequestKind.InlineAcknowledgements, false, true)]
+    [Arguments(TelemetryRequestKind.StandaloneAcknowledgements, false, true)]
+    [Arguments(TelemetryRequestKind.SessionClose, false, true)]
+    [Timeout(30_000)]
+    public async Task TelemetryWrite_CancellationCountsOnlySubmittedRequests(
+        TelemetryRequestKind kind, bool afterWrite, bool subscribeDuringLease, CancellationToken cancellationToken)
+    {
+        var gate = new TelemetryWriteGate(afterWrite);
+        var connection = new CapturingConnection(
+            kind == TelemetryRequestKind.StandaloneAcknowledgements ? ApiKey.ShareAcknowledge : ApiKey.ShareFetch, 2)
+        {
+            BeforeWrite = gate.BeforeWriteAsync,
+            ShareFetchHandler = async (_, token) =>
+            {
+                await gate.BeforeResponseAsync(token);
+                return new ShareFetchResponse { ErrorCode = ErrorCode.None, Responses = [], NodeEndpoints = [] };
+            },
+            ShareAcknowledgeHandler = async (_, token) =>
+            {
+                await gate.BeforeResponseAsync(token);
+                return new ShareAcknowledgeResponse { Responses = [], NodeEndpoints = [] };
+            }
+        };
+        var leaseEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLease = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var fixture = CreateFixture(connection, leaseHandler: subscribeDuringLease
+            ? async token =>
+            {
+                leaseEntered.TrySetResult();
+                await releaseLease.Task.WaitAsync(token);
+                return connection;
+            }
+            : null);
+        var metrics = EnableShareTelemetry(fixture.Consumer);
+        if (subscribeDuringLease) metrics.Disable();
+        using var requestCancellation = new CancellationTokenSource();
+        var request = InvokeTelemetryRequest(fixture.Consumer, kind, requestCancellation.Token);
+        var canceled = false;
+        try
+        {
+            if (subscribeDuringLease)
+            {
+                await leaseEntered.Task.WaitAsync(cancellationToken);
+                EnableShareTelemetry(fixture.Consumer);
+                releaseLease.TrySetResult();
+            }
+            await gate.Entered.Task.WaitAsync(cancellationToken);
+            await Assert.That(gate.ObservedToken).IsEqualTo(requestCancellation.Token);
+            await requestCancellation.CancelAsync();
+            try { await request.WaitAsync(cancellationToken); }
+            catch (OperationCanceledException) when (requestCancellation.IsCancellationRequested
+                && !cancellationToken.IsCancellationRequested) { canceled = true; }
+        }
+        finally
+        {
+            releaseLease.TrySetResult();
+            gate.Release();
+            await request.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+        }
+
+        if (kind is TelemetryRequestKind.Fetch or TelemetryRequestKind.InlineAcknowledgements)
+            await Assert.That(canceled).IsTrue();
+        var fetches = kind == TelemetryRequestKind.StandaloneAcknowledgements ? 0d : 1d;
+        var acknowledgements = kind is TelemetryRequestKind.InlineAcknowledgements
+            or TelemetryRequestKind.StandaloneAcknowledgements ? 2d : 0d;
+        await Assert.That(connection.SendCount).IsEqualTo(afterWrite ? 1 : 0);
+        await Assert.That(ShareMetricValue(metrics, "fetch.total")).IsEqualTo(afterWrite ? fetches : 0d);
+        await Assert.That(ShareMetricValue(metrics, "acknowledgements.send.total")).IsEqualTo(afterWrite ? acknowledgements : 0d);
+        await Assert.That(ShareMetricValue(metrics, "acknowledgements.error.total")).IsEqualTo(afterWrite ? acknowledgements : 0d);
+
+        // The same broker state must reset after either canceled attempt.
+        await InvokeTelemetryRequest(fixture.Consumer, kind, cancellationToken);
+        await Assert.That(ShareMetricValue(metrics, "fetch.total")).IsEqualTo(fetches * (afterWrite ? 2 : 1));
+        await Assert.That(ShareMetricValue(metrics, "acknowledgements.send.total")).IsEqualTo(acknowledgements * (afterWrite ? 2 : 1));
+        await Assert.That(ShareMetricValue(metrics, "acknowledgements.error.total")).IsEqualTo(afterWrite ? acknowledgements : 0d);
+    }
+
+    public enum TelemetryRequestKind { Fetch, InlineAcknowledgements, StandaloneAcknowledgements, SessionClose }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    [Timeout(30_000)]
+    public async Task TelemetryWrite_OrdinaryCommitKeepsCanceledOutcome(bool afterWrite, CancellationToken cancellationToken)
+    {
+        var gate = new TelemetryWriteGate(afterWrite);
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2)
+        {
+            BeforeWrite = gate.BeforeWriteAsync,
+            ShareAcknowledgeHandler = async (_, token) =>
+            {
+                await gate.BeforeResponseAsync(token);
+                return CreateAcknowledgeResponse((0, ErrorCode.None));
+            }
+        };
+        var failures = new List<Exception?>();
+        await using var fixture = CreateFixture(connection, acknowledgementCommitCallback: results =>
+        {
+            foreach (ref readonly var result in results) failures.Add(result.Exception);
+        });
+        var metrics = EnableShareTelemetry(fixture.Consumer);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Acknowledge(CreateRecord(), AcknowledgeType.Accept);
+        using var caller = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var commit = fixture.Consumer.CommitAsync(caller.Token).AsTask();
+        try
+        {
+            await gate.Entered.Task.WaitAsync(cancellationToken);
+            await caller.CancelAsync();
+            await Assert.That(async () => await commit.WaitAsync(cancellationToken)).Throws<OperationCanceledException>();
+        }
+        finally
+        {
+            gate.Release();
+            await commit.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+        }
+        await Assert.That(failures.Count).IsEqualTo(1);
+        await Assert.That(failures[0] is OperationCanceledException).IsTrue();
+        await Assert.That(ShareMetricValue(metrics, "acknowledgements.send.total")).IsEqualTo(afterWrite ? 1d : 0d);
+        await Assert.That(ShareMetricValue(metrics, "acknowledgements.error.total")).IsEqualTo(afterWrite ? 1d : 0d);
+    }
+
+    private static Task InvokeTelemetryRequest(
+        KafkaShareConsumer<string, string> consumer, TelemetryRequestKind kind, CancellationToken cancellationToken)
+    {
+        var partition = new TopicPartition("topic", 0);
+        var acknowledgements = new Dictionary<TopicPartition, List<AcknowledgementBatchData>>();
+        if (kind is TelemetryRequestKind.InlineAcknowledgements or TelemetryRequestKind.StandaloneAcknowledgements)
+            acknowledgements.Add(partition,
+                [new AcknowledgementBatchData(42, 44, [(byte)AcknowledgeType.Accept, (byte)AcknowledgeType.Gap, (byte)AcknowledgeType.Release])]);
+        return kind switch
+        {
+            TelemetryRequestKind.StandaloneAcknowledgements => (Task)InvokePrivate(
+                consumer, "SendAcknowledgeAsync", 1, acknowledgements, false, cancellationToken, false)!,
+            TelemetryRequestKind.SessionClose => (Task)InvokePrivate(
+                consumer, "CloseSessionForBrokerAsync", 1, new List<TopicPartition> { partition }, cancellationToken)!,
+            _ => (Task)InvokePrivate(consumer, "SendShareFetchForPartitionsAsync", 1,
+                new List<TopicPartition> { partition }, acknowledgements, cancellationToken)!
+        };
+    }
+
+    private sealed class TelemetryWriteGate(bool afterWrite)
+    {
+        private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private bool _active = true;
+        internal TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal CancellationToken ObservedToken { get; private set; }
+        internal ValueTask BeforeWriteAsync(CancellationToken token) => afterWrite ? default : WaitAsync(token);
+        internal ValueTask BeforeResponseAsync(CancellationToken token) => afterWrite ? WaitAsync(token) : default;
+        private async ValueTask WaitAsync(CancellationToken token)
+        {
+            if (!_active) return;
+            ObservedToken = token;
+            Entered.TrySetResult();
+            await _release.Task.WaitAsync(token);
+        }
+        internal void Release()
+        {
+            _active = false;
+            _release.TrySetResult();
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -1585,7 +1585,8 @@ public sealed partial class ShareConsumerRenewalTests
         bool supportShareFetch = false) :
         IKafkaConnection,
         IKafkaCapabilityProvider,
-        IKafkaRequestCancellationConnection
+        IKafkaRequestCancellationConnection,
+        IKafkaRequestWriteObserverConnection
     {
         public int BrokerId => brokerId;
         public string Host => "localhost";
@@ -1634,10 +1635,49 @@ public sealed partial class ShareConsumerRenewalTests
                 await BeforeWrite(cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
             context.MarkWriteStarted();
-            return await SendAsync<TRequest, TResponse>(request, apiVersion, context.ResponseCancellationToken);
+            return await SendCoreAsync<TRequest, TResponse>(request, apiVersion, context.ResponseCancellationToken);
         }
 
         public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => BeforeWrite is null
+                ? SendCoreAsync<TRequest, TResponse>(request, apiVersion, cancellationToken)
+                : SendAfterWriteWaitAsync<TRequest, TResponse>(request, apiVersion, null, cancellationToken);
+
+        public ValueTask<TResponse> SendWithWriteObservationAsync<TRequest, TResponse>(
+            TRequest request, short apiVersion, Action requestWriteStarted,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            if (BeforeWrite is not null)
+                return SendAfterWriteWaitAsync<TRequest, TResponse>(request, apiVersion, requestWriteStarted, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            requestWriteStarted();
+            return SendCoreAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+        }
+
+        public ValueTask<PipelinedResponse<TResponse>> SendPipelinedWithWriteObservationAfterWriteAsync<TRequest, TResponse>(
+            TRequest request, short apiVersion, Action requestWriteStarted,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => throw new NotSupportedException();
+
+        private async ValueTask<TResponse> SendAfterWriteWaitAsync<TRequest, TResponse>(
+            TRequest request, short apiVersion, Action? requestWriteStarted, CancellationToken cancellationToken)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            await BeforeWrite!(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            requestWriteStarted?.Invoke();
+            return await SendCoreAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+        }
+
+        private ValueTask<TResponse> SendCoreAsync<TRequest, TResponse>(
             TRequest request,
             short apiVersion,
             CancellationToken cancellationToken = default)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/HostedShareRequestBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/HostedShareRequestBenchmarks.cs
@@ -7,6 +7,7 @@ using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Serialization;
 using Dekaf.ShareConsumer;
+using Dekaf.Telemetry;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
@@ -20,6 +21,8 @@ public class HostedShareRequestBenchmarks
     [Params(1, 16)]
     public int PartitionCount { get; set; }
 
+    internal ShareRequestTelemetryMode TelemetryMode { get; set; }
+
     private KafkaShareConsumer<string, string> _consumer = null!;
     private MetadataManager _metadata = null!;
     private readonly CancellationTokenSource _shutdown = new();
@@ -30,6 +33,7 @@ public class HostedShareRequestBenchmarks
         CancellationToken, Task> _fetch = null!;
     private Func<int, Dictionary<TopicPartition, List<AcknowledgementBatchData>>, bool,
         CancellationToken, Task> _acknowledge = null!;
+    private Func<int, List<TopicPartition>, CancellationToken, Task> _close = null!;
 
     [GlobalSetup]
     public async Task Setup()
@@ -88,11 +92,17 @@ public class HostedShareRequestBenchmarks
                 hostedOverload.Invoke(_consumer, [observer, _shutdown.Token]);
         }
         const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+        var collector = (ClientTelemetryMetricCollector)typeof(KafkaShareConsumer<string, string>)
+            .GetField("_telemetryMetricCollector", flags)!.GetValue(_consumer)!;
+        if (TelemetryMode != ShareRequestTelemetryMode.Unsubscribed)
+            collector.ShareConsumerMetrics!.Subscribe(["org.apache.kafka.consumer.share."]);
         typeof(KafkaShareConsumer<string, string>).GetField("_initialized", flags)!.SetValue(_consumer, true);
         var coordinator = typeof(KafkaShareConsumer<string, string>).GetField("_coordinator", flags)!.GetValue(_consumer)!;
         typeof(ShareConsumerCoordinator).GetField("_memberId", flags)!.SetValue(coordinator, "benchmark-member");
         _fetch = typeof(KafkaShareConsumer<string, string>).GetMethod("SendShareFetchForPartitionsAsync", flags)!
             .CreateDelegate<Func<int, List<TopicPartition>, Dictionary<TopicPartition, List<AcknowledgementBatchData>>, CancellationToken, Task>>(_consumer);
+        _close = typeof(KafkaShareConsumer<string, string>).GetMethod("CloseSessionForBrokerAsync", flags)!
+            .CreateDelegate<Func<int, List<TopicPartition>, CancellationToken, Task>>(_consumer);
         // Older products have four parameters; batch-session cleanup adds an optional fifth.
         // Bind the same direct-call adapter on both revisions outside measurement.
         var acknowledge = typeof(KafkaShareConsumer<string, string>).GetMethod("SendAcknowledgeAsync", flags)!;
@@ -115,6 +125,8 @@ public class HostedShareRequestBenchmarks
         await Commit();
         if (connection.RequestCount != 3 || sessions.GetSessionEpoch(1) != 2)
             throw new InvalidOperationException("Commit must submit its tracked acknowledgement outcomes.");
+        if (TelemetryMode == ShareRequestTelemetryMode.Disabled)
+            collector.ShareConsumerMetrics!.Disable();
     }
 
     // Costs are per request with PartitionCount acknowledgement batches. Cached replies exclude
@@ -124,6 +136,8 @@ public class HostedShareRequestBenchmarks
 
     [Benchmark]
     public Task ShareAcknowledge() => _acknowledge(1, _acknowledgements, false, CancellationToken.None);
+
+    internal Task CloseSession() => _close(1, _partitions, CancellationToken.None);
 
     [Benchmark]
     public ValueTask Commit()
@@ -141,13 +155,31 @@ public class HostedShareRequestBenchmarks
         _shutdown.Dispose();
     }
 
-    private sealed class Connection(ShareFetchResponse fetch, ShareAcknowledgeResponse acknowledge) : IKafkaConnection
+    private sealed class Connection(ShareFetchResponse fetch, ShareAcknowledgeResponse acknowledge)
+        : IKafkaConnection, IKafkaRequestWriteObserverConnection, IKafkaRequestCancellationConnection
     {
         internal int RequestCount { get; private set; }
         public int BrokerId => 1;
         public string Host => "localhost";
         public int Port => 9092;
         public bool IsConnected => true;
+        public ValueTask<TResponse> SendWithWriteObservationAsync<TRequest, TResponse>(
+            TRequest request, short version, Action onWriteStarted, CancellationToken token = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse
+        {
+            onWriteStarted();
+            return SendAsync<TRequest, TResponse>(request, version, token);
+        }
+        public ValueTask<TResponse> SendWithResponseCancellationAsync<TRequest, TResponse>(
+            TRequest request, short version, KafkaRequestWriteContext context, CancellationToken token)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse
+        {
+            context.MarkWriteStarted();
+            return SendAsync<TRequest, TResponse>(request, version, context.ResponseCancellationToken);
+        }
+        public ValueTask<PipelinedResponse<TResponse>> SendPipelinedWithWriteObservationAfterWriteAsync<TRequest, TResponse>(
+            TRequest request, short version, Action onWriteStarted, CancellationToken token = default)
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => throw new NotSupportedException();
         public ValueTask<TResponse> SendAsync<TRequest, TResponse>(TRequest request, short version, CancellationToken token = default)
             where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse
         {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerTelemetryCloseBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerTelemetryCloseBenchmarks.cs
@@ -1,0 +1,30 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Per-request close telemetry with cached broker state; every response completes synchronously.</summary>
+[MemoryDiagnoser]
+public class ShareConsumerTelemetryCloseBenchmarks
+{
+    private HostedShareRequestBenchmarks _requests = null!;
+
+    [Params(false, true)]
+    public bool Hosted { get; set; }
+
+    [ParamsAllValues]
+    public ShareRequestTelemetryMode Telemetry { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _requests = new() { Hosted = Hosted, PartitionCount = 16, TelemetryMode = Telemetry };
+        await _requests.Setup();
+        await _requests.CloseSession();
+    }
+
+    [Benchmark]
+    public Task CloseSession() => _requests.CloseSession();
+
+    [GlobalCleanup]
+    public Task Cleanup() => _requests.Cleanup();
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerTelemetryRequestBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerTelemetryRequestBenchmarks.cs
@@ -1,0 +1,38 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+public enum ShareRequestTelemetryMode { Unsubscribed, Subscribed, Disabled }
+
+/// <summary>
+/// Steady-state write observation and telemetry for successful requests carrying 16 acknowledgement batches.
+/// Setup warms broker state and cached callbacks; Disabled measures requests after a subscription is disabled.
+/// Costs are per request, excluding transport, parsing and the one-time broker context allocation.
+/// </summary>
+[MemoryDiagnoser]
+public class ShareConsumerTelemetryRequestBenchmarks
+{
+    private HostedShareRequestBenchmarks _requests = null!;
+
+    [Params(false, true)]
+    public bool Hosted { get; set; }
+
+    [ParamsAllValues]
+    public ShareRequestTelemetryMode Telemetry { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _requests = new() { Hosted = Hosted, PartitionCount = 16, TelemetryMode = Telemetry };
+        await _requests.Setup();
+    }
+
+    [Benchmark]
+    public Task ShareFetch() => _requests.ShareFetch();
+
+    [Benchmark]
+    public Task ShareAcknowledge() => _requests.ShareAcknowledge();
+
+    [GlobalCleanup]
+    public Task Cleanup() => _requests.Cleanup();
+}


### PR DESCRIPTION
Retention correction: the local mutation and final archives at `D:/Dekaf-evidence/pr-3275-close-review` retain the exact sources, actual compiled binaries and raw console logs, but **not the generated HTML test reports**. Those reports were written to the worktree-root `TestResults` directory, which the archive inputs omitted; worktree cleanup removed the originals. The earlier “binaries/reports” statement was too broad. The 695-entry mutation and 1,974-entry final binary archives remain SHA-256 verified. Raw logs retain both expected mutation failures and the passing final test counts. No test rerun is being presented as recovery of deleted reports.

The [current-head microbenchmark gate](https://github.com/thomhurst/Dekaf/actions/runs/34643887220) completed successfully on `c8c1f5ddb27c2f6bb7a5a1b6c132a02b383fcf68`. This does not satisfy the still-open telemetry-enabled loaded requirement. #3248 remains an acquisition/lifecycle prerequisite, and this PR must not merge on the green microbenchmark gate alone.

**Loaded acceptance is required and remains blocked. Do not merge on the microbenchmark gate alone.**

The new review finding is valid: the request-write and session-close changes require a telemetry-enabled loaded comparison with `baseline_sha`. The earlier description records that no such run exists; deferring broader work to #3033 does not satisfy this PR's loaded requirement.

The maintained `hosted-share-1b` scenario currently creates two hosted consumers without client-metrics subscriptions. It also uses the classic polling path with the existing 16,384-record outstanding window and default MaxPollRecords=500. Its acquisition/drain prerequisite remains in open #3248, whose current resubscription performance gate is a confirmed regression with no approved tradeoff. The existing failure and required combined lifecycle validation are tracked in #3245. Dispatching that unchanged lane would neither exercise subscribed telemetry nor establish valid loaded acceptance.

The remaining work is to enable and verify real broker telemetry subscriptions in maintained stress tooling, preserve identical setup for baseline and candidate, and run the relevant subscribed workload after its acquisition/lifecycle prerequisites are usable. Keep ordinary/hosted request semantics, complete drain, acknowledgement validation, protected metrics and workload bounds intact. No larger poll-limit workaround, suppressed shutdown failure, custom harness or paid run was added during this review. Outbox run 34642337592 has since finished INCONCLUSIVE and its verdict is recorded on #3277; it does not provide telemetry acceptance.

The review thread remains open. The integration-test fix and its mutation evidence remain valid but do not replace loaded acceptance.

Review follow-up on `c8c1f5ddb27c2f6bb7a5a1b6c132a02b383fcf68`, rebased as one commit onto main `1f28994b63b78b313b6dc8fe38cec52a17523734`:

The receiver test now drains prior fetch deltas through two observed application-gauge markers before disposal. Built-ins are collected before application gauges, so the first marker can race with an earlier collection; the second proves that a complete subsequent export reached the receiver after polling stopped. The test then requires exactly one additional fetch for its single-broker session close, summing periodic and terminating deltas.

A diagnostic mutation removed only the successful close-fetch accounting while still sending the real request. Both classic and batch cases fail at the new final assertion: expected 2, found 1. Restoring the accounting passes all eight telemetry receiver/subscription integration cases on Kafka 4.3.1. All 14 write-boundary unit cases pass on each of net8.0 and net10.0. The full Release build has zero warnings/errors; artifact policy and diff checks pass. The custom-connection fallback comment is also clarified as requested in the Claude review.

Exact mutation and final source, actual test binaries and raw console logs and verified SHA-256 inventories are retained at `D:/Dekaf-evidence/pr-3275-close-review`. The final archive contains binaries for both runtimes; generated HTML reports were omitted, as corrected above. The review change adds no production behavior or hot-path work; the earlier benchmark results remain diagnostic. Existing hosted gate run 34640177706 was still pending when this necessary review update was prepared; it is not reported as a pass. New CI/review and hosted performance acceptance remain required. No paid stress run is dispatched.

Previous implementation validation and evidence:

Cancellation before a share-consumer request starts writing no longer increments fetch totals or acknowledgement send/error totals. Fetches, inline acknowledgements, standalone commits, and best-effort session-close fetches use the existing connection write observer. Failures after write starts still count once.

Ordinary requests retain caller cancellation. Hosted requests retain their separate response/shutdown budget and existing custom-connection fallback. Telemetry-only contexts cannot select the hosted `NotSent` path. The marker is selected after leasing, so a subscription that activates during a lease wait is covered. Gap entries, acknowledgement callbacks and retry/requeue behavior remain unchanged.

The ordinary marker and cached delegate live in the existing concurrent broker sample map. Different brokers can finish leasing concurrently without mutating the hosted context dictionary. Disabled/unsubscribed requests do not create markers. There is no per-record observation work or new per-request delegate/state-machine allocation. The marker is first created by an ordinary subscribed request, or by a subscribed close when hosted requests use their separate context. State is amortized per broker: an observed sample's first use adds 112 B on the measured .NET 10 x64 runtime (104 B context/delegate plus an 8 B sample reference); other allocated samples add the 8 B reference. Subsequent marker use allocates 0 B. The consumer remains 312 B of raw object data, and fetch/acknowledge/close async states remain 160/192/120 B with unchanged field counts.

Validation:

- TDD on main reproduced four pre-write cancellation failures; all four post-write controls passed. Fourteen new cases now cover the write boundary, subscription activation during leasing, subsequent successful requests, and ordinary canceled commit callbacks.
- 391 ShareConsumer/Telemetry unit cases passed on each of net8.0 and net10.0. Full Release build passed with no warnings or errors.
- 15 Kafka 4.3.1 receiver, subscription and hosted-share integration cases passed. Receiver coverage verifies acknowledgement totals and the final close fetch across periodic and terminating delta exports. Initial new receiver assertions incorrectly treated deltas as cumulative; the corrected test sums captured exports.
- Repository artifact policy and diff checks passed. Reuse/quality/performance review completed.
- Thirty steady-state MemoryDiagnoser cases (12 existing request cases, 12 telemetry request cases, and 6 close cases) cover existing hosted requests plus subscribed, unsubscribed and disabled fetch/acknowledge/close paths. The exact PR fixture sources compile and run against both main and the candidate. Against main `c77800beb673e7080e61245695eb1da1865e3168`, final candidate `fb9e5ed4c54d93f00209f9d6901b43746147be65` has exact allocation parity in all 30 cases; median timing deltas range from -42.63% to +7.91%. An earlier implementation (`defc9c458`) had local losses up to +63.89%; those measurements remain archived. The final implementation removes a redundant hosted marker reset and restores the static send helper. Local runs do not establish causation or a performance win.

These local measurements are diagnostic only. Hosted A1/B/A2 performance checks must pass; no tolerance changes or green reruns are requested. No paid stress run was dispatched: the maintained hosted-share lane has no telemetry subscription and does not exercise ordinary subscribed request observation. Parent #3033 retains telemetry-enabled loaded acceptance and the rest of its original scope.

Raw logs, reports, measured fixture/source snapshots, binaries, generated BenchmarkDotNet workers, allocation/layout probe source and SHA-256 inventories are retained outside removable worktrees at `C:/git/Dekaf-evidence/issue-3272/write-boundary/`. The final source/binary/worker archive is `fb9e5ed4c-validation`; the main control archive is `baseline-workers`. This includes the original red cases and the failed intermediate integration/test-fixture diagnostics. No evidence files are committed.

Closes #3272

Parent #3033 remains open. Follows the unresolved write-boundary finding in #3252: https://github.com/thomhurst/Dekaf/pull/3252#discussion_r3991634092.


