### PR TITLE
Fix CI benchmark timeout and release integration failures

### DIFF
--- a/tests/Dekaf.Tests.Integration/AdminClassicGroupDescriptionTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdminClassicGroupDescriptionTests.cs
@@ -8,6 +8,7 @@ namespace Dekaf.Tests.Integration;
 public sealed class AdminClassicGroupDescriptionTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]
+    [SkipWhenNativeAot("Confluent.Kafka native delegate binding requires runtime reflection.")]
     public async Task ConsumerProtocolGroup_IsListedButNotDescribedAsClassic()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync();
@@ -44,6 +45,7 @@ public sealed class AdminClassicGroupDescriptionTests(KafkaTestContainer kafka) 
     }
 
     [Test]
+    [SkipWhenNativeAot("Confluent.Kafka native delegate binding requires runtime reflection.")]
     public async Task ClassicConsumer_PreservesMemberAssignmentAndEmptyStateAfterLeave()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync();

--- a/tests/Dekaf.Tests.Integration/ControllerBootstrapIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ControllerBootstrapIntegrationTests.cs
@@ -20,7 +20,9 @@ public sealed class ControllerBootstrapIntegrationTests(ControllerOnlyKafkaConta
         var cluster = await admin.DescribeClusterAsync(timeout.Token).ConfigureAwait(false);
         var live = await admin.DescribeClusterAsync(new DescribeClusterOptions(), timeout.Token).ConfigureAwait(false);
         await Assert.That(live.EndpointType).IsEqualTo(Dekaf.Protocol.Messages.DescribeClusterEndpointType.Controller);
-        await Assert.That(live.Nodes.Single().IsFenced).IsNull();
+        var controller = live.Nodes.Single();
+        await Assert.That($"{controller.Host}:{controller.Port}").IsEqualTo(kafka.BootstrapControllers);
+        await Assert.That(controller.IsFenced).IsNull();
         await Assert.ThrowsAsync<NotSupportedException>(async () =>
             await admin.DescribeClusterAsync(new DescribeClusterOptions { IncludeFencedBrokers = true }, timeout.Token));
         var quorum = await admin.DescribeMetadataQuorumAsync(timeout.Token).ConfigureAwait(false);

--- a/tests/Dekaf.Tests.Integration/ControllerOnlyKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/ControllerOnlyKafkaContainer.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using TUnit.Core.Interfaces;
@@ -15,17 +16,26 @@ public sealed class ControllerOnlyKafkaContainer : IAsyncInitializer, IAsyncDisp
 
     public async Task InitializeAsync()
     {
+        // Kafka 4.0's Docker launcher rejects KAFKA_ADVERTISED_LISTENERS on controllers.
+        // Configure Kafka directly so discovery returns the endpoint reachable from the host.
+        var config = $"""
+            process.roles=controller
+            node.id=1
+            controller.quorum.voters=1@localhost:{_hostPort}
+            controller.listener.names=CONTROLLER
+            listeners=CONTROLLER://0.0.0.0:{_hostPort}
+            advertised.listeners=CONTROLLER://{BootstrapControllers}
+            listener.security.protocol.map=CONTROLLER:PLAINTEXT
+            log.dirs=/tmp/controller-logs
+            """;
+
         _container = new ContainerBuilder($"apache/kafka:{KafkaContainerDefault.ImageTag}")
             .WithName($"dekaf-controller-only-{Guid.NewGuid():N}")
             .WithPortBinding(_hostPort, _hostPort)
-            .WithEnvironment("CLUSTER_ID", "MkU3OEVBNTcwNTJENDM2Qk")
-            .WithEnvironment("KAFKA_NODE_ID", "1")
-            .WithEnvironment("KAFKA_PROCESS_ROLES", "controller")
-            .WithEnvironment("KAFKA_LISTENERS", $"CONTROLLER://0.0.0.0:{_hostPort}")
-            .WithEnvironment("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "CONTROLLER:PLAINTEXT")
-            .WithEnvironment("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER")
-            .WithEnvironment("KAFKA_CONTROLLER_QUORUM_VOTERS", $"1@localhost:{_hostPort}")
             .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx384m -Xms384m")
+            .WithResourceMapping(Encoding.UTF8.GetBytes(config), "/tmp/controller.properties")
+            .WithEntrypoint("/bin/bash")
+            .WithCommand("-ec", "/opt/kafka/bin/kafka-storage.sh format -t MkU3OEVBNTcwNTJENDM2Qk -c /tmp/controller.properties; exec /opt/kafka/bin/kafka-server-start.sh /tmp/controller.properties")
             .WithWaitStrategy(Wait.ForUnixContainer()
                 .UntilInternalTcpPortIsAvailable(_hostPort))
             .Build();

--- a/tools/Dekaf.Pipeline/Modules/RunBenchmarksModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunBenchmarksModule.cs
@@ -27,7 +27,9 @@ public class RunBenchmarksModule : Module<CommandResult>
             new DotNetRunOptions
             {
                 Configuration = "Release",
-                Arguments = ["--filter", "*Memory*", "--exporters", "GitHub", "CSV", "HTML"]
+                NoBuild = true,
+                // Match the performance gate's allowance for building the generated benchmark harness.
+                Arguments = ["--filter", "*Memory*", "--exporters", "GitHub", "CSV", "HTML", "--buildTimeout", "900"]
             },
             new CommandExecutionOptions
             {


### PR DESCRIPTION
Fixes the three root causes in [CI run 34704024944](https://github.com/thomhurst/Dekaf/actions/runs/34704024944).

- The [build job](https://github.com/thomhurst/Dekaf/actions/runs/34704024944/job/103580713569) passed compilation and unit tests, then BenchmarkDotNet exceeded its default 120-second generated-harness build timeout and cancelled packaging. Reuse the Release build and pass `--buildTimeout 900`, matching the performance gate's build allowance. Benchmark selection, measurement settings, and failure propagation remain unchanged.
- Both NativeAOT consumer-group jobs failed when `AdminClassicGroupDescriptionTests` constructed Confluent consumers. Apply the existing `SkipWhenNativeAot` guard to those two reflection-dependent tests; both still execute under JIT.
- The Kafka 4.0.2 messaging job failed because controller discovery advertised a container hostname unreachable from the test host. Start the controller with an explicit configuration advertising its host endpoint, following the existing dynamic-quorum fixture pattern. Kafka 4.0's Docker launcher rejects the equivalent environment variable. Assert the discovered endpoint matches the bootstrap endpoint.

Validation:
- Release builds of `tools/Dekaf.Pipeline` and `tools/Dekaf.Benchmarks` with warnings treated as errors: passed.
- Existing `*Memory*` selection with `--no-build --buildTimeout 900 --job Dry`: all 65 cases compiled and executed successfully. This validates execution, not performance.
- Reproduced the original controller DNS failure locally on Kafka 4.0.2 before the fix.
- `ControllerBootstrapIntegrationTests` and `AdminClassicGroupDescriptionTests`, Release/net10.0: all 3 tests passed on Kafka 4.0.2 and again on 4.3.1.
- `git diff --check`: passed. Final changes reviewed for reuse, quality, and efficiency.
- NativeAOT execution was not run locally; CI validation remains pending.

Only pipeline orchestration and integration fixtures change. There are no product hot-path changes or new per-message costs, and no performance thresholds are changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved controller bootstrap integration coverage by validating node count, host, port, and fencing status.
  * Updated controller-only Kafka test setup for Kafka 4.0 compatibility.
  * Excluded selected integration tests from Native AOT runs when runtime reflection is unavailable.

* **Chores**
  * Updated benchmark execution to avoid rebuilding and allow additional time for generated harness compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->