### PR TITLE
ci: balance integration matrix and cover uncategorized tests

### DIFF
--- a/.github/workflows/integration-groups.yml
+++ b/.github/workflows/integration-groups.yml
@@ -32,30 +32,28 @@ jobs:
     name: ${{ matrix.group }} (${{ inputs.framework }}, Kafka ${{ inputs.kafka-tag }})
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    env:
+      # The catch-all derives exclusions from the same map that selects jobs.
+      INTEGRATION_TEST_MATRIX_JSON: ${{ toJSON(matrix) }}
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
         # Keep the longest groups near seven minutes. ShareConsumer is serial
         # within a runner, so its core and remaining tests need separate VMs.
         # Small connection and transaction categories fill otherwise short jobs.
-        group: [connections, resilience, produce, consume, consumer-groups, share-core, share-other, messaging]
+        group: &integration-groups [connections, resilience, produce, consume, consumer-groups, share-core, share-other, messaging, catch-all]
         include:
-          - group: connections
-            categories: Tls,Authentication,Authorization,NetworkPartition,Retry
-          - group: resilience
-            categories: Resilience
-          - group: produce
-            categories: Producer,MultiInFlightProducer,Backpressure,Compression,Transaction
-          - group: consume
-            categories: Consumer,ConsumerLag,Offsets
-          - group: consumer-groups
-            categories: ConsumerGroup,ShareConsumerAdmin
-          - group: share-core
-            categories: ShareConsumerCore
-          - group: share-other
-            categories: ShareConsumerOther
-          - group: messaging
-            categories: Messaging,MessagingPatterns,MessagingOrdering,Serialization,Interop,Telemetry,Admin
+          - groups: *integration-groups
+            categories:
+              connections: Tls,Authentication,Authorization,NetworkPartition,Retry
+              resilience: Resilience
+              produce: Producer,MultiInFlightProducer,Backpressure,Compression,Transaction
+              consume: Consumer,ConsumerLag,Offsets
+              consumer-groups: ConsumerGroup,ShareConsumerAdmin
+              share-core: ShareConsumerCore
+              share-other: ShareConsumerOther
+              messaging: Messaging,MessagingPatterns,MessagingOrdering,Serialization,Interop,Telemetry,Admin
+              catch-all: CatchAll
 
     steps:
       - name: Add Swap Space
@@ -105,6 +103,12 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
             core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
 
+      - name: Verify ShareConsumer shard discovery
+        if: matrix.group == 'share-core'
+        env:
+          KAFKA_TEST_IMAGE_TAG: ${{ inputs.kafka-tag }}
+        run: bash scripts/tests/run-integration-categories-tests.sh --discovery ${{ inputs.framework }}
+
       # Keep the Ryuk image aligned with DotNet.Testcontainers in Directory.Packages.props.
       - name: Pre-pull integration images
         run: |
@@ -122,7 +126,7 @@ jobs:
       - name: Run integration tests
         env:
           KAFKA_TEST_IMAGE_TAG: ${{ inputs.kafka-tag }}
-        run: bash scripts/run-integration-categories.sh ${{ inputs.framework }} "${{ matrix.categories }}"
+        run: bash scripts/run-integration-categories.sh ${{ inputs.framework }} "${{ matrix.categories[matrix.group] }}"
 
       - name: Upload Test Results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/integration-groups.yml
+++ b/.github/workflows/integration-groups.yml
@@ -35,18 +35,25 @@ jobs:
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
-        group: [tls, security, faults, produce, consume, messaging]
+        # Keep the longest groups near seven minutes. ShareConsumer is serial
+        # within a runner, so its core and remaining tests need separate VMs.
+        # Small connection and transaction categories fill otherwise short jobs.
+        group: [connections, resilience, produce, consume, consumer-groups, share-core, share-other, messaging]
         include:
-          - group: tls
-            categories: Tls
-          - group: security
-            categories: Authentication,Authorization
-          - group: faults
-            categories: Transaction,Resilience,NetworkPartition,Retry
+          - group: connections
+            categories: Tls,Authentication,Authorization,NetworkPartition,Retry
+          - group: resilience
+            categories: Resilience
           - group: produce
-            categories: Producer,MultiInFlightProducer,Backpressure,Compression
+            categories: Producer,MultiInFlightProducer,Backpressure,Compression,Transaction
           - group: consume
