### PR TITLE
perf(share-consumer): reduce resubscribe overflow overhead

### DIFF
--- a/src/Dekaf/Protocol/Messages/ShareFetchRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ShareFetchRequest.cs
@@ -152,6 +152,39 @@ public sealed class ShareFetchRequestTopic
 /// </summary>
 public sealed class ShareFetchRequestPartition
 {
+    private object? _acknowledgementBatches;
+
+    // Request models own their descriptors after the consumer returns its temporary
+    // snapshot containers. Most partitions need only one acknowledgement batch.
+    internal List<Dekaf.ShareConsumer.AcknowledgementBatchData>? AcknowledgementData
+    {
+        init
+        {
+            if (value is null)
+                return;
+            if (value.Count == 1)
+            {
+                _acknowledgementBatches = CreateAcknowledgementBatch(value[0]);
+                return;
+            }
+            var batches = new ShareFetchAcknowledgementBatch[value.Count];
+            for (var index = 0; index < batches.Length; index++)
+                batches[index] = CreateAcknowledgementBatch(value[index]);
+            _acknowledgementBatches = batches;
+        }
+    }
+
+    internal ShareFetchAcknowledgementBatch? SingleAcknowledgement
+        => _acknowledgementBatches as ShareFetchAcknowledgementBatch;
+
+    private static ShareFetchAcknowledgementBatch CreateAcknowledgementBatch(Dekaf.ShareConsumer.AcknowledgementBatchData batch)
+        => new()
+        {
+            FirstOffset = batch.FirstOffset,
+            LastOffset = batch.LastOffset,
+            AcknowledgeTypes = batch.PublicAcknowledgeTypes
+        };
+
     /// <summary>
     /// Partition index.
     /// </summary>
@@ -165,7 +198,16 @@ public sealed class ShareFetchRequestPartition
     /// <summary>
     /// Acknowledgement batches to include with this fetch.
     /// </summary>
-    public IReadOnlyList<ShareFetchAcknowledgementBatch>? AcknowledgementBatches { get; init; }
+    public IReadOnlyList<ShareFetchAcknowledgementBatch>? AcknowledgementBatches
+    {
+        get
+        {
+            if (_acknowledgementBatches is ShareFetchAcknowledgementBatch batch)
+                _acknowledgementBatches = new[] { batch };
+            return (IReadOnlyList<ShareFetchAcknowledgementBatch>?)_acknowledgementBatches;
+        }
+        init => _acknowledgementBatches = value;
+    }
 
     public void Write(ref KafkaProtocolWriter writer, short version)
     {
@@ -176,9 +218,17 @@ public sealed class ShareFetchRequestPartition
             writer.WriteInt32(PartitionMaxBytes);
         }
 
-        writer.WriteCompactArray(
-            AcknowledgementBatches ?? [],
-            static (ref KafkaProtocolWriter w, ShareFetchAcknowledgementBatch b) => b.Write(ref w));
+        if (SingleAcknowledgement is { } batch)
+        {
+            writer.WriteUnsignedVarInt(2);
+            batch.Write(ref writer);
+        }
+        else
+        {
+            writer.WriteCompactArray(
+                AcknowledgementBatches ?? [],
+                static (ref KafkaProtocolWriter w, ShareFetchAcknowledgementBatch b) => b.Write(ref w));
+        }
 
         writer.WriteEmptyTaggedFields();
     }

--- a/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 #if NETSTANDARD2_0
 using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
 #else
@@ -24,6 +26,32 @@ internal sealed class AcknowledgementTracker
     private Dictionary<TopicPartition, PartitionAcknowledgements> _pendingAcks = new();
     private PartitionAcknowledgements? _freePartitions;
     private int _peakPendingPartitions;
+    private PollBatchPool? _pollBatchPool;
+
+    private sealed class PollBatchPool(int capacity)
+    {
+        internal readonly Dictionary<TopicPartition, List<AcknowledgementBatchData>> Batches = new(capacity);
+        internal readonly List<List<AcknowledgementBatchData>> Spare = [];
+        internal bool InUse;
+    }
+
+    // Only the callback-free classic fetch path borrows these containers. Request
+    // models copy batch descriptors and keep their immutable disposition arrays.
+    internal Dictionary<TopicPartition, List<AcknowledgementBatchData>> FlushForPoll() => FlushCore(false, reuseForPoll: true);
+
+    internal void ReturnPollBatches(Dictionary<TopicPartition, List<AcknowledgementBatchData>>? batches)
+    {
+        var pool = _pollBatchPool;
+        if (pool is not { InUse: true } || !ReferenceEquals(batches, pool.Batches))
+            return;
+        foreach (var list in batches!.Values)
+        {
+            list.Clear();
+            pool.Spare.Add(list);
+        }
+        batches.Clear();
+        pool.InUse = false;
+    }
 
     /// <summary>
     /// Tracks delivered records awaiting implicit acceptance by the next poll or commit.
@@ -85,6 +113,8 @@ internal sealed class AcknowledgementTracker
     /// Returned batches own their arrays independently of the reusable tracking state.
     /// </summary>
     /// <returns>Per-TopicPartition acknowledgement batches for the wire format.</returns>
+    // Keep the owned path independently inlineable so short-lived trackers can remain stack-allocated.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal Dictionary<TopicPartition, List<AcknowledgementBatchData>> Flush(bool releaseImplicit = false)
     {
         var pending = _pendingAcks;
@@ -97,6 +127,8 @@ internal sealed class AcknowledgementTracker
             _pendingAcks = new Dictionary<TopicPartition, PartitionAcknowledgements>();
             _freePartitions = null;
             _peakPendingPartitions = count;
+            if (_pollBatchPool is not { InUse: true })
+                _pollBatchPool = null;
         }
         else if (count > _peakPendingPartitions)
         {
@@ -127,6 +159,70 @@ internal sealed class AcknowledgementTracker
         }
     }
 
+    private Dictionary<TopicPartition, List<AcknowledgementBatchData>> FlushCore(bool releaseImplicit, bool reuseForPoll)
+    {
+        var pending = _pendingAcks;
+        var count = pending.Count;
+        var reusePending = count >= _peakPendingPartitions / 4;
+        if (!reusePending)
+        {
+            // A smaller assignment must not keep clearing the old peak dictionary
+            // capacity on every poll. Drop idle scratch at the same boundary.
+            _pendingAcks = new Dictionary<TopicPartition, PartitionAcknowledgements>();
+            _freePartitions = null;
+            _peakPendingPartitions = count;
+            if (_pollBatchPool is not { InUse: true })
+                _pollBatchPool = null;
+        }
+        else if (count > _peakPendingPartitions)
+        {
+            _peakPendingPartitions = count;
+        }
+
+        try
+        {
+            reuseForPoll &= _pollBatchPool is not { InUse: true };
+            PollBatchPool? pool = null;
+            if (reuseForPoll)
+            {
+                pool = _pollBatchPool ??= new(count);
+                pool.InUse = true;
+            }
+            var result = pool?.Batches ?? new Dictionary<TopicPartition, List<AcknowledgementBatchData>>(count);
+            foreach (var (tp, partitionAcks) in pending)
+            {
+                List<AcknowledgementBatchData>? scratch = null;
+                if (pool is not null && pool.Spare.Count != 0)
+                {
+                    var last = pool.Spare.Count - 1;
+                    scratch = pool.Spare[last];
+                    pool.Spare.RemoveAt(last);
+                }
+                var batches = partitionAcks.BuildBatches(releaseImplicit ? AcknowledgeType.Release : AcknowledgeType.Accept, scratch);
+                if (batches.Count > 0)
+                    result[tp] = batches;
+
+                partitionAcks.Reset();
+                partitionAcks.Next = _freePartitions;
+                _freePartitions = partitionAcks;
+            }
+            return result;
+        }
+        catch
+        {
+            if (reuseForPoll)
+                ReturnPollBatches(_pollBatchPool?.Batches);
+            throw;
+        }
+        finally
+        {
+            // Flush is synchronous and single-threaded. Detach even when materialization
+            // throws, preserving the previous swap's consumption of the pending state.
+            if (reusePending)
+                pending.Clear();
+        }
+    }
+
     /// <summary>
     /// Re-queues previously flushed acknowledgement data back into the tracker.
     /// Used when CommitAsync partially fails — the failed partitions' acks are
