### PR TITLE
test(stress): add key-ordered consumer replay lane

### DIFF
--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -106,11 +106,39 @@ def _identity(result):
         result.get("idempotent"),
         result.get("roundTripSteadySeconds"),
     )
+    if str(result.get("scenario", "")).casefold() == "consumer-keyed":
+        keyed = result["keyedConsumer"]
+        return identity + tuple(keyed[name] for name in KEYED_DIMENSIONS)
     return identity + (
         (outbox.get("idle") or {}).get("requestedSeconds"),
         outbox.get("activeRequestedSeconds"),
         (outbox.get("idleWarmup") or {}).get("requestedSeconds"),
     ) if outbox else identity
+
+
+KEYED_DIMENSIONS = (
+    "shape", "keySizeBytes", "partitions", "keysPerPartition", "recordsPerPartition",
+    "handlerConcurrency", "bufferedRecordsPerPartition", "yieldEveryKeyRecords",
+)
+
+
+def validate_keyed_consumer(result):
+    if str(result.get("scenario", "")).casefold() != "consumer-keyed":
+        return
+    keyed = result.get("keyedConsumer")
+    if not isinstance(keyed, dict) or any(name not in keyed for name in KEYED_DIMENSIONS):
+        raise ValueError("Keyed consumer workload dimensions are missing")
+    sizes = {"scalar": 4, "binary": 16, "large-distinct": 4096, "large-colliding": 4096}
+    if keyed["shape"] not in sizes or keyed["keySizeBytes"] != sizes[keyed["shape"]]:
+        raise ValueError("Invalid keyed consumer shape or size")
+    for name in KEYED_DIMENSIONS[1:] + ("completedPasses", "completedRecords"):
+        if type(keyed.get(name)) is not int or keyed[name] <= 0:
+            raise ValueError(f"Invalid keyed consumer {name}")
+    expected = keyed["completedPasses"] * keyed["partitions"] * keyed["recordsPerPartition"]
+    if keyed["completedRecords"] != expected or expected != result["throughput"].get("totalMessages"):
+        raise ValueError("Keyed consumer replay has an incomplete pass")
+    if result.get("latency") is not None:
+        raise ValueError("Keyed consumer replay does not record delivery latency")
 
 
 def _average_request_kib(result):