-            categories: Consumer,ConsumerLag,ConsumerGroup,Offsets,ShareConsumer,ShareConsumerAdmin
+            categories: Consumer,ConsumerLag,Offsets
+          - group: consumer-groups
+            categories: ConsumerGroup,ShareConsumerAdmin
+          - group: share-core
+            categories: ShareConsumerCore
+          - group: share-other
+            categories: ShareConsumerOther
           - group: messaging
             categories: Messaging,MessagingPatterns,MessagingOrdering,Serialization,Interop,Telemetry,Admin
 
@@ -102,11 +109,10 @@ jobs:
       - name: Pre-pull integration images
         run: |
           case "${{ matrix.group }}" in
-            tls|security) kafka_tags=(4.0.2) ;;
-            faults) kafka_tags=("${{ inputs.kafka-tag }}" 4.0.2 4.2.1) ;;
+            connections) kafka_tags=("${{ inputs.kafka-tag }}" 4.0.2) ;;
+            resilience|produce) kafka_tags=("${{ inputs.kafka-tag }}" 4.0.2 4.2.1) ;;
             messaging) kafka_tags=("${{ inputs.kafka-tag }}" 4.0.2) ;;
-            consume) kafka_tags=("${{ inputs.kafka-tag }}" 4.2.1) ;;
-            produce) kafka_tags=("${{ inputs.kafka-tag }}" 4.2.1) ;;
+            consume|consumer-groups) kafka_tags=("${{ inputs.kafka-tag }}" 4.2.1) ;;
             *) kafka_tags=("${{ inputs.kafka-tag }}") ;;
           esac
           bash scripts/prepull-kafka-images.sh \

--- a/scripts/run-integration-categories.sh
+++ b/scripts/run-integration-categories.sh
@@ -49,19 +49,31 @@ for category in "${categories[@]}"; do
     continue
   fi
 
+  # The two ShareConsumer shards partition the original category. Untagged
+  # future tests automatically join ShareConsumerOther, preserving coverage.
+  filter="/**[Category=$category]"
+  case "$category" in
+    ShareConsumerCore)
+      filter="/**[(Category=ShareConsumer)&(Category=ShareConsumerCore)]"
+      ;;
+    ShareConsumerOther)
+      filter="/**[(Category=ShareConsumer)&(Category!=ShareConsumerCore)]"
+      ;;
+  esac
+
   echo "::group::Category $category"
   args=(
     --hangdump
     --hangdump-timeout 5m
     --log-level Debug
-    --treenode-filter "/**[Category=$category]"
+    --treenode-filter "$filter"
     --results-directory "TestResults/$category"
   )
   case "$category" in
     Producer|Compression)
       args+=(--maximum-parallel-tests 4)
       ;;
-    EventHubs|NetworkPartition|ShareConsumer|ShareConsumerAdmin|Serialization)
+    EventHubs|NetworkPartition|ShareConsumer|ShareConsumerCore|ShareConsumerOther|ShareConsumerAdmin|Serialization)
       args+=(--maximum-parallel-tests 1)
       ;;
   esac

--- a/scripts/run-integration-categories.sh
+++ b/scripts/run-integration-categories.sh
@@ -8,8 +8,8 @@
 # Fallback if the apphost lost its executable bit and chmod is unavailable:
 #   dotnet exec tests/Dekaf.Tests.Integration/bin/Release/<tfm>/Dekaf.Tests.Integration.dll <args>
 #
-# Single source of truth for per-category runner arguments (parallelism caps,
-# hang budgets). Every CI lane calls this script, so these settings never drift.
+# Single source of truth for category filters and hang budgets. Every CI lane
+# calls this script. Tests declare shared-resource constraints with NotInParallel.
 set -euo pipefail
 
 if [ $# -ne 2 ]; then
@@ -69,14 +69,6 @@ for category in "${categories[@]}"; do
     --treenode-filter "$filter"
     --results-directory "TestResults/$category"
   )
-  case "$category" in
-    Producer|Compression)
-      args+=(--maximum-parallel-tests 4)
-      ;;
-    EventHubs|NetworkPartition|ShareConsumer|ShareConsumerCore|ShareConsumerOther|ShareConsumerAdmin|Serialization)
-      args+=(--maximum-parallel-tests 1)
-      ;;
-  esac
   "$exe" "${args[@]}"
   echo "::endgroup::"
 done

