### PR TITLE
Close coverage gaps in encryption, authorization, credentials, and AOT

### DIFF
--- a/src/Dekaf.SchemaRegistry/SchemaRegistryCsfleRules.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryCsfleRules.cs
@@ -1111,9 +1111,9 @@ public sealed class SchemaRegistryCsfleRuleHandler : ISchemaRegistryRuleTransfor
         {
             var siv = destination.Slice(offset, AesSivLength);
             var ciphertext = destination[(offset + AesSivLength)..];
-            var mac = workspace.GetBlockCipher(dek.KeyMaterial, 0);
-            ComputeSiv(mac, plaintext, ReadOnlySpan<byte>.Empty, siv);
-            AesCtrCrypt(workspace.GetBlockCipher(dek.KeyMaterial, 32), siv, plaintext, ciphertext);
+            var ciphers = workspace.GetSivCiphers(dek.KeyMaterial);
+            ComputeSiv(ciphers, plaintext, siv);
+            AesCtrCrypt(ciphers.Encryption, siv, plaintext, ciphertext);
             return;
         }
 
@@ -1168,11 +1168,18 @@ public sealed class SchemaRegistryCsfleRuleHandler : ISchemaRegistryRuleTransfor
             if (dek.Algorithm == DekAlgorithm.Aes256Siv)
             {
                 var siv = payload[..AesSivLength];
-                AesCtrCrypt(workspace.GetBlockCipher(dek.KeyMaterial, 32), siv, payload[AesSivLength..], destination);
+                var ciphers = workspace.GetSivCiphers(dek.KeyMaterial);
+                AesCtrCrypt(ciphers.Encryption, siv, payload[AesSivLength..], destination);
                 Span<byte> expectedSiv = stackalloc byte[AesSivLength];
-                ComputeSiv(workspace.GetBlockCipher(dek.KeyMaterial, 0), destination, ReadOnlySpan<byte>.Empty, expectedSiv);
-                if (!CryptographicOperations.FixedTimeEquals(expectedSiv, siv))
+                Span<byte> legacySiv = stackalloc byte[AesSivLength];
+                // Authenticate both constructions using a shared CMAC prefix. Legacy reads
+                // must not require a second pass over large messages after correcting writes.
+                ComputeSiv(ciphers, destination, expectedSiv, legacySiv);
+                var valid = CryptographicOperations.FixedTimeEquals(expectedSiv, siv)
+                    | CryptographicOperations.FixedTimeEquals(legacySiv, siv);
+                if (!valid)
                 {
+                    CryptographicOperations.ZeroMemory(destination);
                     throw new SchemaRegistryRuleException(
                         $"Schema Registry rule '{ruleName}' failed to authenticate encrypted payload.");
                 }
@@ -1290,24 +1297,19 @@ public sealed class SchemaRegistryCsfleRuleHandler : ISchemaRegistryRuleTransfor
     }
 
     private static void ComputeSiv(
-        BlockCipher cipher,
+        SivCiphers ciphers,
         ReadOnlySpan<byte> plaintext,
-        ReadOnlySpan<byte> associatedData,
-        Span<byte> destination)
+        Span<byte> destination,
+        Span<byte> legacyDestination = default)
     {
         Span<byte> d = stackalloc byte[16];
-        AesCmac(cipher, ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, d);
-        if (!associatedData.IsEmpty)
-        {
-            DoubleBlock(d);
-            Span<byte> adMac = stackalloc byte[16];
-            AesCmac(cipher, associatedData, ReadOnlySpan<byte>.Empty, adMac);
-            XorInPlace(d, adMac);
-        }
+        Span<byte> legacy = stackalloc byte[16];
+        ciphers.InitialState.CopyTo(d);
+        ciphers.LegacyInitialState.CopyTo(legacy);
 
         if (plaintext.Length >= 16)
         {
-            AesCmac(cipher, plaintext, d, destination);
+            AesCmac(ciphers.Mac, plaintext, d, destination, legacy, legacyDestination);
             return;
         }
 
@@ -1316,36 +1318,63 @@ public sealed class SchemaRegistryCsfleRuleHandler : ISchemaRegistryRuleTransfor
         plaintext.CopyTo(input);
         input[plaintext.Length] = 0x80;
         DoubleBlock(d);
-        XorInPlace(input, d);
-        AesCmac(cipher, input, ReadOnlySpan<byte>.Empty, destination);
+        DoubleBlock(legacy);
+        AesCmac(ciphers.Mac, input, d, destination, legacy, legacyDestination);
     }
 
     private static void AesCmac(
         BlockCipher cipher,
         ReadOnlySpan<byte> message,
         ReadOnlySpan<byte> xorLast16,
-        Span<byte> destination)
+        Span<byte> destination,
+        ReadOnlySpan<byte> alternateXorLast16 = default,
+        Span<byte> alternateDestination = default)
     {
         Span<byte> zero = stackalloc byte[16];
-        Span<byte> l = stackalloc byte[16];
-        cipher.EncryptBlock(zero, l);
-
+        zero.Clear();
         Span<byte> k1 = stackalloc byte[16];
-        l.CopyTo(k1);
+        cipher.EncryptBlock(zero, k1);
         DoubleBlock(k1);
-
         Span<byte> k2 = stackalloc byte[16];
         k1.CopyTo(k2);
         DoubleBlock(k2);
 
+        // The two S2V constructions differ only in their final 16 plaintext bytes.
+        // Process their common prefix once, then finish at most two blocks per tag.
+        var commonBlockCount = Math.Max(0, (message.Length - 16) / 16);
+        Span<byte> state = stackalloc byte[16];
+        state.Clear();
+        Span<byte> block = stackalloc byte[16];
+        for (var index = 0; index < commonBlockCount; index++)
+        {
+            message.Slice(index * 16, 16).CopyTo(block);
+            XorInPlace(block, state);
+            cipher.EncryptBlock(block, state);
+        }
+
+        FinishAesCmac(cipher, message, xorLast16, commonBlockCount, state, k1, k2, destination);
+        if (!alternateDestination.IsEmpty)
+            FinishAesCmac(cipher, message, alternateXorLast16, commonBlockCount, state, k1, k2, alternateDestination);
+    }
+
+    private static void FinishAesCmac(
+        BlockCipher cipher,
+        ReadOnlySpan<byte> message,
+        ReadOnlySpan<byte> xorLast16,
+        int startBlock,
+        ReadOnlySpan<byte> prefixState,
+        ReadOnlySpan<byte> k1,
+        ReadOnlySpan<byte> k2,
+        Span<byte> destination)
+    {
         var blockCount = Math.Max(1, (message.Length + 15) / 16);
         Span<byte> state = stackalloc byte[16];
+        prefixState.CopyTo(state);
         Span<byte> block = stackalloc byte[16];
-
-        for (var blockIndex = 0; blockIndex < blockCount - 1; blockIndex++)
+        for (var index = startBlock; index < blockCount - 1; index++)
         {
-            message.Slice(blockIndex * 16, 16).CopyTo(block);
-            XorSivTail(block, blockIndex * 16, message.Length, xorLast16);
+            message.Slice(index * 16, 16).CopyTo(block);
+            XorSivTail(block, index * 16, message.Length, xorLast16);
             XorInPlace(block, state);
             cipher.EncryptBlock(block, state);
         }
@@ -1353,23 +1382,18 @@ public sealed class SchemaRegistryCsfleRuleHandler : ISchemaRegistryRuleTransfor
         block.Clear();
         var lastOffset = (blockCount - 1) * 16;
         var remaining = message.Length - lastOffset;
-        if (remaining == 16 && message.Length != 0)
+        if (remaining > 0)
         {
-            message.Slice(lastOffset, 16).CopyTo(block);
-            XorSivTail(block, lastOffset, message.Length, xorLast16);
-            XorInPlace(block, k1);
+            message.Slice(lastOffset, remaining).CopyTo(block);
+            XorSivTail(block[..remaining], lastOffset, message.Length, xorLast16);
         }
+        if (remaining == 16)
+            XorInPlace(block, k1);
         else
         {
-            if (remaining > 0)
-            {
-                message.Slice(lastOffset, remaining).CopyTo(block);
-                XorSivTail(block[..remaining], lastOffset, message.Length, xorLast16);
-            }
             block[remaining] = 0x80;
             XorInPlace(block, k2);
         }
-
         XorInPlace(block, state);
         cipher.EncryptBlock(block, destination);
     }
@@ -2112,7 +2136,7 @@ public sealed class SchemaRegistryCsfleRuleHandler : ISchemaRegistryRuleTransfor
             return _overflowGcmCiphers.GetValue(key, static value => new GcmCipher(value));
         }
 
