### PR TITLE
fix(share-consumer): retain configured header routing names

### DIFF
--- a/src/Dekaf/Internal/Utf8StringInternCache.cs
+++ b/src/Dekaf/Internal/Utf8StringInternCache.cs
@@ -57,6 +57,17 @@ internal sealed class Utf8StringInternCache
             return entry.Value;
         }
 
+        return InternUncached(utf8Bytes, hash);
+    }
+
+    /// <summary>Decodes a lookup miss using the hash returned by <see cref="TryGetCached"/>.</summary>
+    internal string InternUncached(ReadOnlySpan<byte> utf8Bytes, ulong hash)
+    {
+        if (utf8Bytes.Length == 0)
+            return string.Empty;
+        if (utf8Bytes.Length > _maxCachedBytes)
+            return Decode(utf8Bytes);
+
         var value = Decode(utf8Bytes);
         if (Volatile.Read(ref _count) >= _maxCachedEntries)
             return value;
@@ -68,7 +79,7 @@ internal sealed class Utf8StringInternCache
             if (_cacheLastEntry)
                 Volatile.Write(ref _lastEntry, newEntry);
         }
-        else if (_cache.TryGetValue(hash, out entry) && entry.Matches(utf8Bytes))
+        else if (_cache.TryGetValue(hash, out var entry) && entry.Matches(utf8Bytes))
         {
             if (_cacheLastEntry)
                 Volatile.Write(ref _lastEntry, entry);
@@ -76,6 +87,28 @@ internal sealed class Utf8StringInternCache
         }
 
         return value;
+    }
+
+    /// <summary>Looks up an existing value without decoding or populating the cache.</summary>
+    internal bool TryGetCached(ReadOnlySpan<byte> utf8Bytes, out string value, out ulong hash)
+    {
+        hash = 0;
+        if (utf8Bytes.Length == 0)
+        {
+            value = string.Empty;
+            return true;
+        }
+        if (utf8Bytes.Length <= _maxCachedBytes)
+        {
+            hash = XxHash64.HashToUInt64(utf8Bytes);
+            if (_cache.TryGetValue(hash, out var entry) && entry.Matches(utf8Bytes))
+            {
+                value = entry.Value;
+                return true;
+            }
+        }
+        value = null!;
+        return false;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Serialization/HeaderProtocol.cs
+++ b/src/Dekaf/Serialization/HeaderProtocol.cs
@@ -10,7 +10,7 @@ namespace Dekaf.Serialization;
 internal static class HeaderProtocol
 {
     private const int MaxCachedKeys = 128;
-    private const int MaxCachedKeyBytes = 256;
+    internal const int MaxCachedKeyBytes = 256;
     private static readonly Utf8StringInternCache s_keyCache = new(MaxCachedKeys, MaxCachedKeyBytes);
 
     internal static string InternKey(ReadOnlyMemory<byte> bytes) => s_keyCache.Intern(bytes);

--- a/src/Dekaf/Serialization/HeaderProtocol.cs
+++ b/src/Dekaf/Serialization/HeaderProtocol.cs
@@ -13,8 +13,6 @@ internal static class HeaderProtocol
     internal const int MaxCachedKeyBytes = 256;
     private static readonly Utf8StringInternCache s_keyCache = new(MaxCachedKeys, MaxCachedKeyBytes);
 
-    internal static string InternKey(ReadOnlyMemory<byte> bytes) => s_keyCache.Intern(bytes);
-
     internal static bool TryGetCachedKey(ReadOnlyMemory<byte> bytes, out string name, out ulong hash) =>
         s_keyCache.TryGetCached(bytes.Span, out name, out hash);
 

--- a/src/Dekaf/Serialization/HeaderProtocol.cs
+++ b/src/Dekaf/Serialization/HeaderProtocol.cs
@@ -13,6 +13,14 @@ internal static class HeaderProtocol
     private const int MaxCachedKeyBytes = 256;
     private static readonly Utf8StringInternCache s_keyCache = new(MaxCachedKeys, MaxCachedKeyBytes);
 
+    internal static string InternKey(ReadOnlyMemory<byte> bytes) => s_keyCache.Intern(bytes);
+
+    internal static bool TryGetCachedKey(ReadOnlyMemory<byte> bytes, out string name, out ulong hash) =>
+        s_keyCache.TryGetCached(bytes.Span, out name, out hash);
+
+    internal static string InternUncachedKey(ReadOnlyMemory<byte> bytes, ulong hash) =>
+        s_keyCache.InternUncached(bytes.Span, hash);
+
     [SkipLocalsInit]
     internal static void Write(in Header header, ref KafkaProtocolWriter writer)
     {

--- a/src/Dekaf/Serialization/ISerializer.cs
+++ b/src/Dekaf/Serialization/ISerializer.cs
@@ -34,6 +34,7 @@ internal sealed class RecordHeaderRoutingPlan
     }
 
     internal int Count => _slots.Count;
+    internal Dictionary<string, int>.KeyCollection HeaderNames => _slots.Keys;
     internal bool KeyRequiresMaterializedHeaders { get; }
     internal bool ValueRequiresMaterializedHeaders { get; }
     internal bool NeedsMaterializedHeaders =>

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
@@ -485,8 +485,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
         internal readonly int DeliveryCount = deliveryCount;
     }
 
+    // Keep records without routing or headers out of the materialization stack frame.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private RecordHeaderRoutingLookup PrepareBatchHeaderRouting(
-        ShareBatchRecordData raw, ref Header[]? headers)
+        in ShareBatchRecordData raw, ref Header[]? headers)
     {
         if (_recordHeaderRoutingPlan is null)
             return default;
@@ -494,8 +496,16 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
             return new RecordHeaderRoutingLookup(_recordHeaderRoutingPlan, null, 0, 0, 0,
                 RecordHeaderRoutingPlan.FullyIndexedWithoutTail);
 
-        var tailCapacity = _recordHeaderRoutingPlan.Count > 2
-            ? _recordHeaderRoutingPlan.GetRoutingTailCapacity(raw.HeaderCount)
+        return MaterializeBatchHeaderRouting(in raw, ref headers);
+    }
+
+    private RecordHeaderRoutingLookup MaterializeBatchHeaderRouting(
+        in ShareBatchRecordData raw, ref Header[]? headers)
+    {
+        var plan = _recordHeaderRoutingPlan!;
+
+        var tailCapacity = plan.Count > 2
+            ? plan.GetRoutingTailCapacity(raw.HeaderCount)
             : 0;
         var requiredCapacity = checked(raw.HeaderCount + tailCapacity);
         if (headers is null || headers.Length < requiredCapacity)
@@ -507,14 +517,14 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
         }
 
         var reader = new KafkaProtocolReader(raw.HeaderBytes);
-        if (_recordHeaderRoutingPlan.Count == 0)
+        if (plan.Count == 0)
         {
             for (var index = 0; index < raw.HeaderCount; index++)
                 headers[index] = HeaderProtocol.Read(ref reader, raw.HeaderBytes.Length);
         }
         else
         {
-            var keys = _batchHeaderKeys ??= new ShareBatchHeaderKeys(_recordHeaderRoutingPlan);
+            var keys = _batchHeaderKeys ??= new ShareBatchHeaderKeys(plan);
             for (var index = 0; index < raw.HeaderCount; index++)
             {
                 var key = keys.Get(reader.ReadContiguousMemorySlice(reader.ReadVarInt()));
@@ -524,7 +534,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
             }
         }
         var record = new Record { Headers = headers, HeaderCount = raw.HeaderCount }