--- a/scripts/run-integration-categories.sh
+++ b/scripts/run-integration-categories.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Runs Dekaf integration test categories against prebuilt test binaries.
 #
-# Usage: run-integration-categories.sh <net8.0|net10.0|aot> <comma-separated-categories>
+# Usage: run-integration-categories.sh <net8.0|net10.0|aot> <comma-separated-categories> [--list-tests]
 #
 # Expects binaries at tests/Dekaf.Tests.Integration/bin/Release/<tfm>/ (managed)
 # or artifacts/aot/integration/ (NativeAOT), as produced by the CI build job.
@@ -12,8 +12,8 @@
 # calls this script. Tests declare shared-resource constraints with NotInParallel.
 set -euo pipefail
 
-if [ $# -ne 2 ]; then
-  echo "Usage: $0 <net8.0|net10.0|aot> <comma-separated-categories>" >&2
+if { [ $# -ne 2 ] && [ $# -ne 3 ]; } || { [ $# -eq 3 ] && [ "$3" != "--list-tests" ]; }; then
+  echo "Usage: $0 <net8.0|net10.0|aot> <comma-separated-categories> [--list-tests]" >&2
   exit 2
 fi
 
@@ -59,6 +59,34 @@ for category in "${categories[@]}"; do
     ShareConsumerOther)
       filter="/**[(Category=ShareConsumer)&(Category!=ShareConsumerCore)]"
       ;;
+    CatchAll)
+      # EventHubs has a dedicated CI lane outside this matrix. Expand virtual
+      # ShareConsumer shards to their parent so uncategorized/new tests remain
+      # selected without rerunning anything assigned to another job.
+      covered_categories="$(python3 -c 'import json, sys
+matrix = json.load(sys.stdin)
+groups, categories = matrix["groups"], matrix["categories"]
+if not groups or len(groups) != len(set(groups)) or set(groups) != set(categories):
+    sys.exit("Scheduled matrix groups and category map must match exactly")
+print(",".join(categories[group] for group in groups))' \
+        <<< "${INTEGRATION_TEST_MATRIX_JSON:?CatchAll requires the matrix category map}")"
+      IFS=',' read -ra covered <<< "$covered_categories"
+      filter="/**[(Category!=EventHubs)"
+      for excluded in "${covered[@]}"; do
+        case "$excluded" in
+          CatchAll) continue ;;
+          ShareConsumerCore|ShareConsumerOther) excluded=ShareConsumer ;;
+        esac
+        if [[ ! "$excluded" =~ ^[A-Za-z][A-Za-z0-9]*$ ]]; then
+          echo "Invalid matrix category: $excluded" >&2
+          exit 2
+        fi
+        if [[ "$filter" != *"(Category!=$excluded)"* ]]; then
+          filter+="&(Category!=$excluded)"
+        fi
+      done
+      filter+="]"
+      ;;
   esac
 
   echo "::group::Category $category"
@@ -69,6 +97,9 @@ for category in "${categories[@]}"; do
     --treenode-filter "$filter"
     --results-directory "TestResults/$category"
   )
+  if [ "${3:-}" = "--list-tests" ]; then
+    args+=(--list-tests --no-ansi)
+  fi
   "$exe" "${args[@]}"
   echo "::endgroup::"
 done

--- a/scripts/tests/run-integration-categories-tests.sh
+++ b/scripts/tests/run-integration-categories-tests.sh
@@ -34,22 +34,31 @@ grep -q 'Category=Serialization' "$CALLS_FILE"
 : > "$CALLS_FILE"
 bash scripts/run-integration-categories.sh net10.0 "Messaging,Interop,Serialization,EventHubs"
 grep -q 'Category=Interop' "$CALLS_FILE"
-grep -q 'Category=Serialization.*--maximum-parallel-tests 1' "$CALLS_FILE"
-grep -q 'Category=EventHubs.*--maximum-parallel-tests 1' "$CALLS_FILE"
+grep -q 'Category=Serialization' "$CALLS_FILE"
+grep -q 'Category=EventHubs' "$CALLS_FILE"
 