@@ -144,7 +240,7 @@ internal sealed class AcknowledgementTracker
                 long runEnd = 0;
                 var runType = AcknowledgeType.Accept;
 
-                for (var i = 0; i < batch.AcknowledgeTypes.Length; i++)
+                for (var i = 0; i < batch.OffsetCount; i++)
                 {
                     var offset = batch.FirstOffset + i;
                     // Preserve any acknowledgement tracked after the flush. A newer
@@ -161,7 +257,7 @@ internal sealed class AcknowledgementTracker
                         continue;
                     }
 
-                    var type = (AcknowledgeType)batch.AcknowledgeTypes[i];
+                    var type = (AcknowledgeType)batch.GetAcknowledgeType(i);
                     if (runStart is not null && type == runType && offset == runEnd + 1)
                     {
                         runEnd = offset;
@@ -184,12 +280,17 @@ internal sealed class AcknowledgementTracker
 
     private PartitionAcknowledgements GetOrAddPartition(TopicPartition tp)
     {
+#if NET6_0_OR_GREATER
+        ref var partitionAcks = ref System.Runtime.InteropServices.CollectionsMarshal.GetValueRefOrAddDefault(_pendingAcks, tp, out _);
+        return partitionAcks ??= RentPartition();
+#else
         if (_pendingAcks.TryGetValue(tp, out var partitionAcks))
             return partitionAcks;
 
         partitionAcks = RentPartition();
         _pendingAcks[tp] = partitionAcks;
         return partitionAcks;
+#endif
     }
 
     private PartitionAcknowledgements RentPartition()
@@ -223,20 +324,23 @@ internal sealed class AcknowledgementTracker
 
             var incoming = new AckRange(firstOffset, lastOffset, type);
 
-            if (_ranges.Count > 0)
+            if (_ranges.Count == 0)
             {
-                var last = _ranges[^1];
-                if (last.AcknowledgeType == type && TouchesOrOverlaps(last, incoming))
-                {
-                    _ranges[^1] = Merge(last, incoming);
-                    return;
-                }
+                _ranges.Add(incoming);
+                return;
+            }
 
-                if (firstOffset > last.LastOffset)
-                {
-                    _ranges.Add(incoming);
-                    return;
-                }
+            var last = _ranges[^1];
+            if (last.AcknowledgeType == type && TouchesOrOverlaps(last, incoming))
+            {
+                _ranges[^1] = Merge(last, incoming);
+                return;
+            }
+
+            if (firstOffset > last.LastOffset)
+            {
+                _ranges.Add(incoming);
+                return;
             }
 
             InsertRange(incoming);
@@ -330,9 +434,9 @@ internal sealed class AcknowledgementTracker
             _explicitAcks[offset] = type;
         }
 
