### PR TITLE
fix: complete SASL exchanges and close functional coverage gaps

### DIFF
--- a/.github/workflows/integration-groups.yml
+++ b/.github/workflows/integration-groups.yml
@@ -79,6 +79,12 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Install local Kerberos test tools
+        if: matrix.group == 'connections' && inputs.framework != 'net8.0'
+        run: |
+          sudo apt-get update
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y krb5-kdc krb5-admin-server krb5-user
+
       - name: Download test binaries
         if: inputs.framework != 'aot'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/scripts/run-integration-categories.sh
+++ b/scripts/run-integration-categories.sh
@@ -97,6 +97,11 @@ print(",".join(categories[group] for group in groups))' \
     --treenode-filter "$filter"
     --results-directory "TestResults/$category"
   )
+  if [ "$category" = "CatchAll" ]; then
+    # The fallback is empty when every test belongs to an explicit CI category.
+    # MTP exit code 8 means zero tests; assertion and infrastructure failures still fail.
+    args+=(--ignore-exit-code 8)
+  fi
   if [ "${3:-}" = "--list-tests" ]; then
     args+=(--list-tests --no-ansi)
   fi

--- a/scripts/tests/run-integration-categories-tests.sh
+++ b/scripts/tests/run-integration-categories-tests.sh
@@ -91,6 +91,10 @@ for framework in net10.0 aot; do
   grep -Fq -- '--treenode-filter /**[Category=ShareConsumer] --results-directory TestResults/ShareConsumer' "$CALLS_FILE"
   grep -Fq -- '--treenode-filter /**[(Category=ShareConsumer)&(Category=ShareConsumerCore)] --results-directory TestResults/ShareConsumerCore' "$CALLS_FILE"
   grep -Fq -- '--treenode-filter /**[(Category=ShareConsumer)&(Category!=ShareConsumerCore)] --results-directory TestResults/ShareConsumerOther' "$CALLS_FILE"
+  if grep -Fq -- '--ignore-exit-code' "$CALLS_FILE"; then
+    echo "Explicit integration categories must fail when no tests are selected" >&2
+    exit 1
+  fi
 done
 
 # Discovery uses the same filters and reaches the runner without executing tests.
@@ -109,6 +113,7 @@ fi
 INTEGRATION_TEST_MATRIX_JSON='{"groups":["produce","core","other","future","catch-all"],"categories":{"produce":"Producer","core":"ShareConsumerCore","other":"ShareConsumerOther","future":"FutureCategory","catch-all":"CatchAll"}}' \
   bash scripts/run-integration-categories.sh net10.0 "CatchAll" --list-tests
 grep -Fq -- '--treenode-filter /**[(Category!=EventHubs)&(Category!=Producer)&(Category!=ShareConsumer)&(Category!=FutureCategory)]' "$CALLS_FILE"
+grep -Fq -- '--ignore-exit-code 8' "$CALLS_FILE"
 if INTEGRATION_TEST_MATRIX_JSON= bash scripts/run-integration-categories.sh net10.0 "CatchAll"; then
   echo "Catch-all accepted a missing matrix category map" >&2
   exit 1

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -146,6 +146,7 @@ public sealed partial class KafkaConnection :
     private readonly CancellationTokenSourcePool _timeoutCtsPool;
     private readonly ClientTelemetryMetricCollector? _telemetryMetricCollector;
     private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly SaslReauthenticationGate? _reauthenticationGate;
     private readonly SemaphoreSlim _scatterGatherSenderLock = new(1, 1);
     private SocketScatterGatherSender? _scatterGatherSender;
 
@@ -279,6 +280,7 @@ public sealed partial class KafkaConnection :
         _port = port;
         _clientId = clientId;
         _options = options ?? new ConnectionOptions();
+        _reauthenticationGate = _options.SaslMechanism == SaslMechanism.None ? null : new SaslReauthenticationGate();
         var connectionSizes = PoolSizing.ForConnection(_options.MaxInFlightRequestsPerConnection);
         _pendingRequestShards = CreatePendingRequestShards(connectionSizes.PendingRequests);
         _pendingRequestSlots = new SemaphoreSlim(connectionSizes.PendingRequests, connectionSizes.PendingRequests);
@@ -649,20 +651,30 @@ public sealed partial class KafkaConnection :
     // existing callback slot. Constrained calls avoid boxing and per-request observer objects.
     private interface IRequestObservation
     {
+        bool IsReauthentication { get; }
         Action? WriteStartedCallback { get; }
         CancellationToken AfterWriteStarts(CancellationToken cancellationToken);
     }
 
     private readonly struct WriteObservation(Action? callback) : IRequestObservation
     {
+        public bool IsReauthentication => false;
         public Action? WriteStartedCallback => callback;
         public CancellationToken AfterWriteStarts(CancellationToken cancellationToken) => cancellationToken;
     }
 
     private readonly struct CancellationObservation(KafkaRequestWriteContext context) : IRequestObservation
     {
+        public bool IsReauthentication => false;
         public Action? WriteStartedCallback => context.WriteStartedCallback;
         public CancellationToken AfterWriteStarts(CancellationToken cancellationToken) => context.ResponseCancellationToken;
+    }
+
+    private readonly struct ReauthenticationObservation(Action? callback) : IRequestObservation
+    {
+        public bool IsReauthentication => true;
+        public Action? WriteStartedCallback => callback;
+        public CancellationToken AfterWriteStarts(CancellationToken cancellationToken) => cancellationToken;
     }
 
     private async ValueTask<TResponse> SendAsyncCore<TRequest, TResponse, TObservation>(
@@ -686,79 +698,90 @@ public sealed partial class KafkaConnection :
         await _brokerThrottleState.WaitAsync(cancellationToken, _pendingRequestSlotCts.Token)
             .ConfigureAwait(false);
 
-        using var operation = TrackOperation();
-
-        if (requireReady ? !IsConnected : !(_socket?.Connected ?? false))
-            throw new InvalidOperationException("Not connected");
-
-        Touch();
-        var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
-        var headerVersion = KafkaMessageMetadata<TRequest, TResponse>.GetRequestHeaderVersion(apiVersion);
-        var responseHeaderVersion = KafkaMessageMetadata<TRequest, TResponse>.GetResponseHeaderVersion(apiVersion);
-
-        await ReservePendingRequestSlotAsync(cancellationToken).ConfigureAwait(false);
-        var pending = _pendingRequestPool.Rent();
-        var responseMemoryPool = request is FetchRequest fetchRequest
-            ? fetchRequest.ResponseMemoryPool
-            : null;
-        pending.Initialize(
-            responseHeaderVersion,
-            cancellationToken,
-            registerCancellation: false,
-            checkCrcs: request is FetchRequest { CheckCrcs: true },
-            responseMemoryPool: responseMemoryPool);
-        try
-        {
-            AddPendingRequest(correlationId, pending);
-        }
-        catch
-        {
-            ReleasePendingRequestSlot();
-            _pendingRequestPool.Return(pending);
-            throw;
-        }
-
-        ThrowIfDisposedAfterAddingPendingRequest(correlationId);
+        if (_reauthenticationGate is not null && !observation.IsReauthentication)
+            await _reauthenticationGate.EnterAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {
-            var telemetryStartTimestamp = _telemetryMetricCollector is null ? 0 : Stopwatch.GetTimestamp();
+            using var operation = TrackOperation();
 
-            // Write phase
-            LogSendingRequest(KafkaMessageMetadata<TRequest, TResponse>.ApiKey, correlationId, apiVersion, _host, _port);
+            if (requireReady ? !IsConnected : !(_socket?.Connected ?? false))
+                throw new InvalidOperationException("Not connected");
 
-            await PreSerializeAndWriteCoreAsync<TRequest, TResponse, TObservation>(
-                    request,
-                    correlationId,
-                    apiVersion,
-                    headerVersion,
-                    callerOwnsTimeout: false,
-                    observation,
-                    cancellationToken)
-                .ConfigureAwait(false);
+            Touch();
+            var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
+            var headerVersion = KafkaMessageMetadata<TRequest, TResponse>.GetRequestHeaderVersion(apiVersion);
+            var responseHeaderVersion = KafkaMessageMetadata<TRequest, TResponse>.GetResponseHeaderVersion(apiVersion);
 
-            LogRequestSentWaitingForResponse(correlationId);
-
-            cancellationToken = observation.AfterWriteStarts(cancellationToken);
-
-            // Response phase: await response with timeout and parse
-            var response = await AwaitAndParseResponseAsync<TRequest, TResponse>(
-                pending, correlationId, apiVersion, callerOwnsTimeout: false, cancellationToken).ConfigureAwait(false);
-            TouchSuccessful();
-            _telemetryMetricCollector?.RecordRequestLatency(BrokerId, telemetryStartTimestamp);
-            return response;
-        }
-        catch
-        {
-            // Clean up pending request on any failure (write lock cancelled, write failed,
-            // or response error). AwaitAndParseResponseAsync has its own finally that also
-            // tries TryRemove — the second attempt harmlessly returns false.
-            if (TryRemovePendingRequest(correlationId, out var removed))
+            await ReservePendingRequestSlotAsync(cancellationToken).ConfigureAwait(false);
+            var pending = _pendingRequestPool.Rent();
+            var responseMemoryPool = request is FetchRequest fetchRequest
+                ? fetchRequest.ResponseMemoryPool
+                : null;
+            pending.Initialize(
+                responseHeaderVersion,
+                cancellationToken,
+                registerCancellation: false,
+                checkCrcs: request is FetchRequest { CheckCrcs: true },
+                responseMemoryPool: responseMemoryPool);
+            try
             {
-                _pendingRequestPool.Return(removed.Request);
+                AddPendingRequest(correlationId, pending);
+            }
+            catch
+            {
+                ReleasePendingRequestSlot();
+                _pendingRequestPool.Return(pending);
+                throw;
             }
 
-            throw;
+            ThrowIfDisposedAfterAddingPendingRequest(correlationId);
+
+            try
+            {
+                var telemetryStartTimestamp = _telemetryMetricCollector is null ? 0 : Stopwatch.GetTimestamp();
+
+                // Write phase
+                LogSendingRequest(KafkaMessageMetadata<TRequest, TResponse>.ApiKey, correlationId, apiVersion, _host, _port);
+
+                await PreSerializeAndWriteCoreAsync<TRequest, TResponse, TObservation>(
+                        request,
+                        correlationId,
+                        apiVersion,
+                        headerVersion,
+                        callerOwnsTimeout: false,
+                        observation,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
+                LogRequestSentWaitingForResponse(correlationId);
+
+                cancellationToken = observation.AfterWriteStarts(cancellationToken);
+
+                // Response phase: await response with timeout and parse
+                var response = await AwaitAndParseResponseAsync<TRequest, TResponse>(
+                    pending, correlationId, apiVersion, callerOwnsTimeout: false, cancellationToken).ConfigureAwait(false);
+                TouchSuccessful();
+                _telemetryMetricCollector?.RecordRequestLatency(BrokerId, telemetryStartTimestamp);
+                return response;
+            }
+            catch
+            {
+                // Clean up pending request on any failure (write lock cancelled, write failed,
+                // or response error). AwaitAndParseResponseAsync has its own finally that also
+                // tries TryRemove — the second attempt harmlessly returns false.
+                if (TryRemovePendingRequest(correlationId, out var removed))
+                {
+                    _pendingRequestPool.Return(removed.Request);
+                }
+
+                throw;
+            }
+        }
+        finally
+        {
+            if (_reauthenticationGate is not null && !observation.IsReauthentication)
+                _reauthenticationGate.Exit();
         }
     }
 
@@ -935,24 +958,35 @@ public sealed partial class KafkaConnection :
         await _brokerThrottleState.WaitAsync(cancellationToken, _pendingRequestSlotCts.Token)
             .ConfigureAwait(false);
 
-        using var operation = TrackOperation();
+        if (_reauthenticationGate is not null)
+            await _reauthenticationGate.EnterAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!IsConnected)
-            throw new InvalidOperationException("Not connected");
+        try
+        {
+            using var operation = TrackOperation();
 
-        Touch();
-        var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
-        var headerVersion = KafkaMessageMetadata<TRequest, TResponse>.GetRequestHeaderVersion(apiVersion);
+            if (!IsConnected)
+                throw new InvalidOperationException("Not connected");
 
-        // Don't register a pending request - we won't receive a response
+            Touch();
+            var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
+            var headerVersion = KafkaMessageMetadata<TRequest, TResponse>.GetRequestHeaderVersion(apiVersion);
 
-        LogSendingFireAndForgetRequest(KafkaMessageMetadata<TRequest, TResponse>.ApiKey, correlationId, apiVersion, _host, _port);
+            // Don't register a pending request - we won't receive a response
 
-        await PreSerializeAndWriteAsync<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion, cancellationToken, callerOwnsTimeout)
-            .ConfigureAwait(false);
+            LogSendingFireAndForgetRequest(KafkaMessageMetadata<TRequest, TResponse>.ApiKey, correlationId, apiVersion, _host, _port);
 
-        TouchSuccessful();
-        LogFireAndForgetRequestSent(correlationId);
+            await PreSerializeAndWriteAsync<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion, cancellationToken, callerOwnsTimeout)
+                .ConfigureAwait(false);
+
+            TouchSuccessful();
+            LogFireAndForgetRequestSent(correlationId);
+        }
+        finally
+        {
+            if (_reauthenticationGate is not null)
+                _reauthenticationGate.Exit();
+        }
     }
 
     public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
@@ -1061,75 +1095,88 @@ public sealed partial class KafkaConnection :
         await _brokerThrottleState.WaitAsync(cancellationToken, _pendingRequestSlotCts.Token)
             .ConfigureAwait(false);
 
