### PR TITLE
fix(share-consumer): isolate nested deserializer context

### DIFF
--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -56,11 +56,6 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     private readonly ILogger _logger;
     private ShareAcknowledgementCommitCallback? _acknowledgementCommitCallback;
 
-    // ThreadStatic reusable SerializationContext to avoid per-record allocations in ParsePartitionRecords.
-    // Matches the pattern used by ConsumeResult<TKey, TValue> in the regular consumer.
-    [ThreadStatic]
-    private static SerializationContext t_serializationContext;
-
     private volatile HashSet<string> _subscriptionSnapshot = new();
     private volatile TopicPartitionSet _assignmentSnapshot = new HashSet<TopicPartition>();
 
@@ -1608,16 +1603,17 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     parserState.RecordIndex++;
                     continue;
                 }
-                t_serializationContext.Topic = topicInfo.Name;
-                t_serializationContext.Component = SerializationComponent.Key;
-                t_serializationContext.KeyData = ReadOnlyMemory<byte>.Empty;
-                t_serializationContext.IsNull = record.IsKeyNull;
+                // A key deserializer can synchronously poll another consumer on this thread.
+                var serializationContext = new SerializationContext { Topic = topicInfo.Name };
+                serializationContext.Component = SerializationComponent.Key;
+                serializationContext.KeyData = ReadOnlyMemory<byte>.Empty;
+                serializationContext.IsNull = record.IsKeyNull;
                 var headerRouting = record.CreateHeaderRoutingLookup(
                     _recordHeaderRoutingPlan);
                 var materializedHeaders = _recordHeaderDeserializationHeaders;
                 if (materializedHeaders is not null)
                     headerRouting.CopyTo(materializedHeaders);
-                t_serializationContext.Headers = headerRouting.KeyRequiresMaterializedHeaders
+                serializationContext.Headers = headerRouting.KeyRequiresMaterializedHeaders
                     ? materializedHeaders
                     : null;
                 var key = record.IsKeyNull
@@ -1625,15 +1621,15 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     : RecordHeaderDeserializer.Deserialize(
                         _keyDeserializer,
                         record.Key,
-                        t_serializationContext,
+                        serializationContext,
                         in headerRouting);
 
-                t_serializationContext.Component = SerializationComponent.Value;
-                t_serializationContext.KeyData = SerializationContext.NormalizeKeyData(
+                serializationContext.Component = SerializationComponent.Value;
+                serializationContext.KeyData = SerializationContext.NormalizeKeyData(
                     record.Key,
                     record.IsKeyNull);
-                t_serializationContext.IsNull = record.IsValueNull;
-                t_serializationContext.Headers = headerRouting.ValueRequiresMaterializedHeaders
+                serializationContext.IsNull = record.IsValueNull;
+                serializationContext.Headers = headerRouting.ValueRequiresMaterializedHeaders
                     ? materializedHeaders
                     : null;
                 var value = record.IsValueNull
@@ -1641,7 +1637,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     : RecordHeaderDeserializer.Deserialize(
                         _valueDeserializer,
                         record.Value,
-                        t_serializationContext,
+                        serializationContext,
                         in headerRouting);
 
                 var headers = Array.Empty<Header>();
@@ -1782,16 +1778,17 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                         continue;
                     }
 
-                    t_serializationContext.Topic = topicInfo.Name;
-                    t_serializationContext.Component = SerializationComponent.Key;
-                    t_serializationContext.KeyData = ReadOnlyMemory<byte>.Empty;
-                    t_serializationContext.IsNull = record.IsKeyNull;
+                    // Keep nested consumer calls from changing this record's context.
+                    var serializationContext = new SerializationContext { Topic = topicInfo.Name };
+                    serializationContext.Component = SerializationComponent.Key;
+                    serializationContext.KeyData = ReadOnlyMemory<byte>.Empty;
+                    serializationContext.IsNull = record.IsKeyNull;
                     var headerRouting = record.CreateHeaderRoutingLookup(
                         _recordHeaderRoutingPlan);
                     var materializedHeaders = _recordHeaderDeserializationHeaders;
                     if (materializedHeaders is not null)
                         headerRouting.CopyTo(materializedHeaders);
