### PR TITLE
fix(stress): limit startup warning to incomplete validation

### DIFF
--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -534,9 +534,10 @@ def markdown(comparison, baseline_sha, candidate_sha):
             f"{name}={value}" for name, value in comparison["keyedConsumer"].items()) + "."])
     if comparison.get("startupAssessment"):
         assessment = comparison["startupAssessment"]
-        lines.extend(["", f"Startup assessment: {assessment['verdict']}",
-                      "The following raw metric classifications and deltas are diagnostic. "
-                      "Incomplete startup assessment prevents acceptance or a confirmed performance-regression conclusion."])
+        lines.extend(["", f"Startup assessment: {assessment['verdict']}"])
+        if assessment["verdict"] != "VALIDATED":
+            lines.append("The following raw metric classifications and deltas are diagnostic. "
+                         "Incomplete startup assessment prevents acceptance or a confirmed performance-regression conclusion.")
         lines.extend(f"- {error}" for error in assessment["errors"])
     lines.extend([
         "",

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -85,6 +85,35 @@ def metric(comparison, key):
 
 
 class StressAbaComparisonTests(unittest.TestCase):
+    def test_validated_startup_does_not_explain_metric_verdict_as_incomplete(self):
+        for candidate, expected in ((100, "pass"), (96, "inconclusive"), (90, "regression")):
+            with self.subTest(verdict=expected):
+                comparison = compare(consumer(throughput=100), consumer(throughput=candidate),
+                                     consumer(throughput=98))
+                self.assertEqual(expected, comparison["verdict"])
+                comparison["startupAssessment"] = {"verdict": "VALIDATED", "errors": []}
+                before = json.dumps(comparison, sort_keys=True)
+
+                report = markdown(comparison, "a", "b")
+
+                self.assertIn("Startup assessment: VALIDATED", report)
+                self.assertIn(f"**Verdict: {expected.upper()}**", report)
+                self.assertNotIn("Incomplete startup assessment", report)
+                self.assertEqual(before, json.dumps(comparison, sort_keys=True))
+
+    def test_incomplete_startup_keeps_warning_and_validation_errors(self):
+        comparison = compare(consumer(), consumer(), consumer())
+        comparison["verdict"] = "inconclusive"
+        comparison["startupAssessment"] = {
+            "verdict": "INCONCLUSIVE", "errors": ["Worker count changed during measurement"]
+        }
+
+        report = markdown(comparison, "a", "b")
+
+        self.assertIn("Startup assessment: INCONCLUSIVE", report)
+        self.assertIn("Incomplete startup assessment prevents acceptance", report)
+        self.assertIn("- Worker count changed during measurement", report)
+
     def assert_pass(self, comparison):
         self.assertEqual("pass", comparison["verdict"])
         for item in comparison["metrics"]:


### PR DESCRIPTION
The exact-SHA report prints an incomplete-startup warning even when startup is VALIDATED. Run [34650056822](https://github.com/thomhurst/Dekaf/actions/runs/34650056822/job/103429901250) exposed this: its INCONCLUSIVE result comes from one-sided throughput/CPU differences, while startup validation passes.

Render that warning only when startup validation is incomplete. Keep the startup verdict and validation errors visible. Comparison logic, metric classifications and exit codes are unchanged.

Validation on `0b6c3369c408d50362ef4bcec8994e4bd1664b02`, rebased onto main `e63abf23a8f6ca16b1bb3cc838dca507b9f65b79`: 351 Python tests pass, with 12 platform skips (363 total). New tests reproduce the warning under PASS, INCONCLUSIVE and REGRESSION metric outcomes, and retain the incomplete-startup warning/error case. Re-rendering the original run preserves its INCONCLUSIVE verdict and input JSON. Artifact policy, diff and simplification checks pass.

Exact before/after sources (2,729 verified entries each), raw regression/full-suite logs, corrected original-run rendering, input hash and Python runtime details are retained at `D:/Dekaf-evidence/issue-3283`, with a SHA-256 inventory verified against originals. No paid run is needed for this reporting correction.

Current source (2,749 entries), raw full-suite output, review snapshots, Python runtime hash and the unchanged corrected original-run rendering are retained at `D:/Dekaf-evidence/pr-3284-current-main/`. All source inventory entries were verified against originals. The patch retains identical behavior; only surrounding keyed-renderer context changed during rebase.

Closes #3283
