### PR TITLE
test(consumer): dispose checkpoint test storage exactly once

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/BatchCheckpointTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/BatchCheckpointTests.cs
@@ -89,11 +89,16 @@ public class BatchCheckpointTests
     [Arguments(true)]
     public async Task EndAndDisposal_InvalidateAccessButNotCapturedValue(bool raw)
     {
-        using var pending = CreatePending();
-        var batch = new CheckpointBatch(pending, raw);
-        batch.MoveNext();
-        await Assert.That(batch.Capture(out var checkpoint)).IsTrue();
-        pending.Dispose();
+        CheckpointBatch batch;
+        TopicPartitionOffset checkpoint;
+        // Dispose exactly once before checking the expired window: another test can
+        // rent the returned instance while these assertions await.
+        using (var pending = CreatePending())
+        {
+            batch = new CheckpointBatch(pending, raw);
+            batch.MoveNext();
+            await Assert.That(batch.Capture(out checkpoint)).IsTrue();
+        }
         await Assert.That(batch.Capture(out _)).IsFalse();
         await Assert.That(checkpoint.Offset).IsEqualTo(11);
     }


### PR DESCRIPTION
`EndAndDisposal_InvalidateAccessButNotCapturedValue` explicitly disposed its pooled `PendingFetchData`, awaited assertions, then disposed the same reference again when its `using var` scope ended. If another test rented that object meanwhile, the second disposal cleared the new owner's storage. The test now ends a single owning scope before checking the expired checkpoint. Both typed/raw cases retain every assertion and cleanup on failure.

Refs #3267. This fixes demonstrated test interference; it does **not** attribute or close that issue's original simultaneous .NET 8 coordination timeouts. No deadlines, concurrency settings, allocation assertions, or product code change.

Validation at `ebbfd71184eae9e74f5b9a221d7631f9ec55d672`, based on `f034989d7`:

- A temporary diagnostic hook rented the just-returned object before the original test completed, verified reference identity, then checked the new owner's state. Both typed/raw cases failed before the fix because the second disposal cleared `Topic`; both passed with the single owning scope, including advancing the new rental. The hook is not in the final patch.
- Normal full Release .NET 10 suite: 10,631 passed, zero failed/skipped.
- Normal full Release .NET 8 suite: 10,447 passed, one failed, zero skipped. All checkpoint cases passed. `FragmentedCompletion_UsesReservedStorageWithoutAllocating(4098, 2)` measured 7,624 B against its unchanged zero assertion. Its source and product path are unchanged; the allocating cause remains unestablished. No rerun was made to obtain green.
- Code-simplifier review, `git diff --check`, and repository artifact policy passed. This test-only scope adds no per-message or amortized product costs; no benchmark or stress dispatch was needed.

The interference was discovered during an expanded Avro diagnostic run, which failed a different checkpoint test in `PendingFetchData.HasCurrentRecord`. That run does not establish the cause of #3087. Original failure output, diagnostic patches and before/after binaries, final binaries/reports, and exact source archives are retained outside the worktree at `C:/git/Dekaf-evidence/issue-3267-checkpoint-ownership-20260912/`. No generated evidence is committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated checkpoint disposal coverage to ensure resources are disposed exactly once.
  * Preserved validation that captured values remain available while access is invalidated after disposal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->