-                    t_serializationContext.Headers = headerRouting.KeyRequiresMaterializedHeaders
+                    serializationContext.Headers = headerRouting.KeyRequiresMaterializedHeaders
                         ? materializedHeaders
                         : null;
                     TKey? key = default;
@@ -1806,7 +1803,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                             if (!TryDeserializePrepared(
                                     keyPreparer,
                                     record.Key,
-                                    t_serializationContext,
+                                    serializationContext,
                                     in headerRouting,
                                     out key))
                             {
@@ -1824,17 +1821,17 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                             key = RecordHeaderDeserializer.Deserialize(
                                 _keyDeserializer,
                                 record.Key,
-                                t_serializationContext,
+                                serializationContext,
                                 in headerRouting);
                         }
                     }
 
-                    t_serializationContext.Component = SerializationComponent.Value;
-                    t_serializationContext.KeyData = SerializationContext.NormalizeKeyData(
+                    serializationContext.Component = SerializationComponent.Value;
+                    serializationContext.KeyData = SerializationContext.NormalizeKeyData(
                         record.Key,
                         record.IsKeyNull);
-                    t_serializationContext.IsNull = record.IsValueNull;
-                    t_serializationContext.Headers = headerRouting.ValueRequiresMaterializedHeaders
+                    serializationContext.IsNull = record.IsValueNull;
+                    serializationContext.Headers = headerRouting.ValueRequiresMaterializedHeaders
                         ? materializedHeaders
                         : null;
                     TValue value;
@@ -1847,7 +1844,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                         if (!TryDeserializePrepared(
                                 valuePreparer,
                                 record.Value,
-                                t_serializationContext,
+                                serializationContext,
                                 in headerRouting,
                                 out value))
                         {
@@ -1865,7 +1862,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                         value = RecordHeaderDeserializer.Deserialize(
                             _valueDeserializer,
                             record.Value,
-                            t_serializationContext,
+                            serializationContext,
                             in headerRouting);
                     }
 

--- a/tests/Dekaf.Tests.Integration/ShareConsumerSerializationContextTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerSerializationContextTests.cs
@@ -1,0 +1,121 @@
+using Dekaf.Admin;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("ShareConsumer")]
+[SupportsKafka(420)]
+[NotInParallel("ShareConsumerKafka42")]
+public class ShareConsumerSerializationContextTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task BufferedNestedConsumer_PreservesOuterValueTopic(bool prepared)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var nestedTopic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        var outerTopic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        var nestedGroup = $"nested-context-{Guid.NewGuid():N}";
+        var outerGroup = $"outer-context-{Guid.NewGuid():N}";
+        await using (var admin = Kafka.CreateAdminClient().WithBootstrapServers(KafkaContainer.BootstrapServers).Build())
+        {
+            await admin.IncrementalAlterConfigsAsync(new Dictionary<ConfigResource, IReadOnlyList<ConfigAlter>>
+            {
+                [new ConfigResource { Type = ConfigResourceType.Group, Name = nestedGroup }] = [ConfigAlter.Set("share.auto.offset.reset", "earliest")],
+                [new ConfigResource { Type = ConfigResourceType.Group, Name = outerGroup }] = [ConfigAlter.Set("share.auto.offset.reset", "earliest")]
+            }, cancellationToken: timeout.Token);
+        }
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).WithLinger(TimeSpan.FromMinutes(1)).BuildAsync(timeout.Token);
+        await producer.FireAsync(nestedTopic, "nested-key-0", "nested-0");
+        await producer.FireAsync(nestedTopic, "nested-key-1", "nested-1");
+        await producer.FireAsync(outerTopic, "outer-key", "outer-value");
+        await producer.FlushAsync(timeout.Token);
+
+        var nestedValue = new TopicCapturingDeserializer(prepared);
+        await using var nested = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId(nestedGroup)
+            .WithValueDeserializer(nestedValue).WithMaxPollRecords(1)
+            .WithAcknowledgementMode(ShareAcknowledgementMode.Explicit).BuildAsync(timeout.Token);
+        nested.Subscribe(nestedTopic);
+        await using (var first = nested.PollAsync(timeout.Token).GetAsyncEnumerator())
+        {
+            await Assert.That(await first.MoveNextAsync()).IsTrue();
+            await Assert.That(first.Current.Value).IsEqualTo("nested-0");
+            nested.Acknowledge(first.Current);
+            await nested.CommitAsync(timeout.Token);
+        }
+
+        // The remaining record is acquired in the same producer batch but not yet parsed.
+        // Reading it in the outer key callback reenters the same generic parser on this thread.
+        await using var nestedPoll = nested.PollAsync(timeout.Token).GetAsyncEnumerator();
+        Task<bool>? unexpectedPendingMove = null;
+        var outerKey = new CallbackDeserializer(() =>
+        {
+            var move = nestedPoll.MoveNextAsync();
+            if (!move.IsCompletedSuccessfully)
+            {
+                unexpectedPendingMove = move.AsTask();
+                throw new InvalidOperationException("The acquired nested record must be available synchronously.");
+            }
+            if (!move.GetAwaiter().GetResult()) throw new InvalidOperationException("Missing acquired nested record.");
+        });
+        var outerValue = new TopicCapturingDeserializer(prepared);
+        await using var outer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId(outerGroup)
+            .WithKeyDeserializer(outerKey).WithValueDeserializer(outerValue).WithMaxPollRecords(1)
+            .WithAcknowledgementMode(ShareAcknowledgementMode.Explicit).BuildAsync(timeout.Token);
+        outer.Subscribe(outerTopic);
+        try
+        {
+            await using var outerPoll = outer.PollAsync(timeout.Token).GetAsyncEnumerator();
+            await Assert.That(await outerPoll.MoveNextAsync()).IsTrue();
+            await Assert.That(nestedPoll.Current.Value).IsEqualTo("nested-1");
+            await Assert.That(nestedValue.Topic).IsEqualTo(nestedTopic);
+            await Assert.That(outerValue.Topic).IsEqualTo(outerTopic);
+            outer.Acknowledge(outerPoll.Current);
+            nested.Acknowledge(nestedPoll.Current);
+            await outer.CommitAsync(timeout.Token);
+            await nested.CommitAsync(timeout.Token);
+        }
+        finally
+        {
+            if (unexpectedPendingMove is not null)
+            {
+                await timeout.CancelAsync();
+                try { await unexpectedPendingMove; }
+                catch (OperationCanceledException) when (timeout.IsCancellationRequested) { }
+            }
+        }
+    }
+
+    private sealed class CallbackDeserializer(Action callback) : IDeserializer<string>
+    {
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            callback();
+            return Serializers.String.Deserialize(data, context);
+        }
+    }
+
+    private sealed class TopicCapturingDeserializer(bool prepared) : IDeserializer<string>,
+        IAsyncDeserializerPreparer<string>, IAsyncDeserializerPreparationRequirement
+    {
+        public bool RequiresPreparation => prepared;
+        internal string? Topic { get; private set; }
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            Topic = context.Topic;
+            return Serializers.String.Deserialize(data, context);
+        }
+        public bool TryDeserialize(ReadOnlyMemory<byte> data, SerializationContext context, out string value)
+        {
+            value = Deserialize(data, context);
+            return true;
+        }
+        public ValueTask PrepareAsync(ReadOnlyMemory<byte> data, SerializationContext context, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("The test deserializer is warm.");
+    }
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRecordPoolingTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRecordPoolingTests.cs
@@ -53,7 +53,10 @@ public sealed class ShareConsumerRecordPoolingTests
                 var pending = consumer.ParsePartitionRecordsWithPreparation(topic, partition, 3, [], ref state, false, null);
                 await Assert.That(pending).IsNull();
             }
