### PR TITLE
perf(share-consumer): reuse borrowed record reader

### DIFF
--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
@@ -369,7 +369,9 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
         where TRecordTelemetry : struct
     {
         var data = source.GetUnparsedRecordData();
-        while (state.ByteOffset < data.Length && storage.Count < capacity
+        var segmentOffset = state.ByteOffset;
+        var reader = new KafkaProtocolReader(data[segmentOffset..]);
+        while (!reader.End && storage.Count < capacity
             && state.ParsedCount < source.UnparsedLazyRecordCount)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -377,7 +379,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
             try
             {
                 var startOffset = state.ByteOffset;
-                raw = ReadBorrowedRecord(data, ref state.ByteOffset);
+                raw = ShareBatchRecordReader.Read(ref reader);
+                // Commit only complete records. A cold preparer resumes here with a new
+                // reader; a truncated tail is still classified from the record's start.
+                state.ByteOffset = segmentOffset + checked((int)reader.Consumed);
                 if (typeof(TRecordTelemetry) == typeof(RecordTelemetryEnabled))
                     state.CurrentRecordBytes = state.ByteOffset - startOffset;
             }
@@ -477,14 +482,6 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
         internal SerializationContext Context = context;
         internal TKey? Key = key;
         internal readonly int DeliveryCount = deliveryCount;
-    }
-
-    private static ShareBatchRecordData ReadBorrowedRecord(ReadOnlyMemory<byte> data, ref int byteOffset)
-    {
-        var reader = new KafkaProtocolReader(data[byteOffset..]);
-        var record = ShareBatchRecordReader.Read(ref reader);
-        byteOffset += checked((int)reader.Consumed);
-        return record;
     }
 
     private RecordHeaderRoutingLookup PrepareBatchHeaderRouting(

--- a/tests/Dekaf.Tests.Integration/ShareConsumerBatchTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerBatchTests.cs
@@ -1,4 +1,6 @@
 using Dekaf.Admin;
+using Dekaf.Producer;
+using Dekaf.Serialization;
 using Dekaf.ShareConsumer;
 
 namespace Dekaf.Tests.Integration;
@@ -8,6 +10,68 @@ namespace Dekaf.Tests.Integration;
 [NotInParallel("ShareConsumerKafka42")]
 public class ShareConsumerBatchTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task ColdPreparation_ResumesWithinProducerBatch(bool prepareKey)
+    {
+        const int messageCount = 16;
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        var group = $"share-batch-preparation-{Guid.NewGuid():N}";
+        await ConfigureEarliestAsync(group);
+        await using var producer = await Kafka.CreateProducer<int, int>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLinger(TimeSpan.FromMinutes(1)).WithBatchSize(1024 * 1024).BuildAsync();
+        for (var index = 0; index < messageCount; index++)
+            await producer.FireAsync(new ProducerMessage<int, int>
+            {
+                Topic = topic, Partition = 0, Key = index, Value = index,
+                Headers = Headers.Create("identity", new byte[] { (byte)index })
+            });
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await producer.FlushAsync(timeout.Token);
+
+        var preparer = new MidBatchPreparer();
+        await using var consumer = await Kafka.CreateShareConsumer<int, int>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId(group)
+            .WithKeyDeserializer(prepareKey ? preparer : Serializers.Int32)
+            .WithValueDeserializer(prepareKey ? Serializers.Int32 : preparer)
+            .WithAcknowledgementMode(ShareAcknowledgementMode.Explicit)
+            .WithMaxPollRecords(messageCount).BuildAsync(timeout.Token);
+        consumer.Subscribe(topic);
+        var received = 0;
+        var largestBatch = 0;
+        await foreach (var batch in consumer.PollBatchesAsync(timeout.Token))
+        {
+            largestBatch = Math.Max(largestBatch, batch.Count);
+            foreach (var record in batch)
+            {
+                await Assert.That(record.Key).IsEqualTo(received);
+                await Assert.That(record.Value).IsEqualTo(received);
+                var identityHeaders = 0;
+                foreach (var header in record.Headers)
+                {
+                    // The producer may also propagate the test runner's trace context.
+                    if (!header.KeyUtf8.Span.SequenceEqual("identity"u8))
+                        continue;
+                    await Assert.That(header.Value.Length).IsEqualTo(1);
+                    await Assert.That(header.Value.Span[0]).IsEqualTo((byte)received);
+                    identityHeaders++;
+                }
+                await Assert.That(identityHeaders).IsEqualTo(1);
+                batch.Acknowledge(record);
+                received++;
+            }
+            await consumer.CommitAsync(timeout.Token);
+            if (received == messageCount)
+                break;
+        }
+        await Assert.That(received).IsEqualTo(messageCount);
+        await Assert.That(largestBatch).IsEqualTo(messageCount);
+        await Assert.That(preparer.Preparations).IsEqualTo(1);
+        await consumer.CloseAsync(timeout.Token);
+    }
+
     [Test]
     public async Task Unsubscribe_RedeliversUnparsedProducerBatchesBeforeLockExpiry()
     {
@@ -239,6 +303,28 @@ public class ShareConsumerBatchTests(KafkaTestContainer kafka) : KafkaIntegratio
         var expected = terminal ? producedValues.Where(value => value != firstValue) : producedValues;
         await Assert.That(values).IsEquivalentTo(expected);
         await second.CommitAsync(timeout.Token);
+    }
+
+    private sealed class MidBatchPreparer : IDeserializer<int>, IAsyncDeserializerPreparer<int>
+    {
+        internal int Preparations;
+
+        public int Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) =>
+            throw new InvalidOperationException("Use the preparation-aware path.");
+
+        public bool TryDeserialize(ReadOnlyMemory<byte> data, SerializationContext context, out int value)
+        {
+            value = Serializers.Int32.Deserialize(data, context);
+            return value != 3 || Preparations != 0;
+        }
+
+        public async ValueTask PrepareAsync(ReadOnlyMemory<byte> data, SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            cancellationToken.ThrowIfCancellationRequested();
+            Preparations++;
+        }
     }
 
     private async Task ConfigureEarliestAsync(string group)

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumeBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumeBatchTests.cs
@@ -295,6 +295,53 @@ public sealed class ShareConsumeBatchTests
     }
 
     [Test]