-        internal List<AcknowledgementBatchData> BuildBatches(AcknowledgeType implicitDisposition)
+        internal List<AcknowledgementBatchData> BuildBatches(AcknowledgeType implicitDisposition, List<AcknowledgementBatchData>? scratch = null)
         {
-            var batches = new List<AcknowledgementBatchData>(_ranges.Count);
+            var batches = scratch ?? new List<AcknowledgementBatchData>(_ranges.Count);
 
             foreach (var range in _ranges)
                 batches.Add(BuildRangeBatch(range, implicitDisposition));
@@ -350,6 +454,10 @@ internal sealed class AcknowledgementTracker
         private AcknowledgementBatchData BuildRangeBatch(AckRange range, AcknowledgeType implicitDisposition)
         {
             var length = checked((int)(range.LastOffset - range.FirstOffset + 1));
+            // Kafka accepts one disposition for a whole range. Undisclosed acquisitions
+            // need no per-offset storage; explicit outcomes still use the mixed path.
+            if (range.AcknowledgeType == AcknowledgeType.Release && _explicitAcks is null)
+                return new(range.FirstOffset, range.LastOffset, AcknowledgementBatchData.ReleaseTypes);
             var acknowledgeTypes = new byte[length];
             Array.Fill(acknowledgeTypes, (byte)(range.AcknowledgeType == ImplicitDelivery
                 ? implicitDisposition
@@ -437,9 +545,9 @@ internal sealed class AcknowledgementTracker
                     continue;
                 }
 
-                var combinedTypes = new byte[current.AcknowledgeTypes.Length + next.AcknowledgeTypes.Length];
-                Array.Copy(current.AcknowledgeTypes, combinedTypes, current.AcknowledgeTypes.Length);
-                Array.Copy(next.AcknowledgeTypes, 0, combinedTypes, current.AcknowledgeTypes.Length, next.AcknowledgeTypes.Length);
+                var combinedTypes = new byte[checked(current.OffsetCount + next.OffsetCount)];
+                current.CopyTypesTo(combinedTypes.AsSpan(0, current.OffsetCount));
+                next.CopyTypesTo(combinedTypes.AsSpan(current.OffsetCount));
                 current = new AcknowledgementBatchData(current.FirstOffset, next.LastOffset, combinedTypes);
             }
 
@@ -455,4 +563,21 @@ internal sealed class AcknowledgementTracker
 /// <summary>
 /// Wire-format acknowledgement batch data ready for serialization.
 /// </summary>
-internal readonly record struct AcknowledgementBatchData(long FirstOffset, long LastOffset, byte[] AcknowledgeTypes);
+internal readonly record struct AcknowledgementBatchData(long FirstOffset, long LastOffset, byte[] AcknowledgeTypes)
+{
+    internal static readonly byte[] ReleaseTypes = [(byte)AcknowledgeType.Release];
+    private static readonly IReadOnlyList<byte> ReadOnlyReleaseTypes = System.Array.AsReadOnly(ReleaseTypes);
+    internal IReadOnlyList<byte> PublicAcknowledgeTypes => ReferenceEquals(AcknowledgeTypes, ReleaseTypes)
+        ? ReadOnlyReleaseTypes : AcknowledgeTypes;
+    internal int OffsetCount => AcknowledgeTypes.Length == 1
+        ? checked((int)(LastOffset - FirstOffset + 1)) : AcknowledgeTypes.Length;
+    internal byte GetAcknowledgeType(int index) => AcknowledgeTypes.Length == 1 ? AcknowledgeTypes[0] : AcknowledgeTypes[index];
+
+    internal void CopyTypesTo(Span<byte> destination)
+    {
+        if (AcknowledgeTypes.Length == 1)
+            destination.Fill(AcknowledgeTypes[0]);
+        else
+            AcknowledgeTypes.AsSpan().CopyTo(destination);
+    }
+}

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.BufferedRecords.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.BufferedRecords.cs
@@ -30,6 +30,40 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
     private DeserializerPreparationParserState _pendingParserState;
     private long _pendingPartitionLastParsedOffset = -1;
     private bool _hasBufferedAcquisitionReleases;
+    // Routing scratch is borrowed until every broker task completes, including retries.
+    // Re-resolve leaders on every fetch; only the empty containers are reused.
+    private Dictionary<int, List<TopicPartition>>? _pollPartitionGroups;
+    private readonly List<List<TopicPartition>> _sparePartitionGroups = [];
+    private bool _pollPartitionGroupsInUse;
+    private int _peakGroupedPartitions;
+
+    private Dictionary<int, List<TopicPartition>>? TakePollPartitionGroups(int partitionCount)
+    {
+        if (_pollPartitionGroupsInUse)
+            return null;
+        if (partitionCount < _peakGroupedPartitions / 4)
+        {
+            _pollPartitionGroups = null;
+            _sparePartitionGroups.Clear();
+            _peakGroupedPartitions = partitionCount;
+        }
+        _peakGroupedPartitions = Math.Max(_peakGroupedPartitions, partitionCount);
+        _pollPartitionGroupsInUse = true;
+        return _pollPartitionGroups ??= new();
+    }
+
+    private void ReturnPollPartitionGroups()
+    {
+        if (!_pollPartitionGroupsInUse)
+            return;
+        foreach (var list in _pollPartitionGroups!.Values)
+        {
+            list.Clear();
+            _sparePartitionGroups.Add(list);
+        }
+        _pollPartitionGroups.Clear();
+        _pollPartitionGroupsInUse = false;
+    }
 
     private bool RemoveBufferedRecordsOutsideAssignment(TopicPartitionSet assignment)
     {
@@ -433,7 +467,6 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
 
     private void ClearBufferedRecords(bool releaseAcquisitions = false)
     {
-        _spareBufferedRecords = null;
         if (_pendingFetches is not null)
         {
             if (releaseAcquisitions)

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.Telemetry.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.Telemetry.cs
@@ -70,6 +70,11 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue>
             var partitions = request.Topics[topicIndex].Partitions;
             for (var partitionIndex = 0; partitionIndex < partitions.Count; partitionIndex++)
             {
+                if (partitions[partitionIndex].SingleAcknowledgement is { } single)
+                {
+                    count += CountAcknowledgedRecords(single.FirstOffset, single.LastOffset, single.AcknowledgeTypes);
+                    continue;
+                }
                 var batches = partitions[partitionIndex].AcknowledgementBatches;
                 if (batches is null) continue;
                 for (var index = 0; index < batches.Count; index++)

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -277,7 +277,16 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         // Cleared windows no longer participate in assignment-revocation cleanup.
         // Recheck their outcomes when the replacement assignment becomes available.
         _hasBufferedAcquisitionReleases |= _ackTracker.HasPending;
-        _recordBatchOwnerPools?.Clear();
+        if (_recordBatchOwnerPools is not null)
+        {
+            List<TopicPartition>? removed = null;
+            foreach (var partition in _recordBatchOwnerPools.Keys)
+                if (!subscription.Contains(partition.Topic))
+                    (removed ??= []).Add(partition);
+            if (removed is not null)
+                foreach (var partition in removed)
+                    _recordBatchOwnerPools.Remove(partition);
+        }
         _subscriptionSnapshot = subscription;
         _coordinator.UpdateSubscription(subscription);
         return this;
@@ -386,10 +395,12 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 {
                     RequeueAcknowledgements(pendingAcks);
                     InvokeAcknowledgementCommitCallback(pendingAcks, ex);
+                    _ackTracker.ReturnPollBatches(pendingAcks);
                     throw;
                 }
                 finally
                 {
+                    ReturnPollPartitionGroups();
                     ShareMetrics?.EndPollWait();
                 }
 
@@ -400,6 +411,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 }
                 finally
                 {
+                    _ackTracker.ReturnPollBatches(pendingAcks);
                     // Keep successful acquisitions even when another broker's bookkeeping fails.
                     // A late response after close/disposal remains owned by the response scope.
                     stopped = Volatile.Read(ref _disposed) != 0 || Volatile.Read(ref _closed) != 0;
@@ -531,10 +543,16 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         _rawBuffer?.ResetWrittenCount();
 
         // Flush pending acks from previous poll as inline acknowledgements with the fetch
-        pendingAcks = HasPendingAcknowledgements ? FlushAcknowledgements() : null;
+        pendingAcks = null;
+        if (HasPendingAcknowledgements)
+        {
+            pendingAcks = _batchAcknowledgements is null && _acknowledgementCommitCallback is null
+                ? _ackTracker.FlushForPoll() : FlushAcknowledgements();
+        }
 
         // Group assigned partitions by leader broker
-        var partitionsByBroker = GroupPartitionsByLeader(assignment);
+        var partitionsByBroker = GroupPartitionsByLeader(assignment,
+            _batchAcknowledgements is null ? TakePollPartitionGroups(assignment.Count) : null);
 
         // Send fetch requests to all brokers concurrently. Session epochs are per-broker
         // and independent, so parallelism is safe. This avoids waiting for each broker's
@@ -599,8 +617,11 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 {
                     // Cancellation before the write is not an acknowledgement outcome.
                     // Retain these dispositions for final commit without reporting success.
-                    foreach (var partition in sentAcks.Keys)
-                        pendingAcks!.Remove(partition);
+                    if (ReferenceEquals(pendingAcks, sentAcks))
+                        pendingAcks!.Clear();
+                    else
+                        foreach (var partition in sentAcks.Keys)
+                            pendingAcks!.Remove(partition);
                 }
                 continue;
             }
@@ -1483,23 +1504,28 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
     /// Groups assigned partitions by their leader broker.
     /// </summary>
     private Dictionary<int, List<TopicPartition>> GroupPartitionsByLeader(
-        TopicPartitionSet assignment)
+        TopicPartitionSet assignment, Dictionary<int, List<TopicPartition>>? reusable = null)
     {
-        var result = new Dictionary<int, List<TopicPartition>>();
+        var result = reusable ?? new Dictionary<int, List<TopicPartition>>();
 
         foreach (var tp in assignment)
         {
-            var topicInfo = _metadataManager.Metadata.GetTopic(tp.Topic);
-            if (topicInfo is null)
-                continue;
-
             var leaderNode = _metadataManager.Metadata.GetPartitionLeader(tp.Topic, tp.Partition);
             if (leaderNode is null)
                 continue;
 
             if (!result.TryGetValue(leaderNode.NodeId, out var list))
             {
-                list = [];
+                if (reusable is not null && _sparePartitionGroups.Count != 0)
+                {
+                    var last = _sparePartitionGroups.Count - 1;
+                    list = _sparePartitionGroups[last];
+                    _sparePartitionGroups.RemoveAt(last);
+                }
+                else
+                {
+                    list = [];
+                }
                 result[leaderNode.NodeId] = list;
             }
             list.Add(tp);
@@ -2053,42 +2079,38 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         short version)
     {
         var topicMap = new Dictionary<string, (Guid TopicId, List<ShareFetchRequestPartition> Partitions)>();
+        string? currentTopic = null;
+        List<ShareFetchRequestPartition>? currentPartitions = null;
 
         foreach (var tp in partitions)
         {
-            var topicInfo = _metadataManager.Metadata.GetTopic(tp.Topic);
-            if (topicInfo is null)
-                continue;
-
-            if (!topicMap.TryGetValue(tp.Topic, out var entry))
+            // Assigned partitions commonly arrive in topic runs. Keep the current
+            // request entry without hashing the same topic for every partition.
+            if (currentPartitions is null || currentTopic != tp.Topic)
             {
-                entry = (topicInfo.TopicId, []);
-                topicMap[tp.Topic] = entry;
-            }
-
-            List<ShareFetchAcknowledgementBatch>? ackBatches = null;
-            if (pendingAcks is not null && pendingAcks.TryGetValue(tp, out var batchDataList))
-            {
-                ackBatches = new List<ShareFetchAcknowledgementBatch>(batchDataList.Count);
-                foreach (var bd in batchDataList)
+                if (!topicMap.TryGetValue(tp.Topic, out var entry))
                 {
-                    ackBatches.Add(new ShareFetchAcknowledgementBatch
-                    {
-                        FirstOffset = bd.FirstOffset,
-                        LastOffset = bd.LastOffset,
-                        AcknowledgeTypes = bd.AcknowledgeTypes
-                    });
+                    var topicInfo = _metadataManager.Metadata.GetTopic(tp.Topic);
+                    if (topicInfo is null)
+                        continue;
+                    entry = (topicInfo.TopicId, []);
+                    topicMap[tp.Topic] = entry;
                 }
+                currentTopic = tp.Topic;
+                currentPartitions = entry.Partitions;
             }
+
+            List<AcknowledgementBatchData>? ackBatches = null;
+            pendingAcks?.TryGetValue(tp, out ackBatches);
 
             var fetchPartition = new ShareFetchRequestPartition
             {
                 PartitionIndex = tp.Partition,
                 PartitionMaxBytes = version == 0 ? _options.MaxPartitionFetchBytes : 0,
-                AcknowledgementBatches = ackBatches
+                AcknowledgementData = ackBatches
             };
 
-            entry.Partitions.Add(fetchPartition);
+            currentPartitions.Add(fetchPartition);
         }
 
         var topics = new List<ShareFetchRequestTopic>(topicMap.Count);
@@ -2111,13 +2133,24 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         if (pendingAcks is null)
             return null;
 
+        // The common single-broker case already owns exactly this snapshot. Reuse it
+        // only after checking membership, including missing leaders and revoked partitions.
+        var matched = 0;
+        foreach (var partition in partitions)
+            if (pendingAcks.ContainsKey(partition))
+                matched++;
+        if (matched == pendingAcks.Count)
+            return pendingAcks;
+        if (matched == 0)
+            return null;
+
         Dictionary<TopicPartition, List<AcknowledgementBatchData>>? selected = null;
         foreach (var partition in partitions)
         {
             if (!pendingAcks.TryGetValue(partition, out var batches))
                 continue;
 
-            selected ??= [];
+            selected ??= new(matched);
             selected[partition] = batches;
         }
 
@@ -2435,13 +2468,13 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
         {
             foreach (var batch in batches)
             {
-                for (var i = 0; i < batch.AcknowledgeTypes.Length; i++)
+                for (var i = 0; i < batch.OffsetCount; i++)
                 {
                     var key = new RenewedRecordKey(
                         topicPartition.Topic,
                         topicPartition.Partition,
                         batch.FirstOffset + i);
-                    var type = (AcknowledgeType)batch.AcknowledgeTypes[i];
+                    var type = (AcknowledgeType)batch.GetAcknowledgeType(i);
                     if (type == AcknowledgeType.Renew)
                     {
                         if (_renewedRecords.TryGetValue(key, out var state))
@@ -2711,7 +2744,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> :
                 {
                     FirstOffset = bd.FirstOffset,
                     LastOffset = bd.LastOffset,
-                    AcknowledgeTypes = bd.AcknowledgeTypes
+                    AcknowledgeTypes = bd.PublicAcknowledgeTypes
                 });
             }
 

--- a/src/Dekaf/ShareConsumer/ShareAcknowledgedOffsets.cs
+++ b/src/Dekaf/ShareConsumer/ShareAcknowledgedOffsets.cs
@@ -7,6 +7,7 @@ public readonly struct ShareAcknowledgedOffsets
 {
     private readonly List<AcknowledgementBatchData>? _batches;
     private readonly bool _hasGaps;
+    private readonly bool _requiresOffsetScan;
 
     internal ShareAcknowledgedOffsets(List<AcknowledgementBatchData> batches)
     {
@@ -14,20 +15,24 @@ public readonly struct ShareAcknowledgedOffsets
 
         var length = 0;
         var hasGaps = false;
+        var hasCompactRanges = false;
         for (var i = 0; i < batches.Count; i++)
         {
-            var types = batches[i].AcknowledgeTypes;
-            var count = types.Length;
+            var batch = batches[i];
+            var types = batch.AcknowledgeTypes;
+            var count = batch.OffsetCount;
+            hasCompactRanges |= count != types.Length;
             var firstGap = types.AsSpan().IndexOf((byte)AcknowledgeType.Gap);
             if (firstGap >= 0)
             {
                 hasGaps = true;
-                count -= CountGaps(types.AsSpan(firstGap));
+                count -= types.Length == 1 ? count : CountGaps(types.AsSpan(firstGap));
             }
             length = checked(length + count);
         }
 
         _hasGaps = hasGaps;
+        _requiresOffsetScan = hasGaps || hasCompactRanges;
         Length = length;
     }
 
@@ -52,17 +57,18 @@ public readonly struct ShareAcknowledgedOffsets
             ArgumentOutOfRangeException.ThrowIfNegative(index);
             ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Length);
 
-            if (_hasGaps)
+            if (_requiresOffsetScan)
                 return GetSparseOffset(_batches!, index);
 
             var batches = _batches!;
             for (var batchIndex = 0; batchIndex < batches.Count; batchIndex++)
             {
                 var batch = batches[batchIndex];
-                if (index < batch.AcknowledgeTypes.Length)
+                var count = batch.AcknowledgeTypes.Length;
+                if (index < count)
                     return batch.FirstOffset + index;
 
-                index -= batch.AcknowledgeTypes.Length;
+                index -= count;
             }
 
             throw new InvalidOperationException("Offset index was not present in the acknowledgement batches.");
@@ -76,6 +82,15 @@ public readonly struct ShareAcknowledgedOffsets
         {
             var batch = batches[batchIndex];
             var types = batch.AcknowledgeTypes;
+            if (types.Length == 1)
+            {
+                if (types[0] == (byte)AcknowledgeType.Gap)
+                    continue;
+                if (index < batch.OffsetCount)
+                    return batch.FirstOffset + index;
+                index -= batch.OffsetCount;
+                continue;
+            }
             var offset = 0;
             // Keep short logical suffixes scalar so counting setup stays amortized over a prefix.
             while (index >= 16 && offset < types.Length)
@@ -130,8 +145,19 @@ public readonly struct ShareAcknowledgedOffsets
         for (var batchIndex = 0; batchIndex < batches.Count; batchIndex++)
         {
             var batch = batches[batchIndex];
-            for (var offsetIndex = 0; offsetIndex < batch.AcknowledgeTypes.Length; offsetIndex++)
-                if (!_hasGaps || batch.AcknowledgeTypes[offsetIndex] != (byte)AcknowledgeType.Gap)
+            var types = batch.AcknowledgeTypes;
+            if (types.Length == 1)
+            {
+                if (types[0] != (byte)AcknowledgeType.Gap)
+                {
+                    var count = batch.OffsetCount;
+                    for (var offsetIndex = 0; offsetIndex < count; offsetIndex++)
+                        destination[index++] = batch.FirstOffset + offsetIndex;
+                }
+                continue;
+            }
+            for (var offsetIndex = 0; offsetIndex < types.Length; offsetIndex++)
+                if (!_hasGaps || types[offsetIndex] != (byte)AcknowledgeType.Gap)
                     destination[index++] = batch.FirstOffset + offsetIndex;
         }
     }
@@ -150,6 +176,9 @@ public readonly struct ShareAcknowledgedOffsets
         private readonly bool _hasGaps;
         private int _batchIndex;
         private int _offsetIndex;
+        private int _offsetCount;
+        private long _firstOffset;
+        private byte[]? _types;
 
         internal Enumerator(List<AcknowledgementBatchData>? batches, bool hasGaps)
         {
@@ -157,6 +186,9 @@ public readonly struct ShareAcknowledgedOffsets
             _hasGaps = hasGaps;
             _batchIndex = 0;
             _offsetIndex = -1;
+            _offsetCount = 0;
+            _firstOffset = 0;
+            _types = null;
             Current = default;
         }
 
@@ -170,23 +202,39 @@ public readonly struct ShareAcknowledgedOffsets
         /// </summary>
         public bool MoveNext()
         {
-            var batches = _batches;
-            while (batches is not null && _batchIndex < batches.Count)
+            while (true)
             {
-                var batch = batches[_batchIndex];
-                while (++_offsetIndex < batch.AcknowledgeTypes.Length)
+                while (++_offsetIndex < _offsetCount)
                 {
-                    if (_hasGaps && batch.AcknowledgeTypes[_offsetIndex] == (byte)AcknowledgeType.Gap)
+                    if (_types is not null && _types[_offsetIndex] == (byte)AcknowledgeType.Gap)
                         continue;
-                    Current = batch.FirstOffset + _offsetIndex;
+                    Current = _firstOffset + _offsetIndex;
                     return true;
                 }
 
-                _batchIndex++;
+                if (!MoveToNextBatch())
+                    return false;
+            }
+        }
+
+        // Resolve compact ranges and gap-free batches only at the batch boundary.
+        private bool MoveToNextBatch()
+        {
+            var batches = _batches;
+            if (batches is null || _batchIndex >= batches.Count)
+            {
+                _offsetCount = 0;
                 _offsetIndex = -1;
+                return false;
             }
 
-            return false;
+            var batch = batches[_batchIndex++];
+            var types = batch.AcknowledgeTypes;
+            _offsetCount = types.Length == 1 && types[0] == (byte)AcknowledgeType.Gap ? 0 : batch.OffsetCount;
+            _firstOffset = batch.FirstOffset;
+            _types = _hasGaps && types.Length != 1 ? types : null;
+            _offsetIndex = -1;
+            return true;
         }
     }
 }

--- a/src/Dekaf/ShareConsumer/ShareBatchAcknowledgements.cs
+++ b/src/Dekaf/ShareConsumer/ShareBatchAcknowledgements.cs
@@ -389,9 +389,9 @@ internal sealed class ShareBatchAcknowledgements<TKey, TValue> : IDisposable
                 if (record.Storage is null)
                     continue;
                 var typeIndex = record.Offset - batch.FirstOffset;
-                if ((ulong)typeIndex >= (ulong)batch.AcknowledgeTypes.Length)
+                if ((ulong)typeIndex >= (ulong)batch.OffsetCount)
                     continue;
-                var type = batch.AcknowledgeTypes[typeIndex];
+                var type = batch.GetAcknowledgeType((int)typeIndex);
                 if (type != 0)
                 {
                     record.Storage.Complete(record.Index, type, batch.AcknowledgeTypes, successful);

--- a/tests/Dekaf.Tests.Integration/ShareConsumerSubscriptionTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerSubscriptionTests.cs
@@ -1,4 +1,6 @@
 using Dekaf.Admin;
+using Dekaf.Producer;
+using Dekaf.Serialization;
 using Dekaf.ShareConsumer;
 
 namespace Dekaf.Tests.Integration;
@@ -8,6 +10,57 @@ namespace Dekaf.Tests.Integration;
 [NotInParallel("ShareConsumerKafka42")]
 public sealed class ShareConsumerSubscriptionTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
+    [Test]
+    public async Task ReplacementSubscription_ReleasesOverflowWithoutRedeliveringAcceptedRecords()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);
+        var additional = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        var group = $"share-overflow-{Guid.NewGuid():N}";
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).Build();
+        await admin.IncrementalAlterConfigsAsync(new Dictionary<ConfigResource, IReadOnlyList<ConfigAlter>>
+        {
+            [new ConfigResource { Type = ConfigResourceType.Group, Name = group }] =
+                [ConfigAlter.Set("share.auto.offset.reset", "earliest")]
+        });
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(45));
+        await using var producer = await Kafka.CreateProducer<int, byte[]>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLinger(TimeSpan.FromMinutes(1)).BuildAsync();
+        for (var index = 0; index < 128; index++)
+            await producer.FireAsync(new ProducerMessage<int, byte[]>
+            {
+                Topic = topic, Partition = index % 2, Key = index, Value = [(byte)index]
+            });
+        await producer.FlushAsync(timeout.Token);
+        await using var consumer = await Kafka.CreateShareConsumer<int, ReadOnlyMemory<byte>>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).WithGroupId(group)
+            .WithValueDeserializer(Serializers.RawBytes).WithMaxPollRecords(2)
+            .WithAcknowledgementMode(ShareAcknowledgementMode.Explicit).BuildAsync();
+        consumer.Subscribe(topic);
+        var received = new HashSet<int>();
+        ShareConsumeResult<int, ReadOnlyMemory<byte>> first;
+        await using (var poll = consumer.PollAsync(timeout.Token).GetAsyncEnumerator())
+        {
+            await Assert.That(await poll.MoveNextAsync()).IsTrue();
+            first = poll.Current;
+            received.Add(first.Key);
+            consumer.Acknowledge(first);
+        }
+        consumer.Subscribe(topic, additional);
+        await foreach (var record in consumer.PollAsync(timeout.Token))
+        {
+            await Assert.That(received.Add(record.Key)).IsTrue();
+            await Assert.That(record.Value.Span[0]).IsEqualTo((byte)record.Key);
+            await Assert.That(() => consumer.Acknowledge(first, AcknowledgeType.Renew)).Throws<InvalidOperationException>();
+            consumer.Acknowledge(record);
+            if (received.Count == 128) break;
+        }
+        await Assert.That(received.Count).IsEqualTo(128);
+        await consumer.CommitAsync(timeout.Token);
+        await consumer.CloseAsync(timeout.Token);
+    }
+
     [Test]
     [Arguments(false)]
     [Arguments(true)]

--- a/tests/Dekaf.Tests.Unit/Protocol/ShareFetchMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ShareFetchMessageTests.cs
@@ -9,6 +9,67 @@ namespace Dekaf.Tests.Unit.Protocol;
 /// </summary>
 public sealed class ShareFetchMessageTests
 {
+    [Test]
+    [Arguments((short)0)]
+    [Arguments((short)1)]
+    [Arguments((short)2)]
+    public async Task RequestPartition_InternalAcknowledgementsMatchPublicWireFormat(short version)
+    {
+        var partition = new ShareFetchRequestPartition
+        {
+            PartitionIndex = 3, PartitionMaxBytes = 1024,
+            AcknowledgementData = [new(10, 137, [2]), new(200, 202, [1, 3, 4])]
+        };
+        var direct = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(direct);
+        partition.Write(ref writer, version);
+
+        // Observing the public model must not alter its subsequent serialization.
+        var batches = partition.AcknowledgementBatches!;
+        await Assert.That(batches.Count).IsEqualTo(2);
+        var inspected = new ArrayBufferWriter<byte>();
+        writer = new KafkaProtocolWriter(inspected);
+        partition.Write(ref writer, version);
+        await Assert.That(direct.WrittenSpan.SequenceEqual(inspected.WrittenSpan)).IsTrue();
+
+        var reader = new KafkaProtocolReader(new ReadOnlySequence<byte>(direct.WrittenMemory));
+        var decoded = ShareFetchRequestPartition.Read(ref reader, version);
+        await Assert.That(decoded.AcknowledgementBatches![0].FirstOffset).IsEqualTo(10);
+        await Assert.That(decoded.AcknowledgementBatches[0].LastOffset).IsEqualTo(137);
+        await Assert.That(decoded.AcknowledgementBatches[0].AcknowledgeTypes).IsEquivalentTo(new byte[] { 2 });
+        await Assert.That(decoded.AcknowledgementBatches[1].AcknowledgeTypes).IsEquivalentTo(new byte[] { 1, 3, 4 });
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task RequestPartition_PooledSnapshotRetainsRequestData(bool multipleRanges)
+    {
+        var tracker = new Dekaf.ShareConsumer.AcknowledgementTracker();
+        var topicPartition = new TopicPartition("topic", 0);
+        tracker.TrackDeliveredRecords(topicPartition, 10, 12);
+        if (multipleRanges)
+            tracker.ReleaseUndeliveredRecords(topicPartition, 20, 22);
+        var first = tracker.FlushForPoll();
+        var request = new ShareFetchRequestPartition { AcknowledgementData = first[topicPartition] };
+        tracker.ReturnPollBatches(first);
+        tracker.ReleaseUndeliveredRecords(topicPartition, 100, 200);
+        var second = tracker.FlushForPoll();
+        tracker.ReturnPollBatches(second);
+
+        var batches = request.AcknowledgementBatches!;
+        await Assert.That(batches.Count).IsEqualTo(multipleRanges ? 2 : 1);
+        await Assert.That(batches[0].FirstOffset).IsEqualTo(10);
+        await Assert.That(batches[0].LastOffset).IsEqualTo(12);
+        await Assert.That(batches[0].AcknowledgeTypes).IsEquivalentTo(new byte[] { 1, 1, 1 });
+        if (multipleRanges)
+        {
+            await Assert.That(batches[1].FirstOffset).IsEqualTo(20);
+            await Assert.That(batches[1].LastOffset).IsEqualTo(22);
+            await Assert.That(batches[1].AcknowledgeTypes).IsEquivalentTo(new byte[] { 2 });
+        }
+    }
+
     #region Request Construction
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
@@ -5,6 +5,83 @@ namespace Dekaf.Tests.Unit.ShareConsumer;
 public class AcknowledgementTrackerTests
 {
     [Test]
+    public async Task Flush_DoesNotBorrowOrClearOutstandingPollContainers()
+    {
+        var tracker = new AcknowledgementTracker();
+        var partition = new TopicPartition("topic", 0);
+        tracker.TrackDeliveredRecords(partition, 10, 12);
+        var poll = tracker.FlushForPoll();
+        tracker.TrackDeliveredRecords(partition, 20, 22);
+        var owned = tracker.Flush();
+        tracker.ReturnPollBatches(owned);
+        await Assert.That(poll[partition][0].FirstOffset).IsEqualTo(10);
+        tracker.ReturnPollBatches(poll);
+        tracker.TrackDeliveredRecords(partition, 30, 32);
+        var nextPoll = tracker.FlushForPoll();
+        tracker.ReturnPollBatches(nextPoll);
+        await Assert.That(owned[partition][0].FirstOffset).IsEqualTo(20);
+        await Assert.That(owned[partition][0].LastOffset).IsEqualTo(22);
+    }
+
+    [Test]
+    public async Task FlushForPoll_DoesNotReuseAnOutstandingSnapshot()
+    {
+        var tracker = new AcknowledgementTracker();
+        var partition = new TopicPartition("topic", 0);
+        tracker.TrackDeliveredRecords(partition, 10, 12);
+        var first = tracker.FlushForPoll();
+        tracker.TrackDeliveredRecords(partition, 20, 22);
+        var second = tracker.FlushForPoll();
+        tracker.ReturnPollBatches(second);
+        await Assert.That(first[partition][0].FirstOffset).IsEqualTo(10);
+        tracker.ReturnPollBatches(first);
+        await Assert.That(second[partition][0].FirstOffset).IsEqualTo(20);
+    }
+
+    [Test]
+    public async Task FlushForPoll_MaterializationFailureReturnsTemporaryContainers()
+    {
+        var tracker = new AcknowledgementTracker();
+        var partition = new TopicPartition("topic", 0);
+        tracker.TrackDeliveredRecords(partition, 0, 1);
+        tracker.TrackDeliveredRecords(new("topic", 1), 0, long.MaxValue);
+        await Assert.That(() => tracker.FlushForPoll()).Throws<OverflowException>();
+        await Assert.That(tracker.HasPending).IsFalse();
+        tracker.TrackDeliveredRecords(partition, 20, 22);
+        var snapshot = tracker.FlushForPoll();
+        await Assert.That(snapshot.Count).IsEqualTo(1);
+        await Assert.That(snapshot[partition][0].FirstOffset).IsEqualTo(20);
+        tracker.ReturnPollBatches(snapshot);
+    }
+
+    [Test]
+    [Arguments(AcknowledgeType.Accept)]
+    [Arguments(AcknowledgeType.Reject)]
+    [Arguments(AcknowledgeType.Renew)]
+    public async Task ReleaseRange_RetryPreservesEveryOffsetAndNewExplicitOutcome(AcknowledgeType outcome)
+    {
+        var tracker = new AcknowledgementTracker();
+        var partition = new TopicPartition("topic", 0);
+        tracker.ReleaseUndeliveredRecords(partition, 100, 227);
+        var submitted = tracker.Flush();
+        var release = submitted[partition][0];
+        await Assert.That(release.AcknowledgeTypes).IsEquivalentTo(new byte[] { 2 });
+        await Assert.That(release.FirstOffset).IsEqualTo(100);
+        await Assert.That(release.LastOffset).IsEqualTo(227);
+
+        tracker.Acknowledge(partition, 150, outcome, requireTracked: false);
+        tracker.RequeueAcks(submitted);
+        var retried = tracker.Flush()[partition];
+        var offsets = new ShareAcknowledgedOffsets(retried);
+        await Assert.That(offsets.Length).IsEqualTo(128);
+        foreach (var batch in retried)
+            for (var index = 0; index < batch.OffsetCount; index++)
+                await Assert.That(batch.GetAcknowledgeType(index)).IsEqualTo(
+                    (byte)(batch.FirstOffset + index == 150 ? outcome : AcknowledgeType.Release));
+        await Assert.That(release.AcknowledgeTypes).IsEquivalentTo(new byte[] { 2 });
+    }
+
+    [Test]
     [Arguments(1)]
     [Arguments(64)]
     public async Task Flush_ReusedStateDoesNotChangePreviousBatchesOrCarryExplicitOutcomes(int partitionCount)

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareAcknowledgedOffsetsTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareAcknowledgedOffsetsTests.cs
@@ -5,6 +5,47 @@ namespace Dekaf.Tests.Unit.ShareConsumer;
 public sealed class ShareAcknowledgedOffsetsTests
 {
     [Test]
+    public async Task OffsetView_EnumeratorSkipsEmptyAndCompactGapBatchesAndStaysExhausted()
+    {
+        List<AcknowledgementBatchData> batches =
+        [
+            new(0, -1, []), new(10, 12, [0]), new(20, 22, [2]),
+            new(30, 32, [0, 1, 0]), new(40, 39, []), new(50, 52, [0])
+        ];
+        var offsets = new ShareAcknowledgedOffsets(batches);
+        long[] expected = [20, 21, 22, 31];
+        var enumerator = offsets.GetEnumerator();
+        foreach (var offset in expected)
+        {
+            await Assert.That(enumerator.MoveNext()).IsTrue();
+            await Assert.That(enumerator.Current).IsEqualTo(offset);
+        }
+        await Assert.That(enumerator.MoveNext()).IsFalse();
+        await Assert.That(enumerator.MoveNext()).IsFalse();
+        var copied = new long[expected.Length];
+        offsets.CopyTo(copied);
+        await Assert.That(copied).IsEquivalentTo(expected);
+    }
+
+    [Test]
+    public async Task OffsetView_CompactRangesPreserveIndexEnumerationAndCopies()
+    {
+        List<AcknowledgementBatchData> batches = [new(10, 12, [2]), new(20, 22, [0]), new(30, 32, [1, 0, 3])];
+        var offsets = new ShareAcknowledgedOffsets(batches);
+        long[] expected = [10, 11, 12, 30, 32];
+        var copy = new long[offsets.Length];
+        offsets.CopyTo(copy);
+        await Assert.That(copy).IsEquivalentTo(expected);
+        var index = 0;
+        foreach (var offset in offsets)
+        {
+            await Assert.That(offset).IsEqualTo(expected[index]);
+            await Assert.That(offsets[index]).IsEqualTo(expected[index++]);
+        }
+        await Assert.That(index).IsEqualTo(expected.Length);
+    }
+
+    [Test]
     [Arguments(false)]
     [Arguments(true)]
     public async Task OffsetView_FirstAccessDoesNotAllocate(bool sparse)

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerPollBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerPollBufferTests.cs
@@ -151,7 +151,7 @@ public sealed partial class ShareConsumerRenewalTests
             await Assert.That(released).HasSingleItem();
             await Assert.That(released[0].FirstOffset).IsEqualTo(44);
             await Assert.That(released[0].LastOffset).IsEqualTo(46);
-            await Assert.That(released[0].AcknowledgeTypes).IsEquivalentTo([(byte)AcknowledgeType.Release, (byte)AcknowledgeType.Release, (byte)AcknowledgeType.Release]);
+            await Assert.That(ExpandAcknowledgementTypes(released[0].FirstOffset, released[0].LastOffset, released[0].AcknowledgeTypes)).IsEquivalentTo([(byte)AcknowledgeType.Release, (byte)AcknowledgeType.Release, (byte)AcknowledgeType.Release]);
         }
         else
         {
@@ -328,7 +328,7 @@ public sealed partial class ShareConsumerRenewalTests
         var released = first.ShareAcknowledgeRequests[0].Topics[0].Partitions[0].AcknowledgementBatches[0];
         await Assert.That(released.FirstOffset).IsEqualTo(101);
         await Assert.That(released.LastOffset).IsEqualTo(102);
-        await Assert.That(released.AcknowledgeTypes)
+        await Assert.That(ExpandAcknowledgementTypes(released.FirstOffset, released.LastOffset, released.AcknowledgeTypes))
             .IsEquivalentTo([(byte)AcknowledgeType.Release, (byte)AcknowledgeType.Release]);
     }
 
@@ -481,7 +481,7 @@ public sealed partial class ShareConsumerRenewalTests
         var secondPartition = pending[new("topic", 1)];
         await Assert.That(secondPartition[0].FirstOffset).IsEqualTo(200);
         await Assert.That(secondPartition[^1].LastOffset).IsEqualTo(201);
-        await Assert.That(secondPartition.SelectMany(static batch => batch.AcknowledgeTypes))
+        await Assert.That(secondPartition.SelectMany(static batch => ExpandAcknowledgementTypes(batch.FirstOffset, batch.LastOffset, batch.AcknowledgeTypes)))
             .IsEquivalentTo([(byte)AcknowledgeType.Release, (byte)AcknowledgeType.Release]);
         await Assert.That(secondFrame.Disposed).IsTrue();
     }

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.AcquisitionReview.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.AcquisitionReview.cs
@@ -9,6 +9,9 @@ namespace Dekaf.Tests.Unit.ShareConsumer;
 
 public sealed partial class ShareConsumerRenewalTests
 {
+    private static IEnumerable<byte> ExpandAcknowledgementTypes(long firstOffset, long lastOffset, IReadOnlyList<byte> types)
+        => types.Count == 1 ? Enumerable.Repeat(types[0], checked((int)(lastOffset - firstOffset + 1))) : types;
+
     [Test]
     [Arguments(false, false, false)]
     [Arguments(true, false, false)]
@@ -67,7 +70,8 @@ public sealed partial class ShareConsumerRenewalTests
         // The first window committed offset 100 before parsing the remaining buffer.
         await Assert.That(released?.FirstOffset ?? inline!.FirstOffset).IsEqualTo(101);
         await Assert.That(released?.LastOffset ?? inline!.LastOffset).IsEqualTo(102);
-        await Assert.That(released?.AcknowledgeTypes ?? inline!.AcknowledgeTypes)
+        await Assert.That(ExpandAcknowledgementTypes(released?.FirstOffset ?? inline!.FirstOffset,
+            released?.LastOffset ?? inline!.LastOffset, released?.AcknowledgeTypes ?? inline!.AcknowledgeTypes))
             .IsEquivalentTo([(byte)AcknowledgeType.Release, (byte)AcknowledgeType.Release]);
     }
 
@@ -98,7 +102,8 @@ public sealed partial class ShareConsumerRenewalTests
         var outcomes = FlushPendingAcknowledgements(fixture.Consumer);
         await Assert.That(outcomes[new("topic", 0)][0].AcknowledgeTypes)
             .IsEquivalentTo([(byte)AcknowledgeType.Accept, (byte)AcknowledgeType.Accept]);
-        await Assert.That(outcomes[new("topic", 1)][0].AcknowledgeTypes)
+        var undisclosed = outcomes[new("topic", 1)][0];
+        await Assert.That(ExpandAcknowledgementTypes(undisclosed.FirstOffset, undisclosed.LastOffset, undisclosed.AcknowledgeTypes))
             .IsEquivalentTo([(byte)AcknowledgeType.Release, (byte)AcknowledgeType.Release]);
     }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgedOffsetsBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgedOffsetsBenchmarks.cs
@@ -20,6 +20,14 @@ public class ShareAcknowledgedOffsetsBenchmarks
         var offsets = new ShareAcknowledgedOffsets(_batches);
         if (offsets.Length != (Sparse ? (RecordCount + 1) / 2 : RecordCount))
             throw new InvalidOperationException("The callback included an unacknowledged offset.");
+        var copy = new long[offsets.Length];
+        offsets.CopyTo(copy);
+        var enumerator = offsets.GetEnumerator();
+        for (var index = 0; index < copy.Length; index++)
+            if (!enumerator.MoveNext() || enumerator.Current != copy[index] || offsets[index] != copy[index])
+                throw new InvalidOperationException("Every access path must preserve batch boundaries.");
+        if (enumerator.MoveNext() || enumerator.MoveNext())
+            throw new InvalidOperationException("An exhausted enumerator must remain exhausted.");
         long expectedSum = 0;
         foreach (var batch in _batches)
             for (var index = 0; index < batch.AcknowledgeTypes.Length; index++)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgementReleaseBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgementReleaseBenchmarks.cs
@@ -51,7 +51,7 @@ public class ShareAcknowledgementReleaseBenchmarks
                 var expected = ExplicitOverrides && index == 0 ? AcknowledgeType.Accept
                     : ExplicitOverrides && index == RecordCount - 1 ? AcknowledgeType.Reject
                     : AcknowledgeType.Release;
-                if (types[index] != (byte)expected)
+                if (types[types.Length == 1 ? 0 : index] != (byte)expected)
                     throw new InvalidOperationException("Explicit dispositions must override the released range.");
             }
         }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgementTrackingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgementTrackingBenchmarks.cs
@@ -9,11 +9,13 @@ public class ShareAcknowledgementTrackingBenchmarks
     private readonly TopicPartition _partition = new("topic", 0);
     private AcknowledgementTracker _tracker = null!;
     private long _offset;
+    private AcknowledgementTracker _flushTracker = null!;
 
     [GlobalSetup]
     public void Setup()
     {
         _tracker = new AcknowledgementTracker();
+        _flushTracker = new AcknowledgementTracker();
         _tracker.TrackDeliveredRecords(_partition, 0, 0);
         _tracker.Acknowledge(_partition, 0, AcknowledgeType.Accept);
     }
@@ -31,6 +33,13 @@ public class ShareAcknowledgementTrackingBenchmarks
     {
         _tracker.Acknowledge(_partition, 0, AcknowledgeType.Accept);
         return _tracker.HasPending;
+    }
+
+    [Benchmark]
+    public int FlushReusedBatch()
+    {
+        _flushTracker.TrackDeliveredRecords(_partition, 0, 999);
+        return _flushTracker.Flush()[_partition][0].AcknowledgeTypes.Length;
     }
 
     [Benchmark]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerPollBufferBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerPollBufferBenchmarks.cs
@@ -49,6 +49,8 @@ public class ShareConsumerPollBufferBenchmarks
     public bool RenewalBuffering { get; set; }
 
     internal int RecordsPerIteration { get; set; }
+    internal bool CommitCallback { get; set; }
+    internal bool SerializeRequests { get; set; }
 
     [GlobalSetup]
     public async Task Setup()
@@ -94,11 +96,12 @@ public class ShareConsumerPollBufferBenchmarks
                 Partitions = partitionResponses
             }]
         };