-            finally { state.DisposeCurrentBatch(); }
+            finally
+            {
+                state.DisposeCurrentBatch();
+            }
         }
         else
         {
@@ -499,7 +502,11 @@ public sealed class ShareConsumerRecordPoolingTests
 
     [Test]
     [NotInParallel]
-    public async Task ParsePartitionRecords_ReentrantConsumerPreservesOuterRecordHeaders()
+    [Arguments(false, false)]
+    [Arguments(false, true)]
+    [Arguments(true, false)]
+    [Arguments(true, true)]
+    public async Task ParsePartitionRecords_ReentrantConsumerPreservesOuterRecordContext(bool outerPrepared, bool nestedPrepared)
     {
         var nestedBuffer = new ArrayBufferWriter<byte>();
         using var nestedBatch = new RecordBatch
@@ -552,11 +559,12 @@ public sealed class ShareConsumerRecordPoolingTests
         var method = typeof(KafkaShareConsumer<string, string>).GetMethod(
             "ParsePartitionRecords",
             BindingFlags.Instance | BindingFlags.NonPublic)!;
-        var topicInfo = new TopicInfo { Name = "topic", Partitions = [] };
+        var outerTopic = new TopicInfo { Name = "outer-topic", Partitions = [] };
+        var nestedTopic = new TopicInfo { Name = "nested-topic", Partitions = [] };
         var nestedPartition = CreatePartition(nestedBuffer.WrittenMemory);
         var outerValueDeserializer = new HeaderValueCapturingStringDeserializer();
         var outerKeyDeserializer = new CallbackStringDeserializer(() =>
-            _ = method.Invoke(nestedConsumer, [topicInfo, nestedPartition, 1]));
+            Parse(nestedConsumer, nestedTopic, nestedPartition, nestedPrepared));
         await using var outerConsumer = new KafkaShareConsumer<string, string>(
             options,
             outerKeyDeserializer,
@@ -564,15 +572,32 @@ public sealed class ShareConsumerRecordPoolingTests
             pool,
             metadataManager);
 
-        _ = method.Invoke(outerConsumer,
-        [
-            topicInfo,
-            CreatePartition(outerBuffer.WrittenMemory),
-            1
-        ]);
+        Parse(outerConsumer, outerTopic, CreatePartition(outerBuffer.WrittenMemory), outerPrepared);
 
         await Assert.That(nestedValueDeserializer.HeaderValue).IsEqualTo("nested");
         await Assert.That(outerValueDeserializer.HeaderValue).IsEqualTo("outer");
+        await Assert.That(nestedValueDeserializer.Topic).IsEqualTo("nested-topic");
+        await Assert.That(outerValueDeserializer.Topic).IsEqualTo("outer-topic");
+
+        void Parse(KafkaShareConsumer<string, string> consumer, TopicInfo topic,
+            ShareFetchResponsePartition partition, bool prepared)
+        {
+            if (!prepared)
+            {
+                _ = method.Invoke(consumer, [topic, partition, 1]);
+                return;
+            }
+            var state = new KafkaShareConsumer<string, string>.DeserializerPreparationParserState();
+            try
+            {
+                if (consumer.ParsePartitionRecordsWithPreparation(topic, partition, 1, [], ref state, false, null) is not null)
+                    throw new InvalidOperationException("The test deserializers must complete synchronously.");
+            }
+            finally
+            {
+                state.DisposeCurrentBatch();
+            }
+        }
     }
 
     [Test]
