### PR TITLE
perf(share-consumer): recover sparse acknowledged-offset indexing

### DIFF
--- a/src/Dekaf/ShareConsumer/ShareAcknowledgedOffsets.cs
+++ b/src/Dekaf/ShareConsumer/ShareAcknowledgedOffsets.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace Dekaf.ShareConsumer;
 
 /// <summary>
@@ -8,6 +10,7 @@ public readonly struct ShareAcknowledgedOffsets
     private readonly List<AcknowledgementBatchData>? _batches;
     private readonly bool _hasGaps;
     private readonly bool _requiresOffsetScan;
+    private readonly bool _hasCompactRanges;
 
     internal ShareAcknowledgedOffsets(List<AcknowledgementBatchData> batches)
     {
@@ -32,6 +35,7 @@ public readonly struct ShareAcknowledgedOffsets
         }
 
         _hasGaps = hasGaps;
+        _hasCompactRanges = hasCompactRanges;
         _requiresOffsetScan = hasGaps || hasCompactRanges;
         Length = length;
     }
@@ -58,7 +62,7 @@ public readonly struct ShareAcknowledgedOffsets
             ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Length);
 
             if (_requiresOffsetScan)
-                return GetSparseOffset(_batches!, index);
+                return _hasCompactRanges ? GetRangeOffset(_batches!, index) : GetSparseOffset(_batches!, index);
 
             var batches = _batches!;
             for (var batchIndex = 0; batchIndex < batches.Count; batchIndex++)
@@ -76,7 +80,42 @@ public readonly struct ShareAcknowledgedOffsets
     }
 
     // Pass fields so the JIT can keep the view in registers when inlining the indexer.