+    [Arguments(false, false)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(true, true)]
+    public async Task Parser_PreparationResumesAcrossAcquisitionGapsAndTruncatedTail(
+        bool prepareKey, bool truncateTail)
+    {
+        var cold = new ColdDeserializer();
+        var synchronous = new CountingDeserializer();
+        await using var consumer = CreateConsumer(ShareAcknowledgementMode.Explicit,
+            prepareKey ? cold : synchronous, prepareKey ? synchronous : cold);
+        using var encoded = CreateSource(5);
+        var raw = encoded.GetUnparsedRecordData();
+        if (truncateTail)
+            raw = raw[..^3];
+        ShareFetchAcquiredRecords[] acquired =
+        [
+            new() { FirstOffset = 101, LastOffset = 101, DeliveryCount = 2 },
+            new() { FirstOffset = 103, LastOffset = 103, DeliveryCount = 3 }
+        ];
+
+        using var batch = await consumer.ParseRecordBatchAsync(
+            new TopicPartition("batch", 0), WrapRawRecords(raw, 5), acquired, 5, default);
+
+        await Assert.That(batch.Count).IsEqualTo(2);
+        await Assert.That(cold.Preparations).IsEqualTo(2);
+        await Assert.That(synchronous.Calls).IsEqualTo(2);
+        var index = 0;
+        foreach (var record in batch)
+        {
+            var expectedKey = 1 + index * 2;
+            await Assert.That(record.Offset).IsEqualTo(100 + expectedKey);
+            await Assert.That(record.Key).IsEqualTo(expectedKey);
+            await Assert.That(record.Value).IsEqualTo(expectedKey + 1);
+            await Assert.That(record.DeliveryCount).IsEqualTo(index + 2);
+            await Assert.That(record.Headers.Count).IsEqualTo(1);
+            var headers = record.Headers.GetEnumerator();
+            await Assert.That(headers.MoveNext()).IsTrue();
+            await Assert.That(headers.Current.KeyUtf8.Span.SequenceEqual("kind"u8)).IsTrue();
+            await Assert.That(headers.Current.Value.Span.SequenceEqual("test"u8)).IsTrue();
+            batch.Acknowledge(record);
+            index++;
+        }
+        await Assert.That(index).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task Tracker_CloseReleasesOnlyDeliveredImplicitRecords()
     {
         await using var consumer = CreateConsumer(ShareAcknowledgementMode.Implicit);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerBorrowedParsingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerBorrowedParsingBenchmarks.cs
@@ -30,6 +30,11 @@ public class ShareConsumerBorrowedParsingBenchmarks
     [Benchmark]
     public ValueTask<long> ParseBorrowedColdPreparedBatch() => _parsing.ParseBorrowedColdPreparedBatch();
 
+    // A key miss resumes before value deserialization; a value miss retains the key.
+    // Both paths must resume the record reader at the next complete record.
+    [Benchmark]
+    public ValueTask<long> ParseBorrowedColdKeyPreparedBatch() => _parsing.ParseBorrowedColdKeyPreparedBatch();
+
     [GlobalCleanup]
     public ValueTask Cleanup() => _parsing.Cleanup();
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerParsingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerParsingBenchmarks.cs
@@ -24,7 +24,9 @@ public class ShareConsumerParsingBenchmarks
     private KafkaShareConsumer<int, int> _synchronousConsumer = null!;
     private KafkaShareConsumer<int, int> _preparedConsumer = null!;
     private KafkaShareConsumer<int, int> _coldConsumer = null!;
+    private KafkaShareConsumer<int, int> _coldKeyConsumer = null!;
     private readonly ColdInt32Deserializer _coldDeserializer = new();
+    private readonly ColdInt32Deserializer _coldKeyDeserializer = new();
     private Func<TopicInfo, ShareFetchResponsePartition, int, List<ShareConsumeResult<int, int>>> _parse = null!;
     private readonly TopicInfo _topic = new() { Name = "share-benchmark", Partitions = [] };
     private ShareFetchResponsePartition _partition = null!;
@@ -99,6 +101,7 @@ public class ShareConsumerParsingBenchmarks
         var prepared = new WarmInt32Deserializer();
         _preparedConsumer = new KafkaShareConsumer<int, int>(options, prepared, prepared);
         _coldConsumer = new KafkaShareConsumer<int, int>(options, Serializers.Int32, _coldDeserializer);
+        _coldKeyConsumer = new KafkaShareConsumer<int, int>(options, _coldKeyDeserializer, Serializers.Int32);
         _parse = typeof(KafkaShareConsumer<int, int>)
             .GetMethod("ParsePartitionRecords", BindingFlags.Instance | BindingFlags.NonPublic)!
             .CreateDelegate<Func<TopicInfo, ShareFetchResponsePartition, int, List<ShareConsumeResult<int, int>>>>(
@@ -135,6 +138,8 @@ public class ShareConsumerParsingBenchmarks
         await ValidateBorrowedBatch(_preparedConsumer);
         _coldDeserializer.Reset();
         await ValidateBorrowedBatch(_coldConsumer);
+        _coldKeyDeserializer.Reset();
+        await ValidateBorrowedBatch(_coldKeyConsumer);
         await ValidateColdPreparedBatch();
     }
 
@@ -144,6 +149,7 @@ public class ShareConsumerParsingBenchmarks
         await _synchronousConsumer.DisposeAsync();
         await _preparedConsumer.DisposeAsync();
         await _coldConsumer.DisposeAsync();
+        await _coldKeyConsumer.DisposeAsync();
     }
 
     [Benchmark]
@@ -190,6 +196,12 @@ public class ShareConsumerParsingBenchmarks
     {
         _coldDeserializer.Reset();
         return ParseBorrowedBatch(_coldConsumer);
+    }
+
+    public ValueTask<long> ParseBorrowedColdKeyPreparedBatch()
+    {
+        _coldKeyDeserializer.Reset();
+        return ParseBorrowedBatch(_coldKeyConsumer);
     }
 
     [Benchmark]


### PR DESCRIPTION
Borrowed share parsing currently constructs a `KafkaProtocolReader` for every record. Reuse one reader for each uninterrupted parsing segment, removing repeated initialization and slicing from the per-record path. The saved byte offset advances only after a complete record, so key/value preparation resumes at the next record and truncated-tail classification still starts at the incomplete record.

Refs #3260. This addresses one parsing cost; the broader parsing/preparation and loaded acceptance requirements in #3260, #3103 and #3032 remain open.

Reader initialization is now amortized per batch and preparation continuation. The change adds no per-message allocation. The existing synchronous/warm borrowed fixture still measures 128 B per batch at both 64 and 1,024 records. Cold preparation includes the fixture's asynchronous preparation and waiting costs per batch.

Validation:

- Release builds passed without warnings or errors.
- All 446 share-consumer unit tests passed on each of net8.0 and net10.0, including new acquisition-gap/truncated-tail cases with cold key and value preparation.
- The 11 existing Kafka batch cases passed on net10.0. Both new mid-batch preparation cases passed on each runtime against Kafka 4.3.1, checking all 16 records, borrowed headers, acknowledgements and close.
- The maintained borrowed parsing fixture now has 16 steady-state MemoryDiagnoser cases, adding cold-key preparation to synchronous, warm and cold-value coverage. It builds and runs against both baseline `e63abf23a8f6ca16b1bb3cc838dca507b9f65b79` and this candidate. Code-simplifier review and `git diff --check` completed.

Local timing results are diagnostic and mixed. In the unrestricted ShortRun comparison, 1,024 records with two headers and cold-value preparation measured 69.611 us on the final baseline versus 103.275 us on the candidate. That result is retained and is not accepted as a tradeoff.

A targeted follow-up uses identical fixture source, CPU affinity mask 4, five warmups and ten measured iterations to investigate scheduling sensitivity on the i7-12700K. Times below are mean +/- standard deviation, in us per batch:

| Case (1,024 records) | Headers | Baseline | Candidate |
| --- | ---: | ---: | ---: |
| Synchronous | 2 | 71.00 +/- 1.07 | 61.90 +/- 0.67 |
| Warm prepared | 2 | 69.37 +/- 0.58 | 61.66 +/- 0.85 |
| Cold value | 2 | 129.52 +/- 2.14 | 91.94 +/- 38.06 |
| Cold key | 0 | 97.45 +/- 28.45 | 96.19 +/- 32.25 |
| Cold key | 2 | 96.59 +/- 30.99 | 91.43 +/- 36.47 |

Synchronous/warm parsing improves in that experiment; cold measurements remain highly variable. The affinity experiment does not establish the cause of the earlier slowdown or replace hosted performance acceptance. The automatic performance gate must pass before merging; no protected-metric tradeoff is approved here. These microbenchmarks cover partition parsing only and do not establish loaded acceptance.

Original and final fixture sources, product source archives, actual generated benchmark workers, both-runtime test workers, reports and copy-verified SHA-256 inventories are retained outside worktrees at `C:/git/Dekaf-evidence/issue-3260-borrowed-reader/`. No generated evidence is committed. Hosted job summaries and artifacts will provide the reviewable gate evidence.

Hosted performance gate: https://github.com/thomhurst/Dekaf/actions/runs/34658260333 (in progress).