-        using var operation = TrackOperation();
-
-        if (!IsConnected)
-            throw new InvalidOperationException("Not connected");
-
-        Touch();
-        var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
-        var headerVersion = KafkaMessageMetadata<TRequest, TResponse>.GetRequestHeaderVersion(apiVersion);
-        var responseHeaderVersion = KafkaMessageMetadata<TRequest, TResponse>.GetResponseHeaderVersion(apiVersion);
-
-        await ReservePendingRequestSlotAsync(cancellationToken).ConfigureAwait(false);
-        var pending = _pendingRequestPool.Rent();
-        var responseMemoryPool = request is FetchRequest fetchRequest
-            ? fetchRequest.ResponseMemoryPool
-            : null;
-        // The pipelined wrapper performs bounded internal parsing, then only signals the
-        // sender. Resume it in the receive dispatch frame to avoid a ThreadPool round trip.
-        pending.Initialize(
-            responseHeaderVersion,
-            cancellationToken,
-            registerCancellation: false,
-            checkCrcs: request is FetchRequest { CheckCrcs: true },
-            runContinuationsAsynchronously: false,
-            responseMemoryPool: responseMemoryPool);
-        try
-        {
-            AddPendingRequest(correlationId, pending);
-        }
-        catch
-        {
-            ReleasePendingRequestSlot();
-            _pendingRequestPool.Return(pending);
-            throw;
-        }
-
-        ThrowIfDisposedAfterAddingPendingRequest(correlationId);
+        // Admission covers the write only; the response completes separately.
+        // Waiting for a long fetch response here would delay the reauthentication drain.
+        if (_reauthenticationGate is not null)
+            await _reauthenticationGate.EnterAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {
-            var telemetryStartTimestamp = _telemetryMetricCollector is null ? 0 : Stopwatch.GetTimestamp();
+            using var operation = TrackOperation();
 
-            await PreSerializeAndWriteAsync<TRequest, TResponse>(
-                    request,
-                    correlationId,
-                    apiVersion,
-                    headerVersion,
-                    cancellationToken,
-                    callerOwnsTimeout,
-                    requestWriteStarted)
-                .ConfigureAwait(false);
+            if (!IsConnected)
+                throw new InvalidOperationException("Not connected");
 
-            return PooledPipelinedResponse<TRequest, TResponse>.Rent(
-                this,
-                pending,
-                correlationId,
-                apiVersion,
-                callerOwnsTimeout,
-                telemetryStartTimestamp,
-                cancellationToken);
-        }
-        catch
-        {
-            // On failure, ensure we clean up the pending request
-            if (TryRemovePendingRequest(correlationId, out var removed))
+            Touch();
+            var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
+            var headerVersion = KafkaMessageMetadata<TRequest, TResponse>.GetRequestHeaderVersion(apiVersion);
+            var responseHeaderVersion = KafkaMessageMetadata<TRequest, TResponse>.GetResponseHeaderVersion(apiVersion);
+
+            await ReservePendingRequestSlotAsync(cancellationToken).ConfigureAwait(false);
+            var pending = _pendingRequestPool.Rent();
+            var responseMemoryPool = request is FetchRequest fetchRequest
+                ? fetchRequest.ResponseMemoryPool
+                : null;
+            // The pipelined wrapper performs bounded internal parsing, then only signals the
+            // sender. Resume it in the receive dispatch frame to avoid a ThreadPool round trip.
+            pending.Initialize(
+                responseHeaderVersion,
+                cancellationToken,
+                registerCancellation: false,
+                checkCrcs: request is FetchRequest { CheckCrcs: true },
+                runContinuationsAsynchronously: false,
+                responseMemoryPool: responseMemoryPool);
+            try
             {
-                _pendingRequestPool.Return(removed.Request);
+                AddPendingRequest(correlationId, pending);
+            }
+            catch
+            {
+                ReleasePendingRequestSlot();
+                _pendingRequestPool.Return(pending);
+                throw;
             }
 
-            throw;
+            ThrowIfDisposedAfterAddingPendingRequest(correlationId);
+
+            try
+            {
+                var telemetryStartTimestamp = _telemetryMetricCollector is null ? 0 : Stopwatch.GetTimestamp();
+
+                await PreSerializeAndWriteAsync<TRequest, TResponse>(
+                        request,
+                        correlationId,
+                        apiVersion,
+                        headerVersion,
+                        cancellationToken,
+                        callerOwnsTimeout,
+                        requestWriteStarted)
+                    .ConfigureAwait(false);
+
+                return PooledPipelinedResponse<TRequest, TResponse>.Rent(
+                    this,
+                    pending,
+                    correlationId,
+                    apiVersion,
+                    callerOwnsTimeout,
+                    telemetryStartTimestamp,
+                    cancellationToken);
+            }
+            catch
+            {
+                // On failure, ensure we clean up the pending request
+                if (TryRemovePendingRequest(correlationId, out var removed))
+                {
+                    _pendingRequestPool.Return(removed.Request);
+                }
+
+                throw;
+            }
+        }
+        finally
+        {
+            if (_reauthenticationGate is not null)
+                _reauthenticationGate.Exit();
         }
     }
 
@@ -2702,6 +2749,7 @@ public sealed partial class KafkaConnection :
                 Dekaf.MonotonicClock.GetMilliseconds());
         }
 
+        _reauthenticationGate?.Close();
         DisarmReceiveTimeout();
         CancelPendingRequestSlotWaiters();
     }
@@ -3636,9 +3684,11 @@ public sealed partial class KafkaConnection :
                 if (response is null)
                     break;
 
+                // A final client token still needs to reach the broker even if evaluating
+                // the challenge marked the authenticator complete (for example GSSAPI).
                 authBytes = response;
             }
-            while (!authenticator.IsComplete);
+            while (true);
         }
         finally
         {
@@ -3757,8 +3807,8 @@ public sealed partial class KafkaConnection :
     /// <summary>
     /// Performs re-authentication on the existing connection (KIP-368).
     /// Re-authentication uses standard SaslHandshake + SaslAuthenticate API messages sent
-    /// through the normal multiplexed pipeline. The broker handles these in-band with
-    /// other requests per KIP-368.
+    /// through the normal multiplexed pipeline, with application request admission paused
+    /// until the exchange completes, as required by KIP-368.
     /// </summary>
     internal async Task PerformReauthenticationAsync()
     {
@@ -3801,9 +3851,9 @@ public sealed partial class KafkaConnection :
         {
             LogSaslReauthenticationFailed(ex, BrokerId);
 
-            // Don't tear down the connection - let it fail naturally when the broker
-            // rejects requests after session expiry. The connection pool will handle
-            // reconnection at that point.
+            // Credential resolution can fail before the wire exchange starts. The current
+            // session remains usable until expiry. Failures inside the exchange itself
+            // abort the transport before reopening request admission.
         }
         finally
         {
@@ -3828,14 +3878,19 @@ public sealed partial class KafkaConnection :
         var authenticator = await CreateSaslAuthenticatorAsync(cancellationToken).ConfigureAwait(false);
 
         long sessionLifetimeMs = 0;
+        var exchangeStarted = false;
 
         try
         {
-            // Step 1: Send SaslHandshake to negotiate mechanism
-            // Uses the multiplexed pipeline for in-band re-authentication per KIP-368
-            var handshakeResponse = await SendAsync<SaslHandshakeRequest, SaslHandshakeResponse>(
+            await PrepareSaslAuthenticatorAsync(authenticator, cancellationToken).ConfigureAwait(false);
+            if (_reauthenticationGate is not null)
+                await _reauthenticationGate.PauseAsync(cancellationToken).ConfigureAwait(false);
+
+            // A broker expects only SASL messages between handshake and authentication completion.
+            cancellationToken.ThrowIfCancellationRequested();
+            var handshakeResponse = await SendAsyncCore<SaslHandshakeRequest, SaslHandshakeResponse, ReauthenticationObservation>(
                 new SaslHandshakeRequest { Mechanism = authenticator.MechanismName },
-                1,
+                1, requireReady: true, new ReauthenticationObservation(() => exchangeStarted = true),
                 cancellationToken).ConfigureAwait(false);
 
             if (handshakeResponse.ErrorCode != ErrorCode.None)
@@ -3844,9 +3899,6 @@ public sealed partial class KafkaConnection :
                     $"SASL re-auth handshake failed: {handshakeResponse.ErrorCode}. " +
                     $"Supported mechanisms: {string.Join(", ", handshakeResponse.Mechanisms)}");
             }
-
-            // Step 2: Fetch any credentials needed before creating the synchronous initial response.
-            await PrepareSaslAuthenticatorAsync(authenticator, cancellationToken).ConfigureAwait(false);
 
             var authBytes = authenticator.GetInitialResponse();
 
@@ -3857,9 +3909,9 @@ public sealed partial class KafkaConnection :
                 SaslAuthenticateResponse authResponse;
                 try
                 {
-                    authResponse = await SendAsync<SaslAuthenticateRequest, SaslAuthenticateResponse>(
+                    authResponse = await SendAsyncCore<SaslAuthenticateRequest, SaslAuthenticateResponse, ReauthenticationObservation>(
                         new SaslAuthenticateRequest { AuthBytes = sentAuthBytes },
-                        2,
+                        2, requireReady: true, default,
                         cancellationToken).ConfigureAwait(false);
                 }
                 finally
@@ -3886,12 +3938,23 @@ public sealed partial class KafkaConnection :
                 if (response is null)
                     break;
 
+                // A final client token still needs to reach the broker even if evaluating
+                // the challenge marked the authenticator complete (for example GSSAPI).
                 authBytes = response;
             }
-            while (!authenticator.IsComplete);
+            while (true);
+        }
+        catch (Exception ex) when (exchangeStarted)
+        {
+            // Failed or interrupted exchanges cannot safely resume application traffic.
+            // Abort marks the connection disposed, so the outer catch will not log this failure.
+            LogSaslReauthenticationFailed(ex, BrokerId);
+            AbortAfterWriteFailure();
+            throw;
         }
         finally
         {
+            _reauthenticationGate?.Resume();
             (authenticator as IDisposable)?.Dispose();
         }
 
@@ -4425,7 +4488,7 @@ public sealed partial class KafkaConnection :
     [LoggerMessage(Level = LogLevel.Information, Message = "SASL re-authentication successful for broker {BrokerId}. New session lifetime: {SessionLifetimeMs}ms")]
     private partial void LogSaslReauthenticationSuccessful(int brokerId, long sessionLifetimeMs);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "SASL re-authentication failed for broker {BrokerId}. Connection may be terminated by the broker when the session expires")]
+    [LoggerMessage(Level = LogLevel.Error, Message = "SASL re-authentication failed for broker {BrokerId}")]
     private partial void LogSaslReauthenticationFailed(Exception ex, int brokerId);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Disposing connection to broker {BrokerId}: {PendingRequestCount} pending requests")]

--- a/src/Dekaf/Networking/SaslReauthenticationGate.cs
+++ b/src/Dekaf/Networking/SaslReauthenticationGate.cs
@@ -1,0 +1,96 @@
+namespace Dekaf.Networking;
+
+/// <summary>
+/// Stops request admission during a SASL exchange. The uncontended path uses only
+/// atomics; completion sources are allocated once per re-authentication attempt.
+/// The connection serializes calls to PauseAsync/Resume with its re-authentication lock.
+/// </summary>
+internal sealed class SaslReauthenticationGate
+{
+    private TaskCompletionSource<bool>? _resumed;
+    private TaskCompletionSource<bool>? _drained;
+    private int _active;
+    private int _closed;
+
+    // Pair each successful entry with Exit in a finally block. A non-generic ValueTask
+    // reuses the send method's existing awaiter instead of enlarging its async state.
+    public ValueTask EnterAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _closed) != 0, this);
+        return TryEnter() ? ValueTask.CompletedTask : EnterSlowAsync(cancellationToken);
+    }
+
+    private bool TryEnter()
+    {
+        var active = Volatile.Read(ref _active);
+        while (active >= 0)
+        {
+            var observed = Interlocked.CompareExchange(ref _active, active + 1, active);
+            if (observed == active)
+                return true;
+            active = observed;
+        }
+        return false;
+    }
+
+    private async ValueTask EnterSlowAsync(CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _closed) != 0, this);
+            cancellationToken.ThrowIfCancellationRequested();
+            var resumed = Volatile.Read(ref _resumed);
+            if (TryEnter())
+                return;
+            if (resumed is not null)
+                await resumed.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public Task PauseAsync(CancellationToken cancellationToken)
+    {
+        var drained = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Volatile.Write(ref _drained, drained);
+        Volatile.Write(ref _resumed, new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously));
+        var active = Volatile.Read(ref _active);
+        while (true)
+        {
+            var observed = Interlocked.CompareExchange(ref _active, active | int.MinValue, active);
+            if (observed == active)
+                break;
+            active = observed;
+        }
+        if (active == 0 || Volatile.Read(ref _closed) != 0)
+            drained.TrySetResult(true);
+        return drained.Task.WaitAsync(cancellationToken);
+    }
+
+    public void Resume()
+    {
+        // Pause may be cancelled while old requests are still draining. Preserve their count.
+        var active = Volatile.Read(ref _active);
+        while (true)
+        {
+            var observed = Interlocked.CompareExchange(ref _active, active & int.MaxValue, active);
+            if (observed == active)
+                break;
+            active = observed;
+        }
+        Volatile.Write(ref _drained, null);
+        Interlocked.Exchange(ref _resumed, null)?.TrySetResult(true);
+    }
+
+    public void Close()
+    {
+        Volatile.Write(ref _closed, 1);
+        Volatile.Read(ref _drained)?.TrySetResult(true);
+        Volatile.Read(ref _resumed)?.TrySetResult(true);
+    }
+
+    public void Exit()
+    {
+        if (Interlocked.Decrement(ref _active) == int.MinValue)
+            Volatile.Read(ref _drained)?.TrySetResult(true);
+    }
+}