-        public BlockCipher GetBlockCipher(byte[] key, int offset)
+        public SivCiphers GetSivCiphers(byte[] key)
         {
             if (!_sivCiphers.TryGetValue(key, out var ciphers))
             {
@@ -2120,13 +2144,13 @@ public sealed class SchemaRegistryCsfleRuleHandler : ISchemaRegistryRuleTransfor
                 {
                     ciphers = new SivCiphers(key);
                     _sivCiphers.Add(key, ciphers);
-                    return ciphers.Get(offset);
+                    return ciphers;
                 }
 
                 ciphers = _overflowSivCiphers.GetValue(key, static value => new SivCiphers(value));
             }
 
-            return ciphers.Get(offset);
+            return ciphers;
         }
 
         public Span<byte> GetOutputSpan(int slot, int written, int sizeHint)
@@ -2255,15 +2279,25 @@ public sealed class SchemaRegistryCsfleRuleHandler : ISchemaRegistryRuleTransfor
         {
             Mac = new BlockCipher(key.AsSpan(0, 32));
             Encryption = new BlockCipher(key.AsSpan(32, 32));
+            // RFC 5297 S2V starts with CMAC of a zero block and folds in the single
+            // empty associated-data item used by Tink/Confluent. Cache this per key.
+            Span<byte> zero = stackalloc byte[16];
+            zero.Clear();
+            AesCmac(Mac, zero, ReadOnlySpan<byte>.Empty, InitialState);
+            AesCmac(Mac, ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, LegacyInitialState);
+            DoubleBlock(InitialState);
+            XorInPlace(InitialState, LegacyInitialState);
         }
 
-        private BlockCipher Mac { get; }
+        public BlockCipher Mac { get; }
 
-        private BlockCipher Encryption { get; }
+        public BlockCipher Encryption { get; }
+
+        public byte[] InitialState { get; } = new byte[16];
+
+        public byte[] LegacyInitialState { get; } = new byte[16];
 
         ~SivCiphers() => Dispose();
