### PR TITLE
perf(share-consumer): streamline retained replay refresh

### DIFF
--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -2499,10 +2499,9 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
 
             // A terminal CommitAsync inside the replay handler can remove the
             // renewal state. Keep this delivery's payload alive until the next poll.
-            if (state.Record.RetainedBatchOwner is { } retainedOwner)
+            var record = state.Record;
+            if (record.RefreshRetainedBatchOwner() is { } owner)
             {
-                var owner = retainedOwner.RefreshGeneration();
-                state.Record.AttachBatchOwner(owner);
                 if (!owner.RenewalPinned)
                 {
                     owner.Retain();
@@ -2518,7 +2517,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                     }
                 }
             }
-            records.Add(state.Record);
+            records.Add(record);
             if (records.Count == maxRecords)
                 break;
         }

--- a/src/Dekaf/ShareConsumer/ShareConsumeResult.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumeResult.cs
@@ -46,6 +46,23 @@ public sealed class ShareConsumeResult<TKey, TValue>
     // both already own an independent reference across poll boundaries.
     internal ShareRecordBatchOwner? RetainedBatchOwner => _topicOrBatchOwner as ShareRecordBatchOwner;
 
+    internal ShareRecordBatchOwner? RefreshRetainedBatchOwner()
+    {
+        if (_topicOrBatchOwner is not ShareRecordBatchOwner owner)
+            return null;
+        var generation = owner.Generation;
+        if (generation == 0)
+        {
+            owner = owner.RefreshGeneration();
+            _topicOrBatchOwner = owner;
+            generation = owner.Generation;
+        }
+        // A retained replay refreshes its delivery token every poll. Only generation
+        // exhaustion replaces the owner; ordinary replay needs no reference write.
+        _partitionOrGeneration = ~unchecked((int)generation);
+        return owner;
+    }
+
     /// <summary>
     /// The topic this record was consumed from.
     /// </summary>

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRecordPoolingTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRecordPoolingTests.cs
@@ -163,8 +163,10 @@ public sealed class ShareConsumerRecordPoolingTests
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
     [NotInParallel]