-# Preserve serial execution and the complementary category filters in managed
-# and NativeAOT lanes. The original unsplit category remains available too.
+# Preserve complementary category filters in managed and NativeAOT lanes.
+# The original unsplit category remains available too.
 for framework in net10.0 aot; do
   : > "$CALLS_FILE"
   bash scripts/run-integration-categories.sh "$framework" "ShareConsumer,ShareConsumerCore,ShareConsumerOther"
   [ "$(wc -l < "$CALLS_FILE")" -eq 3 ]
-  grep -Fq -- '--treenode-filter /**[Category=ShareConsumer] --results-directory TestResults/ShareConsumer --maximum-parallel-tests 1' "$CALLS_FILE"
-  grep -Fq -- '--treenode-filter /**[(Category=ShareConsumer)&(Category=ShareConsumerCore)] --results-directory TestResults/ShareConsumerCore --maximum-parallel-tests 1' "$CALLS_FILE"
-  grep -Fq -- '--treenode-filter /**[(Category=ShareConsumer)&(Category!=ShareConsumerCore)] --results-directory TestResults/ShareConsumerOther --maximum-parallel-tests 1' "$CALLS_FILE"
+  grep -Fq -- '--treenode-filter /**[Category=ShareConsumer] --results-directory TestResults/ShareConsumer' "$CALLS_FILE"
+  grep -Fq -- '--treenode-filter /**[(Category=ShareConsumer)&(Category=ShareConsumerCore)] --results-directory TestResults/ShareConsumerCore' "$CALLS_FILE"
+  grep -Fq -- '--treenode-filter /**[(Category=ShareConsumer)&(Category!=ShareConsumerCore)] --results-directory TestResults/ShareConsumerOther' "$CALLS_FILE"
 done
 
-grep -Eq 'MaximumParallelTests[[:space:]]*=>[[:space:]]*4' \
-  "$repo_root/tools/Dekaf.Pipeline/Modules/RunProducerIntegrationTestsModule.cs"
+# Test-owned constraints must apply equally to direct runs, managed CI, and AOT.
+for framework in net10.0 aot; do
+  : > "$CALLS_FILE"
+  bash scripts/run-integration-categories.sh "$framework" "Producer,Compression,EventHubs,NetworkPartition,ShareConsumer,ShareConsumerCore,ShareConsumerOther,ShareConsumerAdmin,Serialization"
+  [ "$(wc -l < "$CALLS_FILE")" -eq 9 ]
+  if grep -Fq -- '--maximum-parallel-tests' "$CALLS_FILE"; then
+    echo "Integration runner overrides test-owned parallelism" >&2
+    exit 1
+  fi
+done
+
 grep -Fq "\"$ryuk_image\"" "$repo_root/.github/workflows/ci.yml"
 grep -Fq "\"$ryuk_image\"" "$repo_root/.github/workflows/integration-groups.yml"
 grep -Fq "\"$eventhubs_image\"" "$repo_root/.github/workflows/ci.yml"

--- a/scripts/tests/run-integration-categories-tests.sh
+++ b/scripts/tests/run-integration-categories-tests.sh
@@ -8,6 +8,51 @@ eventhubs_image="mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.2.1@sha2
 azurite_image="mcr.microsoft.com/azure-storage/azurite:3.36.0@sha256:76b8127d608fab8287a14a4bfeb9a5502cdcffb4bf1e86f09f324ebb0e70edba"
 trap 'rm -rf "$temp_root"' EXIT
 