--- a/src/Dekaf/Security/Sasl/GssapiAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/GssapiAuthenticator.cs
@@ -1,5 +1,6 @@
 #if !NETSTANDARD2_0
 using System.Net.Security;
+using System.Buffers;
 #endif
 using Dekaf.Errors;
 
@@ -19,7 +20,7 @@ namespace Dekaf.Security.Sasl;
 /// 1. Client sends SaslHandshake with mechanism "GSSAPI"
 /// 2. Server responds with supported mechanisms
 /// 3. Client initiates GSSAPI token exchange (multi-round)
-/// 4. Once tokens are complete, authentication is established
+/// 4. Exchange the integrity-protected RFC 4752 security-layer offer and selection
 /// </remarks>
 public sealed class GssapiAuthenticator : ISaslAuthenticator, IDisposable
 {
@@ -35,6 +36,7 @@ public sealed class GssapiAuthenticator : ISaslAuthenticator, IDisposable
     {
         Initial,
         TokenExchange,
+        SecurityLayer,
         Complete
     }
 
@@ -93,7 +95,7 @@ public sealed class GssapiAuthenticator : ISaslAuthenticator, IDisposable
 
         if (statusCode == NegotiateAuthenticationStatusCode.Completed)
         {
-            _state = GssapiState.Complete;
+            _state = GssapiState.SecurityLayer;
         }
 
         return outgoingBlob ?? [];
@@ -117,13 +119,32 @@ public sealed class GssapiAuthenticator : ISaslAuthenticator, IDisposable
             return null;
         }
 
+        if (_state == GssapiState.SecurityLayer)
+        {
+            var unwrapped = new ArrayBufferWriter<byte>(4);
+            var unwrapStatus = _auth.Unwrap(challenge, unwrapped, out _);
+            if (unwrapStatus != NegotiateAuthenticationStatusCode.Completed)
+                throw new AuthenticationException($"GSSAPI security-layer offer verification failed: {unwrapStatus}");
+            ValidateSecurityLayerOffer(unwrapped.WrittenSpan);
+
+            // Kafka uses SASL for authentication only. Select no post-authentication
+            // security layer and a zero receive buffer; omit the authorization identity.
+            var wrapped = new ArrayBufferWriter<byte>();
+            var wrapStatus = _auth.Wrap([1, 0, 0, 0], wrapped, requestEncryption: false, out var encrypted);
+            if (wrapStatus != NegotiateAuthenticationStatusCode.Completed || encrypted)
+                throw new AuthenticationException($"GSSAPI security-layer selection failed: {wrapStatus}");
+            _state = GssapiState.Complete;
+            return wrapped.WrittenSpan.ToArray();
+        }
+
         var outgoingBlob = _auth.GetOutgoingBlob(challenge, out var statusCode);
 
         if (statusCode == NegotiateAuthenticationStatusCode.Completed)
         {
-            _state = GssapiState.Complete;
-            // Return any final token if present, otherwise null to indicate completion
-            return outgoingBlob is { Length: > 0 } ? outgoingBlob : null;
+            _state = GssapiState.SecurityLayer;
+            // Even an empty final context token must be sent to obtain the server's
+            // security-layer offer. Kerberos context completion is not SASL completion.
+            return outgoingBlob ?? [];
         }
 
         if (statusCode == NegotiateAuthenticationStatusCode.ContinueNeeded)
@@ -133,6 +154,17 @@ public sealed class GssapiAuthenticator : ISaslAuthenticator, IDisposable
 
         throw new AuthenticationException($"GSSAPI authentication failed: {statusCode}");
 #endif
+    }
+
+    internal static void ValidateSecurityLayerOffer(ReadOnlySpan<byte> offer)
+    {
+        if (offer.Length != 4)
+            throw new AuthenticationException("GSSAPI security-layer offer must contain exactly four bytes.");
+        if ((offer[0] & 1) == 0)
+            throw new AuthenticationException("GSSAPI server does not support authentication without a security layer.");
+        // Kafka's Java SASL server can advertise a nonzero buffer even for auth-only.
+        // We do not use its buffer limit: our selected security layer and receive buffer
+        // are always 1 (no layer) and zero respectively.
     }
 
     /// <inheritdoc />

--- a/src/Dekaf/Security/Sasl/GssapiConfig.cs
+++ b/src/Dekaf/Security/Sasl/GssapiConfig.cs
@@ -105,7 +105,9 @@ public sealed class GssapiConfig
         {
             Package = "Kerberos",
             TargetName = BuildSpn(targetHost),
-            RequiredProtectionLevel = ProtectionLevel.None,
+            // Integrity is required for the RFC 4752 negotiation, even when Kafka traffic
+            // itself does not use a SASL security layer.
+            RequiredProtectionLevel = ProtectionLevel.Sign,
             AllowedImpersonationLevel = TokenImpersonationLevel.Identification
         };
 

--- a/tests/Dekaf.Tests.Integration/AdaptiveFetchSizingIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdaptiveFetchSizingIntegrationTests.cs
@@ -1,0 +1,143 @@
+using System.Collections.Concurrent;
+using Dekaf.Consumer;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Consumer")]
+public sealed class AdaptiveFetchSizingIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task FetchLoop_AdjustsRequestsWithinLimitsAndDeliversEveryOffset(bool memoryPressure, CancellationToken cancellationToken)
+    {
+        const int count = 96;
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        await using (var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).WithBatchSize(16 * 1024).BuildAsync(cancellationToken))
+        {
+            for (var index = 0; index < count; index++)
+                await producer.FireAsync(topic, index.ToString(System.Globalization.CultureInfo.InvariantCulture), new string('x', 8192));
+            await producer.FlushAsync(cancellationToken);
+        }
+
+        var options = new AdaptiveFetchSizingOptions
+        {
+            MinPartitionFetchBytes = 32 * 1024, InitialPartitionFetchBytes = 64 * 1024, MaxPartitionFetchBytes = 256 * 1024,
+            MinFetchMaxBytes = 64 * 1024, InitialFetchMaxBytes = 128 * 1024, MaxFetchMaxBytes = 512 * 1024,
+            StableWindowCount = 1,
+            // Make the grow signal insensitive to runner scheduling; pressure still takes precedence.
+            GrowThreshold = 10000, ShrinkThreshold = 20000
+        };
+        var clientId = $"adaptive-fetch-{Guid.NewGuid():N}";
+        await using var pool = new FetchObservingPool(new ConnectionPool(clientId, new ConnectionOptions()));
+        await using var metadata = new MetadataManager(pool, [KafkaContainer.BootstrapServers]);
+        await using var consumer = new KafkaConsumer<string, string>(new ConsumerOptions
+        {
+            BootstrapServers = [KafkaContainer.BootstrapServers], ClientId = clientId,
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnableAdaptiveFetchSizing = true, AdaptiveFetchSizingOptions = options,
+            QueuedMinMessages = memoryPressure ? 1000 : 1, QueuedMaxMessagesKbytes = 32,
+            EnableFetchSessions = false, PrefetchPipelineDepth = 1
+        }, Serializers.String, Serializers.String, pool, metadata);
+        await consumer.InitializeAsync(cancellationToken);
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        var first = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(10), cancellationToken);
+        await Assert.That(first).IsNotNull();
+        await Assert.That(first!.Value.Offset).IsEqualTo(0);
+        if (memoryPressure)
+        {
+            await TestWait.WaitForConditionAsync(() => consumer.CaptureDiagnosticSnapshot().PrefetchedBytes >= 32 * 1024,
+                TimeSpan.FromSeconds(10), description: "actual prefetch fills the configured byte budget");
+        }
+        for (var expected = 1; expected < count; expected++)
+        {
+            var record = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(10), cancellationToken);
+            await Assert.That(record).IsNotNull();
+            await Assert.That(record!.Value.Offset).IsEqualTo(expected);
+            await Assert.That(record.Value.Key).IsEqualTo(expected.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        var observed = pool.Requests.ToArray();
+        await Assert.That(observed.Length).IsGreaterThan(1);
+        foreach (var request in observed)
+        {
+            await Assert.That(request.PartitionBytes).IsGreaterThanOrEqualTo(options.MinPartitionFetchBytes);
+            await Assert.That(request.PartitionBytes).IsLessThanOrEqualTo(options.MaxPartitionFetchBytes);
+            await Assert.That(request.TotalBytes).IsGreaterThanOrEqualTo(options.MinFetchMaxBytes);
+            await Assert.That(request.TotalBytes).IsLessThanOrEqualTo(options.MaxFetchMaxBytes);
+        }
+        await Assert.That(memoryPressure
+            ? observed.Any(request => request.PartitionBytes < options.InitialPartitionFetchBytes)
+            : observed.Any(request => request.PartitionBytes > options.InitialPartitionFetchBytes)).IsTrue()
+            .Because($"Fetch requests must {(memoryPressure ? "shrink after real memory pressure" : "grow after processing")}: {string.Join(", ", observed)}");
+        await Assert.That(consumer.GetPosition(new TopicPartition(topic, 0))).IsEqualTo(count);
+    }
+
+    private sealed class FetchObservingPool(ConnectionPool inner) : IConnectionPool
+    {
+        public ConcurrentQueue<(int TotalBytes, int PartitionBytes)> Requests { get; } = new();
+        public async ValueTask<IKafkaConnection> GetConnectionAsync(int brokerId, CancellationToken cancellationToken = default) =>
+            new ObservedConnection(this, await inner.GetConnectionAsync(brokerId, cancellationToken));
+        public async ValueTask<IKafkaConnection> GetConnectionByIndexAsync(int brokerId, int index, CancellationToken cancellationToken = default) =>
+            new ObservedConnection(this, await inner.GetConnectionByIndexAsync(brokerId, index, cancellationToken));
+        public ValueTask<IKafkaConnection> GetConnectionAsync(string host, int port, CancellationToken cancellationToken = default) =>
+            inner.GetConnectionAsync(host, port, cancellationToken);
+        public void RegisterBroker(int brokerId, string host, int port) => inner.RegisterBroker(brokerId, host, port);
+        public ValueTask<int> ScaleConnectionGroupAsync(int brokerId, int newCount, CancellationToken cancellationToken = default) =>
+            inner.ScaleConnectionGroupAsync(brokerId, newCount, cancellationToken);
+        public ValueTask<IKafkaConnection?> ShrinkConnectionGroupAsync(int brokerId, int newCount, CancellationToken cancellationToken = default) =>
+            inner.ShrinkConnectionGroupAsync(brokerId, newCount, cancellationToken);
+        public ValueTask RemoveConnectionAsync(int brokerId) => inner.RemoveConnectionAsync(brokerId);
+        public ValueTask CloseAllAsync() => inner.CloseAllAsync();
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+
+        private sealed class ObservedConnection(FetchObservingPool owner, IKafkaConnection connection) : IKafkaConnection
+        {
+            public int BrokerId => connection.BrokerId;
+            public string Host => connection.Host;
+            public int Port => connection.Port;
+            public bool IsConnected => connection.IsConnected;
+            public ValueTask<TResponse> SendAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+                where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse
+            {
+                Observe(request);
+                return connection.SendAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+            }
+            public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+                where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse
+            {
+                Observe(request);
+                return connection.SendPipelinedAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+            }
+            public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+                where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse
+            {
+                Observe(request);
+                return connection.SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+            }
+
+            private void Observe<TRequest>(TRequest request)
+            {
+                if (request is FetchRequest fetch)
+                    foreach (var topic in fetch.Topics)
+                        foreach (var partition in topic.Partitions)
+                            owner.Requests.Enqueue((fetch.MaxBytes, partition.PartitionMaxBytes));
+            }
+
+            public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+                where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => connection.SendFireAndForgetAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+            public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(TRequest request, short apiVersion, CancellationToken cancellationToken = default)
+                where TRequest : IKafkaRequest<TResponse> where TResponse : IKafkaResponse => connection.SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+            public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => connection.ConnectAsync(cancellationToken);
+            public ValueTask DisposeAsync() => connection.DisposeAsync();
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/AdminOperationCoverageTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdminOperationCoverageTests.cs
@@ -1,0 +1,101 @@
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Testcontainers.Kafka;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Admin")]
+public sealed class TransactionListingIntegrationTests(KafkaTestContainer kafka) : TransactionalKafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task ListTransactions_FindsOngoingTransactionAndItsCompletedState(CancellationToken cancellationToken)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var transactionId = $"listing-{Guid.NewGuid():N}";
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithTransactionalId(transactionId).WithAcks(Acks.All).BuildAsync(cancellationToken);
+        await producer.InitTransactionsAsync(cancellationToken);
+        await using var transaction = producer.BeginTransaction();
+        await transaction.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic, Key = "key", Value = "value"
+        }, cancellationToken);
+        await using var admin = KafkaContainer.CreateAdminClient();
+        var ongoing = await admin.ListTransactionsAsync(new ListTransactionsOptions
+        {
+            StateFilters = ["Ongoing"]
+        }, cancellationToken);
+        var listed = ongoing.Transactions.Single(item => item.TransactionalId == transactionId);
+        await Assert.That(listed.TransactionState).IsEqualTo("Ongoing");
+        var described = (await admin.DescribeTransactionsAsync([transactionId], cancellationToken))[transactionId];
+        await Assert.That(listed.ProducerId).IsEqualTo(described.ProducerId);
+        await Assert.That(listed.CoordinatorId).IsEqualTo(described.CoordinatorId);
+
+        await transaction.CommitAsync(cancellationToken);
+        await TestWait.WaitForConditionAsync(async () =>
+        {
+            var result = await admin.ListTransactionsAsync(new ListTransactionsOptions
+            {
+                ProducerIdFilters = [listed.ProducerId], StateFilters = ["CompleteCommit"]
+            }, cancellationToken);
+            return result.Transactions.Any(item => item.TransactionalId == transactionId);
+        }, static ready => ready, description: "committed transaction appears in ListTransactions");
+        var remaining = await admin.ListTransactionsAsync(new ListTransactionsOptions
+        {
+            ProducerIdFilters = [listed.ProducerId], StateFilters = ["Ongoing"]
+        }, cancellationToken);
+        await Assert.That(remaining.Transactions).IsEmpty();
+    }
+}
+
+public sealed class MultiLogDirKafkaContainer : KafkaContainerDefault
+{
+    protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder) => base.ConfigureBuilder(builder)
+        .WithEnvironment("KAFKA_LOG_DIRS", "/tmp/dekaf-log-a,/tmp/dekaf-log-b");
+}
+
+[Category("Admin")]
+[ClassDataSource<MultiLogDirKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class ReplicaLogDirMovementIntegrationTests(MultiLogDirKafkaContainer kafka)
+{
+    [Test]
+    public async Task AlterReplicaLogDirs_MovesStoredRecordsAndPreservesSubsequentDelivery(CancellationToken cancellationToken)
+    {
+        var topic = await kafka.CreateTestTopicAsync();
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers).BuildAsync(cancellationToken);
+        await producer.ProduceAsync(topic, "before", "before", cancellationToken);
+        await using var admin = kafka.CreateAdminClient();
+        var description = (await admin.DescribeTopicsAsync([topic], cancellationToken))[topic];
+        var replica = new TopicPartitionReplica(topic, 0, description.Partitions.Single().LeaderId);
+        var current = (await admin.DescribeReplicaLogDirsAsync([replica], cancellationToken: cancellationToken))[replica];
+        await Assert.That(current.CurrentReplicaLogDir).IsNotNull();
+        var target = current.CurrentReplicaLogDir == "/tmp/dekaf-log-a" ? "/tmp/dekaf-log-b" : "/tmp/dekaf-log-a";
+
+        var altered = await admin.AlterReplicaLogDirsAsync(new Dictionary<TopicPartitionReplica, string>
+        {
+            [replica] = target
+        }, cancellationToken);
+        await Assert.That(altered[replica].ErrorCode).IsEqualTo(ErrorCode.None);
+        await TestWait.WaitForConditionAsync(async () =>
+        {
+            var result = (await admin.DescribeReplicaLogDirsAsync([replica], cancellationToken: cancellationToken))[replica];
+            return result.CurrentReplicaLogDir == target && result.FutureReplicaLogDir is null;
+        }, static ready => ready, description: "replica finishes moving to the requested directory");
+
+        await producer.ProduceAsync(topic, "after", "after", cancellationToken);
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers).WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .BuildAsync(cancellationToken);
+        consumer.Assign(new TopicPartition(topic, 0));
+        foreach (var expected in new[] { "before", "after" })
+        {
+            var record = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(10), cancellationToken);
+            await Assert.That(record).IsNotNull();
+            await Assert.That(record!.Value.Value).IsEqualTo(expected);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ClientStatusIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ClientStatusIntegrationTests.cs
@@ -8,7 +8,7 @@ using Dekaf.Protocol.Messages;
 
 namespace Dekaf.Tests.Integration;
 
-[Category("Diagnostics")]
+[Category("Telemetry")]
 public sealed class ClientStatusIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]