-        var pool = new Pool(new Connection(response));
+        var pool = new Pool(new Connection(response, SerializeRequests));
         var options = new ShareConsumerOptions
         {
             BootstrapServers = ["localhost:9092"], GroupId = "poll-buffer-benchmark",
             AcknowledgementMode = ShareAcknowledgementMode.Explicit,
+            AcknowledgementCommitCallback = CommitCallback ? static _ => { } : null,
             MaxPollRecords = Overflow ? 16 : _recordCount
         };
         _windowSize = options.MaxPollRecords;
@@ -202,8 +205,9 @@ public class ShareConsumerPollBufferBenchmarks
             => throw new InvalidOperationException("Benchmark deserializer is already prepared.");
     }
 
-    private sealed class Connection(ShareFetchResponse response) : IKafkaConnection, IKafkaCapabilityProvider
+    private sealed class Connection(ShareFetchResponse response, bool serializeRequests) : IKafkaConnection, IKafkaCapabilityProvider
     {
+        private readonly ArrayBufferWriter<byte> _requestBytes = new();
         public int BrokerId => 1;
         public string Host => "localhost";
         public int Port => 9092;
@@ -213,11 +217,20 @@ public class ShareConsumerPollBufferBenchmarks
             ErrorCode = ErrorCode.None, ApiKeys = [new ApiVersion(ApiKey.ShareFetch, 0, 2)]
         });
         public ValueTask<TResponse> SendAsync<TRequest, TResponse>(TRequest request, short version, CancellationToken token = default)
