### PR TITLE
test: cover hosted retry and flush cancellation regressions

### DIFF
--- a/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
+++ b/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
@@ -26,6 +26,7 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
     private readonly KafkaConsumerServiceOptions _serviceOptions;
     private readonly object _retryTopicPostponementsLock = new();
     private readonly Dictionary<TopicPartition, RetryTopicPostponement> _retryTopicPostponements = [];
+    private long _retryTopicAssignmentEpoch;
     private IKafkaProducer<byte[]?, byte[]?>? _dlqProducer;
     private int _disposeStarted;
     private volatile bool _hasInDoubtFailedRecord;
@@ -188,6 +189,10 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
             await _consumer.InitializeAsync(stoppingToken).ConfigureAwait(false);
         }
 
+        using var retryRebalanceRegistration = _retryTopicOptions?.IsEnabled == true
+            && _consumer is IConsumerRebalanceEventSource eventSource
+                ? eventSource.RegisterRuntimeRebalanceListener(new RetryTopicRebalanceListener(this))
+                : null;
         var subscriptionTopics = BuildSubscriptionTopics();
         _consumer.Subscribe(subscriptionTopics);
 
@@ -485,7 +490,7 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
                     continue;
                 }
 
-                var deadLetterFailureCount = previousFailureCount + attempt;
+                var deadLetterFailureCount = (int)Math.Min((long)previousFailureCount + attempt, int.MaxValue);
                 var retryTopicFailureCount = GetNextRetryTopicFailureCount(previousFailureCount);
                 var retryTopicOutcome = await TryRouteToRetryTopicAsync(
                         result,
@@ -595,7 +600,8 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
         }
     }
 
-    private static int GetNextRetryTopicFailureCount(int previousFailureCount) => previousFailureCount + 1;
+    private static int GetNextRetryTopicFailureCount(int previousFailureCount) =>
+        previousFailureCount == int.MaxValue ? int.MaxValue : previousFailureCount + 1;
 
     /// <summary>
     /// Sends a DLQ or retry-topic copy, awaiting broker acknowledgment when
@@ -660,37 +666,55 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
             return false;
 
         var partition = new TopicPartition(result.Topic, result.Partition);
-        var postponement = new RetryTopicPostponement(result.Offset, dueAt, delay);
-        if (!TryBeginRetryTopicPostponement(partition, postponement))
-            return true;
+        RetryTopicPostponement postponement;
+        lock (_retryTopicPostponementsLock)
+        {
+            postponement = new RetryTopicPostponement(result.Offset, dueAt, delay, _retryTopicAssignmentEpoch);
+            if (_retryTopicPostponements.TryGetValue(partition, out var pending)
+                && !IsEarlierRetryTopicPostponement(postponement, pending))
+            {
+                return true;
+            }
+
+            _retryTopicPostponements[partition] = postponement;
+            // Serialize the pause/seek with revocation and delayed resume. None of this runs
+            // for ordinary records or retry records whose due time has already passed.
+            _consumer.Partitions.Pause(partition);
+            _consumer.Positions.Seek(new TopicPartitionOffset(
+                result.Topic, result.Partition, result.Offset, result.LeaderEpoch ?? -1));
+        }
 
         LogRetryTopicDelay(result.Topic, result.Partition, result.Offset, delay);
-
-        _consumer.Partitions.Pause(partition);
-        _consumer.Positions.Seek(new TopicPartitionOffset(
-            result.Topic,
-            result.Partition,
-            result.Offset,
-            result.LeaderEpoch ?? -1));
-
         _ = ResumeRetryTopicPartitionAfterDelayAsync(partition, postponement, cancellationToken);
         return true;
     }
 
-    private bool TryBeginRetryTopicPostponement(
-        TopicPartition partition,
-        RetryTopicPostponement postponement)
+    private void InvalidateRetryTopicPostponements(IEnumerable<TopicPartition> partitions)
     {
         lock (_retryTopicPostponementsLock)
         {
-            if (_retryTopicPostponements.TryGetValue(partition, out var pending) &&
-                !IsEarlierRetryTopicPostponement(postponement, pending))
-            {
-                return false;
-            }
+            // The epoch also distinguishes an identical offset/due time replay after reassignment.
+            _retryTopicAssignmentEpoch++;
+            foreach (var partition in partitions)
+                _retryTopicPostponements.Remove(partition);
+        }
+    }
 
-            _retryTopicPostponements[partition] = postponement;
-            return true;
+    private sealed class RetryTopicRebalanceListener(KafkaConsumerService<TKey, TValue> service) : IRebalanceListener
+    {
+        public ValueTask OnPartitionsAssignedAsync(IEnumerable<TopicPartition> partitions, CancellationToken cancellationToken)
+            => default;
+
+        public ValueTask OnPartitionsRevokedAsync(IEnumerable<TopicPartition> partitions, CancellationToken cancellationToken)
+        {
+            service.InvalidateRetryTopicPostponements(partitions);
+            return default;
+        }
+
+        public ValueTask OnPartitionsLostAsync(IEnumerable<TopicPartition> partitions, CancellationToken cancellationToken)
+        {
+            service.InvalidateRetryTopicPostponements(partitions);
+            return default;
         }
     }
 
@@ -707,6 +731,8 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
             }
 
             _retryTopicPostponements.Remove(partition);
+            // Revocation must not run between validating ownership and resuming the partition.
+            _consumer.Partitions.Resume(partition);
             return true;
         }
     }
