### PR TITLE
perf(consumer): bound binary collision promotion

### DIFF
--- a/.github/scripts/performance_gate.py
+++ b/.github/scripts/performance_gate.py
@@ -42,7 +42,8 @@ COMMENT = re.compile(r'//[^\n]*|/\*.*?\*/', re.S)
 SENTINELS = ('AccumulatorAppendBenchmarks', 'ConsumerHotPathBenchmarks',
              'FetchResponseParsingBenchmarks', 'ProduceResponseParsingBenchmarks')
 KEY_DISPATCH_BENCHMARKS = ('PartitionMessageKeyBenchmarks', 'CustomKeyOrderedDispatchBenchmarks', 'BinaryKeyDispatchBenchmarks',
-                           'DistinctBinaryKeyDispatchBenchmarks', 'SharedSuffixBinaryKeyDispatchBenchmarks')
+                           'DistinctBinaryKeyDispatchBenchmarks', 'SharedSuffixBinaryKeyDispatchBenchmarks',
+                           'BinaryHashPromotionBenchmarks')
 COMPONENTS = {
     'src/Dekaf/Consumer/KeyOrderedPartitionDispatcher': KEY_DISPATCH_BENCHMARKS,
     'src/Dekaf/Consumer/PartitionMessageKey.cs': KEY_DISPATCH_BENCHMARKS,

--- a/.github/scripts/test_performance_gate.py
+++ b/.github/scripts/test_performance_gate.py
@@ -69,7 +69,8 @@ class SelectionTests(unittest.TestCase):
         path = 'src/Dekaf/Consumer/PartitionMessageKey.cs'
         selected = self.names(gate.select([path], root=REPO_ROOT))
         for name in ('PartitionMessageKeyBenchmarks', 'CustomKeyOrderedDispatchBenchmarks', 'BinaryKeyDispatchBenchmarks',
-                     'DistinctBinaryKeyDispatchBenchmarks', 'SharedSuffixBinaryKeyDispatchBenchmarks'):
+                     'DistinctBinaryKeyDispatchBenchmarks', 'SharedSuffixBinaryKeyDispatchBenchmarks',
+                     'BinaryHashPromotionBenchmarks'):
             self.assertIn(name, selected)
 
     def test_key_ordered_dispatcher_selects_message_key_fixture(self):
@@ -78,7 +79,8 @@ class SelectionTests(unittest.TestCase):
             with self.subTest(path=path):
                 selected = self.names(gate.select([path], root=REPO_ROOT))
                 for name in ('PartitionMessageKeyBenchmarks', 'CustomKeyOrderedDispatchBenchmarks', 'BinaryKeyDispatchBenchmarks',
-                             'DistinctBinaryKeyDispatchBenchmarks', 'SharedSuffixBinaryKeyDispatchBenchmarks'):
+                             'DistinctBinaryKeyDispatchBenchmarks', 'SharedSuffixBinaryKeyDispatchBenchmarks',
+                             'BinaryHashPromotionBenchmarks'):
                     self.assertIn(name, selected)
 
     def test_detailed_mutation_paths_select_direct_fixture(self):

--- a/src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.cs
+++ b/src/Dekaf/Consumer/KeyOrderedPartitionDispatcher.cs
@@ -182,6 +182,8 @@ internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
             }
 
             ReleaseLanes();