-
-        public BlockCipher Get(int offset) => offset == 0 ? Mac : Encryption;
 
         public void Dispose()
         {
@@ -2271,6 +2305,8 @@ public sealed class SchemaRegistryCsfleRuleHandler : ISchemaRegistryRuleTransfor
             {
                 Mac.Dispose();
                 Encryption.Dispose();
+                CryptographicOperations.ZeroMemory(InitialState);
+                CryptographicOperations.ZeroMemory(LegacyInitialState);
             }
             GC.SuppressFinalize(this);
         }

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -3404,7 +3404,7 @@ public sealed partial class AdminClient :
             {
                 if (resourceResponse.ErrorCode != Protocol.ErrorCode.None)
                 {
-                    throw new KafkaException(resourceResponse.ErrorCode,
+                    throw KafkaException.FromErrorCode(resourceResponse.ErrorCode,
                         $"Failed to incrementally alter configs for {(ConfigResourceType)resourceResponse.ResourceType}:{resourceResponse.ResourceName}: " +
                         $"{resourceResponse.ErrorMessage ?? resourceResponse.ErrorCode.ToString()}");
                 }

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -3346,7 +3346,7 @@ public sealed partial class AdminClient :
             {
                 if (resourceResponse.ErrorCode != Protocol.ErrorCode.None)
                 {
-                    throw new KafkaException(resourceResponse.ErrorCode,
+                    throw KafkaException.FromErrorCode(resourceResponse.ErrorCode,
                         $"Failed to alter configs for {(ConfigResourceType)resourceResponse.ResourceType}:{resourceResponse.ResourceName}: " +
                         $"{resourceResponse.ErrorMessage ?? resourceResponse.ErrorCode.ToString()}");
                 }

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -671,6 +671,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                 if (errorCode != ErrorCode.None)
                 {
+                    if (errorCode == ErrorCode.GroupAuthorizationFailed)
+                        throw KafkaException.FromErrorCode(errorCode, $"FindCoordinator failed: {errorCode}");
+
                     throw new Errors.GroupException(errorCode, $"FindCoordinator failed: {errorCode}")
                     {
                         GroupId = _options.GroupId
@@ -1691,6 +1694,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     {
         throw response.ErrorCode switch
         {
+            ErrorCode.GroupAuthorizationFailed or ErrorCode.TopicAuthorizationFailed or ErrorCode.ClusterAuthorizationFailed
+                => KafkaException.FromErrorCode(response.ErrorCode,
+                    $"ConsumerGroupHeartbeat failed: {response.ErrorCode} - {response.ErrorMessage}"),
+
             ErrorCode.UnknownMemberId => new GroupException(response.ErrorCode,
                 $"ConsumerGroupHeartbeat: unknown member ID (fenced): {response.ErrorMessage}")
             { GroupId = _options.GroupId },
@@ -2000,7 +2007,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 catch (Exception ex) when (
                     ex is ObjectDisposedException ||
                     (ex is Errors.KafkaException ke &&
-                     ke is not Errors.GroupException and not BrokerVersionException &&
+                     ke is not Errors.GroupException and not BrokerVersionException
+                         and not AuthorizationException and not AuthenticationException &&
                      !cancellationToken.IsCancellationRequested))
                 {
                     LogCoordinatorConnectionDisposed();
@@ -2071,9 +2079,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 LogHeartbeatFailed(ex);
                 Volatile.Write(ref _lastHeartbeatFailure, ex.Message);
 
-                if (ex is BrokerVersionException brokerVersionException)
+                if (ex is BrokerVersionException or AuthorizationException or AuthenticationException)
                 {
-                    await StoreFatalHeartbeatExceptionAsync(brokerVersionException).ConfigureAwait(false);
+                    await StoreFatalHeartbeatExceptionAsync((KafkaException)ex).ConfigureAwait(false);
                     break;
                 }
 

--- a/tests/Dekaf.Tests.Aot/Dekaf.Tests.Aot.csproj
+++ b/tests/Dekaf.Tests.Aot/Dekaf.Tests.Aot.csproj
@@ -25,6 +25,7 @@
                       ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Serialization.Json\Dekaf.Serialization.Json.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Serialization.Routing\Dekaf.Serialization.Routing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dekaf.Tests.Aot/Program.cs
+++ b/tests/Dekaf.Tests.Aot/Program.cs
@@ -45,6 +45,7 @@ internal static class AotSmoke
         PackedEpochSmoke.Run();
         RunCompressionSmoke();
         RunJsonSmoke();
+        await SchemaIdRoutingSmoke.RunAsync();
         RunSchemaRegistryHttpPipelineConstructionSmoke();
         await RunSchemaRegistrySmokeAsync();
         await RunSchemaRegistryGuidSmokeAsync();

--- a/tests/Dekaf.Tests.Aot/SchemaIdRoutingSmoke.cs
+++ b/tests/Dekaf.Tests.Aot/SchemaIdRoutingSmoke.cs
@@ -1,0 +1,96 @@
+using System.Buffers.Binary;
+using Dekaf.Errors;
+using Dekaf.Serialization;
+using Dekaf.Serialization.Routing;
+
+internal static class SchemaIdRoutingSmoke
+{
+    public static async Task RunAsync()
+    {
+        var context = new SerializationContext { Topic = "aot-routes", Component = SerializationComponent.Value };
+        var first = new PreparingRoute<FirstEvent>(static value => new FirstEvent(value));
+        var second = new PreparingRoute<SecondEvent>(static value => new SecondEvent(value));
+        var router = new SchemaIdRoutingDeserializer<RoutedEvent>()
+            .Register(10, first)
+            .Register(11, second)
+            .Freeze();
+        var preparer = (IAsyncDeserializerPreparer<RoutedEvent>)router;
+        var frame = Frame(10, 42);
+
+        Require(!preparer.TryDeserialize(frame, context, out _), "Unprepared schema route must request preparation.");
+        await preparer.PrepareAsync(frame, context);
+        Require(preparer.TryDeserialize(frame, context, out var result), "Prepared schema route must deserialize.");
+        Require(result is FirstEvent { Value: 42 }, "Schema ID 10 must preserve the derived type and payload.");
+        Require(first.LastFrame.Span.SequenceEqual(frame), "Route must receive the complete Confluent frame.");
+
+        var secondFrame = Frame(11, 99);
+        Require(!preparer.TryDeserialize(secondFrame, context, out _), "Preparation must remain route-specific.");
+        await preparer.PrepareAsync(secondFrame, context);
+        Require(router.Deserialize(secondFrame, context) is SecondEvent { Value: 99 }, "Schema ID 11 must select its own route.");
+        Require(router.Deserialize(frame, context) is FirstEvent { Value: 42 }, "Alternating IDs must retain both routes.");
+
+        RequireRejected(router, Frame(12, 0), context);
+        RequireRejected(router, new byte[4], context);
+        var badMagic = Frame(10, 1);
+        badMagic[0] = 1;
+        RequireRejected(router, badMagic, context);
+        Console.WriteLine("Schema-ID routing NativeAOT smoke passed.");
+    }
+
+    private static byte[] Frame(int id, byte value)
+    {
+        var bytes = new byte[6];
+        BinaryPrimitives.WriteInt32BigEndian(bytes.AsSpan(1, 4), id);
+        bytes[5] = value;
+        return bytes;
+    }
+
+    private static void RequireRejected(SchemaIdRoutingDeserializer<RoutedEvent> router, byte[] frame, SerializationContext context)
+    {
+        try
+        {
+            router.Deserialize(frame, context);
+        }
+        catch (SerializationException)
+        {
+            return;
+        }
+        throw new InvalidOperationException("Invalid or unregistered schema frame was accepted.");
+    }
+
+    private static void Require(bool condition, string message)
+    {
+        if (!condition)
+            throw new InvalidOperationException(message);
+    }
+
+    private abstract record RoutedEvent(byte Value);
+    private sealed record FirstEvent(byte Value) : RoutedEvent(Value);
+    private sealed record SecondEvent(byte Value) : RoutedEvent(Value);
+
+    private sealed class PreparingRoute<T>(Func<byte, T> create) : IDeserializer<T>, IAsyncDeserializerPreparer<T>
+    {
+        private bool _prepared;
+        public ReadOnlyMemory<byte> LastFrame { get; private set; }
+
+        public T Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            Require(_prepared, "Route was not prepared.");
+            LastFrame = data.ToArray();
+            return create(data.Span[5]);
+        }
+
+        public bool TryDeserialize(ReadOnlyMemory<byte> data, SerializationContext context, out T result)
+        {
+            result = _prepared ? Deserialize(data, context) : default!;
+            return _prepared;
+        }
+
+        public async ValueTask PrepareAsync(ReadOnlyMemory<byte> data, SerializationContext context, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+            _prepared = true;
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryRuleIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryRuleIntegrationTests.cs
@@ -23,7 +23,9 @@ namespace Dekaf.Tests.Integration;
 public sealed class SchemaRegistryRuleIntegrationTests(KafkaWithSchemaRegistryContainer testInfra)
 {
     [Test]
-    public async Task RegisteredAvroCsfleRule_ProduceConsume_RoundTripsTaggedField()
+    [Arguments("AES256_GCM")]
+    [Arguments("AES256_SIV")]
+    public async Task RegisteredAvroCsfleRule_ProduceConsume_RoundTripsTaggedField(string algorithm)
     {
         const string schemaText = """
             {
@@ -52,6 +54,7 @@ public sealed class SchemaRegistryRuleIntegrationTests(KafkaWithSchemaRegistryCo
             Parameters = new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["encrypt.kek.name"] = $"integration-kek-{Guid.NewGuid():N}",
+                ["encrypt.dek.algorithm"] = algorithm,
                 ["encrypt.kms.type"] = LocalKmsProvider.DefaultType,
                 ["encrypt.kms.key.id"] = "local://integration"
             }

--- a/tests/Dekaf.Tests.Integration/Security/AclEnforcementTests.cs
+++ b/tests/Dekaf.Tests.Integration/Security/AclEnforcementTests.cs
@@ -76,7 +76,7 @@ public class AclEnforcementTests(AclKafkaContainer kafka)
         // Act & Assert: producing without WRITE permission should fail. The denial can surface
         // either when the idempotent producer initializes (ClusterAuthorizationFailed) or when it
         // produces to the topic (TopicAuthorizationFailed), so the build is inside the assertion.
-        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+        var exception = await Assert.ThrowsAsync<AuthorizationException>(async () =>
         {
             await using var producer = await Kafka.CreateProducer<string, string>()
                 .WithBootstrapServers(kafka.BootstrapServers)
@@ -96,7 +96,6 @@ public class AclEnforcementTests(AclKafkaContainer kafka)
 
         await Assert.That(exception).IsNotNull();
         await Assert.That(
-            exception is AuthorizationException ||
             exception.ErrorCode == Dekaf.Protocol.ErrorCode.TopicAuthorizationFailed ||
             exception.ErrorCode == Dekaf.Protocol.ErrorCode.ClusterAuthorizationFailed
         ).IsTrue();
@@ -216,8 +215,7 @@ public class AclEnforcementTests(AclKafkaContainer kafka)
                 break;
             }
         }
-        catch (KafkaException ex) when (
-            ex is AuthorizationException ||
+        catch (AuthorizationException ex) when (
             ex.ErrorCode == Dekaf.Protocol.ErrorCode.TopicAuthorizationFailed)
         {
             exceptionThrown = true;
@@ -291,9 +289,7 @@ public class AclEnforcementTests(AclKafkaContainer kafka)
                 break;
             }
         }
-        catch (KafkaException ex) when (
-            ex is AuthorizationException ||
-            ex is GroupException ||
+        catch (AuthorizationException ex) when (
             ex.ErrorCode == Dekaf.Protocol.ErrorCode.GroupAuthorizationFailed)
         {
             exceptionThrown = true;
@@ -404,7 +400,7 @@ public class AclEnforcementTests(AclKafkaContainer kafka)
             .Build();
 
         // Act & Assert: altering topic config without ALTER permission should fail
-        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+        var exception = await Assert.ThrowsAsync<AuthorizationException>(async () =>
         {
             var configs = new Dictionary<ConfigResource, IReadOnlyList<ConfigEntry>>
             {
@@ -418,9 +414,7 @@ public class AclEnforcementTests(AclKafkaContainer kafka)
         });
 
         await Assert.That(exception).IsNotNull();
-        // Should be either AuthorizationException or a KafkaException with authorization error code
         await Assert.That(
-            exception is AuthorizationException ||
             exception.ErrorCode == Dekaf.Protocol.ErrorCode.TopicAuthorizationFailed ||
             exception.ErrorCode == Dekaf.Protocol.ErrorCode.ClusterAuthorizationFailed
         ).IsTrue();
@@ -482,8 +476,7 @@ public class AclEnforcementTests(AclKafkaContainer kafka)
                     Value = "value"
                 }, CancellationToken.None);
             }
-            catch (KafkaException ex) when (
-                ex is AuthorizationException ||
+            catch (AuthorizationException ex) when (
                 ex.ErrorCode == Dekaf.Protocol.ErrorCode.TopicAuthorizationFailed ||
                 ex.ErrorCode == Dekaf.Protocol.ErrorCode.ClusterAuthorizationFailed)
             {
@@ -563,8 +556,7 @@ public class AclEnforcementTests(AclKafkaContainer kafka)
                     Value = "value"
                 }, CancellationToken.None);
             }
-            catch (KafkaException ex) when (
-                ex is AuthorizationException ||
+            catch (AuthorizationException ex) when (
                 ex.ErrorCode == Dekaf.Protocol.ErrorCode.TopicAuthorizationFailed ||
                 ex.ErrorCode == Dekaf.Protocol.ErrorCode.ClusterAuthorizationFailed)
             {

--- a/tests/Dekaf.Tests.Integration/Security/AclEnforcementTests.cs
+++ b/tests/Dekaf.Tests.Integration/Security/AclEnforcementTests.cs
@@ -386,7 +386,9 @@ public class AclEnforcementTests(AclKafkaContainer kafka)
     #region Admin ACL Enforcement
 
     [Test]
-    public async Task AdminClient_WithoutAlterPermission_FailsOnConfigChange()
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task AdminClient_WithoutAlterPermission_FailsOnConfigChange(bool incremental)
     {
         // Arrange: create topic as admin
         var topic = await kafka.CreateTestTopicAsync();
@@ -402,15 +404,25 @@ public class AclEnforcementTests(AclKafkaContainer kafka)
         // Act & Assert: altering topic config without ALTER permission should fail
         var exception = await Assert.ThrowsAsync<AuthorizationException>(async () =>
         {
-            var configs = new Dictionary<ConfigResource, IReadOnlyList<ConfigEntry>>
+            if (incremental)
             {
-                [ConfigResource.Topic(topic)] =
-                [
-                    new ConfigEntry { Name = "retention.ms", Value = "3600000" }
-                ]
-            };
-
-            await restrictedAdmin.AlterConfigsAsync(configs);
+                await restrictedAdmin.IncrementalAlterConfigsAsync(
+                    new Dictionary<ConfigResource, IReadOnlyList<ConfigAlter>>
+                    {
+                        [ConfigResource.Topic(topic)] = [ConfigAlter.Set("retention.ms", "3600000")]
+                    });
+            }
+            else
+            {
+                await restrictedAdmin.AlterConfigsAsync(
+                    new Dictionary<ConfigResource, IReadOnlyList<ConfigEntry>>
+                    {
+                        [ConfigResource.Topic(topic)] =
+                        [
+                            new ConfigEntry { Name = "retention.ms", Value = "3600000" }
+                        ]
+                    });
+            }
         });
 
         await Assert.That(exception).IsNotNull();

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientDetailedConfigTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientDetailedConfigTests.cs
@@ -11,6 +11,27 @@ namespace Dekaf.Tests.Unit.Admin;
 public sealed class AdminClientDetailedConfigTests
 {
     [Test]
+    [Arguments(ErrorCode.TopicAuthorizationFailed)]
+    [Arguments(ErrorCode.ClusterAuthorizationFailed)]
+    public async Task AlterConfigs_AuthorizationFailureThrowsTypedException(ErrorCode error)
+    {
+        var (admin, connections) = CreateAdmin();
+        await using var client = admin;
+        var resource = ConfigResource.Topic("denied");
+        Setup(connections[1], false, _ => [(resource, error, "denied")]);
+
+        var exception = await Assert.That(async () => await admin.AlterConfigsAsync(
+            new Dictionary<ConfigResource, IReadOnlyList<ConfigEntry>>
+            {
+                [resource] = [new ConfigEntry { Name = "retention.ms", Value = "1000" }]
+            })).Throws<AuthorizationException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(error);
+        await connections[1].Received(1).SendAsync<AlterConfigsRequest, AlterConfigsResponse>(
+            Arg.Any<AlterConfigsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     [Arguments(false)]
     [Arguments(true)]
     public async Task MixedResults_PreserveResourceTypeAndOriginalBrokerError(bool incremental)

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientDetailedConfigTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientDetailedConfigTests.cs
@@ -11,24 +11,41 @@ namespace Dekaf.Tests.Unit.Admin;
 public sealed class AdminClientDetailedConfigTests
 {
     [Test]
-    [Arguments(ErrorCode.TopicAuthorizationFailed)]
-    [Arguments(ErrorCode.ClusterAuthorizationFailed)]
-    public async Task AlterConfigs_AuthorizationFailureThrowsTypedException(ErrorCode error)
+    [Arguments(false, ErrorCode.TopicAuthorizationFailed)]
+    [Arguments(false, ErrorCode.ClusterAuthorizationFailed)]
+    [Arguments(true, ErrorCode.TopicAuthorizationFailed)]
+    [Arguments(true, ErrorCode.ClusterAuthorizationFailed)]
+    public async Task AlterConfigs_AuthorizationFailureThrowsTypedException(bool incremental, ErrorCode error)
     {
         var (admin, connections) = CreateAdmin();
         await using var client = admin;
         var resource = ConfigResource.Topic("denied");
-        Setup(connections[1], false, _ => [(resource, error, "denied")]);
+        Setup(connections[1], incremental, _ => [(resource, error, "denied")]);
 
-        var exception = await Assert.That(async () => await admin.AlterConfigsAsync(
-            new Dictionary<ConfigResource, IReadOnlyList<ConfigEntry>>
+        var exception = await Assert.That(async () =>
+        {
+            var input = Input(resource);
+            if (incremental)
             {
-                [resource] = [new ConfigEntry { Name = "retention.ms", Value = "1000" }]
-            })).Throws<AuthorizationException>();
+                await admin.IncrementalAlterConfigsAsync(input);
+            }
+            else
+            {
+                await admin.AlterConfigsAsync(Replacement(input));
+            }
+        }).Throws<AuthorizationException>();
 
         await Assert.That(exception!.ErrorCode).IsEqualTo(error);
-        await connections[1].Received(1).SendAsync<AlterConfigsRequest, AlterConfigsResponse>(
-            Arg.Any<AlterConfigsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>());
+        if (incremental)
+        {
+            await connections[1].Received(1).SendAsync<IncrementalAlterConfigsRequest, IncrementalAlterConfigsResponse>(
+                Arg.Any<IncrementalAlterConfigsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>());
+        }
+        else
+        {
+            await connections[1].Received(1).SendAsync<AlterConfigsRequest, AlterConfigsResponse>(
+                Arg.Any<AlterConfigsRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>());
+        }
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -132,6 +132,31 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             RetryBackoffMaxMs = retryBackoffMaxMs
         };
 
+    [Test]
+    public async Task FindCoordinator_GroupAuthorizationFailureIsTypedAndNeverRetried()
+    {
+        _connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new FindCoordinatorResponse
+            {
+                Coordinators = [new Coordinator
+                {
+                    Key = "test-group", NodeId = -1, Host = string.Empty, Port = -1,
+                    ErrorCode = ErrorCode.GroupAuthorizationFailed
+                }]
+            }));
+        await using var coordinator = new ConsumerCoordinator(CreateConsumerProtocolOptions(), _connectionPool, _metadataManager);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var exception = await Assert.That(async () =>
+                await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, timeout.Token))
+            .Throws<AuthorizationException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.GroupAuthorizationFailed);
+        await _connection.Received(1).SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+            Arg.Any<FindCoordinatorRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>());
+    }
+
     private void SetupFindCoordinator()
     {
         _connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
@@ -3905,6 +3930,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
 
     [Test]
     [Arguments(ErrorCode.GroupAuthorizationFailed)]
+    [Arguments(ErrorCode.TopicAuthorizationFailed)]
+    [Arguments(ErrorCode.ClusterAuthorizationFailed)]
     [Arguments(ErrorCode.InvalidGroupId)]
     public async Task ConsumerProtocol_FatalGroupErrorDuringHeartbeat_PropagatesOnNextEnsureActiveGroup(
         ErrorCode errorCode)
@@ -3952,19 +3979,25 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await InvokeConsumerProtocolHeartbeatLoopAsync(coordinator, CancellationToken.None);
         await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
 
-        GroupException? caught = null;
+        KafkaException? caught = null;
         try
         {
             await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
         }
-        catch (GroupException ex)
+        catch (KafkaException ex)
         {
             caught = ex;
         }
 
         await Assert.That(caught).IsNotNull();
         await Assert.That(caught!.ErrorCode).IsEqualTo(errorCode);
-        await Assert.That(caught.GroupId).IsEqualTo("test-group");
+        if (errorCode == ErrorCode.InvalidGroupId)
+        {
+            await Assert.That(caught).IsTypeOf<GroupException>();
+            await Assert.That(((GroupException)caught).GroupId).IsEqualTo("test-group");
+        }
+        else
+            await Assert.That(caught.GetType()).IsEqualTo(typeof(AuthorizationException));
         await Assert.That(callCount).IsEqualTo(2);
     }
 

--- a/tests/Dekaf.Tests.Unit/Errors/KafkaExceptionMappingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Errors/KafkaExceptionMappingTests.cs
@@ -1,0 +1,44 @@
+using Dekaf.Errors;
+using Dekaf.Protocol;
+
+namespace Dekaf.Tests.Unit.Errors;
+
+public sealed class KafkaExceptionMappingTests
+{
+    [Test]
+    [Arguments(ErrorCode.TopicAuthorizationFailed)]
+    [Arguments(ErrorCode.GroupAuthorizationFailed)]
+    [Arguments(ErrorCode.ClusterAuthorizationFailed)]
+    [Arguments(ErrorCode.TransactionalIdAuthorizationFailed)]
+    [Arguments(ErrorCode.DelegationTokenAuthorizationFailed)]
+    public async Task AuthorizationErrors_MapToExactAuthorizationException(ErrorCode code)
+    {
+        var exception = KafkaException.FromErrorCode(code, "denied");
+        await Assert.That(exception.GetType()).IsEqualTo(typeof(AuthorizationException));
+        await Assert.That(exception.ErrorCode).IsEqualTo(code);
+        await Assert.That(exception.Message).IsEqualTo("denied");
+        await Assert.That(exception.IsRetriable).IsFalse();
+    }
+
+    [Test]
+    public async Task SaslFailure_MapsToExactAuthenticationException()
+    {
+        var exception = KafkaException.FromErrorCode(ErrorCode.SaslAuthenticationFailed, "invalid credentials");
+        await Assert.That(exception.GetType()).IsEqualTo(typeof(AuthenticationException));
+        await Assert.That(exception.ErrorCode).IsEqualTo(ErrorCode.SaslAuthenticationFailed);
+        await Assert.That(exception.Message).IsEqualTo("invalid credentials");
+        await Assert.That(exception.IsRetriable).IsFalse();
+    }
+
+    [Test]
+    [Arguments(ErrorCode.NotLeaderOrFollower, true)]
+    [Arguments(ErrorCode.InvalidTopicException, false)]
+    public async Task OtherErrors_PreserveCodeMessageAndRetryClassification(ErrorCode code, bool retriable)
+    {
+        var exception = KafkaException.FromErrorCode(code, "broker error");
+        await Assert.That(exception.GetType()).IsEqualTo(typeof(KafkaException));
+        await Assert.That(exception.ErrorCode).IsEqualTo(code);
+        await Assert.That(exception.Message).IsEqualTo("broker error");
+        await Assert.That(exception.IsRetriable).IsEqualTo(retriable);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCsfleRuleTests.Cryptography.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCsfleRuleTests.Cryptography.cs
@@ -1,0 +1,170 @@
+using System.Buffers.Binary;
+using Dekaf.SchemaRegistry;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public sealed partial class SchemaRegistryCsfleRuleTests
+{
+    // Independent vectors generated with Python cryptography 48.0.1 (OpenSSL AESSIV):
+    // AESSIV(bytes(range(64))).encrypt(bytes(range(length)), [b""]).hex()
+    // Tink/Confluent supplies one empty associated-data item, not zero items.
+    // https://github.com/tink-crypto/tink-java/blob/main/src/main/java/com/google/crypto/tink/subtle/AesSiv.java
+    [Test]
+    [Arguments(0, "6ff5b8ef53fc365606cd3ea047374885")]
+    [Arguments(1, "bbcda500ab22fb1ab45fe96068870dfe1e")]
+    [Arguments(15, "0de333fe4d5bad07944c5c56dec45671a322c688be60c6c70e79fc8304c241")]
+    [Arguments(16, "9ecf98ce2cb3f71206a949776d15f9be5a82761b5c0496412e99c0fe98667c0e")]
+    [Arguments(17, "49f74bb21732c89f5157cb7eb8af6e28b9ee83720da541e33752bd67796ba35815")]
+    [Arguments(32, "63bfa4a6e4faf322411d0d4e29ca546a304cc7c76e679bcd8744c659ea028d9e255dd44737c823c9b4be28de3268827c")]
+    [Arguments(65, "e0a79cc86c46c9cbbfa6a3d9f3a958199d1dcd8fd3b7d983c1f07394857935784c756330c78fb9a06686cc0c480eec397d249543291dfda062bd54bd0e11985776856e049f50b631f7ee4a4b52e10029e9")]
+    public async Task AesSiv_MatchesIndependentCiphertextAndDecryptsExternalPayload(int length, string ciphertextHex)
+    {
+        var key = Enumerable.Range(0, 64).Select(static value => (byte)value).ToArray();
+        var payload = Enumerable.Range(0, length).Select(static value => (byte)value).ToArray();
+        var client = CreateDekClient();
+        client.AddDek(TestDek(DekAlgorithm.Aes256Siv, key));
+        var handler = CreateHandler(client);
+        var context = CreateHandlerContext(AlgorithmRule(DekAlgorithm.Aes256Siv));
+        var expected = Convert.FromHexString(ciphertextHex);
+
+        var encrypted = handler.TransformSerializedPayload(payload, context).ToArray();
+        await Assert.That(encrypted.AsSpan().SequenceEqual(expected)).IsTrue();
+        var decrypted = handler.TransformDeserializedPayload(expected, context).ToArray();
+        await Assert.That(decrypted.AsSpan().SequenceEqual(payload)).IsTrue();
+    }
+
+    [Test]
+    [Arguments(DekAlgorithm.Aes256Gcm, "tag")]
+    [Arguments(DekAlgorithm.Aes256Gcm, "ciphertext")]
+    [Arguments(DekAlgorithm.Aes256Gcm, "truncated")]
+    [Arguments(DekAlgorithm.Aes256Gcm, "wrong-key")]
+    [Arguments(DekAlgorithm.Aes256Siv, "tag")]
+    [Arguments(DekAlgorithm.Aes256Siv, "ciphertext")]
+    [Arguments(DekAlgorithm.Aes256Siv, "truncated")]
+    [Arguments(DekAlgorithm.Aes256Siv, "wrong-key")]
+    public async Task Decrypt_RejectsUnauthenticatedPayloadAndRecovers(DekAlgorithm algorithm, string corruption)
+    {
+        var key = new byte[algorithm == DekAlgorithm.Aes256Siv ? 64 : 32];
+        var client = CreateDekClient();
+        client.AddDek(TestDek(algorithm, key));
+        var writer = CreateHandler(client);
+        var context = CreateHandlerContext(AlgorithmRule(algorithm));
+        var payload = "confidential payload crossing a block boundary"u8.ToArray();
+        var valid = writer.TransformSerializedPayload(payload, context).ToArray();
+        var damaged = valid.ToArray();
+        var readerClient = CreateDekClient();
+        var readerKey = key.ToArray();
+        switch (corruption)
+        {
+            case "tag":
+                damaged[algorithm == DekAlgorithm.Aes256Siv ? 0 : damaged.Length - 1] ^= 1;
+                break;
+            case "ciphertext":
+                damaged[algorithm == DekAlgorithm.Aes256Siv ? 16 : 12] ^= 1;
+                break;
+            case "truncated":
+                damaged = damaged[..(algorithm == DekAlgorithm.Aes256Siv ? 15 : 27)];
+                break;
+            case "wrong-key":
+                readerKey[0] ^= 1;
+                break;
+        }
+        readerClient.AddDek(TestDek(algorithm, readerKey));
+        var reader = CreateHandler(readerClient);
+
+        await Assert.That(() => reader.TransformDeserializedPayload(damaged, context))
+            .Throws<SchemaRegistryRuleException>();
+
+        // A failure must not poison the handler's workspace or its cached key.
+        var recoveryWriter = CreateHandler(readerClient);
+        var recoveryCiphertext = recoveryWriter.TransformSerializedPayload(payload, context).ToArray();
+        await Assert.That(reader.TransformDeserializedPayload(recoveryCiphertext, context).Span.SequenceEqual(payload)).IsTrue();
+    }
+
+    [Test]
+    [Arguments(DekAlgorithm.Aes256Gcm)]
+    [Arguments(DekAlgorithm.Aes256Siv)]
+    public async Task ExpiredDek_RotatesOnceAndFreshReaderDecryptsBothVersions(DekAlgorithm algorithm)
+    {
+        var client = CreateDekClient();
+        var key = new byte[algorithm == DekAlgorithm.Aes256Siv ? 64 : 32];
+        client.AddDek(TestDek(algorithm, key, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()));
+        var context = CreateHandlerContext(AlgorithmRule(algorithm, rotate: true));
+        var payload = "message before rotation"u8.ToArray();
+        var oldCiphertext = CreateHandler(client).TransformSerializedPayload(payload, context).ToArray();
+        client.AddDek(TestDek(algorithm, key, DateTimeOffset.UtcNow.AddDays(-2).ToUnixTimeMilliseconds()));
+        var writer = CreateHandler(client);
+        using var ready = new CountdownEvent(8);
+        using var releaseRegistration = new ManualResetEventSlim();
+        var registrationEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.BeforeRegisterDek = () =>
+        {
+            registrationEntered.TrySetResult();
+            if (!releaseRegistration.Wait(TimeSpan.FromSeconds(15)))
+                throw new TimeoutException("Concurrent DEK registration was not released.");
+        };
+        var operations = Enumerable.Range(0, 8).Select(_ => Task.Factory.StartNew(() =>
+        {
+            ready.Signal();
+            return writer.TransformSerializedPayload(payload, context).ToArray();
+        }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)).ToArray();
+        try
+        {
+            await registrationEntered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await Assert.That(ready.Wait(TimeSpan.FromSeconds(10))).IsTrue();
+        }
+        finally
+        {
+            releaseRegistration.Set();
+        }
+        var ciphertexts = await Task.WhenAll(operations).WaitAsync(TimeSpan.FromSeconds(15));
+
+        await Assert.That(client.RegisterDekCallCount).IsEqualTo(1);
+        await Assert.That(BinaryPrimitives.ReadInt32BigEndian(oldCiphertext.AsSpan(1, 4))).IsEqualTo(1);
+        var reader = CreateHandler(client);
+        foreach (var ciphertext in ciphertexts)
+        {
+            await Assert.That(ciphertext[0]).IsEqualTo((byte)0);
+            await Assert.That(BinaryPrimitives.ReadInt32BigEndian(ciphertext.AsSpan(1, 4))).IsEqualTo(2);
+            await Assert.That(reader.TransformDeserializedPayload(ciphertext, context).Span.SequenceEqual(payload)).IsTrue();
+        }
+        // Read old data after loading version 2, using versioned registry lookup rather than writer caches.
+        await Assert.That(reader.TransformDeserializedPayload(oldCiphertext, context).Span.SequenceEqual(payload)).IsTrue();
+    }
+
+    // Ciphertexts from the original Dekaf S2V construction (CMAC(empty), no AD item).
+    [Test]
+    [Arguments(0, "64699f564e16f177875ad70d35a153b3")]
+    [Arguments(15, "3628604b08d1e04dade900b3f2189a36581ce214ff544eb395e8db619bc338")]
+    [Arguments(16, "8cc71f65ca46060c3def6f15900e0fa0d09f6b4a95c88ab264025ddd2cd931b7")]
+    [Arguments(17, "c7aaadbb44383d477fa69e96767a7f64fb10bcb18fd7f68ba45d2e831bad648eff")]
+    [Arguments(65, "6f695de39428b8d94bf4a34832c5c848f18e9de6a7edb89fb4e43831879ff18ef9a868f1b549ec00bf96626f815131457724b3678c26257a3549e403ac3270a9fd586f34a676ff6e68ba6dd9c3a0d23653")]
+    public async Task AesSiv_AuthenticatesLegacyCiphertextAndRejectsTampering(int length, string ciphertextHex)
+    {
+        var key = Enumerable.Range(0, 64).Select(static value => (byte)value).ToArray();
+        var client = CreateDekClient();
+        client.AddDek(TestDek(DekAlgorithm.Aes256Siv, key));
+        var handler = CreateHandler(client);
+        var context = CreateHandlerContext(AlgorithmRule(DekAlgorithm.Aes256Siv));
+        var ciphertext = Convert.FromHexString(ciphertextHex);
+        var expected = Enumerable.Range(0, length).Select(static value => (byte)value).ToArray();
+
+        await Assert.That(handler.TransformDeserializedPayload(ciphertext, context).Span.SequenceEqual(expected)).IsTrue();
+        ciphertext[^1] ^= 1;
+        await Assert.That(() => handler.TransformDeserializedPayload(ciphertext, context)).Throws<SchemaRegistryRuleException>();
+    }
+
+    private static Dek TestDek(DekAlgorithm algorithm, byte[] key, long? timestamp = null) => new()
+    {
+        KekName = "payments-kek", Subject = "orders-value", Version = 1,
+        Algorithm = algorithm, KeyMaterial = Convert.ToBase64String(key), Timestamp = timestamp
+    };
+
+    private static SchemaRule AlgorithmRule(DekAlgorithm algorithm, bool rotate = false) => CreateRule(
+        parameters: new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["encrypt.kek.name"] = "payments-kek",
+            ["encrypt.dek.algorithm"] = algorithm == DekAlgorithm.Aes256Siv ? "AES256_SIV" : "AES256_GCM",
+            ["encrypt.dek.expiry.days"] = rotate ? "1" : "0"
+        });
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCsfleRuleTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCsfleRuleTests.cs
@@ -15,7 +15,7 @@ using AvroSchema = Avro.Schema;
 
 namespace Dekaf.Tests.Unit.SchemaRegistry;
 
-public sealed class SchemaRegistryCsfleRuleTests
+public sealed partial class SchemaRegistryCsfleRuleTests
 {
     private static readonly byte[] KekMaterial =
     [
@@ -2622,6 +2622,8 @@ public sealed class SchemaRegistryCsfleRuleTests
 
         public TimeSpan RegisterDekDelay { get; set; }
 
+        public Action? BeforeRegisterDek { get; set; }
+
         public int GetKekCallCount
         {
             get
@@ -2787,6 +2789,7 @@ public sealed class SchemaRegistryCsfleRuleTests
             RegisterDekRequest request,
             CancellationToken cancellationToken = default)
         {
+            BeforeRegisterDek?.Invoke();
             if (RegisterDekDelay > TimeSpan.Zero)
                 Thread.Sleep(RegisterDekDelay);
 

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/VaultKmsProviderTests.AppRole.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/VaultKmsProviderTests.AppRole.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using System.Text.Json;
+using Dekaf.SchemaRegistry.Kms.Vault;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public partial class VaultKmsProviderTests
+{
+    private const string SuccessfulLogin = "{\"auth\":{\"client_token\":\"recovered-token\",\"lease_duration\":3600}}";
+
+    [Test]
+    [Arguments("{}")]
+    [Arguments("{\"auth\":{\"client_token\":\"\",\"lease_duration\":3600}}")]
+    [Arguments("{\"auth\":{\"client_token\":\"token\",\"lease_duration\":0}}")]
+    [Arguments("{\"auth\":{\"client_token\":\"token\",\"lease_duration\":-1}}")]
+    [Arguments("{\"auth\":{\"client_token\":\"token\\ninvalid\",\"lease_duration\":3600}}")]
+    public async Task AppRole_InvalidLoginIsNotCachedAndNextCallRecovers(string body)
+    {
+        var calls = 0;
+        using var http = new HttpClient(new RecordingHandler((_, _) => Task.FromResult(
+            JsonResponse(++calls == 1 ? body : SuccessfulLogin))));
+        var provider = new VaultAppRoleTokenProvider(http, "role", "secret");
+
+        await Assert.That(async () => await provider.GetTokenAsync(VaultAddress, null)).Throws<InvalidOperationException>();
+        await Assert.That(await provider.GetTokenAsync(VaultAddress, null)).IsEqualTo("recovered-token");
+        await Assert.That(await provider.GetTokenAsync(VaultAddress, null)).IsEqualTo("recovered-token");
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task AppRole_HttpOrMalformedJsonFailureReleasesGate(bool malformedJson)
+    {
+        var calls = 0;
+        using var http = new HttpClient(new RecordingHandler((_, _) =>
+        {
+            if (++calls != 1)
+                return Task.FromResult(JsonResponse(SuccessfulLogin));
+            return Task.FromResult(malformedJson ? JsonResponse("{") : new HttpResponseMessage(HttpStatusCode.Forbidden));
+        }));
+        var provider = new VaultAppRoleTokenProvider(http, "role", "secret");
+
+        if (malformedJson)
+            await Assert.That(async () => await provider.GetTokenAsync(VaultAddress, null)).Throws<JsonException>();
+        else
+            await Assert.That(async () => await provider.GetTokenAsync(VaultAddress, null)).Throws<HttpRequestException>();
+
+        var recovered = await provider.GetTokenAsync(VaultAddress, null).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        await Assert.That(recovered).IsEqualTo("recovered-token");
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task AppRole_CancellationDuringRefreshDoesNotStrandOtherCallers(bool cancelOwner)
+    {
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        using var http = new HttpClient(new RecordingHandler(async (_, token) =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+            {
+                entered.SetResult();
+                await release.Task.WaitAsync(token);
+            }
+            return JsonResponse(SuccessfulLogin);
+        }));
+        var provider = new VaultAppRoleTokenProvider(http, "role", "secret");
+        using var cancellation = new CancellationTokenSource();
+        var owner = provider.GetTokenAsync(VaultAddress, null, cancelOwner ? cancellation.Token : default).AsTask();
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var waiter = provider.GetTokenAsync(VaultAddress, null, cancelOwner ? default : cancellation.Token).AsTask();
+        try
+        {
+            cancellation.Cancel();
+            await Assert.That(async () => await (cancelOwner ? owner : waiter)).Throws<OperationCanceledException>();
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+        var survivor = await (cancelOwner ? waiter : owner).WaitAsync(TimeSpan.FromSeconds(10));
+        await Assert.That(survivor).IsEqualTo("recovered-token");
+        await Assert.That(await provider.GetTokenAsync(VaultAddress, null)).IsEqualTo(survivor);
+        await Assert.That(calls).IsEqualTo(cancelOwner ? 2 : 1);
+    }
+
+    [Test]
+    public async Task AppRole_ExpiredTokenFailedRefreshNeverReturnsStaleToken()
+    {
+        var time = new TestTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var calls = 0;
+        using var http = new HttpClient(new RecordingHandler((_, _) => Task.FromResult(++calls switch
+        {
+            1 => JsonResponse("{\"auth\":{\"client_token\":\"old-token\",\"lease_duration\":60}}"),
+            2 => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable),
+            _ => JsonResponse(SuccessfulLogin)
+        })));
+        var provider = new VaultAppRoleTokenProvider(http, "role", "secret", "approle", time);
+        await Assert.That(await provider.GetTokenAsync(VaultAddress, null)).IsEqualTo("old-token");
+        time.Advance(TimeSpan.FromSeconds(60));
+
+        await Assert.That(async () => await provider.GetTokenAsync(VaultAddress, null)).Throws<HttpRequestException>();
+        await Assert.That(await provider.GetTokenAsync(VaultAddress, null)).IsEqualTo("recovered-token");
+        await Assert.That(calls).IsEqualTo(3);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/VaultKmsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/VaultKmsProviderTests.cs
@@ -7,7 +7,7 @@ using NSubstitute;
 
 namespace Dekaf.Tests.Unit.SchemaRegistry;
 
-public class VaultKmsProviderTests
+public partial class VaultKmsProviderTests
 {
     private const string KeyReference = "https://vault.example:8200/transit/keys/orders-kek";
     private const string NestedMountKeyReference =

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamDefaultCredentialsProviderTests.Refresh.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamDefaultCredentialsProviderTests.Refresh.cs
@@ -1,0 +1,235 @@
+using System.Net;
+using System.Text.Json;
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Tests.Unit.Security.Sasl;
+
+public sealed partial class AwsMskIamDefaultCredentialsProviderTests
+{
+    [Test]
+    public async Task WebIdentity_ParsesNamespacedStsResponseAndCachesCredentials()
+    {
+        using var environment = new CredentialEnvironment();
+        Environment.SetEnvironmentVariable("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/test");
+        Environment.SetEnvironmentVariable("AWS_WEB_IDENTITY_TOKEN_FILE", environment.WriteFile("web-identity-token"));
+        Environment.SetEnvironmentVariable("AWS_ROLE_SESSION_NAME", "test-session");
+        var expiration = DateTimeOffset.UtcNow.AddHours(1);
+        var calls = 0;
+        using var http = new HttpClient(new CredentialHandler(async (request, token) =>
+        {
+            calls++;
+            await Assert.That(request.RequestUri!.AbsoluteUri).IsEqualTo("https://sts.us-east-1.amazonaws.com/");
+            await Assert.That(request.Method).IsEqualTo(HttpMethod.Post);
+            var body = await request.Content!.ReadAsStringAsync(token);
+            await Assert.That(body).Contains("Action=AssumeRoleWithWebIdentity");
+            await Assert.That(body).Contains("WebIdentityToken=web-identity-token");
+            await Assert.That(body).Contains("RoleSessionName=test-session");
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent($"""
+                    <AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+                      <AssumeRoleWithWebIdentityResult><Credentials>
+                        <AccessKeyId>sts-access</AccessKeyId><SecretAccessKey>sts-secret</SecretAccessKey>
+                        <SessionToken>sts-token</SessionToken><Expiration>{expiration:O}</Expiration>
+                      </Credentials></AssumeRoleWithWebIdentityResult>
+                    </AssumeRoleWithWebIdentityResponse>
+                    """)
+            };
+        }));
+        var provider = new AwsMskIamDefaultCredentialsProvider(http);
+
+        var credentials = await provider.GetCredentialsAsync();
+        var cached = await provider.GetCredentialsAsync();
+
+        await AssertCredentialsAsync(credentials, "sts-access", "sts-secret", "sts-token", expiration);
+        await Assert.That(cached).IsSameReferenceAs(credentials);
+        await Assert.That(calls).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Container_ParsesCredentialsAndSendsAuthorization(bool tokenFile)
+    {
+        using var environment = new CredentialEnvironment();
+        Environment.SetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/credentials/test");
+        Environment.SetEnvironmentVariable(tokenFile ? "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE" : "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+            tokenFile ? environment.WriteFile("container-token\n") : "container-token");
+        var expiration = DateTimeOffset.UtcNow.AddHours(1);
+        using var http = new HttpClient(new CredentialHandler(async (request, _) =>
+        {
+            await Assert.That(request.RequestUri!.AbsoluteUri).IsEqualTo("http://169.254.170.2/credentials/test");
+            await Assert.That(request.Method).IsEqualTo(HttpMethod.Get);
+            await Assert.That(request.Headers.GetValues("Authorization").Single()).IsEqualTo("container-token");
+            return CredentialResponse(expiration);
+        }));
+
+        var credentials = await new AwsMskIamDefaultCredentialsProvider(http).GetCredentialsAsync();
+
+        await AssertCredentialsAsync(credentials, "access", "secret", "token", expiration);
+    }
+
+    [Test]
+    public async Task ImdsV2_UsesTokenForRoleDiscoveryAndCredentialRequest()
+    {
+        using var environment = new CredentialEnvironment();
+        Environment.SetEnvironmentVariable("AWS_EC2_METADATA_DISABLED", "false");
+        var expiration = DateTimeOffset.UtcNow.AddHours(1);
+        var calls = 0;
+        using var http = new HttpClient(new CredentialHandler(async (request, _) =>
+        {
+            var index = calls++;
+            await Assert.That(request.RequestUri!.Host).IsEqualTo("169.254.169.254");
+            if (index == 0)
+            {
+                await Assert.That(request.Method).IsEqualTo(HttpMethod.Put);
+                await Assert.That(request.RequestUri.AbsolutePath).IsEqualTo("/latest/api/token");
+                await Assert.That(request.Headers.GetValues("X-aws-ec2-metadata-token-ttl-seconds").Single()).IsEqualTo("21600");
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("imds-token") };
+            }
+            await Assert.That(request.Method).IsEqualTo(HttpMethod.Get);
+            await Assert.That(request.Headers.GetValues("X-aws-ec2-metadata-token").Single()).IsEqualTo("imds-token");
+            await Assert.That(request.RequestUri.AbsolutePath).IsEqualTo(index == 1
+                ? "/latest/meta-data/iam/security-credentials/"
+                : "/latest/meta-data/iam/security-credentials/test-role");
+            return index == 1
+                ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("test-role\n") }
+                : CredentialResponse(expiration);
+        }));
+
+        var credentials = await new AwsMskIamDefaultCredentialsProvider(http).GetCredentialsAsync();
+
+        await AssertCredentialsAsync(credentials, "access", "secret", "token", expiration);
+        await Assert.That(calls).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task ExpiringCredentials_ConcurrentRefreshAndCanceledWaiterShareOneRequest()
+    {
+        using var environment = new CredentialEnvironment();
+        Environment.SetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/credentials/test");
+        var refreshEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRefresh = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        using var http = new HttpClient(new CredentialHandler(async (_, token) =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+                return CredentialResponse(DateTimeOffset.UtcNow.AddMinutes(1));
+            refreshEntered.SetResult();
+            await releaseRefresh.Task.WaitAsync(token);
+            return CredentialResponse(DateTimeOffset.UtcNow.AddHours(1), "refreshed");
+        }));
+        var provider = new AwsMskIamDefaultCredentialsProvider(http);
+        _ = await provider.GetCredentialsAsync();
+        var refresh = provider.GetCredentialsAsync().AsTask();
+        await refreshEntered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        using var cancellation = new CancellationTokenSource();
+        var canceled = provider.GetCredentialsAsync(cancellation.Token).AsTask();
+        var waiters = Enumerable.Range(0, 16).Select(_ => provider.GetCredentialsAsync().AsTask()).ToArray();
+        try
+        {
+            cancellation.Cancel();
+            await Assert.That(async () => await canceled).Throws<OperationCanceledException>();
+            await Assert.That(calls).IsEqualTo(2);
+        }
+        finally
+        {
+            releaseRefresh.TrySetResult();
+        }
+        var refreshed = await refresh;
+        foreach (var credentials in await Task.WhenAll(waiters))
+            await Assert.That(credentials).IsSameReferenceAs(refreshed);
+        await Assert.That(refreshed.AccessKeyId).IsEqualTo("refreshed");
+        await Assert.That(await provider.GetCredentialsAsync()).IsSameReferenceAs(refreshed);
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task CanceledRefresh_ReleasesGateAndLaterCallRecovers()
+    {
+        using var environment = new CredentialEnvironment();
+        Environment.SetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/credentials/test");
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        using var http = new HttpClient(new CredentialHandler(async (_, token) =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+            {
+                entered.SetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            }
+            return CredentialResponse(DateTimeOffset.UtcNow.AddHours(1));
+        }));
+        var provider = new AwsMskIamDefaultCredentialsProvider(http);
+        using var cancellation = new CancellationTokenSource();
+        var refresh = provider.GetCredentialsAsync(cancellation.Token).AsTask();
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        cancellation.Cancel();
+        await Assert.That(async () => await refresh).Throws<OperationCanceledException>();
+
+        var recovered = await provider.GetCredentialsAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+
+        await Assert.That(recovered.AccessKeyId).IsEqualTo("access");
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    private static HttpResponseMessage CredentialResponse(DateTimeOffset expiration, string access = "access") => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(JsonSerializer.Serialize(new Dictionary<string, string>
+        {
+            ["AccessKeyId"] = access, ["SecretAccessKey"] = "secret", ["Token"] = "token", ["Expiration"] = expiration.ToString("O")
+        }))
+    };
+
+    private static async Task AssertCredentialsAsync(AwsCredentials credentials, string access, string secret, string token, DateTimeOffset expiration)
+    {
+        await Assert.That(credentials.AccessKeyId).IsEqualTo(access);
+        await Assert.That(credentials.SecretAccessKey).IsEqualTo(secret);
+        await Assert.That(credentials.SessionToken).IsEqualTo(token);
+        await Assert.That(credentials.Expiration).IsEqualTo(expiration);
+    }
+
+    private sealed class CredentialHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> send) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => send(request, cancellationToken);
+    }
+
+    private sealed class CredentialEnvironment : IDisposable
+    {
+        private static readonly string[] Names =
+        [
+            "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_ROLE_ARN", "AWS_ROLE_SESSION_NAME",
+            "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_REGION", "AWS_DEFAULT_REGION", "AWS_SHARED_CREDENTIALS_FILE", "AWS_CONFIG_FILE",
+            "AWS_PROFILE", "AWS_CONTAINER_CREDENTIALS_FULL_URI", "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+            "AWS_CONTAINER_AUTHORIZATION_TOKEN", "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", "AWS_EC2_METADATA_DISABLED"
+        ];
+        private readonly EnvironmentSnapshot _snapshot = EnvironmentSnapshot.Capture(Names);
+        private readonly List<string> _files = [];
+
+        public CredentialEnvironment()
+        {
+            foreach (var name in Names)
+                Environment.SetEnvironmentVariable(name, null);
+            Environment.SetEnvironmentVariable("AWS_PROFILE", "dekaf-test-missing-" + Guid.NewGuid().ToString("N"));
+            Environment.SetEnvironmentVariable("AWS_SHARED_CREDENTIALS_FILE", WriteFile(string.Empty));
+            Environment.SetEnvironmentVariable("AWS_CONFIG_FILE", WriteFile(string.Empty));
+            Environment.SetEnvironmentVariable("AWS_EC2_METADATA_DISABLED", "true");
+        }
+
+        public string WriteFile(string content)
+        {
+            var path = Path.GetTempFileName();
+            _files.Add(path);
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        public void Dispose()
+        {
+            _snapshot.Restore();
+            foreach (var file in _files)
+                File.Delete(file);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamDefaultCredentialsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamDefaultCredentialsProviderTests.cs
@@ -4,7 +4,7 @@ using Dekaf.Security.Sasl;
 namespace Dekaf.Tests.Unit.Security.Sasl;
 
 [NotInParallel("AwsEnvironment")]
-public sealed class AwsMskIamDefaultCredentialsProviderTests
+public sealed partial class AwsMskIamDefaultCredentialsProviderTests
 {
     [Test]
     public async Task GetCredentialsAsync_UsesEnvironmentCredentials()

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistryAesSivBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SchemaRegistryAesSivBenchmarks.cs
@@ -1,0 +1,78 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.SchemaRegistry;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Measures warmed AES-SIV transforms, including short and multi-block payloads.</summary>
+[MemoryDiagnoser]
+public class SchemaRegistryAesSivBenchmarks
+{
+    private SchemaRegistryCsfleRuleHandler _handler = null!;
+    private SchemaRegistryRuleHandlerContext _context = null!;
+    private byte[] _plaintext = null!;
+    private byte[] _ciphertext = null!;
+
+    [Params(0, 15, 16, 17, 256, 4096)]
+    public int PayloadSize { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _plaintext = new byte[PayloadSize];
+        new Random(42).NextBytes(_plaintext);
+        var rule = new SchemaRule
+        {
+            Name = "encrypt", Kind = SchemaRuleKind.Transform, Mode = SchemaRuleMode.WriteRead,
+            Type = SchemaRegistryCsfleRuleHandler.EncryptRuleType,
+            Parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["encrypt.kek.name"] = "benchmark-kek", ["encrypt.dek.algorithm"] = "AES256_SIV"
+            }
+        };
+        _handler = new SchemaRegistryCsfleRuleHandler(new KeyRegistry(), []);
+        _context = new SchemaRegistryRuleHandlerContext
+        {
+            Rule = rule, Direction = SchemaRegistryRuleDirection.Write,
+            PayloadContext = new SchemaRegistryRuleContext
+            {
+                Topic = "benchmark", Subject = "benchmark-value", SchemaId = 1, Component = SerializationComponent.Value,
+                PayloadFormat = SchemaRegistryPayloadFormat.Custom
+            }
+        };
+        _ciphertext = _handler.TransformSerializedPayload(_plaintext, _context).ToArray();
+        _ = _handler.TransformDeserializedPayload(_ciphertext, _context);
+    }
+
+    [Benchmark]
+    public ReadOnlyMemory<byte> Encrypt() => _handler.TransformSerializedPayload(_plaintext, _context);
+
+    [Benchmark]
+    public ReadOnlyMemory<byte> Decrypt() => _handler.TransformDeserializedPayload(_ciphertext, _context);
+
+    private sealed class KeyRegistry : ISchemaRegistryClient
+    {
+        private static readonly Task<Kek> KeyEncryptionKey = Task.FromResult(new Kek
+        {
+            Name = "benchmark-kek", KmsType = "local-kms", KmsKeyId = "benchmark-key"
+        });
+        private static readonly Task<Dek> DataEncryptionKey = Task.FromResult(new Dek
+        {
+            KekName = "benchmark-kek", Subject = "benchmark-value", Version = 1,
+            Algorithm = DekAlgorithm.Aes256Siv, KeyMaterial = Convert.ToBase64String(new byte[64])
+        });
+
+        public Task<Kek> GetKekAsync(string name, bool deleted = false, CancellationToken cancellationToken = default) => KeyEncryptionKey;
+        public Task<Dek> GetDekAsync(string kekName, string subject, DekAlgorithm? algorithm = null,
+            bool deleted = false, CancellationToken cancellationToken = default) => DataEncryptionKey;
+        public Task<int> RegisterSchemaAsync(string subject, Schema schema, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Schema> GetSchemaAsync(int id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(string subject, string version = "latest", CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<int> GetOrRegisterSchemaAsync(string subject, Schema schema, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<string>> GetAllSubjectsAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<int>> GetVersionsAsync(string subject, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> IsCompatibleAsync(string subject, Schema schema, string version = "latest", CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<int>> DeleteSubjectAsync(string subject, bool permanent = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
AES-SIV encryption previously round-tripped within Dekaf but produced ciphertext incompatible with independent AES-SIV implementations. Consumer coordinator and admin configuration failures also surfaced generic exceptions instead of the promised `AuthorizationException`; typed authorization failures could be retried as connection failures.

This PR adds coverage for all six audited gaps and fixes the defects exposed:

- Check AES-SIV ciphertext against independent OpenSSL-backed vectors at empty, partial-block, block-aligned, and multi-block sizes. Reject tampering, truncated ciphertext, and wrong keys for AES-GCM and AES-SIV.
- Rotate expired DEKs concurrently and verify that a fresh reader can decrypt both old and new key versions. Preserve authenticated reads of ciphertext written by the previous Dekaf AES-SIV implementation.
- Assert exact exception types for authorization failures, including coordinator discovery, foreground propagation of fatal heartbeat errors, and admin configuration mutations. Stop retrying authentication and authorization failures as connection failures.
- Run schema-ID routing in the existing NativeAOT smoke executable, covering multiple derived types, asynchronous preparation, full-frame forwarding, unknown IDs, and malformed frames.
- Exercise successful STS web-identity, ECS, and IMDSv2 credential acquisition with injected HTTP responses, plus expiry, concurrent refresh, waiter cancellation, and recovery after canceled refresh.
- Exercise Vault AppRole malformed/failed login, cancellation of refresh owners and waiters, expired tokens, and subsequent recovery. No external accounts or credentials are required.

New AES-SIV writes use RFC 5297/Tink-compatible S2V initialization, including the empty associated-data item. Reads authenticate both standard and legacy tags using a shared CMAC prefix, avoiding a second pass over large legacy messages. Key-only setup and two 16-byte state buffers are amortized per cached key/workspace; successful message transforms allocate 0 B in the steady-state fixture. Authorization changes execute on error paths.

Compatibility: upgraded readers accept old and new ciphertext. Older Dekaf readers cannot read newly corrected AES-SIV ciphertext, so upgrade readers before writers in mixed-version deployments.

Validation:

- `dotnet build -c Release`: passed, 0 warnings and 0 errors.
- Full unit suites: .NET 10 **10,815 passed**; .NET 8 **10,632 passed**.
- Focused Kafka integration coverage: 18 passing tests for ACL enforcement and Schema Registry rules, including both encryption algorithms.
- NativeAOT: published and executed the complete core smoke executable in a local Linux SDK container; schema-ID routing passed. Windows publish could not link because the C++ workload is absent.
- BenchmarkDotNet `Dry` and `Short`: all 12 steady-state AES-SIV cases execute successfully with 0 B/op. The same fixture was run against main `8797e7f6a` locally. No mean delta exceeded the repository's case-size tolerance; local results are diagnostic, not acceptance evidence.
- Repository artifact-policy check and diff whitespace check passed. No logs, benchmark exports, or evidence files are committed.

Loaded comparison: [consumer-1b A1/B/A2 run](https://github.com/thomhurst/Dekaf/actions/runs/34695529814), `dispatch_shape=cheap`, `duration_minutes=5` per sample, `full_run=false`, `baseline_sha=8797e7f6aca8ccf9f66b6492dc0634f4c703b7da`, candidate `4cd53e5a2ac504c8be7c1318f8421dd1bf6e24cc`. **Verdict pending**; one run dispatched. This covers the consumer heartbeat error-handling change under load. No merge or additional paid run is requested.

[Hosted performance gate](https://github.com/thomhurst/Dekaf/actions/runs/34695521061): pending; supplies the A1/B/A2 microbenchmark evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved AES-SIV encryption performance while maintaining compatibility with existing encrypted data.
  - Strengthened tamper detection and recovery during encrypted payload processing.

- **Bug Fixes**
  - Authorization and authentication failures now report more specific error types.
  - Consumer operations no longer retry authorization or authentication failures as temporary connection issues.
  - Fatal coordinator and heartbeat errors now stop processing promptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->