@@ -733,7 +759,6 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
             if (!TryCompleteRetryTopicPostponement(partition, postponement))
                 return;
 
-            _consumer.Partitions.Resume(partition);
             LogRetryTopicPartitionResumed(partition.Topic, partition.Partition, postponement.Delay);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -766,7 +791,8 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
     private readonly record struct RetryTopicPostponement(
         long Offset,
         DateTimeOffset DueAt,
-        TimeSpan Delay);
+        TimeSpan Delay,
+        long AssignmentEpoch);
 
     private void CaptureRawBytesOnFirstFailure(int attempt, ref byte[]? rawKey, ref byte[]? rawValue)
     {
@@ -775,8 +801,8 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
             _consumer is IRawRecordAccessor accessor &&
             accessor.TryGetCurrentRawRecord(out var rawKeyMemory, out var rawValueMemory))
         {
-            rawKey = rawKeyMemory.IsEmpty ? null : rawKeyMemory.ToArray();
-            rawValue = rawValueMemory.IsEmpty ? null : rawValueMemory.ToArray();
+            rawKey = rawKeyMemory.Equals(default(ReadOnlyMemory<byte>)) ? null : rawKeyMemory.ToArray();
+            rawValue = rawValueMemory.Equals(default(ReadOnlyMemory<byte>)) ? null : rawValueMemory.ToArray();
         }
     }
 
@@ -804,7 +830,7 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
             {
                 Topic = dlqTopic,
                 Key = rawKey,
-                Value = rawValue ?? [],
+                Value = rawValue,
                 Headers = headers
             };
 
@@ -850,7 +876,7 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
             {
                 Topic = retryTopic,
                 Key = rawKey,
-                Value = rawValue ?? [],
+                Value = rawValue,
                 Headers = headers
             };
 