@@ -154,7 +154,7 @@ public sealed class ClientStatusIntegrationTests(KafkaTestContainer kafka) : Kaf
     }
 }
 
-[Category("Diagnostics")]
+[Category("Telemetry")]
 [Category("Resilience")]
 [NotInParallel("RackAwareKafkaContainer")]
 [ClassDataSource<RackAwareKafkaContainer>(Shared = SharedType.PerTestSession)]

--- a/tests/Dekaf.Tests.Integration/ConsumerGroupCrashClientProcess.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupCrashClientProcess.cs
@@ -282,6 +282,7 @@ internal sealed class ConsumerGroupCrashClientProcess : IAsyncDisposable
 /// Child-process entry point. The parent kills this process while its consumer is
 /// live, so no graceful group-leave path can run.
 /// </summary>
+[Category("ConsumerGroup")]
 public sealed class ConsumerGroupCrashClient
 {
     [Test]

--- a/tests/Dekaf.Tests.Integration/ControllerBootstrapIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ControllerBootstrapIntegrationTests.cs
@@ -4,6 +4,7 @@ namespace Dekaf.Tests.Integration;
 
 [NotInParallel("ControllerOnlyKafkaContainer")]
 [ClassDataSource<ControllerOnlyKafkaContainer>(Shared = SharedType.PerTestSession)]
+[Category("Admin")]
 public sealed class ControllerBootstrapIntegrationTests(ControllerOnlyKafkaContainer kafka)
 {
     [Test]

--- a/tests/Dekaf.Tests.Integration/DynamicQuorumIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/DynamicQuorumIntegrationTests.cs
@@ -1,0 +1,139 @@
+using System.Text;
+using Dekaf.Admin;
+using Dekaf.Errors;
+using Dekaf.Protocol;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+using TUnit.Core.Interfaces;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Admin")]
+[ClassDataSource<DynamicQuorumKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class DynamicQuorumIntegrationTests(DynamicQuorumKafkaContainer kafka)
+{
+    [Test]
+    public async Task AddAndRemoveVoter_ChangesRealControllerMembership(CancellationToken cancellationToken)
+    {
+        await using var admin = new AdminClientBuilder().WithBootstrapControllers(kafka.BootstrapControllers).Build();
+        var observed = await TestWait.WaitForConditionAsync(
+            async () => await admin.DescribeMetadataQuorumAsync(cancellationToken),
+            quorum => quorum.Observers.Any(replica => replica.ReplicaId == 2 && replica.ReplicaDirectoryId is not null),
+            description: "second controller joins as an observer");
+        var observer = observed.Observers.Single(replica => replica.ReplicaId == 2);
+        await Assert.That(observed.CurrentVoters.Select(replica => replica.ReplicaId)).IsEquivalentTo([1]);
+        var directoryId = observer.ReplicaDirectoryId!.Value;
+
+        await admin.AddRaftVoterAsync(2, directoryId,
+            [new RaftVoterEndpoint { Name = "CONTROLLER", Host = "controller-2", Port = 9093 }], cancellationToken: cancellationToken);
+        var expanded = await TestWait.WaitForConditionAsync(
+            async () => await admin.DescribeMetadataQuorumAsync(cancellationToken),
+            quorum => quorum.CurrentVoters.Count == 2, description: "AddRaftVoter is committed");
+        await Assert.That(expanded.CurrentVoters.Single(replica => replica.ReplicaId == 2).ReplicaDirectoryId).IsEqualTo(directoryId);
+
+        await admin.RemoveRaftVoterAsync(2, directoryId, cancellationToken: cancellationToken);
+        await TestWait.WaitForConditionAsync(
+            async () => await admin.DescribeMetadataQuorumAsync(cancellationToken),
+            quorum => quorum.CurrentVoters.Count == 1 && quorum.CurrentVoters[0].ReplicaId == 1,
+            description: "RemoveRaftVoter is committed");
+    }
+}
+
+public sealed class DynamicQuorumKafkaContainer : IAsyncInitializer, IAsyncDisposable
+{
+    private readonly INetwork _network = new NetworkBuilder().Build();
+    private IContainer? _leader;
+    private IContainer? _observer;
+    private const int ExternalPort = 9094;
+    public string BootstrapControllers => _leader is { } leader
+        ? $"{leader.Hostname}:{leader.GetMappedPublicPort(ExternalPort)}"
+        : throw new InvalidOperationException("Controller has not started.");
+
+    public async Task InitializeAsync()
+    {
+        await _network.CreateAsync();
+        _leader = CreateController(1);
+        _observer = CreateController(2);
+        await _leader.StartAsync();
+        await _observer.StartAsync();
+    }
+
+    private IContainer CreateController(int nodeId)
+    {
+        var format = nodeId == 1 ? "--standalone" : "--no-initial-controllers";
+        return new ContainerBuilder($"apache/kafka:{KafkaContainerDefault.ImageTag}")
+            .WithNetwork(_network).WithNetworkAliases($"controller-{nodeId}")
+            .WithPortBinding(ExternalPort, true)
+            .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx384m -Xms384m")
+            .WithEntrypoint("/bin/bash")
+            .WithCommand("-ec", $"while [ ! -f /tmp/controller.ready ]; do sleep 0.1; done; /opt/kafka/bin/kafka-storage.sh format -t MkU3OEVBNTcwNTJENDM2Qk -c /tmp/controller.properties {format}; exec /opt/kafka/bin/kafka-server-start.sh /tmp/controller.properties")
+            .WithStartupCallback(async (container, cancellationToken) =>
+            {
+                // Docker owns the host port before Kafka advertises it. Signal readiness
+                // only after the complete configuration has been copied into the container.
+                var config = $"""
+                    process.roles=controller
+                    node.id={nodeId}
+                    controller.quorum.bootstrap.servers=controller-1:9093
+                    controller.listener.names=CONTROLLER,EXTERNAL
+                    listeners=CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:{ExternalPort}
+                    advertised.listeners=CONTROLLER://controller-{nodeId}:9093,EXTERNAL://{container.Hostname}:{container.GetMappedPublicPort(ExternalPort)}
+                    listener.security.protocol.map=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+                    log.dirs=/tmp/quorum
+                    """;
+                await container.CopyAsync(Encoding.UTF8.GetBytes(config), "/tmp/controller.properties", ct: cancellationToken);
+                await container.CopyAsync(Array.Empty<byte>(), "/tmp/controller.ready", ct: cancellationToken);
+            })
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(9093)).Build();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_observer is not null)
+                await _observer.DisposeAsync();
+        }
+        finally
+        {
+            try
+            {
+                if (_leader is not null)
+                    await _leader.DisposeAsync();
+            }
+            finally { await _network.DisposeAsync(); }
+        }
+    }
+}
+
+[Category("Admin")]
+[NotInParallel("RackAwareKafkaContainer")]
+[ClassDataSource<RackAwareKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class BrokerUnregistrationIntegrationTests(RackAwareKafkaContainer kafka)
+{
+    [Test]
+    public async Task UnregisterStoppedBroker_RemovesRegistrationAndAllowsRestart(CancellationToken cancellationToken)
+    {
+        await using var admin = kafka.CreateAdminClient();
+        await kafka.StopBrokerAsync(3, cancellationToken);
+        try
+        {
+            await TestWait.WaitForConditionAsync(
+                async () => await admin.DescribeClusterAsync(new DescribeClusterOptions(), cancellationToken),
+                cluster => cluster.Nodes.All(broker => broker.NodeId != 3),
+                description: "stopped broker is fenced");
+            await admin.UnregisterBrokerAsync(3, cancellationToken);
+            var exception = await Assert.That(async () => await admin.UnregisterBrokerAsync(3, cancellationToken))
+                .Throws<KafkaException>();
+            await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.BrokerIdNotRegistered);
+        }
+        finally
+        {
+            await kafka.StartBrokerAsync(3, cancellationToken);
+        }
+        await TestWait.WaitForConditionAsync(
+            async () => await admin.DescribeClusterAsync(new DescribeClusterOptions(), cancellationToken),
+            cluster => cluster.Nodes.Any(broker => broker.NodeId == 3), description: "restarted broker registers again");
+    }
+}

--- a/tests/Dekaf.Tests.Integration/KafkaClientIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaClientIntegrationTests.cs
@@ -3,6 +3,7 @@ using Dekaf.Producer;
 
 namespace Dekaf.Tests.Integration;
 
+[Category("Messaging")]
 public sealed class KafkaClientIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]

--- a/tests/Dekaf.Tests.Integration/MemoryBudgetTests.cs
+++ b/tests/Dekaf.Tests.Integration/MemoryBudgetTests.cs
@@ -7,6 +7,7 @@ namespace Dekaf.Tests.Integration;
 /// Integration tests verifying that <see cref="Dekaf.Internal.DekafMemoryBudget"/> rebalances
 /// live producer instances when additional producers are built and disposed.
 /// </summary>
+[Category("Producer")]
 public class MemoryBudgetTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     private const ulong ProducerFloorBytes = 32UL * 1024 * 1024;