@@ -370,6 +398,7 @@ def compare(
                 raise ValueError(f"Expected a {field} object")
         _validate_completed_messages(result)
         validate_outbox(result)
+        validate_keyed_consumer(result)
 
     identities = {
         _identity(baseline_a_result),
@@ -456,6 +485,8 @@ def compare(
         "minimumLatencySamples": MIN_LATENCY_SAMPLES,
         "latencySampleCounts": latency_sample_counts,
         "identity": list(_identity(candidate_result)),
+        **({"keyedConsumer": {name: candidate_result["keyedConsumer"][name] for name in KEYED_DIMENSIONS}}
+           if candidate_result.get("keyedConsumer") else {}),
         "metrics": metrics,
     }
 
@@ -498,6 +529,9 @@ def markdown(comparison, baseline_sha, candidate_sha):
     if comparison.get("validationError"):
         lines.extend(["", f"Evidence validation failed: {comparison['validationError']}"])
         return "\n".join(lines) + "\n"
+    if comparison.get("keyedConsumer"):
+        lines.extend(["", "Keyed consumer workload: " + ", ".join(
+            f"{name}={value}" for name, value in comparison["keyedConsumer"].items()) + "."])
     if comparison.get("startupAssessment"):
         assessment = comparison["startupAssessment"]
         lines.extend(["", f"Startup assessment: {assessment['verdict']}",

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -826,7 +826,7 @@ class StressAbaWorkflowTests(unittest.TestCase):
             "Exact-SHA A-B-A requires a duration-based producer, consumer replay, hosted-share, or outbox lane",
             self.workflow,
         )
-        self.assertIn("consumer-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b|hosted-share-1b|outbox-1b|consumer-follower-recovery-3b) ;;", self.workflow)
+        self.assertIn("consumer-1b|consumer-keyed-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b|hosted-share-1b|outbox-1b|consumer-follower-recovery-3b) ;;", self.workflow)
 
     def test_matrix_forces_three_single_connection_dekaf_segments(self):
         self.assertIn('.baseline_sha = $baseline_sha', self.workflow)

--- a/.github/scripts/test_stress_keyed.py
+++ b/.github/scripts/test_stress_keyed.py
@@ -1,0 +1,137 @@
+import copy
+import json
+import re
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from stress_aba import compare, markdown, validate_keyed_consumer
+from test_stress_aba import consumer
+from test_fixed_worker_pool import bash_path, workflow_script
+
+
+def keyed_result():
+    value = consumer()
+    value["scenario"] = "consumer-keyed"
+    value["throughput"]["totalMessages"] = 196608
+    value["keyedConsumer"] = {
+        "shape": "scalar", "keySizeBytes": 4, "partitions": 6,
+        "keysPerPartition": 32, "recordsPerPartition": 32768,
+        "handlerConcurrency": 4, "bufferedRecordsPerPartition": 256,
+        "yieldEveryKeyRecords": 64, "completedPasses": 1, "completedRecords": 196608,
+    }
+    value.pop("deliveredMessages", None)
+    return value
+
+
+class KeyedConsumerTests(unittest.TestCase):
+    def test_identical_replays_pass_without_latency(self):
+        result = keyed_result()
+        comparison = compare(result, result, result)
+        self.assertEqual("pass", comparison["verdict"])
+        self.assertIn("shape=scalar", markdown(comparison, "a" * 40, "b" * 40))
+        self.assertTrue(all(not metric["gated"] for metric in comparison["metrics"] if metric["key"] in ("p50", "p95", "p99")))
+
+    def test_workload_dimensions_cannot_change_between_revisions(self):
+        for field, value in (("shape", "binary"), ("handlerConcurrency", 8),
+                             ("bufferedRecordsPerPartition", 512), ("yieldEveryKeyRecords", 128)):
+            with self.subTest(field=field):
+                control = keyed_result()
+                candidate = copy.deepcopy(control)
+                candidate["keyedConsumer"][field] = value
+                if field == "shape":
+                    candidate["keyedConsumer"]["keySizeBytes"] = 16
+                with self.assertRaisesRegex(ValueError, "workload identity"):
+                    compare(control, candidate, control)
+
+    def test_missing_tail_and_missing_dimensions_are_rejected(self):
+        for field in ("completedRecords", "completedPasses", "partitions", "recordsPerPartition"):
+            with self.subTest(field=field):
+                value = keyed_result()
+                value["keyedConsumer"][field] += 1
+                with self.assertRaisesRegex(ValueError, "incomplete pass"):
+                    validate_keyed_consumer(value)
+        value = keyed_result()
+        del value["keyedConsumer"]["shape"]
+        with self.assertRaisesRegex(ValueError, "dimensions are missing"):
+            validate_keyed_consumer(value)
+
+    def test_replay_age_cannot_be_reported_as_delivery_latency(self):
+        value = keyed_result()
+        value["latency"] = {"count": 100}
+        with self.assertRaisesRegex(ValueError, "does not record delivery latency"):
+            validate_keyed_consumer(value)
+
+    @unittest.skipUnless(bash_path(), "bash is required for dispatch validation")
+    def test_invalid_shape_and_size_fail_before_paid_job(self):
+        script = workflow_script("Select lanes for this run").split("# Manual full_run", 1)[0]
+        for shape, lane, size, full in (("bad", "consumer-keyed-1b", "128", "false"),
+                                      ("binary", "consumer-1b", "128", "false"),
+                                      ("binary", "consumer-keyed-1b", "128", "true"),
+                                      ("scalar", "consumer-keyed-1b", "7", "false"),
+                                      ("scalar", "consumer-keyed-1b", "4097", "false"),
+                                      ("scalar", "consumer-keyed-1b", "1+1", "false")):
+            with self.subTest(shape=shape, lane=lane, size=size, full=full):
+                environment = dict(os.environ, EVENT_NAME="workflow_dispatch", LANE=lane,
+                                   KEYED_SHAPE=shape, MESSAGE_SIZE=size, FULL_RUN=full,
+                                   FIXED_WORKER_THREADS="0", BASELINE_SHA="")
+                run = subprocess.run([bash_path(), "-e", "-o", "pipefail", "-c", script],
+                                     env=environment, capture_output=True, encoding="utf-8", timeout=30)
+                self.assertNotEqual(0, run.returncode)
+                self.assertIn("::error::", run.stdout)
+
+    @unittest.skipUnless(bash_path() and shutil.which("jq"), "bash and jq are required for full lane selection")
+    def test_actual_selector_preserves_shapes_and_excludes_full_matrix(self):
+        script = 'python3() { "$TEST_PYTHON" "$@"; }\n' + workflow_script("Select lanes for this run")
+        for shape, lane, full, baseline in (
+                ("scalar", "consumer-keyed-1b", "false", ""),
+                ("binary", "consumer-keyed-1b", "false", "a" * 40),
+                ("large-distinct", "consumer-keyed-1b", "false", "a" * 40),
+                ("large-colliding", "consumer-keyed-1b", "false", "a" * 40),
+                ("scalar", "all", "false", ""), ("scalar", "all", "true", "")):
+            with self.subTest(shape=shape, full=full), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                (root / ".github/scripts").mkdir(parents=True)
+                shutil.copyfile(Path(__file__).with_name("stress_timeout.py"), root / ".github/scripts/stress_timeout.py")
+                environment = dict(os.environ, EVENT_NAME="workflow_dispatch", LANE=lane,
+                                   KEYED_SHAPE=shape, MESSAGE_SIZE="128", FULL_RUN=full,
+                                   FIXED_WORKER_THREADS="0", BASELINE_SHA=baseline,
+                                   GITHUB_REF="refs/heads/main", DISPATCH_SHAPE="cheap", PROFILE_MODE="off",
+                                   CONSUMER_FETCH_DIAGNOSTICS="false", ADAPTIVE_CONNECTIONS="false",
+                                   ABA_SECOND_CANDIDATE="false", DURATION_MINUTES="5",
+                                   PRODUCER_WARMUP_SECONDS="180", GITHUB_OUTPUT="output.txt",
+                                   TEST_PYTHON=Path(sys.executable).as_posix())
+                (root / "workflow.sh").write_text(script, encoding="utf-8", newline="\n")
+                run = subprocess.run([bash_path(), "-e", "-o", "pipefail", "workflow.sh"],
+                                     cwd=root, env=environment, capture_output=True, encoding="utf-8", timeout=30)
+                self.assertEqual(0, run.returncode, run.stdout + run.stderr)
+                outputs = dict(line.split("=", 1) for line in (root / "output.txt").read_text().splitlines())
+                selected = json.loads(outputs["matrix"])["include"]
+                if lane == "all":
+                    self.assertEqual(12, len(selected))
+                    self.assertNotIn("consumer-keyed-1b", [item["lane"] for item in selected])
+                else:
+                    self.assertEqual(1, len(selected))
+                    self.assertEqual(shape, selected[0]["keyed_shape"])
+                    self.assertEqual(baseline, selected[0].get("baseline_sha", ""))
+                    self.assertEqual("dekaf", selected[0]["client"])
+
+    def test_lane_is_explicit_and_never_in_default_matrix(self):
+        workflow = (Path(__file__).parents[1] / "workflows/stress-tests.yml").read_text()
+        lanes = json.loads(re.search(r"cat > lanes.json << 'EOF'\n(.*?)\n\s*EOF", workflow, re.S)[1])
+        lane = next(item for item in lanes if item["lane"] == "consumer-keyed-1b")
+        self.assertTrue(lane["manual_only"])
+        self.assertEqual("dekaf", lane["client"])
+        self.assertEqual("consumer-keyed", lane["scenario"])
+        self.assertIn('select(($lane == "all" and .manual_only != true) or .lane == $lane)', workflow)
+        self.assertIn('consumer-1b|consumer-keyed-1b|consumer-batch-1b', workflow)
+        self.assertIn('EXTRA_ARGS+=(--keyed-shape "$KEYED_SHAPE" --keyed-records-per-partition 32768 --partitions 6)', workflow)
+        self.assertIn('scalar|binary|large-distinct|large-colliding)', workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_stress_timeout.py
+++ b/.github/scripts/test_stress_timeout.py
@@ -25,7 +25,7 @@ class StressTimeoutTests(unittest.TestCase):
         ):
             with self.subTest(baseline=bool(baseline), segments=segments, warmup=warmup):
                 selected = subprocess.run(
-                    ["jq", "-c", "--arg", "lane", "outbox-1b", "--arg", "client", "dekaf",
+                    ["jq", "-c", "--arg", "keyed_shape", "scalar", "--arg", "lane", "outbox-1b", "--arg", "client", "dekaf",
                      "--arg", "shape", "cheap", "--arg", "profile_mode", "off",
                      "--arg", "baseline_sha", baseline, "--argjson", "aba_segments", str(segments),
                      selection.group("filter")],

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -2004,7 +2004,7 @@ class StressTrendTests(unittest.TestCase):
         regular = [lane for lane in lanes if not lane.get("manual_only", False)]
         manual = [lane for lane in lanes if lane.get("manual_only", False)]
         self.assertEqual(12, len(regular))
-        self.assertEqual(["hosted-share-1b", "outbox-1b", "consumer-follower-recovery-3b"], [lane["lane"] for lane in manual])
+        self.assertEqual(["consumer-keyed-1b", "hosted-share-1b", "outbox-1b", "consumer-follower-recovery-3b"], [lane["lane"] for lane in manual])
         self.assertEqual("dekaf", manual[0]["client"])
         self.assertIn('select(($lane == "all" and .manual_only != true) or .lane == $lane)', workflow)
         self.assertIn('consumer-raw-batch-1b|hosted-share-1b|outbox-1b|consumer-follower-recovery-3b) ;;', workflow)

--- a/.github/scripts/test_stress_warmup.py
+++ b/.github/scripts/test_stress_warmup.py
@@ -286,7 +286,7 @@ class StressWarmupTests(unittest.TestCase):
         self.assertIn("--require-startup-assessment", workflow)
         self.assertLess(workflow.index('Build Stress Tests (exact baseline)'), workflow.index('run_aba()'))
         self.assertNotIn("schedule:", workflow)
-        self.assertIn("consumer-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b|hosted-share-1b|outbox-1b|consumer-follower-recovery-3b) ;;", workflow)
+        self.assertIn("consumer-1b|consumer-keyed-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b|hosted-share-1b|outbox-1b|consumer-follower-recovery-3b) ;;", workflow)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -26,6 +26,7 @@ on:
           - producer-transactional-3b
           - producer-roundtrip-steady-1b
           - consumer-1b
+          - consumer-keyed-1b
           - consumer-batch-1b
           - consumer-raw-1b
           - consumer-raw-batch-1b
@@ -37,6 +38,16 @@ on:
         description: 'Test duration in minutes'
         required: false
         default: '15'
+      keyed_shape:
+        description: 'consumer-keyed-1b only: one reproducible key shape; 32 keys/partition, 32768 records/partition'
+        required: false
+        type: choice
+        default: scalar
+        options:
+          - scalar
+          - binary
+          - large-distinct
+          - large-colliding
       producer_warmup_seconds:
         description: 'Warmup seconds per workload phase, including each outbox phase (minimum 20 seconds; no adaptive extension)'
         required: false
@@ -151,6 +162,8 @@ jobs:
         id: select
         env:
           LANE: ${{ github.event.inputs.lane }}
+          KEYED_SHAPE: ${{ github.event.inputs.keyed_shape }}
+          MESSAGE_SIZE: ${{ github.event.inputs.message_size }}
           DISPATCH_SHAPE: ${{ github.event.inputs.dispatch_shape }}
           FULL_RUN: ${{ github.event.inputs.full_run }}
           CONSUMER_FETCH_DIAGNOSTICS: ${{ github.event.inputs.consumer_fetch_diagnostics }}
@@ -171,6 +184,24 @@ jobs:
             exit 1
           fi
           lane="${LANE:-all}"
+
+          keyed_shape="${KEYED_SHAPE:-scalar}"
+          case "$keyed_shape" in
+            scalar|binary|large-distinct|large-colliding) ;;
+            *) echo '::error::Unknown keyed_shape.'; exit 1 ;;
+          esac
+          if [ "$keyed_shape" != "scalar" ] && { [ "$lane" != "consumer-keyed-1b" ] || [ "$FULL_RUN" = "true" ]; }; then
+            echo '::error::A non-default keyed_shape requires the explicit consumer-keyed-1b lane.'
+            exit 1
+          fi
+
+          if [ "$lane" = "consumer-keyed-1b" ] && [ "$FULL_RUN" != "true" ]; then
+            keyed_bytes="${MESSAGE_SIZE:-1000}"
+            if ! [[ "$keyed_bytes" =~ ^[0-9]{1,4}$ ]] || (( 10#$keyed_bytes < 8 || 10#$keyed_bytes > 4096 )); then
+              echo '::error::Keyed replay message_size must be 8..4096 bytes.'
+              exit 1
+            fi
+          fi
 
           fixed_workers="${FIXED_WORKER_THREADS:-0}"
           if ! [[ "$fixed_workers" =~ ^0*[0-9]{1,4}$ ]]; then
@@ -271,7 +302,7 @@ jobs:
             fi
             case "$lane" in
               producer-1b|producer-3b|producer-idempotent-1b|producer-idempotent-3b|producer-acks-all-1b|producer-acks-all-3b) ;;
-              consumer-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b|hosted-share-1b|outbox-1b|consumer-follower-recovery-3b) ;;
+              consumer-1b|consumer-keyed-1b|consumer-batch-1b|consumer-raw-1b|consumer-raw-batch-1b|hosted-share-1b|outbox-1b|consumer-follower-recovery-3b) ;;
               *)
                 echo "::error::Exact-SHA A-B-A requires a duration-based producer, consumer replay, hosted-share, or outbox lane."
                 exit 1
@@ -293,6 +324,7 @@ jobs:
             {"lane": "producer-transactional-3b", "scenario": "producer-transactional", "client": "all", "brokers": 3, "timeout_minutes": 150, "name": "Transactional EOS (Paired, 3 Brokers)"},
             {"lane": "producer-roundtrip-steady-1b", "scenario": "producer-roundtrip-steady", "client": "all", "brokers": 1, "message_size": 128, "roundtrip_steady_seconds": 60, "timeout_minutes": 90, "name": "Producer → Consumer Round-Trip Steady State (Paired)"},
             {"lane": "consumer-1b", "scenario": "consumer", "client": "all", "brokers": 1, "timeout_minutes": 90, "name": "Consumer (Paired)"},
+            {"lane": "consumer-keyed-1b", "scenario": "consumer-keyed", "client": "dekaf", "brokers": 1, "manual_only": true, "timeout_minutes": 60, "name": "Dekaf Key-Ordered Consumer"},
             {"lane": "consumer-batch-1b", "scenario": "consumer-batch", "client": "dekaf", "brokers": 1, "timeout_minutes": 60, "name": "Dekaf Consumer Batch"},
             {"lane": "consumer-raw-1b", "scenario": "consumer-raw", "client": "dekaf", "brokers": 1, "timeout_minutes": 60, "name": "Dekaf Consumer Raw"},
             {"lane": "consumer-raw-batch-1b", "scenario": "consumer-raw-batch", "client": "dekaf", "brokers": 1, "timeout_minutes": 60, "name": "Dekaf Consumer Raw Batch"},
@@ -317,12 +349,13 @@ jobs:
           if [ -n "$baseline_sha" ] && [ "$ABA_SECOND_CANDIDATE" = "true" ]; then
             aba_segments=4
           fi
-          matrix=$(jq -c --arg lane "$lane" --arg client "$client" --arg shape "$shape" --arg profile_mode "$profile_mode" --arg baseline_sha "$baseline_sha" --argjson aba_segments "$aba_segments" '
+          matrix=$(jq -c --arg keyed_shape "$keyed_shape" --arg lane "$lane" --arg client "$client" --arg shape "$shape" --arg profile_mode "$profile_mode" --arg baseline_sha "$baseline_sha" --argjson aba_segments "$aba_segments" '
             def segments: ((.paired_samples // 1) * (if .client == "all" then 2 else 1 end)) + (if .run_3conn == true then 1 else 0 end) + (if .run_adaptive == true then 1 else 0 end);
             def drop_3conn: .run_3conn = false | .artifact_suffix = "";
             def drop_adaptive: .run_adaptive = false;
             {include: [ .[]
               | select(($lane == "all" and .manual_only != true) or .lane == $lane)
+              | if .scenario == "consumer-keyed" then .keyed_shape = $keyed_shape else . end
               | segments as $full_segments
               | ((.timeout_minutes / $full_segments) | ceil) as $segment_budget
               | if $client != "" and .client == "all" then
@@ -568,6 +601,7 @@ jobs:
           BASELINE_SHA: ${{ matrix.baseline_sha }}
           PRODUCER_WARMUP_SECONDS: ${{ github.event.inputs.producer_warmup_seconds || '180' }}
           DURATION_MINUTES: ${{ github.event.inputs.duration_minutes || '15' }}
+          KEYED_SHAPE: ${{ matrix.keyed_shape }}
         run: |
           # Background disk monitor: samples every broker's log-dir usage so a tmpfs
           # fill (ingestion outpacing retention — the known broker-halt failure mode)
@@ -599,6 +633,9 @@ jobs:
           # space-separated string as one quoted element would reach the client as a
           # single unparseable argument.
           EXTRA_ARGS=()
+          if [ "${{ matrix.scenario }}" = "consumer-keyed" ]; then
+            EXTRA_ARGS+=(--keyed-shape "$KEYED_SHAPE" --keyed-records-per-partition 32768 --partitions 6)
+          fi
           if ! [[ "$PRODUCER_WARMUP_SECONDS" =~ ^[0-9]{1,6}$ ]] || (( 10#$PRODUCER_WARMUP_SECONDS < 20 )); then
             echo "::error::producer_warmup_seconds must be an integer from 20 to 999999."
             exit 1

--- a/tools/Dekaf.StressTests.Tests/ConsumerObservationTests.cs
+++ b/tools/Dekaf.StressTests.Tests/ConsumerObservationTests.cs
@@ -1,0 +1,42 @@
+using Dekaf.StressTests.Diagnostics;
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Scenarios;
+
+namespace Dekaf.StressTests.Tests;
+
+public class ConsumerObservationTests
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task DeadlineDuringPass_ObservesDrainAndRetainsFailure(bool failAfterDrain)
+    {
+        using var watchdog = new ProgressWatchdog(Path.GetTempPath());
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var options = new StressTestOptions
+        {
+            BootstrapServers = "unused", Topic = "observation-test", DurationMinutes = 0,
+            MessageSizeBytes = 8, ProgressWatchdog = watchdog
+        };
+        var tracker = new ThroughputTracker();
+        var cycle = await StressTestHelpers.RunConsumerCycleAsync(options, new KeyedConsumerStressTest(),
+            async (throughput, ingress) =>
+            {
+                // Expire ingress before recording the final pass's completion. The
+                // observer must sample this completion before the pass may return.
+                var expired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                using var registration = ingress.Register(() => expired.TrySetResult());
+                await expired.Task.WaitAsync(timeout.Token);
+                throughput.RecordMessage(8);
+                while (throughput.GetSnapshot().IntervalSamples.Count == 0)
+                    await Task.Delay(10, timeout.Token);
+                if (failAfterDrain) throw new InvalidOperationException("drain failure");
+            }, 1, null, TimeSpan.Zero, tracker, timeout.Token);
+
+        await Assert.That(cycle.Result.Throughput.TotalMessages).IsEqualTo(1L);
+        await Assert.That(cycle.Result.Throughput.IntervalSamples[^1].AcceptedMessages).IsEqualTo(1L);
+        await Assert.That(cycle.Result.Throughput.TotalErrors).IsEqualTo(failAfterDrain ? 1L : 0L);
+        if (failAfterDrain)
+            await Assert.That(cycle.Result.Throughput.ErrorSamples.Single().Message).IsEqualTo("drain failure");
+    }
+}

--- a/tools/Dekaf.StressTests.Tests/KeyedConsumerWorkloadTests.cs
+++ b/tools/Dekaf.StressTests.Tests/KeyedConsumerWorkloadTests.cs
@@ -1,0 +1,146 @@
+using System.Buffers.Binary;
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Scenarios;
+
+namespace Dekaf.StressTests.Tests;
+
+public class KeyedConsumerWorkloadTests
+{
+    [Test]
+    public void InterleavedKeysAndPartitions_CompleteExactlyOnePass()
+    {
+        using var stop = new CancellationTokenSource();
+        var tracker = new ThroughputTracker();
+        var pass = new KeyedConsumerPass(2, 64, tracker, stop);
+        for (var key = 31; key >= 0; key--)
+            for (var offset = key; offset < 64; offset += 32)
+                for (var partition = 1; partition >= 0; partition--)
+                    pass.Complete(pass.Enter(partition, key, offset, Payload(offset)), 8);
+        pass.ValidateComplete();
+        if (!stop.IsCancellationRequested || tracker.MessageCount != 128)
+            throw new InvalidOperationException("Full replay must stop ingress and count every completion.");
+    }
+
+    [Test]
+    public async Task EqualKeysInDifferentPartitions_CanOverlap()
+    {
+        using var stop = new CancellationTokenSource();
+        var pass = new KeyedConsumerPass(2, 32, new ThroughputTracker(), stop);
+        var first = pass.Enter(0, 0, 0, Payload(0));
+        var second = pass.Enter(1, 0, 0, Payload(0));
+        pass.Complete(second, 8);
+        pass.Complete(first, 8);
+        await Assert.That(pass.Completed).IsEqualTo(2L);
+    }
+
+    [Test]
+    public async Task EqualKeysInOnePartition_OverlapFails()
+    {
+        using var stop = new CancellationTokenSource();
+        var pass = new KeyedConsumerPass(1, 64, new ThroughputTracker(), stop);
+        pass.Enter(0, 0, 0, Payload(0));
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        {
+            pass.Enter(0, 0, 32, Payload(32));
+            return Task.CompletedTask;
+        });
+    }
+
+    [Test]
+    [Arguments(0, 0, 32L, 32L)] // missing earlier equal-key record
+    [Arguments(0, 1, 0L, 0L)] // wrong logical key
+    [Arguments(0, 0, 0L, 1L)] // corrupt payload
+    [Arguments(1, 0, 0L, 0L)] // unknown partition
+    [Arguments(0, 32, 0L, 0L)] // unknown key
+    [Arguments(0, 0, 64L, 64L)] // beyond seeded end
+    public async Task InvalidRecord_Fails(int partition, int key, long offset, long payload)
+    {
+        using var stop = new CancellationTokenSource();
+        var pass = new KeyedConsumerPass(1, 64, new ThroughputTracker(), stop);
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        {
+            pass.Enter(partition, key, offset, Payload(payload));
+            return Task.CompletedTask;
+        });
+    }
+
+    [Test]
+    public async Task MissingFinalCompletion_FailsEvenWhenEveryOtherKeyFinished()
+    {
+        using var stop = new CancellationTokenSource();
+        var pass = new KeyedConsumerPass(1, 32, new ThroughputTracker(), stop);
+        for (var key = 0; key < 32; key++)
+        {
+            var index = pass.Enter(0, key, key, Payload(key));
+            if (key != 31) pass.Complete(index, 8);
+        }
+        await Assert.That(stop.IsCancellationRequested).IsFalse();
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        {
+            pass.ValidateComplete();
+            return Task.CompletedTask;
+        });
+    }
+
+    [Test]
+    public async Task DuplicateAfterCompletion_Fails()
+    {
+        using var stop = new CancellationTokenSource();
+        var pass = new KeyedConsumerPass(1, 32, new ThroughputTracker(), stop);
+        pass.Complete(pass.Enter(0, 0, 0, Payload(0)), 8);
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        {
+            pass.Enter(0, 0, 0, Payload(0));
+            return Task.CompletedTask;
+        });
+    }
+
+    [Test]
+    [Arguments("binary")]
+    [Arguments("large-distinct")]
+    [Arguments("large-colliding")]
+    public async Task BinaryKeys_AreIndependentBuffersWithStableContent(string shape)
+    {
+        var first = KeyedConsumerWorkload.CreateBinaryKey(shape, 7);
+        var equal = KeyedConsumerWorkload.CreateBinaryKey(shape, 7);
+        var unequal = KeyedConsumerWorkload.CreateBinaryKey(shape, 8);
+        await Assert.That(ReferenceEquals(first, equal)).IsFalse();
+        await Assert.That(first.AsSpan().SequenceEqual(equal)).IsTrue();
+        await Assert.That(first.AsSpan().SequenceEqual(unequal)).IsFalse();
+        await Assert.That(KeyedConsumerWorkload.ReadBinaryKey(shape, unequal)).IsEqualTo(8);
+    }
+
+    [Test]
+    public async Task CollisionShape_PreservesEverySampledWindowButChangesFullContent()
+    {
+        var first = KeyedConsumerWorkload.CreateBinaryKey("large-colliding", 0);
+        var other = KeyedConsumerWorkload.CreateBinaryKey("large-colliding", 31);
+        foreach (var start in new[] { 0, first.Length / 3, first.Length * 2 / 3, first.Length - 16 })
+            await Assert.That(first.AsSpan(start, 16).SequenceEqual(other.AsSpan(start, 16))).IsTrue();
+        await Assert.That(first.AsSpan().SequenceEqual(other)).IsFalse();
+    }
+
+    [Test]
+    [Arguments("bad", 2, 32, 128)]
+    [Arguments("scalar", 0, 32, 128)]
+    [Arguments("scalar", 7, 32, 128)]
+    [Arguments("scalar", 2, 33, 128)]
+    [Arguments("scalar", 2, 65568, 128)]
+    [Arguments("scalar", 2, 32, 7)]
+    [Arguments("scalar", 2, 32, 4097)]
+    public async Task UnboundedOrInvalidDimensions_AreRejected(string shape, int partitions, int records, int bytes)
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+        {
+            KeyedConsumerWorkload.Validate(shape, partitions, records, bytes);
+            return Task.CompletedTask;
+        });
+    }
+
+    private static byte[] Payload(long offset)
+    {
+        var bytes = new byte[8];
+        BinaryPrimitives.WriteInt64LittleEndian(bytes, offset);
+        return bytes;
+    }
+}

--- a/tools/Dekaf.StressTests/KeyedConsumer.md
+++ b/tools/Dekaf.StressTests/KeyedConsumer.md
@@ -1,0 +1,46 @@
+# Key-ordered consumer replay
+
+`consumer-keyed` exercises the public `RunPartitionedAsync` record-handler API with `Ordering = Key`. The manual `consumer-keyed-1b` workflow lane is Dekaf-only and excluded from `lane=all`, `full_run=true`, and the runner's `--scenario all`. It does not change the existing 12-job full matrix or runtime defaults.
+
+Choose one shape for the hypothesis being tested:
+
+| `keyed_shape` / `--keyed-shape` | Deserialized key | Workload |
+| --- | --- | --- |
+| `scalar` (default) | `int` | Ordinary scalar keys |
+| `binary` | `byte[16]` | Repeated equal content in independently deserialized buffers |
+| `large-distinct` | `byte[4096]` | Distinct IDs in the first sampled window |
+| `large-colliding` | `byte[4096]` | Distinct IDs outside all four sampled windows; equal sampled hashes, unequal full content |
+
+The workflow fixes six partitions, 32 keys per partition, 32,768 records per partition, four handlers per partition, and a 256-record buffer per partition. Values contain their partition-relative sequence in the first eight bytes. The key ID is the offset modulo 32. Seeding uses explicit partitions and waits for delivery before measurement; every partition's end offset must equal the declared seed size. The largest default shape with 1,000-byte values seeds approximately 956 MiB of key/value bytes, plus Kafka framing. Each process gets a fresh topic and the exact-SHA path gets a fresh broker.
+
+The consumer uses explicit assignment, the existing high-throughput preset, and manual commits without broker offset commits. This isolates dispatch and replay rather than group rebalancing. Every pass creates a new partitioned runtime and checks every record's partition, key, offset, payload sequence and per-key handler exclusion. Different keys and partitions can finish concurrently. A pass stops only after every seeded record completes. The runtime then drains and returns before the harness seeks. A missing tail, duplicate, sequence gap, handler failure or 60-second pass deadline fails the run. Explicit caller cancellation cancels the runtime and produces no accepted result.
+
+The duration boundary stops starting new passes and finishes the current pass. That final pass, runtime startup/shutdown, seeking and validation remain inside elapsed time, CPU and allocation measurement. Throughput, resource and optional fetch-diagnostic samplers remain active until the pass drains, including any overrun beyond the nominal duration. A timed cycle can therefore exceed its nominal duration by one pass. The pass deadline and the runtime's 30-second stop deadline bound failure handling. No partial pass is treated as complete or silently removed from counts.
+
+## Observer cost and results
+
+The existing six-cycle warmup, process CPU/allocation counters, runtime samples, throughput sampler, watchdog and stability analysis run unchanged. JSON retains `keyedConsumer` dimensions and completed pass/record counts. `replayBookkeepingSeconds` measures seek, resume, pass-state allocation and final sequence validation; it does **not** isolate runtime construction or drain time. Those costs are still in the main measurements. Small local seed sizes deliberately magnify replay overhead and are correctness probes, not throughput acceptance experiments.
+
+Per record, the oracle reads the sequence/key ID, checks one array slot, uses `Interlocked` for exclusion and completion, and updates the existing throughput counter. Most handlers return a completed `ValueTask`; one in 64 records per key uses `Task.Yield` to keep asynchronous key lanes active. That sampled handler allocates an async state machine and schedules a continuation. Normal byte-array deserialization also allocates key/value buffers. Per pass, delegates, cancellation sources, oracle arrays and the partitioned runtime are recreated. All these costs apply equally to both revisions and remain measured. This fixture makes no claim of zero allocation per record.
+
+Consumer replay does not record delivery latency: replay age is not processing latency. The existing A/B/A screen compares throughput, CPU/message, allocations/message and stability; latency rows remain n/a. Separate evidence is required for a product change's p50/p99 claims. The comparer rejects different workload dimensions or incomplete passes before comparing metrics.
+
+## Run locally
+
+Docker is required unless `KAFKA_BOOTSTRAP_SERVERS` supplies a broker. This bounded correctness smoke uses fewer records than the acceptance lane:
+
+```powershell
+dotnet run -c Release --project tools/Dekaf.StressTests -- --scenario consumer-keyed --client dekaf --keyed-shape large-colliding --partitions 2 --keyed-records-per-partition 2048 --message-size 128 --producer-warmup-seconds 20 --duration 1
+```
+
+Local dimensions are validated: 1..6 partitions, 32..65,536 records per partition in multiples of 32, and 8..4,096 value bytes. The workflow validates shape and value size before starting the runner.
+
+## Exact-SHA acceptance
+
+Use one relevant shape, five to fifteen minutes per sample, and the fresh-main SHA contained in the candidate. Candidate and controls build the identical harness against their own pinned product sources. The existing workflow runs correctness preflights, then baseline/candidate/baseline with unchanged warmup and acceptance rules. Fixed-worker setup remains the existing optional experiment setting; zero preserves runtime defaults.
+
+```powershell
+gh workflow run stress-tests.yml --ref <candidate-branch> -f lane=consumer-keyed-1b -f keyed_shape=large-colliding -f dispatch_shape=cheap -f duration_minutes=5 -f producer_warmup_seconds=180 -f message_size=1000 -f baseline_sha=<fresh-main-40-character-SHA> -f profile_mode=off
+```
+
+Record the run URL, exact SHAs, lane, shape, duration and verdict in the product PR. Landing this harness does not establish #3048 acceptance and requires no paid acceptance run of its own. The collision-promotion implementation and its latency/CPU assessment remain separate product work.

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -19,7 +19,7 @@ namespace Dekaf.StressTests;
 /// Options:
 ///   --duration &lt;minutes&gt;    Test duration in minutes (default: 15)
 ///   --message-size &lt;bytes&gt;  Message size in bytes (default: 1000)
-///   --scenario &lt;name&gt;       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip-steady, consumer, consumer-batch, consumer-raw, consumer-raw-batch, consumer-follower-recovery, hosted-share, outbox, all (default: all)
+///   --scenario &lt;name&gt;       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip-steady, consumer, consumer-batch, consumer-raw, consumer-raw-batch, consumer-keyed, consumer-follower-recovery, hosted-share, outbox, all (default: all)
 ///   --client &lt;name&gt;         Run specific client: dekaf, confluent, all (default: all)
 ///   --output &lt;path&gt;         Output directory for results (default: ./results)
 ///   --brokers &lt;count&gt;      Number of Kafka brokers (default: 1, use 3 for multi-broker)
@@ -121,6 +121,8 @@ public static class Program
 
     private static async Task<int> RunStressTestsAsync(CliOptions options)
     {
+        if (options.Scenario == "consumer-keyed")
+            KeyedConsumerWorkload.Validate(options.KeyedShape, options.Partitions, options.KeyedRecordsPerPartition, options.MessageSizeBytes);
         Console.WriteLine("Dekaf Stress Test Runner");
         Console.WriteLine($"Duration: {options.DurationMinutes} minutes");
         Console.WriteLine($"Message Size: {options.MessageSizeBytes} bytes");
@@ -209,6 +211,10 @@ public static class Program
             await SeedConsumerTopicAsync(kafka.BootstrapServers, consumerTopic, options).ConfigureAwait(false);
         }
 
+        if (options.Scenario == "consumer-keyed")
+            await KeyedConsumerStressTest.SeedAsync(kafka.BootstrapServers, consumerTopic, options.KeyedShape,
+                options.Partitions, options.KeyedRecordsPerPartition, options.MessageSizeBytes).ConfigureAwait(false);
+
         var results = new List<StressTestResult>();
         var runStartedAt = DateTime.UtcNow;
 
@@ -245,6 +251,8 @@ public static class Program
             ProducerWarmupSeconds = options.ProducerWarmupSeconds,
             MessageSizeBytes = options.MessageSizeBytes,
             Partitions = options.Partitions,
+            KeyedShape = options.KeyedShape,
+            KeyedRecordsPerPartition = options.KeyedRecordsPerPartition,
             LingerMs = options.LingerMs,
             BatchSize = options.BatchSize,
             ConsumerSeedBatchSizeBytes = UsesProducerTopic(scenario.Name) ? null : ConsumerSeedBatchSizeBytes,
@@ -554,6 +562,11 @@ public static class Program
                     $"run ended early ({result.Throughput.ElapsedSeconds:N0}s of {expectedSeconds:N0}s)");
             }
 