-            .IndexPooledHeaders(_recordHeaderRoutingPlan);
-        return record.CreateHeaderRoutingLookup(_recordHeaderRoutingPlan);
+            .IndexPooledHeaders(plan);
+        return record.CreateHeaderRoutingLookup(plan);
     }
 }

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Batches.cs
@@ -14,6 +14,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
     private byte _consumptionMode;
     private ShareBatchAcknowledgements<TKey, TValue>? _batchAcknowledgements;
     private ShareConsumeBatch<TKey, TValue>? _activeShareBatch;
+    private ShareBatchHeaderKeys? _batchHeaderKeys;
 
     private bool HasPendingAcknowledgements => _batchAcknowledgements?.HasPending ?? _ackTracker.HasPending;
 
@@ -506,8 +507,22 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
         }
 
         var reader = new KafkaProtocolReader(raw.HeaderBytes);
-        for (var index = 0; index < raw.HeaderCount; index++)
-            headers[index] = HeaderProtocol.Read(ref reader, raw.HeaderBytes.Length);
+        if (_recordHeaderRoutingPlan.Count == 0)
+        {
+            for (var index = 0; index < raw.HeaderCount; index++)
+                headers[index] = HeaderProtocol.Read(ref reader, raw.HeaderBytes.Length);
+        }
+        else
+        {
+            var keys = _batchHeaderKeys ??= new ShareBatchHeaderKeys(_recordHeaderRoutingPlan);
+            for (var index = 0; index < raw.HeaderCount; index++)
+            {
+                var key = keys.Get(reader.ReadContiguousMemorySlice(reader.ReadVarInt()));
+                var valueLength = reader.ReadVarInt();
+                var value = valueLength < 0 ? ReadOnlyMemory<byte>.Empty : reader.ReadContiguousMemorySlice(valueLength);
+                headers[index] = new Header(key, value, isNull: valueLength < 0);
+            }
+        }
         var record = new Record { Headers = headers, HeaderCount = raw.HeaderCount }
             .IndexPooledHeaders(_recordHeaderRoutingPlan);
         return record.CreateHeaderRoutingLookup(_recordHeaderRoutingPlan);

--- a/src/Dekaf/ShareConsumer/ShareBatchHeaderKeys.cs
+++ b/src/Dekaf/ShareConsumer/ShareBatchHeaderKeys.cs
@@ -7,7 +7,7 @@ namespace Dekaf.ShareConsumer;
 /// <summary>Retains configured routing names independently of the bounded global header cache.</summary>
 internal sealed class ShareBatchHeaderKeys
 {
-    private readonly Dictionary<ReadOnlyMemory<byte>, string> _names = new(ByteComparer.Instance);
+    private readonly Dictionary<HashedName, string> _names = new();
 
     internal ShareBatchHeaderKeys(RecordHeaderRoutingPlan plan)
     {
@@ -16,7 +16,7 @@ internal sealed class ShareBatchHeaderKeys
             var bytes = Encoding.UTF8.GetBytes(name);
             // An unpaired surrogate cannot match its replacement-encoded wire name.
             if (Encoding.UTF8.GetString(bytes) == name)
-                _names.TryAdd(bytes, name);
+                _names.TryAdd(new HashedName(bytes, XxHash64.HashToUInt64(bytes)), name);
         }
     }
 
@@ -24,13 +24,21 @@ internal sealed class ShareBatchHeaderKeys
     {
         if (HeaderProtocol.TryGetCachedKey(bytes, out var name, out var hash))
             return name;
-        return _names.TryGetValue(bytes, out name) ? name : HeaderProtocol.InternUncachedKey(bytes, hash);
+        // The global lookup skips hashing oversized names; all other misses already have a hash.
+        if (bytes.Length > HeaderProtocol.MaxCachedKeyBytes)
+            hash = XxHash64.HashToUInt64(bytes.Span);
+        return _names.TryGetValue(new HashedName(bytes, hash), out name)
+            ? name
+            : HeaderProtocol.InternUncachedKey(bytes, hash);
     }
 
-    private sealed class ByteComparer : IEqualityComparer<ReadOnlyMemory<byte>>
+    private readonly struct HashedName(ReadOnlyMemory<byte> bytes, ulong hash) : IEquatable<HashedName>
     {
-        internal static readonly ByteComparer Instance = new();
-        public bool Equals(ReadOnlyMemory<byte> x, ReadOnlyMemory<byte> y) => x.Span.SequenceEqual(y.Span);
-        public int GetHashCode(ReadOnlyMemory<byte> obj) => unchecked((int)XxHash64.HashToUInt64(obj.Span));
+        private readonly ReadOnlyMemory<byte> _bytes = bytes;
+        private readonly int _hashCode = unchecked((int)hash);
+
+        public bool Equals(HashedName other) => _bytes.Span.SequenceEqual(other._bytes.Span);
+        public override bool Equals(object? obj) => obj is HashedName other && Equals(other);
+        public override int GetHashCode() => _hashCode;
     }
 }

--- a/src/Dekaf/ShareConsumer/ShareBatchHeaderKeys.cs
+++ b/src/Dekaf/ShareConsumer/ShareBatchHeaderKeys.cs
@@ -8,6 +8,7 @@ namespace Dekaf.ShareConsumer;
 internal sealed class ShareBatchHeaderKeys
 {
     private readonly Dictionary<HashedName, string> _names = new();
+    private readonly HashSet<int>? _oversizedNameLengths;
 
     internal ShareBatchHeaderKeys(RecordHeaderRoutingPlan plan)
     {
@@ -16,7 +17,11 @@ internal sealed class ShareBatchHeaderKeys
             var bytes = Encoding.UTF8.GetBytes(name);
             // An unpaired surrogate cannot match its replacement-encoded wire name.
             if (Encoding.UTF8.GetString(bytes) == name)
+            {
                 _names.TryAdd(new HashedName(bytes, XxHash64.HashToUInt64(bytes)), name);
+                if (bytes.Length > HeaderProtocol.MaxCachedKeyBytes)
+                    (_oversizedNameLengths ??= new()).Add(bytes.Length);
+            }
         }
     }
 
@@ -26,7 +31,12 @@ internal sealed class ShareBatchHeaderKeys
             return name;
         // The global lookup skips hashing oversized names; all other misses already have a hash.
         if (bytes.Length > HeaderProtocol.MaxCachedKeyBytes)
+        {
+            // A different byte length cannot match any configured name. Decode without scanning for a hash.
+            if (_oversizedNameLengths is null || !_oversizedNameLengths.Contains(bytes.Length))
+                return HeaderProtocol.InternUncachedKey(bytes, hash);
             hash = XxHash64.HashToUInt64(bytes.Span);
+        }
         return _names.TryGetValue(new HashedName(bytes, hash), out name)
             ? name
             : HeaderProtocol.InternUncachedKey(bytes, hash);

--- a/src/Dekaf/ShareConsumer/ShareBatchHeaderKeys.cs
+++ b/src/Dekaf/ShareConsumer/ShareBatchHeaderKeys.cs
@@ -15,7 +15,7 @@ internal sealed class ShareBatchHeaderKeys
         {
             var bytes = Encoding.UTF8.GetBytes(name);
             // An unpaired surrogate cannot match its replacement-encoded wire name.
-            if (HeaderProtocol.InternKey(bytes) == name)
+            if (Encoding.UTF8.GetString(bytes) == name)
                 _names.TryAdd(bytes, name);
         }
     }