+    // Keep the scan out of the caller's traversal loop to avoid inflating its register pressure.
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static long GetSparseOffset(List<AcknowledgementBatchData> batches, int index)
+    {
+        for (var batchIndex = 0; batchIndex < batches.Count; batchIndex++)
+        {
+            var batch = batches[batchIndex];
+            var types = batch.AcknowledgeTypes;
+            var offset = 0;
+            // Keep short logical suffixes scalar so counting setup stays amortized over a prefix.
+            while (index >= 16 && offset < types.Length)
+            {
+                // At most index + 1 entries cannot pass the requested logical offset.
+                // A match inside this prefix therefore means every entry was acknowledged.
+                var prefixLength = Math.Min(index + 1, types.Length - offset);
+                var acknowledged = prefixLength - CountGaps(types.AsSpan(offset, prefixLength));
+                if (index < acknowledged)
+                    return batch.FirstOffset + offset + index;
+                index -= acknowledged;
+                offset += prefixLength;
+            }
+
+            for (; offset < types.Length; offset++)
+            {
+                if (types[offset] == (byte)AcknowledgeType.Gap)
+                    continue;
+                if (index-- == 0)
+                    return batch.FirstOffset + offset;
+            }
+        }
+
+        throw new InvalidOperationException("Offset index was not present in the acknowledgement batches.");
+    }
+
+    // Keep compact-range branches out of the expanded-vector scan.
+    private static long GetRangeOffset(List<AcknowledgementBatchData> batches, int index)
     {
         for (var batchIndex = 0; batchIndex < batches.Count; batchIndex++)
         {

--- a/src/Dekaf/ShareConsumer/ShareAcknowledgedOffsets.cs
+++ b/src/Dekaf/ShareConsumer/ShareAcknowledgedOffsets.cs
@@ -9,7 +9,6 @@ public readonly struct ShareAcknowledgedOffsets
 {
     private readonly List<AcknowledgementBatchData>? _batches;
     private readonly bool _hasGaps;
-    private readonly bool _requiresOffsetScan;
     private readonly bool _hasCompactRanges;
 
     internal ShareAcknowledgedOffsets(List<AcknowledgementBatchData> batches)
@@ -36,7 +35,6 @@ public readonly struct ShareAcknowledgedOffsets
 
         _hasGaps = hasGaps;
         _hasCompactRanges = hasCompactRanges;
-        _requiresOffsetScan = hasGaps || hasCompactRanges;
         Length = length;
     }
 
@@ -61,8 +59,10 @@ public readonly struct ShareAcknowledgedOffsets
             ArgumentOutOfRangeException.ThrowIfNegative(index);
             ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Length);
 
-            if (_requiresOffsetScan)
-                return _hasCompactRanges ? GetRangeOffset(_batches!, index) : GetSparseOffset(_batches!, index);
+            if (_hasCompactRanges)
+                return GetRangeOffset(_batches!, index);
+            if (_hasGaps)
+                return GetSparseOffset(_batches!, index);
 
             var batches = _batches!;
             for (var batchIndex = 0; batchIndex < batches.Count; batchIndex++)

--- a/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
@@ -292,6 +292,8 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         const int messageCount = 64;
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
         ShareAcknowledgementCommitResult[]? outcomes = null;
+        long[] callbackIndexed = [];
+        long[] callbackEnumerated = [];
         await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .BuildAsync();
@@ -300,7 +302,20 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
             .WithGroupId($"share-sparse-offsets-{Guid.NewGuid():N}")
             .WithAcknowledgementMode(ShareAcknowledgementMode.Explicit)
             .WithMaxPollRecords(messageCount)
-            .WithAcknowledgementCommitCallback(results => outcomes = results.ToArray())
+            .WithAcknowledgementCommitCallback(results =>
+            {
+                outcomes = results.ToArray();
+                if (results.Length != 1)
+                    return;
+                var offsets = results[0].Offsets;
+                callbackIndexed = new long[offsets.Length];
+                callbackEnumerated = new long[offsets.Length];
+                for (var index = 0; index < offsets.Length; index++)
+                    callbackIndexed[index] = offsets[index];
+                var enumeratedCount = 0;
+                foreach (var offset in offsets)
+                    callbackEnumerated[enumeratedCount++] = offset;
+            })
             .BuildAsync();
         consumer.Subscribe(topic);
         await ShareConsumerTestHelper.PrimeShareConsumerAsync(consumer);
@@ -324,6 +339,8 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         await Assert.That(outcomes).HasSingleItem();
         var firstOutcome = outcomes![0];
         var firstOffsets = firstOutcome.Offsets;
+        var firstCallbackIndexed = callbackIndexed;
+        var firstCallbackEnumerated = callbackEnumerated;
         await Assert.That(firstOutcome.Succeeded).IsTrue();
         await Assert.That(firstOffsets.Length).IsEqualTo(messageCount / 2);
 
@@ -342,8 +359,12 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         for (var index = 0; index < copied.Length; index++)
         {
             await Assert.That(copied[index]).IsEqualTo(received[index * 2].Offset);
+            await Assert.That(firstCallbackIndexed[index]).IsEqualTo(copied[index]);
+            await Assert.That(firstCallbackEnumerated[index]).IsEqualTo(copied[index]);
             await Assert.That(firstOutcome.Offsets[index]).IsEqualTo(copied[index]);
             await Assert.That(secondOutcome.Offsets[index]).IsEqualTo(received[index * 2 + 1].Offset);
+            await Assert.That(callbackIndexed[index]).IsEqualTo(received[index * 2 + 1].Offset);
+            await Assert.That(callbackEnumerated[index]).IsEqualTo(received[index * 2 + 1].Offset);
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareAcknowledgedOffsetsTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareAcknowledgedOffsetsTests.cs
@@ -5,6 +5,51 @@ namespace Dekaf.Tests.Unit.ShareConsumer;
 public sealed class ShareAcknowledgedOffsetsTests
 {
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task OffsetView_MixedRangesPreserveRandomAccessAndZeroAllocation(bool compactFirst)
+    {
+        var expanded = new byte[65];
+        var expected = new List<long>();
+        for (var index = 0; index < expanded.Length; index++)
+            expanded[index] = index % 2 == 0 ? (byte)255 : (byte)0;
+        var compact = new AcknowledgementBatchData(100, 132, [2]);
+        var sparse = new AcknowledgementBatchData(200, 264, expanded);
+        List<AcknowledgementBatchData> batches = compactFirst ? [compact, sparse] : [sparse, compact];
+        batches.Insert(1, new AcknowledgementBatchData(300, 331, [0]));
+        batches.Add(new AcknowledgementBatchData(400, 400, [3]));
+        foreach (var batch in batches)
+            for (var offset = batch.FirstOffset; offset <= batch.LastOffset; offset++)
+                if (batch.AcknowledgeTypes[batch.AcknowledgeTypes.Length == 1 ? 0 : (int)(offset - batch.FirstOffset)] != 0)
+                    expected.Add(offset);
+
+        var indexed = new long[expected.Count];
+        var copied = new long[expected.Count];
+        var enumerated = new long[expected.Count];
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        var offsets = new ShareAcknowledgedOffsets(batches);
+        var retainedCopy = offsets;
+        var enumerator = offsets.GetEnumerator();
+        for (var index = expected.Count - 1; index >= 0; index--)
+            indexed[index] = retainedCopy[index];
+        var count = 0;
+        while (enumerator.MoveNext())
+            enumerated[count++] = enumerator.Current;
+        var remainsExhausted = !enumerator.MoveNext();
+        offsets.CopyTo(copied);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
+        await Assert.That(offsets.Length).IsEqualTo(expected.Count);
+        await Assert.That(indexed.SequenceEqual(expected)).IsTrue();
+        await Assert.That(copied.SequenceEqual(expected)).IsTrue();
+        await Assert.That(enumerated.SequenceEqual(expected)).IsTrue();
+        await Assert.That(remainsExhausted).IsTrue();
+        await Assert.That(() => offsets[-1]).Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => offsets[expected.Count]).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
     public async Task OffsetView_EnumeratorSkipsEmptyAndCompactGapBatchesAndStaysExhausted()
     {
         List<AcknowledgementBatchData> batches =

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgedOffsetsRangeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareAcknowledgedOffsetsRangeBenchmarks.cs
@@ -1,0 +1,75 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Measures compact ranges alone and mixed with expanded sparse vectors.</summary>
+[MemoryDiagnoser]
+public class ShareAcknowledgedOffsetsRangeBenchmarks
+{
+    private List<AcknowledgementBatchData> _batches = null!;
+    private long[] _destination = null!;
+
+    [Params(64, 1024)] public int RecordCount { get; set; }
+    [Params(false, true)] public bool Mixed { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _batches = [new(10, 10 + RecordCount - 1, [(byte)AcknowledgeType.Release])];
+        var expected = new List<long>();
+        for (var index = 0; index < RecordCount; index++)
+            expected.Add(10 + index);
+        if (Mixed)
+        {
+            _batches.Add(new(2000, 2000 + RecordCount - 1, [(byte)AcknowledgeType.Gap]));
+            var types = new byte[RecordCount];
+            for (var index = 0; index < RecordCount; index += 2)
+            {
+                types[index] = (byte)AcknowledgeType.Accept;
+                expected.Add(4000 + index);
+            }
+            _batches.Add(new(4000, 4000 + RecordCount - 1, types));
+        }
+
+        _destination = new long[expected.Count];
+        var offsets = new ShareAcknowledgedOffsets(_batches);
+        if (offsets.Length != expected.Count)
+            throw new InvalidOperationException("Compact ranges must count logical offsets.");
+        offsets.CopyTo(_destination);
+        var enumerator = offsets.GetEnumerator();
+        for (var index = 0; index < expected.Count; index++)
+            if (_destination[index] != expected[index] || offsets[index] != expected[index]
+                || !enumerator.MoveNext() || enumerator.Current != expected[index])
+                throw new InvalidOperationException("Every access path must preserve compact and sparse offsets.");
+        if (enumerator.MoveNext() || enumerator.MoveNext())
+            throw new InvalidOperationException("The enumerator must remain exhausted.");
+    }
+
+    [Benchmark]
+    public long CreateAndIndex()
+    {
+        var offsets = new ShareAcknowledgedOffsets(_batches);
+        long sum = 0;
+        for (var index = 0; index < offsets.Length; index++)
+            sum += offsets[index];
+        return sum;
+    }
+
+    [Benchmark]
+    public long CreateAndEnumerate()
+    {
+        var offsets = new ShareAcknowledgedOffsets(_batches);
+        long sum = 0;
+        foreach (var offset in offsets)
+            sum += offset;
+        return sum;
+    }
+
+    [Benchmark]
+    public long CreateAndCopy()
+    {
+        new ShareAcknowledgedOffsets(_batches).CopyTo(_destination);
+        return _destination[^1];
+    }
+}


### PR DESCRIPTION
Sparse indexed traversal regressed when compact-range handling was added to `ShareAcknowledgedOffsets`. This change restores the expanded-vector scan and routes compact/mixed views through the range-aware scan. Enumeration and `CopyTo` retain their implementations.

The view stores only the independent gap and compact-range flags. The indexer checks compact ranges, then gaps, instead of maintaining a third, redundant combined flag. Disassembly showed that the extra state changes generated branch layout even when enumerator source is unchanged. The sparse helper retains `NoInlining` to avoid inflating the caller's indexed traversal loop.

Flag checks are per indexed access; construction costs remain amortized per acknowledgement callback view. This adds no allocations, per-message work outside callbacks, cached index, mutable cursor, or pooled ownership. Sparse indexing remains O(n) per lookup and O(n²) for a complete indexed traversal; `foreach` and `CopyTo` remain O(n).

Validation:
- Release build passes for all configured library targets with no warnings. All 43 focused offset-view tests pass on each of net8.0 and net10.0. The Kafka callback integration test passes with indexed/enumerated traversal and retained offsets after another commit.
- The PR includes a steady-state `[MemoryDiagnoser]` fixture with 12 compact/mixed-range cases covering indexing, enumeration, and `CopyTo`.
- All 28 expanded and compact/mixed cases complete locally and report 0 B/op. Windows ShortRun showed one borderline dense-indexing difference; the targeted Linux comparison below investigates it. Local measurements are diagnostic, not hosted acceptance.
- Targeted Linux A1/B/A2, with 10 warmups and 15 measurement iterations per phase, measures the previously failing mixed-range enumeration case at 85.58 / 81.17 / 87.51 ns. Dense indexing at 1024 records / one batch measures 798.4 / 902.9 / 798.9 ns: +13.1%/+13.0%, within the local 15% screen tolerance. The previous hosted dense baseline was 1.46 µs, which uses the stricter 10% tolerance; hosted acceptance remains essential. All phases report 0 B/op; no performance tradeoff is claimed or accepted from these local results.
- The previous [fresh-main gate](https://github.com/thomhurst/Dekaf/actions/runs/34694175836/job/103554746198) reproduced the mixed-range enumeration regression at 64 records: 124.0 ns versus 92.6/93.0 ns controls, with 0 B/op. This remains a recorded regression on the previous revision. The expanded-offset fixture passed that gate. The updated [range-fixture gate](https://github.com/thomhurst/Dekaf/actions/runs/34698366535/job/103565722636) passes at `591a33fedd1d953d6cbe4ea37d0f8d47dc8f9f36`: the formerly failing case measures 114.4 / 114.3 / 120.2 ns, all 0 B/op. The expanded-offset fixture and remaining matrix verdicts are pending.
- The previous [historical comparison](https://github.com/thomhurst/Dekaf/actions/runs/34694175528) failed before measurement because `git fetch` received an abbreviated candidate SHA. It provides no performance verdict. Historical recovery against `b8295c5d5c46edd3840525e4d47e147c2dd454c2` remains unconfirmed; the issue distinguishes two reproduced 64-record regressions from the unconfirmed 1024-record difference.

This PR does not claim loaded performance acceptance. The synchronous callback integration test checks correctness, including traversal during callbacks and retained offsets after another commit. The old hosted-share run did not traverse offsets and cannot establish loaded acceptance for this change. Historical 64-partition resubscription debt remains tracked by #3294.

Fixes #3304.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved acknowledgement offset handling for compact ranges and batches with gaps.
  * Preserved correct indexed access, enumeration, copying, and exhaustion behavior across mixed acknowledgement ranges.
  * Ensured sparse commit offsets remain valid after subsequent commits.

* **Performance**
  * Added coverage and benchmarks for range-based and sparse acknowledgement processing, including zero-allocation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