-            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => request switch
+            where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse
+        {
+            if (serializeRequests)
+            {
+                _requestBytes.Clear();
+                var writer = new KafkaProtocolWriter(_requestBytes);
+                request.Write(ref writer, version);
+            }
+            return request switch
             {
                 ShareFetchRequest => ValueTask.FromResult((TResponse)(object)response),
                 _ => throw new NotSupportedException()
             };
+        }
         public ValueTask ConnectAsync(CancellationToken token = default) => ValueTask.CompletedTask;
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
         public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(TRequest request, short version, CancellationToken token = default)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerResubscribeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerResubscribeBenchmarks.cs
@@ -18,12 +18,19 @@ public class ShareConsumerResubscribeBenchmarks
     [Params(false, true)]
     public bool Overflow { get; set; }
 
+    [Params(false, true)]
+    public bool CommitCallback { get; set; }
+
+    [Params(false, true)]
+    public bool SerializeRequests { get; set; }
+
     [GlobalSetup]
     public async Task Setup()
     {
         _poll = new ShareConsumerPollBufferBenchmarks
         {
-            PartitionCount = PartitionCount, Overflow = Overflow
+            PartitionCount = PartitionCount, Overflow = Overflow,
+            CommitCallback = CommitCallback, SerializeRequests = SerializeRequests
         };
         await _poll.Setup();
     }