@@ -840,9 +865,11 @@ public sealed class ShareConsumerRecordPoolingTests
         public bool ConsumesRecordHeaders => true;
 
         internal string? HeaderValue { get; private set; }
+        internal string? Topic { get; private set; }
 
         public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
         {
+            Topic = context.Topic;
             HeaderValue = context.Headers?[0].GetValueAsString();
             return System.Text.Encoding.UTF8.GetString(data.Span);
         }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerContextBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerContextBenchmarks.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Measures full batches with serializers that consume topic, component and raw-key context.</summary>
+[MemoryDiagnoser]
+public class ShareConsumerContextBenchmarks
+{
+    private ShareConsumerParsingBenchmarks _parsing = null!;
+
+    [Params(64, 1024)]
+    public int RecordCount { get; set; }
+
+    [Params(0, 2)]
+    public int HeaderCount { get; set; }
+
+    [GlobalSetup]
+    public ValueTask Setup()
+    {
+        _parsing = new ShareConsumerParsingBenchmarks
+        {
+            RecordCount = RecordCount, HeaderCount = HeaderCount, ContextDependentDeserialization = true
+        };
+        return _parsing.Setup();
+    }
+
+    [Benchmark]
+    public long ParseSynchronousBatch() => _parsing.ParseSynchronousBatch();
+
+    [Benchmark]
+    public long ParseWarmPreparedBatch() => _parsing.ParseWarmPreparedBatch();
+
+    [GlobalCleanup]
+    public ValueTask Cleanup() => _parsing.Cleanup();
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerParsingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerParsingBenchmarks.cs
@@ -39,6 +39,9 @@ public class ShareConsumerParsingBenchmarks
     [Params(0, 2)]
     public int HeaderCount { get; set; }
 
+    // The separate context fixture exercises serializers that consume topic/key metadata.
+    public bool ContextDependentDeserialization { get; set; }
+
     [GlobalSetup]
     public async ValueTask Setup()
     {
@@ -95,8 +98,9 @@ public class ShareConsumerParsingBenchmarks
             BootstrapServers = ["localhost:9092"],
             GroupId = "share-parsing-benchmark"
         };
-        _synchronousConsumer = new KafkaShareConsumer<int, int>(options, Serializers.Int32, Serializers.Int32);
-        var prepared = new WarmInt32Deserializer();
+        IDeserializer<int> synchronous = ContextDependentDeserialization ? new ContextInt32Deserializer() : Serializers.Int32;
+        _synchronousConsumer = new KafkaShareConsumer<int, int>(options, synchronous, synchronous);
+        IDeserializer<int> prepared = ContextDependentDeserialization ? new ContextInt32Deserializer() : new WarmInt32Deserializer();
         _preparedConsumer = new KafkaShareConsumer<int, int>(options, prepared, prepared);
         _coldConsumer = new KafkaShareConsumer<int, int>(options, Serializers.Int32, _coldDeserializer);
         _parse = typeof(KafkaShareConsumer<int, int>)
@@ -362,6 +366,30 @@ public class ShareConsumerParsingBenchmarks
                     || record.Headers[1].Key != "nullable" || !record.Headers[1].IsValueNull))
                 throw new InvalidOperationException("The parser changed header data or nullability.");
         }