--- a/src/Dekaf/ShareConsumer/ShareBatchHeaderKeys.cs
+++ b/src/Dekaf/ShareConsumer/ShareBatchHeaderKeys.cs
@@ -1,0 +1,36 @@
+using System.IO.Hashing;
+using System.Text;
+using Dekaf.Serialization;
+
+namespace Dekaf.ShareConsumer;
+
+/// <summary>Retains configured routing names independently of the bounded global header cache.</summary>
+internal sealed class ShareBatchHeaderKeys
+{
+    private readonly Dictionary<ReadOnlyMemory<byte>, string> _names = new(ByteComparer.Instance);
+
+    internal ShareBatchHeaderKeys(RecordHeaderRoutingPlan plan)
+    {
+        foreach (var name in plan.HeaderNames)
+        {
+            var bytes = Encoding.UTF8.GetBytes(name);
+            // An unpaired surrogate cannot match its replacement-encoded wire name.
+            if (HeaderProtocol.InternKey(bytes) == name)
+                _names.TryAdd(bytes, name);
+        }
+    }
+
+    internal string Get(ReadOnlyMemory<byte> bytes)
+    {
+        if (HeaderProtocol.TryGetCachedKey(bytes, out var name, out var hash))
+            return name;
+        return _names.TryGetValue(bytes, out name) ? name : HeaderProtocol.InternUncachedKey(bytes, hash);
+    }
+
+    private sealed class ByteComparer : IEqualityComparer<ReadOnlyMemory<byte>>
+    {
+        internal static readonly ByteComparer Instance = new();
+        public bool Equals(ReadOnlyMemory<byte> x, ReadOnlyMemory<byte> y) => x.Span.SequenceEqual(y.Span);
+        public int GetHashCode(ReadOnlyMemory<byte> obj) => unchecked((int)XxHash64.HashToUInt64(obj.Span));
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ShareConsumerBatchTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerBatchTests.cs
@@ -11,6 +11,61 @@ namespace Dekaf.Tests.Integration;
 public class ShareConsumerBatchTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]
+    public async Task LongHeaderRouting_ResumesColdPreparationAndPreservesBorrowedHeaders()
+    {
+        const int messageCount = 16;
+        var name = new string('r', 512);
+        var nameBytes = System.Text.Encoding.UTF8.GetBytes(name);
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        var group = $"share-batch-routing-{Guid.NewGuid():N}";
+        await ConfigureEarliestAsync(group);
+        await using var producer = await Kafka.CreateProducer<int, int>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLinger(TimeSpan.FromMinutes(1)).WithBatchSize(1024 * 1024).BuildAsync();
+        for (var index = 0; index < messageCount; index++)
+            await producer.FireAsync(new ProducerMessage<int, int>
+            {
+                Topic = topic, Partition = 0, Key = index, Value = index,
+                Headers = Headers.Create(name, "selected"u8.ToArray())
+            });
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await producer.FlushAsync(timeout.Token);
+        var preparer = new MidBatchPreparer();
+        var router = new HeaderRoutingDeserializer<int>(name, new UnexpectedRouteDeserializer(),
+            new HeaderDeserializerRoute<int>("selected"u8.ToArray(), preparer));
+        await using var consumer = await Kafka.CreateShareConsumer<int, int>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId(group)
+            .WithValueDeserializer(router).WithAcknowledgementMode(ShareAcknowledgementMode.Explicit)
+            .BuildAsync(timeout.Token);
+        consumer.Subscribe(topic);
+        var received = 0;
+        await foreach (var batch in consumer.PollBatchesAsync(timeout.Token))
+        {
+            foreach (var record in batch)
+            {
+                await Assert.That(record.Value).IsEqualTo(received++);
+                var matched = 0;
+                foreach (var header in record.Headers)
+                {
+                    if (header.KeyUtf8.Span.SequenceEqual(nameBytes))
+                    {
+                        await Assert.That(header.Value.Span.SequenceEqual("selected"u8)).IsTrue();
+                        matched++;
+                    }
+                }
+                await Assert.That(matched).IsEqualTo(1);
+                batch.Acknowledge(record);
+            }
+            await consumer.CommitAsync(timeout.Token);
+            if (received == messageCount)
+                break;
+        }
+        await Assert.That(received).IsEqualTo(messageCount);
+        await Assert.That(preparer.Preparations).IsEqualTo(1);
+        await consumer.CloseAsync(timeout.Token);
+    }
+
+    [Test]
     [Arguments(false)]
     [Arguments(true)]
     public async Task ColdPreparation_ResumesWithinProducerBatch(bool prepareKey)
@@ -303,6 +358,12 @@ public class ShareConsumerBatchTests(KafkaTestContainer kafka) : KafkaIntegratio
         var expected = terminal ? producedValues.Where(value => value != firstValue) : producedValues;
         await Assert.That(values).IsEquivalentTo(expected);
         await second.CommitAsync(timeout.Token);
+    }
+
+    private sealed class UnexpectedRouteDeserializer : IDeserializer<int>
+    {
+        public int Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) =>
+            throw new InvalidOperationException("The configured header route was not selected.");
     }
 
     private sealed class MidBatchPreparer : IDeserializer<int>, IAsyncDeserializerPreparer<int>

--- a/tests/Dekaf.Tests.Integration/ShareConsumerBatchTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerBatchTests.cs
@@ -16,6 +16,8 @@ public class ShareConsumerBatchTests(KafkaTestContainer kafka) : KafkaIntegratio
         const int messageCount = 16;
         var name = new string('r', 512);
         var nameBytes = System.Text.Encoding.UTF8.GetBytes(name);
+        var unrelatedName = new string('u', 4096);
+        var unrelatedNameBytes = System.Text.Encoding.UTF8.GetBytes(unrelatedName);
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
         var group = $"share-batch-routing-{Guid.NewGuid():N}";
         await ConfigureEarliestAsync(group);
@@ -26,7 +28,11 @@ public class ShareConsumerBatchTests(KafkaTestContainer kafka) : KafkaIntegratio
             await producer.FireAsync(new ProducerMessage<int, int>
             {
                 Topic = topic, Partition = 0, Key = index, Value = index,
-                Headers = Headers.Create(name, "selected"u8.ToArray())
+                Headers = new Headers
+                {
+                    { unrelatedName, "other"u8.ToArray() },
+                    { name, "selected"u8.ToArray() }
+                }
             });
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         await producer.FlushAsync(timeout.Token);
@@ -45,6 +51,7 @@ public class ShareConsumerBatchTests(KafkaTestContainer kafka) : KafkaIntegratio
             {
                 await Assert.That(record.Value).IsEqualTo(received++);
                 var matched = 0;
+                var unrelated = 0;
                 foreach (var header in record.Headers)
                 {
                     if (header.KeyUtf8.Span.SequenceEqual(nameBytes))
@@ -52,8 +59,14 @@ public class ShareConsumerBatchTests(KafkaTestContainer kafka) : KafkaIntegratio
                         await Assert.That(header.Value.Span.SequenceEqual("selected"u8)).IsTrue();
                         matched++;
                     }
+                    if (header.KeyUtf8.Span.SequenceEqual(unrelatedNameBytes))
+                    {
+                        await Assert.That(header.Value.Span.SequenceEqual("other"u8)).IsTrue();
+                        unrelated++;
+                    }
                 }
                 await Assert.That(matched).IsEqualTo(1);