--- a/tests/Dekaf.Tests.Integration/ProducerPurgeIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerPurgeIntegrationTests.cs
@@ -1,0 +1,133 @@
+using Dekaf.Consumer;
+using Dekaf.Diagnostics;
+using Dekaf.Errors;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Producer")]
+[NotInParallel("ProducerHealthKafkaContainer")]
+[ClassDataSource<ProducerHealthKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class ProducerPurgeIntegrationTests(ProducerHealthKafkaContainer kafka)
+{
+    [Test]
+    [Arguments(PurgeOptions.Queue)]
+    [Arguments(PurgeOptions.InFlight)]
+    [Arguments(PurgeOptions.All)]
+    [Timeout(90_000)]
+    public async Task Purge_CompletesOnceAndProducerRemainsUsable(PurgeOptions options, CancellationToken cancellationToken)
+    {
+        var topic = await kafka.CreateTestTopicAsync();
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers).WithAcks(Acks.All)
+            .WithIdempotence(true).WithConnectionsPerBroker(1).WithoutAdaptiveConnections().WithLinger(TimeSpan.FromSeconds(30))
+            .WithBatchSize(1024 * 1024).WithDeliveryTimeout(TimeSpan.FromSeconds(60))
+            .BuildAsync(cancellationToken);
+        var warmup = producer.ProduceAsync(topic, "warmup", "warmup", cancellationToken).AsTask();
+        await producer.FlushAsync(cancellationToken);
+        await warmup;
+        var status = (IKafkaClientStatusProvider)producer;
+        var callbackCount = 0;
+        var callback = new TaskCompletionSource<Exception?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task? flush = null;
+        await kafka.SetPausedAsync(true);
+        try
+        {
+            await producer.FireAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic, Key = "purged", Value = "purged"
+            }, (_, exception) =>
+            {
+                Interlocked.Increment(ref callbackCount);
+                callback.TrySetResult(exception);
+            });
+            if (options != PurgeOptions.Queue)
+            {
+                flush = producer.FlushAsync(cancellationToken).AsTask();
+                await TestWait.WaitForConditionAsync(
+                    () => Task.FromResult(status.GetStatus()),
+                    snapshot => snapshot.Producer!.Value.InFlightBatchCount > 0
+                        && snapshot.Producer.Value.QueuedBatchCount == 0
+                        // BrokerSender releases the accumulator reservation after writing the frame.
+                        && snapshot.Producer.Value.BufferedBytes == 0,
+                    maxRetries: 10, initialDelayMs: 100,
+                    description: "batch leaves the queue and its frame is written while the broker is paused",
+                    formatObserved: snapshot => $"{snapshot.Producer}");
+            }
+            else
+            {
+                await Assert.That(status.GetStatus().Producer!.Value.UnsealedBatchCount).IsGreaterThan(0);
+                await Assert.That(status.GetStatus().Producer!.Value.InFlightBatchCount).IsEqualTo(0);
+            }
+
+            await producer.PurgeAsync(options, cancellationToken);
+            var failure = await callback.Task.WaitAsync(cancellationToken);
+            await Assert.That(failure).IsTypeOf<ProduceException>();
+            await Assert.That(((ProduceException)failure!).Kind).IsEqualTo(ProduceErrorKind.Purged);
+            await Assert.That(Volatile.Read(ref callbackCount)).IsEqualTo(1);
+        }
+        finally
+        {
+            await kafka.SetPausedAsync(false);
+            if (flush is not null)
+                await flush.WaitAsync(cancellationToken);
+        }
+
+        // A later acknowledgement for the purged batch must not complete its callback again
+        // or break the next idempotent sequence. Flush also waits for buffer reclamation.
+        var after = producer.ProduceAsync(topic, "after", "after", cancellationToken).AsTask();
+        await producer.FlushAsync(cancellationToken);
+        await after;
+        await TestWait.WaitForConditionAsync(() => status.GetStatus().Producer!.Value.BufferedBytes == 0,
+            TimeSpan.FromSeconds(10), description: "purged producer releases its reservations");
+        await Assert.That(Volatile.Read(ref callbackCount)).IsEqualTo(1);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers).WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .BuildAsync(cancellationToken);
+        consumer.Assign(new TopicPartition(topic, 0));
+        var values = new List<string>();
+        while (!values.Contains("after"))
+        {
+            var record = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(10), cancellationToken);
+            await Assert.That(record).IsNotNull();
+            values.Add(record!.Value.Value);
+        }
+        await Assert.That(values.Count(value => value == "after")).IsEqualTo(1);
+        if (options == PurgeOptions.Queue)
+            await Assert.That(values).IsEquivalentTo(["warmup", "after"]);
+    }
+}
+
+[Category("Transaction")]
+public sealed class TransactionalPurgeIntegrationTests(KafkaTestContainer kafka) : TransactionalKafkaIntegrationTest(kafka)
+{
+    [Test]
+    [Arguments(PurgeOptions.Queue)]
+    [Arguments(PurgeOptions.InFlight)]
+    [Arguments(PurgeOptions.All)]
+    public async Task ActiveTransaction_RejectsPurgeAndCanStillCommit(PurgeOptions options, CancellationToken cancellationToken)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithTransactionalId($"purge-transaction-{Guid.NewGuid():N}")
+            .BuildAsync(cancellationToken);
+        await producer.InitTransactionsAsync(cancellationToken);
+        await using var transaction = producer.BeginTransaction();
+        await transaction.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic, Key = "key", Value = "committed"
+        }, cancellationToken);
+        await Assert.That(async () => await producer.PurgeAsync(options, cancellationToken))
+            .Throws<InvalidOperationException>();
+        await transaction.CommitAsync(cancellationToken);
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers).WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithIsolationLevel(Dekaf.Protocol.Messages.IsolationLevel.ReadCommitted).BuildAsync(cancellationToken);
+        consumer.Assign(new TopicPartition(topic, 0));
+        var record = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(10), cancellationToken);
+        await Assert.That(record).IsNotNull();
+        await Assert.That(record!.Value.Value).IsEqualTo("committed");
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ProducerStateGaugeIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerStateGaugeIntegrationTests.cs
@@ -10,7 +10,7 @@ namespace Dekaf.Tests.Integration;
 /// not just that the instrument names exist (unit tests cover the buffer gauges,
 /// but the per-broker dictionaries only populate with a live connection).
 /// </summary>
-[Category("ProducerStateGauges")]
+[Category("Telemetry")]
 public sealed class ProducerStateGaugeIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     private static readonly string[] BrokerLongGauges =

--- a/tests/Dekaf.Tests.Integration/ReassignmentSequenceOracleTests.cs
+++ b/tests/Dekaf.Tests.Integration/ReassignmentSequenceOracleTests.cs
@@ -1,5 +1,6 @@
 namespace Dekaf.Tests.Integration;
 
+[Category("Resilience")]
 public sealed class ReassignmentSequenceOracleTests
 {
     [Test]

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryHttpPipelineIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryHttpPipelineIntegrationTests.cs
@@ -11,6 +11,7 @@ using Dekaf.Security.Sasl;
 namespace Dekaf.Tests.Integration;
 
 [ClassDataSource<KafkaWithSchemaRegistryContainer>(Shared = SharedType.PerTestSession)]
+[Category("Serialization")]
 public sealed class SchemaRegistryHttpPipelineIntegrationTests(KafkaWithSchemaRegistryContainer testInfra)
 {
     [Test]
@@ -130,6 +131,7 @@ public sealed class SchemaRegistryHttpPipelineIntegrationTests(KafkaWithSchemaRe
     }
 }
 
+[Category("Tls")]
 public sealed class SchemaRegistryTlsIntegrationTests
 {
     [Test]

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryOAuthConcurrencyIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryOAuthConcurrencyIntegrationTests.cs
@@ -5,6 +5,7 @@ using Dekaf.Security.Sasl;
 namespace Dekaf.Tests.Integration;
 
 [ClassDataSource<KafkaWithSchemaRegistryContainer>(Shared = SharedType.PerTestSession)]
+[Category("Serialization")]
 public sealed class SchemaRegistryOAuthConcurrencyIntegrationTests(KafkaWithSchemaRegistryContainer testInfra)
 {
     [Test]

--- a/tests/Dekaf.Tests.Integration/Security/GssapiAuthenticationIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/Security/GssapiAuthenticationIntegrationTests.cs
@@ -1,0 +1,216 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Security.Sasl;
+using Testcontainers.Kafka;
+
+namespace Dekaf.Tests.Integration.Security;
+
+[Category("Authentication")]
+[NotInParallel("KerberosEnvironment")]
+public sealed class GssapiAuthenticationIntegrationTests
+{
+    [Test]
+    [RequiresLocalKerberos]
+    [Timeout(120_000)]
+    public async Task LocalKdc_AuthenticatesKafkaRoundTripAndRejectsWrongService(CancellationToken cancellationToken)
+    {
+        var bootstrapServers = Environment.GetEnvironmentVariable("DEKAF_KERBEROS_BOOTSTRAP");
+        if (bootstrapServers is null)
+        {
+            await using var realm = new LocalKerberosRealm();
+            await realm.InitializeAsync(cancellationToken);
+            await using var kafka = new KerberosKafkaContainer(realm);
+            await kafka.InitializeAsync();
+            await realm.RunClientAsync(kafka.BootstrapServers, cancellationToken);
+            return;
+        }
+        var topic = $"kerberos-{Guid.NewGuid():N}";
+        await using var admin = new AdminClientBuilder().WithBootstrapServers(bootstrapServers)
+            .WithGssapi(new GssapiConfig()).Build();
+        await admin.CreateTopicsAsync([new NewTopic { Name = topic, NumPartitions = 1, ReplicationFactor = 1 }], cancellationToken: cancellationToken);
+        var config = new GssapiConfig();
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(bootstrapServers).WithGssapi(config).BuildAsync(cancellationToken);
+        await producer.ProduceAsync(topic, "kerberos-key", "kerberos-value", cancellationToken);
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(bootstrapServers).WithGssapi(config)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest).BuildAsync(cancellationToken);
+        consumer.Assign(new TopicPartition(topic, 0));
+        var record = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(15), cancellationToken);
+        await Assert.That(record).IsNotNull();
+        await Assert.That(record!.Value.Key).IsEqualTo("kerberos-key");
+        await Assert.That(record.Value.Value).IsEqualTo("kerberos-value");
+
+        await Assert.That(async () =>
+        {
+            await using var invalid = await Kafka.CreateProducer<string, string>()
+                .WithBootstrapServers(bootstrapServers)
+                .WithGssapi(new GssapiConfig { ServiceName = "missing-service" })
+                .BuildAsync(cancellationToken);
+        }).Throws<AuthenticationException>();
+    }
+}
+
+public sealed class RequiresLocalKerberosAttribute() : SkipAttribute(
+    "The local MIT Kerberos fixture requires Linux and Dekaf's net10.0 asset; netstandard2.0 has no GSSAPI implementation.")
+{
+    public override Task<bool> ShouldSkip(TestRegisteredContext context)
+    {
+#if NET8_0
+        return Task.FromResult(true);
+#else
+        return Task.FromResult(!OperatingSystem.IsLinux());
+#endif
+    }
+}
+
+internal sealed class KerberosKafkaContainer(LocalKerberosRealm realm) : KafkaContainerDefault
+{
+    protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder) => base.ConfigureBuilder(builder)
+        .WithResourceMapping(File.ReadAllBytes(realm.ServerKeytab), "/tmp/kafka.keytab")
+        .WithResourceMapping(File.ReadAllBytes(realm.Configuration), "/tmp/krb5.conf")
+        .WithEnvironment("KAFKA_OPTS", "-Djava.security.krb5.conf=/tmp/krb5.conf")
+        .WithEnvironment("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "PLAINTEXT:SASL_PLAINTEXT,BROKER:PLAINTEXT,CONTROLLER:PLAINTEXT")
+        .WithEnvironment("KAFKA_SASL_ENABLED_MECHANISMS", "GSSAPI")
+        .WithEnvironment("KAFKA_SASL_KERBEROS_SERVICE_NAME", "kafka")
+        .WithEnvironment("KAFKA_LISTENER_NAME_PLAINTEXT_SASL_ENABLED_MECHANISMS", "GSSAPI")
+        .WithEnvironment("KAFKA_LISTENER_NAME_PLAINTEXT_GSSAPI_SASL_JAAS_CONFIG",
+            "com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true " +
+            $"doNotPrompt=true isInitiator=false keyTab=\"/tmp/kafka.keytab\" principal=\"kafka/{realm.BrokerHost}@{LocalKerberosRealm.Realm}\";");
+
+    public override IAdminClient CreateAdminClient() => new AdminClientBuilder()
+        .WithBootstrapServers(BootstrapServers).WithGssapi(new GssapiConfig()).Build();
+}
+
+internal sealed class LocalKerberosRealm : IAsyncDisposable
+{
+    public const string Realm = "DEKAF.TEST";
+    private readonly DirectoryInfo _directory = Directory.CreateTempSubdirectory("dekaf-kerberos-");
+    private Process? _kdc;
+    private Task<string>? _kdcOutput;
+    private Task<string>? _kdcError;
+    public string BrokerHost { get; } = Environment.GetEnvironmentVariable("TESTCONTAINERS_HOST_OVERRIDE") ?? "127.0.0.1";
+    public string Configuration => Path.Combine(_directory.FullName, "krb5.conf");
+    public string ServerKeytab => Path.Combine(_directory.FullName, "server.keytab");
+    private string KdcProfile => Path.Combine(_directory.FullName, "kdc.conf");
+
+    public async Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        using var portReservation = new TcpListener(IPAddress.Loopback, 0);
+        portReservation.Start();
+        var port = ((IPEndPoint)portReservation.LocalEndpoint).Port;
+        portReservation.Stop();
+        await File.WriteAllTextAsync(Configuration, $$"""
+            [libdefaults]
+              default_realm = {{Realm}}
+              dns_lookup_kdc = false
+              dns_lookup_realm = false
+              rdns = false
+              udp_preference_limit = 1
+            [realms]
+              {{Realm}} = {
+                kdc = 127.0.0.1:{{port}}
+              }
+            """, cancellationToken);
+        await File.WriteAllTextAsync(KdcProfile, $$"""
+            [kdcdefaults]
+              kdc_ports = {{port}}
+              kdc_tcp_ports = {{port}}
+            [realms]
+              {{Realm}} = {
+                database_name = {{_directory.FullName}}/principal
+                key_stash_file = {{_directory.FullName}}/stash
+                acl_file = {{_directory.FullName}}/kadm5.acl
+              }
+            """, cancellationToken);
+        await RunAsync("/usr/sbin/kdb5_util", ["create", "-s", "-P", "local-test-master", "-r", Realm], cancellationToken);
+        await RunAsync("/usr/sbin/kadmin.local", ["-r", Realm, "-q", $"addprinc -randkey kafka/{BrokerHost}@{Realm}"], cancellationToken);
+        await RunAsync("/usr/sbin/kadmin.local", ["-r", Realm, "-q", $"ktadd -k {ServerKeytab} kafka/{BrokerHost}@{Realm}"], cancellationToken);
+        await RunAsync("/usr/sbin/kadmin.local", ["-r", Realm, "-q", $"addprinc -randkey client@{Realm}"], cancellationToken);
+        var clientKeytab = Path.Combine(_directory.FullName, "client.keytab");
+        await RunAsync("/usr/sbin/kadmin.local", ["-r", Realm, "-q", $"ktadd -k {clientKeytab} client@{Realm}"], cancellationToken);
+        _kdc = Process.Start(StartInfo("/usr/sbin/krb5kdc", ["-n", "-r", Realm]))!;
+        _kdcOutput = _kdc.StandardOutput.ReadToEndAsync(CancellationToken.None);
+        _kdcError = _kdc.StandardError.ReadToEndAsync(CancellationToken.None);
+        await TestWait.WaitForConditionAsync(async () =>
+        {
+            using var socket = new TcpClient();
+            try { await socket.ConnectAsync(IPAddress.Loopback, port, cancellationToken); return true; }
+            catch (SocketException) { return false; }
+        }, static ready => ready, description: "isolated local KDC accepts TCP connections");
+        var cache = Path.Combine(_directory.FullName, "ccache");
+        await RunAsync("kinit", ["-kt", clientKeytab, "-c", cache, $"client@{Realm}"], cancellationToken);
+
+    }
+
+    public Task RunClientAsync(string bootstrapServers, CancellationToken cancellationToken)
+    {
+        // Native GSSAPI reads the environment inherited at process startup. Managed
+        // Environment.SetEnvironmentVariable does not update native getenv on Unix.
+        var processPath = Environment.ProcessPath ?? throw new InvalidOperationException("Cannot find test executable.");
+        var info = StartInfo(processPath, []);
+        if (Path.GetFileNameWithoutExtension(processPath).Equals("dotnet", StringComparison.OrdinalIgnoreCase))
+            info.ArgumentList.Add(Environment.GetCommandLineArgs()[0]);
+        info.ArgumentList.Add("--treenode-filter");
+        info.ArgumentList.Add("/*/*/GssapiAuthenticationIntegrationTests/*");
+        info.ArgumentList.Add("--results-directory");
+        info.ArgumentList.Add(Path.Combine(_directory.FullName, "results"));
+        info.Environment["DEKAF_KERBEROS_BOOTSTRAP"] = bootstrapServers;
+        info.Environment["KRB5CCNAME"] = $"FILE:{Path.Combine(_directory.FullName, "ccache")}";
+        return RunAsync(info, cancellationToken);
+    }
+
+    private ProcessStartInfo StartInfo(string executable, string[] arguments)
+    {
+        var info = new ProcessStartInfo(executable)
+        {
+            UseShellExecute = false, CreateNoWindow = true, RedirectStandardOutput = true, RedirectStandardError = true
+        };
+        foreach (var argument in arguments)
+            info.ArgumentList.Add(argument);
+        info.Environment["KRB5_CONFIG"] = Configuration;
+        info.Environment["KRB5_KDC_PROFILE"] = KdcProfile;
+        return info;
+    }
+
+    private Task RunAsync(string executable, string[] arguments, CancellationToken cancellationToken)
+        => RunAsync(StartInfo(executable, arguments), cancellationToken);
+
+    private static async Task RunAsync(ProcessStartInfo info, CancellationToken cancellationToken)
+    {
+        using var process = Process.Start(info)!;
+        var stdout = process.StandardOutput.ReadToEndAsync(CancellationToken.None);
+        var stderr = process.StandardError.ReadToEndAsync(CancellationToken.None);
+        try { await process.WaitForExitAsync(cancellationToken); }
+        finally
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                await process.WaitForExitAsync(CancellationToken.None);
+            }
+        }
+        var output = await stdout;
+        var error = await stderr;
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"{info.FileName} failed ({process.ExitCode}): {output} {error}");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_kdc is not null)
+        {
+            if (!_kdc.HasExited)
+                _kdc.Kill(entireProcessTree: true);
+            await _kdc.WaitForExitAsync();
+            Console.WriteLine(await _kdcOutput!);
+            Console.WriteLine(await _kdcError!);
+            _kdc.Dispose();
+        }
+        _directory.Delete(recursive: true);
+    }
+}