+# Run against the actual prebuilt executable in CI. Use the production runner
+# so discovery and execution cannot drift to different filters.
+if [ "${1:-}" = "--discovery" ] && [ $# -eq 2 ]; then
+  cd "$repo_root"
+  for category in ShareConsumer ShareConsumerCore ShareConsumerOther; do
+    if ! bash scripts/run-integration-categories.sh "$2" "$category" --list-tests > "$temp_root/$category.txt"; then
+      cat "$temp_root/$category.txt" >&2
+      exit 1
+    fi
+  done
+  python3 - "$temp_root" <<'PY'
+import pathlib
+import re
+import sys
+
+root = pathlib.Path(sys.argv[1])
+
+def discover(category):
+    output = (root / f"{category}.txt").read_text(encoding="utf-8-sig")
+    summary = re.search(r"^Test discovery summary: found (\d+) test\(s\)", output, re.MULTILINE)
+    if summary is None:
+        raise SystemExit(f"{category}: missing discovery summary\n{output}")
+    # MTP lists indented display names before the summary. Reject ambiguous
+    # names and format changes rather than silently collapsing test identities.
+    names = [line.strip() for line in output[:summary.start()].splitlines() if line.startswith("  ")]
+    if not names or len(names) != int(summary[1]) or len(names) != len(set(names)):
+        raise SystemExit(f"{category}: empty, ambiguous, or unrecognized discovery output\n{output}")
+    return set(names)
+
+original = discover("ShareConsumer")
+core = discover("ShareConsumerCore")
+other = discover("ShareConsumerOther")
+overlap = core & other
+missing = original - (core | other)
+extra = (core | other) - original
+if overlap or missing or extra:
+    raise SystemExit(f"Invalid ShareConsumer partition: overlap={sorted(overlap)}, missing={sorted(missing)}, extra={sorted(extra)}")
+print(f"ShareConsumer discovery verified: {len(original)} tests = {len(core)} core + {len(other)} other; no overlap or omissions.")
+PY
+  exit 0
+elif [ $# -ne 0 ]; then
+  echo "Usage: $0 [--discovery <net8.0|net10.0|aot>]" >&2
+  exit 2
+fi
+
 mkdir -p "$temp_root/scripts" \
   "$temp_root/fake-bin" \
   "$temp_root/artifacts/aot/integration" \
@@ -47,6 +92,32 @@ for framework in net10.0 aot; do
   grep -Fq -- '--treenode-filter /**[(Category=ShareConsumer)&(Category=ShareConsumerCore)] --results-directory TestResults/ShareConsumerCore' "$CALLS_FILE"
   grep -Fq -- '--treenode-filter /**[(Category=ShareConsumer)&(Category!=ShareConsumerCore)] --results-directory TestResults/ShareConsumerOther' "$CALLS_FILE"
 done
+
+# Discovery uses the same filters and reaches the runner without executing tests.
+: > "$CALLS_FILE"
+bash scripts/run-integration-categories.sh net10.0 "ShareConsumerCore" --list-tests
+grep -Fq -- '--treenode-filter /**[(Category=ShareConsumer)&(Category=ShareConsumerCore)]' "$CALLS_FILE"
+grep -Fq -- '--list-tests --no-ansi' "$CALLS_FILE"
+if bash scripts/run-integration-categories.sh net10.0 "ShareConsumerCore" --invalid; then
+  echo "Integration runner accepted an unknown discovery option" >&2
+  exit 1
+fi
+
+# The catch-all follows matrix changes, excludes the parent of both share
+# shards, and fails closed if the matrix category map is missing.
+: > "$CALLS_FILE"
+INTEGRATION_TEST_MATRIX_JSON='{"groups":["produce","core","other","future","catch-all"],"categories":{"produce":"Producer","core":"ShareConsumerCore","other":"ShareConsumerOther","future":"FutureCategory","catch-all":"CatchAll"}}' \
+  bash scripts/run-integration-categories.sh net10.0 "CatchAll" --list-tests
+grep -Fq -- '--treenode-filter /**[(Category!=EventHubs)&(Category!=Producer)&(Category!=ShareConsumer)&(Category!=FutureCategory)]' "$CALLS_FILE"
+if INTEGRATION_TEST_MATRIX_JSON= bash scripts/run-integration-categories.sh net10.0 "CatchAll"; then
+  echo "Catch-all accepted a missing matrix category map" >&2
+  exit 1
+fi
+if INTEGRATION_TEST_MATRIX_JSON='{"groups":["catch-all"],"categories":{"produce":"Producer","catch-all":"CatchAll"}}' \
+  bash scripts/run-integration-categories.sh net10.0 "CatchAll"; then
+  echo "Catch-all excluded an unscheduled category" >&2
+  exit 1
+fi
 
 # Test-owned constraints must apply equally to direct runs, managed CI, and AOT.
 for framework in net10.0 aot; do

--- a/scripts/tests/run-integration-categories-tests.sh
+++ b/scripts/tests/run-integration-categories-tests.sh
@@ -37,6 +37,17 @@ grep -q 'Category=Interop' "$CALLS_FILE"
 grep -q 'Category=Serialization.*--maximum-parallel-tests 1' "$CALLS_FILE"
 grep -q 'Category=EventHubs.*--maximum-parallel-tests 1' "$CALLS_FILE"
 
+# Preserve serial execution and the complementary category filters in managed
+# and NativeAOT lanes. The original unsplit category remains available too.
+for framework in net10.0 aot; do
+  : > "$CALLS_FILE"
+  bash scripts/run-integration-categories.sh "$framework" "ShareConsumer,ShareConsumerCore,ShareConsumerOther"
+  [ "$(wc -l < "$CALLS_FILE")" -eq 3 ]
+  grep -Fq -- '--treenode-filter /**[Category=ShareConsumer] --results-directory TestResults/ShareConsumer --maximum-parallel-tests 1' "$CALLS_FILE"
+  grep -Fq -- '--treenode-filter /**[(Category=ShareConsumer)&(Category=ShareConsumerCore)] --results-directory TestResults/ShareConsumerCore --maximum-parallel-tests 1' "$CALLS_FILE"
+  grep -Fq -- '--treenode-filter /**[(Category=ShareConsumer)&(Category!=ShareConsumerCore)] --results-directory TestResults/ShareConsumerOther --maximum-parallel-tests 1' "$CALLS_FILE"
+done
+
 grep -Eq 'MaximumParallelTests[[:space:]]*=>[[:space:]]*4' \
   "$repo_root/tools/Dekaf.Pipeline/Modules/RunProducerIntegrationTestsModule.cs"
 grep -Fq "\"$ryuk_image\"" "$repo_root/.github/workflows/ci.yml"

--- a/tests/Dekaf.Tests.Integration/ConsumerGroupCrashClientProcess.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupCrashClientProcess.cs
@@ -265,8 +265,6 @@ internal sealed class ConsumerGroupCrashClientProcess : IAsyncDisposable
 
         startInfo.ArgumentList.Add("--treenode-filter");
         startInfo.ArgumentList.Add("/*/*/ConsumerGroupCrashClient/*");
-        startInfo.ArgumentList.Add("--maximum-parallel-tests");
-        startInfo.ArgumentList.Add("1");
         startInfo.Environment[EnabledVariable] = "1";
         startInfo.Environment[BootstrapServersVariable] = bootstrapServers;
         startInfo.Environment[TopicVariable] = topic;

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryHttpPipelineIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryHttpPipelineIntegrationTests.cs
@@ -379,6 +379,7 @@ public sealed class SchemaRegistryTlsIntegrationTests
 
         Func<Task> request = async () => _ = await client.GetAllSubjectsAsync();
         await Assert.That(request).Throws<HttpRequestException>();
+        await Assert.That(async () => await server.Completion).Throws<AuthenticationException>();
     }
 
     [Test]
@@ -405,6 +406,7 @@ public sealed class SchemaRegistryTlsIntegrationTests
 
         Func<Task> request = async () => _ = await client.GetAllSubjectsAsync();
         await Assert.That(request).Throws<HttpRequestException>();
+        await Assert.That(async () => await server.Completion).Throws<AuthenticationException>();
     }
 
     [Test]