+                await Assert.That(unrelated).IsEqualTo(1);
                 batch.Acknowledge(record);
             }
             await consumer.CommitAsync(timeout.Token);

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedCompletionStorageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedCompletionStorageTests.cs
@@ -552,6 +552,7 @@ public class PartitionedCompletionStorageTests
     }
 
     [Test]
+    [NotInParallel]
     [Arguments(34, 2L)]
     [Arguments(258, 2L)]
     [Arguments(4098, 2L)]
@@ -565,10 +566,23 @@ public class PartitionedCompletionStorageTests
             records[index] = Deliver(lane, batch, 10 + index * offsetStep);
         lane.EndBatch(batch, count);
 
-        var before = GC.GetAllocatedBytesForCurrentThread();
-        for (var index = 1; index < count; index += 2)
-            lane.MarkProcessed(records[index]);
-        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        // Background GC can charge unused allocation-context space to this thread's
+        // counter. Exclude collections from the synchronous measurement, while still
+        // counting every allocation made by the first fragmented completion.
+        if (!GC.TryStartNoGCRegion(16 * 1024 * 1024))
+            throw new InvalidOperationException("Unable to isolate the allocation measurement from GC.");
+        long allocated;
+        try
+        {
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (var index = 1; index < count; index += 2)
+                lane.MarkProcessed(records[index]);
+            allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        }
+        finally
+        {
+            GC.EndNoGCRegion();
+        }
 
         await Assert.That(allocated).IsEqualTo(0);
         await Assert.That(lane.GetCommitOffset()).IsNull();