+    }
+
+    private sealed class ContextInt32Deserializer : IDeserializer<int>, IAsyncDeserializerPreparer<int>
+    {
+        public int Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            var value = Serializers.Int32.Deserialize(data, context);
+            // Models topic-aware decoding and key/value correlation without external I/O.
+            if (context.Topic != "share-benchmark" || context.IsNull || context.Headers is not null
+                || (context.Component == SerializationComponent.Key
+                    ? !context.KeyData.IsEmpty
+                    : context.KeyData.Length != 4 || Serializers.Int32.Deserialize(context.KeyData, default) + 1 != value))
+                throw new InvalidOperationException("Deserializer context does not match its record.");
+            return value;
+        }
+
+        public bool TryDeserialize(ReadOnlyMemory<byte> data, SerializationContext context, out int value)
+        {
+            value = Deserialize(data, context);
+            return true;
+        }
+
+        public ValueTask PrepareAsync(ReadOnlyMemory<byte> data, SerializationContext context,
+            CancellationToken cancellationToken = default) => throw new InvalidOperationException("The context deserializer is warm.");
     }
 
     private sealed class WarmInt32Deserializer : IDeserializer<int>, IAsyncDeserializerPreparer<int>


### PR DESCRIPTION
A key deserializer can synchronously poll a buffered record from another share consumer with the same generic arguments. The shared `ThreadStatic` context then gives the outer value deserializer the nested topic. Both compatibility parser cores now use a local `SerializationContext` struct.