--- a/tests/Dekaf.Tests.Integration/Security/SaslReauthenticationIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/Security/SaslReauthenticationIntegrationTests.cs
@@ -1,0 +1,262 @@
+using Dekaf.Networking;
+using Dekaf.Errors;
+using Dekaf.Protocol.Messages;
+using Dekaf.Security.Sasl;
+using Microsoft.Extensions.Logging;
+using System.Reflection;
+using Testcontainers.Kafka;
+
+namespace Dekaf.Tests.Integration.Security;
+
+public sealed class ReauthKafkaContainer : SaslKafkaContainer
+{
+    protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder) => base.ConfigureBuilder(builder)
+        .WithEnvironment("KAFKA_LISTENER_NAME_PLAINTEXT_PLAIN_CONNECTIONS_MAX_REAUTH_MS", "3000");
+}
+
+public sealed class ReauthOAuthKafkaContainer : OAuthBearerKafkaContainer
+{
+    protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder) => base.ConfigureBuilder(builder)
+        .WithEnvironment("KAFKA_LISTENER_NAME_PLAINTEXT_OAUTHBEARER_CONNECTIONS_MAX_REAUTH_MS", "60000");
+}
+
+[Category("Authentication")]
+[ClassDataSource<ReauthOAuthKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class OAuthReauthenticationIntegrationTests(ReauthOAuthKafkaContainer kafka)
+{
+    [Test]
+    [Arguments("write lock")]
+    [Arguments("pending slot")]
+    [Arguments("broker throttle")]
+    public async Task CancelledHandshakeBeforeWrite_PreservesSession(string wait, CancellationToken cancellationToken)
+    {
+        var endpoint = BootstrapServerList.Parse(kafka.BootstrapServers);
+        await using var connection = new KafkaConnection(endpoint.Host, endpoint.Port, options: new ConnectionOptions
+        {
+            SaslMechanism = SaslMechanism.OAuthBearer,
+            OAuthBearerTokenProvider = OAuthBearerKafkaContainer.GetTokenAsync,
+            SaslReauthenticationConfig = new SaslReauthenticationConfig { Enabled = false }
+        });
+        await connection.ConnectAsync(cancellationToken);
+        using var cancelled = new CancellationTokenSource();
+        SemaphoreSlim? held = null;
+        var heldCount = 0;
+        var throttle = GetPrivateField<BrokerThrottleState>(connection, "_brokerThrottleState");
+        try
+        {
+            if (wait == "broker throttle")
+                throttle.Observe(60_000);
+            else
+            {
+                held = GetPrivateField<SemaphoreSlim>(connection,
+                    wait == "write lock" ? "_writeLock" : "_pendingRequestSlots");
+                while (held.Wait(0, cancellationToken))
+                    heldCount++;
+            }
+
+            // Control the exchange token directly so cancellation occurs while the
+            // resource is held, without racing the connection's receive timeout.
+            var exchange = (ValueTask<long>)typeof(KafkaConnection)
+                .GetMethod("PerformSaslReauthExchangeAsync", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(connection, [cancelled.Token])!;
+            await Assert.That(exchange.IsCompleted).IsFalse();
+            await cancelled.CancelAsync();
+            await Assert.That(async () => await exchange).Throws<OperationCanceledException>();
+            await Assert.That(connection.IsConnected).IsTrue();
+        }
+        finally
+        {
+            if (heldCount != 0)
+                held!.Release(heldCount);
+            typeof(BrokerThrottleState).GetField("_throttleUntilMs", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(throttle, 0L);
+        }
+
+        var metadata = await connection.SendAsync<MetadataRequest, MetadataResponse>(
+            new MetadataRequest { Topics = [] }, 9, cancellationToken);
+        await Assert.That(metadata.Brokers.Count).IsGreaterThan(0);
+        await connection.PerformReauthenticationAsync().WaitAsync(cancellationToken);
+        await Assert.That(connection.IsConnected).IsTrue();
+    }
+
+    private static T GetPrivateField<T>(KafkaConnection connection, string name) =>
+        (T)typeof(KafkaConnection).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(connection)!;
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task TokenRefreshFailure_PreservesSessionAndAllowsNextRenewal(bool timeout, CancellationToken cancellationToken)
+    {
+        var calls = 0;
+        var endpoint = BootstrapServerList.Parse(kafka.BootstrapServers);
+        await using var connection = new KafkaConnection(endpoint.Host, endpoint.Port, $"oauth-reauth-{Guid.NewGuid():N}", new ConnectionOptions
+        {
+            SaslMechanism = SaslMechanism.OAuthBearer,
+            OAuthBearerTokenProvider = async token =>
+            {
+                if (Interlocked.Increment(ref calls) == 2)
+                {
+                    if (timeout)
+                        await Task.Delay(Timeout.Infinite, token);
+                    throw new InvalidOperationException("Token provider unavailable");
+                }
+                return OAuthBearerKafkaContainer.CreateToken(OAuthBearerKafkaContainer.Principal);
+            },
+            RequestTimeout = TimeSpan.FromSeconds(3),
+            SaslReauthenticationConfig = new SaslReauthenticationConfig { Enabled = false }
+        });
+        await connection.ConnectAsync(cancellationToken);
+
+        // PerformReauthenticationAsync logs preparation failures and preserves the current session.
+        await connection.PerformReauthenticationAsync().WaitAsync(cancellationToken);
+        await Assert.That(calls).IsEqualTo(2);
+        await Assert.That(connection.IsConnected).IsTrue();
+        var metadata = await connection.SendAsync<MetadataRequest, MetadataResponse>(
+            new MetadataRequest { Topics = [] }, 9, cancellationToken);
+        await Assert.That(metadata.Brokers.Count).IsGreaterThan(0);
+
+        await connection.PerformReauthenticationAsync().WaitAsync(cancellationToken);
+        await Assert.That(calls).IsEqualTo(3);
+        await Assert.That(connection.IsConnected).IsTrue();
+        metadata = await connection.SendAsync<MetadataRequest, MetadataResponse>(
+            new MetadataRequest { Topics = [] }, 9, cancellationToken);
+        await Assert.That(metadata.Brokers.Count).IsGreaterThan(0);
+    }
+}
+
+[Category("Authentication")]
+[ClassDataSource<ReauthKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class SaslReauthenticationIntegrationTests(ReauthKafkaContainer kafka)
+{
+    [Test]
+    public async Task Timer_RenewsMultipleSessionsWithoutReconnect(CancellationToken cancellationToken)
+    {
+        var credentialCalls = 0;
+        await using var connection = CreateConnection(_ =>
+        {
+            Interlocked.Increment(ref credentialCalls);
+            return ValueTask.FromResult(ValidCredentials());
+        }, automatic: true);
+        await connection.ConnectAsync(cancellationToken);
+        var started = System.Diagnostics.Stopwatch.StartNew();
+        // Cross two complete broker session lifetimes while exercising the same connection.
+        while (started.Elapsed < TimeSpan.FromSeconds(7))
+        {
+            await ReadMetadataAsync(connection, cancellationToken);
+            await Task.Delay(100, cancellationToken);
+        }
+        await Assert.That(Volatile.Read(ref credentialCalls)).IsGreaterThanOrEqualTo(3);
+        await Assert.That(connection.IsConnected).IsTrue();
+    }
+
+    [Test]
+    public async Task ConcurrentTraffic_DuringCredentialRefreshCompletesOnSameConnection(CancellationToken cancellationToken)
+    {
+        var calls = 0;
+        var refreshing = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var credentials = new TaskCompletionSource<SaslCredentials>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var connection = CreateConnection(token =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+                return ValueTask.FromResult(ValidCredentials());
+            refreshing.TrySetResult();
+            return new ValueTask<SaslCredentials>(credentials.Task.WaitAsync(token));
+        });
+        await connection.ConnectAsync(cancellationToken);
+        var renewal = connection.PerformReauthenticationAsync();
+        try
+        {
+            await refreshing.Task.WaitAsync(cancellationToken);
+            var requests = Enumerable.Range(0, 16).Select(_ => ReadMetadataAsync(connection, cancellationToken)).ToArray();
+            await Task.WhenAll(requests).WaitAsync(cancellationToken);
+        }
+        finally
+        {
+            credentials.TrySetResult(ValidCredentials());
+            await renewal.WaitAsync(cancellationToken);
+        }
+        await ReadMetadataAsync(connection, cancellationToken);
+        await Assert.That(calls).IsEqualTo(2);
+        await Assert.That(connection.IsConnected).IsTrue();
+    }
+
+    [Test]
+    public async Task RejectedRenewal_ClosesAuthenticatedConnection(CancellationToken cancellationToken)
+    {
+        var calls = 0;
+        using var logs = new CapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(logs));
+        await using var connection = CreateConnection(_ => ValueTask.FromResult(
+            Interlocked.Increment(ref calls) == 1 ? ValidCredentials() : new SaslCredentials(SaslKafkaContainer.SaslUsername, "invalid")),
+            logger: loggerFactory.CreateLogger<KafkaConnection>());
+        await connection.ConnectAsync(cancellationToken);
+        await ReadMetadataAsync(connection, cancellationToken);
+        try { await connection.PerformReauthenticationAsync().WaitAsync(cancellationToken); }
+        catch (AuthenticationException exception)
+        {
+            await Assert.That(exception.ErrorCode).IsEqualTo(Dekaf.Protocol.ErrorCode.SaslAuthenticationFailed);
+        }
+        await TestWait.WaitForConditionAsync(() => !connection.IsConnected, TimeSpan.FromSeconds(10),
+            description: "broker disconnects rejected SASL session");
+        await Assert.That(calls).IsEqualTo(2);
+        await Assert.That(logs.Entries.Count(entry => entry.LogLevel == LogLevel.Error &&
+            entry.Message.Contains("SASL re-authentication failed", StringComparison.Ordinal))).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Dispose_DuringCredentialRefreshSettlesRenewal(CancellationToken cancellationToken)
+    {
+        var calls = 0;
+        var refreshing = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<SaslCredentials>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var connection = CreateConnection(token =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+                return ValueTask.FromResult(ValidCredentials());
+            refreshing.TrySetResult();
+            return new ValueTask<SaslCredentials>(release.Task.WaitAsync(token));
+        });
+        await connection.ConnectAsync(cancellationToken);
+        var renewal = connection.PerformReauthenticationAsync();
+        try
+        {
+            await refreshing.Task.WaitAsync(cancellationToken);
+            await connection.DisposeAsync();
+        }
+        finally
+        {
+            release.TrySetResult(ValidCredentials());
+            // Once disposal wins, the in-flight exchange may report its closed transport.
+            try { await renewal.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken); }
+            catch (ObjectDisposedException) { }
+            catch (InvalidOperationException) when (!connection.IsConnected) { }
+        }
+        await Assert.That(connection.IsConnected).IsFalse();
+        await connection.PerformReauthenticationAsync();
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    private KafkaConnection CreateConnection(Func<CancellationToken, ValueTask<SaslCredentials>> credentials,
+        bool automatic = false, ILogger<KafkaConnection>? logger = null)
+    {
+        var endpoint = BootstrapServerList.Parse(kafka.BootstrapServers);
+        return new KafkaConnection(endpoint.Host, endpoint.Port, $"reauth-{Guid.NewGuid():N}", new ConnectionOptions
+        {
+            SaslMechanism = SaslMechanism.Plain,
+            SaslCredentialProvider = credentials,
+            RequestTimeout = TimeSpan.FromSeconds(10),
+            SaslReauthenticationConfig = new SaslReauthenticationConfig
+            {
+                Enabled = automatic, MinSessionLifetimeMs = 0, ReauthenticationThreshold = 0.5
+            }
+        }, logger);
+    }
+
+    private static SaslCredentials ValidCredentials() => new(SaslKafkaContainer.SaslUsername, SaslKafkaContainer.SaslPassword);
+
+    private static async Task ReadMetadataAsync(KafkaConnection connection, CancellationToken cancellationToken)
+    {
+        var metadata = await connection.SendAsync<MetadataRequest, MetadataResponse>(new MetadataRequest { Topics = [] }, 9, cancellationToken);
+        await Assert.That(metadata.Brokers.Count).IsGreaterThan(0);
+    }
+}

--- a/tests/Dekaf.Tests.Integration/TestInfrastructureTests.cs
+++ b/tests/Dekaf.Tests.Integration/TestInfrastructureTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Tests.Integration;
 
+[Category("Admin")]
 public sealed partial class TestInfrastructureTests
 {
     [Test]

--- a/tests/Dekaf.Tests.Integration/TransactionalCrashClientProcess.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionalCrashClientProcess.cs
@@ -303,6 +303,7 @@ internal sealed class TransactionalCrashClientProcess : IAsyncDisposable
 /// Child-process entry point used by <see cref="TransactionCrashRecoveryTests"/>.
 /// It is inert during ordinary discovery and activated only through the harness environment.
 /// </summary>
+[Category("Transaction")]
 public sealed class TransactionalCrashClient
 {
     [Test]

--- a/tests/Dekaf.Tests.Unit/IntegrationCategoryCoverageTests.cs
+++ b/tests/Dekaf.Tests.Unit/IntegrationCategoryCoverageTests.cs
@@ -1,0 +1,98 @@
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Dekaf.Tests.Unit;
+
+public sealed class IntegrationCategoryCoverageTests
+{
+    [Test]
+    public async Task EveryIntegrationTest_IsSelectedByACiCategory()
+    {
+        var root = FindRepositoryRoot();
+        var groups = File.ReadAllText(Path.Combine(root, ".github/workflows/integration-groups.yml"));
+        var categories = Regex.Matches(groups, @"(?m)^ {14}[\w-]+: ([A-Za-z][A-Za-z0-9,]+)\r?$")
+            .SelectMany(match => match.Groups[1].Value.Split(',', StringSplitOptions.TrimEntries))
+            .ToHashSet(StringComparer.Ordinal);
+        // These virtual shards partition the parent category in the runner script.
+        if (categories.Contains("ShareConsumerCore") && categories.Contains("ShareConsumerOther"))
+            categories.Add("ShareConsumer");
+        var ci = File.ReadAllText(Path.Combine(root, ".github/workflows/ci.yml"));
+        foreach (Match match in Regex.Matches(ci, "run-integration-categories\\.sh net10\\.0 \"([^\"]+)\""))
+            categories.UnionWith(match.Groups[1].Value.Split(',', StringSplitOptions.TrimEntries));
+
+        await Assert.That(categories.Count).IsGreaterThan(20);
+        var declarations = Directory.EnumerateFiles(Path.Combine(root, "tests/Dekaf.Tests.Integration"), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !path.Split(Path.DirectorySeparatorChar).Any(part => part is "bin" or "obj"))
+            .SelectMany(path => CSharpSyntaxTree.ParseText(File.ReadAllText(path), path: path)
+                .GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>())
+            .ToArray();
+        var classes = declarations.ToLookup(type => type.Identifier.ValueText);
+        var missing = new List<string>();
+        var testCount = 0;
+        foreach (var type in declarations)
+        {
+            foreach (var method in type.Members.OfType<MethodDeclarationSyntax>())
+            {
+                if (!Attributes(method.AttributeLists).Any(attribute => AttributeName(attribute) == "Test"))
+                    continue;
+                testCount++;
+                var selected = CategoryNames(method.AttributeLists)
+                    .Concat(ClassCategories(type.Identifier.ValueText, classes, new HashSet<string>(StringComparer.Ordinal)))
+                    .Any(categories.Contains);
+                if (!selected)
+                    missing.Add($"{type.Identifier.ValueText}.{method.Identifier.ValueText}");
+            }
+        }
+
+        await Assert.That(testCount).IsGreaterThan(500);
+        await Assert.That(missing).IsEmpty()
+            .Because($"Every integration test must run in CI. Unselected tests: {string.Join(", ", missing)}");
+    }
+
+    private static IEnumerable<string> ClassCategories(string name,
+        ILookup<string, ClassDeclarationSyntax> classes, HashSet<string> visited)
+    {
+        if (!visited.Add(name))
+            yield break;
+        foreach (var type in classes[name])
+        {
+            foreach (var category in CategoryNames(type.AttributeLists))
+                yield return category;
+            if (type.BaseList is null)
+                continue;
+            foreach (var parent in type.BaseList.Types)
+                foreach (var category in ClassCategories(parent.Type.ToString(), classes, visited))
+                    yield return category;
+        }
+    }
+
+    private static IEnumerable<AttributeSyntax> Attributes(SyntaxList<AttributeListSyntax> lists) =>
+        lists.SelectMany(list => list.Attributes);
+
+    private static string AttributeName(AttributeSyntax attribute)
+    {
+        var name = attribute.Name switch
+        {
+            QualifiedNameSyntax qualified => qualified.Right.Identifier.ValueText,
+            AliasQualifiedNameSyntax alias => alias.Name.Identifier.ValueText,
+            SimpleNameSyntax simple => simple.Identifier.ValueText,
+            _ => attribute.Name.ToString()
+        };
+        return name.EndsWith("Attribute", StringComparison.Ordinal) ? name[..^9] : name;
+    }
+
+    private static IEnumerable<string> CategoryNames(SyntaxList<AttributeListSyntax> lists) =>
+        Attributes(lists).Where(attribute => AttributeName(attribute) == "Category")
+            .Select(attribute => attribute.ArgumentList!.Arguments[0].Expression)
+            .OfType<LiteralExpressionSyntax>().Select(expression => expression.Token.ValueText);
+
+    private static string FindRepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+            if (File.Exists(Path.Combine(directory.FullName, ".github/workflows/integration-groups.yml")))
+                return directory.FullName;
+        throw new DirectoryNotFoundException("Cannot find integration-groups.yml above the test output directory.");
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Networking/SaslReauthenticationGateTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/SaslReauthenticationGateTests.cs
@@ -1,0 +1,74 @@
+using Dekaf.Networking;
+
+namespace Dekaf.Tests.Unit.Networking;
+
+public class SaslReauthenticationGateTests
+{
+    [Test]
+    public async Task Pause_DrainsExistingRequestsAndBlocksNewRequests(CancellationToken cancellationToken)
+    {
+        var gate = new SaslReauthenticationGate();
+        await gate.EnterAsync(cancellationToken);
+        await gate.EnterAsync(cancellationToken);
+        var paused = gate.PauseAsync(cancellationToken);
+        var waiting = gate.EnterAsync(cancellationToken).AsTask();
+        await Assert.That(paused.IsCompleted).IsFalse();
+        await Assert.That(waiting.IsCompleted).IsFalse();
+        gate.Exit();
+        await Assert.That(paused.IsCompleted).IsFalse();
+        gate.Exit();
+        await paused.WaitAsync(cancellationToken);
+        await Assert.That(waiting.IsCompleted).IsFalse();
+        gate.Resume();
+        await waiting.WaitAsync(cancellationToken);
+        gate.Exit();
+    }
+
+    [Test]
+    public async Task CancelledWaiter_DoesNotPreventNextRenewal(CancellationToken cancellationToken)
+    {
+        var gate = new SaslReauthenticationGate();
+        await gate.PauseAsync(cancellationToken);
+        using var cancelled = new CancellationTokenSource();
+        var waiting = gate.EnterAsync(cancelled.Token).AsTask();
+        cancelled.Cancel();
+        await Assert.That(async () => await waiting).Throws<OperationCanceledException>();
+        gate.Resume();
+        await gate.EnterAsync(cancellationToken);
+        gate.Exit();
+        await gate.PauseAsync(cancellationToken).WaitAsync(cancellationToken);
+        gate.Resume();
+    }
+
+    [Test]
+    public async Task CancelledPause_PreservesOutstandingRequestCount(CancellationToken cancellationToken)
+    {
+        var gate = new SaslReauthenticationGate();
+        await gate.EnterAsync(cancellationToken);
+        using var cancelled = new CancellationTokenSource();
+        var pause = gate.PauseAsync(cancelled.Token);
+        cancelled.Cancel();
+        await Assert.That(async () => await pause).Throws<OperationCanceledException>();
+        gate.Resume();
+        var nextPause = gate.PauseAsync(cancellationToken);
+        await Assert.That(nextPause.IsCompleted).IsFalse();
+        gate.Exit();
+        await nextPause.WaitAsync(cancellationToken);
+        gate.Resume();
+    }
+
+    [Test]
+    public async Task Close_ReleasesBlockedRequestsAndRenewal(CancellationToken cancellationToken)
+    {
+        var gate = new SaslReauthenticationGate();
+        await gate.EnterAsync(cancellationToken);
+        var pause = gate.PauseAsync(cancellationToken);
+        var waiting = gate.EnterAsync(cancellationToken).AsTask();
+        gate.Close();
+        await pause.WaitAsync(cancellationToken);
+        await Assert.That(async () => await waiting).Throws<ObjectDisposedException>();
+        gate.Resume();
+        await Assert.That(async () => await gate.EnterAsync(cancellationToken)).Throws<ObjectDisposedException>();
+        gate.Exit();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AliCloudSdkKmsClientTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AliCloudSdkKmsClientTests.cs
@@ -1,0 +1,160 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using AlibabaCloud.OpenApiClient.Models;
+using AlibabaCloud.SDK.Kms20160120;
+using Dekaf.SchemaRegistry.Kms.AliCloud;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public sealed class AliCloudSdkKmsClientTests
+{
+    [Test]
+    public async Task Encrypt_MapsSdkRequestAndReturnsOpaqueCiphertext()
+    {
+        await using var endpoint = new KmsEndpoint("""{"CiphertextBlob":"opaque+/ciphertext=="}""");
+        var ciphertext = await endpoint.Client.EncryptAsync("alias/orders", new byte[] { 0, 1, 255 });
+        var request = await endpoint.Request.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(request).Contains("x-acs-action: Encrypt");
+        await Assert.That(Uri.UnescapeDataString(request)).Contains("KeyId=alias/orders");
+        await Assert.That(Uri.UnescapeDataString(request)).Contains("Plaintext=AAH/");
+        await Assert.That(Encoding.UTF8.GetString(ciphertext)).IsEqualTo("opaque+/ciphertext==");
+    }
+
+    [Test]
+    public async Task Decrypt_MapsOpaqueCiphertextAndDecodesSdkPlaintext()
+    {
+        await using var endpoint = new KmsEndpoint("""{"Plaintext":"AAH/"}""");
+        var plaintext = await endpoint.Client.DecryptAsync("opaque+/ciphertext=="u8.ToArray());
+        var request = await endpoint.Request.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(request).Contains("x-acs-action: Decrypt");
+        await Assert.That(Uri.UnescapeDataString(request)).Contains("CiphertextBlob=opaque+/ciphertext==");
+        await Assert.That(plaintext).IsEquivalentTo(new byte[] { 0, 1, 255 });
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task MissingSdkPayload_ReturnsEmptyForProviderValidation(bool decrypt)
+    {
+        await using var endpoint = new KmsEndpoint("{}");
+        var result = decrypt
+            ? await endpoint.Client.DecryptAsync(new byte[] { 1 })
+            : await endpoint.Client.EncryptAsync("key", new byte[] { 1 });
+        await Assert.That(result).IsEmpty();
+    }
+
+    [Test]
+    public async Task Decrypt_MalformedBase64_FailsInsteadOfReturningCorruptedKey()
+    {
+        await using var endpoint = new KmsEndpoint("""{"Plaintext":"not base64!"}""");
+        await Assert.That(async () => await endpoint.Client.DecryptAsync(new byte[] { 1 }))
+            .Throws<FormatException>();
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Cancellation_StopsWaitingForAnInFlightSdkCall(bool decrypt)
+    {
+        await using var endpoint = new KmsEndpoint("{}", holdResponse: true);
+        using var cancellation = new CancellationTokenSource();
+        var pending = decrypt
+            ? endpoint.Client.DecryptAsync(new byte[] { 1 }, cancellation.Token).AsTask()
+            : endpoint.Client.EncryptAsync("key", new byte[] { 1 }, cancellation.Token).AsTask();
+        await endpoint.Request.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await cancellation.CancelAsync();
+        try
+        {
+            await Assert.That(async () => await pending.WaitAsync(TimeSpan.FromSeconds(5)))
+                .Throws<OperationCanceledException>();
+        }
+        finally
+        {
+            endpoint.ReleaseResponse.TrySetResult();
+        }
+    }
+
+    [Test]
+    public async Task ServiceFailure_PreservesSdkError()
+    {
+        await using var endpoint = new KmsEndpoint(
+            """{"Code":"InvalidKeyId.NotFound","Message":"local test key missing","RequestId":"offline"}""", status: 400);
+        var exception = await Assert.That(async () => await endpoint.Client.EncryptAsync("missing", new byte[] { 1 }))
+            .ThrowsException();
+        await Assert.That(exception!.Message).Contains("local test key missing");
+    }
+
+    // Exercises the unmodified, non-virtual SDK methods over loopback, including SDK wire encoding.
+    private sealed class KmsEndpoint : IAsyncDisposable
+    {
+        private readonly TcpListener _listener = new(IPAddress.Loopback, 0);
+        private readonly CancellationTokenSource _stopping = new(TimeSpan.FromSeconds(15));
+        private readonly Task _server;
+        public TaskCompletionSource<string> Request { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource ReleaseResponse { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public AliCloudSdkKmsClient Client { get; }
+
+        public KmsEndpoint(string response, bool holdResponse = false, int status = 200)
+        {
+            _listener.Start();
+            var port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            Client = new AliCloudSdkKmsClient(new Client(new Config
+            {
+                AccessKeyId = "offline-test-id", AccessKeySecret = "offline-test-secret",
+                Endpoint = $"127.0.0.1:{port}", Protocol = "http", RegionId = "cn-chengdu",
+                ReadTimeout = 5000, ConnectTimeout = 5000
+            }));
+            if (!holdResponse)
+                ReleaseResponse.SetResult();
+            _server = ServeAsync(response, status);
+        }
+
+        private async Task ServeAsync(string response, int status)
+        {
+            using var socket = await _listener.AcceptTcpClientAsync(_stopping.Token);
+            await using var stream = socket.GetStream();
+            using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);
+            var captured = new StringBuilder();
+            var contentLength = 0;
+            var expectContinue = false;
+            while (await reader.ReadLineAsync(_stopping.Token) is { Length: > 0 } line)
+            {
+                captured.AppendLine(line);
+                if (line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase))
+                    contentLength = int.Parse(line[15..], System.Globalization.CultureInfo.InvariantCulture);
+                if (line.Equals("Expect: 100-continue", StringComparison.OrdinalIgnoreCase))
+                    expectContinue = true;
+            }
+            if (expectContinue)
+                await stream.WriteAsync("HTTP/1.1 100 Continue\r\n\r\n"u8.ToArray(), _stopping.Token);
+            var body = new char[contentLength];
+            if (contentLength > 0)
+                await reader.ReadBlockAsync(body.AsMemory(), _stopping.Token);
+            captured.Append(body);
+            Request.TrySetResult(captured.ToString());
+            await ReleaseResponse.Task.WaitAsync(_stopping.Token);
+            var bytes = Encoding.UTF8.GetBytes(response);
+            var headers = Encoding.ASCII.GetBytes($"HTTP/1.1 {status} Test\r\nContent-Type: application/json\r\nContent-Length: {bytes.Length}\r\nConnection: close\r\n\r\n");
+            await stream.WriteAsync(headers, _stopping.Token);
+            await stream.WriteAsync(bytes, _stopping.Token);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            ReleaseResponse.TrySetResult();
+            try { await _server.WaitAsync(TimeSpan.FromSeconds(5)); }
+            catch (TimeoutException) { /* Force shutdown below without masking the test failure. */ }
+            finally
+            {
+                await _stopping.CancelAsync();
+                _listener.Stop();
+                try { await _server; }
+                catch (OperationCanceledException) when (_stopping.IsCancellationRequested) { }
+                finally { _stopping.Dispose(); }
+            }
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Security/GssapiAuthenticatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/GssapiAuthenticatorTests.cs
@@ -224,7 +224,7 @@ public class GssapiConfigTests
 
         await Assert.That(options.Package).IsEqualTo("Kerberos");
         await Assert.That(options.TargetName).IsEqualTo("kafka/broker.example.com");
-        await Assert.That(options.RequiredProtectionLevel).IsEqualTo(System.Net.Security.ProtectionLevel.None);
+        await Assert.That(options.RequiredProtectionLevel).IsEqualTo(System.Net.Security.ProtectionLevel.Sign);
         await Assert.That(options.Credential).IsNotNull();
     }
 

--- a/tests/Dekaf.Tests.Unit/Security/GssapiSecurityLayerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/GssapiSecurityLayerTests.cs
@@ -1,0 +1,25 @@
+using Dekaf.Errors;
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Tests.Unit.Security;
+
+public class GssapiSecurityLayerTests
+{
+    [Test]
+    [Arguments(new byte[] { 1, 0, 0, 0 })]
+    [Arguments(new byte[] { 1, 1, 0, 0 })]
+    [Arguments(new byte[] { 3, 0, 16, 0 })]
+    [Arguments(new byte[] { 7, 255, 255, 255 })]
+    public void AuthenticationOnlyOffered_AcceptsOffer(byte[] offer)
+        => GssapiAuthenticator.ValidateSecurityLayerOffer(offer);
+
+    [Test]
+    [Arguments(new byte[] { })]
+    [Arguments(new byte[] { 1, 0, 0 })]
+    [Arguments(new byte[] { 1, 0, 0, 0, 0 })]
+    [Arguments(new byte[] { 0, 0, 0, 0 })]
+    [Arguments(new byte[] { 2, 0, 16, 0 })]
+    [Arguments(new byte[] { 4, 0, 16, 0 })]
+    public async Task MalformedOrUnsupportedOffer_RejectsAuthentication(byte[] offer)
+        => await Assert.That(() => GssapiAuthenticator.ValidateSecurityLayerOffer(offer)).Throws<AuthenticationException>();
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SaslReauthenticationGateBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SaslReauthenticationGateBenchmarks.cs
@@ -1,0 +1,18 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Networking;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Measures admission per Kafka request, amortized across each produce/fetch batch.</summary>
+[MemoryDiagnoser]
+public class SaslReauthenticationGateBenchmarks
+{
+    private readonly SaslReauthenticationGate _gate = new();
+
+    [Benchmark]
+    public async ValueTask AdmitRequest()
+    {
+        await _gate.EnterAsync(CancellationToken.None).ConfigureAwait(false);
+        _gate.Exit();
+    }
+}


### PR DESCRIPTION
Several integration suites were omitted by CI category filters, while producer purge, adaptive fetch sizing, five admin operations, SASL renewal, successful GSSAPI authentication, and the AliCloud KMS SDK adapter lacked behavioral coverage.

The new tests also expose and fix two authentication defects: normal requests could interrupt a SASL renewal, and GSSAPI stopped before RFC 4752 security-layer negotiation completed. Renewal now pauses request admission through the exchange and closes a failed exchange before allowing more traffic. Initial authentication and renewal both transmit final client tokens before accepting completion.

- Restore integration categories and add a Roslyn-based guard that checks every integration test against CI's category selections.
- Exercise queue/in-flight/all purge, callback uniqueness, buffer reclamation, continued idempotent delivery, and rejection during active transactions. The paused-broker fixture waits until the batch leaves the queue and its frame releases its accumulator reservation.
- Observe real Fetch requests while adaptive sizing grows or shrinks under actual prefetch pressure, checking limits and every delivered offset.
- Verify ListTransactions, AlterReplicaLogDirs, AddRaftVoter, RemoveRaftVoter, and UnregisterBroker against local Kafka, including a two-controller dynamic quorum.
- Cover repeated SASL renewal, concurrent credential refresh, rejection, disposal, and deterministic admission/cancellation races.
- Run successful GSSAPI produce/consume and wrong-service rejection with an isolated MIT KDC, keytabs, and inherited ticket cache. CI installs the local tools on Linux net10.0/NativeAOT connections lanes; the unsupported netstandard2.0 GSSAPI asset and Windows skip this fixture.
- Exercise the unmodified AliCloud SDK over loopback HTTP with fake credentials, including request encoding, response decoding, malformed/missing payloads, service errors, and cancellation. No cloud account or real external authentication service is required.

Review and CI fixes:
- Preserve authenticated connections when OAuth/AWS credential preparation fails or request admission is cancelled before the SASL exchange starts. OAuth integration cases cover provider exceptions, refresh timeouts, cancellation while waiting for the write lock/pending slots/broker throttle, continued metadata requests, and a later successful renewal. The exchange starts only when its handshake write-start callback runs. Authentication failures are logged before abort suppresses the outer catch; the rejection test asserts one failure log. Failures after the exchange starts still close the transport.
- Keep the catch-all shard green when no tests remain outside explicit CI categories, while preserving zero-test failures in named categories and all assertion/infrastructure failures. Linux runner-script tests and the real MTP zero-test exit were checked.
- Preserve pipelined and caller-timeout forwarding in the adaptive-fetch observer; prevent an unused KMS listener cleanup timeout from masking test failures.
- Let Docker allocate controller host ports, then publish the assigned endpoints before Kafka starts. This removes the released-port reservation race.
- Rebase onto b1e96f783ce07a593924cde3c4d423595e9fad8c, retaining the TLS fixture fix from main that refuses HTTP retries after its one accepted connection. Move Kerberos setup to the renamed connections shard and adapt the source category guard to the new matrix.
- Fix the reproduced +32 B/request allocation regression in OrdinaryRequest and ObservedRequest from [the original performance gate](https://github.com/thomhurst/Dekaf/actions/runs/34689869618/job/103543189030). Admission now returns a non-generic ValueTask and releases in finally, allowing send methods to reuse their existing awaiter without carrying a lease or another generic awaiter in their async state.

Validation on the revised branch:
- Release solution build: no warnings or errors.
- Full unit suites: 10,751 passed on .NET 10; 10,568 passed on .NET 8.
- Focused integration coverage: 28 distinct cases passed on each of .NET 10 and .NET 8, including OAuth/SASL renewal, dynamic quorum membership, adaptive fetch sizing, and schema registry TLS. The final authentication/adaptive-fetch changes passed all 11 affected cases on both frameworks.
- Final affected unit checks: 77 passed on .NET 8, and all eight AliCloud SDK tests passed on .NET 10.
- Linux .NET 10 schema registry TLS suite: all 16 passed, including rejection of a missing client certificate.
- Simplification review and git diff --check completed.

Performance: admission uses atomics and a synchronous ValueTask fast path; its cost is per Kafka request, amortized over produce/fetch batches. Unauthenticated connections bypass the gate. Gate storage is per connection; pause completion sources, handshake callback storage, and GSSAPI buffers are per authentication attempt. ShortRun with MemoryDiagnoser measured admission at 13.04 ns / 0 B, and ordinary/observed requests at approximately 1,015 B/request after the allocation fix. These are local diagnostics, not a baseline performance claim. The allocation fix passed the hosted [PipelinedResponseAllocationBenchmarks A1/B/A2 check](https://github.com/thomhurst/Dekaf/actions/runs/34691157575/job/103546582625) on 959080d94. The [final performance gate](https://github.com/thomhurst/Dekaf/actions/runs/34691900286) passed for 043bf1839, including all eight selected benchmark classes. The [complete CI workflow](https://github.com/thomhurst/Dekaf/actions/runs/34691900438) also passed, including every integration shard.

The original [producer-idempotent-1b A1/B/A2 stress run](https://github.com/thomhurst/Dekaf/actions/runs/34689874883) finished **REGRESSION** against baseline 63f3b59a4 (candidate 744ae376b; dispatch_shape=cheap, duration_minutes=5 per sample, producer_warmup_seconds=180, full_run=false). p50 was +4.37%/+3.46% and p95 +12.19%/+10.35% versus the two controls; throughput, CPU/message, allocations/message, and stability passed. The summary and original artifacts were inspected. The revised product removes the generic admission awaiter and lease from all three send paths; the subsequent comparison against fresh main assessed the revised state size and allocation behavior under load (result below). No tolerance or stress defaults were changed, and the original result is not accepted as a tradeoff.

The [revised producer-idempotent-1b A1/B/A2 stress comparison](https://github.com/thomhurst/Dekaf/actions/runs/34691907813) finished **INCONCLUSIVE** for candidate 043bf1839 against fresh-main baseline b1e96f783ce07a593924cde3c4d423595e9fad8c (dispatch_shape=cheap, duration_minutes=5 per sample, producer_warmup_seconds=180, full_run=false; verdict INCONCLUSIVE). Runtime coverage was validated, but baseline A2 breached the throughput slope and intra-run drift thresholds (first-to-last-third throughput -2.83%); p50 control drift was 33.50%. This does not establish loaded-performance acceptance and is not a recorded maintainer tradeoff. The PR was merged by the maintainer while this run was still in progress; no additional paid repeat has been dispatched. This exercises the shared connection/send path under load; SASL/GSSAPI exchanges are covered by the authentication integration suites.