+            if (result.Scenario == "consumer-keyed" && (result.KeyedConsumer is not { } keyed
+                || keyed.CompletedPasses <= 0 || keyed.CompletedRecords != accepted
+                || keyed.CompletedRecords != keyed.CompletedPasses * keyed.Partitions * keyed.RecordsPerPartition))
+                reasons.Add("keyed consumer replay did not complete every seeded pass");
+
             if (result.Outbox is { } outbox
                 && (!outbox.HasCompleteDuration(result.DurationMinutes, result.Throughput.ElapsedSeconds)
                     || outbox.CommittedMessages != accepted || outbox.UniqueConsumedMessages != accepted
@@ -833,6 +846,7 @@ public static class Program
                     && !s.Name.Equals("hosted-share", StringComparison.OrdinalIgnoreCase)
                     && !s.Name.Equals("outbox", StringComparison.OrdinalIgnoreCase)
                     && !s.Name.Equals("consumer-follower-recovery", StringComparison.OrdinalIgnoreCase)
+                    && !s.Name.Equals("consumer-keyed", StringComparison.OrdinalIgnoreCase)
                 : s.Name.Equals(options.Scenario, StringComparison.OrdinalIgnoreCase))
             .Where(s => options.Client == "all" || s.Client.Equals(options.Client, StringComparison.OrdinalIgnoreCase))
             .ToList();
@@ -863,6 +877,7 @@ public static class Program
             new ProducerRoundTripStressTest(),
             new ConfluentProducerRoundTripStressTest(),
             new ConsumerStressTest(),
+            new KeyedConsumerStressTest(),
             new ConsumerBatchStressTest(),
             new ConsumerRawStressTest(),
             new ConsumerRawBatchStressTest(),
@@ -959,6 +974,13 @@ public static class Program
                     break;
                 case "--duration":
                     options.DurationMinutes = int.Parse(args[++i]);
+                    break;
+                case "--keyed-shape":
+                    options.KeyedShape = args[++i];
+                    _ = KeyedConsumerWorkload.KeySize(options.KeyedShape);
+                    break;
+                case "--keyed-records-per-partition":
+                    options.KeyedRecordsPerPartition = ParsePositiveInt(args[++i], arg);
                     break;
                 case "--producer-warmup-seconds":
                     options.ProducerWarmupSeconds = ParsePositiveInt(args[++i], "--producer-warmup-seconds");
@@ -1135,7 +1157,7 @@ public static class Program
               --duration <minutes>    Test duration in minutes (default: 15)
               --producer-warmup-seconds <n>  Producer and consumer replay workload warmup (default: {ProducerWarmup.DefaultSeconds}; minimum: {ProducerWarmup.MinimumSeconds})
               --message-size <bytes>  Message size in bytes (default: 1000)
-              --scenario <name>       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip-steady, consumer, consumer-batch, consumer-raw, consumer-raw-batch, consumer-follower-recovery, hosted-share, outbox, soak, all (default: all; all excludes hosted-share, outbox, consumer-follower-recovery and soak)
+              --scenario <name>       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip-steady, consumer, consumer-batch, consumer-raw, consumer-raw-batch, consumer-keyed, consumer-follower-recovery, hosted-share, outbox, soak, all (default: all; all excludes consumer-keyed, hosted-share, outbox, consumer-follower-recovery and soak)
               --client <name>         Run specific client: dekaf, confluent, all (default: all)
               --output <path>         Output directory for results (default: ./results)
               --partitions <count>    Number of topic partitions (default: 6)
@@ -1145,6 +1167,8 @@ public static class Program
               --brokers <count>      Number of Kafka brokers (default: 1, use 3 for multi-broker)
               --connections-per-broker <n>  TCP connections per broker (default: 1, pass 3 for multi-connection comparison)
               --adaptive-connections  Keep Dekaf's default adaptive connection scaling (results labelled "Dekaf (adaptive)")
+              --keyed-shape <name>    consumer-keyed only: scalar, binary, large-distinct, large-colliding (default: scalar)
+              --keyed-records-per-partition <n>  Keyed replay size, multiple of 32 (default: 32768; maximum: 65536)
               --seed-messages <count> Messages pre-seeded into the consumer topic (default: 2000000)
               --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message loss and watchdog stalls
               --consumer-fetch-diagnostics  Capture Dekaf consumer fetch diagnostics (debug runs only; adds Dekaf-only overhead)
@@ -1206,6 +1230,8 @@ public static class Program
         public int ConnectionsPerBroker { get; set; } = 1;
         public bool AdaptiveConnections { get; set; }
         public int SeedMessages { get; set; } = 2_000_000;
+        public string KeyedShape { get; set; } = "scalar";
+        public int KeyedRecordsPerPartition { get; set; } = KeyedConsumerWorkload.DefaultRecordsPerPartition;
         public int RoundTripSteadySeconds { get; set; } = 60;
         public bool EnableProducerDeliveryDiagnostics { get; set; }
         public bool EnableConsumerFetchDiagnostics { get; set; }

--- a/tools/Dekaf.StressTests/README.md
+++ b/tools/Dekaf.StressTests/README.md
@@ -1,6 +1,6 @@
 # Stress runner
 
-For the manual EF outbox workload, see [idle and active outbox coverage](Outbox.md).
+For the manual EF outbox workload, see [idle and active outbox coverage](Outbox.md). For public key-ordered processing, see [keyed consumer replay](KeyedConsumer.md).
 
 `hosted-share` is an explicit manual scenario. It runs an idempotent live producer and two instances of the same hosted share service under distinct DI keys in one Kafka share group. The `hosted-share-1b` workflow lane is excluded from both `lane=all` and `full_run=true`; the existing full matrix remains 12 jobs.
 

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -37,6 +37,7 @@ internal sealed class StressTestResult
     public RoundTripPhaseSnapshot? RoundTripPhases { get; init; }
     public int? RoundTripSteadySeconds { get; init; }
     public OutboxWorkloadSnapshot? Outbox { get; init; }
+    public KeyedConsumerSnapshot? KeyedConsumer { get; set; }
 
     /// <summary>
     /// Whether the scenario's producer ran with idempotence enabled. Must mirror the

--- a/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
+++ b/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
@@ -22,6 +22,8 @@ internal sealed class StressTestOptions
     public required int MessageSizeBytes { get; init; }
     public int ProducerWarmupSeconds { get; init; } = ProducerWarmup.DefaultSeconds;
     public int Partitions { get; init; } = 6;
+    public string KeyedShape { get; init; } = "scalar";
+    public int KeyedRecordsPerPartition { get; init; } = KeyedConsumerWorkload.DefaultRecordsPerPartition;
     public int LingerMs { get; init; } = 5;
     public int BatchSize { get; init; } = 16384;
     public int DeliveryLatencyTargetMs { get; init; } = 10;

--- a/tools/Dekaf.StressTests/Scenarios/KeyedConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/KeyedConsumerStressTest.cs
@@ -1,0 +1,144 @@
+using System.Buffers.Binary;
+using System.Diagnostics;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Reporting;
+
+namespace Dekaf.StressTests.Scenarios;
+
+internal sealed class KeyedConsumerStressTest : IStressTestScenario
+{
+    public string Name => "consumer-keyed";
+    public string Client => "Dekaf";
+
+    public Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
+    {
+        KeyedConsumerWorkload.Validate(options.KeyedShape, options.Partitions, options.KeyedRecordsPerPartition, options.MessageSizeBytes);
+        return options.KeyedShape == "scalar"
+            ? RunAsync<int>(options, static key => key, cancellationToken)
+            : RunAsync<byte[]>(options, key => KeyedConsumerWorkload.ReadBinaryKey(options.KeyedShape, key), cancellationToken);
+    }
+
+    private async Task<StressTestResult> RunAsync<TKey>(StressTestOptions options, Func<TKey, int> keyId, CancellationToken cancellationToken)
+    {
+        await using var consumer = await Kafka.CreateConsumer<TKey, byte[]>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
+            .WithBootstrapServers(options.BootstrapServers)
+            .WithClientId("stress-keyed-consumer")
+            .WithGroupId($"stress-keyed-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .ForHighThroughput()
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .BuildAsync(cancellationToken).ConfigureAwait(false);
+        var partitions = new TopicPartition[options.Partitions];
+        for (var p = 0; p < partitions.Length; p++) partitions[p] = new(options.Topic, p);
+        consumer.Partitions.Assign(partitions);
+        var ends = await StressTestHelpers.QueryEndOffsetsAsync(consumer, options.Topic, options.Partitions, cancellationToken).ConfigureAwait(false);
+        foreach (var end in ends)
+            if (end != options.KeyedRecordsPerPartition) throw new InvalidOperationException("Seeded keyed replay partition has an unexpected end offset.");
+
+        var processing = new PartitionedProcessingOptions
+        {
+            Ordering = PartitionedProcessingOrder.Key,
+            MaxConcurrentHandlersPerPartition = KeyedConsumerWorkload.HandlerConcurrency,
+            MaxBufferedRecordsPerPartition = KeyedConsumerWorkload.BufferedRecords,
+            StopPolicy = PartitionStopPolicy.Drain,
+            StopTimeout = TimeSpan.FromSeconds(30),
+            ErrorPolicy = PartitionWorkerErrorPolicy.StopConsumer,
+            CommitPolicy = PartitionCommitPolicy.UserManaged
+        };
+        long passes = 0;
+        long completed = 0;
+        double boundarySeconds = 0;
+        var result = await StressTestHelpers.RunConsumerAsync(options, this,
+            async (throughput, durationToken) =>
+            {
+                passes = 0;
+                completed = 0;
+                boundarySeconds = 0;
+                while (!durationToken.IsCancellationRequested)
+                {
+                    // Runtime and every handler from the preceding pass have stopped.
+                    // Seek never races a handler or changes offsets beneath queued work.
+                    var boundary = Stopwatch.GetTimestamp();
+                    consumer.Positions.SeekToBeginning(partitions);
+                    consumer.Partitions.Resume(partitions);
+                    using var stop = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    stop.CancelAfter(TimeSpan.FromSeconds(60));
+                    var pass = new KeyedConsumerPass(options.Partitions, options.KeyedRecordsPerPartition, throughput, stop);
+                    boundarySeconds += Stopwatch.GetElapsedTime(boundary).TotalSeconds;
+                    try
+                    {
+                        await consumer.RunPartitionedAsync((_, record, _) =>
+                        {
+                            var index = pass.Enter(record.Partition, keyId(record.Key!), record.Offset, record.Value);
+                            if (record.Offset / KeyedConsumerWorkload.KeyCount % KeyedConsumerWorkload.YieldInterval == 0)
+                                return CompleteAfterYieldAsync(pass, index, record.Value.Length);
+                            pass.Complete(index, record.Value.Length);
+                            return ValueTask.CompletedTask;
+                        }, processing, stop.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (stop.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                    {
+                        // Only full completion is success; the 60-second deadline below
+                        // fails a partial pass, including a dropped final queued record.
+                    }
+                    cancellationToken.ThrowIfCancellationRequested();
+                    boundary = Stopwatch.GetTimestamp();
+                    pass.ValidateComplete();
+                    completed += pass.Completed;
+                    passes++;
+                    boundarySeconds += Stopwatch.GetElapsedTime(boundary).TotalSeconds;
+                }
+            }, StressTestOptions.HighThroughputConsumerConnectionsPerBroker,
+            captureConsumerDiagnostics: () => StressTestHelpers.CaptureConsumerDiagnostics(consumer),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        result.KeyedConsumer = new KeyedConsumerSnapshot
+        {
+            Shape = options.KeyedShape, KeySizeBytes = KeyedConsumerWorkload.KeySize(options.KeyedShape),
+            Partitions = options.Partitions, RecordsPerPartition = options.KeyedRecordsPerPartition,
+            CompletedPasses = passes, CompletedRecords = completed, ReplayBookkeepingSeconds = boundarySeconds
+        };
+        return result;
+    }
+
+    // Deterministic asynchronous work keeps multiple key lanes active. Most handlers
+    // complete synchronously; one in 64 records per key pays this state machine/yield.
+    private static async ValueTask CompleteAfterYieldAsync(KeyedConsumerPass pass, int index, int valueBytes)
+    {
+        await Task.Yield();
+        pass.Complete(index, valueBytes);
+    }
+
+    internal static Task SeedAsync(string bootstrapServers, string topic, string shape, int partitions, int recordsPerPartition, int messageSize)
+    {
+        KeyedConsumerWorkload.Validate(shape, partitions, recordsPerPartition, messageSize);
+        return shape == "scalar"
+            ? SeedAsync<int>(bootstrapServers, topic, partitions, recordsPerPartition, messageSize, static id => id)
+            : SeedAsync<byte[]>(bootstrapServers, topic, partitions, recordsPerPartition, messageSize, id => KeyedConsumerWorkload.CreateBinaryKey(shape, id));
+    }
+
+    private static async Task SeedAsync<TKey>(string bootstrapServers, string topic, int partitions, int recordsPerPartition, int messageSize, Func<int, TKey> createKey)
+    {
+        await using var producer = await Kafka.CreateProducer<TKey, byte[]>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
+            .WithBootstrapServers(bootstrapServers).WithAcks(Acks.All)
+            .WithLinger(TimeSpan.FromMilliseconds(5)).WithBatchSize(1_048_576).BuildAsync().ConfigureAwait(false);
+        var keys = new TKey[KeyedConsumerWorkload.KeyCount];
+        for (var i = 0; i < keys.Length; i++) keys[i] = createKey(i);
+        var value = new byte[messageSize];
+        for (var offset = 0; offset < recordsPerPartition; offset++)
+        {
+            BinaryPrimitives.WriteInt64LittleEndian(value, offset);
+            for (var partition = 0; partition < partitions; partition++)
+                await producer.FireAsync(new ProducerMessage<TKey, byte[]>
+                {
+                    Topic = topic, Partition = partition, Key = keys[offset % keys.Length], Value = value
+                }).ConfigureAwait(false);
+            if (offset % 1024 == 1023) await producer.FlushAsync().ConfigureAwait(false);
+        }
+        await producer.FlushAsync().ConfigureAwait(false);
+        Console.WriteLine($"Keyed replay seeded: {partitions} partitions, {recordsPerPartition} records/partition.");
+    }
+}

--- a/tools/Dekaf.StressTests/Scenarios/KeyedConsumerWorkload.cs
+++ b/tools/Dekaf.StressTests/Scenarios/KeyedConsumerWorkload.cs
@@ -1,0 +1,128 @@
+using System.Buffers.Binary;
+using Dekaf.StressTests.Metrics;
+
+namespace Dekaf.StressTests.Scenarios;
+
+internal static class KeyedConsumerWorkload
+{
+    internal const int KeyCount = 32;
+    internal const int DefaultRecordsPerPartition = 32768;
+    internal const int HandlerConcurrency = 4;
+    internal const int BufferedRecords = 256;
+    internal const int YieldInterval = 64;
+
+    internal static int KeySize(string shape) => shape switch
+    {
+        "scalar" => sizeof(int),
+        "binary" => 16,
+        "large-distinct" or "large-colliding" => 4096,
+        _ => throw new ArgumentException($"Unknown keyed consumer shape: {shape}.")
+    };
+
+    internal static void Validate(string shape, int partitions, int recordsPerPartition, int messageSize)
+    {
+        _ = KeySize(shape);
+        if (partitions is < 1 or > 6 || recordsPerPartition is < KeyCount or > 65536
+            || recordsPerPartition % KeyCount != 0 || messageSize is < 8 or > 4096)
+            throw new ArgumentException("Keyed replay requires 1..6 partitions, 32..65536 records per partition (multiple of 32), and 8..4096 value bytes.");
+    }
+
+    internal static byte[] CreateBinaryKey(string shape, int id)
+    {
+        var key = new byte[KeySize(shape)];
+        key.AsSpan().Fill(0x5a);
+        // Keep all four sampled windows identical for the collision shape. The ID
+        // precedes the final 16-byte sample and remains part of content equality.
+        var position = shape == "large-colliding" ? key.Length - 32 : 0;
+        BinaryPrimitives.WriteInt32LittleEndian(key.AsSpan(position), id);
+        return key;
+    }
+
+    internal static int ReadBinaryKey(string shape, byte[] key)
+    {
+        if (key.Length != KeySize(shape)) throw new InvalidOperationException("Unexpected key size.");
+        return BinaryPrimitives.ReadInt32LittleEndian(key.AsSpan(shape == "large-colliding" ? key.Length - 32 : 0));
+    }
+}
+
+// Independent sequence state is per partition AND logical key. A successful pass
+// must include every seeded record; a duration boundary never discards its tail.
+internal sealed class KeyedConsumerPass
+{
+    private readonly Slot[] _slots;
+    private readonly int _recordsPerPartition;
+    private readonly ThroughputTracker _throughput;
+    private readonly CancellationTokenSource _stop;
+    private long _completed;
+    internal long Completed => Interlocked.Read(ref _completed);
+    internal long Expected { get; }
+
+    internal KeyedConsumerPass(int partitions, int recordsPerPartition, ThroughputTracker throughput, CancellationTokenSource stop)
+    {
+        _recordsPerPartition = recordsPerPartition;
+        _throughput = throughput;
+        _stop = stop;
+        Expected = (long)partitions * recordsPerPartition;
+        _slots = new Slot[partitions * KeyedConsumerWorkload.KeyCount];
+        for (var i = 0; i < _slots.Length; i++)
+            _slots[i].Next = i % KeyedConsumerWorkload.KeyCount;
+    }
+
+    internal int Enter(int partition, int key, long offset, ReadOnlySpan<byte> value)
+    {
+        if ((uint)partition >= (uint)(_slots.Length / KeyedConsumerWorkload.KeyCount)
+            || (uint)key >= KeyedConsumerWorkload.KeyCount || offset < 0 || offset >= _recordsPerPartition
+            || value.Length < sizeof(long) || BinaryPrimitives.ReadInt64LittleEndian(value) != offset)
+            throw new InvalidOperationException("Unexpected keyed replay record or payload sequence.");
+        var index = partition * KeyedConsumerWorkload.KeyCount + key;
+        ref var slot = ref _slots[index];
+        if (Interlocked.CompareExchange(ref slot.Active, 1, 0) != 0)
+            throw new InvalidOperationException("Equal-key handlers overlapped within one partition.");
+        if (slot.Next != offset)
+        {
+            Volatile.Write(ref slot.Active, 0);
+            throw new InvalidOperationException($"Keyed replay order violation: partition={partition}, key={key}, expected={slot.Next}, actual={offset}.");
+        }
+        return index;
+    }
+
+    internal void Complete(int index, int valueBytes)
+    {
+        ref var slot = ref _slots[index];
+        slot.Next += KeyedConsumerWorkload.KeyCount;
+        _throughput.RecordMessage(valueBytes);
+        Volatile.Write(ref slot.Active, 0);
+        if (Interlocked.Increment(ref _completed) == Expected) _stop.Cancel();
+    }
+
+    internal void ValidateComplete()
+    {
+        if (Completed != Expected) throw new InvalidOperationException($"Keyed replay incomplete: {Completed}/{Expected} records completed.");
+        for (var i = 0; i < _slots.Length; i++)
+        {
+            if (_slots[i].Active != 0 || _slots[i].Next != _recordsPerPartition + i % KeyedConsumerWorkload.KeyCount)
+                throw new InvalidOperationException("Keyed replay did not drain every handler and sequence.");
+        }
+    }
+
+    private struct Slot
+    {
+        internal long Next;
+        internal int Active;
+    }
+}
+
+internal sealed class KeyedConsumerSnapshot
+{
+    public required string Shape { get; init; }
+    public required int KeySizeBytes { get; init; }
+    public required int Partitions { get; init; }
+    public int KeysPerPartition => KeyedConsumerWorkload.KeyCount;
+    public required int RecordsPerPartition { get; init; }
+    public int HandlerConcurrency => KeyedConsumerWorkload.HandlerConcurrency;
+    public int BufferedRecordsPerPartition => KeyedConsumerWorkload.BufferedRecords;
+    public int YieldEveryKeyRecords => KeyedConsumerWorkload.YieldInterval;
+    public required long CompletedPasses { get; init; }
+    public required long CompletedRecords { get; init; }
+    public required double ReplayBookkeepingSeconds { get; init; }
+}

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -26,83 +26,92 @@ internal static class StressTestHelpers
         throughput.Warmup = await ProducerWarmup.RunAsync(options.ProducerWarmupSeconds,
             async (duration, cycleThroughput, token) =>
             {
-                var cycle = await RunCycleAsync(duration, cycleThroughput, token).ConfigureAwait(false);
+                var cycle = await RunConsumerCycleAsync(options, scenario, consume, connectionsPerBroker,
+                    captureConsumerDiagnostics, duration, cycleThroughput, token).ConfigureAwait(false);
                 return new ProducerWorkloadResult(cycle.WorkloadSeconds, cycle.Result.Throughput, cycle.Result.GcStats);
             }, cancellationToken).ConfigureAwait(false);
-        return (await RunCycleAsync(TimeSpan.FromMinutes(options.DurationMinutes), throughput, cancellationToken).ConfigureAwait(false)).Result;
+        return (await RunConsumerCycleAsync(options, scenario, consume, connectionsPerBroker,
+            captureConsumerDiagnostics, TimeSpan.FromMinutes(options.DurationMinutes), throughput, cancellationToken).ConfigureAwait(false)).Result;
+    }
 
-        async Task<(StressTestResult Result, double WorkloadSeconds)> RunCycleAsync(
-            TimeSpan duration, ThroughputTracker tracker, CancellationToken token)
+    internal static async Task<(StressTestResult Result, double WorkloadSeconds)> RunConsumerCycleAsync(
+        StressTestOptions options, IStressTestScenario scenario,
+        Func<ThroughputTracker, CancellationToken, Task> consume, int connectionsPerBroker,
+        Func<ConsumerDiagnosticSnapshot?>? captureConsumerDiagnostics,
+        TimeSpan duration, ThroughputTracker tracker, CancellationToken token)
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        using var gcStats = new GcStats();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
+        // The duration stops ingress. Observers stay alive until the consumer has
+        // finished its current pass and drained, including any deadline overrun.
+        using var observations = CancellationTokenSource.CreateLinkedTokenSource(token);
+        using var diagnostics = captureConsumerDiagnostics is null ? null
+            : new ConsumerFetchDiagnosticsTracker(options.Topic, enabled: options.EnableConsumerFetchDiagnostics);
+        if (captureConsumerDiagnostics?.Invoke() is { } initial)
+            diagnostics?.Start(initial);
+
+        var startedAt = DateTime.UtcNow;
+        if (tracker.Warmup is not null)
+            Console.WriteLine($"  Running {scenario.Client} {scenario.Name} stress test for {options.DurationMinutes} minutes...");
+        LogResourceUsage("Initial");
+        tracker.Start();
+        var stop = ProducerWorkload.StopIngressAsync(cts, duration, TimeProvider.System);
+        using var watchdog = options.ProgressWatchdog.Track(tracker, scenario.Client, scenario.Name,
+            captureConsumerDiagnostics: captureConsumerDiagnostics);
+        var sampler = RunSamplerAsync(tracker, observations.Token);
+        var resources = RunResourceMonitorAsync(observations.Token);
+        var diagnosticSampler = diagnostics?.RunSamplerAsync(captureConsumerDiagnostics!, observations.Token) ?? Task.CompletedTask;
+        double workloadSeconds;
+        try
         {
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
-            using var gcStats = new GcStats();
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
-            using var diagnostics = captureConsumerDiagnostics is null ? null
-                : new ConsumerFetchDiagnosticsTracker(options.Topic, enabled: options.EnableConsumerFetchDiagnostics);
-            if (captureConsumerDiagnostics?.Invoke() is { } initial)
-                diagnostics?.Start(initial);
-
-            var startedAt = DateTime.UtcNow;
-            if (tracker.Warmup is not null)
-                Console.WriteLine($"  Running {scenario.Client} {scenario.Name} stress test for {options.DurationMinutes} minutes...");
-            LogResourceUsage("Initial");
-            tracker.Start();
-            var stop = ProducerWorkload.StopIngressAsync(cts, duration, TimeProvider.System);
-            using var watchdog = options.ProgressWatchdog.Track(tracker, scenario.Client, scenario.Name,
-                captureConsumerDiagnostics: captureConsumerDiagnostics);
-            var sampler = RunSamplerAsync(tracker, cts.Token);
-            var resources = RunResourceMonitorAsync(cts.Token);
-            var diagnosticSampler = diagnostics?.RunSamplerAsync(captureConsumerDiagnostics!, cts.Token) ?? Task.CompletedTask;
-            double workloadSeconds;
-            try
-            {
-                await consume(tracker, cts.Token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (cts.IsCancellationRequested && !token.IsCancellationRequested)
-            {
-                // The declared workload duration ended; the iterator has unwound.
-            }
-            catch (Exception error) when (!token.IsCancellationRequested)
-            {
-                // Retain the replay failure even if an observer also fails during cleanup.
-                Console.Error.WriteLine($"  {scenario.Client} {scenario.Name} error: {error}");
-                tracker.RecordError(error, $"{scenario.Name} loop");
-            }
-            finally
-            {
-                workloadSeconds = tracker.Elapsed.TotalSeconds;
-                cts.Cancel();
-                await stop.ConfigureAwait(false);
-                try { await Task.WhenAll(sampler, resources, diagnosticSampler).ConfigureAwait(false); }
-                catch (OperationCanceledException) when (cts.IsCancellationRequested) { }
-                tracker.Stop();
-                gcStats.Capture();
-            }
-            token.ThrowIfCancellationRequested();
-            if (captureConsumerDiagnostics is not null)
-                diagnostics?.TryTakeSample(captureConsumerDiagnostics);
-            Console.WriteLine($"  Completed: {tracker.MessageCount:N0} messages, {tracker.GetAverageMessagesPerSecond():N0} msg/sec");
-            LogResourceUsage("Final");
-            return (new StressTestResult
-            {
-                Scenario = scenario.Name,
-                Client = scenario.Client,
-                DurationMinutes = options.DurationMinutes,
-                BrokerCount = options.BrokerCount,
-                MessageSizeBytes = options.MessageSizeBytes,
-                ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
-                ConsumerConnectionsPerBroker = connectionsPerBroker,
-                StartedAtUtc = startedAt,
-                CompletedAtUtc = DateTime.UtcNow,
-                Throughput = tracker.GetSnapshot(),
-                Latency = null,
-                GcStats = gcStats.ToSnapshot(),
-                CpuTimeSeconds = tracker.CpuTimeSeconds,
-                ConsumerFetchDiagnostics = diagnostics?.GetSnapshot()
-            }, workloadSeconds);
+            await consume(tracker, cts.Token).ConfigureAwait(false);
         }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested && !token.IsCancellationRequested)
+        {
+            // The declared workload duration ended; the iterator has unwound.
+        }
+        catch (Exception error) when (!token.IsCancellationRequested)
+        {
+            // Retain the replay failure even if an observer also fails during cleanup.
+            Console.Error.WriteLine($"  {scenario.Client} {scenario.Name} error: {error}");
+            tracker.RecordError(error, $"{scenario.Name} loop");
+        }
+        finally
+        {
+            workloadSeconds = tracker.Elapsed.TotalSeconds;
+            cts.Cancel();
+            observations.Cancel();
+            await stop.ConfigureAwait(false);
+            try { await Task.WhenAll(sampler, resources, diagnosticSampler).ConfigureAwait(false); }
+            catch (OperationCanceledException) when (observations.IsCancellationRequested) { }
+            tracker.Stop();
+            gcStats.Capture();
+        }
+        token.ThrowIfCancellationRequested();
+        if (captureConsumerDiagnostics is not null)
+            diagnostics?.TryTakeSample(captureConsumerDiagnostics);
+        Console.WriteLine($"  Completed: {tracker.MessageCount:N0} messages, {tracker.GetAverageMessagesPerSecond():N0} msg/sec");
+        LogResourceUsage("Final");
+        return (new StressTestResult
+        {
+            Scenario = scenario.Name,
+            Client = scenario.Client,
+            DurationMinutes = options.DurationMinutes,
+            BrokerCount = options.BrokerCount,
+            MessageSizeBytes = options.MessageSizeBytes,
+            ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
+            ConsumerConnectionsPerBroker = connectionsPerBroker,
+            StartedAtUtc = startedAt,
+            CompletedAtUtc = DateTime.UtcNow,
+            Throughput = tracker.GetSnapshot(),
+            Latency = null,
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = tracker.CpuTimeSeconds,
+            ConsumerFetchDiagnostics = diagnostics?.GetSnapshot()
+        }, workloadSeconds);
     }
 
     /// <summary>


### PR DESCRIPTION
Existing consumer replay lanes do not call `RunPartitionedAsync`, so they cannot validate key-dispatch changes under load. Add the explicit manual-only `consumer-keyed-1b` lane with scalar, repeated binary, large distinct and large sampled-hash-collision shapes. It uses the public key-ordered record handler, a fixed bounded seed and per-partition/per-key sequence and overlap checks.

Each pass must complete every seeded record and drain the runtime before seeking. Duration stops new passes; the current pass finishes inside the measurement window. Throughput, resource and optional fetch-diagnostic observers use a separate cancellation lifetime and continue until that pass drains. Missing tails and handler failures fail the run. JSON retains shape, dimensions and complete pass/record counts, checked across A1/B/A2. Consumer latency remains n/a.

Current head `a36d87bbe2dfd14b21bcd2012e6921b7504e3352` is one commit above main `b51cc0f1acaff22d07f967f56a862b7974c32256`. The rebase integrates merged #3259 without losing either manual lane: keyed and follower-recovery remain selectable explicitly and excluded from default/full matrices. It preserves follower topic/seeding behavior, the strict follower baseline warning and keyed shape forwarding. Existing fixed-worker setup and acceptance thresholds remain unchanged.

Per-message observer costs are sequence checks, indexed state, Interlocked and throughput counters. Most handlers complete synchronously; one in 64 records per key pays an async state machine and Task.Yield. Deserialization remains measured. Cancellation sources (including the observer lifetime), delegates, state arrays, runtime construction/drain, seek and final validation are amortized per pass or cycle. This harness does not claim zero allocations or establish #3048 performance acceptance; collision promotion and p50/p99 evidence remain parent work.

Validation:

- Full Release build: zero warnings/errors. All 100 stress-tool tests pass after integrating both lanes. The Python suite passes 349 tests with 12 platform skips (361 total), including actual Bash/jq lane selection. Artifact policy and diff checks pass.
- The observer regression first fails both cases on the old cancellation behavior: no post-deadline sample arrives. The fix passes both successful-drain and failure-after-drain cases, preserving the original failure.
- Current-head local Kafka 4.3.1 smoke: large-colliding shape, two partitions, 2,048 records/partition, 128-byte values, 20-second warmup and one measured minute. All 119 measured passes / 487,424 records complete with zero errors. Measurement ends at 60.1631261 seconds; the final interval sample is at 59.9609531 seconds. This bounded smoke proves correctness and observation coverage, not a controlled performance comparison.
- Earlier validated heads retain the original four-shape smokes (1,000 complete passes / 4,096,000 records total), the sampler-fix smoke (216 passes / 884,736 records), and the first main rebase smoke (215 passes / 880,640 records). These separate local runs are not A/B/A timing comparisons or evidence of a performance win/loss; their original reports remain retained.
- No paid acceptance run is dispatched for this harness-only issue. No library source or benchmark fixture is changed by this PR.

Current source, actual loaded binaries, root HTML test report, raw logs, smoke JSON/Markdown and conflict-resolution provenance are retained at `D:/Dekaf-evidence/pr-3279-follower-main`. The 2,735 source entries and 475 binary/report entries are SHA-256 verified against originals before cleanup. `SHA256.json` and `provenance.txt` identify the evidence. Earlier exact archives remain at `D:/Dekaf-evidence/pr-3279-current-main`, `D:/Dekaf-evidence/pr-3279-sampler-drain` and `C:/git/Dekaf-evidence/issue-3278/`.

The sampler review thread is resolved after the substantive fix reply and subsequent clear reviews on 8b8aa7a54. The new combined head starts a fresh CI/review cycle. For the result-setter convention suggestion: `StressTestResult.Client` already has a setter for result labeling, and this internal result is not an options type. `KeyedConsumer` is assigned once immediately after measurement. Keeping that narrow existing pattern avoids a class-wide record conversion and an extra result clone.

See `tools/Dekaf.StressTests/KeyedConsumer.md` for workload dimensions and dispatch instructions. Parent #3048 remains open for actual performance/loaded acceptance and its original requirements.

Closes #3278