-    public async Task RenewedReplay_TerminalAcknowledgement_KeepsPayloadUntilNextPoll()
+    public async Task RenewedReplay_TerminalAcknowledgement_KeepsPayloadUntilNextPoll(bool exhaustGeneration)
     {
         var consumer = CreateBorrowedConsumer(out var metadata);
         await using var metadataScope = metadata;
@@ -178,6 +180,29 @@ public sealed class ShareConsumerRecordPoolingTests
         consumer.Acknowledge(record, AcknowledgeType.Renew);
         ApplyAcknowledgement(consumer, AcknowledgeType.Renew);
 
+        var getActive = consumer.GetType().GetMethod("GetActiveRenewedRecords",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        for (var round = 0; round < 4; round++)
+        {
+            if (exhaustGeneration && round == 1)
+            {
+                var owner = record.BatchOwner!;
+                typeof(ShareRecordBatchOwner).GetProperty("Generation",
+                    BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .SetValue(owner, ShareRecordBatchOwner.MaximumGeneration);
+                record.AttachBatchOwner(owner);
+            }
+            using var poll = consumer.BeginRecordBatchScope();
+            await Assert.That(() => record.BatchOwner).Throws<InvalidOperationException>();
+            var replay = (List<ShareConsumeResult<string, ReadOnlyMemory<byte>>>)getActive.Invoke(consumer,
+                [new HashSet<TopicPartition> { new("topic", 0) }, 10])!;
+            await Assert.That(replay[0]).IsSameReferenceAs(record);
+            await Assert.That(record.BatchOwner).IsNotNull();
+            await Assert.That(System.Text.Encoding.UTF8.GetString(record.Value.Span)).IsEqualTo("first");
+            consumer.Acknowledge(record, AcknowledgeType.Renew);
+            ApplyAcknowledgement(consumer, AcknowledgeType.Renew);
+        }
+
         var replayScope = consumer.BeginRecordBatchScope();
         var buffers = (ShareRecordBufferPool)consumer.GetType()
             .GetField("_recordBuffers", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(consumer)!;
@@ -186,8 +211,6 @@ public sealed class ShareConsumerRecordPoolingTests
         string payload;
         try
         {
-            var getActive = consumer.GetType().GetMethod("GetActiveRenewedRecords",
-                BindingFlags.Instance | BindingFlags.NonPublic)!;
             var replay = (List<ShareConsumeResult<string, ReadOnlyMemory<byte>>>)getActive.Invoke(consumer,
                 [new HashSet<TopicPartition> { new("topic", 0) }, 10])!;
             await Assert.That(replay[0]).IsSameReferenceAs(record);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerRenewalReplayBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerRenewalReplayBenchmarks.cs
@@ -25,7 +25,7 @@ public class ShareConsumerRenewalReplayBenchmarks
     [Params(1, 64)]
     public int RecordsPerBatch { get; set; }
 
-    [Params(1, 16, 64)]
+    [Params(1, 16, 64, 128)]
     public int BatchCount { get; set; }
 
     [GlobalSetup]


### PR DESCRIPTION
Renewal replay previously called `RefreshGeneration` for every retained record, then wrote the same owner reference back through `AttachBatchOwner`, even when no owner replacement was needed. It now refreshes the delivery token directly and replaces the owner reference only when its generation is exhausted. The replay loop also captures the record once.

The existing generation-exhaustion transfer, interleaved-owner pinning, reference release and terminal acknowledgement handling remain intact. No fields or recurring per-record allocations are added. Work per record is a generation read and token update; retaining/releasing the poll reference remains once per distinct owner. The existing result list allocates per replay snapshot, unchanged by this PR.

Validation for `c7827e8291a290a2fd3d1c248d8a88f755228de9`, based on main `e6b212dc1d123c36cda980be5361bfc7d9960608`:

- All 679 selected net10.0 unit cases and all 659 net8.0 cases pass on the final rebased head. Main's nested-deserializer context fixes are included; the replay method, result helper and benchmark fixture match the measured pre-rebase candidate.
- All 34 Kafka 4.3.1 cases passed on the pre-rebase candidate: regular and batch delivery, poll buffering, renewal and sustained multi-partition borrowed-payload ownership. The extended unit test covers four replay rounds, stale tokens before replay, valid tokens afterward, optional generation exhaustion and terminal acknowledgement payload lifetime.
- The maintained MemoryDiagnoser fixture now includes 128 batches: eight steady-state cases covering 1/64 records per batch and 1/16/64/128 interleaved owners. Identical fixture source compiles and runs against the candidate, captured main cdb604a09 and the original pre-regression baseline 689e1bb499963c6445893928231c0c21fd396080.
- Local medians for the historically failing cases, in original-baseline / captured-main / candidate order: 1 record x 64 batches = 1.009 / 1.096 / 1.019 us; 64 records x 16 batches = 13.315 / 15.398 / 13.372 us. Allocations match in all eight cases (568 B and 8,248 B for those two snapshots). The smallest 1x1 case is 22.72 / 26.11 / 25.84 ns; its +13.7% against the original is below the gate's 20% tolerance at this size, not an accepted win or loss. These measurements used pre-rebase candidate b2f365105.
- Full Release build, including netstandard2.0: zero warnings/errors. Repository artifact-policy and diff checks pass.

Local Short results are diagnostic only. The last candidate case overlaps an IL inspection process; its timing is not an acceptance claim. The original net10.0 test run had two unrelated first-use offset allocation failures (1,880 B/7,664 B), tracked in #3291. Stage-instrumented runs later measured zero but did not attribute those original failures. They are not waived by this PR.

Raw exports/logs, exact source, experiment inputs and executed benchmark/test binaries are retained at `D:/Dekaf-evidence/issue-3289-renewal-refresh/`, with per-entry SHA-256 verification against originals. The temporary offset instrumentation is excluded from this PR.

Acceptance remains pending the current-main CI/performance gate and a hosted replay comparison against the original 689e1bb baseline. Parent #3245 stays open for resubscribe-overflow regressions and its remaining combined loaded/lifecycle acceptance. This PR does not approve a performance tradeoff.

Closes #3289