### PR DESCRIPTION
Replacing a classic share subscription with undisclosed records previously expanded release ranges into per-offset byte arrays and repeatedly materialized acknowledgement collections. This change sends compact release ranges, reuses temporary acknowledgement/routing containers after broker tasks complete, and avoids singleton-list allocation when constructing ShareFetch requests. Retained-topic owner pools and empty record lists survive subscription replacement.

Request descriptors and disposition data remain valid after temporary containers are returned. Commit callbacks keep independent snapshots. Explicit outcomes, full-range retries, acquisition invalidation, borrowed storage lifetime, cancellation, and observed failures remain covered. The added work and savings are per subscription change or fetch/acknowledgement boundary; no per-record allocation, cleanup scan, lock, or thread-pool hop is added. Request construction also avoids repeated topic metadata lookups and hashing within a topic run.

Addresses #3294. Historical timing acceptance remains open until the hosted comparison finishes; this PR does not waive parent #3245's renewal, parsing, lifecycle, or combined loaded acceptance.

Validation:
- Release solution build passed; the core builds for all target frameworks.
- Relevant unit suites passed on net8.0 and net10.0 (447 tests each). Added compact-range retry/callback coverage and retained-request snapshot checks.
- Kafka 4.3.1 subscription, poll-buffer, and close cases passed on both runtimes (13 cases each), including a new overflow replacement test preserving accepted records and invalidating old acquisition tokens. The final subscription-only check also passed on net10.0. The rebase adds upstream tests only; product and benchmark source are unchanged.
- The maintained MemoryDiagnoser fixture now has 16 steady-state cases, including callback and request-serialization controls. Local ShortRun checks passed. Overflow allocation diagnostics fell from approximately 5.35/38.86 KB on fresh main to 2.77/8.23 KB for 1/64 partitions; non-overflow allocation controls also improved. Local historical 64-partition timing still warrants hosted validation; these local results are not an acceptance verdict.
- Normal fresh-main performance gate: [A1/B/A2 run 34683977527](https://github.com/thomhurst/Dekaf/actions/runs/34683977527), REGRESSION for offset access and fresh-tracker allocations, plus a compact-range benchmark setup failure. The CI follow-up below addresses these failures.
- Historical comparison against 689e1bb499963c6445893928231c0c21fd396080: [A1/B/A2 run 34683977097](https://github.com/thomhurst/Dekaf/actions/runs/34683977097), REGRESSION for 64-partition overflow: 11.33 us versus 6.95/6.61 us on repeat. Historical acceptance remains open; this CI fix does not claim to resolve that separate result. This selects the four original shapes (CommitCallback=false, SerializeRequests=false), including both non-overflow controls; the added callback/serialization cases are covered by the fresh-main gate.
- Loaded comparison: hosted-share-1b, cheap dispatch, 5 minutes per A1/B/A2 sample, baseline b8295c5d5c46edd3840525e4d47e147c2dd454c2: [run 34683979011](https://github.com/thomhurst/Dekaf/actions/runs/34683979011), PASS on e41920079. This passing run was not rerun.

The first stress dispatch, [34683667851](https://github.com/thomhurst/Dekaf/actions/runs/34683667851), was INCONCLUSIVE: main advanced after dispatch, and the fresh-main SHA guard stopped the job before builds or measurements. It produced no samples or executed hosted binaries. Its failed/full logs and artifact were retained before the replacement dispatch. The initial historical run [34683666890](https://github.com/thomhurst/Dekaf/actions/runs/34683666890) was cancelled without a verdict when rebasing; its available artifact was retained. No failed performance verdict was rerun unchanged.
Evidence is outside the repository at D:/Dekaf-evidence/issue-3294/: raw local reports/logs, allocation and CPU traces, baseline source archives, copied fixtures, and executed local binaries. Source archives and executed local benchmark binaries are retained. Benchmark runs used 598dd7d4c; rebased head e41920079 has identical product/fixture source and only adds the upstream offset-view tests, which passed on both runtimes. The hosted performance artifact stores reports/logs; it does not retain the runner's executed binaries or complete product checkout. No such hosted binaries are claimed as retained. Early candidate 1's exact source snapshot was not captured before the next edit; its raw reports and executed binaries were retained.


CI follow-up in 15571a8ad:

- Cache offset enumeration state once per batch and retain direct indexing for dense disposition vectors. Offset access remains 0 B per operation; the added cursor state is a value type, with initialization amortized per batch.
- Keep independently owned flushes separate from pooled poll materialization and explicitly allow inlining. This restores stack allocation of temporary trackers: the fresh-tracker fixture returns to 1,776 B/op, matching main, while reused flushes remain 1,344 B/op. These allocations are per flush; per-record tracking remains 0 B.
- Accept both compact and expanded wire dispositions in the release fixture's setup oracle. Add reusable-flush coverage and tests for snapshot ownership, batch boundaries, and stable enumerator exhaustion.
- The core builds for every target framework with no warnings. Relevant unit suites pass on net8.0 and net10.0 (453 tests each); the final offset-only checks also pass (41 each). All 28 cases across the three affected benchmark classes execute successfully in local Short runs. Final offset validation additionally uses the in-process toolchain; local timings are diagnostic, not a hosted acceptance verdict.
- Fresh [performance gate](https://github.com/thomhurst/Dekaf/actions/runs/34689355785) is pending after the push. No thresholds, selection rules, or CI checks were weakened. Local reports and disassembly are outside the repository at D:/Dekaf-evidence/pr-3298-ci/.