Regression tests use separate topics and cover all four synchronous/preparation parser combinations plus real Kafka nested polls. Context initialization is per record and adds no managed allocation or async state machine. Maintained `MemoryDiagnoser` fixtures exercise topic/component/raw-key consumers; setup serialization and delegate binding are amortized outside the measured batch parse/traverse/release operation.

Validation on `f1577bfaf4fcf07c1106100efd87ada0560f9a7d`, based on main `e63abf23a8f6ca16b1bb3cc838dca507b9f65b79`:

- Full Release build: zero warnings/errors; artifact and diff checks pass.
- 379 focused unit tests on each of net10.0 and net8.0 pass, including preparation cancellation/retry, partial parsing, null/raw-key handling, headers and retained ownership.
- Kafka 4.3.1: 34 net10.0 integration cases and both net8.0 nested-context cases pass. Before the fix, all four unit regression cases and both net10.0 broker cases fail with the outer value receiving the nested topic.
- The retained Short benchmark run completes all eight new context cases, four cold preparation cases and six ordinary/multi-batch cases. Eight shared cases have A1/B/A2 measurements; ten additional cases are candidate-only local validation.

Local medians below are diagnostic, not hosted or loaded acceptance. Control medians drift by up to 37%, so no portable speedup is inferred. Times are microseconds per full batch/poll; allocations are bytes per operation for A1/B/A2. All phases use the same fixture sources, ten warmups, five measurements, 500 ms iterations and retained outliers.

| Case | A1 us | B us | A2 us | A1/B/A2 B/op |
| --- | ---: | ---: | ---: | ---: |
| `Context: ParseWarmPreparedBatch [RecordCount=1024, HeaderCount=0]` | 90.320 | 71.862 | 88.938 | 90341/90328/90328 |
| `Context: ParseWarmPreparedBatch [RecordCount=1024, HeaderCount=2]` | 842.817 | 672.180 | 677.903 | 451136/451136/451136 |
| `Multi-batch: ParseBorrowedPoll [BatchCount=1024]` | 301.195 | 159.882 | 190.186 | 98520/98520/98520 |
| `Multi-batch: ParsePreparedBorrowedPoll [BatchCount=1024]` | 276.817 | 164.425 | 266.301 | 98521/98520/98520 |
| `Parsing: ParseSynchronousBatch [RecordCount=1024, HeaderCount=0]` | 132.381 | 67.688 | 110.381 | 90328/90328/90328 |
| `Parsing: ParseWarmPreparedBatch [RecordCount=1024, HeaderCount=0]` | 82.656 | 68.145 | 111.719 | 90328/90328/90328 |
| `Parsing: ParseSynchronousBatch [RecordCount=1024, HeaderCount=2]` | 810.922 | 656.884 | 881.768 | 451136/451136/451136 |
| `Parsing: ParseWarmPreparedBatch [RecordCount=1024, HeaderCount=2]` | 724.106 | 678.268 | 694.230 | 451136/451136/451136 |

Exact sources, generated worker code, executed benchmark/test DLLs, raw reports and SHA-256 inventories are retained outside removable worktrees at `C:/git/Dekaf-evidence/issue-3260-context-costs/`. `validation-manifest.json` indexes the evidence; `retained-worker-proof.json` verifies each logged worker launch against archived executable, product and fixture DLLs. Preliminary runs lost generated workers during BDN cleanup; those reports remain preserved with explicit corrections in #3260 and #3285. The table uses the new retained comparison.

The automatic hosted performance gate must pass before merge. Parent #3260 and #3103 remain open for historical borrowed parsing/preparation regressions and loaded acceptance; this fix does not approve a performance tradeoff. No paid stress run was dispatched for this serialization-context change.

Final head `6e23e5cfc5effd4aaab3f12e2281c6aeb8e62d2c` is rebased onto main `c7f99d7ac7a44ac7cb3977ca20d4d12488f125e4` after #3282. Its complete product and benchmark source trees match the measured candidate (`source-equivalence.json`). The updated test projects build with zero warnings/errors; 379 unit tests and both broker regression cases pass again on each framework. These newly executed workers and reports are retained separately in `rebased-tests-6e23e5cfc/`.

Closes #3285