+            if (_hasBinaryKeyComparer)
+                Unsafe.As<BinaryPartitionMessageKeyComparer<TKey>>(StandardLanes.Comparer).ReleaseCollisionState();
             if (_failure is not null)
             {
                 // Failed removal or rebuilding can displace lanes. Their retained
@@ -249,13 +251,24 @@ internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
             : PartitionMessageKey<TKey>.From(record.Key, record.IsKeyNull);
         var binaryKeyComparer = _hasBinaryKeyComparer
             ? Unsafe.As<BinaryPartitionMessageKeyComparer<TKey>>(StandardLanes.Comparer) : null;
-        if (binaryKeyComparer is not null && key.HasValue)
-            key = key.WithBinaryHashCode(binaryKeyComparer.GetHashCode(key));
+        KeyLane? lane = null;
+        var sampledHash = false;
+        if (binaryKeyComparer is not null)
+        {
+            // An existing sampled lane already determines the key's membership.
+            // Only unmatched keys need the full hash after collision promotion.
+            if (binaryKeyComparer.TryGetSampledKey(key, out var sampledKey))
+                StandardLanes.TryGetValue(sampledKey, out lane);
+            if (lane is null && key.HasValue)
+                key = key.WithBinaryHashCode(binaryKeyComparer.ComputeHashCode(key, out sampledHash));
+        }
 #if NETSTANDARD2_0
-        if (!TryGetLane(key, out var lane))
+        if (lane is null && !TryGetLane(key, out lane))
         {
             lane = RentLane();
             lane.Key = key;
+            lane.SampledHash = sampledHash;
+            if (sampledHash) binaryKeyComparer!.AddSampledLane();
             lane.StorageOrNext = record.RetainStorage();
             try
             {
@@ -271,15 +284,20 @@ internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
 #else
         // The coordinator owns membership. Publish the lane before retaining its
         // storage, so shutdown owns cleanup even if initialization fails.
-        ref var entry = ref GetLaneEntry(key);
-        var lane = entry;
         if (lane is null)
         {
-            lane = RentLane();
-            entry = lane;
-            lane.Key = key;
-            lane.StorageOrNext = record.RetainStorage();
-            Volatile.Write(ref _laneCount, StorageCount);
+            ref var entry = ref GetLaneEntry(key);
+            lane = entry;
+            if (lane is null)
+            {
+                lane = RentLane();
+                entry = lane;
+                lane.Key = key;
+                lane.SampledHash = sampledHash;
+                if (sampledHash) binaryKeyComparer!.AddSampledLane();
+                lane.StorageOrNext = record.RetainStorage();
+                Volatile.Write(ref _laneCount, StorageCount);
+            }
         }
 #endif
 
@@ -294,48 +312,64 @@ internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
             _readyLanes.Enqueue(lane);
         }
         if (binaryKeyComparer is { NeedsFullHashing: true })
-            StrengthenBinaryHashing(binaryKeyComparer);
+            StrengthenBinaryHashing(binaryKeyComparer, lane);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void StrengthenBinaryHashing(BinaryPartitionMessageKeyComparer<TKey> comparer)
+    private void StrengthenBinaryHashing(BinaryPartitionMessageKeyComparer<TKey> comparer, KeyLane triggeringLane)
     {
-        // Rebuild at most once per dispatcher after repeated expensive collisions.
-        // Reuse dictionary capacity and rent temporary references; ordinary probes
-        // neither allocate another table nor scan the active lanes.
+        // Strengthen at most the eight compared keys and the triggering lane.
+        // Unrelated lanes stay in the same table under their cached sample hashes.
         var dictionary = StandardLanes;
-        var count = dictionary.Count;
-        var lanes = ArrayPool<KeyLane>.Shared.Rent(count);
+        var keys = comparer.TakeCollisionKeys(out var count);
+        comparer.EnableFullHashing();
         try
         {
-            dictionary.Values.CopyTo(lanes, 0);
-            try
+            for (var index = 0; index < count; index++)
             {
-                dictionary.Clear();
-                comparer.EnableFullHashing();
-                for (var index = 0; index < count; index++)
-                {
-                    var lane = lanes[index];
-                    lane.Key = lane.Key.WithBinaryHashCode(comparer.ComputeHashCode(lane.Key));
-                    dictionary.Add(lane.Key, lane);
-                }
+                if (dictionary.TryGetValue(keys[index], out var lane) && lane.SampledHash)
+                    StrengthenLane(lane, comparer);
             }
-            catch (Exception error)
-            {
-                // Mutable binary keys can become equal during the rebuild. Shutdown
-                // must retain every key owner until all in-flight handlers complete,
-                // including lanes no longer reachable from the partially rebuilt table.
-                for (var index = 0; index < count; index++)
-                    ReturnLane(lanes[index]);
-                if (error is ArgumentException)
-                    throw new InvalidOperationException(
-                        "A partition key changed its hash code or equality while being processed.", error);
-                throw;
-            }
+            if (triggeringLane.SampledHash) StrengthenLane(triggeringLane, comparer);
         }
         finally
         {
-            ArrayPool<KeyLane>.Shared.Return(lanes, clearArray: true);
+            Array.Clear(keys, 0, count);
+        }
+    }
+
+    private void StrengthenLane(KeyLane lane, BinaryPartitionMessageKeyComparer<TKey> comparer)
+    {
+        var dictionary = StandardLanes;
+        // Preserve ownership before removing a key; hashing or reinsertion can fail
+        // for invalidated backing memory or a mutated key. Failure cleanup joins workers.
+        var key = lane.Key.WithBinaryHashCode(comparer.ComputeHashCode(lane.Key));
+#if NETSTANDARD2_0
+        if (!dictionary.TryGetValue(lane.Key, out var found) || !ReferenceEquals(found, lane) || !dictionary.Remove(lane.Key))
+            throw new InvalidOperationException("A partition key changed its hash code or equality while being processed.");
+#else
+        if (!dictionary.Remove(lane.Key, out var removed) || !ReferenceEquals(removed, lane))
+        {
+            // Mutation can displace another active lane. Retain its storage until
+            // shutdown has observed every worker, just as completion removal does.
+            if (removed is not null) ReturnLane(removed);
+            throw new InvalidOperationException("A partition key changed its hash code or equality while being processed.");
+        }
+#endif
+        lane.Key = key;
+        lane.SampledHash = false;
+        comparer.RemoveSampledLane();
+        try
+        {
+            dictionary.Add(key, lane);
+        }
+        catch (Exception error)
+        {
+            ReturnLane(lane);
+            if (error is ArgumentException)
+                throw new InvalidOperationException(
+                    "A partition key changed its hash code or equality while being processed.", error);
+            throw;
         }
     }
 
@@ -468,6 +502,8 @@ internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
                 throw new InvalidOperationException("A partition key changed its hash code or equality while being processed.");
             }
 #endif
+            if (lane.SampledHash)
+                Unsafe.As<BinaryPartitionMessageKeyComparer<TKey>>(StandardLanes.Comparer).RemoveSampledLane();
             lane.ReleaseKey();
             lane.Scheduled = false;
             lane.Tail = -1;
@@ -565,12 +601,14 @@ internal sealed partial class KeyOrderedPartitionDispatcher<TKey, TValue>
         internal int Head = -1;
         internal int Tail = -1;
         internal bool Scheduled;
+        internal bool SampledHash;
 
         internal void ReleaseKey()
         {
             Unsafe.As<PendingFetchData>(StorageOrNext)?.ReleaseAfterProcessing();
             StorageOrNext = null;
             Key = default;
+            SampledHash = false;
         }
     }
 