--- a/src/Dekaf/Consumer/DeadLetter/IRawRecordAccessor.cs
+++ b/src/Dekaf/Consumer/DeadLetter/IRawRecordAccessor.cs
@@ -8,6 +8,7 @@ internal interface IRawRecordAccessor
 {
     /// <summary>
     /// Gets the raw key and value bytes for the most recently yielded record.
+    /// Default memory represents null; non-null empty bytes retain an empty array backing store.
     /// Only valid during the current ProcessAsync scope (before MoveNextAsync advances).
     /// </summary>
     /// <returns>True if raw bytes are available; false if tracking is not enabled or no current record.</returns>

--- a/src/Dekaf/Consumer/DeadLetter/RetryTopicHeaders.cs
+++ b/src/Dekaf/Consumer/DeadLetter/RetryTopicHeaders.cs
@@ -64,9 +64,11 @@ public static class RetryTopicHeaders
     /// <summary>
     /// Gets the retry due timestamp from retry headers.
     /// </summary>
+    /// <returns>False when the header is missing, malformed, or outside the DateTimeOffset range.</returns>
     public static bool TryGetDueAt(IReadOnlyList<Header>? headers, out DateTimeOffset dueAt)
     {
-        if (TryGetLong(headers, DueTimestampMsKey, out var timestampMs))
+        if (TryGetLong(headers, DueTimestampMsKey, out var timestampMs)
+            && timestampMs is >= -62135596800000L and <= 253402300799999L)
         {
             dueAt = DateTimeOffset.FromUnixTimeMilliseconds(timestampMs);
             return true;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3396,8 +3396,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             // Store raw byte references for DLQ lazy capture (zero-copy — just memory slices)
                             if (rawTrackingEnabled)
                             {
-                                _currentRawKey = isKeyNull ? ReadOnlyMemory<byte>.Empty : keyData;
-                                _currentRawValue = isValueNull ? ReadOnlyMemory<byte>.Empty : valueData;
+                                _currentRawKey = NormalizeRawRecordBytes(keyData, isKeyNull);
+                                _currentRawValue = NormalizeRawRecordBytes(valueData, isValueNull);
                             }
                         }
                         catch (OperationCanceledException) when (readingProtocolData)
@@ -6170,8 +6170,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                         if (rawTrackingEnabled)
                         {
-                            _currentRawKey = isKeyNull ? ReadOnlyMemory<byte>.Empty : keyData;
-                            _currentRawValue = isValueNull ? ReadOnlyMemory<byte>.Empty : valueData;
+                            _currentRawKey = NormalizeRawRecordBytes(keyData, isKeyNull);
+                            _currentRawValue = NormalizeRawRecordBytes(valueData, isValueNull);
                         }
 
                         return true;
@@ -6478,8 +6478,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                         if (rawTrackingEnabled)
                         {
-                            _currentRawKey = isKeyNull ? ReadOnlyMemory<byte>.Empty : keyData;
-                            _currentRawValue = isValueNull ? ReadOnlyMemory<byte>.Empty : valueData;
+                            _currentRawKey = NormalizeRawRecordBytes(keyData, isKeyNull);
+                            _currentRawValue = NormalizeRawRecordBytes(valueData, isValueNull);
                         }
 
                         return result;
@@ -13562,6 +13562,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     #endregion
 
     #region IRawRecordAccessor
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ReadOnlyMemory<byte> NormalizeRawRecordBytes(ReadOnlyMemory<byte> bytes, bool isNull)
+    {
+        if (isNull)
+            return default;
+        return bytes.IsEmpty ? Array.Empty<byte>() : bytes;
+    }
 
     void DeadLetter.IRawRecordAccessor.EnableRawRecordTracking()
     {

--- a/tests/Dekaf.Tests.Integration/HostedRetryRegressionTests.cs
+++ b/tests/Dekaf.Tests.Integration/HostedRetryRegressionTests.cs
@@ -1,0 +1,74 @@
+using Dekaf.Consumer;
+using Dekaf.Consumer.DeadLetter;
+using Dekaf.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Messaging")]
+public sealed class HostedRetryRegressionTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    [Timeout(90_000)]
+    public async Task FailureRouting_PreservesWireBytes(bool retry, CancellationToken cancellationToken)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var target = topic + (retry ? "-retry-5m" : ".DLQ");
+        await KafkaContainer.CreateTopicAsync(target, partitions: 1);
+        await using var producer = await Kafka.CreateProducer<byte[]?, byte[]?>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).BuildAsync(cancellationToken);
+        var consumer = await Kafka.CreateConsumer<byte[]?, byte[]?>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId($"routing-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest).BuildAsync(cancellationToken);
+        await using var service = new RoutingService(consumer, topic, new DeadLetterOptions
+        {
+            BootstrapServers = KafkaContainer.BootstrapServers,
+            RetryTopics = retry ? new RetryTopicOptions { Delays = [TimeSpan.FromMinutes(5)] } : null
+        });
+        byte[]?[] payloads = [null, [], [0, 128, 255]];
+        await service.StartAsync(cancellationToken);
+        try
+        {
+            foreach (var payload in payloads)
+                await producer.ProduceAsync(topic, payload, payload, cancellationToken);
+
+            await using var verifier = await Kafka.CreateConsumer<byte[]?, byte[]?>()
+                .WithBootstrapServers(KafkaContainer.BootstrapServers)
+                .WithAutoOffsetReset(AutoOffsetReset.Earliest).BuildAsync(cancellationToken);
+            verifier.Assign(new TopicPartition(target, 0));
+            foreach (var expected in payloads)
+            {
+                var record = await verifier.ConsumeOneAsync(TimeSpan.FromSeconds(30), cancellationToken);
+                await Assert.That(record).IsNotNull();
+                if (expected is null)
+                {
+                    await Assert.That(record!.Value.Key).IsNull();
+                    await Assert.That(record.Value.Value).IsNull();
+                }
+                else
+                {
+                    await Assert.That(record!.Value.Key).IsNotNull();
+                    await Assert.That(record.Value.Value).IsNotNull();
+                    await Assert.That(record.Value.Key!.AsSpan().SequenceEqual(expected)).IsTrue();
+                    await Assert.That(record.Value.Value!.AsSpan().SequenceEqual(expected)).IsTrue();
+                }
+            }
+        }
+        finally
+        {
+            await service.StopAsync(cancellationToken);
+        }
+    }
+
+    private sealed class RoutingService(IKafkaConsumer<byte[]?, byte[]?> consumer, string topic, DeadLetterOptions options)
+        : KafkaConsumerService<byte[]?, byte[]?>(consumer, NullLogger.Instance, options,
+            serviceOptions: new KafkaConsumerServiceOptions { DrainOnShutdown = false })
+    {
+        protected override IEnumerable<string> Topics => [topic];
+        protected override ValueTask ProcessAsync(ConsumeResult<byte[]?, byte[]?> result, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("Route the original record bytes.");
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ProducerFlushCancellationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerFlushCancellationTests.cs
@@ -1,0 +1,67 @@
+using Dekaf.Consumer;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Producer")]
+[NotInParallel("ProducerHealthKafkaContainer")]
+[ClassDataSource<ProducerHealthKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class ProducerFlushCancellationTests(ProducerHealthKafkaContainer kafka)
+{
+    [Test]
+    [Timeout(90_000)]
+    public async Task CancelPendingFlush_PreservesOtherWaiterAndDeliversEveryRecord(CancellationToken cancellationToken)
+    {
+        var topic = await kafka.CreateTestTopicAsync();
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithAcks(Acks.All)
+            .WithLinger(TimeSpan.Zero)
+            .WithDeliveryTimeout(TimeSpan.FromSeconds(60))
+            .BuildAsync(cancellationToken);
+        await producer.ProduceAsync(topic, "warmup", "warmup", cancellationToken);
+
+        using var flushCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        Task? survivingFlush = null;
+        await kafka.SetPausedAsync(true);
+        try
+        {
+            // Cached metadata allows append while the paused broker cannot acknowledge delivery.
+            for (var index = 0; index < 10; index++)
+                await producer.FireAsync(topic, $"key-{index}", $"value-{index}");
+
+            var cancelledFlush = producer.FlushAsync(flushCancellation.Token).AsTask();
+            survivingFlush = producer.FlushAsync(cancellationToken).AsTask();
+            await Assert.That(cancelledFlush.IsCompleted).IsFalse();
+            await Assert.That(survivingFlush.IsCompleted).IsFalse();
+
+            await flushCancellation.CancelAsync();
+            await Assert.That(async () => await cancelledFlush.WaitAsync(cancellationToken))
+                .Throws<OperationCanceledException>();
+            await Assert.That(survivingFlush.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            await kafka.SetPausedAsync(false);
+            if (survivingFlush is not null)
+                await survivingFlush.WaitAsync(cancellationToken);
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .BuildAsync(cancellationToken);
+        consumer.Assign(new TopicPartition(topic, 0));
+        var received = new Dictionary<string, string>();
+        while (received.Count < 11)
+        {
+            var record = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(10), cancellationToken);
+            await Assert.That(record).IsNotNull();
+            received.Add(record!.Value.Key!, record.Value.Value);
+        }
+        for (var index = 0; index < 10; index++)
+            await Assert.That(received[$"key-{index}"]).IsEqualTo($"value-{index}");
+        var offsets = await consumer.QueryWatermarkOffsetsAsync(new TopicPartition(topic, 0), cancellationToken);
+        await Assert.That(offsets.High).IsEqualTo(11L);
+    }
+}

--- a/tests/Dekaf.Tests.Integration/RealWorld/ProducerDeliveryGuaranteeTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/ProducerDeliveryGuaranteeTests.cs
@@ -153,52 +153,6 @@ public sealed class ProducerDeliveryGuaranteeTests(KafkaTestContainer kafka) : K
     }
 
     [Test]
-    public async Task FlushWithCancellation_StopsWaitingButDeliveryCompletes()
-    {
-        var topic = await KafkaContainer.CreateTestTopicAsync();
-
-        await using var producer = await Kafka.CreateProducer<string, string>()
-            .WithBootstrapServers(KafkaContainer.BootstrapServers)
-            .WithLinger(TimeSpan.FromMilliseconds(100))
-            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
-            .BuildAsync();
-
-        const int messageCount = 50;
-        for (var i = 0; i < messageCount; i++)
-        {
-            await producer.ProduceAsync(new ProducerMessage<string, string>
-            {
-                Topic = topic,
-                Key = $"key-{i}",
-                Value = $"value-{i}"
-            }, CancellationToken.None);
-        }
-
-        // Give time for messages to send, then flush fully
-        await Task.Delay(500);
-        await producer.FlushWithTimeoutAsync();
-
-        // All messages should be delivered
-        await using var consumer = await Kafka.CreateConsumer<string, string>()
-            .WithBootstrapServers(KafkaContainer.BootstrapServers)
-            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
-            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
-
-        consumer.Assign(new TopicPartition(topic, 0));
-
-        var messages = new List<ConsumeResult<string, string>>();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-
-        await foreach (var msg in consumer.ConsumeAsync(cts.Token))
-        {
-            messages.Add(msg);
-            if (messages.Count >= messageCount) break;
-        }
-
-        await Assert.That(messages).Count().IsEqualTo(messageCount);
-    }
-
-    [Test]
     public async Task SendWithCallback_AllCallbacksInvoked()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.RawTracking.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.RawTracking.cs
@@ -1,0 +1,81 @@
+using Dekaf.Consumer;
+using Dekaf.Consumer.DeadLetter;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed partial class ConsumeOneFastPathTests
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task RawTracking_AfterSuspendedPreparation_PreservesEmptyBytes(bool empty)
+    {
+        ReadOnlyMemory<byte> bytes = empty ? default : "value"u8.ToArray();
+        var fetch = PendingFetchData.Create(Topic, Partition, [CreateBatch(0, new Record
+        {
+            Key = bytes,
+            Value = bytes,
+            IsKeyNull = false,
+            IsValueNull = false
+        })]);
+        var deserializer = new GatedPreparedStringDeserializer();
+        await using var consumer = CreateInitializedConsumerWithDeserializers(fetch, valueDeserializer: deserializer);
+        MarkManualAssignmentCurrent(consumer);
+        var accessor = (IRawRecordAccessor)consumer;
+        accessor.EnableRawRecordTracking();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var consume = consumer.ConsumeOneAsync(TimeSpan.FromSeconds(5), timeout.Token);
+        await deserializer.PreparationStarted.Task.WaitAsync(timeout.Token);
+        await Assert.That(consume.IsCompleted).IsFalse();
+        deserializer.ReleasePreparation();
+
+        await Assert.That(await consume).IsNotNull();
+        await AssertRawBytesAsync(accessor, bytes, isNull: false);
+    }
+
+    [Test]
+    [Arguments(false, 0)]
+    [Arguments(false, 1)]
+    [Arguments(false, 2)]
+    [Arguments(true, 0)]
+    [Arguments(true, 1)]
+    [Arguments(true, 2)]
+    public async Task RawTracking_PreservesWireNullability(bool useIterator, int payloadKind)
+    {
+        ReadOnlyMemory<byte> bytes = payloadKind == 2 ? "value"u8.ToArray() : default;
+        var fetch = PendingFetchData.Create(Topic, Partition, [CreateBatch(0, new Record
+        {
+            Key = bytes,
+            Value = bytes,
+            IsKeyNull = payloadKind == 0,
+            IsValueNull = payloadKind == 0
+        })]);
+        await using var consumer = CreateInitializedConsumer(fetch);
+        var accessor = (IRawRecordAccessor)consumer;
+        accessor.EnableRawRecordTracking();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        if (useIterator)
+        {
+            await using var iterator = consumer.ConsumeAsync(timeout.Token).GetAsyncEnumerator();
+            await Assert.That(await iterator.MoveNextAsync()).IsTrue();
+            await AssertRawBytesAsync(accessor, bytes, payloadKind == 0);
+        }
+        else
+        {
+            await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(5), timeout.Token)).IsNotNull();
+            await AssertRawBytesAsync(accessor, bytes, payloadKind == 0);
+        }
+    }
+
+    private static async Task AssertRawBytesAsync(IRawRecordAccessor accessor, ReadOnlyMemory<byte> bytes, bool isNull)
+    {
+        await Assert.That(accessor.TryGetCurrentRawRecord(out var key, out var value)).IsTrue();
+        await Assert.That(key.Equals(default(ReadOnlyMemory<byte>))).IsEqualTo(isNull);
+        await Assert.That(value.Equals(default(ReadOnlyMemory<byte>))).IsEqualTo(isNull);
+        await Assert.That(key.Span.SequenceEqual(bytes.Span)).IsTrue();
+        await Assert.That(value.Span.SequenceEqual(bytes.Span)).IsTrue();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
-public sealed class ConsumeOneFastPathTests
+public sealed partial class ConsumeOneFastPathTests
 {
     private const string Topic = "test-topic";
     private const int Partition = 0;

--- a/tests/Dekaf.Tests.Unit/Consumer/DeadLetter/RetryTopicHeadersTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/DeadLetter/RetryTopicHeadersTests.cs
@@ -7,6 +7,34 @@ namespace Dekaf.Tests.Unit.Consumer.DeadLetter;
 public sealed class RetryTopicHeadersTests
 {
     [Test]
+    [Arguments(-62135596800000L)]
+    [Arguments(0L)]
+    [Arguments(253402300799999L)]
+    public async Task TryGetDueAt_AcceptsDateTimeOffsetBoundaries(long timestamp)
+    {
+        var headers = new Headers();
+        headers.Add(RetryTopicHeaders.DueTimestampMsKey, timestamp.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        await Assert.That(RetryTopicHeaders.TryGetDueAt(headers.ToList(), out var dueAt)).IsTrue();
+        await Assert.That(dueAt.ToUnixTimeMilliseconds()).IsEqualTo(timestamp);
+    }
+
+    [Test]
+    [Arguments("-62135596800001")]
+    [Arguments("253402300800000")]
+    [Arguments("9223372036854775807")]
+    [Arguments("-9223372036854775808")]
+    [Arguments("not-a-date")]
+    public async Task TryGetDueAt_InvalidTimestamp_ReturnsFalse(string timestamp)
+    {
+        var headers = new Headers();
+        headers.Add(RetryTopicHeaders.DueTimestampMsKey, timestamp);
+
+        await Assert.That(RetryTopicHeaders.TryGetDueAt(headers.ToList(), out var dueAt)).IsFalse();
+        await Assert.That(dueAt).IsEqualTo(default(DateTimeOffset));
+    }
+
+    [Test]
     public async Task Build_IncludesRetryMetadata()
     {
         var dueAt = DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000);

--- a/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.RetryRegressions.cs
+++ b/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.RetryRegressions.cs
@@ -1,0 +1,209 @@
+#if NET10_0_OR_GREATER
+using StringSet = System.Collections.Generic.IReadOnlySet<string>;
+using PartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#else
+using StringSet = System.Collections.Generic.IReadOnlyCollection<string>;
+using PartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#endif
+using Dekaf.Consumer;
+using Dekaf.Consumer.DeadLetter;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Hosting;
+
+public sealed partial class KafkaConsumerServiceTests
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task RetryPostponement_RebalanceInvalidatesOldOwnershipAndPreservesOtherPartitions(bool lost)
+    {
+        var consumer = new RebalanceTestConsumer();
+        var registered = new TaskCompletionSource<IRebalanceListener>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var registration = Substitute.For<IDisposable>();
+        consumer.Register = listener => { registered.TrySetResult(listener); return registration; };
+        consumer.Inner.ConsumeAsync(Arg.Any<CancellationToken>()).Returns(call => WaitForCancellation(call.Arg<CancellationToken>()));
+        await using var service = new TestConsumerService(consumer, ["orders"],
+            options: new Dekaf.Extensions.Hosting.KafkaConsumerServiceOptions { DrainOnShutdown = false },
+            deadLetterOptions: new DeadLetterOptions
+            {
+                RetryTopics = new RetryTopicOptions { Delays = [TimeSpan.FromSeconds(1)] }
+            });
+        using var stopping = new CancellationTokenSource();
+        await service.StartAsync(stopping.Token);
+        try
+        {
+            var listener = await registered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var headers = RetryTopicHeaders.Build(CreateResult("orders"), 1, TimeSpan.FromSeconds(1),
+                DateTimeOffset.UtcNow.AddMinutes(5)).ToList();
+            var revoked = new TopicPartition("orders-retry-1s", 0);
+            var retained = new TopicPartition("orders-retry-1s", 1);
+            var result = CreateResult(revoked.Topic, revoked.Partition, 42, headers);
+            await ProcessWithRetriesAsync(service, result, stopping.Token);
+            await ProcessWithRetriesAsync(service, CreateResult(retained.Topic, retained.Partition, 42, headers), stopping.Token);
+
+            var serviceType = typeof(Dekaf.Extensions.Hosting.KafkaConsumerService<string, string>);
+            var pending = (System.Collections.IDictionary)serviceType.GetField("_retryTopicPostponements",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!.GetValue(service)!;
+            var oldPostponement = pending[revoked]!;
+            var retainedPostponement = pending[retained]!;
+            if (lost)
+                await listener.OnPartitionsLostAsync([revoked], CancellationToken.None);
+            else
+                await listener.OnPartitionsRevokedAsync([revoked], CancellationToken.None);
+            await listener.OnPartitionsAssignedAsync([revoked], CancellationToken.None);
+            await ProcessWithRetriesAsync(service, result, stopping.Token);
+
+            var complete = serviceType.GetMethod("TryCompleteRetryTopicPostponement",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+            await Assert.That((bool)complete.Invoke(service, [revoked, oldPostponement])!).IsFalse();
+            consumer.Partitions.DidNotReceive().Resume(Arg.Any<TopicPartition[]>());
+            await Assert.That(pending.Contains(revoked)).IsTrue();
+            await Assert.That((bool)complete.Invoke(service, [retained, retainedPostponement])!).IsTrue();
+            await Assert.That((bool)complete.Invoke(service, [revoked, pending[revoked]])!).IsTrue();
+            consumer.Partitions.Received(1).Resume(Arg.Is<TopicPartition[]>(partitions => partitions.Length == 1 && partitions[0] == revoked));
+            consumer.Partitions.Received(1).Resume(Arg.Is<TopicPartition[]>(partitions => partitions.Length == 1 && partitions[0] == retained));
+            consumer.Partitions.Received(2).Pause(Arg.Is<TopicPartition[]>(partitions => partitions.Length == 1 && partitions[0] == revoked));
+        }
+        finally
+        {
+            await stopping.CancelAsync();
+            await service.StopAsync(CancellationToken.None);
+        }
+        registration.Received(1).Dispose();
+    }
+
+    [Test]
+    [Arguments(false, 0)]
+    [Arguments(false, 1)]
+    [Arguments(false, 2)]
+    [Arguments(true, 0)]
+    [Arguments(true, 1)]
+    [Arguments(true, 2)]
+    public async Task FailureRouting_PreservesNullEmptyAndNonemptyBytes(bool retry, int payloadKind)
+    {
+        var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions { BootstrapServers = ["localhost:9092"], OffsetCommitMode = OffsetCommitMode.Manual },
+            Serializers.String, Serializers.String);
+        ReadOnlyMemory<byte> bytes = payloadKind switch
+        {
+            0 => default,
+            1 => Array.Empty<byte>(),
+            _ => new byte[] { 0, 128, 255 }
+        };
+        ((IRawRecordAccessor)consumer).EnableRawRecordTracking();
+        var fields = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic;
+        consumer.GetType().GetField("_currentRawKey", fields)!.SetValue(consumer, bytes);
+        consumer.GetType().GetField("_currentRawValue", fields)!.SetValue(consumer, bytes);
+        var producer = Substitute.For<IKafkaProducer<byte[]?, byte[]?>>();
+        ProducerMessage<byte[]?, byte[]?>? sent = null;
+        producer.ProduceAsync(Arg.Any<ProducerMessage<byte[]?, byte[]?>>(), Arg.Any<CancellationToken>())
+            .Returns(call => { sent = call.ArgAt<ProducerMessage<byte[]?, byte[]?>>(0); return new ValueTask<RecordMetadata>(default(RecordMetadata)); });
+        await using var service = new FailingConsumerService(consumer, ["orders"], new DeadLetterOptions
+        {
+            RetryTopics = retry ? new RetryTopicOptions { Delays = [TimeSpan.FromSeconds(1)] } : null
+        });
+        SetDlqProducer(service, producer);
+
+        await ProcessWithRetriesAsync(service, CreateResult("orders"), CancellationToken.None);
+
+        await Assert.That(sent).IsNotNull();
+        await Assert.That(sent!.Topic).IsEqualTo(retry ? "orders-retry-1s" : "orders.DLQ");
+        if (payloadKind == 0)
+        {
+            await Assert.That(sent.Key).IsNull();
+            await Assert.That(sent.Value).IsNull();
+        }
+        else
+        {
+            await Assert.That(sent.Key).IsNotNull();
+            await Assert.That(sent.Value).IsNotNull();
+            await Assert.That(sent.Key!.AsSpan().SequenceEqual(bytes.Span)).IsTrue();
+            await Assert.That(sent.Value!.AsSpan().SequenceEqual(bytes.Span)).IsTrue();
+        }
+    }
+
+    [Test]
+    [Arguments("9223372036854775807")]
+    [Arguments("-9223372036854775808")]
+    [Arguments("253402300800000")]
+    [Arguments("-62135596800001")]
+    [Arguments("invalid")]
+    public async Task InvalidRetryDueTimestamp_DoesNotBypassProcessing(string timestamp)
+    {
+        await using var service = new TestConsumerService(CreateConsumerSubstitute(), ["orders"],
+            deadLetterOptions: new DeadLetterOptions
+            {
+                RetryTopics = new RetryTopicOptions { Delays = [TimeSpan.FromSeconds(1)] }
+            });
+        var result = CreateResult("orders-retry-1s", headers: [new Header(RetryTopicHeaders.DueTimestampMsKey, System.Text.Encoding.UTF8.GetBytes(timestamp))]);
+
+        await ProcessWithRetriesAsync(service, result, CancellationToken.None);
+
+        await Assert.That(service.ProcessedMessages).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task RetryFailureCount_AtMaximum_SaturatesWhenRoutedToDeadLetter(bool retry)
+    {
+        var producer = Substitute.For<IKafkaProducer<byte[]?, byte[]?>>();
+        ProducerMessage<byte[]?, byte[]?>? sent = null;
+        producer.ProduceAsync(Arg.Any<ProducerMessage<byte[]?, byte[]?>>(), Arg.Any<CancellationToken>())
+            .Returns(call => { sent = call.ArgAt<ProducerMessage<byte[]?, byte[]?>>(0); return new ValueTask<RecordMetadata>(default(RecordMetadata)); });
+        await using var service = new FailingConsumerService(CreateConsumerSubstitute(), ["orders"], new DeadLetterOptions
+        {
+            RetryTopics = retry ? new RetryTopicOptions { Delays = [TimeSpan.FromSeconds(1)] } : null
+        });
+        SetDlqProducer(service, producer);
+        var result = CreateResult("orders", headers: [new Header(RetryTopicHeaders.FailureCountKey, "2147483647"u8.ToArray())]);
+
+        await ProcessWithRetriesAsync(service, result, CancellationToken.None);
+
+        await Assert.That(sent).IsNotNull();
+        await Assert.That(sent!.Topic).IsEqualTo("orders.DLQ");
+        await Assert.That(sent.Headers!.GetFirstAsString(DeadLetterHeaders.FailureCountKey)).IsEqualTo("2147483647");
+    }
+    private sealed class RebalanceTestConsumer : IKafkaConsumer<string, string>, IConsumerRebalanceEventSource,
+        IConsumerOffsetStoreTimingConfiguration
+    {
+        internal IKafkaConsumer<string, string> Inner { get; } = Substitute.For<IKafkaConsumer<string, string>>();
+        internal Func<IRebalanceListener, IDisposable> Register { get; set; } = null!;
+        public IDisposable RegisterRuntimeRebalanceListener(IRebalanceListener listener) => Register(listener);
+        public OffsetCommitMode OffsetCommitMode => OffsetCommitMode.Manual;
+        public bool EnableAutoOffsetStore => false;
+        public bool HasConsumerGroup => false;
+        public bool StoresOffsetsOnDelivery => false;
+        public StringSet Subscription => Inner.Subscription;
+        public string? SubscriptionPattern => Inner.SubscriptionPattern;
+        public PartitionSet Assignment => Inner.Assignment;
+        public PartitionSet Paused => Inner.Paused;
+        public string? MemberId => Inner.MemberId;
+        public ConsumerGroupMetadata? ConsumerGroupMetadata => Inner.ConsumerGroupMetadata;
+        public IConsumerPositions Positions => Inner.Positions;
+        public IConsumerPartitions Partitions => Inner.Partitions;
+        public IConsumerOffsets Offsets => Inner.Offsets;
+        public void Subscribe(params string[] topics) => Inner.Subscribe(topics);
+        public void Subscribe(Func<string, bool> filter) => Inner.Subscribe(filter);
+        public void SubscribePattern(string pattern) => Inner.SubscribePattern(pattern);
+        public void Unsubscribe() => Inner.Unsubscribe();
+        public IAsyncEnumerable<ConsumeResult<string, string>> ConsumeAsync(CancellationToken cancellationToken = default) => Inner.ConsumeAsync(cancellationToken);
+        public ValueTask<ConsumeResult<string, string>?> ConsumeOneAsync(TimeSpan timeout, CancellationToken cancellationToken = default) => Inner.ConsumeOneAsync(timeout, cancellationToken);
+        public IAsyncEnumerable<ConsumeBatch<string, string>> ConsumeBatchAsync(CancellationToken cancellationToken = default) => Inner.ConsumeBatchAsync(cancellationToken);
+        public IAsyncEnumerable<ConsumeRawBatch> ConsumeRawBatchAsync(CancellationToken cancellationToken = default) => Inner.ConsumeRawBatchAsync(cancellationToken);
+        public void RegisterMetricForSubscription(Dekaf.Telemetry.ApplicationTelemetryMetric metric) => Inner.RegisterMetricForSubscription(metric);
+        public void UnregisterMetricFromSubscription(string name) => Inner.UnregisterMetricFromSubscription(name);
+        public ValueTask CommitAsync(CancellationToken cancellationToken = default) => Inner.CommitAsync(cancellationToken);
+        public ValueTask CommitAsync(IEnumerable<TopicPartitionOffset> offsets, CancellationToken cancellationToken = default) => Inner.CommitAsync(offsets, cancellationToken);
+        public void StoreOffset(ConsumeResult<string, string> result) => Inner.StoreOffset(result);
+        public void StoreOffset(TopicPartitionOffset offset) => Inner.StoreOffset(offset);
+        public ValueTask InitializeAsync(CancellationToken cancellationToken = default) => Inner.InitializeAsync(cancellationToken);
+        public ValueTask CloseAsync(CancellationToken cancellationToken = default) => Inner.CloseAsync(cancellationToken);
+        public ValueTask CloseAsync(ConsumerCloseOptions options, CancellationToken cancellationToken = default) => Inner.CloseAsync(options, cancellationToken);
+        public ValueTask DisposeAsync() => Inner.DisposeAsync();
+    }
+
+}

--- a/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
@@ -11,7 +11,7 @@ using NSubstitute;
 
 namespace Dekaf.Tests.Unit.Hosting;
 
-public sealed class KafkaConsumerServiceTests
+public sealed partial class KafkaConsumerServiceTests
 {
     #region ExecuteAsync
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerRawTrackingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerRawTrackingBenchmarks.cs
@@ -1,0 +1,72 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Benchmarks.Infrastructure;
+using Dekaf.Consumer;
+using Dekaf.Consumer.DeadLetter;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Steady-state buffered consumption with optional DLQ raw-byte tracking; setup costs are per batch.</summary>
+[MemoryDiagnoser]
+public class ConsumerRawTrackingBenchmarks
+{
+    private const int RecordsPerBatch = 1024;
+    private KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _consumer = null!;
+    private Record[] _records = null!;
+    private Queue<PendingFetchData> _pendingFetches = null!;
+    private long _nextOffset;
+
+    [Params(false, true)]
+    public bool TrackRawBytes { get; set; }
+
+    [Params(0, 1, 100)]
+    public int PayloadKind { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var bytes = PayloadKind > 1 ? new byte[PayloadKind] : Array.Empty<byte>();
+        var records = new Record[RecordsPerBatch];
+        for (var index = 0; index < records.Length; index++)
+            records[index] = new Record
+            {
+                OffsetDelta = index,
+                Key = bytes,
+                Value = bytes,
+                IsKeyNull = PayloadKind == 0,
+                IsValueNull = PayloadKind == 0
+            };
+        _records = records;
+        _consumer = new KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+            new ConsumerOptions { BootstrapServers = ["localhost:9092"], OffsetCommitMode = OffsetCommitMode.Manual },
+            Serializers.RawBytes, Serializers.RawBytes);
+        BufferedConsumerHarness.InitializeForBufferedFastPath(_consumer, "raw-tracking", 0);
+        _pendingFetches = (Queue<PendingFetchData>)BufferedConsumerHarness.GetPrivateField(_consumer, "_pendingFetches")!;
+        if (TrackRawBytes)
+            ((IRawRecordAccessor)_consumer).EnableRawRecordTracking();
+    }
+
+    [Benchmark(OperationsPerInvoke = RecordsPerBatch)]
+    public async ValueTask<long> ConsumeBufferedBatch()
+    {
+        var batch = RecordBatch.RentFromPool();
+        batch.BaseOffset = _nextOffset;
+        batch.LastOffsetDelta = RecordsPerBatch - 1;
+        batch.Records = _records;
+        _pendingFetches.Enqueue(PendingFetchData.Create("raw-tracking", 0, [batch]));
+        _nextOffset += RecordsPerBatch;
+        long lastOffset = -1;
+        for (var index = 0; index < RecordsPerBatch; index++)
+        {
+            var record = await _consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+            lastOffset = record!.Value.Offset;
+        }
+        if (lastOffset != _nextOffset - 1)
+            throw new InvalidOperationException("Buffered batch was not fully consumed.");
+        return lastOffset;
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup() => await _consumer.DisposeAsync();
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/RetryTopicHeaderBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/RetryTopicHeaderBenchmarks.cs
@@ -1,0 +1,30 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Consumer.DeadLetter;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+public class RetryTopicHeaderBenchmarks
+{
+    private IReadOnlyList<Header> _headers = null!;
+
+    [Params(-62135596800000L, 1700000000000L, 253402300799999L)]
+    public long Timestamp { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var headers = new Headers();
+        headers.Add(RetryTopicHeaders.DueTimestampMsKey, Timestamp.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        _headers = headers.ToList();
+    }
+
+    [Benchmark]
+    public DateTimeOffset ReadDueTimestamp()
+    {
+        if (!RetryTopicHeaders.TryGetDueAt(_headers, out var dueAt))
+            throw new InvalidOperationException("Valid retry timestamp was rejected.");
+        return dueAt;
+    }
+}


### PR DESCRIPTION
Adds regression coverage for hosted retry/DLQ payload preservation, malformed retry timestamps, retry-count overflow, rebalance ownership, and cancellation while broker delivery is blocked. The tests exposed bugs, so this PR includes the fixes needed to make the new guarantees pass.

- Preserve null, empty, and nonempty raw keys/values through the consumer fast path, asynchronous preparation, iterator path, and real-broker DLQ/retry routing.
- Treat out-of-range retry timestamps as invalid headers, and saturate cumulative failure counts at `int.MaxValue`.
- Invalidate delayed retry resumptions on revoke/lost callbacks, preserve unaffected partitions, and serialize ownership checks with pause/seek/resume. Dispose the runtime listener registration when the hosted consume loop exits.
- Replace an integration test that never cancelled with a broker-paused test: one pending flush cancels, another remains pending, and every record is delivered after the broker resumes.

Validation:
- `dotnet build --configuration Release`: passed, no warnings or errors.
- Full net10.0 unit suite: 10,685 passed.
- Focused net8.0 consumer/hosting/header suite: 123 passed.
- Hosted service and new broker regression integration suites: 19 passed.
- Both new steady-state MemoryDiagnoser fixtures passed Dry and Short runs (nine cases total).
- Initial regression selection reproduced 14 failures against the baseline before the fixes.

Performance costs: raw tracking normalizes two memory slices per delivered record only when tracking is enabled; it adds no per-message allocation or async work. The raw-tracking fixture reports 0 B/message, with fixture setup amortized per 1,024-record batch. Retry-header parsing retains its existing string decoding allocation (48–56 B per header read in the local fixture); the range check adds no allocation. Raw-byte copying and failure-count arithmetic occur only on processing failure. Listener allocation/registration occurs once per hosted service; cleanup is per revoked partition. Existing postponement synchronization remains limited to delayed retry records. Local timings are diagnostic, not evidence of a speedup.

Loaded validation: [consumer A1/B/A2 stress run](https://github.com/thomhurst/Dekaf/actions/runs/34684312401). Lane: `consumer-1b`; dispatch shape: `cheap`; duration: 5 minutes per sample; baseline: `28a9fa7aab2c36a1a81e65a9046d0ae5b970160d`; candidate: `eed87fbe6c0c355d413e94aec72cabb67ec10b2a`. Verdict: pending (run in progress). This lane protects the ordinary consumer path under load; enabled DLQ raw tracking is exercised by the new microbenchmark and broker integration tests. No performance acceptance is claimed until CI and stress results finish.