--- a/tests/Dekaf.Tests.Unit/Internal/Utf8StringInternCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/Utf8StringInternCacheTests.cs
@@ -5,6 +5,60 @@ namespace Dekaf.Tests.Unit.Internal;
 public sealed class Utf8StringInternCacheTests
 {
     [Test]
+    public async Task InternUncached_OversizedKeyRetainsDecodeOnlyBehavior()
+    {
+        var cache = new Utf8StringInternCache(maxCachedEntries: 1, maxCachedBytes: 4);
+        var hit = cache.TryGetCached("longer"u8, out _, out var hash);
+        var first = cache.InternUncached("longer"u8, hash);
+        var second = cache.InternUncached("longer"u8, hash);
+        var cached = cache.TryGetCached("longer"u8, out _, out _);
+
+        await Assert.That(hit).IsFalse();
+        await Assert.That(cached).IsFalse();
+        await Assert.That(first).IsEqualTo("longer");
+        await Assert.That(second).IsEqualTo(first);
+        await Assert.That(second).IsNotSameReferenceAs(first);
+    }
+
+    [Test]
+    public async Task InternUncached_UsesLookupHashAndPreservesCompetingAdmission()
+    {
+        var cache = new Utf8StringInternCache(maxCachedEntries: 3, maxCachedBytes: 64);
+        var miss = cache.TryGetCached("first"u8, out _, out var firstHash);
+        var first = cache.InternUncached("first"u8, firstHash);
+        var cached = cache.Intern("first"u8);
+        var secondMiss = cache.TryGetCached("second"u8, out _, out var secondHash);
+        var competing = cache.Intern("second"u8);
+        var second = cache.InternUncached("second"u8, secondHash);
+
+        await Assert.That(miss).IsFalse();
+        await Assert.That(secondMiss).IsFalse();
+        await Assert.That(cached).IsSameReferenceAs(first);
+        await Assert.That(second).IsSameReferenceAs(competing);
+    }
+
+    [Test]
+    public async Task TryGetCached_MissesDoNotDecodeOrConsumeCapacity()
+    {
+        var cache = new Utf8StringInternCache(maxCachedEntries: 1, maxCachedBytes: 6);
+        var missing = cache.TryGetCached("absent"u8, out _, out _);
+        var tooLong = cache.TryGetCached("oversize"u8, out _, out _);
+        var empty = cache.TryGetCached([], out var emptyValue, out _);
+        var first = cache.Intern("cached"u8);
+        var hit = cache.TryGetCached("cached"u8, out var cached, out _);
+        _ = cache.Intern("filled"u8);
+        var overflow = cache.TryGetCached("filled"u8, out _, out _);
+
+        await Assert.That(missing).IsFalse();
+        await Assert.That(tooLong).IsFalse();
+        await Assert.That(empty).IsTrue();
+        await Assert.That(emptyValue).IsEqualTo(string.Empty);
+        await Assert.That(hit).IsTrue();
+        await Assert.That(cached).IsSameReferenceAs(first);
+        await Assert.That(overflow).IsFalse();
+    }
+
+    [Test]
     public async Task Intern_EntryLimitExceeded_DecodesWithoutCaching()
     {
         var cache = new Utf8StringInternCache(maxCachedEntries: 1, maxCachedBytes: 64);

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareBatchHeaderRoutingTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareBatchHeaderRoutingTests.cs
@@ -53,6 +53,42 @@ public sealed class ShareBatchHeaderRoutingTests
     }
 
     [Test]
+    [Arguments(8, 257)]
+    [Arguments(512, 257)]
+    [Arguments(512, 512)]
+    [Arguments(512, 4096)]
+    public async Task OversizedUnrelatedNames_PreserveDecodedName(int configuredLength, int unrelatedLength)
+    {
+        var name = new string('r', configuredLength);
+        var router = new HeaderRoutingDeserializer<int>(name, Serializers.Int32,
+            new HeaderDeserializerRoute<int>("selected"u8.ToArray(), Serializers.Int32));
+        var keys = new ShareBatchHeaderKeys(RecordHeaderRoutingPlan.Create(Serializers.Int32, router)!);
+        var unrelated = new string('u', unrelatedLength);
+        var bytes = Encoding.UTF8.GetBytes($"before{unrelated}after");
+
+        await Assert.That(keys.Get(bytes.AsMemory(6, unrelatedLength))).IsEqualTo(unrelated);
+        await Assert.That(ReferenceEquals(keys.Get(Encoding.UTF8.GetBytes(name)), name)).IsTrue();
+    }
+
+    [Test]
+    public async Task OversizedConfiguredNames_UseUtf8LengthsAcrossNestedRoutes()
+    {
+        string[] names = [new('r', 257), new('路', 100), new('s', 512)];
+        IDeserializer<int> router = Serializers.Int32;
+        foreach (var name in names)
+            router = new HeaderRoutingDeserializer<int>(name, Serializers.Int32,
+                new HeaderDeserializerRoute<int>("selected"u8.ToArray(), router));
+        var keys = new ShareBatchHeaderKeys(RecordHeaderRoutingPlan.Create(Serializers.Int32, router)!);
+
+        foreach (var name in names)
+            await Assert.That(ReferenceEquals(keys.Get(Encoding.UTF8.GetBytes(name)), name)).IsTrue();
+
+        // This byte length falls between configured lengths but is not itself configured.
+        var unrelated = new string('u', 400);
+        await Assert.That(keys.Get(Encoding.UTF8.GetBytes(unrelated))).IsEqualTo(unrelated);
+    }
+
+    [Test]
     [NotInParallel]
     public async Task ConfiguredNames_DoNotPopulateTheSharedHeaderCache()
     {

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareBatchHeaderRoutingTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareBatchHeaderRoutingTests.cs
@@ -11,6 +11,31 @@ namespace Dekaf.Tests.Unit.ShareConsumer;
 public sealed class ShareBatchHeaderRoutingTests
 {
     [Test]
+    [NotInParallel]
+    public async Task ConfiguredNames_DoNotPopulateTheSharedHeaderCache()
+    {
+        var prefix = Guid.NewGuid().ToString("N");
+        var names = new byte[129][];
+        IDeserializer<int> router = Serializers.Int32;
+        for (var index = 0; index < names.Length; index++)
+        {
+            var name = $"{prefix}-{index}";
+            names[index] = Encoding.UTF8.GetBytes(name);
+            router = new HeaderRoutingDeserializer<int>(name, Serializers.Int32,
+                new HeaderDeserializerRoute<int>("selected"u8.ToArray(), router));
+        }
+
+        var plan = RecordHeaderRoutingPlan.Create(Serializers.Int32, router)!;
+        var keys = new ShareBatchHeaderKeys(plan);
+        foreach (var name in names)
+        {
+            await Assert.That(HeaderProtocol.TryGetCachedKey(name, out _, out _)).IsFalse();
+            await Assert.That(keys.Get(name)).IsEqualTo(Encoding.UTF8.GetString(name));
+            await Assert.That(HeaderProtocol.TryGetCachedKey(name, out _, out _)).IsFalse();
+        }
+    }
+
+    [Test]
     [Arguments('x', 256)]
     [Arguments('x', 257)]
     [Arguments('x', 512)]

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareBatchHeaderRoutingTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareBatchHeaderRoutingTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.IO.Hashing;
 using System.Text;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
@@ -10,6 +11,47 @@ namespace Dekaf.Tests.Unit.ShareConsumer;
 
 public sealed class ShareBatchHeaderRoutingTests
 {
+    [Test]
+    [Arguments(8)]
+    [Arguments(256)]
+    [Arguments(257)]
+    [Arguments(512)]
+    public async Task ConfiguredNames_ReuseRetainedStringForBorrowedSlices(int nameLength)
+    {
+        var name = new string('r', nameLength);
+        var router = new HeaderRoutingDeserializer<int>(name, Serializers.Int32,
+            new HeaderDeserializerRoute<int>("selected"u8.ToArray(), Serializers.Int32));
+        var keys = new ShareBatchHeaderKeys(RecordHeaderRoutingPlan.Create(Serializers.Int32, router)!);
+        var bytes = Encoding.UTF8.GetBytes($"before{name}after");
+        var slice = bytes.AsMemory(6, nameLength);
+
+        await Assert.That(ReferenceEquals(keys.Get(slice), name)).IsTrue();
+        await Assert.That(ReferenceEquals(keys.Get(slice.ToArray()), name)).IsTrue();
+
+        bytes[6] = (byte)'s';
+        await Assert.That(keys.Get(slice)).IsEqualTo("s" + name[1..]);
+    }
+
+    [Test]
+    public async Task ConfiguredNames_DistinguishCollidingDictionaryHashes()
+    {
+        const string first = "collision-169050";
+        const string second = "collision-178685";
+        var firstBytes = Encoding.UTF8.GetBytes(first);
+        var secondBytes = Encoding.UTF8.GetBytes(second);
+        await Assert.That(unchecked((int)XxHash64.HashToUInt64(firstBytes)))
+            .IsEqualTo(unchecked((int)XxHash64.HashToUInt64(secondBytes)));
+
+        var firstRouter = new HeaderRoutingDeserializer<int>(first, Serializers.Int32,
+            new HeaderDeserializerRoute<int>("selected"u8.ToArray(), Serializers.Int32));
+        var secondRouter = new HeaderRoutingDeserializer<int>(second, Serializers.Int32,
+            new HeaderDeserializerRoute<int>("selected"u8.ToArray(), firstRouter));
+        var keys = new ShareBatchHeaderKeys(RecordHeaderRoutingPlan.Create(Serializers.Int32, secondRouter)!);
+
+        await Assert.That(keys.Get(firstBytes)).IsEqualTo(first);
+        await Assert.That(keys.Get(secondBytes)).IsEqualTo(second);
+    }
+
     [Test]
     [NotInParallel]
     public async Task ConfiguredNames_DoNotPopulateTheSharedHeaderCache()
@@ -36,6 +78,7 @@ public sealed class ShareBatchHeaderRoutingTests
     }
 
     [Test]
+    [Arguments('x', 8)]
     [Arguments('x', 256)]
     [Arguments('x', 257)]
     [Arguments('x', 512)]

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareBatchHeaderRoutingTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareBatchHeaderRoutingTests.cs
@@ -1,0 +1,158 @@
+using System.Buffers;
+using System.Text;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public sealed class ShareBatchHeaderRoutingTests
+{
+    [Test]
+    [Arguments('x', 256)]
+    [Arguments('x', 257)]
+    [Arguments('x', 512)]
+    [Arguments('x', 1024)]
+    [Arguments('路', 85)]
+    [Arguments('路', 86)]
+    public async Task ConfiguredNames_DoNotAllocatePerRecord(char character, int nameLength)
+    {
+        var name = new string(character, nameLength);
+        var router = new HeaderRoutingDeserializer<int>(name, Serializers.Int32,
+            new HeaderDeserializerRoute<int>("selected"u8.ToArray(), Serializers.Int32));
+        await using var consumer = CreateConsumer(router);
+        var small = CreateBytes(name, 1);
+        var large = CreateBytes(name, 64);
+        ShareFetchAcquiredRecords[] acquired = [new() { FirstOffset = 0, LastOffset = 63, DeliveryCount = 1 }];
+        Parse(consumer, small, acquired);
+        Parse(consumer, large, acquired);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        Parse(consumer, small, acquired);
+        var smallAllocation = GC.GetAllocatedBytesForCurrentThread() - before;
+        before = GC.GetAllocatedBytesForCurrentThread();
+        Parse(consumer, large, acquired);
+        var largeAllocation = GC.GetAllocatedBytesForCurrentThread() - before;
+        await Assert.That(largeAllocation).IsEqualTo(smallAllocation);
+    }
+
+    [Test]
+    [Arguments("route")]
+    [Arguments("routé-路")]
+    [Arguments("replacement-\uFFFD")]
+    public async Task Routing_PreservesDuplicatesNullsAndRawHeaders(string name)
+    {
+        var selected = new ConstantDeserializer(42);
+        var fallback = new ConstantDeserializer(-1);
+        var router = new HeaderRoutingDeserializer<int>(name, fallback,
+            new HeaderDeserializerRoute<int>("selected"u8.ToArray(), selected));
+        await using var consumer = CreateConsumer(router);
+        var bytes = CreateBytes(name, 3, duplicateNull: true);
+        var reader = new KafkaProtocolReader(bytes);
+        using var batch = await consumer.ParseRecordBatchAsync(new TopicPartition("routing", 0),
+            RecordBatch.Read(ref reader), [new() { FirstOffset = 0, LastOffset = 2, DeliveryCount = 2 }], 3, default);
+        var count = 0;
+        foreach (var record in batch)
+        {
+            await Assert.That(record.Value).IsEqualTo(count == 1 ? -1 : 42);
+            await Assert.That(record.DeliveryCount).IsEqualTo(2);
+            await Assert.That(record.Headers.Count).IsEqualTo(count == 1 ? 3 : 2);
+            var headers = record.Headers.GetEnumerator();
+            await Assert.That(headers.MoveNext()).IsTrue();
+            await Assert.That(Encoding.UTF8.GetString(headers.Current.KeyUtf8.Span)).IsEqualTo(name);
+            count++;
+        }
+        await Assert.That(count).IsEqualTo(3);
+    }
+
+    [Test]
+    [Arguments(4)]
+    [Arguments(129)]
+    public async Task NestedRoutingNames_UseEveryConfiguredName(int count)
+    {
+        IDeserializer<int> router = new ConstantDeserializer(42);
+        var names = new string[count];
+        for (var index = 0; index < count; index++)
+        {
+            names[index] = new string('r', 512) + index;
+            router = new HeaderRoutingDeserializer<int>(names[index], new ConstantDeserializer(-1),
+                new HeaderDeserializerRoute<int>("selected"u8.ToArray(), router));
+        }
+        var headers = new Header[count];
+        for (var index = 0; index < count; index++)
+            headers[index] = new Header(names[index], "selected"u8.ToArray());
+        using var source = new RecordBatch
+        {
+            Records = [new Record { IsKeyNull = true, Value = new byte[4], Headers = headers, HeaderCount = count }]
+        };
+        var output = new ArrayBufferWriter<byte>();
+        source.Write(output);
+        await using var consumer = CreateConsumer(router);
+        var reader = new KafkaProtocolReader(output.WrittenMemory);
+        using var batch = await consumer.ParseRecordBatchAsync(new TopicPartition("routing", 0),
+            RecordBatch.Read(ref reader), [new() { FirstOffset = 0, LastOffset = 0, DeliveryCount = 1 }], 1, default);
+        var records = batch.GetEnumerator();
+        await Assert.That(records.MoveNext()).IsTrue();
+        await Assert.That(records.Current.Value).IsEqualTo(42);
+        await Assert.That(records.Current.Headers.Count).IsEqualTo(count);
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(256)]
+    public async Task InvalidConfiguredSurrogate_DoesNotMatchReplacementEncodedWireName(int padding)
+    {
+        var invalidName = new string('x', padding) + "invalid-\uD800";
+        var router = new HeaderRoutingDeserializer<int>(invalidName, new ConstantDeserializer(-1),
+            new HeaderDeserializerRoute<int>("selected"u8.ToArray(), new ConstantDeserializer(42)));
+        await using var consumer = CreateConsumer(router);
+        var reader = new KafkaProtocolReader(CreateBytes(invalidName, 1));
+        using var batch = await consumer.ParseRecordBatchAsync(new TopicPartition("routing", 0),
+            RecordBatch.Read(ref reader), [new() { FirstOffset = 0, LastOffset = 0, DeliveryCount = 1 }], 1, default);
+        var records = batch.GetEnumerator();
+        await Assert.That(records.MoveNext()).IsTrue();
+        await Assert.That(records.Current.Value).IsEqualTo(-1);
+    }
+
+    private static KafkaShareConsumer<int, int> CreateConsumer(IDeserializer<int> value) =>
+        new(new ShareConsumerOptions { BootstrapServers = ["localhost:9092"], GroupId = "routing" },
+            Serializers.Int32, value);
+
+    private static ReadOnlyMemory<byte> CreateBytes(string name, int count, bool duplicateNull = false)
+    {
+        var records = new Record[count];
+        for (var index = 0; index < count; index++)
+        {
+            Header[] headers = duplicateNull && index == 1
+                ? [new(name, "selected"u8.ToArray()), new("unrelated", "other"u8.ToArray()), new(name, (byte[]?)null)]
+                : [new(name, "selected"u8.ToArray()), new("unrelated", "other"u8.ToArray())];
+            records[index] = new Record
+            {
+                OffsetDelta = index, IsKeyNull = true, Value = new byte[4], Headers = headers, HeaderCount = headers.Length
+            };
+        }
+        using var source = new RecordBatch { Records = records };
+        var output = new ArrayBufferWriter<byte>();
+        source.Write(output);
+        return output.WrittenMemory;
+    }
+
+    private static void Parse(KafkaShareConsumer<int, int> consumer, ReadOnlyMemory<byte> bytes,
+        ShareFetchAcquiredRecords[] acquired)
+    {
+        var reader = new KafkaProtocolReader(bytes);
+        var operation = consumer.ParseRecordBatchAsync(new TopicPartition("routing", 0),
+            RecordBatch.Read(ref reader), acquired, 64, default);
+        if (!operation.IsCompletedSuccessfully)
+            throw new InvalidOperationException("The prepared parser must complete synchronously.");
+        using var batch = operation.GetAwaiter().GetResult();
+        foreach (var record in batch)
+            _ = record.Value;
+    }
+
+    private sealed class ConstantDeserializer(int value) : IDeserializer<int>
+    {
+        public int Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) => value;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareBatchHeaderRoutingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareBatchHeaderRoutingBenchmarks.cs
@@ -1,0 +1,98 @@
+using System.Buffers;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Complete borrowed batches, including routing, traversal and storage release. Costs are per batch.</summary>
+[MemoryDiagnoser]
+public class ShareBatchHeaderRoutingBenchmarks
+{
+    private KafkaShareConsumer<int, int> _consumer = null!;
+    private ReadOnlyMemory<byte> _bytes;
+    private ShareFetchAcquiredRecords[] _acquired = null!;
+
+    [Params(1, 64)]
+    public int RecordCount { get; set; }
+
+    [Params(8, 512)]
+    public int KeyLength { get; set; }
+
+    [Params(false, true)]
+    public bool UnrelatedHeader { get; set; }
+
+    [Params(false, true)]
+    public bool FullCache { get; set; }
+
+    [GlobalSetup]
+    public async ValueTask Setup()
+    {
+        if (FullCache)
+            FillHeaderCache();
+        var name = new string('r', KeyLength);
+        var router = new HeaderRoutingDeserializer<int>(name, Serializers.Int32,
+            new HeaderDeserializerRoute<int>("selected"u8.ToArray(), Serializers.Int32));
+        _consumer = new KafkaShareConsumer<int, int>(
+            new ShareConsumerOptions { BootstrapServers = ["localhost:9092"], GroupId = "routing-benchmark" },
+            Serializers.Int32, router);
+        var records = new Record[RecordCount];
+        for (var index = 0; index < records.Length; index++)
+        {
+            Header[] headers = UnrelatedHeader
+                ? [new(name, "selected"u8.ToArray()), new(FullCache ? $"uncached-{index}" : "unrelated", "other"u8.ToArray())]
+                : [new(name, "selected"u8.ToArray())];
+            records[index] = new Record
+            {
+                OffsetDelta = index, IsKeyNull = true, Value = new byte[4], Headers = headers, HeaderCount = headers.Length
+            };
+        }
+        using var source = new RecordBatch { Records = records };
+        var output = new ArrayBufferWriter<byte>();
+        source.Write(output);
+        _bytes = output.WrittenMemory;
+        _acquired = [new() { FirstOffset = 0, LastOffset = RecordCount - 1, DeliveryCount = 1 }];
+        if (await ParseBatch() != RecordCount)
+            throw new InvalidOperationException("The fixture must deliver every acquired record.");
+    }
+
+    private static void FillHeaderCache()
+    {
+        // The shared header cache admits 128 names. These names differ from every
+        // measured routing/unrelated name; a full cache never admits the latter.
+        for (var index = 0; index < 256; index++)
+            _ = ReadHeader($"cache-fill-{index}");
+        var first = ReadHeader("verify-full-cache");
+        var second = ReadHeader("verify-full-cache");
+        if (ReferenceEquals(first.Key, second.Key))
+            throw new InvalidOperationException("The fixture requires an exhausted header cache.");
+    }
+
+    private static Header ReadHeader(string name)
+    {
+        var output = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(output);
+        var header = new Header(name, ReadOnlyMemory<byte>.Empty);
+        HeaderProtocol.Write(in header, ref writer);
+        var reader = new KafkaProtocolReader(output.WrittenMemory);
+        return HeaderProtocol.Read(ref reader, output.WrittenCount);
+    }
+
+    [Benchmark]
+    public async ValueTask<int> ParseBatch()
+    {
+        var reader = new KafkaProtocolReader(_bytes);
+        using var batch = await _consumer.ParseRecordBatchAsync(new TopicPartition("routing", 0),
+            RecordBatch.Read(ref reader), _acquired, RecordCount, default);
+        var count = 0;
+        foreach (var record in batch)
+            count += record.Value + 1;
+        return count;
+    }
+
+    [GlobalCleanup]
+    public ValueTask Cleanup() => _consumer.DisposeAsync();
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareBatchHeaderRoutingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareBatchHeaderRoutingBenchmarks.cs
@@ -34,6 +34,19 @@ public class ShareBatchHeaderRoutingBenchmarks
         if (FullCache)
             FillHeaderCache();
         var name = new string('r', KeyLength);
+        // The default out-of-process toolchain gives each case its own static cache.
+        // Verify the measured names too, so incompatible execution fails explicitly.
+        if (FullCache)
+            VerifyHeaderCache(name, cached: false);
+        else
+            VerifyHeaderCache("verify-available-cache", cached: true);
+        // Do not prime configured names: consumer-owned retention must also be
+        // measured when no other consumer has admitted the name globally.
+        if (UnrelatedHeader)
+        {
+            for (var index = 0; index < RecordCount; index++)
+                VerifyHeaderCache(FullCache ? $"uncached-{index}" : "unrelated", cached: !FullCache);
+        }
         var router = new HeaderRoutingDeserializer<int>(name, Serializers.Int32,
             new HeaderDeserializerRoute<int>("selected"u8.ToArray(), Serializers.Int32));
         _consumer = new KafkaShareConsumer<int, int>(
@@ -79,6 +92,14 @@ public class ShareBatchHeaderRoutingBenchmarks
         HeaderProtocol.Write(in header, ref writer);
         var reader = new KafkaProtocolReader(output.WrittenMemory);
         return HeaderProtocol.Read(ref reader, output.WrittenCount);
+    }
+
+    private static void VerifyHeaderCache(string name, bool cached)
+    {
+        var first = ReadHeader(name);
+        var second = ReadHeader(name);
+        if (ReferenceEquals(first.Key, second.Key) != cached)
+            throw new InvalidOperationException("The measured header name has an unexpected cache state.");
     }
 
     [Benchmark]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareBatchOversizedHeaderBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareBatchOversizedHeaderBenchmarks.cs
@@ -1,0 +1,39 @@
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>One configured and one unrelated header lookup per record, including unrelated-name decoding.</summary>
+[MemoryDiagnoser]
+public class ShareBatchOversizedHeaderBenchmarks
+{
+    private ShareBatchHeaderKeys _keys = null!;
+    private ReadOnlyMemory<byte> _configured;
+    private ReadOnlyMemory<byte> _unrelated;
+
+    [Params(8, 512)]
+    public int ConfiguredNameBytes { get; set; }
+
+    [Params(257, 512, 4096)]
+    public int UnrelatedNameBytes { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var name = new string('r', ConfiguredNameBytes);
+        var unrelatedName = new string('u', UnrelatedNameBytes);
+        var router = new HeaderRoutingDeserializer<int>(name, Serializers.Int32,
+            new HeaderDeserializerRoute<int>("selected"u8.ToArray(), Serializers.Int32));
+        _keys = new ShareBatchHeaderKeys(RecordHeaderRoutingPlan.Create(Serializers.Int32, router)!);
+        _configured = Encoding.UTF8.GetBytes(name);
+        _unrelated = Encoding.UTF8.GetBytes(unrelatedName);
+        // Configured names stay consumer-owned; oversized unrelated names cannot enter the shared cache.
+        if (!ReferenceEquals(_keys.Get(_configured), name) || _keys.Get(_unrelated) != unrelatedName)
+            throw new InvalidOperationException("The fixture must preserve both header names.");
+    }
+
+    [Benchmark]
+    public int LookupRecordHeaders() => _keys.Get(_configured).Length + _keys.Get(_unrelated).Length;
+}


### PR DESCRIPTION
Latest review fix (`9047050bf`): oversized header names now check the consumer-owned set of configured UTF-8 byte lengths before hashing. A missing length decodes directly, avoiding both the hash scan and the configured-name dictionary probe. Same-length candidates still compare full UTF-8 bytes. Length storage allocates once per consumer, only when a valid oversized routing name exists; no new per-record allocation is introduced. Short-name cache hits retain their existing path. The unused internal `InternKey` helper flagged in an earlier review was also removed.

Validation: Release build passes with zero warnings/errors; 55 focused unit tests pass on each of .NET 8 and .NET 10; all 14 Kafka 4.3.1 batch integration tests pass. The integration test now preserves a 4,096-byte unrelated header through asynchronous preparation alongside the configured route. Added tests cover borrowed slices, same/different lengths, multiple configured lengths, and UTF-8 byte lengths. Simplification review, diff checks, and repository artifact policy pass.

The new six-case steady-state MemoryDiagnoser fixture passes Dry and sequential Short A1/B/A2 runs against the previous PR head, `92e28125c`. Allocations remain exactly 536/1,048/8,216 B per record in all three samples (existing unrelated-name decoding). For 8-byte configured names, candidate medians are 50.28/74.45/396.95 ns versus 78.88/123.65/686.99 ns in A1 and 83.50/118.23/686.57 ns in A2. The 512-byte same-length candidate case measures 146.54 ns versus 153.99/142.97 ns controls, inside tolerance. Other oversized configured-name cases are below both controls. These local Short measurements are diagnostic, not hosted acceptance. Raw logs and exports remain outside the repository at `C:/git/Dekaf-evidence/pr-3292-oversized/`. Normal performance-gate selection includes the new fixture with no skipped classes; new-head CI remains pending.

CI reliability follow-up (`92e28125c`): the failed [Build & Unit Test job](https://github.com/thomhurst/Dekaf/actions/runs/34683985528/job/103527628310) measured 7,904 B in `FragmentedCompletion_UsesReservedStorageWithoutAllocating(4098, 2)`. An allocation-free probe on both .NET 8 and .NET 10 reproduced counter increases when background GC finished after the thread obtained an allocation buffer; blocking collections reported 0 B. CoreCLR's background sweep clears the remaining allocation context, which can increase `GC.GetAllocatedBytesForCurrentThread()` without a managed allocation in the measured code. This explains a concrete source of contamination; the original CI failure did not contain an allocation trace.

The test now runs exclusively and protects only its synchronous measurement with a 16 MiB no-GC region, restored in `finally` before assertions. It still measures first fragmented completion, asserts exactly 0 B, and checks commit progress and storage release. Failure to establish or retain the region fails the test. No product code or performance thresholds changed in this follow-up. Main is merged through `b8295c5d5`.

Validation: all 10,685 Release net10.0 unit tests pass on four-CPU Linux; all 10,502 Release net8.0 unit tests pass on Windows; all 40 focused storage tests pass on Windows net10.0. On each runtime, 12 protected allocation-free probe windows report 0 B and 12 positive-control windows report the expected 56 B. Diff and simplification review pass. Raw logs and probe source remain outside the repository under `C:/git/Dekaf-evidence/pr-3292-ci*`. The previously failing [Build & Unit Test (net10.0) check now passes](https://github.com/thomhurst/Dekaf/actions/runs/34684990668/job/103530372639) on this head. Code quality, leak gates, vulnerability audit, documentation, and NativeAOT publish/smoke also pass. Downstream integration/net8.0 checks and the performance gate are still pending.

Borrowed batch header routing allocated a decoded string per record for configured names longer than the shared cache's 256-byte limit, and for short names after its 128-entry capacity was exhausted. A 512-character name allocated 1,048 B per record after warmup.

The borrowed parser now retains configured names in a consumer-owned UTF-8 lookup. Global-cache hits keep their existing fast path; misses check configured names before decoding, reusing the global lookup hash for the decoding fallback. Configured-name validation uses a UTF-8 round trip without admitting names into the process-wide cache. Unpaired surrogates, duplicate/null headers, nested routes, raw borrowed headers, and asynchronous preparation preserve their semantics.

The routing helper keeps its null-plan and zero-header returns in a small inline method. Only records that need materialized headers enter the larger parsing method, with raw record data passed by readonly reference. This removes the materialization stack-frame initialization from ordinary per-record parsing. The previous head's local Windows x64 Tier1 disassembly showed eight saved registers, a 504-byte frame, and a zeroing loop before the null-plan return.

Per-record work stays synchronous. Configured-name bytes, validation strings, and lookup storage allocate once per consumer at its first routed batch. Configured-name decoding adds no steady-state per-record allocation; the fixture retains 128 B of storage/lease allocation per batch. Unconfigured names that cannot enter the global cache retain their existing decoding allocations. No new locks, tasks, thread hops, or per-record async state machines are introduced.

Refs #3032. The parent remains open for its remaining allocation and loaded-performance acceptance requirements.

Current review follow-up: `74e5ed7985c44dfa1774d5e3899ae0413e3cbc96` reuses the global-cache lookup hash in a value-type configured-name key. Oversized names are hashed once locally, and dictionary equality still compares UTF-8 bytes. Retained hash storage is amortized per consumer; no per-record allocation or global-cache admission is added.

Validation of this follow-up: Release build passes with zero warnings/errors; 110 focused tests pass on each of .NET 8 and .NET 10; all 14 Kafka batch integration tests pass; all 16 routing fixture cases complete Dry and Short runs. Four short-name cases have local A1/B/A2 comparisons against the previous head with identical allocations. Timing differences are inside tolerance or affected by control drift, so no stable speedup or hosted acceptance is claimed. [Review response and measurement details](https://github.com/thomhurst/Dekaf/pull/3292#discussion_r3995687192). The normal performance gate remains required for this head. Raw local reports are retained outside the repository at `C:/git/Dekaf-evidence/pr-3292-hash/`.

Earlier validation of `6a81c4bbf45923fd90516f86f89de8c6996e7a73`, based on `e6b212dc1d123c36cda980be5361bfc7d9960608`:

- Full Release build: zero warnings/errors, including netstandard2.0.
- 83 focused routing, intern-cache, borrowed-batch, and record-pooling tests pass on each of .NET 8 and .NET 10. The new 129-name cache-pollution test fails against the previous PR head and passes with the fix.
- All 14 Kafka 4.3.1 batch integration cases pass, including long-name routing through asynchronous preparation, acknowledgement, and close.
- The 16-case steady-state MemoryDiagnoser fixture checks available/exhausted cache state and each measured exhausted-cache name. Cases use separate BenchmarkDotNet worker processes. Setup does not prime configured names when capacity is available, so it also measures consumer-owned retention before another consumer caches the name globally.
- Sequential local Short A1/B/A2 runs cover six acknowledgement cases and both 64-record, zero-header cold preparation cases against the same baseline as the failed hosted run. All eight candidate medians are below both controls; acknowledgement allocations remain exactly 536/1,016 B per batch. The second control drifted substantially (20% to 70%), and its cold-parser allocation readings varied from 726 to 790 B versus 791 B in A1 and B. These results are diagnostic, not a claimed stable speedup or hosted acceptance. All 16 final routing Short cases complete successfully: configured-only batches allocate 128 B for both 1 and 64 records; saturated unrelated-header cases retain the expected 176/3,200 B. Raw timing variation remains visible in the reports.
- Final simplification review, diff checks, and repository artifact policy pass. No generated evidence is committed.

The previous head `8760362` failed the hosted [acknowledgement screen](https://github.com/thomhurst/Dekaf/actions/runs/34665965838/job/103477921046) and [borrowed-parsing screen](https://github.com/thomhurst/Dekaf/actions/runs/34665965838/job/103477921056). Both reproduced on the gate's automatic repeat. Their [acknowledgement artifact](https://github.com/thomhurst/Dekaf/actions/runs/34665965838/artifacts/10289614694) and [parsing artifact](https://github.com/thomhurst/Dekaf/actions/runs/34665965838/artifacts/10289820603) were inspected before the product fix. The prior [routing screen](https://github.com/thomhurst/Dekaf/actions/runs/34665965838/job/103477920998) passed all 16 cases; its [artifact](https://github.com/thomhurst/Dekaf/actions/runs/34665965838/artifacts/10288869011) remains available. These previous results are not acceptance evidence for the new head. New hosted checks remain required; no tolerances, gate selection rules, or benchmark workloads were relaxed.

No paid stress run was dispatched. This change concerns header-name decoding and the parser's routing helper; it makes no loaded throughput or latency claim.

Earlier broader test failures remain recorded: two unchanged first-use offset allocation assertions are retained in [#3291](https://github.com/thomhurst/Dekaf/issues/3291#issuecomment-5642388329), and an earlier .NET 8 full run at `6ce08e8` failed the unchanged `LargeReservation_InitializesOnlyPublishedChunks(1025)` same-array reuse assertion. These focused passes do not replace those historical full-suite results.

Current local raw logs, BenchmarkDotNet exports, and JIT disassembly are retained outside the repository at `C:/git/Dekaf-evidence/pr-3292-review/`. Earlier evidence remains at `C:/git/Dekaf-evidence/pr-3292-cache-miss/`, `pr-3292-fastpath/`, and `issue-3032-header-routing/`.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved header-based routing efficiency, reducing repeated processing and allocations while handling cached and uncached header names.

- **Reliability**
  - Improved routing for batches during deserializer preparation, including long header names, multi-byte names, duplicate headers, and null header values.
  - Preserved original header keys and values during routing.
  - Invalid header-name characters are handled safely without unintended matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->