@@ -694,6 +696,9 @@ public sealed class SchemaRegistryTlsIntegrationTests
         private async Task ServeAsync()
         {
             using var tcpClient = await _listener.AcceptTcpClientAsync(_stopping.Token);
+            // This server handles one connection. Refuse HTTP retries instead of leaving
+            // them queued without a handler after a rejected TLS handshake.
+            _listener.Stop();
             await using var stream = new SslStream(
                 tcpClient.GetStream(),
                 leaveInnerStreamOpen: false,

--- a/tests/Dekaf.Tests.Integration/ShareConsumerBatchTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerBatchTests.cs
@@ -6,6 +6,7 @@ using Dekaf.ShareConsumer;
 namespace Dekaf.Tests.Integration;
 
 [Category("ShareConsumer")]
+[Category("ShareConsumerCore")]
 [SupportsKafka(420)]
 [NotInParallel("ShareConsumerKafka42")]
 public class ShareConsumerBatchTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)

--- a/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
@@ -16,6 +16,7 @@ namespace Dekaf.Tests.Integration;
 /// them to be within the acquisition window.
 /// </summary>
 [Category("ShareConsumer")]
+[Category("ShareConsumerCore")]
 [SupportsKafka(420)]
 [NotInParallel("ShareConsumerKafka42")]
 public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)