--- a/src/Dekaf/Consumer/PartitionMessageKey.cs
+++ b/src/Dekaf/Consumer/PartitionMessageKey.cs
@@ -1,5 +1,6 @@
 using System.IO.Hashing;
 using System.Runtime.CompilerServices;
+using Dekaf.Producer;
 
 namespace Dekaf.Consumer;
 
@@ -113,9 +114,12 @@ internal static class PartitionMessageKeyComparer<TKey>
 // backing storage, so cleanup can reuse the hash without scanning the bytes again.
 internal sealed class BinaryPartitionMessageKeyComparer<TKey> : IEqualityComparer<PartitionMessageKey<TKey>>
 {
-    private int _unequalLargeKeys;
-    private bool _fullHashing;
-    internal bool NeedsFullHashing { get; private set; }
+    private const int CollisionThreshold = 8;
+    // Keep comparers at one field. Rent state when the first sampled lane appears;
+    // allocate its bounded key slots only if an expensive collision occurs.
+    private CollisionState? _state;
+    internal bool NeedsFullHashing => _state is { SampledLanes: < 0, Count: CollisionThreshold };
+    internal bool UsesSampledHashing => _state is null || _state.SampledLanes < 0;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Equals(PartitionMessageKey<TKey> x, PartitionMessageKey<TKey> y)
@@ -128,45 +132,123 @@ internal sealed class BinaryPartitionMessageKeyComparer<TKey> : IEqualityCompare
         var right = GetBytes(y.Value!);
         if (left.SequenceEqual(right))
             return true;
-        return ObserveCollision(left.Length, right.Length);
+        return ObserveCollision(x, left.Length, right.Length);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private bool ObserveCollision(int leftLength, int rightLength)
+    private bool ObserveCollision(PartitionMessageKey<TKey> key, int leftLength, int rightLength)
     {
         // Count expensive collisions within one dictionary probe, not across the
         // lifetime of a healthy dispatcher. Only its single coordinator uses this comparer.
-        if (!_fullHashing && leftLength > 64 && leftLength == rightLength && ++_unequalLargeKeys >= 8)
-            NeedsFullHashing = true;
+        if (UsesSampledHashing && leftLength > 64 && leftLength == rightLength)
+        {
+            var state = _state ??= CollisionStatePool.Instance.Rent();
+            if (state.Count < CollisionThreshold)
+            {
+                var keys = state.Keys ??= new PartitionMessageKey<TKey>[CollisionThreshold];
+                keys[state.Count++] = key;
+            }
+        }
         return false;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int GetHashCode(PartitionMessageKey<TKey> obj)
     {
-        _unequalLargeKeys = 0;
+        if (_state is { Count: > 0 } state)
+        {
+            Array.Clear(state.Keys!, 0, state.Count);
+            state.Count = 0;
+        }
         if (obj.HasBinaryHashCode)
             return obj.BinaryHashCode;
         return ComputeHashCode(obj);
     }
 
-    internal int ComputeHashCode(PartitionMessageKey<TKey> obj)
-        => obj.HasValue ? HashBytes(GetBytes(obj.Value!)) : 0;
+    internal int ComputeHashCode(PartitionMessageKey<TKey> obj) => ComputeHashCode(obj, out _);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal int ComputeHashCode(PartitionMessageKey<TKey> obj, out bool sampled)
+    {
+        sampled = false;
+        if (!obj.HasValue) return 0;
+        var bytes = GetBytes(obj.Value!);
+        sampled = bytes.Length > 64 && UsesSampledHashing;
+        return sampled ? HashSample(bytes) : unchecked((int)XxHash3.HashToUInt64(bytes));
+    }
+
+    internal void AddSampledLane()
+    {
+        var state = _state ??= CollisionStatePool.Instance.Rent();
+        state.SampledLanes--;
+    }
 
     internal void EnableFullHashing()
     {
-        _fullHashing = true;
-        NeedsFullHashing = false;
+        var state = _state ??= CollisionStatePool.Instance.Rent();
+        if (state.SampledLanes < 0) state.SampledLanes = ~state.SampledLanes;
     }
 
-    private int HashBytes(ReadOnlySpan<byte> bytes)
+    internal PartitionMessageKey<TKey>[] TakeCollisionKeys(out int count)
     {
-        if (bytes.Length <= 64 || _fullHashing)
-            return unchecked((int)XxHash3.HashToUInt64(bytes));
+        var state = _state!;
+        count = state.Count;
+        // Migration performs dictionary probes. They must not reset these keys
+        // before the dispatcher has visited the captured collision group.
+        state.Count = 0;
+        return state.Keys!;
+    }
 
-        // Bound dispatch hashing for large binary keys. Equality still compares
-        // every byte. Repeated expensive collisions switch this dispatcher's table
-        // to full hashes once, without charging every large-key workload for a full scan.
+    internal void ReleaseCollisionState()
+    {
+        if (_state is not { } state) return;
+        _state = null;
+        CollisionStatePool.Instance.Return(state);
+    }
+
+    internal void RemoveSampledLane()
+    {
+        if (_state is not { } state) return;
+        if (state.SampledLanes < -1) state.SampledLanes++;
+        else if (state.SampledLanes > 0) state.SampledLanes--;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryGetSampledKey(PartitionMessageKey<TKey> key, out PartitionMessageKey<TKey> sampledKey)
+    {
+        sampledKey = default;
+        if (_state is not { SampledLanes: > 0 } || !key.HasValue) return false;
+        var bytes = GetBytes(key.Value!);
+        if (bytes.Length <= 64) return false;
+        sampledKey = key.WithBinaryHashCode(HashSample(bytes));
+        return true;
+    }
+
+    private sealed class CollisionState
+    {
+        internal PartitionMessageKey<TKey>[]? Keys;
+        internal int Count;
+        // Before promotion, encode the count as its complement; afterward count
+        // remaining sampled lanes directly. The sign also identifies hashing mode.
+        internal int SampledLanes = -1;
+    }
+
+    private sealed class CollisionStatePool() : ObjectPool<CollisionState>(maxPoolSize: 64, threadLocalFastPath: false)
+    {
+        internal static readonly CollisionStatePool Instance = new();
+        protected override CollisionState Create() => new();
+        protected override void Reset(CollisionState state)
+        {
+            if (state.Keys is { } keys) Array.Clear(keys, 0, keys.Length);
+            state.Count = 0;
+            state.SampledLanes = -1;
+        }
+    }
+
+    private static int HashSample(ReadOnlySpan<byte> bytes)
+    {
+        // Equality still compares every byte. Only the triggering collision group
+        // changes hashes; other active lanes retain their cached sample until drained.
         Span<byte> sample = stackalloc byte[64];
         bytes[..16].CopyTo(sample);
         bytes.Slice(bytes.Length / 3, 16).CopyTo(sample[16..]);

--- a/tests/Dekaf.Tests.Integration/PartitionedKeyComparerIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/PartitionedKeyComparerIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using Dekaf.Consumer;
 using Dekaf.Serialization;
 using Dekaf.Producer;
@@ -139,6 +140,94 @@ public sealed class PartitionedKeyComparerIntegrationTests(KafkaTestContainer ka
         await Assert.That(emptyKey!.Value.IsKeyNull).IsFalse();
         await Assert.That(nullKey.Value.Key.IsEmpty).IsTrue();
         await Assert.That(emptyKey.Value.Key.IsEmpty).IsTrue();
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public Task PublicHandlers_CollisionTransitionKeepsExistingKeyOrdered(bool rawMemory)
+        => rawMemory ? VerifyCollisionTransitionAsync(Serializers.RawBytes)
+            : VerifyCollisionTransitionAsync(Serializers.ByteArray);
+
+    private async Task VerifyCollisionTransitionAsync<TKey>(IDeserializer<TKey> deserializer)
+    {
+        const int recordCount = 14;
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        await using var producer = await Kafka.CreateProducer<byte[], string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).BuildAsync();
+        for (var offset = 0; offset < recordCount; offset++)
+        {
+            var identity = offset switch { 11 => 0, 12 => 2, _ => offset };
+            var key = new byte[1024];
+            BinaryPrimitives.WriteInt32LittleEndian(key.AsSpan(identity is < 2 or 13 ? 1020 : 992), identity + 1);
+            await producer.ProduceAsync(topic, key, "value");
+        }
+        var allKeysRead = NewSignal();
+        await using var consumer = await Kafka.CreateConsumer<TKey, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithKeyDeserializer(new CountingKeyDeserializer<TKey>(deserializer, recordCount, allKeysRead))
+            .WithValueDeserializer(Serializers.String)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithQueuedMinMessages(1).BuildAsync();
+        consumer.Assign([new TopicPartition(topic, 0)]);
+        var releaseFirst = NewSignal();
+        var releaseSecond = NewSignal();
+        var equalStarted = NewSignal();
+        var sentinelStarted = NewSignal();
+        var complete = NewSignal();
+        var processed = 0;
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var options = new PartitionedProcessingOptions
+        {
+            Ordering = PartitionedProcessingOrder.Key,
+            MaxConcurrentHandlersPerPartition = 2,
+            MaxHandlerBatchSize = 1,
+            CommitPolicy = PartitionCommitPolicy.UserManaged
+        };
+        var running = consumer.RunPartitionedAsync(async (_, record, cancellationToken) =>
+        {
+            switch (record.Offset)
+            {
+                case 0: await releaseFirst.Task.WaitAsync(cancellationToken); break;
+                case 1: await releaseSecond.Task.WaitAsync(cancellationToken); break;
+                case 11: equalStarted.TrySetResult(); break;
+                case 13: sentinelStarted.TrySetResult(); break;
+            }
+            if (Interlocked.Increment(ref processed) == recordCount) complete.TrySetResult();
+        }, options, timeout.Token).AsTask();
+        try
+        {
+            // Both workers hold their lanes while all nine colliding keys enter
+            // the coordinator. Release only the second worker to drain other keys.
+            await allKeysRead.Task.WaitAsync(timeout.Token);
+            releaseSecond.TrySetResult();
+            await sentinelStarted.Task.WaitAsync(timeout.Token);
+            await Assert.That(equalStarted.Task.IsCompleted).IsFalse();
+            releaseFirst.TrySetResult();
+            await complete.Task.WaitAsync(timeout.Token);
+            await Assert.That(equalStarted.Task.IsCompleted).IsTrue();
+        }
+        finally
+        {
+            releaseFirst.TrySetResult();
+            releaseSecond.TrySetResult();
+            await timeout.CancelAsync();
+            try { await running; }
+            catch (OperationCanceledException) when (timeout.IsCancellationRequested) { }
+        }
+    }
+
+    private sealed class CountingKeyDeserializer<TKey>(IDeserializer<TKey> inner, int expected, TaskCompletionSource complete)
+        : IDeserializer<TKey>
+    {
+        private int _count;
+        public TKey Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            var key = inner.Deserialize(data, context);
+            if (Interlocked.Increment(ref _count) == expected) complete.TrySetResult();
+            return key;
+        }
     }
 
     private async Task VerifyOrderingAsync<TKey>(

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedDispatchHashTransitionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedDispatchHashTransitionTests.cs
@@ -1,0 +1,230 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+using Dekaf.Consumer;
+using Dekaf.Protocol;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public class PartitionedDispatchHashTransitionTests
+{
+    [Test]
+    [Arguments(16, 1024)]
+    [Arguments(128, 65536)]
+    public async Task CollisionThreshold_DoesNotReadUnrelatedActiveKeys(int unrelatedCount, int keySize)
+    {
+        var count = unrelatedCount + 9;
+        var input = new PartitionLane<ReadOnlyMemory<byte>, int>(new TopicPartition("dispatch", 0), count,
+            static (_, _) => default, static _ => { }, static (_, _) => { });
+        var memory = new CountingMemory[count];
+        for (var offset = 0; offset < count; offset++)
+        {
+            var key = memory[offset] = new CountingMemory(keySize);
+            BinaryPrimitives.WriteInt32LittleEndian(
+                key.Bytes.AsSpan(offset < unrelatedCount ? keySize - sizeof(int) : keySize - 32),
+                offset + 1);
+            var record = new ConsumeResult<ReadOnlyMemory<byte>, int>("dispatch", 0, offset,
+                key.Memory, false, key.Bytes.AsMemory(0, sizeof(int)), false, null, 0, TimestampType.CreateTime, null,
+                Serializers.RawBytes, Serializers.Int32);
+            await Assert.That(input.TryEnqueueForTest(record)).IsTrue();
+        }
+        await input.StopAsync(PartitionStopPolicy.Drain, Timeout.InfiniteTimeSpan);
+        // The first colliding key reaches the dispatcher after unrelated lanes exist.
+        // Observe the transition itself without counting their initial lookup work.
+        memory[unrelatedCount].FirstRead = () =>
+        {
+            for (var index = 0; index < unrelatedCount; index++) memory[index].Reads = 0;
+        };
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var processed = 0;
+        var dispatcher = new KeyOrderedPartitionDispatcher<ReadOnlyMemory<byte>, int>(
+            new PartitionProcessorContext<ReadOnlyMemory<byte>, int>(input), 1, 2, count,
+            (records, _) =>
+            {
+                processed++;
+                return records[0].Offset < 2 ? new ValueTask(release.Task) : default;
+            }, automaticCompletion: true);
+        var running = dispatcher.RunAsync(CancellationToken.None).AsTask();
+        try
+        {
+            await Assert.That(dispatcher.LaneCount).IsEqualTo(count);
+            for (var index = 0; index < unrelatedCount; index++)
+                await Assert.That(memory[index].Reads).IsEqualTo(0);
+        }
+        finally
+        {
+            release.TrySetResult();
+            await running.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        await Assert.That(processed).IsEqualTo(count);
+        await Assert.That(dispatcher.LaneCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [Arguments(-1)]
+    [Arguments(0)]
+    [Arguments(32)]
+    [Arguments(64)]
+    public async Task Promotion_StopsCompatibilityProbesWhileOnlyShortLanesRemain(int heldKeySize)
+    {
+        const int recordCount = 12;
+        var input = new PartitionLane<ReadOnlyMemory<byte>, int>(new TopicPartition("dispatch", 0), recordCount,
+            static (_, _) => default, static _ => { }, static (_, _) => { });
+        var probe = new CountingMemory(1024);
+        probe.Bytes[0] = 0x80;
+        for (var offset = 0; offset < recordCount; offset++)
+        {
+            ReadOnlyMemory<byte> key;
+            if (offset == 0)
+                key = new byte[Math.Max(0, heldKeySize)];
+            else if (offset == 1)
+                key = new byte[] { 1 };
+            else if (offset == recordCount - 1)
+                key = probe.Memory;
+            else
+            {
+                var bytes = new byte[1024];
+                bytes[^32] = (byte)offset;
+                key = bytes;
+            }
+            var record = new ConsumeResult<ReadOnlyMemory<byte>, int>("dispatch", 0, offset,
+                key, offset == 0 && heldKeySize < 0, new byte[sizeof(int)], false, null, 0,
+                TimestampType.CreateTime, null, Serializers.RawBytes, Serializers.Int32);
+            await Assert.That(input.TryEnqueueForTest(record)).IsTrue();
+        }
+        await input.StopAsync(PartitionStopPolicy.Drain, Timeout.InfiniteTimeSpan);
+        probe.Reads = 0;
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var dispatcher = new KeyOrderedPartitionDispatcher<ReadOnlyMemory<byte>, int>(
+            new PartitionProcessorContext<ReadOnlyMemory<byte>, int>(input), 1, 2, recordCount,
+            (records, _) => records[0].Offset < 2 ? new ValueTask(release.Task) : default,
+            automaticCompletion: true);
+        var running = dispatcher.RunAsync(CancellationToken.None).AsTask();
+        try
+        {
+            await Assert.That(dispatcher.LaneCount).IsEqualTo(recordCount);
+            // All nine sampled lanes have migrated. The held short/null keys must
+            // not make a new large key read its memory for a compatibility probe.
+            await Assert.That(probe.Reads).IsEqualTo(1);
+        }
+        finally
+        {
+            release.TrySetResult();
+            await running.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+    }
+
+    [Test]
+    [Arguments(0, 7)]
+    [Arguments(0, 8)]
+    [Arguments(0, 9)]
+    [Arguments(1, 7)]
+    [Arguments(1, 8)]
+    [Arguments(1, 9)]
+    [Arguments(2, 7)]
+    [Arguments(2, 8)]
+    [Arguments(2, 9)]
+    [Arguments(3, 7)]
+    [Arguments(3, 8)]
+    [Arguments(3, 9)]
+    public Task CollisionThreshold_RepeatedKeysKeepOneLane(int representation, int collisionCount) => representation switch
+    {
+        0 => AssertRepeatedKeys(Serializers.ByteArray, collisionCount),
+        1 => AssertRepeatedKeys(Serializers.RawBytes, collisionCount),
+        2 => AssertRepeatedKeys(new MutableMemoryDeserializer(), collisionCount),
+        _ => AssertRepeatedKeys(new SegmentDeserializer(), collisionCount)
+    };
+
+    private static async Task AssertRepeatedKeys<TKey>(IDeserializer<TKey> deserializer, int collisionCount)
+    {
+        // Include two unrelated sampled lanes, colliding lanes, an empty key and
+        // a wire-null key, then repeat all identities using separate backing arrays.
+        var keyCount = collisionCount + 4;
+        var recordCount = keyCount * 2;
+        var input = new PartitionLane<TKey, int>(new TopicPartition("dispatch", 0), recordCount,
+            static (_, _) => default, static _ => { }, static (_, _) => { });
+        for (var offset = 0; offset < recordCount; offset++)
+        {
+            var identity = offset % keyCount;
+            var isNull = identity == keyCount - 1;
+            var key = identity >= keyCount - 2 ? [] : new byte[1024];
+            if (key.Length != 0)
+                BinaryPrimitives.WriteInt32LittleEndian(key.AsSpan(identity < 2 ? 1020 : 992), identity + 1);
+            var value = new byte[sizeof(int)];
+            var record = new ConsumeResult<TKey, int>("dispatch", 0, offset,
+                key, isNull, value, false, null, 0, TimestampType.CreateTime, null,
+                deserializer, Serializers.Int32);
+            await Assert.That(input.TryEnqueueForTest(record)).IsTrue();
+        }
+        await input.StopAsync(PartitionStopPolicy.Drain, Timeout.InfiniteTimeSpan);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var active = new int[keyCount];
+        var completed = new int[keyCount];
+        var dispatcher = new KeyOrderedPartitionDispatcher<TKey, int>(
+            new PartitionProcessorContext<TKey, int>(input), 1, 2, recordCount,
+            async (records, _) =>
+            {
+                var record = records[0];
+                var identity = checked((int)(record.Offset % keyCount));
+                if (Interlocked.Increment(ref active[identity]) != 1 || completed[identity] != record.Offset / keyCount)
+                    throw new InvalidOperationException("Equal keys overlapped or arrived out of order.");
+                try
+                {
+                    if (record.Offset < 2) await release.Task;
+                    completed[identity]++;
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref active[identity]);
+                }
+            }, automaticCompletion: true);
+        var running = dispatcher.RunAsync(CancellationToken.None).AsTask();
+        try
+        {
+            // Both workers are held, so every remaining input has been assigned
+            // without any lane draining. Equal keys must not create extra lanes.
+            await Assert.That(dispatcher.LaneCount).IsEqualTo(keyCount);
+        }
+        finally
+        {
+            release.TrySetResult();
+            await running.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        foreach (var count in completed) await Assert.That(count).IsEqualTo(2);
+        await Assert.That(dispatcher.LaneCount).IsEqualTo(0);
+        await Assert.That(input.GetCommitOffset()?.Offset).IsEqualTo(recordCount);
+    }
+
+    private sealed class MutableMemoryDeserializer : IDeserializer<Memory<byte>>
+    {
+        public Memory<byte> Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+            => MemoryMarshal.AsMemory(data);
+    }
+
+    private sealed class SegmentDeserializer : IDeserializer<ArraySegment<byte>>
+    {
+        public ArraySegment<byte> Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+            => MemoryMarshal.TryGetArray(data, out var segment) ? segment : throw new InvalidOperationException();
+    }
+
+    private sealed class CountingMemory(int length) : MemoryManager<byte>
+    {
+        internal byte[] Bytes { get; } = new byte[length];
+        internal int Reads { get; set; }
+        internal Action? FirstRead { get; set; }
+
+        public override Span<byte> GetSpan()
+        {
+            var callback = FirstRead;
+            FirstRead = null;
+            callback?.Invoke();
+            Reads++;
+            return Bytes;
+        }
+
+        public override MemoryHandle Pin(int elementIndex = 0) => throw new NotSupportedException();
+        public override void Unpin() { }
+        protected override void Dispose(bool disposing) { }
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BinaryHashPromotionBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BinaryHashPromotionBenchmarks.cs
@@ -1,0 +1,49 @@
+using System.Buffers.Binary;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Consumer;
+using Dekaf.Protocol;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures a collision threshold reached after unrelated large keys have filled
+/// active lanes. Reports the complete dispatch cost, including one hash transition.
+/// </summary>
+[MemoryDiagnoser]
+public class BinaryHashPromotionBenchmarks
+{
+    private ConsumeResult<ReadOnlyMemory<byte>, string>[] _records = null!;
+
+    [Params(16, 1024)]
+    public int ExistingLanes { get; set; }
+
+    [Params(1024, 65536)]
+    public int KeySize { get; set; }
+
+    [Params(false, true)]
+    public bool RepeatExistingKeys { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var distinctCount = ExistingLanes + 9;
+        _records = new ConsumeResult<ReadOnlyMemory<byte>, string>[distinctCount + (RepeatExistingKeys ? ExistingLanes : 0)];
+        for (var offset = 0; offset < _records.Length; offset++)
+        {
+            var identity = offset < distinctCount ? offset : offset - distinctCount;
+            var key = new byte[KeySize];
+            // Existing keys differ in the sampled suffix; the final nine differ
+            // outside the sample and reach the expensive-collision threshold.
+            BinaryPrimitives.WriteInt32LittleEndian(
+                key.AsSpan(identity < ExistingLanes ? KeySize - sizeof(int) : KeySize - 32), identity + 1);
+            _records[offset] = new ConsumeResult<ReadOnlyMemory<byte>, string>("topic", 0, offset,
+                key, false, default, false, null, 0, TimestampType.CreateTime, null,
+                Serializers.RawBytes, Serializers.String);
+        }
+    }
+
+    [Benchmark]
+    public Task Dispatch() => BinaryKeyDispatchBenchmarks.DispatchAsync(_records,
+        maxConcurrentHandlers: 2, holdAllWorkers: true, expectedKeyCount: ExistingLanes + 9);
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BinaryKeyDispatchBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BinaryKeyDispatchBenchmarks.cs
@@ -48,7 +48,7 @@ public class BinaryKeyDispatchBenchmarks
     }
 
     internal static async Task DispatchAsync<TKey>(ConsumeResult<TKey, string>[] records, int maxConcurrentHandlers,
-        bool holdAllWorkers = false)
+        bool holdAllWorkers = false, int expectedKeyCount = 0)
     {
         var lane = new PartitionLane<TKey, string>(new TopicPartition("topic", 0), records.Length,
             static (_, _) => ValueTask.CompletedTask, static _ => { }, static (_, error) => throw error);
@@ -82,8 +82,8 @@ public class BinaryKeyDispatchBenchmarks
         var bufferedKeys = dispatcher.LaneCount;
         releaseFirst.SetResult();
         await running.ConfigureAwait(false);
-        if (holdAllWorkers && bufferedKeys != records.Length)
-            throw new InvalidOperationException("The shared-suffix fixture did not fill the keyed buffer.");
+        if (holdAllWorkers && bufferedKeys != (expectedKeyCount == 0 ? records.Length : expectedKeyCount))
+            throw new InvalidOperationException("The binary fixture did not fill the expected keyed buffer.");
         if (lane.GetCommitOffset()?.Offset != records.Length)
             throw new InvalidOperationException("The dispatcher did not complete every input record.");
     }
@@ -148,15 +148,19 @@ public class SharedSuffixBinaryKeyDispatchBenchmarks
     [Params(1024, 65536)]
     public int KeySize { get; set; }
 
+    [Params(false, true)]
+    public bool HoldSmallKeys { get; set; }
+
     [GlobalSetup]
     public void Setup()
     {
         _records = new ConsumeResult<ReadOnlyMemory<byte>, string>[RecordCount];
         for (var index = 0; index < _records.Length; index++)
         {
-            var key = new byte[KeySize];
+            var small = HoldSmallKeys && index < 2;
+            var key = new byte[small ? 8 : KeySize];
             key.AsSpan().Fill(0x61);
-            System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(key.AsSpan(KeySize - 32), index);
+            System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(key.AsSpan(small ? key.Length - sizeof(int) : key.Length - 32), index);
             _records[index] = new ConsumeResult<ReadOnlyMemory<byte>, string>("topic", 0, index,
                 key, false, default, false, null, 0, TimestampType.CreateTime, null,
                 Serializers.RawBytes, Serializers.String);


### PR DESCRIPTION
After eight expensive binary-key collisions, key-ordered dispatch previously rehashed every active lane synchronously. Promotion now visits at most the eight compared lanes and the triggering lane. Unrelated active lanes keep their cached sample hashes until completion, so a late collision does not reread every large key in the pending window.

During the transition, incoming keys probe sampled membership before computing a full hash. Only lanes whose keys actually used sampled hashes contribute to the transition count: null, empty and keys up to 64 bytes cannot keep compatibility lookup active. Equal-key ordering, null provenance, custom comparers and retained ownership remain intact. Failure cleanup observes all workers before releasing displaced key storage.

Per-record work stays synchronous: hashing, state checks and a compatibility lookup while old sampled lanes remain. A sampled lane adds/removes one counter update over its lifetime. There is no new recurring per-record allocation, async operation, lock or thread hop. State is rented once when the first large sampled lane appears; the eight collision-key slots allocate only if an expensive collision occurs. Pool misses and initial pool creation are amortized per dispatcher/type, including healthy large-key dispatchers. Comparer, dispatcher and lane object sizes remain unchanged across scalar, string and all four binary representations on the inspected .NET 10.0.12 binaries.

Validation for `b4c14001fe1eac518a7fd80e91bbdd93383480d7`, based on main `77252dab460681ffa3460c99286d823ee6a2b5d4`:

- 238 focused ordering, ownership, null, comparer, backpressure and completion unit cases pass on each of net8.0 and net10.0. Four new short/null-lane cases fail before the review fix because a later large key reads its memory twice instead of once. Existing transition tests prove that unrelated active keys are not reread and cover all binary representations around the collision threshold.
- All 24 Kafka 4.3.1 key-comparer integration cases pass, including equal-key ordering across promotion for byte arrays and raw memory.
- The performance selector permanently includes `BinaryHashPromotionBenchmarks` for dispatcher/message-key changes. All 45 selector tests pass, including the assertions that failed before registration.
- All 30 local Short benchmark cases complete using identical maintained fixture source against both revisions. The new promotion fixture has eight cases; the shared-suffix fixture now has four, including held small-key lanes. Control allocations match at report precision except one 1 B/op difference; promotion fixtures differ by -208 to +39 bytes per complete dispatcher. Timing is inconclusive locally: the 8-byte raw-memory/two-handler control is +23.83%, and another worker's build/tests overlapped the later baseline cases. No timing win or tradeoff acceptance is inferred. These runs used base cdb604a09; all eight changed source blobs are identical after the final rebase.
- Full Release build, including netstandard2.0: zero warnings/errors. Final rebased tests and the repository artifact-policy check pass.

Original implementation evidence remains at `D:/Dekaf-evidence/issue-3048-hash-transition/`. Review-fix evidence is at `D:/Dekaf-evidence/pr-3288-review-fixes/`: raw reports/logs, failing and passing tests, source patches, object-layout results and actual generated benchmark workers. Each executed-file ZIP entry was SHA-256 verified against its original. Local measurements are diagnostic only; earlier 2c683b0 results are not attributed to the review-fix head.

Hosted performance gate [34661521050](https://github.com/thomhurst/Dekaf/actions/runs/34661521050) and the exact-SHA [loaded comparison 34662075236](https://github.com/thomhurst/Dekaf/actions/runs/34662075236) pass for measured revision `b4c14001fe1eac518a7fd80e91bbdd93383480d7`. The latter uses `consumer-keyed-1b` / `large-colliding`, five minutes per sample and 32 fixed workers, with startup/runtime coverage VALIDATED. Consumer replay does not measure processing p50/p99 latency.

Final rebase `6e7da3d7d4b327c014b8345dcc5a464cf337e7d7` contains fresh main `e6b212dc1d123c36cda980be5361bfc7d9960608`. The only difference from the measured revision is main's unrelated `BatchCheckpointTests.cs` fix. Complete `src/` and `tools/` trees, root build inputs and performance selector are byte-identical by Git object ID. All 29 checkpoint tests pass on each of net8.0 and net10.0 after rebase. Those 1,287 executed source/binary/report entries are SHA-256 verified under `final-rebase-tests/`; `final-rebase-equivalence.json` records the source comparison. The automatic rebased-head checks are pending. No passing paid experiment is repeated or represented as an execution of the new SHA.

The original hosted microbenchmark artifacts are retained locally under `gate-34661521050/` (652 inventoried files). Loaded artifacts under `stress-34662075236/` include all 314 executed binary entries, verified against the workflow's original SHA-256 manifest. The historical #3269 [PartitionedOffsetCompletionBenchmarks regression](https://github.com/thomhurst/Dekaf/actions/runs/34634532334/job/103380177780) remains unresolved; unchanged source and later measurements do not waive it. This PR does not close #3048 or approve a recorded tradeoff.

Follow-up to #3048.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved key-ordered processing for binary keys by using sampled hashing and promoting only collision-related lanes to full hashing.
  * Preserved correct ordering when distinct keys produce hash collisions.
  * Added performance coverage for collision handling and hash promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->