--- a/tests/Dekaf.Tests.Integration/TransactionalCrashClientProcess.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionalCrashClientProcess.cs
@@ -264,8 +264,6 @@ internal sealed class TransactionalCrashClientProcess : IAsyncDisposable
 
         startInfo.ArgumentList.Add("--treenode-filter");
         startInfo.ArgumentList.Add("/*/*/TransactionalCrashClient/*");
-        startInfo.ArgumentList.Add("--maximum-parallel-tests");
-        startInfo.ArgumentList.Add("1");
         return startInfo;
     }
 

--- a/tools/Dekaf.Pipeline/Modules/RunCompressionIntegrationTestsModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunCompressionIntegrationTestsModule.cs
@@ -7,6 +7,4 @@ public class RunCompressionIntegrationTestsModule : RunIntegrationTestsModule
     protected override TimeSpan ModuleTimeout => TimeSpan.FromMinutes(30);
 
     protected override TimeSpan ProcessTimeout => TimeSpan.FromMinutes(20);
-
-    protected override int? MaximumParallelTests => 4;
 }

--- a/tools/Dekaf.Pipeline/Modules/RunIntegrationTestsModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunIntegrationTestsModule.cs
@@ -23,8 +23,6 @@ public abstract class RunIntegrationTestsModule : Module<IReadOnlyList<CommandRe
 
     protected virtual TimeSpan ProcessTimeout => TimeSpan.FromMinutes(12);
 
-    protected virtual int? MaximumParallelTests => null;
-
     protected override ModuleConfiguration Configure()
     {
         return new ModuleConfigurationBuilder()
@@ -61,12 +59,6 @@ public abstract class RunIntegrationTestsModule : Module<IReadOnlyList<CommandRe
             "--log-level", "Debug",
             "--treenode-filter", $"/**[Category={Category}]"
         };
-
-        if (MaximumParallelTests is { } maximumParallelTests)
-        {
-            arguments.Add("--maximum-parallel-tests");
-            arguments.Add(maximumParallelTests.ToString(System.Globalization.CultureInfo.InvariantCulture));
-        }
 
         context.Logger.LogInformation("Running integration tests for category: {Category}", Category);
 

--- a/tools/Dekaf.Pipeline/Modules/RunNetworkPartitionIntegrationTestsModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunNetworkPartitionIntegrationTestsModule.cs
@@ -3,5 +3,4 @@ namespace Dekaf.Pipeline.Modules;
 public class RunNetworkPartitionIntegrationTestsModule : RunIntegrationTestsModule
 {
     protected override string Category => "NetworkPartition";
-    protected override int? MaximumParallelTests => 1;
 }

--- a/tools/Dekaf.Pipeline/Modules/RunProducerIntegrationTestsModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunProducerIntegrationTestsModule.cs
@@ -3,6 +3,4 @@ namespace Dekaf.Pipeline.Modules;
 public class RunProducerIntegrationTestsModule : RunIntegrationTestsModule
 {
     protected override string Category => "Producer";
-
-    protected override int? MaximumParallelTests => 4;
 }

--- a/tools/Dekaf.Pipeline/Modules/RunSerializationIntegrationTestsModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunSerializationIntegrationTestsModule.cs
@@ -3,5 +3,4 @@ namespace Dekaf.Pipeline.Modules;
 public class RunSerializationIntegrationTestsModule : RunIntegrationTestsModule
 {
     protected override string Category => "Serialization";
-    protected override int? MaximumParallelTests => 1;
 }

--- a/tools/Dekaf.Pipeline/Modules/RunShareConsumerAdminIntegrationTestsModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunShareConsumerAdminIntegrationTestsModule.cs
@@ -3,5 +3,4 @@ namespace Dekaf.Pipeline.Modules;
 public class RunShareConsumerAdminIntegrationTestsModule : RunIntegrationTestsModule
 {
     protected override string Category => "ShareConsumerAdmin";
-    protected override int? MaximumParallelTests => 1;
 }

--- a/tools/Dekaf.Pipeline/Modules/RunShareConsumerIntegrationTestsModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunShareConsumerIntegrationTestsModule.cs
@@ -3,5 +3,4 @@ namespace Dekaf.Pipeline.Modules;
 public class RunShareConsumerIntegrationTestsModule : RunIntegrationTestsModule
 {
     protected override string Category => "ShareConsumer";
-    protected override int? MaximumParallelTests => 1;
 }


### PR DESCRIPTION
The old integration matrix waits roughly 21 minutes for `consume` while other groups finish in 1-11 minutes. Replace six uneven groups with eight balanced groups plus a catch-all, shared by PR, manual, and release lanes. Remove runner-wide `--maximum-parallel-tests` flags from CI, local pipeline modules, and crash-client launches. Existing `NotInParallel` attributes and the four-test Kafka fixture capacity gate still apply.

Across ten successful matrix runs on September 12, median job times were: consume 20.7 minutes (20.3-21.1), faults 11.4, messaging 7.0, produce 3.9, tls 2.6, and security 1.1. Setup accounts for less than one minute of the median consume job.

| New group | Coverage | Estimated test phase |
| --- | --- | --- |
| connections | Tls, Authentication, Authorization, NetworkPartition, Retry | ~4.0 min |
| resilience | Resilience | ~7.0 min |
| produce | Producer, MultiInFlightProducer, Backpressure, Compression, Transaction | ~5.3 min |
| consume | Consumer, ConsumerLag, Offsets | ~4.6 min |
| consumer-groups | ConsumerGroup, ShareConsumerAdmin | ~4.3 min |
| share-core | ShareConsumerTests, ShareConsumerBatchTests | ~5.8 min |
| share-other | Remaining ShareConsumer tests | ~5.0 min |
| messaging | Existing messaging categories | ~6.1 min |
| catch-all | Everything outside scheduled categories and the dedicated EventHubs lane | New coverage; hosted timing pending |

The ShareConsumer selections are complementary: new untagged ShareConsumer tests automatically enter share-other. The catch-all derives exclusions from the same category map used to select jobs, verifies that the map matches the scheduled groups, and includes new categories and uncategorized tests automatically. It restores 40 tests omitted by the old matrix, including diagnostics, controller bootstrap, and schema-registry HTTP tests. EventHubs remains in its dedicated lane.

The share-core job now runs real TUnit discovery through the production runner for the original ShareConsumer selection and both shards. It checks disjointness, union coverage, nonempty selections, discovery-summary counts, and ambiguous display names. This runs once per framework/broker combination, including release AOT lanes, without adding another runner.

The estimates above use category boundaries from three recent job logs and ShareConsumer class durations from a TUnit artifact, before removal of concurrency caps. They project an integration tail near eight minutes including setup, down from roughly 21, and typical CI completion near 17-18 minutes rather than 29-31. Candidate timings still need CI confirmation, particularly for new catch-all coverage and higher concurrency. This adds three runner setups per framework/broker combination. NativeAOT publish plus smoke already takes about 16 minutes, so further splitting has diminishing benefit for PR completion. Runner queues can remain material.

Evidence: [run 34683977584](https://github.com/thomhurst/Dekaf/actions/runs/34683977584), [run 34682346584](https://github.com/thomhurst/Dekaf/actions/runs/34682346584), [run 34665629646](https://github.com/thomhurst/Dekaf/actions/runs/34665629646). The middle run's `test-results-integration-net10.0-4.3.1-consume` artifact supplies class durations.

Validation:
- Release integration project (net10.0) and pipeline builds: zero warnings/errors.
- Real discovery gate: 53 ShareConsumer tests = 28 core + 25 other, with no overlap or omissions.
- Full-assembly discovery: 1,200 tests = 1,160 assigned to existing categories (including EventHubs) + 40 catch-all tests; disjoint selections and matching multiplicities.
- Local Docker-backed runs without runner caps: Serialization 111/111, EventHubs 7/7, and catch-all 40/40 passed (net10.0, Windows host with Linux containers).
- Runner regression suite passes, including discovery arguments, dynamic catch-all exclusions, missing/mismatched matrix rejection, and absence of concurrency caps.
- actionlint and git diff --check pass. Final changes reviewed for reuse, clarity, and efficiency.
- Full framework/broker execution remains in this PR's CI. No product hot paths change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integration tests now use duration-balanced groups, including dedicated ShareConsumer partitions and catch-all handling.
  * Added test discovery validation for ShareConsumer partitions and support for listing tests by category.

* **Bug Fixes**
  * Improved mutual-TLS failure validation by confirming server-side handshake errors.
  * Prevented rejected TLS connections from remaining queued for retries.

* **Test Execution**
  * Removed runner-enforced parallelism limits so test-owned concurrency settings are respected.
  * Expanded ShareConsumer category coverage for batch and core tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->